### PR TITLE
[PM-13650] Use transpiled JS build

### DIFF
--- a/languages/js/sdk-internal/index.js
+++ b/languages/js/sdk-internal/index.js
@@ -1,8 +1,37 @@
+// https://stackoverflow.com/a/47880734
+const supported = (() => {
+  try {
+    if (typeof WebAssembly === "object" && typeof WebAssembly.instantiate === "function") {
+      const module = new WebAssembly.Module(
+        Uint8Array.of(0x0, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00),
+      );
+      if (module instanceof WebAssembly.Module) {
+        return new WebAssembly.Instance(module) instanceof WebAssembly.Instance;
+      }
+    }
+  } catch (e) {}
+  return false;
+})();
+
 import { __wbg_set_wasm } from "./bitwarden_wasm_internal_bg.js";
 
-// In order to support a fallback strategy for web we need to conditionally load the wasm file
-export function init(wasm) {
-  __wbg_set_wasm(wasm);
+let loaded_wasm;
+
+export async function init(wasm) {
+  if (loaded_wasm) {
+    return;
+  }
+
+  // If the caller provided a wasm module, use it for backwards compatibility.
+  if (wasm) {
+    loaded_wasm = wasm;
+  } else if (supported) {
+    loaded_wasm = await import("./bitwarden_wasm_internal_bg.wasm");
+  } else {
+    loaded_wasm = await import("./bitwarden_wasm_internal_bg.wasm.js");
+  }
+
+  __wbg_set_wasm(loaded_wasm);
 }
 
 export * from "./bitwarden_wasm_internal_bg.js";

--- a/languages/js/sdk-internal/package.json
+++ b/languages/js/sdk-internal/package.json
@@ -13,11 +13,12 @@
     "node/bitwarden_wasm_internal_bg.wasm",
     "node/bitwarden_wasm_internal_bg.wasm.d.ts",
     "node/bitwarden_wasm_internal.d.ts",
-    "node/bitwarden_wasm_internal.js"
+    "node/bitwarden_wasm_internal.js",
+    "types.d.ts"
   ],
   "main": "node/bitwarden_wasm_internal.js",
   "module": "index.js",
-  "types": "bitwarden_wasm_internal.d.ts",
+  "types": "types.d.ts",
   "scripts": {},
   "sideEffects": [
     "./bitwarden_wasm_internal.js"

--- a/languages/js/sdk-internal/types.d.ts
+++ b/languages/js/sdk-internal/types.d.ts
@@ -1,0 +1,3 @@
+export * from "./bitwarden_wasm_internal";
+
+export function init(module?: any): Promise<void>;


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-13650

## 📔 Objective

We're bundling the transpiled WASM to JS SDK, but never actually using it. This PR loads the transpiled JS when WASM isn't supported.

I've also added typing support for the init function.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation
  team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
