### PR TITLE
Remove legacy ciphers

### DIFF
--- a/crates/bitwarden-crypto/src/keys/master_key.rs
+++ b/crates/bitwarden-crypto/src/keys/master_key.rs
@@ -145,10 +145,6 @@ pub(super) fn decrypt_user_key(
     user_key: EncString,
 ) -> Result<SymmetricCryptoKey> {
     let mut dec: Vec<u8> = match user_key {
-        // Legacy. user_keys were encrypted using `AesCbc256_B64` a long time ago. We've since
-        // moved to using `AesCbc256_HmacSha256_B64`. However, we still need to support
-        // decrypting these old keys.
-        EncString::AesCbc256_B64 { .. } => user_key.decrypt_with_key(key)?,
         _ => {
             let stretched_key = stretch_kdf_key(key)?;
             user_key.decrypt_with_key(&stretched_key)?


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective

This PR removes legacy ciphers types 0 and 1. Especially 0 is too dangerous to have in production code. Migration can be done via the web clients which will have the cipher type specifically enabled for legacy migration, but nothing else.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation
  team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
