### PR TITLE
[PM-16602] Remove legacy ciphers

### DIFF
--- a/crates/bitwarden-crypto/src/aes.rs
+++ b/crates/bitwarden-crypto/src/aes.rs
@@ -7,7 +7,7 @@
 
 use aes::cipher::{
     block_padding::Pkcs7,
-    typenum::{U16, U32},
+    typenum::U32,
     BlockDecryptMut, BlockEncryptMut, KeyIvInit,
 };
 use generic_array::GenericArray;
@@ -111,42 +111,6 @@ fn encrypt_aes256_internal(
     (iv, data)
 }
 
-/// Decrypt using AES-128 in CBC mode.
-///
-/// Behaves similar to [decrypt_aes128_hmac], but does not validate the MAC.
-fn decrypt_aes128(iv: &[u8; 16], data: Vec<u8>, key: &GenericArray<u8, U16>) -> Result<Vec<u8>> {
-    // Decrypt data
-    let iv = GenericArray::from_slice(iv);
-    let mut data = data;
-    let decrypted_key_slice = cbc::Decryptor::<aes::Aes128>::new(key, iv)
-        .decrypt_padded_mut::<Pkcs7>(&mut data)
-        .map_err(|_| CryptoError::KeyDecrypt)?;
-
-    // Data is decrypted in place and returns a subslice of the original Vec, to avoid cloning it,
-    // we truncate to the subslice length
-    let decrypted_len = decrypted_key_slice.len();
-    data.truncate(decrypted_len);
-
-    Ok(data)
-}
-
-/// Decrypt using AES-128 in CBC mode with MAC.
-///
-/// Behaves similar to [decrypt_aes128], but also validates the MAC.
-pub(crate) fn decrypt_aes128_hmac(
-    iv: &[u8; 16],
-    mac: &[u8; 32],
-    data: Vec<u8>,
-    mac_key: &GenericArray<u8, U16>,
-    key: &GenericArray<u8, U16>,
-) -> Result<Vec<u8>> {
-    let res = generate_mac(mac_key, iv, &data)?;
-    if res.ct_ne(mac).into() {
-        return Err(CryptoError::InvalidMac);
-    }
-    decrypt_aes128(iv, data, key)
-}
-
 /// Generate a MAC using HMAC-SHA256.
 fn generate_mac(mac_key: &[u8], iv: &[u8], data: &[u8]) -> Result<[u8; 32]> {
     let mut hmac =
@@ -210,19 +174,6 @@ mod tests {
         assert!(result.is_ok());
         let mac = result.unwrap();
         assert_eq!(mac.len(), 32);
-    }
-
-    #[test]
-    fn test_decrypt_aes128() {
-        let iv = generate_vec(16, 0, 1);
-        let iv: &[u8; 16] = iv.as_slice().try_into().unwrap();
-        let key = generate_generic_array(0, 1);
-
-        let data = STANDARD.decode("dC0X+2IjFbeL4WLLg2jX7Q==").unwrap();
-
-        let decrypted = decrypt_aes128(iv, data, &key).unwrap();
-
-        assert_eq!(String::from_utf8(decrypted).unwrap(), "EncryptMe!");
     }
 
     #[test]

--- a/crates/bitwarden-crypto/src/aes.rs
+++ b/crates/bitwarden-crypto/src/aes.rs
@@ -6,9 +6,7 @@
 //! [KeyEncryptable][crate::KeyEncryptable] & [KeyDecryptable][crate::KeyDecryptable] instead.
 
 use aes::cipher::{
-    block_padding::Pkcs7,
-    typenum::U32,
-    BlockDecryptMut, BlockEncryptMut, KeyIvInit,
+    block_padding::Pkcs7, typenum::U32, BlockDecryptMut, BlockEncryptMut, KeyIvInit,
 };
 use generic_array::GenericArray;
 use hmac::Mac;

--- a/crates/bitwarden-crypto/src/enc_string/symmetric.rs
+++ b/crates/bitwarden-crypto/src/enc_string/symmetric.rs
@@ -32,8 +32,6 @@ export type EncString = string;
 /// variants, but we should be opinionated in which variants are used for encrypting.
 ///
 /// ## Variants
-/// - [AesCbc256_B64](EncString::AesCbc256_B64)
-/// - [AesCbc128_HmacSha256_B64](EncString::AesCbc128_HmacSha256_B64)
 /// - [AesCbc256_HmacSha256_B64](EncString::AesCbc256_HmacSha256_B64)
 ///
 /// ## Serialization
@@ -42,14 +40,13 @@ export type EncString = string;
 /// custom scheme to represent the different variants.
 ///
 /// The scheme is one of the following schemes:
-/// - `[type].[iv]|[data]`
 /// - `[type].[iv]|[data]|[mac]`
 ///
 /// Where:
 /// - `[type]`: is a digit number representing the variant.
 /// - `[iv]`: (optional) is the initialization vector used for encryption.
 /// - `[data]`: is the encrypted data.
-/// - `[mac]`: (optional) is the MAC used to validate the integrity of the data.
+/// - `[mac]`: is the MAC used to validate the integrity of the data.
 #[derive(Clone, zeroize::ZeroizeOnDrop, PartialEq)]
 #[allow(unused, non_camel_case_types)]
 pub enum EncString {

--- a/crates/bitwarden-crypto/src/enc_string/symmetric.rs
+++ b/crates/bitwarden-crypto/src/enc_string/symmetric.rs
@@ -248,9 +248,7 @@ mod tests {
     use schemars::schema_for;
 
     use super::EncString;
-    use crate::{
-        derive_symmetric_key, KeyDecryptable, KeyEncryptable,
-    };
+    use crate::{derive_symmetric_key, KeyDecryptable, KeyEncryptable};
 
     #[test]
     fn test_enc_string_roundtrip() {

--- a/crates/bitwarden-crypto/src/keys/master_key.rs
+++ b/crates/bitwarden-crypto/src/keys/master_key.rs
@@ -171,7 +171,7 @@ mod tests {
     use rand::SeedableRng;
 
     use super::{make_user_key, HashPurpose, Kdf, MasterKey};
-    use crate::{keys::symmetric_crypto_key::derive_symmetric_key, EncString, SymmetricCryptoKey};
+    use crate::{keys::symmetric_crypto_key::derive_symmetric_key, SymmetricCryptoKey};
 
     #[test]
     fn test_master_key_derive_pbkdf2() {
@@ -322,36 +322,6 @@ mod tests {
         assert_eq!(
             decrypted.mac_key, user_key.mac_key,
             "Decrypted key doesn't match user key"
-        );
-    }
-
-    #[test]
-    fn test_decrypt_user_key_aes_cbc256_b64() {
-        let password = "asdfasdfasdf";
-        let salt = "legacy@bitwarden.com";
-        let kdf = Kdf::PBKDF2 {
-            iterations: NonZeroU32::new(600_000).unwrap(),
-        };
-
-        let master_key = MasterKey::derive(password, salt, &kdf).unwrap();
-
-        let user_key: EncString = "0.8UClLa8IPE1iZT7chy5wzQ==|6PVfHnVk5S3XqEtQemnM5yb4JodxmPkkWzmDRdfyHtjORmvxqlLX40tBJZ+CKxQWmS8tpEB5w39rbgHg/gqs0haGdZG4cPbywsgGzxZ7uNI=".parse().unwrap();
-
-        let decrypted = master_key.decrypt_user_key(user_key).unwrap();
-
-        assert_eq!(
-            decrypted.key.as_slice(),
-            [
-                12, 95, 151, 203, 37, 4, 236, 67, 137, 97, 90, 58, 6, 127, 242, 28, 209, 168, 125,
-                29, 118, 24, 213, 44, 117, 202, 2, 115, 132, 165, 125, 148
-            ]
-        );
-        assert_eq!(
-            decrypted.mac_key.as_ref().unwrap().as_slice(),
-            [
-                186, 215, 234, 137, 24, 169, 227, 29, 218, 57, 180, 237, 73, 91, 189, 51, 253, 26,
-                17, 52, 226, 4, 134, 75, 194, 208, 178, 133, 128, 224, 140, 167
-            ]
         );
     }
 }

--- a/crates/bitwarden-crypto/src/keys/master_key.rs
+++ b/crates/bitwarden-crypto/src/keys/master_key.rs
@@ -145,10 +145,6 @@ pub(super) fn decrypt_user_key(
     user_key: EncString,
 ) -> Result<SymmetricCryptoKey> {
     let mut dec: Vec<u8> = match user_key {
-        // Legacy. user_keys were encrypted using `AesCbc256_B64` a long time ago. We've since
-        // moved to using `AesCbc256_HmacSha256_B64`. However, we still need to support
-        // decrypting these old keys.
-        EncString::AesCbc256_B64 { .. } => user_key.decrypt_with_key(key)?,
         _ => {
             let stretched_key = stretch_kdf_key(key)?;
             user_key.decrypt_with_key(&stretched_key)?

--- a/crates/bitwarden-crypto/src/keys/master_key.rs
+++ b/crates/bitwarden-crypto/src/keys/master_key.rs
@@ -144,12 +144,8 @@ pub(super) fn decrypt_user_key(
     key: &SymmetricCryptoKey,
     user_key: EncString,
 ) -> Result<SymmetricCryptoKey> {
-    let mut dec: Vec<u8> = match user_key {
-        _ => {
-            let stretched_key = stretch_kdf_key(key)?;
-            user_key.decrypt_with_key(&stretched_key)?
-        }
-    };
+    let stretched_key = stretch_kdf_key(key)?;
+    let mut dec: Vec<u8> = user_key.decrypt_with_key(&stretched_key)?;
 
     SymmetricCryptoKey::try_from(dec.as_mut_slice())
 }


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-16602

## 📔 Objective

Removes legacy cipher types 0 and 1. 0 could previously be abused into leaking vault contents and modifying data the clients decrypts, and pose too big of an implementation risk to keep in the regular clients. Migration is possible via web, without use of the sdk.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation
  team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
