### PR TITLE
[PM-15918] Fix format difference between export of ssh keys on web and sdk

### DIFF
--- a/crates/bitwarden-exporters/resources/json_export.json
+++ b/crates/bitwarden-exporters/resources/json_export.json
@@ -153,7 +153,7 @@
       "sshKey": {
         "privateKey": "-----BEGIN OPENSSH PRIVATE KEY-----\nb3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAAAAAABAAAAMwAAAAtzc2gtZW\nQyNTUxOQAAACBinNE5chMtCHh3BV0H1+CpPlEQBwR5cD+Xb9i8MaHGiwAAAKAy48fwMuPH\n8AAAAAtzc2gtZWQyNTUxOQAAACBinNE5chMtCHh3BV0H1+CpPlEQBwR5cD+Xb9i8MaHGiw\nAAAEAYUCIdfLI14K3XIy9V0FDZLQoZ9gcjOnvFjb4uA335HmKc0TlyEy0IeHcFXQfX4Kk+\nURAHBHlwP5dv2LwxocaLAAAAHHF1ZXh0ZW5ATWFjQm9vay1Qcm8tMTYubG9jYWwB\n-----END OPENSSH PRIVATE KEY-----",
         "publicKey": "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGKc0TlyEy0IeHcFXQfX4Kk+URAHBHlwP5dv2LwxocaL",
-        "fingerprint": "SHA256:1JjFjvPRkj1Gbf2qRP1dgHiIzEuNAEvp+92x99jw3K0"
+        "keyFingerprint": "SHA256:1JjFjvPRkj1Gbf2qRP1dgHiIzEuNAEvp+92x99jw3K0"
       },
       "favorite": false,
       "reprompt": 0,

--- a/crates/bitwarden-exporters/src/json.rs
+++ b/crates/bitwarden-exporters/src/json.rs
@@ -215,7 +215,7 @@ impl From<Identity> for JsonIdentity {
 struct JsonSshKey {
     private_key: String,
     public_key: String,
-    fingerprint: String,
+    key_fingerprint: String,
 }
 
 impl From<SshKey> for JsonSshKey {
@@ -223,7 +223,7 @@ impl From<SshKey> for JsonSshKey {
         JsonSshKey {
             private_key: ssh_key.private_key,
             public_key: ssh_key.public_key,
-            fingerprint: ssh_key.fingerprint,
+            key_fingerprint: ssh_key.fingerprint,
         }
     }
 }
@@ -661,7 +661,7 @@ mod tests {
             "sshKey": {
               "privateKey": "private",
               "publicKey": "public",
-              "fingerprint": "fingerprint"
+              "keyFingerprint": "fingerprint"
             },
             "favorite": false,
             "collectionIds": null


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-15918
https://bitwarden.atlassian.net/browse/PM-15898

## 📔 Objective

The sdk currently exports ssh keys with the `fingerprint` key, in contrast to web which exports as `keyFingerprint`. This PR brings these formats in line in favor of `keyFingerprint`.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation
  team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
