### PR TITLE
Remove need to depend on js-sys when consuming errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -357,7 +357,6 @@ dependencies = [
  "chrono",
  "getrandom",
  "hmac",
- "js-sys",
  "log",
  "rand",
  "rand_chacha",

--- a/crates/bitwarden-core/Cargo.toml
+++ b/crates/bitwarden-core/Cargo.toml
@@ -23,7 +23,6 @@ secrets = [] # Secrets manager API
 wasm = [
     "bitwarden-error/wasm",
     "dep:wasm-bindgen",
-    "dep:js-sys",
     "dep:tsify-next",
 ] # WASM support
 
@@ -54,7 +53,6 @@ wasm-bindgen = { workspace = true, optional = true }
 zeroize = { version = ">=1.7.0, <2.0", features = ["derive", "aarch64"] }
 zxcvbn = { version = ">=3.0.1, <4.0", optional = true }
 tsify-next = { workspace = true, optional = true }
-js-sys = { workspace = true, optional = true }
 bitwarden-error = { workspace = true }
 
 [target.'cfg(not(target_arch="wasm32"))'.dependencies]

--- a/crates/bitwarden-error-macro/src/basic/attribute.rs
+++ b/crates/bitwarden-error-macro/src/basic/attribute.rs
@@ -43,7 +43,7 @@ fn basic_error_wasm(
 
             #[wasm_bindgen(js_name = #is_error_function_name, skip_typescript)]
             pub fn is_error(error: &JsValue) -> bool {
-                let name_js_value = js_sys::Reflect::get(&error, &JsValue::from_str("name")).unwrap_or(JsValue::NULL);
+                let name_js_value = bitwarden_error::js_sys::Reflect::get(&error, &JsValue::from_str("name")).unwrap_or(JsValue::NULL);
                 let name = name_js_value.as_string().unwrap_or_default();
                 name == #export_as_identifier_str
             }

--- a/crates/bitwarden-error-macro/src/basic/attribute.rs
+++ b/crates/bitwarden-error-macro/src/basic/attribute.rs
@@ -36,7 +36,7 @@ fn basic_error_wasm(
 
     quote! {
         const _: () = {
-            use wasm_bindgen::prelude::*;
+            use bitwarden_error::wasm_bindgen::prelude::*;
 
             #[wasm_bindgen(typescript_custom_section)]
             const TS_APPEND_CONTENT: &'static str = #ts_code;

--- a/crates/bitwarden-error-macro/src/flat/attribute.rs
+++ b/crates/bitwarden-error-macro/src/flat/attribute.rs
@@ -89,7 +89,7 @@ fn flat_error_wasm(
 
     quote! {
         const _: () = {
-            use wasm_bindgen::prelude::*;
+            use bitwarden_error::wasm_bindgen::prelude::*;
 
             #[wasm_bindgen(typescript_custom_section)]
             const TS_APPEND_CONTENT: &'static str = #ts_code;

--- a/crates/bitwarden-error-macro/src/flat/attribute.rs
+++ b/crates/bitwarden-error-macro/src/flat/attribute.rs
@@ -96,7 +96,7 @@ fn flat_error_wasm(
 
             #[wasm_bindgen(js_name = #is_error_function_name, skip_typescript)]
             pub fn is_error(error: &JsValue) -> bool {
-                let name_js_value = js_sys::Reflect::get(&error, &JsValue::from_str("name")).unwrap_or(JsValue::NULL);
+                let name_js_value = bitwarden_error::js_sys::Reflect::get(&error, &JsValue::from_str("name")).unwrap_or(JsValue::NULL);
                 let name = name_js_value.as_string().unwrap_or_default();
                 name == #export_as_identifier_str
             }

--- a/crates/bitwarden-error-macro/src/full/attribute.rs
+++ b/crates/bitwarden-error-macro/src/full/attribute.rs
@@ -14,7 +14,7 @@ pub(crate) fn bitwarden_error_full(
 
     let wasm_attributes = cfg!(feature = "wasm").then(|| {
         quote! {
-            #[derive(tsify_next::Tsify)]
+            #[derive(bitwarden_error::tsify_next::Tsify)]
             #[tsify(into_wasm_abi)]
         }
     });

--- a/crates/bitwarden-error/Cargo.toml
+++ b/crates/bitwarden-error/Cargo.toml
@@ -10,19 +10,23 @@ license-file.workspace = true
 keywords.workspace = true
 
 [features]
-wasm = ["bitwarden-error-macro/wasm", "dep:js-sys", "dep:wasm-bindgen"]
+wasm = [
+    "bitwarden-error-macro/wasm",
+    "dep:js-sys",
+    "dep:tsify-next",
+    "dep:wasm-bindgen",
+]
 
 [dependencies]
 bitwarden-error-macro = { workspace = true }
 js-sys = { workspace = true, optional = true }
+tsify-next = { workspace = true, optional = true }
 wasm-bindgen = { workspace = true, optional = true }
 
 [lints]
 workspace = true
 
 [dev-dependencies]
-js-sys = "0.3.72"
 serde.workspace = true
 trybuild = "1.0.101"
-tsify-next.workspace = true
 wasm-bindgen-test = "0.3.45"

--- a/crates/bitwarden-error/Cargo.toml
+++ b/crates/bitwarden-error/Cargo.toml
@@ -10,10 +10,11 @@ license-file.workspace = true
 keywords.workspace = true
 
 [features]
-wasm = ["bitwarden-error-macro/wasm", "dep:wasm-bindgen"]
+wasm = ["bitwarden-error-macro/wasm", "dep:js-sys", "dep:wasm-bindgen"]
 
 [dependencies]
 bitwarden-error-macro = { workspace = true }
+js-sys = { workspace = true, optional = true }
 wasm-bindgen = { workspace = true, optional = true }
 
 [lints]

--- a/crates/bitwarden-error/src/lib.rs
+++ b/crates/bitwarden-error/src/lib.rs
@@ -3,6 +3,10 @@ pub mod flat_error;
 #[cfg(feature = "wasm")]
 pub mod wasm;
 
+/// Re-export the `js_sys` crate since the proc macro depends on it.
+#[cfg(feature = "wasm")]
+pub use ::js_sys;
+
 pub mod prelude {
     pub use bitwarden_error_macro::*;
 

--- a/crates/bitwarden-error/src/lib.rs
+++ b/crates/bitwarden-error/src/lib.rs
@@ -7,16 +7,14 @@ pub mod wasm;
 #[cfg(feature = "wasm")]
 #[doc(hidden)]
 pub use ::js_sys;
-
-/// Re-export the `wasm_bindgen` crate since the proc macro depends on it.
-#[cfg(feature = "wasm")]
-#[doc(hidden)]
-pub use ::wasm_bindgen;
-
 /// Re-export the `tsify_next` crate since the proc macro depends on it.
 #[cfg(feature = "wasm")]
 #[doc(hidden)]
 pub use ::tsify_next;
+/// Re-export the `wasm_bindgen` crate since the proc macro depends on it.
+#[cfg(feature = "wasm")]
+#[doc(hidden)]
+pub use ::wasm_bindgen;
 
 pub mod prelude {
     pub use bitwarden_error_macro::*;

--- a/crates/bitwarden-error/src/lib.rs
+++ b/crates/bitwarden-error/src/lib.rs
@@ -5,7 +5,18 @@ pub mod wasm;
 
 /// Re-export the `js_sys` crate since the proc macro depends on it.
 #[cfg(feature = "wasm")]
+#[doc(hidden)]
 pub use ::js_sys;
+
+/// Re-export the `wasm_bindgen` crate since the proc macro depends on it.
+#[cfg(feature = "wasm")]
+#[doc(hidden)]
+pub use ::wasm_bindgen;
+
+/// Re-export the `tsify_next` crate since the proc macro depends on it.
+#[cfg(feature = "wasm")]
+#[doc(hidden)]
+pub use ::tsify_next;
 
 pub mod prelude {
     pub use bitwarden_error_macro::*;


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Switch from requiring consumers to depend on js-sys and let bitwarden-error crate re-expose it. Do we need to do the same thing for tsify?

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation
  team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
