### PR TITLE
[PM-17981] Remove bitwarden_core::Error from wasm-internal

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -421,6 +421,7 @@ dependencies = [
  "aes",
  "argon2",
  "base64",
+ "bitwarden-error",
  "cbc",
  "criterion",
  "generic-array",

--- a/crates/bitwarden-core/src/error.rs
+++ b/crates/bitwarden-core/src/error.rs
@@ -4,13 +4,12 @@ use std::{borrow::Cow, fmt::Debug};
 
 use bitwarden_api_api::apis::Error as ApiApisError;
 use bitwarden_api_identity::apis::Error as IdentityError;
-use bitwarden_error::bitwarden_error;
 use reqwest::StatusCode;
 use thiserror::Error;
 
 use crate::client::encryption_settings::EncryptionSettingsError;
 
-#[bitwarden_error(flat, export_as = "CoreError")]
+/// Deprecated, use a domain specific Error instead
 #[derive(Debug, Error)]
 pub enum Error {
     #[error(transparent)]

--- a/crates/bitwarden-core/src/mobile/crypto.rs
+++ b/crates/bitwarden-core/src/mobile/crypto.rs
@@ -2,8 +2,8 @@ use std::collections::HashMap;
 
 use base64::{engine::general_purpose::STANDARD, Engine};
 use bitwarden_crypto::{
-    AsymmetricCryptoKey, AsymmetricEncString, EncString, Kdf, KeyDecryptable, KeyEncryptable,
-    MasterKey, SymmetricCryptoKey, UserKey,
+    AsymmetricCryptoKey, AsymmetricEncString, CryptoError, EncString, Kdf, KeyDecryptable,
+    KeyEncryptable, MasterKey, SymmetricCryptoKey, UserKey,
 };
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -407,7 +407,7 @@ pub struct MakeKeyPairResponse {
     user_key_encrypted_private_key: EncString,
 }
 
-pub fn make_key_pair(user_key: String) -> Result<MakeKeyPairResponse> {
+pub fn make_key_pair(user_key: String) -> Result<MakeKeyPairResponse, CryptoError> {
     let user_key = UserKey::new(SymmetricCryptoKey::try_from(user_key)?);
 
     let key_pair = user_key.make_key_pair()?;
@@ -444,7 +444,7 @@ pub struct VerifyAsymmetricKeysResponse {
 
 pub fn verify_asymmetric_keys(
     request: VerifyAsymmetricKeysRequest,
-) -> Result<VerifyAsymmetricKeysResponse> {
+) -> Result<VerifyAsymmetricKeysResponse, CryptoError> {
     #[derive(Debug, thiserror::Error)]
     enum VerifyError {
         #[error("Failed to decrypt private key: {0:?}")]

--- a/crates/bitwarden-core/src/mobile/crypto_client.rs
+++ b/crates/bitwarden-core/src/mobile/crypto_client.rs
@@ -1,3 +1,4 @@
+use bitwarden_crypto::CryptoError;
 #[cfg(feature = "internal")]
 use bitwarden_crypto::{AsymmetricEncString, EncString};
 
@@ -6,16 +7,13 @@ use super::crypto::{
     DeriveKeyConnectorRequest, EnrollAdminPasswordResetError, MakeKeyPairResponse,
     MobileCryptoError, VerifyAsymmetricKeysRequest, VerifyAsymmetricKeysResponse,
 };
-use crate::{client::encryption_settings::EncryptionSettingsError, Client};
 #[cfg(feature = "internal")]
-use crate::{
-    error::Result,
-    mobile::crypto::{
-        derive_pin_key, derive_pin_user_key, enroll_admin_password_reset, get_user_encryption_key,
-        initialize_org_crypto, initialize_user_crypto, update_password, DerivePinKeyResponse,
-        InitOrgCryptoRequest, InitUserCryptoRequest, UpdatePasswordResponse,
-    },
+use crate::mobile::crypto::{
+    derive_pin_key, derive_pin_user_key, enroll_admin_password_reset, get_user_encryption_key,
+    initialize_org_crypto, initialize_user_crypto, update_password, DerivePinKeyResponse,
+    InitOrgCryptoRequest, InitUserCryptoRequest, UpdatePasswordResponse,
 };
+use crate::{client::encryption_settings::EncryptionSettingsError, Client};
 
 pub struct CryptoClient<'a> {
     pub(crate) client: &'a crate::Client,
@@ -73,14 +71,14 @@ impl CryptoClient<'_> {
         derive_key_connector(request)
     }
 
-    pub fn make_key_pair(&self, user_key: String) -> Result<MakeKeyPairResponse> {
+    pub fn make_key_pair(&self, user_key: String) -> Result<MakeKeyPairResponse, CryptoError> {
         make_key_pair(user_key)
     }
 
     pub fn verify_asymmetric_keys(
         &self,
         request: VerifyAsymmetricKeysRequest,
-    ) -> Result<VerifyAsymmetricKeysResponse> {
+    ) -> Result<VerifyAsymmetricKeysResponse, CryptoError> {
         verify_asymmetric_keys(request)
     }
 }

--- a/crates/bitwarden-crypto/Cargo.toml
+++ b/crates/bitwarden-crypto/Cargo.toml
@@ -27,6 +27,7 @@ argon2 = { version = ">=0.5.0, <0.6", features = [
     "zeroize",
 ], default-features = false }
 base64 = ">=0.22.1, <0.23"
+bitwarden-error = { workspace = true }
 cbc = { version = ">=0.1.2, <0.2", features = ["alloc", "zeroize"] }
 generic-array = { version = ">=0.14.7, <1.0", features = ["zeroize"] }
 hkdf = ">=0.12.3, <0.13"

--- a/crates/bitwarden-crypto/src/error.rs
+++ b/crates/bitwarden-crypto/src/error.rs
@@ -1,10 +1,12 @@
 use std::fmt::Debug;
 
+use bitwarden_error::bitwarden_error;
 use thiserror::Error;
 use uuid::Uuid;
 
 use crate::fingerprint::FingerprintError;
 
+#[bitwarden_error(flat)]
 #[derive(Debug, Error)]
 pub enum CryptoError {
     #[error("The provided key is not the expected type")]

--- a/crates/bitwarden-wasm-internal/src/crypto.rs
+++ b/crates/bitwarden-wasm-internal/src/crypto.rs
@@ -8,6 +8,7 @@ use bitwarden_core::{
     },
     Client,
 };
+use bitwarden_crypto::CryptoError;
 use wasm_bindgen::prelude::*;
 
 #[wasm_bindgen]
@@ -41,10 +42,7 @@ impl CryptoClient {
 
     /// Generates a new key pair and encrypts the private key with the provided user key.
     /// Crypto initialization not required.
-    pub fn make_key_pair(
-        &self,
-        user_key: String,
-    ) -> Result<MakeKeyPairResponse, bitwarden_core::Error> {
+    pub fn make_key_pair(&self, user_key: String) -> Result<MakeKeyPairResponse, CryptoError> {
         self.0.crypto().make_key_pair(user_key)
     }
 
@@ -54,7 +52,7 @@ impl CryptoClient {
     pub fn verify_asymmetric_keys(
         &self,
         request: VerifyAsymmetricKeysRequest,
-    ) -> Result<VerifyAsymmetricKeysResponse, bitwarden_core::Error> {
+    ) -> Result<VerifyAsymmetricKeysResponse, CryptoError> {
         self.0.crypto().verify_asymmetric_keys(request)
     }
 }


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

https://bitwarden.atlassian.net/browse/PM-17981

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Removes bitwarden_error macro from bitwarden_core::Error and replaces the existing usages with CryptoError.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation
  team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
