### PR TITLE
[PM-17907] Remove core::Error from bitwarden-exporters

### DIFF
--- a/crates/bitwarden-core/src/auth/password/validate.rs
+++ b/crates/bitwarden-core/src/auth/password/validate.rs
@@ -3,7 +3,7 @@ use bitwarden_crypto::{HashPurpose, MasterKey};
 use crate::{
     auth::determine_password_hash,
     client::{LoginMethod, UserLoginMethod},
-    error::{Error, Result},
+    error::{NotAuthenticatedError, Result},
     Client,
 };
 
@@ -16,7 +16,7 @@ pub(crate) fn validate_password(
     let login_method = client
         .internal
         .get_login_method()
-        .ok_or(Error::NotAuthenticated)?;
+        .ok_or(NotAuthenticatedError)?;
 
     #[allow(irrefutable_let_patterns)]
     if let LoginMethod::User(login_method) = login_method.as_ref() {
@@ -34,7 +34,7 @@ pub(crate) fn validate_password(
             }
         }
     } else {
-        Err(Error::NotAuthenticated)
+        Err(NotAuthenticatedError)?
     }
 }
 
@@ -47,7 +47,7 @@ pub(crate) fn validate_password_user_key(
     let login_method = client
         .internal
         .get_login_method()
-        .ok_or(Error::NotAuthenticated)?;
+        .ok_or(NotAuthenticatedError)?;
 
     #[allow(irrefutable_let_patterns)]
     if let LoginMethod::User(login_method) = login_method.as_ref() {
@@ -72,7 +72,7 @@ pub(crate) fn validate_password_user_key(
             }
         }
     } else {
-        Err(Error::NotAuthenticated)
+        Err(NotAuthenticatedError)?
     }
 }
 

--- a/crates/bitwarden-core/src/auth/pin.rs
+++ b/crates/bitwarden-core/src/auth/pin.rs
@@ -2,7 +2,7 @@ use bitwarden_crypto::{EncString, PinKey};
 
 use crate::{
     client::{LoginMethod, UserLoginMethod},
-    error::{Error, Result},
+    error::{NotAuthenticatedError, Result},
     Client,
 };
 
@@ -14,11 +14,11 @@ pub(crate) fn validate_pin(
     let login_method = client
         .internal
         .get_login_method()
-        .ok_or(Error::NotAuthenticated)?;
+        .ok_or(NotAuthenticatedError)?;
 
     #[allow(irrefutable_let_patterns)]
     let LoginMethod::User(login_method) = login_method.as_ref() else {
-        return Err(Error::NotAuthenticated);
+        return Err(NotAuthenticatedError)?;
     };
 
     match login_method {

--- a/crates/bitwarden-core/src/auth/renew.rs
+++ b/crates/bitwarden-core/src/auth/renew.rs
@@ -9,7 +9,7 @@ use crate::{
 use crate::{
     auth::api::{request::ApiTokenRequest, response::IdentityTokenResponse},
     client::{internal::InternalClient, LoginMethod, UserLoginMethod},
-    error::{Error, Result},
+    error::{Error, NotAuthenticatedError, Result},
 };
 
 pub(crate) async fn renew_token(client: &InternalClient) -> Result<()> {
@@ -40,7 +40,7 @@ pub(crate) async fn renew_token(client: &InternalClient) -> Result<()> {
         let res = match login_method.as_ref() {
             LoginMethod::User(u) => match u {
                 UserLoginMethod::Username { client_id, .. } => {
-                    let refresh = tokens.refresh_token.ok_or(Error::NotAuthenticated)?;
+                    let refresh = tokens.refresh_token.ok_or(NotAuthenticatedError)?;
 
                     crate::auth::api::request::RenewTokenRequest::new(refresh, client_id.to_owned())
                         .send(&config)
@@ -105,5 +105,5 @@ pub(crate) async fn renew_token(client: &InternalClient) -> Result<()> {
         }
     }
 
-    Err(Error::NotAuthenticated)
+    Err(NotAuthenticatedError)?
 }

--- a/crates/bitwarden-core/src/client/internal.rs
+++ b/crates/bitwarden-core/src/client/internal.rs
@@ -19,7 +19,7 @@ use crate::{
 use crate::{
     client::encryption_settings::EncryptionSettingsError,
     client::{flags::Flags, login_method::UserLoginMethod},
-    error::Error,
+    error::NotAuthenticatedError,
 };
 
 #[derive(Debug, Clone)]
@@ -138,7 +138,7 @@ impl InternalClient {
     }
 
     #[cfg(feature = "internal")]
-    pub fn get_kdf(&self) -> Result<Kdf> {
+    pub fn get_kdf(&self) -> Result<Kdf, NotAuthenticatedError> {
         match self
             .login_method
             .read()
@@ -148,7 +148,7 @@ impl InternalClient {
             Some(LoginMethod::User(
                 UserLoginMethod::Username { kdf, .. } | UserLoginMethod::ApiKey { kdf, .. },
             )) => Ok(kdf.clone()),
-            _ => Err(Error::NotAuthenticated),
+            _ => Err(NotAuthenticatedError),
         }
     }
 

--- a/crates/bitwarden-core/src/error.rs
+++ b/crates/bitwarden-core/src/error.rs
@@ -17,9 +17,8 @@ pub enum Error {
     MissingFieldError(#[from] MissingFieldError),
     #[error(transparent)]
     VaultLocked(#[from] VaultLocked),
-
-    #[error("The client is not authenticated or the session has expired")]
-    NotAuthenticated,
+    #[error(transparent)]
+    NotAuthenticated(#[from] NotAuthenticatedError),
 
     #[error("Access token is not in a valid format: {0}")]
     AccessTokenInvalid(#[from] AccessTokenInvalidError),
@@ -137,6 +136,10 @@ pub enum ApiError {
 impl_bitwarden_error!(ApiApisError, ApiError);
 
 pub(crate) type Result<T, E = Error> = std::result::Result<T, E>;
+
+#[derive(Debug, Error)]
+#[error("The client is not authenticated or the session has expired")]
+pub struct NotAuthenticatedError;
 
 #[derive(Debug, Error)]
 #[error("The response received was missing a required field: {0}")]

--- a/crates/bitwarden-core/src/lib.rs
+++ b/crates/bitwarden-core/src/lib.rs
@@ -8,7 +8,7 @@ pub mod admin_console;
 pub mod auth;
 pub mod client;
 mod error;
-pub use error::{ApiError, Error, MissingFieldError, VaultLocked};
+pub use error::{ApiError, Error, MissingFieldError, NotAuthenticatedError, VaultLocked};
 #[cfg(feature = "internal")]
 pub mod mobile;
 #[cfg(feature = "internal")]

--- a/crates/bitwarden-core/src/mobile/crypto.rs
+++ b/crates/bitwarden-core/src/mobile/crypto.rs
@@ -12,7 +12,7 @@ use {tsify_next::Tsify, wasm_bindgen::prelude::*};
 
 use crate::{
     client::{encryption_settings::EncryptionSettingsError, LoginMethod, UserLoginMethod},
-    error::{Error, Result},
+    error::{NotAuthenticatedError, Result},
     Client,
 };
 
@@ -230,7 +230,7 @@ pub fn update_password(client: &Client, new_password: String) -> Result<UpdatePa
     let login_method = client
         .internal
         .get_login_method()
-        .ok_or(Error::NotAuthenticated)?;
+        .ok_or(NotAuthenticatedError)?;
 
     // Derive a new master key from password
     let new_master_key = match login_method.as_ref() {
@@ -239,7 +239,7 @@ pub fn update_password(client: &Client, new_password: String) -> Result<UpdatePa
             | UserLoginMethod::ApiKey { email, kdf, .. },
         ) => MasterKey::derive(&new_password, email, kdf)?,
         #[cfg(feature = "secrets")]
-        LoginMethod::ServiceAccount(_) => return Err(Error::NotAuthenticated),
+        LoginMethod::ServiceAccount(_) => return Err(NotAuthenticatedError)?,
     };
 
     let new_key = new_master_key.encrypt_user_key(user_key)?;
@@ -272,7 +272,7 @@ pub fn derive_pin_key(client: &Client, pin: String) -> Result<DerivePinKeyRespon
     let login_method = client
         .internal
         .get_login_method()
-        .ok_or(Error::NotAuthenticated)?;
+        .ok_or(NotAuthenticatedError)?;
 
     let pin_protected_user_key = derive_pin_protected_user_key(&pin, &login_method, user_key)?;
 
@@ -290,7 +290,7 @@ pub fn derive_pin_user_key(client: &Client, encrypted_pin: EncString) -> Result<
     let login_method = client
         .internal
         .get_login_method()
-        .ok_or(Error::NotAuthenticated)?;
+        .ok_or(NotAuthenticatedError)?;
 
     derive_pin_protected_user_key(&pin, &login_method, user_key)
 }
@@ -308,7 +308,7 @@ fn derive_pin_protected_user_key(
             | UserLoginMethod::ApiKey { email, kdf, .. },
         ) => PinKey::derive(pin.as_bytes(), email.as_bytes(), kdf)?,
         #[cfg(feature = "secrets")]
-        LoginMethod::ServiceAccount(_) => return Err(Error::NotAuthenticated),
+        LoginMethod::ServiceAccount(_) => return Err(NotAuthenticatedError)?,
     };
 
     Ok(derived_key.encrypt_user_key(user_key)?)

--- a/crates/bitwarden-core/src/platform/get_user_api_key.rs
+++ b/crates/bitwarden-core/src/platform/get_user_api_key.rs
@@ -12,7 +12,7 @@ use serde::{Deserialize, Serialize};
 use super::SecretVerificationRequest;
 use crate::{
     client::{LoginMethod, UserLoginMethod},
-    error::{Error, Result},
+    error::{NotAuthenticatedError, Result},
     require, Client,
 };
 
@@ -32,14 +32,14 @@ pub(crate) async fn get_user_api_key(
     UserApiKeyResponse::process_response(response)
 }
 
-fn get_login_method(client: &Client) -> Result<Arc<LoginMethod>> {
+fn get_login_method(client: &Client) -> Result<Arc<LoginMethod>, NotAuthenticatedError> {
     if client.internal.is_authed() {
         client
             .internal
             .get_login_method()
-            .ok_or(Error::NotAuthenticated)
+            .ok_or(NotAuthenticatedError)
     } else {
-        Err(Error::NotAuthenticated)
+        Err(NotAuthenticatedError)
     }
 }
 

--- a/crates/bitwarden-exporters/src/error.rs
+++ b/crates/bitwarden-exporters/src/error.rs
@@ -5,6 +5,8 @@ pub enum ExportError {
     #[error(transparent)]
     MissingField(#[from] bitwarden_core::MissingFieldError),
     #[error(transparent)]
+    NotAuthenticated(#[from] bitwarden_core::NotAuthenticatedError),
+    #[error(transparent)]
     VaultLocked(#[from] bitwarden_core::VaultLocked),
 
     #[error("CSV error: {0}")]
@@ -16,8 +18,6 @@ pub enum ExportError {
     #[error("Encrypted JSON error: {0}")]
     EncryptedJsonError(#[from] crate::encrypted_json::EncryptedJsonError),
 
-    #[error(transparent)]
-    BitwardenError(#[from] bitwarden_core::Error),
     #[error(transparent)]
     BitwardenCryptoError(#[from] bitwarden_crypto::CryptoError),
     #[error(transparent)]

--- a/crates/bitwarden-exporters/src/export.rs
+++ b/crates/bitwarden-exporters/src/export.rs
@@ -34,7 +34,10 @@ pub(crate) fn export_vault(
             folders,
             ciphers,
             password,
-            client.internal.get_kdf()?,
+            client
+                .internal
+                .get_kdf()
+                .map_err(|e| ExportError::BitwardenError(e.into()))?,
         )?),
     }
 }

--- a/crates/bitwarden-exporters/src/export.rs
+++ b/crates/bitwarden-exporters/src/export.rs
@@ -34,10 +34,7 @@ pub(crate) fn export_vault(
             folders,
             ciphers,
             password,
-            client
-                .internal
-                .get_kdf()
-                .map_err(|e| ExportError::BitwardenError(e.into()))?,
+            client.internal.get_kdf()?,
         )?),
     }
 }


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

https://bitwarden.atlassian.net/browse/PM-17907

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

- Extract `NotAuthenticatedError` as a separate error struct.
- Depend on the new `NotAuthenticatedError` instead of `bitwarden_core::Error` in `bitwarden-exporters`.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation
  team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
