### PR TITLE
Fix script error when ran the first time

### DIFF
--- a/crates/bitwarden-uniffi/swift/build.sh
+++ b/crates/bitwarden-uniffi/swift/build.sh
@@ -6,10 +6,9 @@ cd "$(dirname "$0")"
 # Generate an xcframework for the Swift bindings.
 
 # Cleanup dirs
-rm -r BitwardenFFI.xcframework
-rm -r tmp
+rm -rf BitwardenFFI.xcframework
+rm -rf tmp
 
-mkdir tmp
 mkdir -p tmp/target/universal-ios-sim/release
 
 # Build native library
@@ -49,4 +48,4 @@ xcodebuild -create-xcframework \
   -output ./BitwardenFFI.xcframework
 
 # Cleanup temporary files
-rm -r tmp
+rm -rf tmp


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective

In #88 I've updated the scripts to use `set -eo pipefail` to fail at the first error.

The `rm -r ` commands would fail if those files don't exist, so the first run of the command would immediately fail. Adding the `f` flag fixes that. I've also removed a `mkdir` that wasn't needed, as the next `mkdir -p` will create any parent folders anyway.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation
  team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
