### PR TITLE
Explore sharing docs between crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -456,6 +456,7 @@ name = "bitwarden-error"
 version = "1.0.0"
 dependencies = [
  "bitwarden-error-macro",
+ "documented",
  "js-sys",
  "serde",
  "trybuild",
@@ -1001,6 +1002,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
+name = "convert_case"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec182b0ca2f35d8fc196cf3404988fd8b8c739a4d270ff118a398feb0cbec1ca"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1373,6 +1383,32 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
+ "syn",
+]
+
+[[package]]
+name = "documented"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc6db32f0995bc4553d2de888999075acd0dbeef75ba923503f6a724263dc6f3"
+dependencies = [
+ "documented-macros",
+ "phf",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "documented-macros"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a394bb35929b58f9a5fd418f7c6b17a4b616efcc1e53e6995ca123948f87e5fa"
+dependencies = [
+ "convert_case",
+ "itertools 0.13.0",
+ "optfield",
+ "proc-macro2",
+ "quote",
+ "strum 0.26.3",
  "syn",
 ]
 
@@ -2551,6 +2587,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
+name = "optfield"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa59f025cde9c698fcb4fcb3533db4621795374065bee908215263488f2d2a1d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "oslog"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2717,6 +2764,48 @@ name = "percent-encoding"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
+
+[[package]]
+name = "phf"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ade2d8b8f33c7333b51bcf0428d37e217e9f32192ae4772156f65063b8ce03dc"
+dependencies = [
+ "phf_macros",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48e4cc64c2ad9ebe670cb8fd69dd50ae301650392e81c05f9bfcb2d5bdbc24b0"
+dependencies = [
+ "phf_shared",
+ "rand",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3444646e286606587e49f3bcf1679b8cef1dc2c5ecc29ddacaffc305180d464b"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90fcb95eef784c2ac79119d1dd819e162b5da872ce6f3c3abe1e8ca1c082f72b"
+dependencies = [
+ "siphasher",
+]
 
 [[package]]
 name = "pin-project-lite"
@@ -3743,6 +3832,9 @@ name = "strum"
 version = "0.26.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
+dependencies = [
+ "strum_macros 0.26.4",
+]
 
 [[package]]
 name = "strum_macros"
@@ -4619,7 +4711,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/crates/bitwarden-error/Cargo.toml
+++ b/crates/bitwarden-error/Cargo.toml
@@ -14,7 +14,7 @@ wasm = [
     "bitwarden-error-macro/wasm",
     "dep:js-sys",
     "dep:tsify-next",
-    "dep:wasm-bindgen"
+    "dep:wasm-bindgen",
 ]
 
 [dependencies]
@@ -22,6 +22,7 @@ bitwarden-error-macro = { workspace = true }
 js-sys = { workspace = true, optional = true }
 tsify-next = { workspace = true, optional = true }
 wasm-bindgen = { workspace = true, optional = true }
+documented = "0.9.1"
 
 [lints]
 workspace = true

--- a/crates/bitwarden-error/src/lib.rs
+++ b/crates/bitwarden-error/src/lib.rs
@@ -15,6 +15,7 @@ pub use ::tsify_next;
 #[cfg(feature = "wasm")]
 #[doc(hidden)]
 pub use ::wasm_bindgen;
+use documented::docs_const;
 
 pub mod prelude {
     pub use bitwarden_error_macro::*;
@@ -22,4 +23,10 @@ pub mod prelude {
     pub use crate::flat_error::FlatError;
     #[cfg(feature = "wasm")]
     pub use crate::wasm::SdkJsError;
+}
+
+/// A test function.
+#[docs_const]
+pub fn test() {
+    println!("Hello, world!");
 }

--- a/crates/bitwarden-wasm-internal/Cargo.toml
+++ b/crates/bitwarden-wasm-internal/Cargo.toml
@@ -29,5 +29,8 @@ serde_json = ">=1.0.96, <2.0"
 wasm-bindgen = { version = "=0.2.99", features = ["serde-serialize"] }
 wasm-bindgen-futures = "0.4.41"
 
+[build-dependencies]
+bitwarden-error = { version = "1.0.0", path = "../bitwarden-error" }
+
 [lints]
 workspace = true

--- a/crates/bitwarden-wasm-internal/build.rs
+++ b/crates/bitwarden-wasm-internal/build.rs
@@ -1,6 +1,9 @@
 use std::{env, process::Command};
 
 fn main() {
+
+    std::fs::write("doc/test.md", bitwarden_error::TEST_DOCS).unwrap();
+
     // Use the SDK_VERSION environment variable if it is set (e.g. by CI) or get it from Git
     let sdk_version = env::var("SDK_VERSION")
         .or_else(|_| version_from_git_info())

--- a/crates/bitwarden-wasm-internal/src/lib.rs
+++ b/crates/bitwarden-wasm-internal/src/lib.rs
@@ -7,3 +7,8 @@ mod vault;
 pub use client::BitwardenClient;
 pub use crypto::CryptoClient;
 pub use vault::{folders::ClientFolders, VaultClient};
+
+#[doc = include_str!("../doc/test.md")]
+pub fn test2() {
+    println!("Hello, world!");
+}


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

This is a potential approach for sharing documentation between functions in multiple crates. Unfortunately rust `doc` only support string literals which means we need to do some hacks to expose the comment as a markdown which can be included.

1. Add `docs_const` to the function with documentation.
2. Update `build.rs` in the crate you want to access the documentation.
3. Add `#[doc = include_str!("../doc/test.md")]` to access the doc.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation
  team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
