### PR TITLE
Make ssh key fields non-optional

### DIFF
--- a/crates/bitwarden-exporters/src/json.rs
+++ b/crates/bitwarden-exporters/src/json.rs
@@ -213,9 +213,9 @@ impl From<Identity> for JsonIdentity {
 #[derive(serde::Serialize)]
 #[serde(rename_all = "camelCase")]
 struct JsonSshKey {
-    private_key: Option<String>,
-    public_key: Option<String>,
-    fingerprint: Option<String>,
+    private_key: String,
+    public_key: String,
+    fingerprint: String,
 }
 
 impl From<SshKey> for JsonSshKey {
@@ -629,9 +629,9 @@ mod tests {
             notes: None,
 
             r#type: CipherType::SshKey(Box::new(SshKey {
-                private_key: Some("private".to_string()),
-                public_key: Some("public".to_string()),
-                fingerprint: Some("fingerprint".to_string()),
+                private_key: "private".to_string(),
+                public_key: "public".to_string(),
+                fingerprint: "fingerprint".to_string(),
             })),
 
             favorite: false,
@@ -837,9 +837,9 @@ mod tests {
                     notes: None,
 
                     r#type: CipherType::SshKey(Box::new(SshKey {
-                        private_key: Some("-----BEGIN OPENSSH PRIVATE KEY-----\nb3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAAAAAABAAAAMwAAAAtzc2gtZW\nQyNTUxOQAAACBinNE5chMtCHh3BV0H1+CpPlEQBwR5cD+Xb9i8MaHGiwAAAKAy48fwMuPH\n8AAAAAtzc2gtZWQyNTUxOQAAACBinNE5chMtCHh3BV0H1+CpPlEQBwR5cD+Xb9i8MaHGiw\nAAAEAYUCIdfLI14K3XIy9V0FDZLQoZ9gcjOnvFjb4uA335HmKc0TlyEy0IeHcFXQfX4Kk+\nURAHBHlwP5dv2LwxocaLAAAAHHF1ZXh0ZW5ATWFjQm9vay1Qcm8tMTYubG9jYWwB\n-----END OPENSSH PRIVATE KEY-----".to_string()),
-                        public_key: Some("ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGKc0TlyEy0IeHcFXQfX4Kk+URAHBHlwP5dv2LwxocaL".to_string()),
-                        fingerprint: Some("SHA256:1JjFjvPRkj1Gbf2qRP1dgHiIzEuNAEvp+92x99jw3K0".to_string()),
+                        private_key: "-----BEGIN OPENSSH PRIVATE KEY-----\nb3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAAAAAABAAAAMwAAAAtzc2gtZW\nQyNTUxOQAAACBinNE5chMtCHh3BV0H1+CpPlEQBwR5cD+Xb9i8MaHGiwAAAKAy48fwMuPH\n8AAAAAtzc2gtZWQyNTUxOQAAACBinNE5chMtCHh3BV0H1+CpPlEQBwR5cD+Xb9i8MaHGiw\nAAAEAYUCIdfLI14K3XIy9V0FDZLQoZ9gcjOnvFjb4uA335HmKc0TlyEy0IeHcFXQfX4Kk+\nURAHBHlwP5dv2LwxocaLAAAAHHF1ZXh0ZW5ATWFjQm9vay1Qcm8tMTYubG9jYWwB\n-----END OPENSSH PRIVATE KEY-----".to_string(),
+                        public_key: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGKc0TlyEy0IeHcFXQfX4Kk+URAHBHlwP5dv2LwxocaL".to_string(),
+                        fingerprint: "SHA256:1JjFjvPRkj1Gbf2qRP1dgHiIzEuNAEvp+92x99jw3K0".to_string(),
                     })),
 
                     favorite: false,

--- a/crates/bitwarden-exporters/src/lib.rs
+++ b/crates/bitwarden-exporters/src/lib.rs
@@ -137,9 +137,9 @@ pub struct Identity {
 
 pub struct SshKey {
     /// [OpenSSH private key](https://github.com/openssh/openssh-portable/blob/master/PROTOCOL.key), in PEM encoding.
-    pub private_key: Option<String>,
+    pub private_key: String,
     /// Ssh public key (ed25519/rsa) according to [RFC4253](https://datatracker.ietf.org/doc/html/rfc4253#section-6.6)
-    pub public_key: Option<String>,
+    pub public_key: String,
     /// SSH fingerprint using SHA256 in the format: `SHA256:BASE64_ENCODED_FINGERPRINT`
-    pub fingerprint: Option<String>,
+    pub fingerprint: String,
 }

--- a/crates/bitwarden-exporters/src/models.rs
+++ b/crates/bitwarden-exporters/src/models.rs
@@ -77,9 +77,9 @@ impl TryFrom<CipherView> for crate::Cipher {
             CipherType::SshKey => {
                 let s = require!(value.ssh_key);
                 crate::CipherType::SshKey(Box::new(crate::SshKey {
-                    private_key: Some(s.private_key),
-                    public_key: Some(s.public_key),
-                    fingerprint: Some(s.fingerprint),
+                    private_key: s.private_key,
+                    public_key: s.public_key,
+                    fingerprint: s.fingerprint,
                 }))
             }
         };

--- a/crates/bitwarden-exporters/src/models.rs
+++ b/crates/bitwarden-exporters/src/models.rs
@@ -77,9 +77,9 @@ impl TryFrom<CipherView> for crate::Cipher {
             CipherType::SshKey => {
                 let s = require!(value.ssh_key);
                 crate::CipherType::SshKey(Box::new(crate::SshKey {
-                    private_key: s.private_key,
-                    public_key: s.public_key,
-                    fingerprint: s.fingerprint,
+                    private_key: Some(s.private_key),
+                    public_key: Some(s.public_key),
+                    fingerprint: Some(s.fingerprint),
                 }))
             }
         };

--- a/crates/bitwarden-vault/src/cipher/cipher.rs
+++ b/crates/bitwarden-vault/src/cipher/cipher.rs
@@ -340,8 +340,7 @@ impl Cipher {
                     return Ok(String::new());
                 };
 
-                ssh_key
-                    .fingerprint
+                Some(ssh_key.fingerprint.clone())
                     .as_ref()
                     .map(|c| c.decrypt_with_key(key))
                     .transpose()?
@@ -1191,6 +1190,8 @@ mod tests {
         let key = SymmetricCryptoKey::try_from(key).unwrap();
         let original_subtitle = "SHA256:1JjFjvPRkj1Gbf2qRP1dgHiIzEuNAEvp+92x99jw3K0".to_string();
         let fingerprint_encrypted = original_subtitle.to_owned().encrypt_with_key(&key).unwrap();
+        let private_key_encrypted = "".to_string().encrypt_with_key(&key).unwrap();
+        let public_key_encrypted = "".to_string().encrypt_with_key(&key).unwrap();
         let ssh_key_cipher = Cipher {
             id: Some("090c19ea-a61a-4df6-8963-262b97bc6266".parse().unwrap()),
             organization_id: None,
@@ -1208,9 +1209,9 @@ mod tests {
             card: None,
             secure_note: None,
             ssh_key: Some(SshKey {
-                private_key: None,
-                public_key: None,
-                fingerprint: Some(fingerprint_encrypted),
+                private_key: private_key_encrypted,
+                public_key: public_key_encrypted,
+                fingerprint: fingerprint_encrypted,
             }),
             favorite: false,
             reprompt: CipherRepromptType::None,

--- a/crates/bitwarden-vault/src/cipher/ssh_key.rs
+++ b/crates/bitwarden-vault/src/cipher/ssh_key.rs
@@ -9,11 +9,11 @@ use serde::{Deserialize, Serialize};
 #[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
 pub struct SshKey {
     /// SSH private key (ed25519/rsa) in unencrypted openssh private key format [OpenSSH private key](https://github.com/openssh/openssh-portable/blob/master/PROTOCOL.key)
-    pub private_key: Option<EncString>,
+    pub private_key: EncString,
     /// SSH public key (ed25519/rsa) according to [RFC4253](https://datatracker.ietf.org/doc/html/rfc4253#section-6.6)
-    pub public_key: Option<EncString>,
+    pub public_key: EncString,
     /// SSH fingerprint using SHA256 in the format: `SHA256:BASE64_ENCODED_FINGERPRINT`
-    pub fingerprint: Option<EncString>,
+    pub fingerprint: EncString,
 }
 
 #[derive(Serialize, Deserialize, Debug, JsonSchema, Clone)]
@@ -21,11 +21,11 @@ pub struct SshKey {
 #[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
 pub struct SshKeyView {
     /// SSH private key (ed25519/rsa) in unencrypted openssh private key format [OpenSSH private key](https://github.com/openssh/openssh-portable/blob/master/PROTOCOL.key)
-    pub private_key: Option<String>,
+    pub private_key: String,
     /// SSH public key (ed25519/rsa) according to [RFC4253](https://datatracker.ietf.org/doc/html/rfc4253#section-6.6)
-    pub public_key: Option<String>,
+    pub public_key: String,
     /// SSH fingerprint using SHA256 in the format: `SHA256:BASE64_ENCODED_FINGERPRINT`
-    pub fingerprint: Option<String>,
+    pub fingerprint: String,
 }
 
 impl KeyEncryptable<SymmetricCryptoKey, SshKey> for SshKeyView {
@@ -41,9 +41,9 @@ impl KeyEncryptable<SymmetricCryptoKey, SshKey> for SshKeyView {
 impl KeyDecryptable<SymmetricCryptoKey, SshKeyView> for SshKey {
     fn decrypt_with_key(&self, key: &SymmetricCryptoKey) -> Result<SshKeyView, CryptoError> {
         Ok(SshKeyView {
-            private_key: self.private_key.decrypt_with_key(key).ok().flatten(),
-            public_key: self.public_key.decrypt_with_key(key).ok().flatten(),
-            fingerprint: self.fingerprint.decrypt_with_key(key).ok().flatten(),
+            private_key: Some(self.private_key.clone()).decrypt_with_key(key).ok().flatten().ok_or(CryptoError::MissingField("private_key"))?,
+            public_key: Some(self.public_key.clone()).decrypt_with_key(key).ok().flatten().ok_or(CryptoError::MissingField("public_key"))?,
+            fingerprint: Some(self.fingerprint.clone()).decrypt_with_key(key).ok().flatten().ok_or(CryptoError::MissingField("fingerprint"))?,
         })
     }
 }

--- a/crates/bitwarden-vault/src/cipher/ssh_key.rs
+++ b/crates/bitwarden-vault/src/cipher/ssh_key.rs
@@ -41,9 +41,21 @@ impl KeyEncryptable<SymmetricCryptoKey, SshKey> for SshKeyView {
 impl KeyDecryptable<SymmetricCryptoKey, SshKeyView> for SshKey {
     fn decrypt_with_key(&self, key: &SymmetricCryptoKey) -> Result<SshKeyView, CryptoError> {
         Ok(SshKeyView {
-            private_key: Some(self.private_key.clone()).decrypt_with_key(key).ok().flatten().ok_or(CryptoError::MissingField("private_key"))?,
-            public_key: Some(self.public_key.clone()).decrypt_with_key(key).ok().flatten().ok_or(CryptoError::MissingField("public_key"))?,
-            fingerprint: Some(self.fingerprint.clone()).decrypt_with_key(key).ok().flatten().ok_or(CryptoError::MissingField("fingerprint"))?,
+            private_key: Some(self.private_key.clone())
+                .decrypt_with_key(key)
+                .ok()
+                .flatten()
+                .ok_or(CryptoError::MissingField("private_key"))?,
+            public_key: Some(self.public_key.clone())
+                .decrypt_with_key(key)
+                .ok()
+                .flatten()
+                .ok_or(CryptoError::MissingField("public_key"))?,
+            fingerprint: Some(self.fingerprint.clone())
+                .decrypt_with_key(key)
+                .ok()
+                .flatten()
+                .ok_or(CryptoError::MissingField("fingerprint"))?,
         })
     }
 }

--- a/crates/bitwarden-vault/src/cipher/ssh_key.rs
+++ b/crates/bitwarden-vault/src/cipher/ssh_key.rs
@@ -41,21 +41,9 @@ impl KeyEncryptable<SymmetricCryptoKey, SshKey> for SshKeyView {
 impl KeyDecryptable<SymmetricCryptoKey, SshKeyView> for SshKey {
     fn decrypt_with_key(&self, key: &SymmetricCryptoKey) -> Result<SshKeyView, CryptoError> {
         Ok(SshKeyView {
-            private_key: Some(self.private_key.clone())
-                .decrypt_with_key(key)
-                .ok()
-                .flatten()
-                .ok_or(CryptoError::MissingField("private_key"))?,
-            public_key: Some(self.public_key.clone())
-                .decrypt_with_key(key)
-                .ok()
-                .flatten()
-                .ok_or(CryptoError::MissingField("public_key"))?,
-            fingerprint: Some(self.fingerprint.clone())
-                .decrypt_with_key(key)
-                .ok()
-                .flatten()
-                .ok_or(CryptoError::MissingField("fingerprint"))?,
+            private_key: self.private_key.decrypt_with_key(key)?,
+            public_key: self.public_key.decrypt_with_key(key)?,
+            fingerprint: self.fingerprint.decrypt_with_key(key)?,
         })
     }
 }


### PR DESCRIPTION
## 🎟️ Tracking

-

## 📔 Objective

SSH key item fields should never be optional and are always present. All of these are set on creation / update.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation
  team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
