### PR TITLE
Update WASM to use MVP for transpilation

### DIFF
--- a/.github/workflows/build-wasm-internal.yml
+++ b/.github/workflows/build-wasm-internal.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Install rust
         uses: dtolnay/rust-toolchain@7b1c307e0dcbda6122208f10795a713336a9b35a # stable
         with:
-          toolchain: 1.81.0
+          toolchain: stable
           targets: wasm32-unknown-unknown
 
       - name: Cache cargo registry

--- a/.github/workflows/build-wasm-internal.yml
+++ b/.github/workflows/build-wasm-internal.yml
@@ -56,6 +56,7 @@ jobs:
         with:
           toolchain: stable
           targets: wasm32-unknown-unknown
+          components: rust-src
 
       - name: Cache cargo registry
         uses: Swatinem/rust-cache@82a92a6e8fbeee089604da2575dc567ae9ddeaab # v2.7.5

--- a/crates/bitwarden-wasm-internal/build.sh
+++ b/crates/bitwarden-wasm-internal/build.sh
@@ -13,7 +13,7 @@ else
 fi
 
 # Build normally
-cargo build -p bitwarden-wasm-internal --target wasm32-unknown-unknown 
+cargo build -p bitwarden-wasm-internal --target wasm32-unknown-unknown ${RELEASE_FLAG}
 wasm-bindgen --target bundler --out-dir crates/bitwarden-wasm-internal/npm ./target/wasm32-unknown-unknown/${BUILD_FOLDER}/bitwarden_wasm_internal.wasm
 wasm-bindgen --target nodejs --out-dir crates/bitwarden-wasm-internal/npm/node ./target/wasm32-unknown-unknown/${BUILD_FOLDER}/bitwarden_wasm_internal.wasm
 
@@ -21,7 +21,7 @@ wasm-bindgen --target nodejs --out-dir crates/bitwarden-wasm-internal/npm/node .
 # Note that this requirest build-std which is an unstable feature,
 # this normally requires a nightly build, but we can also use the 
 # RUSTC_BOOTSTRAP hack to use the same stable version as the normal build
-RUSTFLAGS=-Ctarget-cpu=mvp RUSTC_BOOTSTRAP=1 cargo build -p bitwarden-wasm-internal -Zbuild-std=panic_abort,std --target wasm32-unknown-unknown 
+RUSTFLAGS=-Ctarget-cpu=mvp RUSTC_BOOTSTRAP=1 cargo build -p bitwarden-wasm-internal -Zbuild-std=panic_abort,std --target wasm32-unknown-unknown ${RELEASE_FLAG}
 cp ./target/wasm32-unknown-unknown/${BUILD_FOLDER}/bitwarden_wasm_internal.wasm ./crates/bitwarden-wasm-internal/npm/node/bitwarden_wasm_internal_bg.mvp.wasm
 
 # Format

--- a/crates/bitwarden-wasm-internal/build.sh
+++ b/crates/bitwarden-wasm-internal/build.sh
@@ -3,23 +3,38 @@ cd "$(dirname "$0")"
 cd ../../
 
 if [ "$1" != "-r" ]; then
-  # Dev
-  cargo build -p bitwarden-wasm-internal --target wasm32-unknown-unknown
-  wasm-bindgen --target bundler --out-dir crates/bitwarden-wasm-internal/npm ./target/wasm32-unknown-unknown/debug/bitwarden_wasm_internal.wasm
-  wasm-bindgen --target nodejs --out-dir crates/bitwarden-wasm-internal/npm/node ./target/wasm32-unknown-unknown/debug/bitwarden_wasm_internal.wasm
+  echo "Building in debug mode"
+  RELEASE_FLAG=""
+  BUILD_FOLDER="debug"
 else
-  # Release
-  cargo build -p bitwarden-wasm-internal --target wasm32-unknown-unknown --release
-  wasm-bindgen --target bundler --out-dir crates/bitwarden-wasm-internal/npm ./target/wasm32-unknown-unknown/release/bitwarden_wasm_internal.wasm
-  wasm-bindgen --target nodejs --out-dir crates/bitwarden-wasm-internal/npm/node ./target/wasm32-unknown-unknown/release/bitwarden_wasm_internal.wasm
+  echo "Building in release mode"
+  RELEASE_FLAG="--release"
+  BUILD_FOLDER="release"
 fi
+
+# Build normally
+cargo build -p bitwarden-wasm-internal --target wasm32-unknown-unknown 
+wasm-bindgen --target bundler --out-dir crates/bitwarden-wasm-internal/npm ./target/wasm32-unknown-unknown/${BUILD_FOLDER}/bitwarden_wasm_internal.wasm
+wasm-bindgen --target nodejs --out-dir crates/bitwarden-wasm-internal/npm/node ./target/wasm32-unknown-unknown/${BUILD_FOLDER}/bitwarden_wasm_internal.wasm
+
+# Build with MVP CPU target, for wasm2js support
+# Note that this requirest build-std which is an unstable feature,
+# this normally requires a nightly build, but we can also use the 
+# RUSTC_BOOTSTRAP hack to use the same stable version as the normal build
+RUSTFLAGS=-Ctarget-cpu=mvp RUSTC_BOOTSTRAP=1 cargo build -p bitwarden-wasm-internal -Zbuild-std=panic_abort,std --target wasm32-unknown-unknown 
+cp ./target/wasm32-unknown-unknown/${BUILD_FOLDER}/bitwarden_wasm_internal.wasm ./crates/bitwarden-wasm-internal/npm/node/bitwarden_wasm_internal_bg.mvp.wasm
 
 # Format
 npx prettier --write ./crates/bitwarden-wasm-internal/npm
 
 # Optimize size
 wasm-opt -Os ./crates/bitwarden-wasm-internal/npm/bitwarden_wasm_internal_bg.wasm -o ./crates/bitwarden-wasm-internal/npm/bitwarden_wasm_internal_bg.wasm
+wasm-opt -Os ./crates/bitwarden-wasm-internal/npm/node/bitwarden_wasm_internal_bg.wasm -o ./crates/bitwarden-wasm-internal/npm/node/bitwarden_wasm_internal_bg.wasm
+wasm-opt -Os ./crates/bitwarden-wasm-internal/npm/node/bitwarden_wasm_internal_bg.mvp.wasm -o ./crates/bitwarden-wasm-internal/npm/node/bitwarden_wasm_internal_bg.mvp.wasm
 
 # Transpile to JS
-wasm2js ./crates/bitwarden-wasm-internal/npm/bitwarden_wasm_internal_bg.wasm -o ./crates/bitwarden-wasm-internal/npm/bitwarden_wasm_internal_bg.wasm.js
+wasm2js ./crates/bitwarden-wasm-internal/npm/node/bitwarden_wasm_internal_bg.mvp.wasm -o ./crates/bitwarden-wasm-internal/npm/bitwarden_wasm_internal_bg.wasm.js
 npx terser ./crates/bitwarden-wasm-internal/npm/bitwarden_wasm_internal_bg.wasm.js -o ./crates/bitwarden-wasm-internal/npm/bitwarden_wasm_internal_bg.wasm.js
+
+# Remove unneeded files
+rm ./crates/bitwarden-wasm-internal/npm/node/bitwarden_wasm_internal_bg.mvp.wasm

--- a/crates/bitwarden-wasm-internal/npm/.gitignore
+++ b/crates/bitwarden-wasm-internal/npm/.gitignore
@@ -3,5 +3,6 @@ bitwarden_wasm_internal_bg.js
 bitwarden_wasm_internal_bg.wasm
 bitwarden_wasm_internal_bg.wasm.d.ts
 bitwarden_wasm_internal_bg.wasm.js
+bitwarden_wasm_internal_bg.mvp.wasm
 bitwarden_wasm_internal.d.ts
 bitwarden_wasm_internal.js


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective

Currently we're stuck on Rust 1.81 because 1.82 started enabling the `reference-types` feature by default, which breaks `wasm2js`. Ideally `wasm2js` would add support for it, but we don't know how long that is going to take.

To disable that feature, we need to use nightly or RUSTC_BOOTSTRAP to use the unstable `build-std` option. In this PR I'm building the WASM version normally first, and then with `build-std` for transpilation, though we could use `build-std` for both.

Local builds seem to work fine, but it'll need some more testing.

Note that webpack has support for `reference-types` in versions `>=5.97.0`, so we might want to make sure clients are updated first. Also the client support: https://caniuse.com/wasm-reference-types

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation
  team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
