### PR TITLE
[PM-14808] Add uris to ListView

### DIFF
--- a/crates/bitwarden-vault/src/cipher/cipher.rs
+++ b/crates/bitwarden-vault/src/cipher/cipher.rs
@@ -14,6 +14,7 @@ use uuid::Uuid;
 use super::{
     attachment, card, field, identity,
     local_data::{LocalData, LocalDataView},
+    login::LoginListView,
     secure_note, ssh_key,
 };
 use crate::{
@@ -133,10 +134,7 @@ pub struct CipherView {
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 #[cfg_attr(feature = "uniffi", derive(uniffi::Enum))]
 pub enum CipherListViewType {
-    Login {
-        has_fido2: bool,
-        totp: Option<EncString>,
-    },
+    Login(LoginListView),
     SecureNote,
     Card,
     Identity,
@@ -182,10 +180,11 @@ impl CipherListView {
         let cipher_key = Cipher::get_cipher_key(key, &self.key)?;
         let key = cipher_key.as_ref().unwrap_or(key);
 
-        let totp = if let CipherListViewType::Login { totp, .. } = self.r#type {
-            totp.decrypt_with_key(key)?
-        } else {
-            None
+        let totp = match self.r#type {
+            CipherListViewType::Login(LoginListView { totp, .. }) => {
+                totp.map(|t| t.decrypt_with_key(key)).transpose()?
+            }
+            _ => None,
         };
 
         Ok(totp)
@@ -562,10 +561,7 @@ impl KeyDecryptable<SymmetricCryptoKey, CipherListView> for Cipher {
                         .login
                         .as_ref()
                         .ok_or(CryptoError::MissingField("login"))?;
-                    CipherListViewType::Login {
-                        has_fido2: login.fido2_credentials.is_some(),
-                        totp: login.totp.clone(),
-                    }
+                    CipherListViewType::Login(login.decrypt_with_key(key)?)
                 }
                 CipherType::SecureNote => CipherListViewType::SecureNote,
                 CipherType::Card => CipherListViewType::Card,
@@ -803,10 +799,11 @@ mod tests {
                 key: cipher.key,
                 name: "My test login".to_string(),
                 sub_title: "test_username".to_string(),
-                r#type: CipherListViewType::Login {
+                r#type: CipherListViewType::Login(LoginListView {
                     has_fido2: true,
-                    totp: cipher.login.as_ref().unwrap().totp.clone()
-                },
+                    totp: cipher.login.as_ref().unwrap().totp.clone(),
+                    uris: None,
+                }),
                 favorite: cipher.favorite,
                 reprompt: cipher.reprompt,
                 edit: cipher.edit,

--- a/crates/bitwarden-vault/src/cipher/login.rs
+++ b/crates/bitwarden-vault/src/cipher/login.rs
@@ -273,6 +273,7 @@ pub struct LoginView {
 #[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
 pub struct LoginListView {
     pub has_fido2: bool,
+    /// The TOTP key is not decrypted. Useable as is with [`crate::generate_totp_cipher_view`].
     pub totp: Option<EncString>,
     pub uris: Option<Vec<LoginUriView>>,
 }

--- a/crates/bitwarden-vault/src/cipher/login.rs
+++ b/crates/bitwarden-vault/src/cipher/login.rs
@@ -11,7 +11,7 @@ use serde_repr::{Deserialize_repr, Serialize_repr};
 
 use crate::VaultParseError;
 
-#[derive(Clone, Copy, Serialize_repr, Deserialize_repr, Debug, JsonSchema)]
+#[derive(Clone, Copy, Serialize_repr, Deserialize_repr, Debug, JsonSchema, PartialEq)]
 #[repr(u8)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 #[cfg_attr(feature = "uniffi", derive(uniffi::Enum))]
@@ -33,7 +33,7 @@ pub struct LoginUri {
     pub uri_checksum: Option<EncString>,
 }
 
-#[derive(Serialize, Deserialize, Debug, JsonSchema, Clone)]
+#[derive(Serialize, Deserialize, Debug, JsonSchema, Clone, PartialEq)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 #[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
 pub struct LoginUriView {
@@ -268,6 +268,15 @@ pub struct LoginView {
     pub fido2_credentials: Option<Vec<Fido2Credential>>,
 }
 
+#[derive(Serialize, Deserialize, Debug, JsonSchema, Clone, PartialEq)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+#[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
+pub struct LoginListView {
+    pub has_fido2: bool,
+    pub totp: Option<EncString>,
+    pub uris: Option<Vec<LoginUriView>>,
+}
+
 impl KeyEncryptable<SymmetricCryptoKey, LoginUri> for LoginUriView {
     fn encrypt_with_key(self, key: &SymmetricCryptoKey) -> Result<LoginUri, CryptoError> {
         Ok(LoginUri {
@@ -312,6 +321,16 @@ impl KeyDecryptable<SymmetricCryptoKey, LoginView> for Login {
             totp: self.totp.decrypt_with_key(key).ok().flatten(),
             autofill_on_page_load: self.autofill_on_page_load,
             fido2_credentials: self.fido2_credentials.clone(),
+        })
+    }
+}
+
+impl KeyDecryptable<SymmetricCryptoKey, LoginListView> for Login {
+    fn decrypt_with_key(&self, key: &SymmetricCryptoKey) -> Result<LoginListView, CryptoError> {
+        Ok(LoginListView {
+            has_fido2: self.fido2_credentials.is_some(),
+            totp: self.totp.clone(),
+            uris: self.uris.decrypt_with_key(key).ok().flatten(),
         })
     }
 }

--- a/crates/bitwarden-vault/src/totp.rs
+++ b/crates/bitwarden-vault/src/totp.rs
@@ -266,7 +266,7 @@ mod tests {
     use uuid::Uuid;
 
     use super::*;
-    use crate::{cipher::cipher::CipherListViewType, CipherRepromptType};
+    use crate::{cipher::cipher::CipherListViewType, login::LoginListView, CipherRepromptType};
 
     #[test]
     fn test_decode_b32() {
@@ -377,10 +377,11 @@ mod tests {
             key: None,
             name: "My test login".to_string(),
             sub_title: "test_username".to_string(),
-            r#type: CipherListViewType::Login {
+            r#type: CipherListViewType::Login(LoginListView{
                 has_fido2: true,
                 totp: Some("2.hqdioUAc81FsKQmO1XuLQg==|oDRdsJrQjoFu9NrFVy8tcJBAFKBx95gHaXZnWdXbKpsxWnOr2sKipIG43pKKUFuq|3gKZMiboceIB5SLVOULKg2iuyu6xzos22dfJbvx0EHk=".parse().unwrap()),
-            },
+                uris: None,
+            }),
             favorite: false,
             reprompt: CipherRepromptType::None,
             edit: true,


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-14808

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Adds the login URIs to `CipherListView` to make it useable for autofill.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation
  team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
