### PR TITLE
fix: SDK_VERSION not echoing properly

### DIFF
--- a/.github/workflows/build-wasm-internal.yml
+++ b/.github/workflows/build-wasm-internal.yml
@@ -37,8 +37,9 @@ jobs:
 
       - name: Set version
         run: |
-          echo SDK_VERSION="${REF_NAME} (${SHA:0:7})" >> $GITHUB_ENV
-          echo "SDK_VERSION=${SDK_VERSION}"
+          export SDK_VERSION="${REF_NAME} (${SHA:0:7})"
+          echo "SDK_VERSION='${SDK_VERSION}'" >> $GITHUB_ENV
+          echo "SDK_VERSION='${SDK_VERSION}'"
 
       - name: Setup Node
         uses: actions/setup-node@0a44ba7841725637a19e28fa30b79a866c81b0a6 # v4.0.4


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective

We were not properly exporting the variable in the workflow, which caused the `echo` to output an empty string

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation
  team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
