### PR TITLE
[PM-17980] Remove core::error from auth used by uniffi

### DIFF
--- a/bitwarden_license/bitwarden-sm/src/error.rs
+++ b/bitwarden_license/bitwarden-sm/src/error.rs
@@ -8,7 +8,7 @@ pub enum SecretsManagerError {
     #[error(transparent)]
     ValidationError(ValidationError),
     #[error(transparent)]
-    VaultLocked(#[from] bitwarden_core::VaultLocked),
+    VaultLocked(#[from] bitwarden_core::VaultLockedError),
     #[error(transparent)]
     CryptoError(#[from] bitwarden_crypto::CryptoError),
     #[error(transparent)]

--- a/crates/bitwarden-core/src/auth/password/mod.rs
+++ b/crates/bitwarden-core/src/auth/password/mod.rs
@@ -2,8 +2,6 @@ mod policy;
 pub(crate) use policy::satisfies_policy;
 pub use policy::MasterPasswordPolicyOptions;
 mod validate;
-pub(crate) use validate::validate_password;
-#[cfg(feature = "internal")]
-pub(crate) use validate::validate_password_user_key;
+pub(crate) use validate::{validate_password, validate_password_user_key};
 mod strength;
 pub(crate) use strength::password_strength;

--- a/crates/bitwarden-core/src/auth/pin.rs
+++ b/crates/bitwarden-core/src/auth/pin.rs
@@ -1,6 +1,7 @@
 use bitwarden_crypto::{EncString, PinKey};
 
 use crate::{
+    auth::AuthValidateError,
     client::{LoginMethod, UserLoginMethod},
     error::{NotAuthenticatedError, Result},
     Client,
@@ -10,7 +11,7 @@ pub(crate) fn validate_pin(
     client: &Client,
     pin: String,
     pin_protected_user_key: EncString,
-) -> Result<bool> {
+) -> Result<bool, AuthValidateError> {
     let login_method = client
         .internal
         .get_login_method()

--- a/crates/bitwarden-core/src/auth/register.rs
+++ b/crates/bitwarden-core/src/auth/register.rs
@@ -2,7 +2,9 @@ use bitwarden_api_identity::{
     apis::accounts_api::accounts_register_post,
     models::{KeysRequestModel, RegisterRequestModel},
 };
-use bitwarden_crypto::{default_pbkdf2_iterations, HashPurpose, Kdf, MasterKey, RsaKeyPair};
+use bitwarden_crypto::{
+    default_pbkdf2_iterations, CryptoError, HashPurpose, Kdf, MasterKey, RsaKeyPair,
+};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
@@ -56,7 +58,7 @@ pub(super) fn make_register_keys(
     email: String,
     password: String,
     kdf: Kdf,
-) -> Result<RegisterKeyResponse> {
+) -> Result<RegisterKeyResponse, CryptoError> {
     let master_key = MasterKey::derive(&password, &email, &kdf)?;
     let master_password_hash =
         master_key.derive_master_key_hash(password.as_bytes(), HashPurpose::ServerAuthorization)?;

--- a/crates/bitwarden-core/src/auth/tde.rs
+++ b/crates/bitwarden-core/src/auth/tde.rs
@@ -4,7 +4,7 @@ use bitwarden_crypto::{
     TrustDeviceResponse, UserKey,
 };
 
-use crate::{error::Result, Client};
+use crate::{client::encryption_settings::EncryptionSettingsError, error::Result, Client};
 
 /// This function generates a new user key and key pair, initializes the client's crypto with the
 /// generated user key, and encrypts the user key with the organization public key for admin
@@ -14,7 +14,7 @@ pub(super) fn make_register_tde_keys(
     email: String,
     org_public_key: String,
     remember_device: bool,
-) -> Result<RegisterTdeKeyResponse> {
+) -> Result<RegisterTdeKeyResponse, EncryptionSettingsError> {
     let public_key = AsymmetricPublicCryptoKey::from_der(&STANDARD.decode(org_public_key)?)?;
 
     let mut rng = rand::thread_rng();

--- a/crates/bitwarden-core/src/client/encryption_settings.rs
+++ b/crates/bitwarden-core/src/client/encryption_settings.rs
@@ -9,7 +9,7 @@ use uuid::Uuid;
 
 #[cfg(feature = "internal")]
 use crate::error::Result;
-use crate::VaultLocked;
+use crate::VaultLockedError;
 
 #[bitwarden_error(flat)]
 #[derive(Debug, Error)]
@@ -21,7 +21,7 @@ pub enum EncryptionSettingsError {
     InvalidBase64(#[from] base64::DecodeError),
 
     #[error(transparent)]
-    VaultLocked(#[from] VaultLocked),
+    VaultLocked(#[from] VaultLockedError),
 
     #[error("Invalid private key")]
     InvalidPrivateKey,

--- a/crates/bitwarden-core/src/client/internal.rs
+++ b/crates/bitwarden-core/src/client/internal.rs
@@ -12,7 +12,7 @@ use super::login_method::ServiceAccountLoginMethod;
 use crate::{
     auth::renew::renew_token,
     client::{encryption_settings::EncryptionSettings, login_method::LoginMethod},
-    error::{Result, VaultLocked},
+    error::{Result, VaultLockedError},
     DeviceType,
 };
 #[cfg(feature = "internal")]
@@ -167,12 +167,12 @@ impl InternalClient {
         &self.external_client
     }
 
-    pub fn get_encryption_settings(&self) -> Result<Arc<EncryptionSettings>, VaultLocked> {
+    pub fn get_encryption_settings(&self) -> Result<Arc<EncryptionSettings>, VaultLockedError> {
         self.encryption_settings
             .read()
             .expect("RwLock is not poisoned")
             .clone()
-            .ok_or(VaultLocked)
+            .ok_or(VaultLockedError)
     }
 
     #[cfg(feature = "internal")]
@@ -241,7 +241,7 @@ impl InternalClient {
             .expect("RwLock is not poisoned");
 
         let Some(enc) = guard.as_mut() else {
-            return Err(VaultLocked.into());
+            return Err(VaultLockedError.into());
         };
 
         let inner = Arc::make_mut(enc);

--- a/crates/bitwarden-core/src/error.rs
+++ b/crates/bitwarden-core/src/error.rs
@@ -16,7 +16,7 @@ pub enum Error {
     #[error(transparent)]
     MissingFieldError(#[from] MissingFieldError),
     #[error(transparent)]
-    VaultLocked(#[from] VaultLocked),
+    VaultLocked(#[from] VaultLockedError),
     #[error(transparent)]
     NotAuthenticated(#[from] NotAuthenticatedError),
 
@@ -147,7 +147,11 @@ pub struct MissingFieldError(pub &'static str);
 
 #[derive(Debug, Error)]
 #[error("The client vault is locked and needs to be unlocked before use")]
-pub struct VaultLocked;
+pub struct VaultLockedError;
+
+#[derive(Debug, thiserror::Error)]
+#[error("Wrong password")]
+pub struct WrongPasswordError;
 
 /// This macro is used to require that a value is present or return an error otherwise.
 /// It is equivalent to using `val.ok_or(Error::MissingFields)?`, but easier to use and

--- a/crates/bitwarden-core/src/lib.rs
+++ b/crates/bitwarden-core/src/lib.rs
@@ -8,7 +8,9 @@ pub mod admin_console;
 pub mod auth;
 pub mod client;
 mod error;
-pub use error::{ApiError, Error, MissingFieldError, NotAuthenticatedError, VaultLocked};
+pub use error::{
+    ApiError, Error, MissingFieldError, NotAuthenticatedError, VaultLockedError, WrongPasswordError,
+};
 #[cfg(feature = "internal")]
 pub mod mobile;
 #[cfg(feature = "internal")]

--- a/crates/bitwarden-core/src/mobile/client_kdf.rs
+++ b/crates/bitwarden-core/src/mobile/client_kdf.rs
@@ -1,4 +1,4 @@
-use bitwarden_crypto::{HashPurpose, Kdf};
+use bitwarden_crypto::{CryptoError, HashPurpose, Kdf};
 
 use crate::{error::Result, mobile::kdf::hash_password, Client};
 
@@ -13,7 +13,7 @@ impl ClientKdf<'_> {
         password: String,
         kdf_params: Kdf,
         purpose: HashPurpose,
-    ) -> Result<String> {
+    ) -> Result<String, CryptoError> {
         hash_password(email, password, kdf_params, purpose).await
     }
 }

--- a/crates/bitwarden-core/src/mobile/crypto.rs
+++ b/crates/bitwarden-core/src/mobile/crypto.rs
@@ -13,7 +13,7 @@ use {tsify_next::Tsify, wasm_bindgen::prelude::*};
 use crate::{
     client::{encryption_settings::EncryptionSettingsError, LoginMethod, UserLoginMethod},
     error::{NotAuthenticatedError, Result},
-    Client, VaultLocked,
+    Client, VaultLockedError, WrongPasswordError,
 };
 
 /// Catch all errors for mobile crypto operations
@@ -22,7 +22,7 @@ pub enum MobileCryptoError {
     #[error(transparent)]
     NotAuthenticated(#[from] NotAuthenticatedError),
     #[error(transparent)]
-    VaultLocked(#[from] VaultLocked),
+    VaultLocked(#[from] VaultLockedError),
     #[error(transparent)]
     Crypto(#[from] bitwarden_crypto::CryptoError),
 }
@@ -338,7 +338,7 @@ fn derive_pin_protected_user_key(
 #[derive(Debug, thiserror::Error)]
 pub enum EnrollAdminPasswordResetError {
     #[error(transparent)]
-    VaultLocked(#[from] VaultLocked),
+    VaultLocked(#[from] VaultLockedError),
     #[error(transparent)]
     Crypto(#[from] bitwarden_crypto::CryptoError),
     #[error(transparent)]
@@ -371,10 +371,6 @@ pub struct DeriveKeyConnectorRequest {
     pub kdf: Kdf,
     pub email: String,
 }
-
-#[derive(Debug, thiserror::Error)]
-#[error("wrong password")]
-pub struct WrongPasswordError;
 
 #[derive(Debug, thiserror::Error)]
 pub enum DeriveKeyConnectorError {

--- a/crates/bitwarden-core/src/mobile/kdf.rs
+++ b/crates/bitwarden-core/src/mobile/kdf.rs
@@ -1,4 +1,4 @@
-use bitwarden_crypto::{HashPurpose, Kdf, MasterKey};
+use bitwarden_crypto::{CryptoError, HashPurpose, Kdf, MasterKey};
 
 use crate::error::Result;
 
@@ -7,8 +7,8 @@ pub async fn hash_password(
     password: String,
     kdf_params: Kdf,
     purpose: HashPurpose,
-) -> Result<String> {
+) -> Result<String, CryptoError> {
     let master_key = MasterKey::derive(&password, &email, &kdf_params)?;
 
-    Ok(master_key.derive_master_key_hash(password.as_bytes(), purpose)?)
+    master_key.derive_master_key_hash(password.as_bytes(), purpose)
 }

--- a/crates/bitwarden-core/src/platform/generate_fingerprint.rs
+++ b/crates/bitwarden-core/src/platform/generate_fingerprint.rs
@@ -5,7 +5,7 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
-use crate::{error::Result, VaultLocked};
+use crate::{error::Result, VaultLockedError};
 
 #[derive(Serialize, Deserialize, Debug, JsonSchema)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
@@ -50,7 +50,7 @@ pub enum UserFingerprintError {
     #[error(transparent)]
     Crypto(#[from] bitwarden_crypto::CryptoError),
     #[error(transparent)]
-    VaultLocked(#[from] VaultLocked),
+    VaultLocked(#[from] VaultLockedError),
     #[error("Missing private key")]
     MissingPrivateKey,
 }

--- a/crates/bitwarden-exporters/src/error.rs
+++ b/crates/bitwarden-exporters/src/error.rs
@@ -7,7 +7,7 @@ pub enum ExportError {
     #[error(transparent)]
     NotAuthenticated(#[from] bitwarden_core::NotAuthenticatedError),
     #[error(transparent)]
-    VaultLocked(#[from] bitwarden_core::VaultLocked),
+    VaultLocked(#[from] bitwarden_core::VaultLockedError),
 
     #[error("CSV error: {0}")]
     Csv(#[from] crate::csv::CsvError),

--- a/crates/bitwarden-fido/src/authenticator.rs
+++ b/crates/bitwarden-fido/src/authenticator.rs
@@ -1,6 +1,6 @@
 use std::sync::Mutex;
 
-use bitwarden_core::{Client, VaultLocked};
+use bitwarden_core::{Client, VaultLockedError};
 use bitwarden_crypto::{CryptoError, KeyContainer, KeyEncryptable};
 use bitwarden_vault::{CipherError, CipherView};
 use itertools::Itertools;
@@ -31,7 +31,7 @@ pub enum GetSelectedCredentialError {
     NoCredentialFound,
 
     #[error(transparent)]
-    VaultLocked(#[from] VaultLocked),
+    VaultLocked(#[from] VaultLockedError),
     #[error(transparent)]
     CryptoError(#[from] CryptoError),
 }
@@ -71,7 +71,7 @@ pub enum SilentlyDiscoverCredentialsError {
     #[error(transparent)]
     CipherError(#[from] CipherError),
     #[error(transparent)]
-    VaultLocked(#[from] VaultLocked),
+    VaultLocked(#[from] VaultLockedError),
     #[error(transparent)]
     InvalidGuid(#[from] InvalidGuid),
     #[error(transparent)]
@@ -85,7 +85,7 @@ pub enum CredentialsForAutofillError {
     #[error(transparent)]
     CipherError(#[from] CipherError),
     #[error(transparent)]
-    VaultLocked(#[from] VaultLocked),
+    VaultLocked(#[from] VaultLockedError),
     #[error(transparent)]
     InvalidGuid(#[from] InvalidGuid),
     #[error(transparent)]
@@ -352,7 +352,7 @@ impl passkey::authenticator::CredentialStore for CredentialStoreImpl<'_> {
         #[derive(Debug, Error)]
         enum InnerError {
             #[error(transparent)]
-            VaultLocked(#[from] VaultLocked),
+            VaultLocked(#[from] VaultLockedError),
             #[error(transparent)]
             CipherError(#[from] CipherError),
             #[error(transparent)]
@@ -435,7 +435,7 @@ impl passkey::authenticator::CredentialStore for CredentialStoreImpl<'_> {
         #[derive(Debug, Error)]
         enum InnerError {
             #[error(transparent)]
-            VaultLocked(#[from] VaultLocked),
+            VaultLocked(#[from] VaultLockedError),
             #[error(transparent)]
             FillCredentialError(#[from] FillCredentialError),
             #[error(transparent)]
@@ -507,7 +507,7 @@ impl passkey::authenticator::CredentialStore for CredentialStoreImpl<'_> {
         #[derive(Debug, Error)]
         enum InnerError {
             #[error(transparent)]
-            VaultLocked(#[from] VaultLocked),
+            VaultLocked(#[from] VaultLockedError),
             #[error(transparent)]
             InvalidGuid(#[from] InvalidGuid),
             #[error("Credential ID does not match selected credential")]

--- a/crates/bitwarden-fido/src/client_fido.rs
+++ b/crates/bitwarden-fido/src/client_fido.rs
@@ -15,7 +15,7 @@ pub struct ClientFido2<'a> {
 #[derive(Debug, Error)]
 pub enum DecryptFido2AutofillCredentialsError {
     #[error(transparent)]
-    VaultLocked(#[from] bitwarden_core::VaultLocked),
+    VaultLocked(#[from] bitwarden_core::VaultLockedError),
     #[error(transparent)]
     Fido2CredentialAutofillViewError(#[from] Fido2CredentialAutofillViewError),
 }

--- a/crates/bitwarden-send/src/send_client.rs
+++ b/crates/bitwarden-send/src/send_client.rs
@@ -12,7 +12,7 @@ pub enum SendEncryptError {
     #[error(transparent)]
     Crypto(#[from] bitwarden_crypto::CryptoError),
     #[error(transparent)]
-    VaultLocked(#[from] bitwarden_core::VaultLocked),
+    VaultLocked(#[from] bitwarden_core::VaultLockedError),
 }
 
 /// Generic error type for send decryption errors
@@ -21,7 +21,7 @@ pub enum SendDecryptError {
     #[error(transparent)]
     Crypto(#[from] bitwarden_crypto::CryptoError),
     #[error(transparent)]
-    VaultLocked(#[from] bitwarden_core::VaultLocked),
+    VaultLocked(#[from] bitwarden_core::VaultLockedError),
 }
 
 /// Generic error type for send encryption errors.

--- a/crates/bitwarden-uniffi/src/error.rs
+++ b/crates/bitwarden-uniffi/src/error.rs
@@ -11,12 +11,6 @@ pub enum BitwardenError {
     E(Error),
 }
 
-impl From<bitwarden_core::Error> for BitwardenError {
-    fn from(e: bitwarden_core::Error) -> Self {
-        Self::E(e.into())
-    }
-}
-
 impl From<Error> for BitwardenError {
     fn from(e: Error) -> Self {
         Self::E(e)
@@ -45,8 +39,6 @@ pub type Result<T, E = BitwardenError> = std::result::Result<T, E>;
 pub enum Error {
     #[error(transparent)]
     Api(#[from] bitwarden_core::ApiError),
-    #[error(transparent)]
-    Core(#[from] bitwarden_core::Error),
     #[error(transparent)]
     DeriveKeyConnector(#[from] bitwarden_core::mobile::crypto::DeriveKeyConnectorError),
     #[error(transparent)]

--- a/crates/bitwarden-uniffi/src/error.rs
+++ b/crates/bitwarden-uniffi/src/error.rs
@@ -57,11 +57,20 @@ pub enum Error {
     EnrollAdminPasswordReset(#[from] bitwarden_core::mobile::crypto::EnrollAdminPasswordResetError),
     #[error(transparent)]
     MobileCrypto(#[from] bitwarden_core::mobile::crypto::MobileCryptoError),
+    #[error(transparent)]
+    AuthValidate(#[from] bitwarden_core::auth::AuthValidateError),
+    #[error(transparent)]
+    ApproveAuthRequest(#[from] bitwarden_core::auth::ApproveAuthRequestError),
+    #[error(transparent)]
+    TrustDevice(#[from] bitwarden_core::auth::auth_client::TrustDeviceError),
 
     #[error(transparent)]
     Fingerprint(#[from] bitwarden_core::platform::FingerprintError),
     #[error(transparent)]
     UserFingerprint(#[from] bitwarden_core::platform::UserFingerprintError),
+
+    #[error(transparent)]
+    Crypto(#[from] bitwarden_crypto::CryptoError),
 
     // Generators
     #[error(transparent)]

--- a/crates/bitwarden-vault/src/cipher/cipher.rs
+++ b/crates/bitwarden-vault/src/cipher/cipher.rs
@@ -1,5 +1,5 @@
 use bitwarden_api_api::models::CipherDetailsResponseModel;
-use bitwarden_core::{require, MissingFieldError, VaultLocked};
+use bitwarden_core::{require, MissingFieldError, VaultLockedError};
 use bitwarden_crypto::{
     CryptoError, EncString, KeyContainer, KeyDecryptable, KeyEncryptable, LocateKey,
     SymmetricCryptoKey,
@@ -27,7 +27,7 @@ pub enum CipherError {
     #[error(transparent)]
     MissingFieldError(#[from] MissingFieldError),
     #[error(transparent)]
-    VaultLocked(#[from] VaultLocked),
+    VaultLocked(#[from] VaultLockedError),
     #[error(transparent)]
     CryptoError(#[from] CryptoError),
     #[error("This cipher contains attachments without keys. Those attachments will need to be reuploaded to complete the operation")]

--- a/crates/bitwarden-vault/src/error.rs
+++ b/crates/bitwarden-vault/src/error.rs
@@ -8,7 +8,7 @@ pub enum EncryptError {
     #[error(transparent)]
     Crypto(#[from] bitwarden_crypto::CryptoError),
     #[error(transparent)]
-    VaultLocked(#[from] bitwarden_core::VaultLocked),
+    VaultLocked(#[from] bitwarden_core::VaultLockedError),
 }
 
 /// Generic error type for decryption errors
@@ -18,7 +18,7 @@ pub enum DecryptError {
     #[error(transparent)]
     Crypto(#[from] bitwarden_crypto::CryptoError),
     #[error(transparent)]
-    VaultLocked(#[from] bitwarden_core::VaultLocked),
+    VaultLocked(#[from] bitwarden_core::VaultLockedError),
 }
 
 #[derive(Debug, Error)]

--- a/crates/bitwarden-vault/src/totp.rs
+++ b/crates/bitwarden-vault/src/totp.rs
@@ -1,6 +1,6 @@
 use std::{collections::HashMap, str::FromStr};
 
-use bitwarden_core::VaultLocked;
+use bitwarden_core::VaultLockedError;
 use bitwarden_crypto::{CryptoError, KeyContainer};
 use bitwarden_error::bitwarden_error;
 use chrono::{DateTime, Utc};
@@ -36,7 +36,7 @@ pub enum TotpError {
     #[error(transparent)]
     CryptoError(#[from] CryptoError),
     #[error(transparent)]
-    VaultLocked(#[from] VaultLocked),
+    VaultLocked(#[from] VaultLockedError),
 }
 
 #[derive(Serialize, Deserialize, Debug, JsonSchema)]


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

https://bitwarden.atlassian.net/browse/PM-17980

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Remove usages of bitwarden_core::Error from auth functions used by the uniffi bindings.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation
  team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
