### PR TITLE
Enable 1.84 MSRV-aware resolution

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,2 +1,5 @@
+[resolver]
+incompatible-rust-versions = "fallback"
+
 [target.'cfg(target_arch="aarch64")']
 rustflags = ["--cfg", "aes_armv8"]


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective

Rust 1.84.0 includes opt-in MSRV-aware version resolution, which ensures `cargo update` won't try to update a package to a MSRV-incompatible version.

Currently we have one package (`cargo-platform`) that can't be updated to the latest version as it's not compatible with our MSRV. Enabling MSRV-aware version resolution ensures that it won't be updated.

A test of it working:

```sh
# Running cargo update will update everything to the latest MSRV-compatible version
% cargo update
    Updating crates.io index
     Locking 31 packages to latest Rust 1.75 compatible versions
    Updating anyhow v1.0.94 -> v1.0.95
    Updating bitflags v2.6.0 -> v2.7.0
    Updating cc v1.2.4 -> v1.2.7
    <..... A few other packages ....>
note: pass `--verbose` to see 5 unchanged dependencies behind latest

# If we disable the MSRV-aware version resolution and run update again, we now get the MSRV incompatible update
% CARGO_RESOLVER_INCOMPATIBLE_RUST_VERSIONS=allow cargo update
    Updating crates.io index
     Locking 1 package to latest compatible version
    Updating cargo-platform v0.1.8 -> v0.1.9
note: pass `--verbose` to see 4 unchanged dependencies behind latest
```


Depends on https://github.com/bitwarden/sdk-internal/pull/112 to fix some lint issues


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation
  team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
