### PR TITLE
Fix memory_dumping Dockerfile

### DIFF
--- a/crates/memory-testing/Dockerfile
+++ b/crates/memory-testing/Dockerfile
@@ -10,6 +10,9 @@ COPY Cargo.toml Cargo.lock /app/
 COPY crates/bitwarden-crypto/Cargo.toml /app/crates/bitwarden-crypto/
 COPY crates/memory-testing/Cargo.toml   /app/crates/memory-testing/
 
+# Patch Cargo.toml to remove `, "bitwarden_license/*"` from the members array
+RUN sed -i 's/, "bitwarden_license\/\*"\(,\?\)/\1/' Cargo.toml
+
 RUN mkdir -p /app/crates/bitwarden-crypto/src \
     /app/crates/bitwarden-crypto/benches \
     /app/crates/memory-testing/src \


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective

When we moved `bitwarden-sm` to `bitwarden_license`, the memory dump docker tool broke as it was not copying those files over.

Because this is just a local test tool, rather than just copy everything over which would cause frequent cache busting, we can  remove the `bitwarden_license` folder from the workspace. 

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation
  team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
