### PR TITLE
[PM-15556] Build TOTP toString

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -633,6 +633,7 @@ dependencies = [
  "bitwarden-crypto",
  "bitwarden-error",
  "chrono",
+ "data-encoding",
  "hmac",
  "rand",
  "reqwest",

--- a/crates/bitwarden-exporters/src/cxf/export.rs
+++ b/crates/bitwarden-exporters/src/cxf/export.rs
@@ -152,8 +152,10 @@ mod tests {
     #[test]
     fn test_convert_totp() {
         let totp = Totp {
+            account: None,
             algorithm: TotpAlgorithm::Sha1,
             digits: 4,
+            issuer: None,
             period: 60,
             secret: "secret".as_bytes().to_vec(),
         };

--- a/crates/bitwarden-vault/Cargo.toml
+++ b/crates/bitwarden-vault/Cargo.toml
@@ -28,6 +28,7 @@ bitwarden-core = { workspace = true, features = ["internal"] }
 bitwarden-crypto = { workspace = true }
 bitwarden-error = { workspace = true }
 chrono = { workspace = true }
+data-encoding = "2.7.0"
 hmac = ">=0.12.1, <0.13"
 rand = ">=0.8.5, <0.9"
 reqwest = { workspace = true }

--- a/crates/bitwarden-vault/Cargo.toml
+++ b/crates/bitwarden-vault/Cargo.toml
@@ -17,7 +17,7 @@ keywords.workspace = true
 uniffi = [
     "bitwarden-core/uniffi",
     "bitwarden-crypto/uniffi",
-    "dep:uniffi",
+    "dep:uniffi"
 ] # Uniffi bindings
 wasm = ["dep:tsify-next", "dep:wasm-bindgen"] # WASM support
 

--- a/crates/bitwarden-vault/Cargo.toml
+++ b/crates/bitwarden-vault/Cargo.toml
@@ -17,7 +17,7 @@ keywords.workspace = true
 uniffi = [
     "bitwarden-core/uniffi",
     "bitwarden-crypto/uniffi",
-    "dep:uniffi"
+    "dep:uniffi",
 ] # Uniffi bindings
 wasm = ["dep:tsify-next", "dep:wasm-bindgen"] # WASM support
 
@@ -28,7 +28,7 @@ bitwarden-core = { workspace = true, features = ["internal"] }
 bitwarden-crypto = { workspace = true }
 bitwarden-error = { workspace = true }
 chrono = { workspace = true }
-data-encoding = "2.7.0"
+data-encoding = ">=2.0, <3"
 hmac = ">=0.12.1, <0.13"
 rand = ">=0.8.5, <0.9"
 reqwest = { workspace = true }

--- a/crates/bitwarden-vault/src/totp.rs
+++ b/crates/bitwarden-vault/src/totp.rs
@@ -91,7 +91,7 @@ pub fn generate_totp_cipher_view(
     generate_totp(key, time)
 }
 
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum TotpAlgorithm {
     Sha1,
     Sha256,

--- a/crates/bitwarden-vault/src/totp.rs
+++ b/crates/bitwarden-vault/src/totp.rs
@@ -589,7 +589,7 @@ mod tests {
     }
 
     #[test]
-    fn test_totp_to_string_period() {
+    fn test_totp_to_string_with_custom_period() {
         let totp = Totp {
             account: Some("test@bitwarden.com".to_string()),
             algorithm: DEFAULT_ALGORITHM,
@@ -623,7 +623,7 @@ mod tests {
     }
 
     #[test]
-    fn test_totp_to_string_issuer_with_spaces() {
+    fn test_totp_to_string_encodes_spaces_in_issuer() {
         let totp = Totp {
             account: Some("test@bitwarden.com".to_string()),
             algorithm: DEFAULT_ALGORITHM,
@@ -640,7 +640,7 @@ mod tests {
     }
 
     #[test]
-    fn test_totp_to_string_issuer_special_characters() {
+    fn test_totp_to_string_encodes_special_characters_in_issuer() {
         let totp = Totp {
             account: Some("test@bitwarden.com".to_string()),
             algorithm: DEFAULT_ALGORITHM,

--- a/crates/bitwarden-vault/src/totp.rs
+++ b/crates/bitwarden-vault/src/totp.rs
@@ -260,7 +260,8 @@ impl fmt::Display for Totp {
     /// Formats the TOTP as an OTP Auth URI.
     ///
     /// Returns a steam::// URI if the algorithm is Steam.
-    /// Otherwise returns an otpauth:// URI according to the Key Uri Format Specification:  <https://docs.yubico.com/yesdk/users-manual/application-oath/uri-string-format.html>
+    /// Otherwise returns an otpauth:// URI according to the Key Uri Format Specification:
+    /// <https://docs.yubico.com/yesdk/users-manual/application-oath/uri-string-format.html>
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let secret_b32 = BASE32_NOPAD.encode(&self.secret);
 

--- a/crates/bitwarden-vault/src/totp.rs
+++ b/crates/bitwarden-vault/src/totp.rs
@@ -260,7 +260,7 @@ impl fmt::Display for Totp {
     /// Formats the TOTP as an OTP Auth URI.
     ///
     /// Returns a steam::// URI if the algorithm is Steam.
-    /// Otherwise returns an otpauth:// URI according to the Key Uri Format Specification:  https://docs.yubico.com/yesdk/users-manual/application-oath/uri-string-format.html
+    /// Otherwise returns an otpauth:// URI according to the Key Uri Format Specification:  <https://docs.yubico.com/yesdk/users-manual/application-oath/uri-string-format.html>
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let secret_b32 = BASE32_NOPAD.encode(&self.secret);
 

--- a/crates/bitwarden-vault/src/totp.rs
+++ b/crates/bitwarden-vault/src/totp.rs
@@ -295,7 +295,7 @@ impl fmt::Display for Totp {
         }
 
         if self.algorithm != DEFAULT_ALGORITHM {
-            query_params.push(format!("algorithm={}", self.algorithm.to_string()));
+            query_params.push(format!("algorithm={}", self.algorithm));
         }
 
         if self.digits != DEFAULT_DIGITS {

--- a/crates/bitwarden-vault/src/totp.rs
+++ b/crates/bitwarden-vault/src/totp.rs
@@ -68,9 +68,6 @@ pub struct TotpResponse {
 pub fn generate_totp(key: String, time: Option<DateTime<Utc>>) -> Result<TotpResponse, TotpError> {
     let params: Totp = key.parse()?;
 
-    println!("original key: {:?}", key);
-    println!("converted: {:?}", params.to_string());
-
     let time = time.unwrap_or_else(Utc::now);
 
     let otp = params.derive_otp(time.timestamp());


### PR DESCRIPTION
## 🎟️ Tracking
https://bitwarden.atlassian.net/browse/PM-15556
<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective
The SDK currently supports going from an otpauth string to a Totp struct. However the Credential Exchange protocol provides otp components, and in order to save the items it must be converted to an otpauth string.

This should be done by implement the ToString trait for Totp.

The format is defined in [URI string format](https://docs.yubico.com/yesdk/users-manual/application-oath/uri-string-format.html) .
<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation
  team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
