### PR TITLE
[PM-13910] Add collection manage property

### DIFF
--- a/crates/bitwarden-vault/src/collection.rs
+++ b/crates/bitwarden-vault/src/collection.rs
@@ -21,6 +21,7 @@ pub struct Collection {
     pub external_id: Option<String>,
     pub hide_passwords: bool,
     pub read_only: bool,
+    pub manage: bool,
 }
 
 #[derive(Serialize, Deserialize, Debug, JsonSchema)]
@@ -35,6 +36,7 @@ pub struct CollectionView {
     pub external_id: Option<String>,
     pub hide_passwords: bool,
     pub read_only: bool,
+    pub manage: bool,
 }
 
 impl LocateKey for Collection {
@@ -57,6 +59,7 @@ impl KeyDecryptable<SymmetricCryptoKey, CollectionView> for Collection {
             external_id: self.external_id.clone(),
             hide_passwords: self.hide_passwords,
             read_only: self.read_only,
+            manage: self.manage,
         })
     }
 }
@@ -72,6 +75,7 @@ impl TryFrom<CollectionDetailsResponseModel> for Collection {
             external_id: collection.external_id,
             hide_passwords: collection.hide_passwords.unwrap_or(false),
             read_only: collection.read_only.unwrap_or(false),
+            manage: collection.manage.unwrap_or(false),
         })
     }
 }

--- a/crates/bitwarden-vault/src/mobile/client_collection.rs
+++ b/crates/bitwarden-vault/src/mobile/client_collection.rs
@@ -58,6 +58,7 @@ mod tests {
             external_id: None,
             hide_passwords: false,
             read_only: false,
+            manage: false,
         }]).unwrap();
 
         assert_eq!(dec[0].name, "Default collection");
@@ -74,6 +75,7 @@ mod tests {
             external_id: None,
             hide_passwords: false,
             read_only: false,
+            manage: false,
         }).unwrap();
 
         assert_eq!(dec.name, "Default collection");


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-13910
## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
Add the `Collection.Manage` boolean property, which is missing from the SDK but which needs to be made available to mobile clients.

It is already returned in the server response and is in the autogenerated response model.

This is my first commit to the SDK, please let me know if I've missed anything.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation
  team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
