### PR TITLE
[PM-5693] Migrate SDK to KeyStore

### DIFF
--- a/bitwarden_license/bitwarden-sm/src/projects/get.rs
+++ b/bitwarden_license/bitwarden-sm/src/projects/get.rs
@@ -20,7 +20,7 @@ pub(crate) async fn get_project(
 
     let res = bitwarden_api_api::apis::projects_api::projects_id_get(&config.api, input.id).await?;
 
-    let enc = client.internal.get_encryption_settings()?;
+    let key_store = client.internal.get_key_store();
 
-    ProjectResponse::process_response(res, &enc)
+    ProjectResponse::process_response(res, &mut key_store.context())
 }

--- a/bitwarden_license/bitwarden-sm/src/secrets/create.rs
+++ b/bitwarden_license/bitwarden-sm/src/secrets/create.rs
@@ -1,6 +1,6 @@
 use bitwarden_api_api::models::SecretCreateRequestModel;
-use bitwarden_core::Client;
-use bitwarden_crypto::KeyEncryptable;
+use bitwarden_core::{key_management::SymmetricKeyId, Client};
+use bitwarden_crypto::Encryptable;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
@@ -34,16 +34,23 @@ pub(crate) async fn create_secret(
 ) -> Result<SecretResponse, SecretsManagerError> {
     input.validate()?;
 
-    let enc = client.internal.get_encryption_settings()?;
-    let key = enc.get_key(&Some(input.organization_id))?;
+    let key_store = client.internal.get_key_store();
+    let key = SymmetricKeyId::Organization(input.organization_id);
+    let mut ctx = key_store.context();
 
     let secret = Some(SecretCreateRequestModel {
-        key: input.key.clone().trim().encrypt_with_key(key)?.to_string(),
-        value: input.value.clone().encrypt_with_key(key)?.to_string(),
-        note: input.note.clone().trim().encrypt_with_key(key)?.to_string(),
+        key: input.key.clone().trim().encrypt(&mut ctx, key)?.to_string(),
+        value: input.value.clone().encrypt(&mut ctx, key)?.to_string(),
+        note: input
+            .note
+            .clone()
+            .trim()
+            .encrypt(&mut ctx, key)?
+            .to_string(),
         project_ids: input.project_ids.clone(),
         access_policies_requests: None,
     });
+    drop(ctx);
 
     let config = client.internal.get_api_configurations().await;
     let res = bitwarden_api_api::apis::secrets_api::organizations_organization_id_secrets_post(
@@ -53,7 +60,7 @@ pub(crate) async fn create_secret(
     )
     .await?;
 
-    SecretResponse::process_response(res, &enc)
+    SecretResponse::process_response(res, &mut key_store.context())
 }
 
 #[cfg(test)]

--- a/bitwarden_license/bitwarden-sm/src/secrets/create.rs
+++ b/bitwarden_license/bitwarden-sm/src/secrets/create.rs
@@ -36,21 +36,22 @@ pub(crate) async fn create_secret(
 
     let key_store = client.internal.get_key_store();
     let key = SymmetricKeyId::Organization(input.organization_id);
-    let mut ctx = key_store.context();
 
-    let secret = Some(SecretCreateRequestModel {
-        key: input.key.clone().trim().encrypt(&mut ctx, key)?.to_string(),
-        value: input.value.clone().encrypt(&mut ctx, key)?.to_string(),
-        note: input
-            .note
-            .clone()
-            .trim()
-            .encrypt(&mut ctx, key)?
-            .to_string(),
-        project_ids: input.project_ids.clone(),
-        access_policies_requests: None,
-    });
-    drop(ctx);
+    let secret = {
+        let mut ctx = key_store.context();
+        Some(SecretCreateRequestModel {
+            key: input.key.clone().trim().encrypt(&mut ctx, key)?.to_string(),
+            value: input.value.clone().encrypt(&mut ctx, key)?.to_string(),
+            note: input
+                .note
+                .clone()
+                .trim()
+                .encrypt(&mut ctx, key)?
+                .to_string(),
+            project_ids: input.project_ids.clone(),
+            access_policies_requests: None,
+        })
+    };
 
     let config = client.internal.get_api_configurations().await;
     let res = bitwarden_api_api::apis::secrets_api::organizations_organization_id_secrets_post(

--- a/bitwarden_license/bitwarden-sm/src/secrets/get.rs
+++ b/bitwarden_license/bitwarden-sm/src/secrets/get.rs
@@ -19,7 +19,7 @@ pub(crate) async fn get_secret(
     let config = client.internal.get_api_configurations().await;
     let res = bitwarden_api_api::apis::secrets_api::secrets_id_get(&config.api, input.id).await?;
 
-    let enc = client.internal.get_encryption_settings()?;
+    let key_store = client.internal.get_key_store();
 
-    SecretResponse::process_response(res, &enc)
+    SecretResponse::process_response(res, &mut key_store.context())
 }

--- a/bitwarden_license/bitwarden-sm/src/secrets/get_by_ids.rs
+++ b/bitwarden_license/bitwarden-sm/src/secrets/get_by_ids.rs
@@ -24,7 +24,7 @@ pub(crate) async fn get_secrets_by_ids(
     let res =
         bitwarden_api_api::apis::secrets_api::secrets_get_by_ids_post(&config.api, request).await?;
 
-    let enc = client.internal.get_encryption_settings()?;
+    let key_store = client.internal.get_key_store();
 
-    SecretsResponse::process_response(res, &enc)
+    SecretsResponse::process_response(res, &mut key_store.context())
 }

--- a/bitwarden_license/bitwarden-sm/src/secrets/update.rs
+++ b/bitwarden_license/bitwarden-sm/src/secrets/update.rs
@@ -1,6 +1,6 @@
 use bitwarden_api_api::models::SecretUpdateRequestModel;
-use bitwarden_core::Client;
-use bitwarden_crypto::KeyEncryptable;
+use bitwarden_core::{key_management::SymmetricKeyId, Client};
+use bitwarden_crypto::Encryptable;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
@@ -33,22 +33,30 @@ pub(crate) async fn update_secret(
 ) -> Result<SecretResponse, SecretsManagerError> {
     input.validate()?;
 
-    let enc = client.internal.get_encryption_settings()?;
-    let key = enc.get_key(&Some(input.organization_id))?;
+    let key_store = client.internal.get_key_store();
+    let key = SymmetricKeyId::Organization(input.organization_id);
+
+    let mut ctx = key_store.context();
 
     let secret = Some(SecretUpdateRequestModel {
-        key: input.key.clone().trim().encrypt_with_key(key)?.to_string(),
-        value: input.value.clone().encrypt_with_key(key)?.to_string(),
-        note: input.note.clone().trim().encrypt_with_key(key)?.to_string(),
+        key: input.key.clone().trim().encrypt(&mut ctx, key)?.to_string(),
+        value: input.value.clone().encrypt(&mut ctx, key)?.to_string(),
+        note: input
+            .note
+            .clone()
+            .trim()
+            .encrypt(&mut ctx, key)?
+            .to_string(),
         project_ids: input.project_ids.clone(),
         access_policies_requests: None,
     });
+    drop(ctx);
 
     let config = client.internal.get_api_configurations().await;
     let res =
         bitwarden_api_api::apis::secrets_api::secrets_id_put(&config.api, input.id, secret).await?;
 
-    SecretResponse::process_response(res, &enc)
+    SecretResponse::process_response(res, &mut key_store.context())
 }
 
 #[cfg(test)]

--- a/bitwarden_license/bitwarden-sm/src/secrets/update.rs
+++ b/bitwarden_license/bitwarden-sm/src/secrets/update.rs
@@ -36,21 +36,21 @@ pub(crate) async fn update_secret(
     let key_store = client.internal.get_key_store();
     let key = SymmetricKeyId::Organization(input.organization_id);
 
-    let mut ctx = key_store.context();
-
-    let secret = Some(SecretUpdateRequestModel {
-        key: input.key.clone().trim().encrypt(&mut ctx, key)?.to_string(),
-        value: input.value.clone().encrypt(&mut ctx, key)?.to_string(),
-        note: input
-            .note
-            .clone()
-            .trim()
-            .encrypt(&mut ctx, key)?
-            .to_string(),
-        project_ids: input.project_ids.clone(),
-        access_policies_requests: None,
-    });
-    drop(ctx);
+    let secret = {
+        let mut ctx = key_store.context();
+        Some(SecretUpdateRequestModel {
+            key: input.key.clone().trim().encrypt(&mut ctx, key)?.to_string(),
+            value: input.value.clone().encrypt(&mut ctx, key)?.to_string(),
+            note: input
+                .note
+                .clone()
+                .trim()
+                .encrypt(&mut ctx, key)?
+                .to_string(),
+            project_ids: input.project_ids.clone(),
+            access_policies_requests: None,
+        })
+    };
 
     let config = client.internal.get_api_configurations().await;
     let res =

--- a/crates/bitwarden-core/src/auth/auth_client.rs
+++ b/crates/bitwarden-core/src/auth/auth_client.rs
@@ -189,6 +189,7 @@ fn trust_device(client: &Client) -> Result<TrustDeviceResponse, TrustDeviceError
 
     let key_store = client.internal.get_key_store();
     let ctx = key_store.context();
+    // FIXME: [PM-18099] Once DeviceKey deals with KeyIds, this should be updated
     #[allow(deprecated)]
     let user_key = ctx.dangerous_get_symmetric_key(SymmetricKeyId::User)?;
 

--- a/crates/bitwarden-core/src/auth/auth_client.rs
+++ b/crates/bitwarden-core/src/auth/auth_client.rs
@@ -185,9 +185,12 @@ pub enum TrustDeviceError {
 
 #[cfg(feature = "internal")]
 fn trust_device(client: &Client) -> Result<TrustDeviceResponse, TrustDeviceError> {
-    let enc = client.internal.get_encryption_settings()?;
+    use crate::key_management::SymmetricKeyId;
 
-    let user_key = enc.get_key(&None)?;
+    let key_store = client.internal.get_key_store();
+    let ctx = key_store.context();
+    #[allow(deprecated)]
+    let user_key = ctx.dangerous_get_symmetric_key(SymmetricKeyId::User)?;
 
     Ok(DeviceKey::trust_device(user_key)?)
 }

--- a/crates/bitwarden-core/src/auth/auth_request.rs
+++ b/crates/bitwarden-core/src/auth/auth_request.rs
@@ -96,7 +96,7 @@ pub(crate) fn approve_auth_request(
 
     let key_store = client.internal.get_key_store();
     let ctx = key_store.context();
-    
+
     // FIXME: [PM-18110] This should be removed once the key store can handle public key encryption
     #[allow(deprecated)]
     let key = ctx.dangerous_get_symmetric_key(SymmetricKeyId::User)?;

--- a/crates/bitwarden-core/src/auth/auth_request.rs
+++ b/crates/bitwarden-core/src/auth/auth_request.rs
@@ -96,6 +96,8 @@ pub(crate) fn approve_auth_request(
 
     let key_store = client.internal.get_key_store();
     let ctx = key_store.context();
+    
+    // FIXME: [PM-18110] This should be removed once the key store can handle public key encryption
     #[allow(deprecated)]
     let key = ctx.dangerous_get_symmetric_key(SymmetricKeyId::User)?;
 

--- a/crates/bitwarden-core/src/auth/auth_request.rs
+++ b/crates/bitwarden-core/src/auth/auth_request.rs
@@ -9,7 +9,7 @@ use thiserror::Error;
 
 #[cfg(feature = "internal")]
 use crate::client::encryption_settings::EncryptionSettingsError;
-use crate::{Client, VaultLockedError};
+use crate::{key_management::SymmetricKeyId, Client, VaultLockedError};
 
 #[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
 pub struct AuthRequestResponse {
@@ -94,8 +94,10 @@ pub(crate) fn approve_auth_request(
 ) -> Result<AsymmetricEncString, ApproveAuthRequestError> {
     let public_key = AsymmetricPublicCryptoKey::from_der(&STANDARD.decode(public_key)?)?;
 
-    let enc = client.internal.get_encryption_settings()?;
-    let key = enc.get_key(&None)?;
+    let key_store = client.internal.get_key_store();
+    let ctx = key_store.context();
+    #[allow(deprecated)]
+    let key = ctx.dangerous_get_symmetric_key(SymmetricKeyId::User)?;
 
     Ok(AsymmetricEncString::encrypt_rsa2048_oaep_sha1(
         &key.to_vec(),
@@ -131,7 +133,10 @@ mod tests {
     use bitwarden_crypto::{Kdf, MasterKey};
 
     use super::*;
-    use crate::mobile::crypto::{AuthRequestMethod, InitUserCryptoMethod, InitUserCryptoRequest};
+    use crate::{
+        key_management::SymmetricKeyId,
+        mobile::crypto::{AuthRequestMethod, InitUserCryptoMethod, InitUserCryptoRequest},
+    };
 
     #[test]
     fn test_approve() {
@@ -246,21 +251,25 @@ mod tests {
 
         // We can validate that the vault is unlocked correctly by confirming the user key is the
         // same
-        assert_eq!(
-            existing_device
-                .internal
-                .get_encryption_settings()
-                .unwrap()
-                .get_key(&None)
-                .unwrap()
-                .to_base64(),
-            new_device
-                .internal
-                .get_encryption_settings()
-                .unwrap()
-                .get_key(&None)
+
+        let existing_key = {
+            let key_store = existing_device.internal.get_key_store();
+            let ctx = key_store.context();
+            #[allow(deprecated)]
+            ctx.dangerous_get_symmetric_key(SymmetricKeyId::User)
                 .unwrap()
                 .to_base64()
-        );
+        };
+
+        let new_key = {
+            let key_store = new_device.internal.get_key_store();
+            let ctx = key_store.context();
+            #[allow(deprecated)]
+            ctx.dangerous_get_symmetric_key(SymmetricKeyId::User)
+                .unwrap()
+                .to_base64()
+        };
+
+        assert_eq!(existing_key, new_key);
     }
 }

--- a/crates/bitwarden-core/src/auth/password/validate.rs
+++ b/crates/bitwarden-core/src/auth/password/validate.rs
@@ -43,6 +43,8 @@ pub(crate) fn validate_password_user_key(
     password: String,
     encrypted_user_key: String,
 ) -> Result<String, AuthValidateError> {
+    use crate::key_management::SymmetricKeyId;
+
     let login_method = client
         .internal
         .get_login_method()
@@ -58,9 +60,10 @@ pub(crate) fn validate_password_user_key(
                     .decrypt_user_key(encrypted_user_key.parse()?)
                     .map_err(|_| WrongPasswordError)?;
 
-                let enc = client.internal.get_encryption_settings()?;
-
-                let existing_key = enc.get_key(&None)?;
+                let key_store = client.internal.get_key_store();
+                let ctx = key_store.context();
+                #[allow(deprecated)]
+                let existing_key = ctx.dangerous_get_symmetric_key(SymmetricKeyId::User)?;
 
                 if user_key.to_vec() != existing_key.to_vec() {
                     return Err(AuthValidateError::WrongUserKey);

--- a/crates/bitwarden-core/src/auth/password/validate.rs
+++ b/crates/bitwarden-core/src/auth/password/validate.rs
@@ -62,6 +62,7 @@ pub(crate) fn validate_password_user_key(
 
                 let key_store = client.internal.get_key_store();
                 let ctx = key_store.context();
+                // FIXME: [PM-18099] Once MasterKey deals with KeyIds, this should be updated
                 #[allow(deprecated)]
                 let existing_key = ctx.dangerous_get_symmetric_key(SymmetricKeyId::User)?;
 

--- a/crates/bitwarden-core/src/auth/pin.rs
+++ b/crates/bitwarden-core/src/auth/pin.rs
@@ -28,6 +28,7 @@ pub(crate) fn validate_pin(
         | UserLoginMethod::ApiKey { email, kdf, .. } => {
             let key_store = client.internal.get_key_store();
             let ctx = key_store.context();
+            // FIXME: [PM-18099] Once PinKey deals with KeyIds, this should be updated
             #[allow(deprecated)]
             let user_key = ctx.dangerous_get_symmetric_key(SymmetricKeyId::User)?;
 

--- a/crates/bitwarden-core/src/auth/pin.rs
+++ b/crates/bitwarden-core/src/auth/pin.rs
@@ -4,6 +4,7 @@ use crate::{
     auth::AuthValidateError,
     client::{LoginMethod, UserLoginMethod},
     error::{NotAuthenticatedError, Result},
+    key_management::SymmetricKeyId,
     Client,
 };
 
@@ -25,8 +26,10 @@ pub(crate) fn validate_pin(
     match login_method {
         UserLoginMethod::Username { email, kdf, .. }
         | UserLoginMethod::ApiKey { email, kdf, .. } => {
-            let enc = client.internal.get_encryption_settings()?;
-            let user_key = enc.get_key(&None)?;
+            let key_store = client.internal.get_key_store();
+            let ctx = key_store.context();
+            #[allow(deprecated)]
+            let user_key = ctx.dangerous_get_symmetric_key(SymmetricKeyId::User)?;
 
             let pin_key = PinKey::derive(pin.as_bytes(), email.as_bytes(), kdf)?;
 

--- a/crates/bitwarden-core/src/client/client.rs
+++ b/crates/bitwarden-core/src/client/client.rs
@@ -1,5 +1,6 @@
 use std::sync::{Arc, RwLock};
 
+use bitwarden_crypto::KeyStore;
 use reqwest::header::{self, HeaderValue};
 
 use super::internal::InternalClient;
@@ -80,7 +81,7 @@ impl Client {
                     device_type: settings.device_type,
                 })),
                 external_client,
-                encryption_settings: RwLock::new(None),
+                key_store: KeyStore::default(),
             },
         }
     }

--- a/crates/bitwarden-core/src/client/encryption_settings.rs
+++ b/crates/bitwarden-core/src/client/encryption_settings.rs
@@ -66,6 +66,7 @@ impl EncryptionSettings {
             // )
         };
 
+        // FIXME: [PM-18098] When this is part of crypto we won't need to use deprecated methods
         #[allow(deprecated)]
         {
             let mut ctx = store.context_mut();
@@ -82,6 +83,7 @@ impl EncryptionSettings {
     /// This is used only for logging in Secrets Manager with an access token
     #[cfg(feature = "secrets")]
     pub(crate) fn new_single_key(key: SymmetricCryptoKey, store: &KeyStore<KeyIds>) {
+        // FIXME: [PM-18098] When this is part of crypto we won't need to use deprecated methods
         #[allow(deprecated)]
         store
             .context_mut()

--- a/crates/bitwarden-core/src/client/encryption_settings.rs
+++ b/crates/bitwarden-core/src/client/encryption_settings.rs
@@ -1,15 +1,16 @@
-use std::collections::HashMap;
-
-use bitwarden_crypto::{AsymmetricCryptoKey, CryptoError, KeyContainer, SymmetricCryptoKey};
+use bitwarden_crypto::{AsymmetricCryptoKey, KeyStore, SymmetricCryptoKey};
 #[cfg(feature = "internal")]
-use bitwarden_crypto::{AsymmetricEncString, EncString, MasterKey};
+use bitwarden_crypto::{AsymmetricEncString, EncString};
 use bitwarden_error::bitwarden_error;
 use thiserror::Error;
 use uuid::Uuid;
 
 #[cfg(feature = "internal")]
 use crate::error::Result;
-use crate::VaultLockedError;
+use crate::{
+    key_management::{AsymmetricKeyId, KeyIds, SymmetricKeyId},
+    VaultLockedError,
+};
 
 #[bitwarden_error(flat)]
 #[derive(Debug, Error)]
@@ -30,32 +31,9 @@ pub enum EncryptionSettingsError {
     MissingPrivateKey,
 }
 
-#[derive(Clone)]
-pub struct EncryptionSettings {
-    user_key: SymmetricCryptoKey,
-    pub(crate) private_key: Option<AsymmetricCryptoKey>,
-    org_keys: HashMap<Uuid, SymmetricCryptoKey>,
-}
-
-impl std::fmt::Debug for EncryptionSettings {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("EncryptionSettings").finish()
-    }
-}
+pub struct EncryptionSettings {}
 
 impl EncryptionSettings {
-    /// Initialize the encryption settings with the master key and the encrypted user keys
-    #[cfg(feature = "internal")]
-    pub(crate) fn new(
-        master_key: MasterKey,
-        user_key: EncString,
-        private_key: EncString,
-    ) -> Result<Self, EncryptionSettingsError> {
-        // Decrypt the user key
-        let user_key = master_key.decrypt_user_key(user_key)?;
-        Self::new_decrypted_key(user_key, private_key)
-    }
-
     /// Initialize the encryption settings with the decrypted user key and the encrypted user
     /// private key This should only be used when unlocking the vault via biometrics or when the
     /// vault is set to lock: "never" Otherwise handling the decrypted user key is dangerous and
@@ -64,9 +42,12 @@ impl EncryptionSettings {
     pub(crate) fn new_decrypted_key(
         user_key: SymmetricCryptoKey,
         private_key: EncString,
-    ) -> Result<Self, EncryptionSettingsError> {
+        store: &KeyStore<KeyIds>,
+    ) -> Result<(), EncryptionSettingsError> {
         use bitwarden_crypto::KeyDecryptable;
         use log::warn;
+
+        use crate::key_management::{AsymmetricKeyId, SymmetricKeyId};
 
         let private_key = {
             let dec: Vec<u8> = private_key.decrypt_with_key(&user_key)?;
@@ -85,76 +66,58 @@ impl EncryptionSettings {
             // )
         };
 
-        Ok(EncryptionSettings {
-            user_key,
-            private_key,
-            org_keys: HashMap::new(),
-        })
+        #[allow(deprecated)]
+        {
+            let mut ctx = store.context_mut();
+            ctx.set_symmetric_key(SymmetricKeyId::User, user_key)?;
+            if let Some(private_key) = private_key {
+                ctx.set_asymmetric_key(AsymmetricKeyId::UserPrivateKey, private_key)?;
+            }
+        }
+
+        Ok(())
     }
 
     /// Initialize the encryption settings with only a single decrypted key.
     /// This is used only for logging in Secrets Manager with an access token
     #[cfg(feature = "secrets")]
-    pub(crate) fn new_single_key(key: SymmetricCryptoKey) -> Self {
-        EncryptionSettings {
-            user_key: key,
-            private_key: None,
-            org_keys: HashMap::new(),
-        }
+    pub(crate) fn new_single_key(key: SymmetricCryptoKey, store: &KeyStore<KeyIds>) {
+        #[allow(deprecated)]
+        store
+            .context_mut()
+            .set_symmetric_key(SymmetricKeyId::User, key)
+            .expect("Mutable context");
     }
 
     #[cfg(feature = "internal")]
     pub(crate) fn set_org_keys(
-        &mut self,
         org_enc_keys: Vec<(Uuid, AsymmetricEncString)>,
-    ) -> Result<&Self, EncryptionSettingsError> {
-        use bitwarden_crypto::KeyDecryptable;
+        store: &KeyStore<KeyIds>,
+    ) -> Result<(), EncryptionSettingsError> {
+        let mut ctx = store.context_mut();
+
+        if !ctx.has_asymmetric_key(AsymmetricKeyId::UserPrivateKey) {
+            return Err(VaultLockedError.into());
+        }
 
         // Make sure we only keep the keys given in the arguments and not any of the previous
         // ones, which might be from organizations that the user is no longer a part of anymore
-        self.org_keys.clear();
+        ctx.retain_symmetric_keys(|key_ref| !matches!(key_ref, SymmetricKeyId::Organization(_)));
 
         // FIXME: [PM-11690] - Early abort to handle private key being corrupt
         if org_enc_keys.is_empty() {
-            return Ok(self);
+            return Ok(());
         }
-
-        let private_key = self
-            .private_key
-            .as_ref()
-            .ok_or(EncryptionSettingsError::MissingPrivateKey)?;
 
         // Decrypt the org keys with the private key
         for (org_id, org_enc_key) in org_enc_keys {
-            let mut dec: Vec<u8> = org_enc_key.decrypt_with_key(private_key)?;
-
-            let org_key = SymmetricCryptoKey::try_from(dec.as_mut_slice())?;
-
-            self.org_keys.insert(org_id, org_key);
+            ctx.decrypt_symmetric_key_with_asymmetric_key(
+                AsymmetricKeyId::UserPrivateKey,
+                SymmetricKeyId::Organization(org_id),
+                &org_enc_key,
+            )?;
         }
 
-        Ok(self)
-    }
-
-    pub fn get_key(&self, org_id: &Option<Uuid>) -> Result<&SymmetricCryptoKey, CryptoError> {
-        // If we don't have a private key set (to decode multiple org keys), we just use the main
-        // user key
-        if self.private_key.is_none() {
-            return Ok(&self.user_key);
-        }
-
-        match org_id {
-            Some(org_id) => self
-                .org_keys
-                .get(org_id)
-                .ok_or(CryptoError::MissingKey(*org_id)),
-            None => Ok(&self.user_key),
-        }
-    }
-}
-
-impl KeyContainer for EncryptionSettings {
-    fn get_key(&self, org_id: &Option<Uuid>) -> Result<&SymmetricCryptoKey, CryptoError> {
-        EncryptionSettings::get_key(self, org_id)
+        Ok(())
     }
 }

--- a/crates/bitwarden-core/src/client/encryption_settings.rs
+++ b/crates/bitwarden-core/src/client/encryption_settings.rs
@@ -96,6 +96,11 @@ impl EncryptionSettings {
     ) -> Result<(), EncryptionSettingsError> {
         let mut ctx = store.context_mut();
 
+        // FIXME: [PM-11690] - Early abort to handle private key being corrupt
+        if org_enc_keys.is_empty() {
+            return Ok(());
+        }
+
         if !ctx.has_asymmetric_key(AsymmetricKeyId::UserPrivateKey) {
             return Err(EncryptionSettingsError::MissingPrivateKey);
         }

--- a/crates/bitwarden-core/src/client/encryption_settings.rs
+++ b/crates/bitwarden-core/src/client/encryption_settings.rs
@@ -109,11 +109,6 @@ impl EncryptionSettings {
         // ones, which might be from organizations that the user is no longer a part of anymore
         ctx.retain_symmetric_keys(|key_ref| !matches!(key_ref, SymmetricKeyId::Organization(_)));
 
-        // FIXME: [PM-11690] - Early abort to handle private key being corrupt
-        if org_enc_keys.is_empty() {
-            return Ok(());
-        }
-
         // Decrypt the org keys with the private key
         for (org_id, org_enc_key) in org_enc_keys {
             ctx.decrypt_symmetric_key_with_asymmetric_key(

--- a/crates/bitwarden-core/src/client/encryption_settings.rs
+++ b/crates/bitwarden-core/src/client/encryption_settings.rs
@@ -97,7 +97,7 @@ impl EncryptionSettings {
         let mut ctx = store.context_mut();
 
         if !ctx.has_asymmetric_key(AsymmetricKeyId::UserPrivateKey) {
-            return Err(VaultLockedError.into());
+            return Err(EncryptionSettingsError::MissingPrivateKey);
         }
 
         // Make sure we only keep the keys given in the arguments and not any of the previous

--- a/crates/bitwarden-core/src/client/internal.rs
+++ b/crates/bitwarden-core/src/client/internal.rs
@@ -218,7 +218,6 @@ impl InternalClient {
         &self,
         org_keys: Vec<(Uuid, AsymmetricEncString)>,
     ) -> Result<(), EncryptionSettingsError> {
-        EncryptionSettings::set_org_keys(org_keys, &self.key_store)?;
-        Ok(())
+        EncryptionSettings::set_org_keys(org_keys, &self.key_store)
     }
 }

--- a/crates/bitwarden-core/src/client/internal.rs
+++ b/crates/bitwarden-core/src/client/internal.rs
@@ -1,5 +1,6 @@
 use std::sync::{Arc, RwLock};
 
+use bitwarden_crypto::KeyStore;
 #[cfg(any(feature = "internal", feature = "secrets"))]
 use bitwarden_crypto::SymmetricCryptoKey;
 #[cfg(feature = "internal")]
@@ -12,7 +13,8 @@ use super::login_method::ServiceAccountLoginMethod;
 use crate::{
     auth::renew::renew_token,
     client::{encryption_settings::EncryptionSettings, login_method::LoginMethod},
-    error::{Result, VaultLockedError},
+    error::Result,
+    key_management::KeyIds,
     DeviceType,
 };
 #[cfg(feature = "internal")]
@@ -58,7 +60,7 @@ pub struct InternalClient {
     #[allow(unused)]
     pub(crate) external_client: reqwest::Client,
 
-    pub(super) encryption_settings: RwLock<Option<Arc<EncryptionSettings>>>,
+    pub(super) key_store: KeyStore<KeyIds>,
 }
 
 impl InternalClient {
@@ -167,12 +169,8 @@ impl InternalClient {
         &self.external_client
     }
 
-    pub fn get_encryption_settings(&self) -> Result<Arc<EncryptionSettings>, VaultLockedError> {
-        self.encryption_settings
-            .read()
-            .expect("RwLock is not poisoned")
-            .clone()
-            .ok_or(VaultLockedError)
+    pub fn get_key_store(&self) -> &KeyStore<KeyIds> {
+        &self.key_store
     }
 
     #[cfg(feature = "internal")]
@@ -182,14 +180,8 @@ impl InternalClient {
         user_key: EncString,
         private_key: EncString,
     ) -> Result<(), EncryptionSettingsError> {
-        *self
-            .encryption_settings
-            .write()
-            .expect("RwLock is not poisoned") = Some(Arc::new(EncryptionSettings::new(
-            master_key,
-            user_key,
-            private_key,
-        )?));
+        let user_key = master_key.decrypt_user_key(user_key)?;
+        EncryptionSettings::new_decrypted_key(user_key, private_key, &self.key_store)?;
 
         Ok(())
     }
@@ -200,12 +192,7 @@ impl InternalClient {
         user_key: SymmetricCryptoKey,
         private_key: EncString,
     ) -> Result<(), EncryptionSettingsError> {
-        *self
-            .encryption_settings
-            .write()
-            .expect("RwLock is not poisoned") = Some(Arc::new(
-            EncryptionSettings::new_decrypted_key(user_key, private_key)?,
-        ));
+        EncryptionSettings::new_decrypted_key(user_key, private_key, &self.key_store)?;
 
         Ok(())
     }
@@ -223,30 +210,15 @@ impl InternalClient {
 
     #[cfg(feature = "secrets")]
     pub(crate) fn initialize_crypto_single_key(&self, key: SymmetricCryptoKey) {
-        *self
-            .encryption_settings
-            .write()
-            .expect("RwLock is not poisoned") =
-            Some(Arc::new(EncryptionSettings::new_single_key(key)));
+        EncryptionSettings::new_single_key(key, &self.key_store);
     }
 
     #[cfg(feature = "internal")]
     pub fn initialize_org_crypto(
         &self,
         org_keys: Vec<(Uuid, AsymmetricEncString)>,
-    ) -> Result<Arc<EncryptionSettings>, EncryptionSettingsError> {
-        let mut guard = self
-            .encryption_settings
-            .write()
-            .expect("RwLock is not poisoned");
-
-        let Some(enc) = guard.as_mut() else {
-            return Err(VaultLockedError.into());
-        };
-
-        let inner = Arc::make_mut(enc);
-        inner.set_org_keys(org_keys)?;
-
-        Ok(enc.clone())
+    ) -> Result<(), EncryptionSettingsError> {
+        EncryptionSettings::set_org_keys(org_keys, &self.key_store)?;
+        Ok(())
     }
 }

--- a/crates/bitwarden-core/src/key_management/mod.rs
+++ b/crates/bitwarden-core/src/key_management/mod.rs
@@ -1,3 +1,12 @@
+//! This module contains the definition for the key identifiers used by the rest of the crates.
+//! Any code that needs to interact with the [KeyStore] should use these types.
+//!
+//! - [SymmetricKeyId] is used to identify symmetric keys.
+//! - [AsymmetricKeyId] is used to identify asymmetric keys.
+//! - [KeyIds] is a helper type that combines both symmetric and asymmetric key identifiers. This is
+//!   usually used in the type bounds of [KeyStore],
+//!   [KeyStoreContext](bitwarden_crypto::KeyStoreContext),
+//!   [Encryptable](bitwarden_crypto::Encryptable) and [Decryptable](bitwarden_crypto::Encryptable).
 use bitwarden_crypto::{key_ids, KeyStore, SymmetricCryptoKey};
 
 key_ids! {
@@ -20,6 +29,9 @@ key_ids! {
     pub KeyIds => SymmetricKeyId, AsymmetricKeyId;
 }
 
+/// This is a helper function to create a test KeyStore with a single user key.
+/// While this function is not marked as #[cfg(test)], it should only be used for testing purposes.
+/// It's only public so that other crates can make use of it in their own tests.
 pub fn create_test_crypto_with_user_key(key: SymmetricCryptoKey) -> KeyStore<KeyIds> {
     let store = KeyStore::default();
 
@@ -32,6 +44,10 @@ pub fn create_test_crypto_with_user_key(key: SymmetricCryptoKey) -> KeyStore<Key
     store
 }
 
+/// This is a helper function to create a test KeyStore with a single user key and an organization
+/// key using the provided organization uuid. While this function is not marked as #[cfg(test)], it
+/// should only be used for testing purposes. It's only public so that other crates can make use of
+/// it in their own tests.
 pub fn create_test_crypto_with_user_and_org_key(
     key: SymmetricCryptoKey,
     org_id: uuid::Uuid,

--- a/crates/bitwarden-core/src/key_management/mod.rs
+++ b/crates/bitwarden-core/src/key_management/mod.rs
@@ -1,0 +1,55 @@
+use bitwarden_crypto::{key_ids, KeyStore, SymmetricCryptoKey};
+
+key_ids! {
+    #[symmetric]
+    pub enum SymmetricKeyId {
+        Master,
+        User,
+        Organization(uuid::Uuid),
+        #[local]
+        Local(&'static str),
+    }
+
+    #[asymmetric]
+    pub enum AsymmetricKeyId {
+        UserPrivateKey,
+        #[local]
+        Local(&'static str),
+    }
+
+    pub KeyIds => SymmetricKeyId, AsymmetricKeyId;
+}
+
+pub fn create_test_crypto_with_user_key(key: SymmetricCryptoKey) -> KeyStore<KeyIds> {
+    let store = KeyStore::default();
+
+    #[allow(deprecated)]
+    store
+        .context_mut()
+        .set_symmetric_key(SymmetricKeyId::User, key.clone())
+        .expect("Mutable context");
+
+    store
+}
+
+pub fn create_test_crypto_with_user_and_org_key(
+    key: SymmetricCryptoKey,
+    org_id: uuid::Uuid,
+    org_key: SymmetricCryptoKey,
+) -> KeyStore<KeyIds> {
+    let store = KeyStore::default();
+
+    #[allow(deprecated)]
+    store
+        .context_mut()
+        .set_symmetric_key(SymmetricKeyId::User, key.clone())
+        .expect("Mutable context");
+
+    #[allow(deprecated)]
+    store
+        .context_mut()
+        .set_symmetric_key(SymmetricKeyId::Organization(org_id), org_key.clone())
+        .expect("Mutable context");
+
+    store
+}

--- a/crates/bitwarden-core/src/lib.rs
+++ b/crates/bitwarden-core/src/lib.rs
@@ -8,6 +8,7 @@ pub mod admin_console;
 pub mod auth;
 pub mod client;
 mod error;
+pub mod key_management;
 pub use error::{
     ApiError, Error, MissingFieldError, NotAuthenticatedError, VaultLockedError, WrongPasswordError,
 };

--- a/crates/bitwarden-core/src/mobile/crypto.rs
+++ b/crates/bitwarden-core/src/mobile/crypto.rs
@@ -221,6 +221,7 @@ pub async fn initialize_org_crypto(
 pub async fn get_user_encryption_key(client: &Client) -> Result<String, MobileCryptoError> {
     let key_store = client.internal.get_key_store();
     let ctx = key_store.context();
+    // This is needed because the mobile clients need access to the user encryption key
     #[allow(deprecated)]
     let user_key = ctx.dangerous_get_symmetric_key(SymmetricKeyId::User)?;
 
@@ -243,6 +244,7 @@ pub fn update_password(
 ) -> Result<UpdatePasswordResponse, MobileCryptoError> {
     let key_store = client.internal.get_key_store();
     let ctx = key_store.context();
+    // FIXME: [PM-18099] Once MasterKey deals with KeyIds, this should be updated
     #[allow(deprecated)]
     let user_key = ctx.dangerous_get_symmetric_key(SymmetricKeyId::User)?;
 
@@ -290,6 +292,7 @@ pub fn derive_pin_key(
 ) -> Result<DerivePinKeyResponse, MobileCryptoError> {
     let key_store = client.internal.get_key_store();
     let ctx = key_store.context();
+    // FIXME: [PM-18099] Once PinKey deals with KeyIds, this should be updated
     #[allow(deprecated)]
     let user_key = ctx.dangerous_get_symmetric_key(SymmetricKeyId::User)?;
 
@@ -312,6 +315,7 @@ pub fn derive_pin_user_key(
 ) -> Result<EncString, MobileCryptoError> {
     let key_store = client.internal.get_key_store();
     let ctx = key_store.context();
+    // FIXME: [PM-18099] Once PinKey deals with KeyIds, this should be updated
     #[allow(deprecated)]
     let user_key = ctx.dangerous_get_symmetric_key(SymmetricKeyId::User)?;
 
@@ -364,6 +368,7 @@ pub(super) fn enroll_admin_password_reset(
     let public_key = AsymmetricPublicCryptoKey::from_der(&STANDARD.decode(public_key)?)?;
     let key_store = client.internal.get_key_store();
     let ctx = key_store.context();
+    // FIXME: [PM-18110] This should be removed once the key store can handle public key encryption
     #[allow(deprecated)]
     let key = ctx.dangerous_get_symmetric_key(SymmetricKeyId::User)?;
 

--- a/crates/bitwarden-core/src/mobile/crypto.rs
+++ b/crates/bitwarden-core/src/mobile/crypto.rs
@@ -13,6 +13,7 @@ use {tsify_next::Tsify, wasm_bindgen::prelude::*};
 use crate::{
     client::{encryption_settings::EncryptionSettingsError, LoginMethod, UserLoginMethod},
     error::{NotAuthenticatedError, Result},
+    key_management::SymmetricKeyId,
     Client, VaultLockedError, WrongPasswordError,
 };
 
@@ -218,8 +219,10 @@ pub async fn initialize_org_crypto(
 }
 
 pub async fn get_user_encryption_key(client: &Client) -> Result<String, MobileCryptoError> {
-    let enc = client.internal.get_encryption_settings()?;
-    let user_key = enc.get_key(&None)?;
+    let key_store = client.internal.get_key_store();
+    let ctx = key_store.context();
+    #[allow(deprecated)]
+    let user_key = ctx.dangerous_get_symmetric_key(SymmetricKeyId::User)?;
 
     Ok(user_key.to_base64())
 }
@@ -238,8 +241,10 @@ pub fn update_password(
     client: &Client,
     new_password: String,
 ) -> Result<UpdatePasswordResponse, MobileCryptoError> {
-    let enc = client.internal.get_encryption_settings()?;
-    let user_key = enc.get_key(&None)?;
+    let key_store = client.internal.get_key_store();
+    let ctx = key_store.context();
+    #[allow(deprecated)]
+    let user_key = ctx.dangerous_get_symmetric_key(SymmetricKeyId::User)?;
 
     let login_method = client
         .internal
@@ -283,8 +288,10 @@ pub fn derive_pin_key(
     client: &Client,
     pin: String,
 ) -> Result<DerivePinKeyResponse, MobileCryptoError> {
-    let enc = client.internal.get_encryption_settings()?;
-    let user_key = enc.get_key(&None)?;
+    let key_store = client.internal.get_key_store();
+    let ctx = key_store.context();
+    #[allow(deprecated)]
+    let user_key = ctx.dangerous_get_symmetric_key(SymmetricKeyId::User)?;
 
     let login_method = client
         .internal
@@ -303,8 +310,10 @@ pub fn derive_pin_user_key(
     client: &Client,
     encrypted_pin: EncString,
 ) -> Result<EncString, MobileCryptoError> {
-    let enc = client.internal.get_encryption_settings()?;
-    let user_key = enc.get_key(&None)?;
+    let key_store = client.internal.get_key_store();
+    let ctx = key_store.context();
+    #[allow(deprecated)]
+    let user_key = ctx.dangerous_get_symmetric_key(SymmetricKeyId::User)?;
 
     let pin: String = encrypted_pin.decrypt_with_key(user_key)?;
     let login_method = client
@@ -353,8 +362,10 @@ pub(super) fn enroll_admin_password_reset(
     use bitwarden_crypto::AsymmetricPublicCryptoKey;
 
     let public_key = AsymmetricPublicCryptoKey::from_der(&STANDARD.decode(public_key)?)?;
-    let enc = client.internal.get_encryption_settings()?;
-    let key = enc.get_key(&None)?;
+    let key_store = client.internal.get_key_store();
+    let ctx = key_store.context();
+    #[allow(deprecated)]
+    let key = ctx.dangerous_get_symmetric_key(SymmetricKeyId::User)?;
 
     Ok(AsymmetricEncString::encrypt_rsa2048_oaep_sha1(
         &key.to_vec(),
@@ -561,22 +572,25 @@ mod tests {
 
         assert_eq!(new_hash, new_password_response.password_hash);
 
-        assert_eq!(
-            client
-                .internal
-                .get_encryption_settings()
-                .unwrap()
-                .get_key(&None)
-                .unwrap()
-                .to_base64(),
-            client2
-                .internal
-                .get_encryption_settings()
-                .unwrap()
-                .get_key(&None)
+        let client_key = {
+            let key_store = client.internal.get_key_store();
+            let ctx = key_store.context();
+            #[allow(deprecated)]
+            ctx.dangerous_get_symmetric_key(SymmetricKeyId::User)
                 .unwrap()
                 .to_base64()
-        );
+        };
+
+        let client2_key = {
+            let key_store = client2.internal.get_key_store();
+            let ctx = key_store.context();
+            #[allow(deprecated)]
+            ctx.dangerous_get_symmetric_key(SymmetricKeyId::User)
+                .unwrap()
+                .to_base64()
+        };
+
+        assert_eq!(client_key, client2_key);
     }
 
     #[tokio::test]
@@ -623,22 +637,25 @@ mod tests {
         .await
         .unwrap();
 
-        assert_eq!(
-            client
-                .internal
-                .get_encryption_settings()
-                .unwrap()
-                .get_key(&None)
-                .unwrap()
-                .to_base64(),
-            client2
-                .internal
-                .get_encryption_settings()
-                .unwrap()
-                .get_key(&None)
+        let client_key = {
+            let key_store = client.internal.get_key_store();
+            let ctx = key_store.context();
+            #[allow(deprecated)]
+            ctx.dangerous_get_symmetric_key(SymmetricKeyId::User)
                 .unwrap()
                 .to_base64()
-        );
+        };
+
+        let client2_key = {
+            let key_store = client2.internal.get_key_store();
+            let ctx = key_store.context();
+            #[allow(deprecated)]
+            ctx.dangerous_get_symmetric_key(SymmetricKeyId::User)
+                .unwrap()
+                .to_base64()
+        };
+
+        assert_eq!(client_key, client2_key);
 
         // Verify we can derive the pin protected user key from the encrypted pin
         let pin_protected_user_key = derive_pin_user_key(&client, pin_key.encrypted_pin).unwrap();
@@ -662,22 +679,25 @@ mod tests {
         .await
         .unwrap();
 
-        assert_eq!(
-            client
-                .internal
-                .get_encryption_settings()
-                .unwrap()
-                .get_key(&None)
-                .unwrap()
-                .to_base64(),
-            client3
-                .internal
-                .get_encryption_settings()
-                .unwrap()
-                .get_key(&None)
+        let client_key = {
+            let key_store = client.internal.get_key_store();
+            let ctx = key_store.context();
+            #[allow(deprecated)]
+            ctx.dangerous_get_symmetric_key(SymmetricKeyId::User)
                 .unwrap()
                 .to_base64()
-        );
+        };
+
+        let client3_key = {
+            let key_store = client3.internal.get_key_store();
+            let ctx = key_store.context();
+            #[allow(deprecated)]
+            ctx.dangerous_get_symmetric_key(SymmetricKeyId::User)
+                .unwrap()
+                .to_base64()
+        };
+
+        assert_eq!(client_key, client3_key);
     }
 
     #[test]
@@ -712,8 +732,13 @@ mod tests {
             AsymmetricCryptoKey::from_der(&STANDARD.decode(private_key).unwrap()).unwrap();
         let decrypted: Vec<u8> = encrypted.decrypt_with_key(&private_key).unwrap();
 
-        let enc = client.internal.get_encryption_settings().unwrap();
-        let expected = enc.get_key(&None).unwrap();
+        let key_store = client.internal.get_key_store();
+        let ctx = key_store.context();
+        #[allow(deprecated)]
+        let expected = ctx
+            .dangerous_get_symmetric_key(SymmetricKeyId::User)
+            .unwrap();
+
         assert_eq!(&decrypted, &expected.to_vec());
     }
 

--- a/crates/bitwarden-core/src/platform/generate_fingerprint.rs
+++ b/crates/bitwarden-core/src/platform/generate_fingerprint.rs
@@ -5,7 +5,7 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
-use crate::{error::Result, VaultLockedError};
+use crate::{error::Result, key_management::AsymmetricKeyId, VaultLockedError};
 
 #[derive(Serialize, Deserialize, Debug, JsonSchema)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
@@ -61,11 +61,10 @@ pub(crate) fn generate_user_fingerprint(
 ) -> Result<String, UserFingerprintError> {
     info!("Generating fingerprint");
 
-    let enc_settings = client.internal.get_encryption_settings()?;
-    let private_key = enc_settings
-        .private_key
-        .as_ref()
-        .ok_or(UserFingerprintError::MissingPrivateKey)?;
+    let key_store = client.internal.get_key_store();
+    let ctx = key_store.context();
+    #[allow(deprecated)]
+    let private_key = ctx.dangerous_get_asymmetric_key(AsymmetricKeyId::UserPrivateKey)?;
 
     let public_key = private_key.to_public_der()?;
     let fingerprint = fingerprint(&fingerprint_material, &public_key)?;

--- a/crates/bitwarden-core/src/platform/generate_fingerprint.rs
+++ b/crates/bitwarden-core/src/platform/generate_fingerprint.rs
@@ -63,7 +63,8 @@ pub(crate) fn generate_user_fingerprint(
 
     let key_store = client.internal.get_key_store();
     let ctx = key_store.context();
-    // FIXME: [PM-18110] This should be removed once the key store can handle public keys and fingerprints
+    // FIXME: [PM-18110] This should be removed once the key store can handle public keys and
+    // fingerprints
     #[allow(deprecated)]
     let private_key = ctx.dangerous_get_asymmetric_key(AsymmetricKeyId::UserPrivateKey)?;
 

--- a/crates/bitwarden-core/src/platform/generate_fingerprint.rs
+++ b/crates/bitwarden-core/src/platform/generate_fingerprint.rs
@@ -63,6 +63,7 @@ pub(crate) fn generate_user_fingerprint(
 
     let key_store = client.internal.get_key_store();
     let ctx = key_store.context();
+    // FIXME: [PM-18110] This should be removed once the key store can handle public keys and fingerprints
     #[allow(deprecated)]
     let private_key = ctx.dangerous_get_asymmetric_key(AsymmetricKeyId::UserPrivateKey)?;
 

--- a/crates/bitwarden-crypto/src/enc_string/symmetric.rs
+++ b/crates/bitwarden-crypto/src/enc_string/symmetric.rs
@@ -8,7 +8,7 @@ use serde::Deserialize;
 use super::{check_length, from_b64, from_b64_vec, split_enc_string};
 use crate::{
     error::{CryptoError, EncStringParseError, Result},
-    KeyDecryptable, KeyEncryptable, LocateKey, SymmetricCryptoKey,
+    KeyDecryptable, KeyEncryptable, SymmetricCryptoKey,
 };
 
 #[cfg(feature = "wasm")]
@@ -228,7 +228,6 @@ impl EncString {
     }
 }
 
-impl LocateKey for EncString {}
 impl KeyEncryptable<SymmetricCryptoKey, EncString> for &[u8] {
     fn encrypt_with_key(self, key: &SymmetricCryptoKey) -> Result<EncString> {
         EncString::encrypt_aes256_hmac(

--- a/crates/bitwarden-crypto/src/keys/key_encryptable.rs
+++ b/crates/bitwarden-crypto/src/keys/key_encryptable.rs
@@ -15,16 +15,6 @@ impl<T: KeyContainer> KeyContainer for Arc<T> {
     }
 }
 
-pub trait LocateKey {
-    fn locate_key<'a>(
-        &self,
-        enc: &'a dyn KeyContainer,
-        org_id: &Option<Uuid>,
-    ) -> Result<&'a SymmetricCryptoKey, CryptoError> {
-        enc.get_key(org_id)
-    }
-}
-
 pub trait CryptoKey {}
 
 pub trait KeyEncryptable<Key: CryptoKey, Output> {

--- a/crates/bitwarden-crypto/src/keys/mod.rs
+++ b/crates/bitwarden-crypto/src/keys/mod.rs
@@ -1,5 +1,5 @@
 mod key_encryptable;
-pub use key_encryptable::{CryptoKey, KeyContainer, KeyDecryptable, KeyEncryptable, LocateKey};
+pub use key_encryptable::{CryptoKey, KeyContainer, KeyDecryptable, KeyEncryptable};
 mod master_key;
 pub use master_key::{
     default_argon2_iterations, default_argon2_memory, default_argon2_parallelism,

--- a/crates/bitwarden-crypto/src/store/mod.rs
+++ b/crates/bitwarden-crypto/src/store/mod.rs
@@ -124,20 +124,25 @@ impl<Ids: KeyIds> KeyStore<Ids> {
         keys.asymmetric_keys.clear();
     }
 
-    /// <div class="warning">
-    /// This is an advanced API, use with care. If you still need to use it, make sure you read this
-    /// documentation to understand how to use it safely. </div>
-    ///
     /// Initiate an encryption/decryption context. This context will have read only access to the
     /// global keys, and will have its own local key stores with read/write access. This
-    /// context-local store will be cleared up when the context is dropped.
+    /// context-local store will be cleared when the context is dropped.
     ///
-    /// Some possible use cases for this API and alternative recommendations are:
-    /// - Decrypting one or more [crate::EncString]s directly. This was the pattern before the
-    ///   introduction of  the [Encryptable] and [Decryptable] traits, but is now considered
-    ///   obsolete. We recommend wrapping the values in a struct that implements these traits
-    ///   instead, and then using [KeyStore::encrypt], [KeyStore::decrypt], [KeyStore::encrypt_list]
-    ///   and [KeyStore::decrypt_list].
+    /// If you are only looking to encrypt or decrypt items, you should implement
+    /// [Encryptable]/[Decryptable] and use the [KeyStore::encrypt], [KeyStore::decrypt],
+    /// [KeyStore::encrypt_list] and [KeyStore::decrypt_list] methods instead.
+    ///
+    /// The current implementation of context only clears the keys automatically when the context is
+    /// dropped, and not between operations. This means that if you are using the same context
+    /// for multiple operations, you may want to clear it manually between them. If possible, we
+    /// recommend using [KeyStore::encrypt_list] and [KeyStore::decrypt_list] instead.
+    ///
+    /// [KeyStoreContext] is not [Send] or [Sync] and should not be shared between threads. Note
+    /// that this can also be problematic in async code, and you should take care to ensure that
+    /// you're not holding references to the context across await points, as that would cause the
+    /// future to also not be [Send].
+    ///
+    /// Some other possible use cases for this API and alternative recommendations are:
     /// - Decrypting or encrypting multiple [Decryptable] or [Encryptable] items while sharing any
     ///   local keys. This is not recommended as it can lead to fragile and flaky
     ///   decryption/encryption operations. We recommend any local keys to be used only in the
@@ -151,19 +156,6 @@ impl<Ids: KeyIds> KeyStore<Ids> {
     ///     - [KeyStoreContext::encrypt_symmetric_key_with_asymmetric_key]
     ///     - [KeyStoreContext::encrypt_asymmetric_key_with_asymmetric_key]
     ///     - [KeyStoreContext::derive_shareable_key]
-    /// - Some other minor and safe operations, like checking if a key exists. This is not exposed
-    ///   in the [KeyStore] directly as we haven't seen many use cases for it, but we can add it if
-    ///   needed.
-    ///
-    /// One of the pitfalls of the current implementations is that keys stored in the context-local
-    /// store only get cleared automatically when the context is dropped, and not between
-    /// operations. This means that if you are using the same context for multiple operations,
-    /// you may want to clear it manually between them.
-    ///
-    /// [KeyStoreContext] is not [Send] or [Sync] and should not be shared between threads. Note
-    /// that this can also be problematic in async code, and you should take care to ensure that
-    /// you're not holding references to the context across await points, as that would cause the
-    /// future to also not be [Send].
     pub fn context(&'_ self) -> KeyStoreContext<'_, Ids> {
         KeyStoreContext {
             global_keys: GlobalKeys::ReadOnly(self.inner.read().expect("RwLock is poisoned")),

--- a/crates/bitwarden-crypto/src/store/mod.rs
+++ b/crates/bitwarden-crypto/src/store/mod.rs
@@ -159,6 +159,11 @@ impl<Ids: KeyIds> KeyStore<Ids> {
     /// store only get cleared automatically when the context is dropped, and not between
     /// operations. This means that if you are using the same context for multiple operations,
     /// you may want to clear it manually between them.
+    ///
+    /// [KeyStoreContext] is not [Send] or [Sync] and should not be shared between threads. Note
+    /// that this can also be problematic in async code, and you should take care to ensure that
+    /// you're not holding references to the context across await points, as that would cause the
+    /// future to also not be [Send].
     pub fn context(&'_ self) -> KeyStoreContext<'_, Ids> {
         KeyStoreContext {
             global_keys: GlobalKeys::ReadOnly(self.inner.read().expect("RwLock is poisoned")),
@@ -183,6 +188,11 @@ impl<Ids: KeyIds> KeyStore<Ids> {
     /// The only supported use case for this API is initializing the store with the user's symetric
     /// and private keys, and setting the organization keys. This method will be marked as
     /// `pub(crate)` in the future, once we have a safe API for key initialization and updating.
+    ///
+    /// [KeyStoreContext] is not [Send] or [Sync] and should not be shared between threads. Note
+    /// that this can also be problematic in async code, and you should take care to ensure that
+    /// you're not holding references to the context across await points, as that would cause the
+    /// future to also not be [Send].
     pub fn context_mut(&'_ self) -> KeyStoreContext<'_, Ids> {
         KeyStoreContext {
             global_keys: GlobalKeys::ReadWrite(self.inner.write().expect("RwLock is poisoned")),

--- a/crates/bitwarden-exporters/src/export.rs
+++ b/crates/bitwarden-exporters/src/export.rs
@@ -1,5 +1,5 @@
-use bitwarden_core::Client;
-use bitwarden_crypto::{KeyContainer, KeyDecryptable, KeyEncryptable, LocateKey};
+use bitwarden_core::{key_management::KeyIds, Client};
+use bitwarden_crypto::{Encryptable, IdentifyKey, KeyStoreContext};
 use bitwarden_vault::{Cipher, CipherView, Collection, Folder, FolderView};
 
 use crate::{
@@ -16,15 +16,14 @@ pub(crate) fn export_vault(
     ciphers: Vec<Cipher>,
     format: ExportFormat,
 ) -> Result<String, ExportError> {
-    let enc = client.internal.get_encryption_settings()?;
-    let key = enc.get_key(&None)?;
+    let key_store = client.internal.get_key_store();
 
-    let folders: Vec<FolderView> = folders.decrypt_with_key(key)?;
+    let folders: Vec<FolderView> = key_store.decrypt_list(&folders)?;
     let folders: Vec<crate::Folder> = folders.into_iter().flat_map(|f| f.try_into()).collect();
 
     let ciphers: Vec<crate::Cipher> = ciphers
         .into_iter()
-        .flat_map(|c| crate::Cipher::from_cipher(&enc, c))
+        .flat_map(|c| crate::Cipher::from_cipher(key_store, c))
         .collect();
 
     match format {
@@ -53,17 +52,20 @@ pub(crate) fn export_cxf(
     account: Account,
     ciphers: Vec<Cipher>,
 ) -> Result<String, ExportError> {
-    let enc = client.internal.get_encryption_settings()?;
+    let key_store = client.internal.get_key_store();
 
     let ciphers: Vec<crate::Cipher> = ciphers
         .into_iter()
-        .flat_map(|c| crate::Cipher::from_cipher(&enc, c))
+        .flat_map(|c| crate::Cipher::from_cipher(key_store, c))
         .collect();
 
     Ok(build_cxf(account, ciphers)?)
 }
 
-fn encrypt_import(enc: &dyn KeyContainer, cipher: ImportingCipher) -> Result<Cipher, ExportError> {
+fn encrypt_import(
+    ctx: &mut KeyStoreContext<KeyIds>,
+    cipher: ImportingCipher,
+) -> Result<Cipher, ExportError> {
     let mut view: CipherView = cipher.clone().into();
 
     // Get passkey from cipher if cipher is type login
@@ -75,23 +77,23 @@ fn encrypt_import(enc: &dyn KeyContainer, cipher: ImportingCipher) -> Result<Cip
     if let Some(passkey) = passkey {
         let passkeys = passkey.into_iter().map(|p| p.into()).collect();
 
-        view.set_new_fido2_credentials(enc, passkeys)?;
+        view.set_new_fido2_credentials(ctx, passkeys)?;
     }
 
-    let key = view.locate_key(enc, &None)?;
-    let new_cipher = view.encrypt_with_key(key)?;
+    let new_cipher = view.encrypt(ctx, view.key_identifier())?;
 
     Ok(new_cipher)
 }
 
 /// See [crate::ClientExporters::import_cxf] for more documentation.
 pub(crate) fn import_cxf(client: &Client, payload: String) -> Result<Vec<Cipher>, ExportError> {
-    let enc = client.internal.get_encryption_settings()?;
+    let key_store = client.internal.get_key_store();
+    let mut ctx = key_store.context();
 
     let ciphers = parse_cxf(payload)?;
     let ciphers: Result<Vec<Cipher>, _> = ciphers
         .into_iter()
-        .map(|c| encrypt_import(&enc, c))
+        .map(|c| encrypt_import(&mut ctx, c))
         .collect();
 
     ciphers

--- a/crates/bitwarden-fido/src/client_fido.rs
+++ b/crates/bitwarden-fido/src/client_fido.rs
@@ -47,11 +47,11 @@ impl<'a> ClientFido2<'a> {
         &'a self,
         cipher_view: CipherView,
     ) -> Result<Vec<Fido2CredentialAutofillView>, DecryptFido2AutofillCredentialsError> {
-        let enc = self.client.internal.get_encryption_settings()?;
+        let key_store = self.client.internal.get_key_store();
 
         Ok(Fido2CredentialAutofillView::from_cipher_view(
             &cipher_view,
-            &*enc,
+            &mut key_store.context(),
         )?)
     }
 }

--- a/crates/bitwarden-fido/src/lib.rs
+++ b/crates/bitwarden-fido/src/lib.rs
@@ -1,5 +1,6 @@
 use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
-use bitwarden_crypto::KeyContainer;
+use bitwarden_core::key_management::KeyIds;
+use bitwarden_crypto::KeyStoreContext;
 use bitwarden_vault::{
     CipherError, CipherView, Fido2CredentialFullView, Fido2CredentialNewView, Fido2CredentialView,
 };
@@ -62,8 +63,8 @@ pub(crate) struct CipherViewContainer {
 }
 
 impl CipherViewContainer {
-    fn new(cipher: CipherView, enc: &dyn KeyContainer) -> Result<Self, CipherError> {
-        let fido2_credentials = cipher.get_fido2_credentials(enc)?;
+    fn new(cipher: CipherView, ctx: &mut KeyStoreContext<KeyIds>) -> Result<Self, CipherError> {
+        let fido2_credentials = cipher.get_fido2_credentials(ctx)?;
         Ok(Self {
             cipher,
             fido2_credentials,

--- a/crates/bitwarden-fido/src/types.rs
+++ b/crates/bitwarden-fido/src/types.rs
@@ -1,7 +1,8 @@
 use std::borrow::Cow;
 
 use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
-use bitwarden_crypto::{CryptoError, KeyContainer};
+use bitwarden_core::key_management::KeyIds;
+use bitwarden_crypto::{CryptoError, KeyStoreContext};
 use bitwarden_vault::CipherView;
 use passkey::types::webauthn::UserVerificationRequirement;
 use reqwest::Url;
@@ -65,9 +66,9 @@ pub enum Fido2CredentialAutofillViewError {
 impl Fido2CredentialAutofillView {
     pub fn from_cipher_view(
         cipher: &CipherView,
-        enc: &dyn KeyContainer,
+        ctx: &mut KeyStoreContext<KeyIds>,
     ) -> Result<Vec<Fido2CredentialAutofillView>, Fido2CredentialAutofillViewError> {
-        let credentials = cipher.decrypt_fido2_credentials(enc)?;
+        let credentials = cipher.decrypt_fido2_credentials(ctx)?;
 
         credentials
             .into_iter()

--- a/crates/bitwarden-send/src/send.rs
+++ b/crates/bitwarden-send/src/send.rs
@@ -3,10 +3,13 @@ use base64::{
     Engine,
 };
 use bitwarden_api_api::models::{SendFileModel, SendResponseModel, SendTextModel};
-use bitwarden_core::require;
+use bitwarden_core::{
+    key_management::{KeyIds, SymmetricKeyId},
+    require,
+};
 use bitwarden_crypto::{
-    derive_shareable_key, generate_random_bytes, CryptoError, EncString, KeyDecryptable,
-    KeyEncryptable, SymmetricCryptoKey,
+    generate_random_bytes, CryptoError, Decryptable, EncString, Encryptable, IdentifyKey,
+    KeyStoreContext,
 };
 use chrono::{DateTime, Utc};
 use schemars::JsonSchema;
@@ -141,82 +144,120 @@ pub struct SendListView {
     pub expiration_date: Option<DateTime<Utc>>,
 }
 
+const SEND_KEY: SymmetricKeyId = SymmetricKeyId::Local("send_key");
+
 impl Send {
     pub fn get_key(
+        ctx: &mut KeyStoreContext<KeyIds>,
         send_key: &EncString,
-        enc_key: &SymmetricCryptoKey,
-    ) -> Result<SymmetricCryptoKey, CryptoError> {
-        let key: Vec<u8> = send_key.decrypt_with_key(enc_key)?;
-        Self::derive_shareable_key(&key)
+        enc_key: SymmetricKeyId,
+    ) -> Result<SymmetricKeyId, CryptoError> {
+        let key: Vec<u8> = send_key.decrypt(ctx, enc_key)?;
+        Self::derive_shareable_key(ctx, &key)
     }
 
-    fn derive_shareable_key(key: &[u8]) -> Result<SymmetricCryptoKey, CryptoError> {
+    fn derive_shareable_key(
+        ctx: &mut KeyStoreContext<KeyIds>,
+        key: &[u8],
+    ) -> Result<SymmetricKeyId, CryptoError> {
         let key = Zeroizing::new(key.try_into().map_err(|_| CryptoError::InvalidKeyLen)?);
-        Ok(derive_shareable_key(key, "send", Some("send")))
+        ctx.derive_shareable_key(SEND_KEY, key, "send", Some("send"))
     }
 }
 
-impl KeyDecryptable<SymmetricCryptoKey, SendTextView> for SendText {
-    fn decrypt_with_key(&self, key: &SymmetricCryptoKey) -> Result<SendTextView, CryptoError> {
+impl IdentifyKey<SymmetricKeyId> for Send {
+    fn key_identifier(&self) -> SymmetricKeyId {
+        SymmetricKeyId::User
+    }
+}
+
+impl IdentifyKey<SymmetricKeyId> for SendView {
+    fn key_identifier(&self) -> SymmetricKeyId {
+        SymmetricKeyId::User
+    }
+}
+
+impl Decryptable<KeyIds, SymmetricKeyId, SendTextView> for SendText {
+    fn decrypt(
+        &self,
+        ctx: &mut KeyStoreContext<KeyIds>,
+        key: SymmetricKeyId,
+    ) -> Result<SendTextView, CryptoError> {
         Ok(SendTextView {
-            text: self.text.decrypt_with_key(key)?,
+            text: self.text.decrypt(ctx, key)?,
             hidden: self.hidden,
         })
     }
 }
 
-impl KeyEncryptable<SymmetricCryptoKey, SendText> for SendTextView {
-    fn encrypt_with_key(self, key: &SymmetricCryptoKey) -> Result<SendText, CryptoError> {
+impl Encryptable<KeyIds, SymmetricKeyId, SendText> for SendTextView {
+    fn encrypt(
+        &self,
+        ctx: &mut KeyStoreContext<KeyIds>,
+        key: SymmetricKeyId,
+    ) -> Result<SendText, CryptoError> {
         Ok(SendText {
-            text: self.text.encrypt_with_key(key)?,
+            text: self.text.encrypt(ctx, key)?,
             hidden: self.hidden,
         })
     }
 }
 
-impl KeyDecryptable<SymmetricCryptoKey, SendFileView> for SendFile {
-    fn decrypt_with_key(&self, key: &SymmetricCryptoKey) -> Result<SendFileView, CryptoError> {
+impl Decryptable<KeyIds, SymmetricKeyId, SendFileView> for SendFile {
+    fn decrypt(
+        &self,
+        ctx: &mut KeyStoreContext<KeyIds>,
+        key: SymmetricKeyId,
+    ) -> Result<SendFileView, CryptoError> {
         Ok(SendFileView {
             id: self.id.clone(),
-            file_name: self.file_name.decrypt_with_key(key)?,
+            file_name: self.file_name.decrypt(ctx, key)?,
             size: self.size.clone(),
             size_name: self.size_name.clone(),
         })
     }
 }
 
-impl KeyEncryptable<SymmetricCryptoKey, SendFile> for SendFileView {
-    fn encrypt_with_key(self, key: &SymmetricCryptoKey) -> Result<SendFile, CryptoError> {
+impl Encryptable<KeyIds, SymmetricKeyId, SendFile> for SendFileView {
+    fn encrypt(
+        &self,
+        ctx: &mut KeyStoreContext<KeyIds>,
+        key: SymmetricKeyId,
+    ) -> Result<SendFile, CryptoError> {
         Ok(SendFile {
             id: self.id.clone(),
-            file_name: self.file_name.encrypt_with_key(key)?,
+            file_name: self.file_name.encrypt(ctx, key)?,
             size: self.size.clone(),
             size_name: self.size_name.clone(),
         })
     }
 }
 
-impl KeyDecryptable<SymmetricCryptoKey, SendView> for Send {
-    fn decrypt_with_key(&self, key: &SymmetricCryptoKey) -> Result<SendView, CryptoError> {
+impl Decryptable<KeyIds, SymmetricKeyId, SendView> for Send {
+    fn decrypt(
+        &self,
+        ctx: &mut KeyStoreContext<KeyIds>,
+        key: SymmetricKeyId,
+    ) -> Result<SendView, CryptoError> {
         // For sends, we first decrypt the send key with the user key, and stretch it to it's full
         // size For the rest of the fields, we ignore the provided SymmetricCryptoKey and
         // the stretched key
-        let k: Vec<u8> = self.key.decrypt_with_key(key)?;
-        let key = Send::derive_shareable_key(&k)?;
+        let k: Vec<u8> = self.key.decrypt(ctx, key)?;
+        let key = Send::derive_shareable_key(ctx, &k)?;
 
         Ok(SendView {
             id: self.id,
             access_id: self.access_id.clone(),
 
-            name: self.name.decrypt_with_key(&key).ok().unwrap_or_default(),
-            notes: self.notes.decrypt_with_key(&key).ok().flatten(),
+            name: self.name.decrypt(ctx, key).ok().unwrap_or_default(),
+            notes: self.notes.decrypt(ctx, key).ok().flatten(),
             key: Some(URL_SAFE_NO_PAD.encode(k)),
             new_password: None,
             has_password: self.password.is_some(),
 
             r#type: self.r#type,
-            file: self.file.decrypt_with_key(&key).ok().flatten(),
-            text: self.text.decrypt_with_key(&key).ok().flatten(),
+            file: self.file.decrypt(ctx, key).ok().flatten(),
+            text: self.text.decrypt(ctx, key).ok().flatten(),
 
             max_access_count: self.max_access_count,
             access_count: self.access_count,
@@ -230,18 +271,22 @@ impl KeyDecryptable<SymmetricCryptoKey, SendView> for Send {
     }
 }
 
-impl KeyDecryptable<SymmetricCryptoKey, SendListView> for Send {
-    fn decrypt_with_key(&self, key: &SymmetricCryptoKey) -> Result<SendListView, CryptoError> {
+impl Decryptable<KeyIds, SymmetricKeyId, SendListView> for Send {
+    fn decrypt(
+        &self,
+        ctx: &mut KeyStoreContext<KeyIds>,
+        key: SymmetricKeyId,
+    ) -> Result<SendListView, CryptoError> {
         // For sends, we first decrypt the send key with the user key, and stretch it to it's full
         // size For the rest of the fields, we ignore the provided SymmetricCryptoKey and
         // the stretched key
-        let key = Send::get_key(&self.key, key)?;
+        let key = Send::get_key(ctx, &self.key, key)?;
 
         Ok(SendListView {
             id: self.id,
             access_id: self.access_id.clone(),
 
-            name: self.name.decrypt_with_key(&key)?,
+            name: self.name.decrypt(ctx, key)?,
             r#type: self.r#type,
 
             disabled: self.disabled,
@@ -253,12 +298,16 @@ impl KeyDecryptable<SymmetricCryptoKey, SendListView> for Send {
     }
 }
 
-impl KeyEncryptable<SymmetricCryptoKey, Send> for SendView {
-    fn encrypt_with_key(self, key: &SymmetricCryptoKey) -> Result<Send, CryptoError> {
+impl Encryptable<KeyIds, SymmetricKeyId, Send> for SendView {
+    fn encrypt(
+        &self,
+        ctx: &mut KeyStoreContext<KeyIds>,
+        key: SymmetricKeyId,
+    ) -> Result<Send, CryptoError> {
         // For sends, we first decrypt the send key with the user key, and stretch it to it's full
         // size For the rest of the fields, we ignore the provided SymmetricCryptoKey and
         // the stretched key
-        let k = match (self.key, self.id) {
+        let k = match (&self.key, &self.id) {
             // Existing send, decrypt key
             (Some(k), _) => URL_SAFE_NO_PAD
                 .decode(k)
@@ -271,23 +320,23 @@ impl KeyEncryptable<SymmetricCryptoKey, Send> for SendView {
             // Existing send without key
             _ => return Err(CryptoError::InvalidKey),
         };
-        let send_key = Send::derive_shareable_key(&k)?;
+        let send_key = Send::derive_shareable_key(ctx, &k)?;
 
         Ok(Send {
             id: self.id,
-            access_id: self.access_id,
+            access_id: self.access_id.clone(),
 
-            name: self.name.encrypt_with_key(&send_key)?,
-            notes: self.notes.encrypt_with_key(&send_key)?,
-            key: k.encrypt_with_key(key)?,
-            password: self.new_password.map(|password| {
+            name: self.name.encrypt(ctx, send_key)?,
+            notes: self.notes.encrypt(ctx, send_key)?,
+            key: k.encrypt(ctx, key)?,
+            password: self.new_password.as_ref().map(|password| {
                 let password = bitwarden_crypto::pbkdf2(password.as_bytes(), &k, SEND_ITERATIONS);
                 STANDARD.encode(password)
             }),
 
             r#type: self.r#type,
-            file: self.file.encrypt_with_key(&send_key)?,
-            text: self.text.encrypt_with_key(&send_key)?,
+            file: self.file.encrypt(ctx, send_key)?,
+            text: self.text.encrypt(ctx, send_key)?,
 
             max_access_count: self.max_access_count,
             access_count: self.access_count,
@@ -361,78 +410,34 @@ impl TryFrom<SendTextModel> for SendText {
 
 #[cfg(test)]
 mod tests {
-    use std::collections::HashMap;
-
-    use bitwarden_crypto::{Kdf, KeyContainer, KeyDecryptable, KeyEncryptable, MasterKey};
+    use bitwarden_core::key_management::create_test_crypto_with_user_key;
+    use bitwarden_crypto::SymmetricCryptoKey;
 
     use super::*;
-
-    struct MockKeyContainer(HashMap<Option<Uuid>, SymmetricCryptoKey>);
-    impl MockKeyContainer {
-        fn new(master_key: MasterKey, user_key: EncString) -> Result<Self, CryptoError> {
-            let user_key = master_key.decrypt_user_key(user_key)?;
-            Ok(Self(HashMap::from([(None, user_key)])))
-        }
-    }
-    impl KeyContainer for MockKeyContainer {
-        fn get_key<'a>(
-            &'a self,
-            org_id: &Option<Uuid>,
-        ) -> Result<&'a SymmetricCryptoKey, CryptoError> {
-            self.0
-                .get(org_id)
-                .ok_or(CryptoError::MissingKey(org_id.unwrap_or_default()))
-        }
-    }
 
     #[test]
     fn test_get_send_key() {
         // Initialize user encryption with some test data
-        let master_key = MasterKey::derive(
-            "asdfasdfasdf",
-            "test@bitwarden.com",
-            &Kdf::PBKDF2 {
-                iterations: 345123.try_into().unwrap(),
-            },
-        )
-        .unwrap();
-        let enc = MockKeyContainer::new(
-            master_key,
-            "2.majkL1/hNz9yptLqNAUSnw==|RiOzMTTJMG948qu8O3Zm1EQUO2E8BuTwFKnO9LWQjMzxMWJM5GbyOq2/A+tumPbTERt4JWur/FKfgHb+gXuYiEYlXPMuVBvT7nv4LPytJuM=|IVqMxHJeR1ZXY0sGngTC0x+WqbG8p6V+BTrdgBbQXjM=".parse().unwrap(),
-        ).unwrap();
-
-        let k = enc.get_key(&None).unwrap();
+        let user_key: SymmetricCryptoKey = "w2LO+nwV4oxwswVYCxlOfRUseXfvU03VzvKQHrqeklPgiMZrspUe6sOBToCnDn9Ay0tuCBn8ykVVRb7PWhub2Q==".to_string().try_into().unwrap();
+        let crypto = create_test_crypto_with_user_key(user_key);
+        let mut ctx = crypto.context();
 
         let send_key = "2.+1KUfOX8A83Xkwk1bumo/w==|Nczvv+DTkeP466cP/wMDnGK6W9zEIg5iHLhcuQG6s+M=|SZGsfuIAIaGZ7/kzygaVUau3LeOvJUlolENBOU+LX7g="
             .parse()
             .unwrap();
 
         // Get the send key
-        let send_key = Send::get_key(&send_key, k).unwrap();
+        let send_key = Send::get_key(&mut ctx, &send_key, SymmetricKeyId::User).unwrap();
+        #[allow(deprecated)]
+        let send_key = ctx.dangerous_get_symmetric_key(send_key).unwrap();
         let send_key_b64 = send_key.to_base64();
         assert_eq!(send_key_b64, "IR9ImHGm6rRuIjiN7csj94bcZR5WYTJj5GtNfx33zm6tJCHUl+QZlpNPba8g2yn70KnOHsAODLcR0um6E3MAlg==");
     }
 
-    fn build_encryption_settings() -> MockKeyContainer {
-        let master_key = MasterKey::derive(
-            "asdfasdfasdf",
-            "test@bitwarden.com",
-            &Kdf::PBKDF2 {
-                iterations: 600_000.try_into().unwrap(),
-            },
-        )
-        .unwrap();
-
-        MockKeyContainer::new(
-            master_key,
-            "2.Q/2PhzcC7GdeiMHhWguYAQ==|GpqzVdr0go0ug5cZh1n+uixeBC3oC90CIe0hd/HWA/pTRDZ8ane4fmsEIcuc8eMKUt55Y2q/fbNzsYu41YTZzzsJUSeqVjT8/iTQtgnNdpo=|dwI+uyvZ1h/iZ03VQ+/wrGEFYVewBUUl/syYgjsNMbE=".parse().unwrap(),
-        ).unwrap()
-    }
-
     #[test]
     pub fn test_decrypt() {
-        let enc = build_encryption_settings();
-        let key = enc.get_key(&None).unwrap();
+        let user_key: SymmetricCryptoKey = "bYCsk857hl8QJJtxyRK65tjUrbxKC4aDifJpsml+NIv4W9cVgFvi3qVD+yJTUU2T4UwNKWYtt9pqWf7Q+2WCCg==".to_string().try_into().unwrap();
+        let crypto = create_test_crypto_with_user_key(user_key);
 
         let send = Send {
             id: "3d80dd72-2d14-4f26-812c-b0f0018aa144".parse().ok(),
@@ -457,7 +462,7 @@ mod tests {
             hide_email: false,
         };
 
-        let view: SendView = send.decrypt_with_key(key).unwrap();
+        let view: SendView = crypto.decrypt(&send).unwrap();
 
         let expected = SendView {
             id: "3d80dd72-2d14-4f26-812c-b0f0018aa144".parse().ok(),
@@ -487,8 +492,8 @@ mod tests {
 
     #[test]
     pub fn test_encrypt() {
-        let enc = build_encryption_settings();
-        let key = enc.get_key(&None).unwrap();
+        let user_key: SymmetricCryptoKey = "bYCsk857hl8QJJtxyRK65tjUrbxKC4aDifJpsml+NIv4W9cVgFvi3qVD+yJTUU2T4UwNKWYtt9pqWf7Q+2WCCg==".to_string().try_into().unwrap();
+        let crypto = create_test_crypto_with_user_key(user_key);
 
         let view = SendView {
             id: "3d80dd72-2d14-4f26-812c-b0f0018aa144".parse().ok(),
@@ -514,19 +519,16 @@ mod tests {
         };
 
         // Re-encrypt and decrypt again to ensure encrypt works
-        let v: SendView = view
-            .clone()
-            .encrypt_with_key(key)
-            .unwrap()
-            .decrypt_with_key(key)
+        let v: SendView = crypto
+            .decrypt(&crypto.encrypt(view.clone()).unwrap())
             .unwrap();
         assert_eq!(v, view);
     }
 
     #[test]
     pub fn test_create() {
-        let enc = build_encryption_settings();
-        let key = enc.get_key(&None).unwrap();
+        let user_key: SymmetricCryptoKey = "bYCsk857hl8QJJtxyRK65tjUrbxKC4aDifJpsml+NIv4W9cVgFvi3qVD+yJTUU2T4UwNKWYtt9pqWf7Q+2WCCg==".to_string().try_into().unwrap();
+        let crypto = create_test_crypto_with_user_key(user_key);
 
         let view = SendView {
             id: None,
@@ -552,11 +554,8 @@ mod tests {
         };
 
         // Re-encrypt and decrypt again to ensure encrypt works
-        let v: SendView = view
-            .clone()
-            .encrypt_with_key(key)
-            .unwrap()
-            .decrypt_with_key(key)
+        let v: SendView = crypto
+            .decrypt(&crypto.encrypt(view.clone()).unwrap())
             .unwrap();
 
         // Ignore key when comparing
@@ -566,8 +565,8 @@ mod tests {
 
     #[test]
     pub fn test_create_password() {
-        let enc = build_encryption_settings();
-        let key = enc.get_key(&None).unwrap();
+        let user_key: SymmetricCryptoKey = "bYCsk857hl8QJJtxyRK65tjUrbxKC4aDifJpsml+NIv4W9cVgFvi3qVD+yJTUU2T4UwNKWYtt9pqWf7Q+2WCCg==".to_string().try_into().unwrap();
+        let crypto = create_test_crypto_with_user_key(user_key);
 
         let view = SendView {
             id: None,
@@ -592,14 +591,14 @@ mod tests {
             expiration_date: None,
         };
 
-        let send: Send = view.encrypt_with_key(key).unwrap();
+        let send: Send = crypto.encrypt(view).unwrap();
 
         assert_eq!(
             send.password,
             Some("vTIDfdj3FTDbejmMf+mJWpYdMXsxfeSd1Sma3sjCtiQ=".to_owned())
         );
 
-        let v: SendView = send.decrypt_with_key(key).unwrap();
+        let v: SendView = crypto.decrypt(&send).unwrap();
         assert_eq!(v.new_password, None);
         assert!(v.has_password);
     }

--- a/crates/bitwarden-vault/src/cipher/attachment.rs
+++ b/crates/bitwarden-vault/src/cipher/attachment.rs
@@ -1,5 +1,6 @@
+use bitwarden_core::key_management::{KeyIds, SymmetricKeyId};
 use bitwarden_crypto::{
-    CryptoError, EncString, KeyDecryptable, KeyEncryptable, SymmetricCryptoKey,
+    CryptoError, Decryptable, EncString, Encryptable, IdentifyKey, KeyStoreContext,
 };
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -56,22 +57,36 @@ pub struct AttachmentFileView<'a> {
     pub attachment: AttachmentView,
     pub contents: &'a [u8],
 }
+const ATTACHMENT_KEY: SymmetricKeyId = SymmetricKeyId::Local("attachment_key");
 
-impl KeyEncryptable<SymmetricCryptoKey, AttachmentEncryptResult> for AttachmentFileView<'_> {
-    fn encrypt_with_key(
-        self,
-        key: &SymmetricCryptoKey,
+impl IdentifyKey<SymmetricKeyId> for AttachmentFileView<'_> {
+    fn key_identifier(&self) -> SymmetricKeyId {
+        self.cipher.key_identifier()
+    }
+}
+impl IdentifyKey<SymmetricKeyId> for AttachmentFile {
+    fn key_identifier(&self) -> SymmetricKeyId {
+        self.cipher.key_identifier()
+    }
+}
+
+impl Encryptable<KeyIds, SymmetricKeyId, AttachmentEncryptResult> for AttachmentFileView<'_> {
+    fn encrypt(
+        &self,
+        ctx: &mut KeyStoreContext<KeyIds>,
+        key: SymmetricKeyId,
     ) -> Result<AttachmentEncryptResult, CryptoError> {
-        let ciphers_key = Cipher::get_cipher_key(key, &self.cipher.key)?;
-        let ciphers_key = ciphers_key.as_ref().unwrap_or(key);
+        let ciphers_key = Cipher::get_cipher_key(ctx, key, &self.cipher.key)?;
+        let ciphers_key = ciphers_key.unwrap_or(key);
 
-        let mut attachment = self.attachment;
+        let mut attachment = self.attachment.clone();
 
         // Because this is a new attachment, we have to generate a key for it, encrypt the contents
         // with it, and then encrypt the key with the cipher key
-        let attachment_key = SymmetricCryptoKey::generate(rand::thread_rng());
-        let encrypted_contents = self.contents.encrypt_with_key(&attachment_key)?;
-        attachment.key = Some(attachment_key.to_vec().encrypt_with_key(ciphers_key)?);
+        let attachment_key = ctx.generate_symmetric_key(ATTACHMENT_KEY)?;
+        let encrypted_contents = self.contents.encrypt(ctx, attachment_key)?;
+        attachment.key =
+            Some(ctx.encrypt_symmetric_key_with_symmetric_key(ciphers_key, attachment_key)?);
 
         let contents = encrypted_contents.to_buffer()?;
 
@@ -80,7 +95,7 @@ impl KeyEncryptable<SymmetricCryptoKey, AttachmentEncryptResult> for AttachmentF
         attachment.size_name = Some(size_name(contents.len()));
 
         Ok(AttachmentEncryptResult {
-            attachment: attachment.encrypt_with_key(ciphers_key)?,
+            attachment: attachment.encrypt(ctx, ciphers_key)?,
             contents,
         })
     }
@@ -96,45 +111,59 @@ fn size_name(size: usize) -> String {
     format!("{} {}", size_round, units[unit])
 }
 
-impl KeyDecryptable<SymmetricCryptoKey, Vec<u8>> for AttachmentFile {
-    fn decrypt_with_key(&self, key: &SymmetricCryptoKey) -> Result<Vec<u8>, CryptoError> {
-        let ciphers_key = Cipher::get_cipher_key(key, &self.cipher.key)?;
-        let ciphers_key = ciphers_key.as_ref().unwrap_or(key);
+impl Decryptable<KeyIds, SymmetricKeyId, Vec<u8>> for AttachmentFile {
+    fn decrypt(
+        &self,
+        ctx: &mut KeyStoreContext<KeyIds>,
+        key: SymmetricKeyId,
+    ) -> Result<Vec<u8>, CryptoError> {
+        let ciphers_key = Cipher::get_cipher_key(ctx, key, &self.cipher.key)?;
+        let ciphers_key = ciphers_key.unwrap_or(key);
 
         // Version 2 or 3, `AttachmentKey` or `CipherKey(AttachmentKey)`
         if let Some(attachment_key) = &self.attachment.key {
-            let mut content_key: Vec<u8> = attachment_key.decrypt_with_key(ciphers_key)?;
-            let content_key = SymmetricCryptoKey::try_from(content_key.as_mut_slice())?;
-
-            self.contents.decrypt_with_key(&content_key)
+            let content_key = ctx.decrypt_symmetric_key_with_symmetric_key(
+                ciphers_key,
+                ATTACHMENT_KEY,
+                attachment_key,
+            )?;
+            self.contents.decrypt(ctx, content_key)
         } else {
             // Legacy attachment version 1, use user/org key
-            self.contents.decrypt_with_key(key)
+            self.contents.decrypt(ctx, key)
         }
     }
 }
 
-impl KeyEncryptable<SymmetricCryptoKey, Attachment> for AttachmentView {
-    fn encrypt_with_key(self, key: &SymmetricCryptoKey) -> Result<Attachment, CryptoError> {
+impl Encryptable<KeyIds, SymmetricKeyId, Attachment> for AttachmentView {
+    fn encrypt(
+        &self,
+        ctx: &mut KeyStoreContext<KeyIds>,
+        key: SymmetricKeyId,
+    ) -> Result<Attachment, CryptoError> {
         Ok(Attachment {
-            id: self.id,
-            url: self.url,
-            size: self.size,
-            size_name: self.size_name,
-            file_name: self.file_name.encrypt_with_key(key)?,
-            key: self.key,
+            id: self.id.clone(),
+            url: self.url.clone(),
+            size: self.size.clone(),
+            size_name: self.size_name.clone(),
+            file_name: self.file_name.encrypt(ctx, key)?,
+            key: self.key.clone(),
         })
     }
 }
 
-impl KeyDecryptable<SymmetricCryptoKey, AttachmentView> for Attachment {
-    fn decrypt_with_key(&self, key: &SymmetricCryptoKey) -> Result<AttachmentView, CryptoError> {
+impl Decryptable<KeyIds, SymmetricKeyId, AttachmentView> for Attachment {
+    fn decrypt(
+        &self,
+        ctx: &mut KeyStoreContext<KeyIds>,
+        key: SymmetricKeyId,
+    ) -> Result<AttachmentView, CryptoError> {
         Ok(AttachmentView {
             id: self.id.clone(),
             url: self.url.clone(),
             size: self.size.clone(),
             size_name: self.size_name.clone(),
-            file_name: self.file_name.decrypt_with_key(key)?,
+            file_name: self.file_name.decrypt(ctx, key)?,
             key: self.key.clone(),
         })
     }
@@ -160,7 +189,8 @@ impl TryFrom<bitwarden_api_api::models::AttachmentResponseModel> for Attachment 
 #[cfg(test)]
 mod tests {
     use base64::{engine::general_purpose::STANDARD, Engine};
-    use bitwarden_crypto::{EncString, KeyDecryptable, KeyEncryptable, SymmetricCryptoKey};
+    use bitwarden_core::key_management::create_test_crypto_with_user_key;
+    use bitwarden_crypto::{EncString, SymmetricCryptoKey};
 
     use crate::{
         cipher::cipher::{CipherRepromptType, CipherType},
@@ -182,6 +212,7 @@ mod tests {
     #[test]
     fn test_encrypt_attachment() {
         let user_key: SymmetricCryptoKey = "w2LO+nwV4oxwswVYCxlOfRUseXfvU03VzvKQHrqeklPgiMZrspUe6sOBToCnDn9Ay0tuCBn8ykVVRb7PWhub2Q==".to_string().try_into().unwrap();
+        let key_store = create_test_crypto_with_user_key(user_key);
 
         let attachment = AttachmentView {
             id: None,
@@ -226,7 +257,7 @@ mod tests {
             contents: contents.as_slice(),
         };
 
-        let result = attachment_file.encrypt_with_key(&user_key).unwrap();
+        let result = key_store.encrypt(attachment_file).unwrap();
 
         assert_eq!(result.contents.len(), 161);
         assert_eq!(result.attachment.size, Some("161".into()));
@@ -236,6 +267,7 @@ mod tests {
     #[test]
     fn test_attachment_key() {
         let user_key: SymmetricCryptoKey = "w2LO+nwV4oxwswVYCxlOfRUseXfvU03VzvKQHrqeklPgiMZrspUe6sOBToCnDn9Ay0tuCBn8ykVVRb7PWhub2Q==".to_string().try_into().unwrap();
+        let key_store = create_test_crypto_with_user_key(user_key);
 
         let attachment = Attachment {
             id: None,
@@ -277,13 +309,13 @@ mod tests {
         let enc_file = STANDARD.decode(b"Ao00qr1xLsV+ZNQpYZ/UwEwOWo3hheKwCYcOGIbsorZ6JIG2vLWfWEXCVqP0hDuzRvmx8otApNZr8pJYLNwCe1aQ+ySHQYGkdubFjoMojulMbQ959Y4SJ6Its/EnVvpbDnxpXTDpbutDxyhxfq1P3lstL2G9rObJRrxiwdGlRGu1h94UA1fCCkIUQux5LcqUee6W4MyQmRnsUziH8gGzmtI=").unwrap();
         let original = STANDARD.decode(b"rMweTemxOL9D0iWWfRxiY3enxiZ5IrwWD6ef2apGO6MvgdGhy2fpwmATmn7BpSj9lRumddLLXm7u8zSp6hnXt1hS71YDNh78LjGKGhGL4sbg8uNnpa/I6GK/83jzqGYN7+ESbg==").unwrap();
 
-        let dec = AttachmentFile {
-            cipher,
-            attachment,
-            contents: EncString::from_buffer(&enc_file).unwrap(),
-        }
-        .decrypt_with_key(&user_key)
-        .unwrap();
+        let dec = key_store
+            .decrypt(&AttachmentFile {
+                cipher,
+                attachment,
+                contents: EncString::from_buffer(&enc_file).unwrap(),
+            })
+            .unwrap();
 
         assert_eq!(dec, original);
     }
@@ -291,6 +323,7 @@ mod tests {
     #[test]
     fn test_attachment_without_key() {
         let user_key: SymmetricCryptoKey = "w2LO+nwV4oxwswVYCxlOfRUseXfvU03VzvKQHrqeklPgiMZrspUe6sOBToCnDn9Ay0tuCBn8ykVVRb7PWhub2Q==".to_string().try_into().unwrap();
+        let key_store = create_test_crypto_with_user_key(user_key);
 
         let attachment = Attachment {
             id: None,
@@ -332,13 +365,13 @@ mod tests {
         let enc_file = STANDARD.decode(b"AsQLXOBHrJ8porroTUlPxeJOm9XID7LL9D2+KwYATXEpR1EFjLBpcCvMmnqcnYLXIEefe9TCeY4Us50ux43kRSpvdB7YkjxDKV0O1/y6tB7qC4vvv9J9+O/uDEnMx/9yXuEhAW/LA/TsU/WAgxkOM0uTvm8JdD9LUR1z9Ql7zOWycMVzkvGsk2KBNcqAdrotS5FlDftZOXyU8pWecNeyA/w=").unwrap();
         let original = STANDARD.decode(b"rMweTemxOL9D0iWWfRxiY3enxiZ5IrwWD6ef2apGO6MvgdGhy2fpwmATmn7BpSj9lRumddLLXm7u8zSp6hnXt1hS71YDNh78LjGKGhGL4sbg8uNnpa/I6GK/83jzqGYN7+ESbg==").unwrap();
 
-        let dec = AttachmentFile {
-            cipher,
-            attachment,
-            contents: EncString::from_buffer(&enc_file).unwrap(),
-        }
-        .decrypt_with_key(&user_key)
-        .unwrap();
+        let dec = key_store
+            .decrypt(&AttachmentFile {
+                cipher,
+                attachment,
+                contents: EncString::from_buffer(&enc_file).unwrap(),
+            })
+            .unwrap();
 
         assert_eq!(dec, original);
     }

--- a/crates/bitwarden-vault/src/cipher/attachment.rs
+++ b/crates/bitwarden-vault/src/cipher/attachment.rs
@@ -76,8 +76,7 @@ impl Encryptable<KeyIds, SymmetricKeyId, AttachmentEncryptResult> for Attachment
         ctx: &mut KeyStoreContext<KeyIds>,
         key: SymmetricKeyId,
     ) -> Result<AttachmentEncryptResult, CryptoError> {
-        let ciphers_key = Cipher::get_cipher_key(ctx, key, &self.cipher.key)?;
-        let ciphers_key = ciphers_key.unwrap_or(key);
+        let ciphers_key = Cipher::decrypt_cipher_key(ctx, key, &self.cipher.key)?;
 
         let mut attachment = self.attachment.clone();
 
@@ -117,8 +116,7 @@ impl Decryptable<KeyIds, SymmetricKeyId, Vec<u8>> for AttachmentFile {
         ctx: &mut KeyStoreContext<KeyIds>,
         key: SymmetricKeyId,
     ) -> Result<Vec<u8>, CryptoError> {
-        let ciphers_key = Cipher::get_cipher_key(ctx, key, &self.cipher.key)?;
-        let ciphers_key = ciphers_key.unwrap_or(key);
+        let ciphers_key = Cipher::decrypt_cipher_key(ctx, key, &self.cipher.key)?;
 
         // Version 2 or 3, `AttachmentKey` or `CipherKey(AttachmentKey)`
         if let Some(attachment_key) = &self.attachment.key {

--- a/crates/bitwarden-vault/src/cipher/card.rs
+++ b/crates/bitwarden-vault/src/cipher/card.rs
@@ -1,7 +1,6 @@
 use bitwarden_api_api::models::CipherCardModel;
-use bitwarden_crypto::{
-    CryptoError, EncString, KeyDecryptable, KeyEncryptable, SymmetricCryptoKey,
-};
+use bitwarden_core::key_management::{KeyIds, SymmetricKeyId};
+use bitwarden_crypto::{CryptoError, Decryptable, EncString, Encryptable, KeyStoreContext};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
@@ -48,28 +47,36 @@ pub enum CardBrand {
     Other,
 }
 
-impl KeyEncryptable<SymmetricCryptoKey, Card> for CardView {
-    fn encrypt_with_key(self, key: &SymmetricCryptoKey) -> Result<Card, CryptoError> {
+impl Encryptable<KeyIds, SymmetricKeyId, Card> for CardView {
+    fn encrypt(
+        &self,
+        ctx: &mut KeyStoreContext<KeyIds>,
+        key: SymmetricKeyId,
+    ) -> Result<Card, CryptoError> {
         Ok(Card {
-            cardholder_name: self.cardholder_name.encrypt_with_key(key)?,
-            exp_month: self.exp_month.encrypt_with_key(key)?,
-            exp_year: self.exp_year.encrypt_with_key(key)?,
-            code: self.code.encrypt_with_key(key)?,
-            brand: self.brand.encrypt_with_key(key)?,
-            number: self.number.encrypt_with_key(key)?,
+            cardholder_name: self.cardholder_name.encrypt(ctx, key)?,
+            exp_month: self.exp_month.encrypt(ctx, key)?,
+            exp_year: self.exp_year.encrypt(ctx, key)?,
+            code: self.code.encrypt(ctx, key)?,
+            brand: self.brand.encrypt(ctx, key)?,
+            number: self.number.encrypt(ctx, key)?,
         })
     }
 }
 
-impl KeyDecryptable<SymmetricCryptoKey, CardView> for Card {
-    fn decrypt_with_key(&self, key: &SymmetricCryptoKey) -> Result<CardView, CryptoError> {
+impl Decryptable<KeyIds, SymmetricKeyId, CardView> for Card {
+    fn decrypt(
+        &self,
+        ctx: &mut KeyStoreContext<KeyIds>,
+        key: SymmetricKeyId,
+    ) -> Result<CardView, CryptoError> {
         Ok(CardView {
-            cardholder_name: self.cardholder_name.decrypt_with_key(key).ok().flatten(),
-            exp_month: self.exp_month.decrypt_with_key(key).ok().flatten(),
-            exp_year: self.exp_year.decrypt_with_key(key).ok().flatten(),
-            code: self.code.decrypt_with_key(key).ok().flatten(),
-            brand: self.brand.decrypt_with_key(key).ok().flatten(),
-            number: self.number.decrypt_with_key(key).ok().flatten(),
+            cardholder_name: self.cardholder_name.decrypt(ctx, key).ok().flatten(),
+            exp_month: self.exp_month.decrypt(ctx, key).ok().flatten(),
+            exp_year: self.exp_year.decrypt(ctx, key).ok().flatten(),
+            code: self.code.decrypt(ctx, key).ok().flatten(),
+            brand: self.brand.decrypt(ctx, key).ok().flatten(),
+            number: self.number.decrypt(ctx, key).ok().flatten(),
         })
     }
 }

--- a/crates/bitwarden-vault/src/cipher/cipher.rs
+++ b/crates/bitwarden-vault/src/cipher/cipher.rs
@@ -1,8 +1,10 @@
 use bitwarden_api_api::models::CipherDetailsResponseModel;
-use bitwarden_core::{require, MissingFieldError, VaultLockedError};
+use bitwarden_core::{
+    key_management::{KeyIds, SymmetricKeyId},
+    require, MissingFieldError, VaultLockedError,
+};
 use bitwarden_crypto::{
-    CryptoError, EncString, KeyContainer, KeyDecryptable, KeyEncryptable, LocateKey,
-    SymmetricCryptoKey,
+    CryptoError, Decryptable, EncString, Encryptable, IdentifyKey, KeyStoreContext,
 };
 use chrono::{DateTime, Utc};
 use schemars::JsonSchema;
@@ -175,15 +177,15 @@ pub struct CipherListView {
 impl CipherListView {
     pub(crate) fn get_totp_key(
         self,
-        enc: &dyn KeyContainer,
+        ctx: &mut KeyStoreContext<KeyIds>,
     ) -> Result<Option<String>, CryptoError> {
-        let key = self.locate_key(enc, &None)?;
-        let cipher_key = Cipher::get_cipher_key(key, &self.key)?;
-        let key = cipher_key.as_ref().unwrap_or(key);
+        let key = self.key_identifier();
+        let cipher_key = Cipher::get_cipher_key(ctx, key, &self.key)?;
+        let key = cipher_key.unwrap_or(key);
 
         let totp = match self.r#type {
             CipherListViewType::Login(LoginListView { totp, .. }) => {
-                totp.map(|t| t.decrypt_with_key(key)).transpose()?
+                totp.map(|t| t.decrypt(ctx, key)).transpose()?
             }
             _ => None,
         };
@@ -192,50 +194,60 @@ impl CipherListView {
     }
 }
 
-impl KeyEncryptable<SymmetricCryptoKey, Cipher> for CipherView {
-    fn encrypt_with_key(mut self, key: &SymmetricCryptoKey) -> Result<Cipher, CryptoError> {
-        let ciphers_key = Cipher::get_cipher_key(key, &self.key)?;
-        let key = ciphers_key.as_ref().unwrap_or(key);
+impl Encryptable<KeyIds, SymmetricKeyId, Cipher> for CipherView {
+    fn encrypt(
+        &self,
+        ctx: &mut KeyStoreContext<KeyIds>,
+        key: SymmetricKeyId,
+    ) -> Result<Cipher, CryptoError> {
+        let ciphers_key = Cipher::get_cipher_key(ctx, key, &self.key)?;
+        let key = ciphers_key.unwrap_or(key);
+
+        let mut cipher_view = self.clone();
 
         // For compatibility reasons, we only create checksums for ciphers that have a key
         if ciphers_key.is_some() {
-            self.generate_checksums();
+            cipher_view.generate_checksums();
         }
 
         Ok(Cipher {
-            id: self.id,
-            organization_id: self.organization_id,
-            folder_id: self.folder_id,
-            collection_ids: self.collection_ids,
-            key: self.key,
-            name: self.name.encrypt_with_key(key)?,
-            notes: self.notes.encrypt_with_key(key)?,
-            r#type: self.r#type,
-            login: self.login.encrypt_with_key(key)?,
-            identity: self.identity.encrypt_with_key(key)?,
-            card: self.card.encrypt_with_key(key)?,
-            secure_note: self.secure_note.encrypt_with_key(key)?,
-            ssh_key: self.ssh_key.encrypt_with_key(key)?,
-            favorite: self.favorite,
-            reprompt: self.reprompt,
-            organization_use_totp: self.organization_use_totp,
-            edit: self.edit,
-            view_password: self.view_password,
-            local_data: self.local_data.encrypt_with_key(key)?,
-            attachments: self.attachments.encrypt_with_key(key)?,
-            fields: self.fields.encrypt_with_key(key)?,
-            password_history: self.password_history.encrypt_with_key(key)?,
-            creation_date: self.creation_date,
-            deleted_date: self.deleted_date,
-            revision_date: self.revision_date,
+            id: cipher_view.id,
+            organization_id: cipher_view.organization_id,
+            folder_id: cipher_view.folder_id,
+            collection_ids: cipher_view.collection_ids,
+            key: cipher_view.key,
+            name: cipher_view.name.encrypt(ctx, key)?,
+            notes: cipher_view.notes.encrypt(ctx, key)?,
+            r#type: cipher_view.r#type,
+            login: cipher_view.login.encrypt(ctx, key)?,
+            identity: cipher_view.identity.encrypt(ctx, key)?,
+            card: cipher_view.card.encrypt(ctx, key)?,
+            secure_note: cipher_view.secure_note.encrypt(ctx, key)?,
+            ssh_key: cipher_view.ssh_key.encrypt(ctx, key)?,
+            favorite: cipher_view.favorite,
+            reprompt: cipher_view.reprompt,
+            organization_use_totp: cipher_view.organization_use_totp,
+            edit: cipher_view.edit,
+            view_password: cipher_view.view_password,
+            local_data: cipher_view.local_data.encrypt(ctx, key)?,
+            attachments: cipher_view.attachments.encrypt(ctx, key)?,
+            fields: cipher_view.fields.encrypt(ctx, key)?,
+            password_history: cipher_view.password_history.encrypt(ctx, key)?,
+            creation_date: cipher_view.creation_date,
+            deleted_date: cipher_view.deleted_date,
+            revision_date: cipher_view.revision_date,
         })
     }
 }
 
-impl KeyDecryptable<SymmetricCryptoKey, CipherView> for Cipher {
-    fn decrypt_with_key(&self, key: &SymmetricCryptoKey) -> Result<CipherView, CryptoError> {
-        let ciphers_key = Cipher::get_cipher_key(key, &self.key)?;
-        let key = ciphers_key.as_ref().unwrap_or(key);
+impl Decryptable<KeyIds, SymmetricKeyId, CipherView> for Cipher {
+    fn decrypt(
+        &self,
+        ctx: &mut KeyStoreContext<KeyIds>,
+        key: SymmetricKeyId,
+    ) -> Result<CipherView, CryptoError> {
+        let ciphers_key = Cipher::get_cipher_key(ctx, key, &self.key)?;
+        let key = ciphers_key.unwrap_or(key);
 
         let mut cipher = CipherView {
             id: self.id,
@@ -243,23 +255,23 @@ impl KeyDecryptable<SymmetricCryptoKey, CipherView> for Cipher {
             folder_id: self.folder_id,
             collection_ids: self.collection_ids.clone(),
             key: self.key.clone(),
-            name: self.name.decrypt_with_key(key).ok().unwrap_or_default(),
-            notes: self.notes.decrypt_with_key(key).ok().flatten(),
+            name: self.name.decrypt(ctx, key).ok().unwrap_or_default(),
+            notes: self.notes.decrypt(ctx, key).ok().flatten(),
             r#type: self.r#type,
-            login: self.login.decrypt_with_key(key).ok().flatten(),
-            identity: self.identity.decrypt_with_key(key).ok().flatten(),
-            card: self.card.decrypt_with_key(key).ok().flatten(),
-            secure_note: self.secure_note.decrypt_with_key(key).ok().flatten(),
-            ssh_key: self.ssh_key.decrypt_with_key(key).ok().flatten(),
+            login: self.login.decrypt(ctx, key).ok().flatten(),
+            identity: self.identity.decrypt(ctx, key).ok().flatten(),
+            card: self.card.decrypt(ctx, key).ok().flatten(),
+            secure_note: self.secure_note.decrypt(ctx, key).ok().flatten(),
+            ssh_key: self.ssh_key.decrypt(ctx, key).ok().flatten(),
             favorite: self.favorite,
             reprompt: self.reprompt,
             organization_use_totp: self.organization_use_totp,
             edit: self.edit,
             view_password: self.view_password,
-            local_data: self.local_data.decrypt_with_key(key).ok().flatten(),
-            attachments: self.attachments.decrypt_with_key(key).ok().flatten(),
-            fields: self.fields.decrypt_with_key(key).ok().flatten(),
-            password_history: self.password_history.decrypt_with_key(key).ok().flatten(),
+            local_data: self.local_data.decrypt(ctx, key).ok().flatten(),
+            attachments: self.attachments.decrypt(ctx, key).ok().flatten(),
+            fields: self.fields.decrypt(ctx, key).ok().flatten(),
+            password_history: self.password_history.decrypt(ctx, key).ok().flatten(),
             creation_date: self.creation_date,
             deleted_date: self.deleted_date,
             revision_date: self.revision_date,
@@ -279,26 +291,38 @@ impl Cipher {
     /// Note that some ciphers do not have individual encryption keys,
     /// in which case this will return Ok(None) and the key associated
     /// with this cipher's user or organization must be used instead
+    ///
+    /// # Arguments
+    ///
+    /// * `ctx` - The key store context where the cipher key will be decrypted, if it exists
+    /// * `key` - The key to use to decrypt the cipher key, this should be the user or organization
+    ///   key
+    /// * `ciphers_key` - The encrypted cipher key
     pub(super) fn get_cipher_key(
-        key: &SymmetricCryptoKey,
+        ctx: &mut KeyStoreContext<KeyIds>,
+        key: SymmetricKeyId,
         ciphers_key: &Option<EncString>,
-    ) -> Result<Option<SymmetricCryptoKey>, CryptoError> {
-        ciphers_key
-            .as_ref()
-            .map(|k| {
-                let mut key: Vec<u8> = k.decrypt_with_key(key)?;
-                SymmetricCryptoKey::try_from(key.as_mut_slice())
-            })
-            .transpose()
+    ) -> Result<Option<SymmetricKeyId>, CryptoError> {
+        const CIPHER_KEY: SymmetricKeyId = SymmetricKeyId::Local("cipher_key");
+        match ciphers_key {
+            Some(ciphers_key) => ctx
+                .decrypt_symmetric_key_with_symmetric_key(key, CIPHER_KEY, ciphers_key)
+                .map(Some),
+            None => Ok(None),
+        }
     }
 
-    fn get_decrypted_subtitle(&self, key: &SymmetricCryptoKey) -> Result<String, CryptoError> {
+    fn get_decrypted_subtitle(
+        &self,
+        ctx: &mut KeyStoreContext<KeyIds>,
+        key: SymmetricKeyId,
+    ) -> Result<String, CryptoError> {
         Ok(match self.r#type {
             CipherType::Login => {
                 let Some(login) = &self.login else {
                     return Ok(String::new());
                 };
-                login.username.decrypt_with_key(key)?.unwrap_or_default()
+                login.username.decrypt(ctx, key)?.unwrap_or_default()
             }
             CipherType::SecureNote => String::new(),
             CipherType::Card => {
@@ -309,11 +333,11 @@ impl Cipher {
                 build_subtitle_card(
                     card.brand
                         .as_ref()
-                        .map(|b| b.decrypt_with_key(key))
+                        .map(|b| b.decrypt(ctx, key))
                         .transpose()?,
                     card.number
                         .as_ref()
-                        .map(|n| n.decrypt_with_key(key))
+                        .map(|n| n.decrypt(ctx, key))
                         .transpose()?,
                 )
             }
@@ -326,12 +350,12 @@ impl Cipher {
                     identity
                         .first_name
                         .as_ref()
-                        .map(|f| f.decrypt_with_key(key))
+                        .map(|f| f.decrypt(ctx, key))
                         .transpose()?,
                     identity
                         .last_name
                         .as_ref()
-                        .map(|l| l.decrypt_with_key(key))
+                        .map(|l| l.decrypt(ctx, key))
                         .transpose()?,
                 )
             }
@@ -342,7 +366,7 @@ impl Cipher {
 
                 Some(ssh_key.fingerprint.clone())
                     .as_ref()
-                    .map(|c| c.decrypt_with_key(key))
+                    .map(|c| c.decrypt(ctx, key))
                     .transpose()?
                     .unwrap_or_default()
             }
@@ -407,16 +431,22 @@ fn build_subtitle_identity(first_name: Option<String>, last_name: Option<String>
 }
 
 impl CipherView {
-    pub fn generate_cipher_key(&mut self, key: &SymmetricCryptoKey) -> Result<(), CryptoError> {
-        let old_ciphers_key = Cipher::get_cipher_key(key, &self.key)?;
-        let old_key = old_ciphers_key.as_ref().unwrap_or(key);
+    pub fn generate_cipher_key(
+        &mut self,
+        ctx: &mut KeyStoreContext<KeyIds>,
+        key: SymmetricKeyId,
+    ) -> Result<(), CryptoError> {
+        let old_ciphers_key = Cipher::get_cipher_key(ctx, key, &self.key)?;
+        let old_key = old_ciphers_key.unwrap_or(key);
 
-        let new_key = SymmetricCryptoKey::generate(rand::thread_rng());
+        const NEW_KEY: SymmetricKeyId = SymmetricKeyId::Local("new_cipher_key");
 
-        self.reencrypt_attachment_keys(old_key, &new_key)?;
-        self.reencrypt_fido2_credentials(old_key, &new_key)?;
+        let new_key = ctx.generate_symmetric_key(NEW_KEY)?;
 
-        self.key = Some(new_key.to_vec().encrypt_with_key(key)?);
+        self.reencrypt_attachment_keys(ctx, old_key, new_key)?;
+        self.reencrypt_fido2_credentials(ctx, old_key, new_key)?;
+
+        self.key = Some(ctx.encrypt_symmetric_key_with_symmetric_key(key, new_key)?);
         Ok(())
     }
 
@@ -436,14 +466,15 @@ impl CipherView {
 
     fn reencrypt_attachment_keys(
         &mut self,
-        old_key: &SymmetricCryptoKey,
-        new_key: &SymmetricCryptoKey,
+        ctx: &mut KeyStoreContext<KeyIds>,
+        old_key: SymmetricKeyId,
+        new_key: SymmetricKeyId,
     ) -> Result<(), CryptoError> {
         if let Some(attachments) = &mut self.attachments {
             for attachment in attachments {
                 if let Some(attachment_key) = &mut attachment.key {
-                    let dec_attachment_key: Vec<u8> = attachment_key.decrypt_with_key(old_key)?;
-                    *attachment_key = dec_attachment_key.encrypt_with_key(new_key)?;
+                    let dec_attachment_key: Vec<u8> = attachment_key.decrypt(ctx, old_key)?;
+                    *attachment_key = dec_attachment_key.encrypt(ctx, new_key)?;
                 }
             }
         }
@@ -452,32 +483,33 @@ impl CipherView {
 
     pub fn decrypt_fido2_credentials(
         &self,
-        enc: &dyn KeyContainer,
+        ctx: &mut KeyStoreContext<KeyIds>,
     ) -> Result<Vec<Fido2CredentialView>, CryptoError> {
-        let key = self.locate_key(enc, &None)?;
-        let cipher_key = Cipher::get_cipher_key(key, &self.key)?;
+        let key = self.key_identifier();
+        let cipher_key = Cipher::get_cipher_key(ctx, key, &self.key)?;
 
-        let key = cipher_key.as_ref().unwrap_or(key);
+        let key = cipher_key.unwrap_or(key);
 
         Ok(self
             .login
             .as_ref()
             .and_then(|l| l.fido2_credentials.as_ref())
-            .map(|f| f.decrypt_with_key(key))
+            .map(|f| f.decrypt(ctx, key))
             .transpose()?
             .unwrap_or_default())
     }
 
     fn reencrypt_fido2_credentials(
         &mut self,
-        old_key: &SymmetricCryptoKey,
-        new_key: &SymmetricCryptoKey,
+        ctx: &mut KeyStoreContext<KeyIds>,
+        old_key: SymmetricKeyId,
+        new_key: SymmetricKeyId,
     ) -> Result<(), CryptoError> {
         if let Some(login) = self.login.as_mut() {
             if let Some(fido2_credentials) = &mut login.fido2_credentials {
                 let dec_fido2_credentials: Vec<Fido2CredentialFullView> =
-                    fido2_credentials.decrypt_with_key(old_key)?;
-                *fido2_credentials = dec_fido2_credentials.encrypt_with_key(new_key)?;
+                    fido2_credentials.decrypt(ctx, old_key)?;
+                *fido2_credentials = dec_fido2_credentials.encrypt(ctx, new_key)?;
             }
         }
         Ok(())
@@ -485,12 +517,11 @@ impl CipherView {
 
     pub fn move_to_organization(
         &mut self,
-        enc: &dyn KeyContainer,
+        ctx: &mut KeyStoreContext<KeyIds>,
         organization_id: Uuid,
     ) -> Result<(), CipherError> {
-        let old_key = enc.get_key(&self.organization_id)?;
-
-        let new_key = enc.get_key(&Some(organization_id))?;
+        let old_key = self.key_identifier();
+        let new_key = SymmetricKeyId::Organization(organization_id);
 
         // If any attachment is missing a key we can't reencrypt the attachment keys
         if self.attachments.iter().flatten().any(|a| a.key.is_none()) {
@@ -499,12 +530,12 @@ impl CipherView {
 
         // If the cipher has a key, we need to re-encrypt it with the new organization key
         if let Some(cipher_key) = &mut self.key {
-            let dec_cipher_key: Vec<u8> = cipher_key.decrypt_with_key(old_key)?;
-            *cipher_key = dec_cipher_key.encrypt_with_key(new_key)?;
+            let dec_cipher_key: Vec<u8> = cipher_key.decrypt(ctx, old_key)?;
+            *cipher_key = dec_cipher_key.encrypt(ctx, new_key)?;
         } else {
             // If the cipher does not have a key, we need to reencrypt all attachment keys
-            self.reencrypt_attachment_keys(old_key, new_key)?;
-            self.reencrypt_fido2_credentials(old_key, new_key)?;
+            self.reencrypt_attachment_keys(ctx, old_key, new_key)?;
+            self.reencrypt_fido2_credentials(ctx, old_key, new_key)?;
         }
 
         self.organization_id = Some(organization_id);
@@ -513,40 +544,43 @@ impl CipherView {
 
     pub fn set_new_fido2_credentials(
         &mut self,
-        enc: &dyn KeyContainer,
+        ctx: &mut KeyStoreContext<KeyIds>,
         creds: Vec<Fido2CredentialFullView>,
     ) -> Result<(), CipherError> {
-        let key = enc.get_key(&self.organization_id)?;
+        let key = self.key_identifier();
 
-        let ciphers_key = Cipher::get_cipher_key(key, &self.key)?;
-        let ciphers_key = ciphers_key.as_ref().unwrap_or(key);
+        let ciphers_key = Cipher::get_cipher_key(ctx, key, &self.key)?;
+        let ciphers_key = ciphers_key.unwrap_or(key);
 
-        require!(self.login.as_mut()).fido2_credentials =
-            Some(creds.encrypt_with_key(ciphers_key)?);
+        require!(self.login.as_mut()).fido2_credentials = Some(creds.encrypt(ctx, ciphers_key)?);
 
         Ok(())
     }
 
     pub fn get_fido2_credentials(
         &self,
-        enc: &dyn KeyContainer,
+        ctx: &mut KeyStoreContext<KeyIds>,
     ) -> Result<Vec<Fido2CredentialFullView>, CipherError> {
-        let key = enc.get_key(&self.organization_id)?;
+        let key = self.key_identifier();
 
-        let ciphers_key = Cipher::get_cipher_key(key, &self.key)?;
-        let ciphers_key = ciphers_key.as_ref().unwrap_or(key);
+        let ciphers_key = Cipher::get_cipher_key(ctx, key, &self.key)?;
+        let ciphers_key = ciphers_key.unwrap_or(key);
 
         let login = require!(self.login.as_ref());
         let creds = require!(login.fido2_credentials.as_ref());
-        let res = creds.decrypt_with_key(ciphers_key)?;
+        let res = creds.decrypt(ctx, ciphers_key)?;
         Ok(res)
     }
 }
 
-impl KeyDecryptable<SymmetricCryptoKey, CipherListView> for Cipher {
-    fn decrypt_with_key(&self, key: &SymmetricCryptoKey) -> Result<CipherListView, CryptoError> {
-        let ciphers_key = Cipher::get_cipher_key(key, &self.key)?;
-        let key = ciphers_key.as_ref().unwrap_or(key);
+impl Decryptable<KeyIds, SymmetricKeyId, CipherListView> for Cipher {
+    fn decrypt(
+        &self,
+        ctx: &mut KeyStoreContext<KeyIds>,
+        key: SymmetricKeyId,
+    ) -> Result<CipherListView, CryptoError> {
+        let ciphers_key = Cipher::get_cipher_key(ctx, key, &self.key)?;
+        let key = ciphers_key.unwrap_or(key);
 
         Ok(CipherListView {
             id: self.id,
@@ -554,15 +588,18 @@ impl KeyDecryptable<SymmetricCryptoKey, CipherListView> for Cipher {
             folder_id: self.folder_id,
             collection_ids: self.collection_ids.clone(),
             key: self.key.clone(),
-            name: self.name.decrypt_with_key(key).ok().unwrap_or_default(),
-            subtitle: self.get_decrypted_subtitle(key).ok().unwrap_or_default(),
+            name: self.name.decrypt(ctx, key).ok().unwrap_or_default(),
+            subtitle: self
+                .get_decrypted_subtitle(ctx, key)
+                .ok()
+                .unwrap_or_default(),
             r#type: match self.r#type {
                 CipherType::Login => {
                     let login = self
                         .login
                         .as_ref()
                         .ok_or(CryptoError::MissingField("login"))?;
-                    CipherListViewType::Login(login.decrypt_with_key(key)?)
+                    CipherListViewType::Login(login.decrypt(ctx, key)?)
                 }
                 CipherType::SecureNote => CipherListViewType::SecureNote,
                 CipherType::Card => CipherListViewType::Card,
@@ -586,31 +623,30 @@ impl KeyDecryptable<SymmetricCryptoKey, CipherListView> for Cipher {
     }
 }
 
-impl LocateKey for Cipher {
-    fn locate_key<'a>(
-        &self,
-        enc: &'a dyn KeyContainer,
-        _: &Option<Uuid>,
-    ) -> Result<&'a SymmetricCryptoKey, CryptoError> {
-        enc.get_key(&self.organization_id)
+impl IdentifyKey<SymmetricKeyId> for Cipher {
+    fn key_identifier(&self) -> SymmetricKeyId {
+        match self.organization_id {
+            Some(organization_id) => SymmetricKeyId::Organization(organization_id),
+            None => SymmetricKeyId::User,
+        }
     }
 }
-impl LocateKey for CipherView {
-    fn locate_key<'a>(
-        &self,
-        enc: &'a dyn KeyContainer,
-        _: &Option<Uuid>,
-    ) -> Result<&'a SymmetricCryptoKey, CryptoError> {
-        enc.get_key(&self.organization_id)
+
+impl IdentifyKey<SymmetricKeyId> for CipherView {
+    fn key_identifier(&self) -> SymmetricKeyId {
+        match self.organization_id {
+            Some(organization_id) => SymmetricKeyId::Organization(organization_id),
+            None => SymmetricKeyId::User,
+        }
     }
 }
-impl LocateKey for CipherListView {
-    fn locate_key<'a>(
-        &self,
-        enc: &'a dyn KeyContainer,
-        _: &Option<Uuid>,
-    ) -> Result<&'a SymmetricCryptoKey, CryptoError> {
-        enc.get_key(&self.organization_id)
+
+impl IdentifyKey<SymmetricKeyId> for CipherListView {
+    fn key_identifier(&self) -> SymmetricKeyId {
+        match self.organization_id {
+            Some(organization_id) => SymmetricKeyId::Organization(organization_id),
+            None => SymmetricKeyId::User,
+        }
     }
 }
 
@@ -685,9 +721,11 @@ impl From<bitwarden_api_api::models::CipherRepromptType> for CipherRepromptType 
 #[cfg(test)]
 mod tests {
 
-    use std::collections::HashMap;
-
     use attachment::AttachmentView;
+    use bitwarden_core::key_management::{
+        create_test_crypto_with_user_and_org_key, create_test_crypto_with_user_key,
+    };
+    use bitwarden_crypto::SymmetricCryptoKey;
     use ssh_key::SshKey;
 
     use super::*;
@@ -732,20 +770,20 @@ mod tests {
         }
     }
 
-    fn generate_fido2(key: &SymmetricCryptoKey) -> Fido2Credential {
+    fn generate_fido2(ctx: &mut KeyStoreContext<KeyIds>, key: SymmetricKeyId) -> Fido2Credential {
         Fido2Credential {
-            credential_id: "123".to_string().encrypt_with_key(key).unwrap(),
-            key_type: "public-key".to_string().encrypt_with_key(key).unwrap(),
-            key_algorithm: "ECDSA".to_string().encrypt_with_key(key).unwrap(),
-            key_curve: "P-256".to_string().encrypt_with_key(key).unwrap(),
-            key_value: "123".to_string().encrypt_with_key(key).unwrap(),
-            rp_id: "123".to_string().encrypt_with_key(key).unwrap(),
+            credential_id: "123".to_string().encrypt(ctx, key).unwrap(),
+            key_type: "public-key".to_string().encrypt(ctx, key).unwrap(),
+            key_algorithm: "ECDSA".to_string().encrypt(ctx, key).unwrap(),
+            key_curve: "P-256".to_string().encrypt(ctx, key).unwrap(),
+            key_value: "123".to_string().encrypt(ctx, key).unwrap(),
+            rp_id: "123".to_string().encrypt(ctx, key).unwrap(),
             user_handle: None,
             user_name: None,
-            counter: "123".to_string().encrypt_with_key(key).unwrap(),
+            counter: "123".to_string().encrypt(ctx, key).unwrap(),
             rp_name: None,
             user_display_name: None,
-            discoverable: "true".to_string().encrypt_with_key(key).unwrap(),
+            discoverable: "true".to_string().encrypt(ctx, key).unwrap(),
             creation_date: "2024-06-07T14:12:36.150Z".parse().unwrap(),
         }
     }
@@ -753,6 +791,7 @@ mod tests {
     #[test]
     fn test_decrypt_cipher_list_view() {
         let key: SymmetricCryptoKey = "w2LO+nwV4oxwswVYCxlOfRUseXfvU03VzvKQHrqeklPgiMZrspUe6sOBToCnDn9Ay0tuCBn8ykVVRb7PWhub2Q==".to_string().try_into().unwrap();
+        let key_store = create_test_crypto_with_user_key(key);
 
         let cipher = Cipher {
             id: Some("090c19ea-a61a-4df6-8963-262b97bc6266".parse().unwrap()),
@@ -770,7 +809,7 @@ mod tests {
                 uris: None,
                 totp: Some("2.hqdioUAc81FsKQmO1XuLQg==|oDRdsJrQjoFu9NrFVy8tcJBAFKBx95gHaXZnWdXbKpsxWnOr2sKipIG43pKKUFuq|3gKZMiboceIB5SLVOULKg2iuyu6xzos22dfJbvx0EHk=".parse().unwrap()),
                 autofill_on_page_load: None,
-                fido2_credentials: Some(vec![generate_fido2(&key)]),
+                fido2_credentials: Some(vec![generate_fido2(&mut key_store.context(), SymmetricKeyId::User)]),
             }),
             identity: None,
             card: None,
@@ -790,7 +829,7 @@ mod tests {
             revision_date: "2024-01-30T17:55:36.150Z".parse().unwrap(),
         };
 
-        let view: CipherListView = cipher.decrypt_with_key(&key).unwrap();
+        let view: CipherListView = key_store.decrypt(&cipher).unwrap();
 
         assert_eq!(
             view,
@@ -823,22 +862,25 @@ mod tests {
     #[test]
     fn test_generate_cipher_key() {
         let key = SymmetricCryptoKey::generate(rand::thread_rng());
+        let key_store = create_test_crypto_with_user_key(key);
 
         let original_cipher = generate_cipher();
 
         // Check that the cipher gets encrypted correctly without it's own key
         let cipher = generate_cipher();
-        let no_key_cipher_enc = cipher.encrypt_with_key(&key).unwrap();
-        let no_key_cipher_dec: CipherView = no_key_cipher_enc.decrypt_with_key(&key).unwrap();
+        let no_key_cipher_enc = key_store.encrypt(cipher).unwrap();
+        let no_key_cipher_dec: CipherView = key_store.decrypt(&no_key_cipher_enc).unwrap();
         assert!(no_key_cipher_dec.key.is_none());
         assert_eq!(no_key_cipher_dec.name, original_cipher.name);
 
         let mut cipher = generate_cipher();
-        cipher.generate_cipher_key(&key).unwrap();
+        cipher
+            .generate_cipher_key(&mut key_store.context(), cipher.key_identifier())
+            .unwrap();
 
         // Check that the cipher gets encrypted correctly when it's assigned it's own key
-        let key_cipher_enc = cipher.encrypt_with_key(&key).unwrap();
-        let key_cipher_dec: CipherView = key_cipher_enc.decrypt_with_key(&key).unwrap();
+        let key_cipher_enc = key_store.encrypt(cipher).unwrap();
+        let key_cipher_dec: CipherView = key_store.decrypt(&key_cipher_enc).unwrap();
         assert!(key_cipher_dec.key.is_some());
         assert_eq!(key_cipher_dec.name, original_cipher.name);
     }
@@ -846,22 +888,36 @@ mod tests {
     #[test]
     fn test_generate_cipher_key_when_a_cipher_key_already_exists() {
         let key = SymmetricCryptoKey::generate(rand::thread_rng());
-
-        let cipher_key = SymmetricCryptoKey::generate(rand::thread_rng());
-        let cipher_key = cipher_key.to_vec().encrypt_with_key(&key).unwrap();
+        let key_store = create_test_crypto_with_user_key(key);
 
         let mut original_cipher = generate_cipher();
-        original_cipher.key = Some(cipher_key.clone());
+        {
+            const CIPHER_KEY: SymmetricKeyId = SymmetricKeyId::Local("test_cipher_key");
+            let mut ctx = key_store.context();
+            let cipher_key = ctx.generate_symmetric_key(CIPHER_KEY).unwrap();
 
-        original_cipher.generate_cipher_key(&key).unwrap();
+            original_cipher.key = Some(
+                ctx.encrypt_symmetric_key_with_symmetric_key(SymmetricKeyId::User, cipher_key)
+                    .unwrap(),
+            );
+        }
+
+        original_cipher
+            .generate_cipher_key(&mut key_store.context(), original_cipher.key_identifier())
+            .unwrap();
 
         // Make sure that the cipher key is decryptable
-        let _: Vec<u8> = original_cipher.key.unwrap().decrypt_with_key(&key).unwrap();
+        let _: Vec<u8> = original_cipher
+            .key
+            .unwrap()
+            .decrypt(&mut key_store.context(), SymmetricKeyId::User)
+            .unwrap();
     }
 
     #[test]
     fn test_generate_cipher_key_ignores_attachments_without_key() {
         let key = SymmetricCryptoKey::generate(rand::thread_rng());
+        let key_store = create_test_crypto_with_user_key(key);
 
         let mut cipher = generate_cipher();
         let attachment = AttachmentView {
@@ -874,44 +930,33 @@ mod tests {
         };
         cipher.attachments = Some(vec![attachment]);
 
-        cipher.generate_cipher_key(&key).unwrap();
+        cipher
+            .generate_cipher_key(&mut key_store.context(), cipher.key_identifier())
+            .unwrap();
         assert!(cipher.attachments.unwrap()[0].key.is_none());
-    }
-
-    struct MockKeyContainer(HashMap<Option<Uuid>, SymmetricCryptoKey>);
-    impl KeyContainer for MockKeyContainer {
-        fn get_key<'a>(
-            &'a self,
-            org_id: &Option<Uuid>,
-        ) -> Result<&'a SymmetricCryptoKey, CryptoError> {
-            self.0
-                .get(org_id)
-                .ok_or(CryptoError::MissingKey(org_id.unwrap_or_default()))
-        }
     }
 
     #[test]
     fn test_move_user_cipher_to_org() {
         let org = uuid::Uuid::new_v4();
-
-        let enc = MockKeyContainer(HashMap::from([
-            (None, SymmetricCryptoKey::generate(rand::thread_rng())),
-            (Some(org), SymmetricCryptoKey::generate(rand::thread_rng())),
-        ]));
+        let key = SymmetricCryptoKey::generate(rand::thread_rng());
+        let org_key = SymmetricCryptoKey::generate(rand::thread_rng());
+        let key_store = create_test_crypto_with_user_and_org_key(key, org, org_key);
 
         // Create a cipher with a user key
         let mut cipher = generate_cipher();
         cipher
-            .generate_cipher_key(enc.get_key(&None).unwrap())
+            .generate_cipher_key(&mut key_store.context(), cipher.key_identifier())
             .unwrap();
 
-        cipher.move_to_organization(&enc, org).unwrap();
+        cipher
+            .move_to_organization(&mut key_store.context(), org)
+            .unwrap();
         assert_eq!(cipher.organization_id, Some(org));
 
         // Check that the cipher can be encrypted/decrypted with the new org key
-        let org_key = enc.get_key(&Some(org)).unwrap();
-        let cipher_enc = cipher.encrypt_with_key(org_key).unwrap();
-        let cipher_dec: CipherView = cipher_enc.decrypt_with_key(org_key).unwrap();
+        let cipher_enc = key_store.encrypt(cipher).unwrap();
+        let cipher_dec: CipherView = key_store.decrypt(&cipher_enc).unwrap();
 
         assert_eq!(cipher_dec.name, "My test login");
     }
@@ -919,34 +964,29 @@ mod tests {
     #[test]
     fn test_move_user_cipher_to_org_manually() {
         let org = uuid::Uuid::new_v4();
-
-        let enc = MockKeyContainer(HashMap::from([
-            (None, SymmetricCryptoKey::generate(rand::thread_rng())),
-            (Some(org), SymmetricCryptoKey::generate(rand::thread_rng())),
-        ]));
+        let key = SymmetricCryptoKey::generate(rand::thread_rng());
+        let org_key = SymmetricCryptoKey::generate(rand::thread_rng());
+        let key_store = create_test_crypto_with_user_and_org_key(key, org, org_key);
 
         // Create a cipher with a user key
         let mut cipher = generate_cipher();
         cipher
-            .generate_cipher_key(enc.get_key(&None).unwrap())
+            .generate_cipher_key(&mut key_store.context(), cipher.key_identifier())
             .unwrap();
 
         cipher.organization_id = Some(org);
 
         // Check that the cipher can not be encrypted, as the
         // cipher key is tied to the user key and not the org key
-        let org_key = enc.get_key(&Some(org)).unwrap();
-        assert!(cipher.encrypt_with_key(org_key).is_err());
+        assert!(key_store.encrypt(cipher).is_err());
     }
 
     #[test]
     fn test_move_user_cipher_with_attachment_without_key_to_org() {
         let org = uuid::Uuid::new_v4();
-
-        let enc = MockKeyContainer(HashMap::from([
-            (None, SymmetricCryptoKey::generate(rand::thread_rng())),
-            (Some(org), SymmetricCryptoKey::generate(rand::thread_rng())),
-        ]));
+        let key = SymmetricCryptoKey::generate(rand::thread_rng());
+        let org_key = SymmetricCryptoKey::generate(rand::thread_rng());
+        let key_store = create_test_crypto_with_user_and_org_key(key, org, org_key);
 
         let mut cipher = generate_cipher();
         let attachment = AttachmentView {
@@ -960,24 +1000,28 @@ mod tests {
         cipher.attachments = Some(vec![attachment]);
 
         // Neither cipher nor attachment have keys, so the cipher can't be moved
-        assert!(cipher.move_to_organization(&enc, org).is_err());
+        assert!(cipher
+            .move_to_organization(&mut key_store.context(), org)
+            .is_err());
     }
 
     #[test]
     fn test_move_user_cipher_with_attachment_with_key_to_org() {
         let org = uuid::Uuid::new_v4();
-
-        let enc = MockKeyContainer(HashMap::from([
-            (None, SymmetricCryptoKey::generate(rand::thread_rng())),
-            (Some(org), SymmetricCryptoKey::generate(rand::thread_rng())),
-        ]));
+        let key = SymmetricCryptoKey::generate(rand::thread_rng());
+        let org_key = SymmetricCryptoKey::generate(rand::thread_rng());
+        let key_store = create_test_crypto_with_user_and_org_key(key, org, org_key);
+        let org_key = SymmetricKeyId::Organization(org);
 
         // Attachment has a key that is encrypted with the user key, as the cipher has no key itself
         let attachment_key = SymmetricCryptoKey::generate(rand::thread_rng());
-        let attachment_key_enc = attachment_key
-            .to_vec()
-            .encrypt_with_key(enc.get_key(&None).unwrap())
-            .unwrap();
+        let attachment_key_enc = {
+            const ATTACHMENT_KEY: SymmetricKeyId = SymmetricKeyId::Local("test_attachment_key");
+            let mut ctx = key_store.context();
+            let attachment_key = ctx.generate_symmetric_key(ATTACHMENT_KEY).unwrap();
+            ctx.encrypt_symmetric_key_with_symmetric_key(SymmetricKeyId::User, attachment_key)
+                .unwrap()
+        };
 
         let mut cipher = generate_cipher();
         let attachment = AttachmentView {
@@ -989,10 +1033,12 @@ mod tests {
             key: Some(attachment_key_enc),
         };
         cipher.attachments = Some(vec![attachment]);
-        let cred = generate_fido2(enc.get_key(&None).unwrap());
+        let cred = generate_fido2(&mut key_store.context(), SymmetricKeyId::User);
         cipher.login.as_mut().unwrap().fido2_credentials = Some(vec![cred]);
 
-        cipher.move_to_organization(&enc, org).unwrap();
+        cipher
+            .move_to_organization(&mut key_store.context(), org)
+            .unwrap();
 
         assert!(cipher.key.is_none());
 
@@ -1000,7 +1046,7 @@ mod tests {
         // and the value matches with the original attachment key
         let new_attachment_key = cipher.attachments.unwrap()[0].key.clone().unwrap();
         let new_attachment_key_dec: Vec<_> = new_attachment_key
-            .decrypt_with_key(enc.get_key(&Some(org)).unwrap())
+            .decrypt(&mut key_store.context(), org_key)
             .unwrap();
         let new_attachment_key_dec: SymmetricCryptoKey = new_attachment_key_dec.try_into().unwrap();
         assert_eq!(new_attachment_key_dec.to_vec(), attachment_key.to_vec());
@@ -1012,7 +1058,7 @@ mod tests {
             .unwrap()
             .first()
             .unwrap()
-            .decrypt_with_key(enc.get_key(&Some(org)).unwrap())
+            .decrypt(&mut key_store.context(), org_key)
             .unwrap();
 
         assert_eq!(cred2.credential_id, "123");
@@ -1021,23 +1067,26 @@ mod tests {
     #[test]
     fn test_move_user_cipher_with_key_with_attachment_with_key_to_org() {
         let org = uuid::Uuid::new_v4();
+        let key = SymmetricCryptoKey::generate(rand::thread_rng());
+        let org_key = SymmetricCryptoKey::generate(rand::thread_rng());
+        let key_store = create_test_crypto_with_user_and_org_key(key, org, org_key);
+        let org_key = SymmetricKeyId::Organization(org);
 
-        let enc = MockKeyContainer(HashMap::from([
-            (None, SymmetricCryptoKey::generate(rand::thread_rng())),
-            (Some(org), SymmetricCryptoKey::generate(rand::thread_rng())),
-        ]));
+        let mut ctx = key_store.context();
 
-        let cipher_key = SymmetricCryptoKey::generate(rand::thread_rng());
-        let cipher_key_enc = cipher_key
-            .to_vec()
-            .encrypt_with_key(enc.get_key(&None).unwrap())
+        let cipher_key = ctx
+            .generate_symmetric_key(SymmetricKeyId::Local("test_cipher_key"))
+            .unwrap();
+        let cipher_key_enc = ctx
+            .encrypt_symmetric_key_with_symmetric_key(SymmetricKeyId::User, cipher_key)
             .unwrap();
 
         // Attachment has a key that is encrypted with the cipher key
-        let attachment_key = SymmetricCryptoKey::generate(rand::thread_rng());
-        let attachment_key_enc = attachment_key
-            .to_vec()
-            .encrypt_with_key(&cipher_key)
+        let attachment_key = ctx
+            .generate_symmetric_key(SymmetricKeyId::Local("test_attachment_key"))
+            .unwrap();
+        let attachment_key_enc = ctx
+            .encrypt_symmetric_key_with_symmetric_key(cipher_key, attachment_key)
             .unwrap();
 
         let mut cipher = generate_cipher();
@@ -1053,22 +1102,25 @@ mod tests {
         };
         cipher.attachments = Some(vec![attachment]);
 
-        let cred = generate_fido2(&cipher_key);
+        let cred = generate_fido2(&mut ctx, cipher_key);
         cipher.login.as_mut().unwrap().fido2_credentials = Some(vec![cred.clone()]);
 
-        cipher.move_to_organization(&enc, org).unwrap();
+        cipher.move_to_organization(&mut ctx, org).unwrap();
 
         // Check that the cipher key has been re-encrypted with the org key,
         let new_cipher_key_dec: Vec<_> = cipher
             .key
             .clone()
             .unwrap()
-            .decrypt_with_key(enc.get_key(&Some(org)).unwrap())
+            .decrypt(&mut ctx, org_key)
             .unwrap();
 
         let new_cipher_key_dec: SymmetricCryptoKey = new_cipher_key_dec.try_into().unwrap();
 
-        assert_eq!(new_cipher_key_dec.to_vec(), cipher_key.to_vec());
+        #[allow(deprecated)]
+        let cipher_key_val = ctx.dangerous_get_symmetric_key(cipher_key).unwrap();
+
+        assert_eq!(new_cipher_key_dec.to_vec(), cipher_key_val.to_vec());
 
         // Check that the attachment key hasn't changed
         assert_eq!(
@@ -1187,12 +1239,15 @@ mod tests {
 
     #[test]
     fn test_subtitle_ssh_key() {
-        let key = "hvBMMb1t79YssFZkpetYsM3deyVuQv4r88Uj9gvYe0+G8EwxvW3v1iywVmSl61iwzd17JW5C/ivzxSP2C9h7Tw==".to_string();
-        let key = SymmetricCryptoKey::try_from(key).unwrap();
+        let key = SymmetricCryptoKey::try_from("hvBMMb1t79YssFZkpetYsM3deyVuQv4r88Uj9gvYe0+G8EwxvW3v1iywVmSl61iwzd17JW5C/ivzxSP2C9h7Tw==".to_string()).unwrap();
+        let key_store = create_test_crypto_with_user_key(key);
+        let key = SymmetricKeyId::User;
+        let mut ctx = key_store.context();
+
         let original_subtitle = "SHA256:1JjFjvPRkj1Gbf2qRP1dgHiIzEuNAEvp+92x99jw3K0".to_string();
-        let fingerprint_encrypted = original_subtitle.to_owned().encrypt_with_key(&key).unwrap();
-        let private_key_encrypted = "".to_string().encrypt_with_key(&key).unwrap();
-        let public_key_encrypted = "".to_string().encrypt_with_key(&key).unwrap();
+        let fingerprint_encrypted = original_subtitle.to_owned().encrypt(&mut ctx, key).unwrap();
+        let private_key_encrypted = "".to_string().encrypt(&mut ctx, key).unwrap();
+        let public_key_encrypted = "".to_string().encrypt(&mut ctx, key).unwrap();
         let ssh_key_cipher = Cipher {
             id: Some("090c19ea-a61a-4df6-8963-262b97bc6266".parse().unwrap()),
             organization_id: None,
@@ -1202,7 +1257,7 @@ mod tests {
             key: None,
             name: "My test ssh key"
                 .to_string()
-                .encrypt_with_key(&key)
+                .encrypt(&mut ctx, key)
                 .unwrap(),
             notes: None,
             login: None,
@@ -1227,7 +1282,9 @@ mod tests {
             deleted_date: None,
             revision_date: "2024-01-01T00:00:00.000Z".parse().unwrap(),
         };
-        let subtitle = ssh_key_cipher.get_decrypted_subtitle(&key).unwrap();
+        let subtitle = ssh_key_cipher
+            .get_decrypted_subtitle(&mut ctx, key)
+            .unwrap();
         assert_eq!(subtitle, original_subtitle);
     }
 }

--- a/crates/bitwarden-vault/src/cipher/cipher.rs
+++ b/crates/bitwarden-vault/src/cipher/cipher.rs
@@ -1014,19 +1014,22 @@ mod tests {
         let org_key = SymmetricKeyId::Organization(org);
 
         // Attachment has a key that is encrypted with the user key, as the cipher has no key itself
-        let mut ctx = key_store.context();
-        let attachment_key = ctx
-            .generate_symmetric_key(SymmetricKeyId::Local("test_attachment_key"))
-            .unwrap();
-        let attachment_key_enc = ctx
-            .encrypt_symmetric_key_with_symmetric_key(SymmetricKeyId::User, attachment_key)
-            .unwrap();
-        #[allow(deprecated)]
-        let attachment_key_val = ctx
-            .dangerous_get_symmetric_key(attachment_key)
-            .unwrap()
-            .clone();
-        drop(ctx);
+        let (attachment_key_enc, attachment_key_val) = {
+            let mut ctx = key_store.context();
+            let attachment_key = ctx
+                .generate_symmetric_key(SymmetricKeyId::Local("test_attachment_key"))
+                .unwrap();
+            let attachment_key_enc = ctx
+                .encrypt_symmetric_key_with_symmetric_key(SymmetricKeyId::User, attachment_key)
+                .unwrap();
+            #[allow(deprecated)]
+            let attachment_key_val = ctx
+                .dangerous_get_symmetric_key(attachment_key)
+                .unwrap()
+                .clone();
+
+            (attachment_key_enc, attachment_key_val)
+        };
 
         let mut cipher = generate_cipher();
         let attachment = AttachmentView {

--- a/crates/bitwarden-vault/src/cipher/cipher.rs
+++ b/crates/bitwarden-vault/src/cipher/cipher.rs
@@ -288,9 +288,9 @@ impl Decryptable<KeyIds, SymmetricKeyId, CipherView> for Cipher {
 }
 
 impl Cipher {
-    /// Decrypt the individual encryption key for this cipher and return it's identifier.
-    /// Note that some ciphers do not have individual encryption keys,
-    /// in which case this will return the provided key instead
+    /// Decrypt the individual encryption key for this cipher into the provided [KeyStoreContext]
+    /// and return it's identifier. Note that some ciphers do not have individual encryption
+    /// keys, in which case this will return the provided key identifier instead
     ///
     /// # Arguments
     ///

--- a/crates/bitwarden-vault/src/cipher/field.rs
+++ b/crates/bitwarden-vault/src/cipher/field.rs
@@ -1,8 +1,9 @@
 use bitwarden_api_api::models::CipherFieldModel;
-use bitwarden_core::require;
-use bitwarden_crypto::{
-    CryptoError, EncString, KeyDecryptable, KeyEncryptable, SymmetricCryptoKey,
+use bitwarden_core::{
+    key_management::{KeyIds, SymmetricKeyId},
+    require,
 };
+use bitwarden_crypto::{CryptoError, Decryptable, EncString, Encryptable, KeyStoreContext};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use serde_repr::{Deserialize_repr, Serialize_repr};
@@ -42,22 +43,30 @@ pub struct FieldView {
     pub linked_id: Option<LinkedIdType>,
 }
 
-impl KeyEncryptable<SymmetricCryptoKey, Field> for FieldView {
-    fn encrypt_with_key(self, key: &SymmetricCryptoKey) -> Result<Field, CryptoError> {
+impl Encryptable<KeyIds, SymmetricKeyId, Field> for FieldView {
+    fn encrypt(
+        &self,
+        ctx: &mut KeyStoreContext<KeyIds>,
+        key: SymmetricKeyId,
+    ) -> Result<Field, CryptoError> {
         Ok(Field {
-            name: self.name.encrypt_with_key(key)?,
-            value: self.value.encrypt_with_key(key)?,
+            name: self.name.encrypt(ctx, key)?,
+            value: self.value.encrypt(ctx, key)?,
             r#type: self.r#type,
             linked_id: self.linked_id,
         })
     }
 }
 
-impl KeyDecryptable<SymmetricCryptoKey, FieldView> for Field {
-    fn decrypt_with_key(&self, key: &SymmetricCryptoKey) -> Result<FieldView, CryptoError> {
+impl Decryptable<KeyIds, SymmetricKeyId, FieldView> for Field {
+    fn decrypt(
+        &self,
+        ctx: &mut KeyStoreContext<KeyIds>,
+        key: SymmetricKeyId,
+    ) -> Result<FieldView, CryptoError> {
         Ok(FieldView {
-            name: self.name.decrypt_with_key(key).ok().flatten(),
-            value: self.value.decrypt_with_key(key).ok().flatten(),
+            name: self.name.decrypt(ctx, key).ok().flatten(),
+            value: self.value.decrypt(ctx, key).ok().flatten(),
             r#type: self.r#type,
             linked_id: self.linked_id,
         })

--- a/crates/bitwarden-vault/src/cipher/identity.rs
+++ b/crates/bitwarden-vault/src/cipher/identity.rs
@@ -1,7 +1,6 @@
 use bitwarden_api_api::models::CipherIdentityModel;
-use bitwarden_crypto::{
-    CryptoError, EncString, KeyDecryptable, KeyEncryptable, SymmetricCryptoKey,
-};
+use bitwarden_core::key_management::{KeyIds, SymmetricKeyId};
+use bitwarden_crypto::{CryptoError, Decryptable, EncString, Encryptable, KeyStoreContext};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
@@ -55,52 +54,60 @@ pub struct IdentityView {
     pub license_number: Option<String>,
 }
 
-impl KeyEncryptable<SymmetricCryptoKey, Identity> for IdentityView {
-    fn encrypt_with_key(self, key: &SymmetricCryptoKey) -> Result<Identity, CryptoError> {
+impl Encryptable<KeyIds, SymmetricKeyId, Identity> for IdentityView {
+    fn encrypt(
+        &self,
+        ctx: &mut KeyStoreContext<KeyIds>,
+        key: SymmetricKeyId,
+    ) -> Result<Identity, CryptoError> {
         Ok(Identity {
-            title: self.title.encrypt_with_key(key)?,
-            first_name: self.first_name.encrypt_with_key(key)?,
-            middle_name: self.middle_name.encrypt_with_key(key)?,
-            last_name: self.last_name.encrypt_with_key(key)?,
-            address1: self.address1.encrypt_with_key(key)?,
-            address2: self.address2.encrypt_with_key(key)?,
-            address3: self.address3.encrypt_with_key(key)?,
-            city: self.city.encrypt_with_key(key)?,
-            state: self.state.encrypt_with_key(key)?,
-            postal_code: self.postal_code.encrypt_with_key(key)?,
-            country: self.country.encrypt_with_key(key)?,
-            company: self.company.encrypt_with_key(key)?,
-            email: self.email.encrypt_with_key(key)?,
-            phone: self.phone.encrypt_with_key(key)?,
-            ssn: self.ssn.encrypt_with_key(key)?,
-            username: self.username.encrypt_with_key(key)?,
-            passport_number: self.passport_number.encrypt_with_key(key)?,
-            license_number: self.license_number.encrypt_with_key(key)?,
+            title: self.title.encrypt(ctx, key)?,
+            first_name: self.first_name.encrypt(ctx, key)?,
+            middle_name: self.middle_name.encrypt(ctx, key)?,
+            last_name: self.last_name.encrypt(ctx, key)?,
+            address1: self.address1.encrypt(ctx, key)?,
+            address2: self.address2.encrypt(ctx, key)?,
+            address3: self.address3.encrypt(ctx, key)?,
+            city: self.city.encrypt(ctx, key)?,
+            state: self.state.encrypt(ctx, key)?,
+            postal_code: self.postal_code.encrypt(ctx, key)?,
+            country: self.country.encrypt(ctx, key)?,
+            company: self.company.encrypt(ctx, key)?,
+            email: self.email.encrypt(ctx, key)?,
+            phone: self.phone.encrypt(ctx, key)?,
+            ssn: self.ssn.encrypt(ctx, key)?,
+            username: self.username.encrypt(ctx, key)?,
+            passport_number: self.passport_number.encrypt(ctx, key)?,
+            license_number: self.license_number.encrypt(ctx, key)?,
         })
     }
 }
 
-impl KeyDecryptable<SymmetricCryptoKey, IdentityView> for Identity {
-    fn decrypt_with_key(&self, key: &SymmetricCryptoKey) -> Result<IdentityView, CryptoError> {
+impl Decryptable<KeyIds, SymmetricKeyId, IdentityView> for Identity {
+    fn decrypt(
+        &self,
+        ctx: &mut KeyStoreContext<KeyIds>,
+        key: SymmetricKeyId,
+    ) -> Result<IdentityView, CryptoError> {
         Ok(IdentityView {
-            title: self.title.decrypt_with_key(key).ok().flatten(),
-            first_name: self.first_name.decrypt_with_key(key).ok().flatten(),
-            middle_name: self.middle_name.decrypt_with_key(key).ok().flatten(),
-            last_name: self.last_name.decrypt_with_key(key).ok().flatten(),
-            address1: self.address1.decrypt_with_key(key).ok().flatten(),
-            address2: self.address2.decrypt_with_key(key).ok().flatten(),
-            address3: self.address3.decrypt_with_key(key).ok().flatten(),
-            city: self.city.decrypt_with_key(key).ok().flatten(),
-            state: self.state.decrypt_with_key(key).ok().flatten(),
-            postal_code: self.postal_code.decrypt_with_key(key).ok().flatten(),
-            country: self.country.decrypt_with_key(key).ok().flatten(),
-            company: self.company.decrypt_with_key(key).ok().flatten(),
-            email: self.email.decrypt_with_key(key).ok().flatten(),
-            phone: self.phone.decrypt_with_key(key).ok().flatten(),
-            ssn: self.ssn.decrypt_with_key(key).ok().flatten(),
-            username: self.username.decrypt_with_key(key).ok().flatten(),
-            passport_number: self.passport_number.decrypt_with_key(key).ok().flatten(),
-            license_number: self.license_number.decrypt_with_key(key).ok().flatten(),
+            title: self.title.decrypt(ctx, key).ok().flatten(),
+            first_name: self.first_name.decrypt(ctx, key).ok().flatten(),
+            middle_name: self.middle_name.decrypt(ctx, key).ok().flatten(),
+            last_name: self.last_name.decrypt(ctx, key).ok().flatten(),
+            address1: self.address1.decrypt(ctx, key).ok().flatten(),
+            address2: self.address2.decrypt(ctx, key).ok().flatten(),
+            address3: self.address3.decrypt(ctx, key).ok().flatten(),
+            city: self.city.decrypt(ctx, key).ok().flatten(),
+            state: self.state.decrypt(ctx, key).ok().flatten(),
+            postal_code: self.postal_code.decrypt(ctx, key).ok().flatten(),
+            country: self.country.decrypt(ctx, key).ok().flatten(),
+            company: self.company.decrypt(ctx, key).ok().flatten(),
+            email: self.email.decrypt(ctx, key).ok().flatten(),
+            phone: self.phone.decrypt(ctx, key).ok().flatten(),
+            ssn: self.ssn.decrypt(ctx, key).ok().flatten(),
+            username: self.username.decrypt(ctx, key).ok().flatten(),
+            passport_number: self.passport_number.decrypt(ctx, key).ok().flatten(),
+            license_number: self.license_number.decrypt(ctx, key).ok().flatten(),
         })
     }
 }

--- a/crates/bitwarden-vault/src/cipher/local_data.rs
+++ b/crates/bitwarden-vault/src/cipher/local_data.rs
@@ -1,4 +1,5 @@
-use bitwarden_crypto::{CryptoError, KeyDecryptable, KeyEncryptable, SymmetricCryptoKey};
+use bitwarden_core::key_management::{KeyIds, SymmetricKeyId};
+use bitwarden_crypto::{CryptoError, Decryptable, Encryptable, KeyStoreContext};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
@@ -18,8 +19,12 @@ pub struct LocalDataView {
     last_launched: Option<u32>,
 }
 
-impl KeyEncryptable<SymmetricCryptoKey, LocalData> for LocalDataView {
-    fn encrypt_with_key(self, _key: &SymmetricCryptoKey) -> Result<LocalData, CryptoError> {
+impl Encryptable<KeyIds, SymmetricKeyId, LocalData> for LocalDataView {
+    fn encrypt(
+        &self,
+        _ctx: &mut KeyStoreContext<KeyIds>,
+        _key: SymmetricKeyId,
+    ) -> Result<LocalData, CryptoError> {
         Ok(LocalData {
             last_used_date: self.last_used_date,
             last_launched: self.last_launched,
@@ -27,8 +32,12 @@ impl KeyEncryptable<SymmetricCryptoKey, LocalData> for LocalDataView {
     }
 }
 
-impl KeyDecryptable<SymmetricCryptoKey, LocalDataView> for LocalData {
-    fn decrypt_with_key(&self, _key: &SymmetricCryptoKey) -> Result<LocalDataView, CryptoError> {
+impl Decryptable<KeyIds, SymmetricKeyId, LocalDataView> for LocalData {
+    fn decrypt(
+        &self,
+        _ctx: &mut KeyStoreContext<KeyIds>,
+        _key: SymmetricKeyId,
+    ) -> Result<LocalDataView, CryptoError> {
         Ok(LocalDataView {
             last_used_date: self.last_used_date,
             last_launched: self.last_launched,

--- a/crates/bitwarden-vault/src/cipher/secure_note.rs
+++ b/crates/bitwarden-vault/src/cipher/secure_note.rs
@@ -1,6 +1,9 @@
 use bitwarden_api_api::models::CipherSecureNoteModel;
-use bitwarden_core::require;
-use bitwarden_crypto::{CryptoError, KeyDecryptable, KeyEncryptable, SymmetricCryptoKey};
+use bitwarden_core::{
+    key_management::{KeyIds, SymmetricKeyId},
+    require,
+};
+use bitwarden_crypto::{CryptoError, Decryptable, Encryptable, KeyStoreContext};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use serde_repr::{Deserialize_repr, Serialize_repr};
@@ -28,16 +31,24 @@ pub struct SecureNoteView {
     pub r#type: SecureNoteType,
 }
 
-impl KeyEncryptable<SymmetricCryptoKey, SecureNote> for SecureNoteView {
-    fn encrypt_with_key(self, _key: &SymmetricCryptoKey) -> Result<SecureNote, CryptoError> {
+impl Encryptable<KeyIds, SymmetricKeyId, SecureNote> for SecureNoteView {
+    fn encrypt(
+        &self,
+        _ctx: &mut KeyStoreContext<KeyIds>,
+        _key: SymmetricKeyId,
+    ) -> Result<SecureNote, CryptoError> {
         Ok(SecureNote {
             r#type: self.r#type,
         })
     }
 }
 
-impl KeyDecryptable<SymmetricCryptoKey, SecureNoteView> for SecureNote {
-    fn decrypt_with_key(&self, _key: &SymmetricCryptoKey) -> Result<SecureNoteView, CryptoError> {
+impl Decryptable<KeyIds, SymmetricKeyId, SecureNoteView> for SecureNote {
+    fn decrypt(
+        &self,
+        _ctx: &mut KeyStoreContext<KeyIds>,
+        _key: SymmetricKeyId,
+    ) -> Result<SecureNoteView, CryptoError> {
         Ok(SecureNoteView {
             r#type: self.r#type,
         })

--- a/crates/bitwarden-vault/src/cipher/ssh_key.rs
+++ b/crates/bitwarden-vault/src/cipher/ssh_key.rs
@@ -1,6 +1,5 @@
-use bitwarden_crypto::{
-    CryptoError, EncString, KeyDecryptable, KeyEncryptable, SymmetricCryptoKey,
-};
+use bitwarden_core::key_management::{KeyIds, SymmetricKeyId};
+use bitwarden_crypto::{CryptoError, Decryptable, EncString, Encryptable, KeyStoreContext};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
@@ -28,22 +27,30 @@ pub struct SshKeyView {
     pub fingerprint: String,
 }
 
-impl KeyEncryptable<SymmetricCryptoKey, SshKey> for SshKeyView {
-    fn encrypt_with_key(self, key: &SymmetricCryptoKey) -> Result<SshKey, CryptoError> {
+impl Encryptable<KeyIds, SymmetricKeyId, SshKey> for SshKeyView {
+    fn encrypt(
+        &self,
+        ctx: &mut KeyStoreContext<KeyIds>,
+        key: SymmetricKeyId,
+    ) -> Result<SshKey, CryptoError> {
         Ok(SshKey {
-            private_key: self.private_key.encrypt_with_key(key)?,
-            public_key: self.public_key.encrypt_with_key(key)?,
-            fingerprint: self.fingerprint.encrypt_with_key(key)?,
+            private_key: self.private_key.encrypt(ctx, key)?,
+            public_key: self.public_key.encrypt(ctx, key)?,
+            fingerprint: self.fingerprint.encrypt(ctx, key)?,
         })
     }
 }
 
-impl KeyDecryptable<SymmetricCryptoKey, SshKeyView> for SshKey {
-    fn decrypt_with_key(&self, key: &SymmetricCryptoKey) -> Result<SshKeyView, CryptoError> {
+impl Decryptable<KeyIds, SymmetricKeyId, SshKeyView> for SshKey {
+    fn decrypt(
+        &self,
+        ctx: &mut KeyStoreContext<KeyIds>,
+        key: SymmetricKeyId,
+    ) -> Result<SshKeyView, CryptoError> {
         Ok(SshKeyView {
-            private_key: self.private_key.decrypt_with_key(key)?,
-            public_key: self.public_key.decrypt_with_key(key)?,
-            fingerprint: self.fingerprint.decrypt_with_key(key)?,
+            private_key: self.private_key.decrypt(ctx, key)?,
+            public_key: self.public_key.decrypt(ctx, key)?,
+            fingerprint: self.fingerprint.decrypt(ctx, key)?,
         })
     }
 }

--- a/crates/bitwarden-vault/src/mobile/folder_client.rs
+++ b/crates/bitwarden-vault/src/mobile/folder_client.rs
@@ -1,5 +1,4 @@
 use bitwarden_core::Client;
-use bitwarden_crypto::{KeyDecryptable, KeyEncryptable};
 
 use crate::{
     error::{DecryptError, EncryptError},
@@ -12,29 +11,20 @@ pub struct ClientFolders<'a> {
 
 impl ClientFolders<'_> {
     pub fn encrypt(&self, folder_view: FolderView) -> Result<Folder, EncryptError> {
-        let enc = self.client.internal.get_encryption_settings()?;
-        let key = enc.get_key(&None)?;
-
-        let folder = folder_view.encrypt_with_key(key)?;
-
+        let key_store = self.client.internal.get_key_store();
+        let folder = key_store.encrypt(folder_view)?;
         Ok(folder)
     }
 
     pub fn decrypt(&self, folder: Folder) -> Result<FolderView, DecryptError> {
-        let enc = self.client.internal.get_encryption_settings()?;
-        let key = enc.get_key(&None)?;
-
-        let folder_view = folder.decrypt_with_key(key)?;
-
+        let key_store = self.client.internal.get_key_store();
+        let folder_view = key_store.decrypt(&folder)?;
         Ok(folder_view)
     }
 
     pub fn decrypt_list(&self, folders: Vec<Folder>) -> Result<Vec<FolderView>, DecryptError> {
-        let enc = self.client.internal.get_encryption_settings()?;
-        let key = enc.get_key(&None)?;
-
-        let views = folders.decrypt_with_key(key)?;
-
+        let key_store = self.client.internal.get_key_store();
+        let views = key_store.decrypt_list(&folders)?;
         Ok(views)
     }
 }

--- a/crates/bitwarden-vault/src/mobile/password_history_client.rs
+++ b/crates/bitwarden-vault/src/mobile/password_history_client.rs
@@ -1,5 +1,4 @@
 use bitwarden_core::Client;
-use bitwarden_crypto::{KeyDecryptable, KeyEncryptable};
 
 use crate::{DecryptError, EncryptError, PasswordHistory, PasswordHistoryView, VaultClient};
 
@@ -12,11 +11,8 @@ impl ClientPasswordHistory<'_> {
         &self,
         history_view: PasswordHistoryView,
     ) -> Result<PasswordHistory, EncryptError> {
-        let enc = self.client.internal.get_encryption_settings()?;
-        let key = enc.get_key(&None)?;
-
-        let history = history_view.encrypt_with_key(key)?;
-
+        let key_store = self.client.internal.get_key_store();
+        let history = key_store.encrypt(history_view)?;
         Ok(history)
     }
 
@@ -24,11 +20,8 @@ impl ClientPasswordHistory<'_> {
         &self,
         history: Vec<PasswordHistory>,
     ) -> Result<Vec<PasswordHistoryView>, DecryptError> {
-        let enc = self.client.internal.get_encryption_settings()?;
-        let key = enc.get_key(&None)?;
-
-        let history_view = history.decrypt_with_key(key)?;
-
+        let key_store = self.client.internal.get_key_store();
+        let history_view = key_store.decrypt_list(&history)?;
         Ok(history_view)
     }
 }

--- a/crates/bitwarden-vault/src/totp_client.rs
+++ b/crates/bitwarden-vault/src/totp_client.rs
@@ -25,8 +25,8 @@ impl<'a> VaultClient<'a> {
         view: CipherListView,
         time: Option<DateTime<Utc>>,
     ) -> Result<TotpResponse, TotpError> {
-        let enc = self.client.internal.get_encryption_settings()?;
+        let key_store = self.client.internal.get_key_store();
 
-        generate_totp_cipher_view(&enc, view, time)
+        generate_totp_cipher_view(&mut key_store.context(), view, time)
     }
 }


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-5693

## 📔 Objective

Migrated from https://github.com/bitwarden/sdk/pull/1117

Migrate the codebase to the new KeyStore introduced in https://github.com/bitwarden/sdk-internal/pull/7.

EncryptionSettings was removed from Client, though it is still used to initialize the KeyStore. Ideally we'd move that initialization code over directly into the crypto crate but this PR is big enough as it is.

There are still some things using keys directly and KeyEncryptable/KeyDecryptable, like MasterKey, PinKey, DeviceKey, private key fingerprint. Those would need to be migrated over on a separate PR. 

We need to remove the rest of the uses of SymmetricCryptoKey from the client crates, then we can remove the internal boxing they are doing, as the keys would be protected by the KeyStore instead.


Secrets Manager code should be moved to using the Encryptable/Decryptable interface, as it's encrypting fields one by one, I'll look into doing that on a separate PR.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation
  team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
