### PR TITLE
[PM-15389] Parse account and issuer from otpauth URLs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -636,6 +636,7 @@ dependencies = [
  "bitwarden-crypto",
  "chrono",
  "hmac",
+ "percent-encoding",
  "rand",
  "reqwest",
  "schemars",

--- a/crates/bitwarden-exporters/src/cxp/export.rs
+++ b/crates/bitwarden-exporters/src/cxp/export.rs
@@ -139,14 +139,14 @@ fn convert_totp(totp: Totp) -> TotpCredential {
         secret: totp.secret.into(),
         period: totp.period as u8,
         digits: totp.digits as u8,
-        username: "".to_string(),
+        username: totp.account.unwrap_or("".to_string()),
         algorithm: match totp.algorithm {
             TotpAlgorithm::Sha1 => OTPHashAlgorithm::Sha1,
             TotpAlgorithm::Sha256 => OTPHashAlgorithm::Sha256,
             TotpAlgorithm::Sha512 => OTPHashAlgorithm::Sha512,
             TotpAlgorithm::Steam => OTPHashAlgorithm::Unknown("steam".to_string()),
         },
-        issuer: None,
+        issuer: totp.issuer,
     }
 }
 
@@ -228,8 +228,10 @@ mod tests {
     #[test]
     fn test_convert_totp() {
         let totp = Totp {
+            account: Some("test-account@example.com".to_string()),
             algorithm: TotpAlgorithm::Sha1,
             digits: 4,
+            issuer: Some("test-issuer".to_string()),
             period: 60,
             secret: "secret".as_bytes().to_vec(),
         };
@@ -238,9 +240,9 @@ mod tests {
         assert_eq!(String::from(credential.secret), "ONSWG4TFOQ");
         assert_eq!(credential.period, 60);
         assert_eq!(credential.digits, 4);
-        assert_eq!(credential.username, "");
+        assert_eq!(credential.username, "test-account@example.com");
         assert_eq!(credential.algorithm, OTPHashAlgorithm::Sha1);
-        assert_eq!(credential.issuer, None);
+        assert_eq!(credential.issuer, Some("test-issuer".to_string()));
     }
 
     #[test]

--- a/crates/bitwarden-vault/Cargo.toml
+++ b/crates/bitwarden-vault/Cargo.toml
@@ -28,6 +28,7 @@ bitwarden-core = { workspace = true, features = ["internal"] }
 bitwarden-crypto = { workspace = true }
 chrono = { workspace = true }
 hmac = ">=0.12.1, <0.13"
+percent-encoding = ">=2.1, <3.0"
 rand = ">=0.8.5, <0.9"
 reqwest = { workspace = true }
 schemars = { workspace = true }

--- a/crates/bitwarden-vault/src/totp.rs
+++ b/crates/bitwarden-vault/src/totp.rs
@@ -176,16 +176,9 @@ impl FromStr for Totp {
             let url = Url::parse(&key).map_err(|_| TotpError::InvalidOtpauth)?;
             let decoded_path = percent_decode_str(url.path()).decode_utf8_lossy();
             let label = decoded_path.strip_prefix("/");
-            let (issuer, account) = if let Some(label) = label {
-                if let Some((issuer, account)) = label.split_once(":") {
-                    (Some(issuer.trim()), Some(account.trim()))
-                } else if let Some((issuer, account)) = label.split_once("%3a") {
-                    (Some(issuer.trim()), Some(account.trim()))
-                } else {
-                    (None, Some(label.trim()))
-                }
-            } else {
-                (None, None)
+            let (issuer, account) = match label.and_then(|v| v.split_once(':')) {
+                Some((issuer, account)) => (Some(issuer.trim()), Some(account.trim())),
+                None => (None, label),
             };
 
             let parts: HashMap<_, _> = url.query_pairs().collect();

--- a/crates/bitwarden-vault/src/totp.rs
+++ b/crates/bitwarden-vault/src/totp.rs
@@ -428,7 +428,8 @@ mod tests {
 
     #[test]
     fn test_parse_totp_label_two_issuers() {
-        // If the label has an issuer and there is an issuer parameter, the parameter is chosen as the issuer
+        // If the label has an issuer and there is an issuer parameter, the parameter is chosen as
+        // the issuer
         let key = "otpauth://totp/test-issuer:test-account@example.com?secret=WQIQ25BRKZYCJVYP&issuer=other-test-issuer";
         let totp = Totp::from_str(key).unwrap();
 

--- a/crates/bitwarden-vault/src/totp.rs
+++ b/crates/bitwarden-vault/src/totp.rs
@@ -5,7 +5,7 @@ use bitwarden_crypto::{CryptoError, KeyStoreContext};
 use bitwarden_error::bitwarden_error;
 use chrono::{DateTime, Utc};
 use hmac::{Hmac, Mac};
-use percent_encoding::{percent_decode, percent_decode_str};
+use percent_encoding::percent_decode_str;
 use reqwest::Url;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};

--- a/crates/bitwarden-vault/src/totp.rs
+++ b/crates/bitwarden-vault/src/totp.rs
@@ -175,12 +175,12 @@ impl FromStr for Totp {
                 .split(":")
                 .map(|v| v.to_string())
                 .collect();
-            let label_issuer = if pieces.iter().count() > 1 {
-                pieces.get(0)
+            let label_issuer = if pieces.len() > 1 {
+                pieces.first()
             } else {
                 None
             };
-            let label_account = if pieces.iter().count() > 1 {
+            let label_account = if pieces.len() > 1 {
                 pieces.get(1)
             } else {
                 label_string.as_ref()

--- a/crates/bitwarden-vault/src/totp.rs
+++ b/crates/bitwarden-vault/src/totp.rs
@@ -364,6 +364,15 @@ mod tests {
     }
 
     #[test]
+    fn test_generate_otpauth_no_label() {
+        let key = "otpauth://totp/?secret=WQIQ25BRKZYCJVYP";
+        let totp = Totp::from_str(key).unwrap();
+
+        assert_eq!(totp.account, Some("".to_string()));
+        assert_eq!(totp.issuer, None);
+    }
+
+    #[test]
     fn test_generate_otpauth_uppercase() {
         let key = "OTPauth://totp/test-account?secret=WQIQ25BRKZYCJVYP".to_string();
         let time = Some(
@@ -435,6 +444,36 @@ mod tests {
 
         assert_eq!(totp.account, Some("test-account@example.com".to_string()));
         assert_eq!(totp.issuer, Some("other-test-issuer".to_string()));
+    }
+
+    #[test]
+    fn test_parse_totp_label_encoded_colon() {
+        // A url-encoded colon is a valid separator
+        let key = "otpauth://totp/test-issuer%3Atest-account@example.com?secret=WQIQ25BRKZYCJVYP&issuer=test-issuer";
+        let totp = Totp::from_str(key).unwrap();
+
+        assert_eq!(totp.account, Some("test-account@example.com".to_string()));
+        assert_eq!(totp.issuer, Some("other-test-issuer".to_string()));
+    }
+
+    #[test]
+    fn test_parse_totp_label_encoded_characters() {
+        // The account and issuer can both be URL-encoded
+        let key = "otpauth://totp/test%20issuer:test-account%40example%2Ecom?secret=WQIQ25BRKZYCJVYP&issuer=test%20issuer";
+        let totp = Totp::from_str(key).unwrap();
+
+        assert_eq!(totp.account, Some("test-account@example.com".to_string()));
+        assert_eq!(totp.issuer, Some("test-issuer".to_string()));
+    }
+
+    #[test]
+    fn test_parse_totp_label_account_spaces() {
+        // The account can have spaces before it
+        let key = "otpauth://totp/test-issuer:   test-account@example.com?secret=WQIQ25BRKZYCJVYP&issuer=test-issuer";
+        let totp = Totp::from_str(key).unwrap();
+
+        assert_eq!(totp.account, Some("test-account@example.com".to_string()));
+        assert_eq!(totp.issuer, Some("test-issuer".to_string()));
     }
 
     #[test]


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-15389

## 📔 Objective

This adds optional `account` and `issuer` properties to the `Totp` object, and parses them out of `otpauth://` URLs. This attempts to follow a similar logic as to how [the iOS PM app currently is doing it](https://github.com/bitwarden/ios/blob/main/BitwardenShared/Core/Vault/Services/TOTP/OTPAuthModel.swift#L65), though compare also [how the iOS BWA app is doing it](https://github.com/bitwarden/authenticator-ios/blob/main/AuthenticatorShared/Core/Vault/Services/TOTP/OTPAuthModel.swift#L88). Ultimately because both the [Yubico spec](https://docs.yubico.com/yesdk/users-manual/application-oath/uri-string-format.html) and [Google spec](https://github.com/google/google-authenticator/wiki/Key-Uri-Format) indicate that colons should not be in issuers or account names, I went with the naïve approach of splitting on a colon. As well, neither spec defines appropriate behavior if the label's issuer and the parameter issuer are different, and I went with using the parameter; it's possible we should instead treat this as an error case?

This is my first foray into Rust, so I fully expect I am not as idiomatic about things as I could be, or that I likely missed some crucial detail.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation
  team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
