### PR TITLE
Fix invalid serde rename

### DIFF
--- a/crates/bitwarden-core/src/auth/api/request/password_token_request.rs
+++ b/crates/bitwarden-core/src/auth/api/request/password_token_request.rs
@@ -31,7 +31,7 @@ pub struct PasswordTokenRequest {
     two_factor_token: Option<String>,
     #[serde(rename = "twoFactorProvider")]
     two_factor_provider: Option<TwoFactorProvider>,
-    #[serde(rename = "twoFactorToken")]
+    #[serde(rename = "twoFactorRemember")]
     two_factor_remember: Option<bool>,
 }
 


### PR DESCRIPTION
## 🎟️ Tracking

## 📔 Objective

I noticed this because it was breaking the lockfile renovate PR, maybe a serde update now detects it?

We were incorrectly renaming `two_factor_remember` to `twoFactorToken`, which already existed.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation
  team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
