### PR TITLE
Use-sdk-for-encrypt-decrypt

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -429,7 +429,6 @@ dependencies = [
  "generic-array",
  "hkdf",
  "hmac",
- "log",
  "num-bigint",
  "num-traits",
  "pbkdf2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -658,8 +658,10 @@ dependencies = [
  "console_log",
  "js-sys",
  "log",
+ "serde",
  "serde_json",
  "thiserror 1.0.69",
+ "tsify-next",
  "wasm-bindgen",
  "wasm-bindgen-futures",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -429,6 +429,7 @@ dependencies = [
  "generic-array",
  "hkdf",
  "hmac",
+ "log",
  "num-bigint",
  "num-traits",
  "pbkdf2",
@@ -659,6 +660,7 @@ dependencies = [
  "js-sys",
  "log",
  "serde_json",
+ "thiserror 1.0.69",
  "wasm-bindgen",
  "wasm-bindgen-futures",
 ]

--- a/crates/bitwarden-crypto/Cargo.toml
+++ b/crates/bitwarden-crypto/Cargo.toml
@@ -31,7 +31,6 @@ cbc = { version = ">=0.1.2, <0.2", features = ["alloc", "zeroize"] }
 generic-array = { version = ">=0.14.7, <1.0", features = ["zeroize"] }
 hkdf = ">=0.12.3, <0.13"
 hmac = ">=0.12.1, <0.13"
-log = "0.4.20"
 num-bigint = ">=0.4, <0.5"
 num-traits = ">=0.2.15, <0.3"
 pbkdf2 = { version = ">=0.12.1, <0.13", default-features = false }

--- a/crates/bitwarden-crypto/Cargo.toml
+++ b/crates/bitwarden-crypto/Cargo.toml
@@ -31,6 +31,7 @@ cbc = { version = ">=0.1.2, <0.2", features = ["alloc", "zeroize"] }
 generic-array = { version = ">=0.14.7, <1.0", features = ["zeroize"] }
 hkdf = ">=0.12.3, <0.13"
 hmac = ">=0.12.1, <0.13"
+log = "0.4.20"
 num-bigint = ">=0.4, <0.5"
 num-traits = ">=0.2.15, <0.3"
 pbkdf2 = { version = ">=0.12.1, <0.13", default-features = false }

--- a/crates/bitwarden-crypto/src/enc_string/symmetric.rs
+++ b/crates/bitwarden-crypto/src/enc_string/symmetric.rs
@@ -4,6 +4,7 @@ use aes::cipher::typenum::U32;
 use base64::{engine::general_purpose::STANDARD, Engine};
 use generic_array::GenericArray;
 use serde::Deserialize;
+use log::info;
 
 use super::{check_length, from_b64, from_b64_vec, split_enc_string};
 use crate::{
@@ -285,6 +286,7 @@ impl KeyEncryptable<SymmetricCryptoKey, EncString> for &str {
 impl KeyDecryptable<SymmetricCryptoKey, String> for EncString {
     fn decrypt_with_key(&self, key: &SymmetricCryptoKey) -> Result<String> {
         let dec: Vec<u8> = self.decrypt_with_key(key)?;
+        info!("decrypted: {:?}", dec);
         String::from_utf8(dec).map_err(|_| CryptoError::InvalidUtf8String)
     }
 }

--- a/crates/bitwarden-crypto/src/enc_string/symmetric.rs
+++ b/crates/bitwarden-crypto/src/enc_string/symmetric.rs
@@ -4,7 +4,6 @@ use aes::cipher::typenum::U32;
 use base64::{engine::general_purpose::STANDARD, Engine};
 use generic_array::GenericArray;
 use serde::Deserialize;
-use log::info;
 
 use super::{check_length, from_b64, from_b64_vec, split_enc_string};
 use crate::{
@@ -286,7 +285,6 @@ impl KeyEncryptable<SymmetricCryptoKey, EncString> for &str {
 impl KeyDecryptable<SymmetricCryptoKey, String> for EncString {
     fn decrypt_with_key(&self, key: &SymmetricCryptoKey) -> Result<String> {
         let dec: Vec<u8> = self.decrypt_with_key(key)?;
-        info!("decrypted: {:?}", dec);
         String::from_utf8(dec).map_err(|_| CryptoError::InvalidUtf8String)
     }
 }

--- a/crates/bitwarden-crypto/src/keys/key_encryptable.rs
+++ b/crates/bitwarden-crypto/src/keys/key_encryptable.rs
@@ -35,6 +35,37 @@ pub trait KeyDecryptable<Key: CryptoKey, Output> {
     fn decrypt_with_key(&self, key: &Key) -> Result<Output>;
 }
 
+pub struct DecryptedWithAdditionalData {
+    clear_text: Vec<u8>,
+    additional_data: HashMap<String, String>,
+}
+
+impl DecryptedWithAdditionalData {
+    pub fn new(clear_text: Vec<u8>, additional_data: HashMap<String, String>) -> Self {
+        Self {
+            clear_text,
+            additional_data,
+        }
+    }
+
+    pub fn clear_bytes(&self) -> &[u8] {
+        &self.clear_text
+    }
+
+    pub fn clear_text_utf8(&self) -> Result<String> {
+        String::from_utf8(self.clear_text.clone()).map_err(|_| CryptoError::InvalidUtf8String)
+    }
+
+    /// Additional data on the context of the decryption of the clear text.
+    /// Note that not all of this data is authenticated for all [crate::EncString] variants.
+    ///
+    ///  See [KeyDecryptable<_,DecryptedWithAdditionalData>::decrypt_with_key] implementation for
+    /// more information.
+    pub fn additional_data(&self) -> &HashMap<String, String> {
+        &self.additional_data
+    }
+}
+
 impl<T: KeyEncryptable<Key, Output>, Key: CryptoKey, Output> KeyEncryptable<Key, Option<Output>>
     for Option<T>
 {

--- a/crates/bitwarden-crypto/src/keys/mod.rs
+++ b/crates/bitwarden-crypto/src/keys/mod.rs
@@ -1,5 +1,7 @@
 mod key_encryptable;
-pub use key_encryptable::{CryptoKey, KeyContainer, KeyDecryptable, KeyEncryptable, LocateKey};
+pub use key_encryptable::{
+    CryptoKey, DecryptedWithAdditionalData, KeyContainer, KeyDecryptable, KeyEncryptable, LocateKey,
+};
 mod master_key;
 pub use master_key::{
     default_argon2_iterations, default_argon2_memory, default_argon2_parallelism,

--- a/crates/bitwarden-wasm-internal/Cargo.toml
+++ b/crates/bitwarden-wasm-internal/Cargo.toml
@@ -25,6 +25,7 @@ console_log = { version = "1.0.0", features = ["color"] }
 js-sys = "0.3.68"
 log = "0.4.20"
 serde_json = ">=1.0.96, <2.0"
+thiserror = { workspace = true }
 # When upgrading wasm-bindgen, make sure to update the version in the workflows!
 wasm-bindgen = { version = "=0.2.99", features = ["serde-serialize"] }
 wasm-bindgen-futures = "0.4.41"

--- a/crates/bitwarden-wasm-internal/Cargo.toml
+++ b/crates/bitwarden-wasm-internal/Cargo.toml
@@ -24,8 +24,10 @@ console_error_panic_hook = "0.1.7"
 console_log = { version = "1.0.0", features = ["color"] }
 js-sys = "0.3.68"
 log = "0.4.20"
+serde.workspace = true
 serde_json = ">=1.0.96, <2.0"
 thiserror = { workspace = true }
+tsify-next.workspace = true
 # When upgrading wasm-bindgen, make sure to update the version in the workflows!
 wasm-bindgen = { version = "=0.2.99", features = ["serde-serialize"] }
 wasm-bindgen-futures = "0.4.41"

--- a/crates/bitwarden-wasm-internal/src/client.rs
+++ b/crates/bitwarden-wasm-internal/src/client.rs
@@ -37,14 +37,17 @@ pub struct BitwardenPure;
 #[wasm_bindgen]
 impl BitwardenPure {
     pub fn version() -> String {
+        Self::setup_once();
         env!("SDK_VERSION").to_owned()
     }
 
     pub fn echo(msg: String) -> String {
+        Self::setup_once();
         msg
     }
 
     pub fn throw(msg: String) -> Result<(), TestError> {
+        Self::setup_once();
         Err(TestError(msg))
     }
 
@@ -52,6 +55,7 @@ impl BitwardenPure {
         enc_string: String,
         key_b64: String,
     ) -> Result<String, PureCryptoError> {
+        Self::setup_once();
         pure_crypto::symmetric_decrypt(enc_string, key_b64)
     }
 
@@ -59,11 +63,21 @@ impl BitwardenPure {
         enc_string: String,
         key_b64: String,
     ) -> Result<Vec<u8>, PureCryptoError> {
+        Self::setup_once();
         pure_crypto::symmetric_decrypt_to_bytes(enc_string, key_b64)
     }
 
     pub fn symmetric_encrypt(plain: String, key_b64: String) -> Result<String, PureCryptoError> {
+        Self::setup_once();
         pure_crypto::symmetric_encrypt(plain, key_b64)
+    }
+
+    fn setup_once() {
+        console_error_panic_hook::set_once();
+        let log_level = convert_level(LogLevel::Info);
+        if let Err(_e) = console_log::init_with_level(log_level) {
+            set_max_level(log_level.to_level_filter())
+        }
     }
 }
 

--- a/crates/bitwarden-wasm-internal/src/client.rs
+++ b/crates/bitwarden-wasm-internal/src/client.rs
@@ -8,7 +8,7 @@ use wasm_bindgen::prelude::*;
 
 use crate::{
     crypto::{
-        pure_crypto::{self, DecryptedBytes, DecryptedString},
+        pure_crypto::{self, DecryptedBytes, DecryptedString, EncryptOptions},
         PureCryptoError,
     },
     vault::ClientVault,
@@ -70,9 +70,13 @@ impl BitwardenPure {
         pure_crypto::symmetric_decrypt_to_bytes(enc_string, key_b64)
     }
 
-    pub fn symmetric_encrypt(plain: String, key_b64: String) -> Result<String, PureCryptoError> {
+    pub fn symmetric_encrypt(
+        plain: String,
+        key_b64: String,
+        encrypt_options: EncryptOptions,
+    ) -> Result<String, PureCryptoError> {
         Self::setup_once();
-        pure_crypto::symmetric_encrypt(plain, key_b64)
+        pure_crypto::symmetric_encrypt(plain, key_b64, encrypt_options)
     }
 
     fn setup_once() {

--- a/crates/bitwarden-wasm-internal/src/client.rs
+++ b/crates/bitwarden-wasm-internal/src/client.rs
@@ -6,7 +6,11 @@ use bitwarden_error::prelude::*;
 use log::{set_max_level, Level};
 use wasm_bindgen::prelude::*;
 
-use crate::{vault::ClientVault, ClientCrypto};
+use crate::{
+    crypto::{pure_crypto, PureCryptoError},
+    vault::ClientVault,
+    ClientCrypto,
+};
 
 #[wasm_bindgen]
 pub enum LogLevel {
@@ -24,6 +28,42 @@ fn convert_level(level: LogLevel) -> Level {
         LogLevel::Info => Level::Info,
         LogLevel::Warn => Level::Warn,
         LogLevel::Error => Level::Error,
+    }
+}
+
+#[wasm_bindgen]
+pub struct BitwardenPure;
+
+#[wasm_bindgen]
+impl BitwardenPure {
+    pub fn version() -> String {
+        env!("SDK_VERSION").to_owned()
+    }
+
+    pub fn echo(msg: String) -> String {
+        msg
+    }
+
+    pub fn throw(msg: String) -> Result<(), TestError> {
+        Err(TestError(msg))
+    }
+
+    pub fn symmetric_decrypt(
+        enc_string: String,
+        key_b64: String,
+    ) -> Result<String, PureCryptoError> {
+        pure_crypto::symmetric_decrypt(enc_string, key_b64)
+    }
+
+    pub fn symmetric_decrypt_to_bytes(
+        enc_string: String,
+        key_b64: String,
+    ) -> Result<Vec<u8>, PureCryptoError> {
+        pure_crypto::symmetric_decrypt_to_bytes(enc_string, key_b64)
+    }
+
+    pub fn symmetric_encrypt(plain: String, key_b64: String) -> Result<String, PureCryptoError> {
+        pure_crypto::symmetric_encrypt(plain, key_b64)
     }
 }
 

--- a/crates/bitwarden-wasm-internal/src/client.rs
+++ b/crates/bitwarden-wasm-internal/src/client.rs
@@ -7,7 +7,10 @@ use log::{set_max_level, Level};
 use wasm_bindgen::prelude::*;
 
 use crate::{
-    crypto::{pure_crypto, PureCryptoError},
+    crypto::{
+        pure_crypto::{self, DecryptedBytes, DecryptedString},
+        PureCryptoError,
+    },
     vault::ClientVault,
     ClientCrypto,
 };
@@ -54,7 +57,7 @@ impl BitwardenPure {
     pub fn symmetric_decrypt(
         enc_string: String,
         key_b64: String,
-    ) -> Result<String, PureCryptoError> {
+    ) -> Result<DecryptedString, PureCryptoError> {
         Self::setup_once();
         pure_crypto::symmetric_decrypt(enc_string, key_b64)
     }
@@ -62,7 +65,7 @@ impl BitwardenPure {
     pub fn symmetric_decrypt_to_bytes(
         enc_string: String,
         key_b64: String,
-    ) -> Result<Vec<u8>, PureCryptoError> {
+    ) -> Result<DecryptedBytes, PureCryptoError> {
         Self::setup_once();
         pure_crypto::symmetric_decrypt_to_bytes(enc_string, key_b64)
     }

--- a/crates/bitwarden-wasm-internal/src/crypto.rs
+++ b/crates/bitwarden-wasm-internal/src/crypto.rs
@@ -87,7 +87,18 @@ pub mod pure_crypto {
         Ok(dec.into())
     }
 
-    pub fn symmetric_encrypt(plain: String, key_b64: String) -> Result<String, PureCryptoError> {
+    pub fn symmetric_encrypt(
+        plain: String,
+        key_b64: String,
+        encrypt_options: EncryptOptions,
+    ) -> Result<String, PureCryptoError> {
+        if encrypt_options
+            .additional_data
+            .is_some_and(|additional_data| additional_data.keys().len() > 0)
+        {
+            panic!("Additional data is not supported yet");
+        }
+
         let key = SymmetricCryptoKey::try_from(key_b64)?;
 
         let encrypted: EncString = plain.encrypt_with_key(&key)?;

--- a/crates/bitwarden-wasm-internal/src/crypto.rs
+++ b/crates/bitwarden-wasm-internal/src/crypto.rs
@@ -1,4 +1,4 @@
-use std::rc::Rc;
+use std::{rc::Rc, str::FromStr};
 
 use bitwarden_core::{
     client::encryption_settings::EncryptionSettingsError,
@@ -8,7 +8,47 @@ use bitwarden_core::{
     },
     Client,
 };
+use bitwarden_crypto::{EncString, KeyDecryptable, KeyEncryptable, SymmetricCryptoKey};
+use bitwarden_error::prelude::*;
+use thiserror::Error;
 use wasm_bindgen::prelude::*;
+
+#[bitwarden_error(flat)]
+#[derive(Debug, Error)]
+pub enum PureCryptoError {
+    #[error("Cryptography error, {0}")]
+    Crypto(#[from] bitwarden_crypto::CryptoError),
+}
+
+pub mod pure_crypto {
+    use super::*;
+
+    pub fn symmetric_decrypt(
+        enc_string: String,
+        key_b64: String,
+    ) -> Result<String, PureCryptoError> {
+        let dec = symmetric_decrypt_to_bytes(enc_string, key_b64)?;
+        Ok(String::from_utf8(dec).map_err(|_| bitwarden_crypto::CryptoError::InvalidUtf8String)?)
+    }
+
+    pub fn symmetric_decrypt_to_bytes(
+        enc_string: String,
+        key_b64: String,
+    ) -> Result<Vec<u8>, PureCryptoError> {
+        let enc_string = EncString::from_str(&enc_string)?;
+        let key = SymmetricCryptoKey::try_from(key_b64)?;
+
+        let decrypted: Vec<u8> = enc_string.decrypt_with_key(&key)?;
+        Ok(decrypted)
+    }
+
+    pub fn symmetric_encrypt(plain: String, key_b64: String) -> Result<String, PureCryptoError> {
+        let key = SymmetricCryptoKey::try_from(key_b64)?;
+
+        let encrypted: EncString = plain.encrypt_with_key(&key)?;
+        Ok(encrypted.to_string())
+    }
+}
 
 #[wasm_bindgen]
 pub struct ClientCrypto(Rc<Client>);


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-15093

## 📔 Objective

Introduces a namespace for pure SDK functions. This PR is a draft to invite discussion over a good way to handle SDK interfaces with differing levels of state.

Currently, SDKs are bound to a server only or a server and a specific authenticated user on that server. However, no type differences between these level of context exist. This PR introduces a new context, one without any state, so I called it `BitwardenPure`.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation
  team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
