### PR TITLE
BRE-404 - Bumping macOS runner version from 12 to 14

### DIFF
--- a/.github/workflows/rust-test.yml
+++ b/.github/workflows/rust-test.yml
@@ -28,7 +28,7 @@ jobs:
       matrix:
         os:
           - ubuntu-22.04
-          - macOS-12
+          - macOS-14
           - windows-2022
 
     steps:


### PR DESCRIPTION
## 🎟️ Tracking

[BRE-404 Update sdk-internal repository from macOS 12 to 14](https://bitwarden.atlassian.net/browse/BRE-404)

## 📔 Objective

Bumps the macOS version for the Rust tests from 12 to 14 as 12 will be deprecated by Github on 12/3/24 with brownouts beginning 11/4/24.

https://github.blog/changelog/2024-08-19-notice-of-upcoming-deprecations-and-breaking-changes-in-github-actions-runners/



## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation
  team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
