### PR TITLE
Fix path in Android build script

### DIFF
--- a/crates/bitwarden-uniffi/kotlin/publish-local.sh
+++ b/crates/bitwarden-uniffi/kotlin/publish-local.sh
@@ -7,7 +7,7 @@ mkdir -p ./sdk/src/main/jniLibs/{arm64-v8a,armeabi-v7a,x86_64,x86}
 
 # Build arm64 for emulator
 cross build -p bitwarden-uniffi --release --target=aarch64-linux-android
-mv ../../target/aarch64-linux-android/release/libbitwarden_uniffi.so ./sdk/src/main/jniLibs/arm64-v8a/libbitwarden_uniffi.so
+mv ../../../target/aarch64-linux-android/release/libbitwarden_uniffi.so ./sdk/src/main/jniLibs/arm64-v8a/libbitwarden_uniffi.so
 
 # Generate latest bindings
 ./build-schemas.sh

--- a/crates/bitwarden-uniffi/kotlin/publish-local.sh
+++ b/crates/bitwarden-uniffi/kotlin/publish-local.sh
@@ -2,12 +2,13 @@
 set -e
 
 cd "$(dirname "$0")"
+SDK_REPO_ROOT="$(git rev-parse --show-toplevel)"
 
 mkdir -p ./sdk/src/main/jniLibs/{arm64-v8a,armeabi-v7a,x86_64,x86}
 
 # Build arm64 for emulator
 cross build -p bitwarden-uniffi --release --target=aarch64-linux-android
-mv ../../../target/aarch64-linux-android/release/libbitwarden_uniffi.so ./sdk/src/main/jniLibs/arm64-v8a/libbitwarden_uniffi.so
+mv $SDK_REPO_ROOT/target/aarch64-linux-android/release/libbitwarden_uniffi.so ./sdk/src/main/jniLibs/arm64-v8a/libbitwarden_uniffi.so
 
 # Generate latest bindings
 ./build-schemas.sh


### PR DESCRIPTION
## 📔 Objective

When following the Contributing Docs to build the Android app, the build script couldn't find my `libbitwarden_uniffi.so` file. It seems the path for this changed in #26. This just updates the build script to use the new path.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation
  team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
