### PR TITLE
[PM-18104] Implement generic key decryption in KeyStoreContext

### DIFF
--- a/crates/bitwarden-core/src/auth/auth_client.rs
+++ b/crates/bitwarden-core/src/auth/auth_client.rs
@@ -191,7 +191,7 @@ fn trust_device(client: &Client) -> Result<TrustDeviceResponse, TrustDeviceError
     let ctx = key_store.context();
     // FIXME: [PM-18099] Once DeviceKey deals with KeyIds, this should be updated
     #[allow(deprecated)]
-    let user_key = ctx.dangerous_get_symmetric_key(SymmetricKeyId::User)?;
+    let user_key = ctx.dangerous_get_key(SymmetricKeyId::User)?;
 
     Ok(DeviceKey::trust_device(user_key)?)
 }

--- a/crates/bitwarden-core/src/auth/auth_request.rs
+++ b/crates/bitwarden-core/src/auth/auth_request.rs
@@ -99,7 +99,7 @@ pub(crate) fn approve_auth_request(
 
     // FIXME: [PM-18110] This should be removed once the key store can handle public key encryption
     #[allow(deprecated)]
-    let key = ctx.dangerous_get_symmetric_key(SymmetricKeyId::User)?;
+    let key = ctx.dangerous_get_key(SymmetricKeyId::User)?;
 
     Ok(AsymmetricEncString::encrypt_rsa2048_oaep_sha1(
         &key.to_vec(),
@@ -258,7 +258,7 @@ mod tests {
             let key_store = existing_device.internal.get_key_store();
             let ctx = key_store.context();
             #[allow(deprecated)]
-            ctx.dangerous_get_symmetric_key(SymmetricKeyId::User)
+            ctx.dangerous_get_key(SymmetricKeyId::User)
                 .unwrap()
                 .to_base64()
         };
@@ -267,7 +267,7 @@ mod tests {
             let key_store = new_device.internal.get_key_store();
             let ctx = key_store.context();
             #[allow(deprecated)]
-            ctx.dangerous_get_symmetric_key(SymmetricKeyId::User)
+            ctx.dangerous_get_key(SymmetricKeyId::User)
                 .unwrap()
                 .to_base64()
         };

--- a/crates/bitwarden-core/src/auth/password/validate.rs
+++ b/crates/bitwarden-core/src/auth/password/validate.rs
@@ -64,7 +64,7 @@ pub(crate) fn validate_password_user_key(
                 let ctx = key_store.context();
                 // FIXME: [PM-18099] Once MasterKey deals with KeyIds, this should be updated
                 #[allow(deprecated)]
-                let existing_key = ctx.dangerous_get_symmetric_key(SymmetricKeyId::User)?;
+                let existing_key = ctx.dangerous_get_key(SymmetricKeyId::User)?;
 
                 if user_key.to_vec() != existing_key.to_vec() {
                     return Err(AuthValidateError::WrongUserKey);

--- a/crates/bitwarden-core/src/auth/pin.rs
+++ b/crates/bitwarden-core/src/auth/pin.rs
@@ -30,7 +30,7 @@ pub(crate) fn validate_pin(
             let ctx = key_store.context();
             // FIXME: [PM-18099] Once PinKey deals with KeyIds, this should be updated
             #[allow(deprecated)]
-            let user_key = ctx.dangerous_get_symmetric_key(SymmetricKeyId::User)?;
+            let user_key = ctx.dangerous_get_key(SymmetricKeyId::User)?;
 
             let pin_key = PinKey::derive(pin.as_bytes(), email.as_bytes(), kdf)?;
 

--- a/crates/bitwarden-core/src/auth/renew.rs
+++ b/crates/bitwarden-core/src/auth/renew.rs
@@ -77,7 +77,7 @@ pub(crate) async fn renew_token(client: &InternalClient) -> Result<()> {
                         let key_store = client.get_key_store();
                         let ctx = key_store.context();
                         #[allow(deprecated)]
-                        if let Ok(enc_key) = ctx.dangerous_get_symmetric_key(SymmetricKeyId::User) {
+                        if let Ok(enc_key) = ctx.dangerous_get_key(SymmetricKeyId::User) {
                             let state =
                                 ClientState::new(r.access_token.clone(), enc_key.to_base64());
                             _ = state::set(state_file, access_token, state);

--- a/crates/bitwarden-core/src/client/encryption_settings.rs
+++ b/crates/bitwarden-core/src/client/encryption_settings.rs
@@ -70,9 +70,9 @@ impl EncryptionSettings {
         #[allow(deprecated)]
         {
             let mut ctx = store.context_mut();
-            ctx.set_symmetric_key(SymmetricKeyId::User, user_key)?;
+            ctx.set_key(SymmetricKeyId::User, user_key)?;
             if let Some(private_key) = private_key {
-                ctx.set_asymmetric_key(AsymmetricKeyId::UserPrivateKey, private_key)?;
+                ctx.set_key(AsymmetricKeyId::UserPrivateKey, private_key)?;
             }
         }
 
@@ -87,7 +87,7 @@ impl EncryptionSettings {
         #[allow(deprecated)]
         store
             .context_mut()
-            .set_symmetric_key(SymmetricKeyId::User, key)
+            .set_key(SymmetricKeyId::User, key)
             .expect("Mutable context");
     }
 
@@ -103,7 +103,7 @@ impl EncryptionSettings {
             return Ok(());
         }
 
-        if !ctx.has_asymmetric_key(AsymmetricKeyId::UserPrivateKey) {
+        if !ctx.has_key(AsymmetricKeyId::UserPrivateKey) {
             return Err(EncryptionSettingsError::MissingPrivateKey);
         }
 
@@ -113,7 +113,7 @@ impl EncryptionSettings {
 
         // Decrypt the org keys with the private key
         for (org_id, org_enc_key) in org_enc_keys {
-            ctx.decrypt_symmetric_key_with_asymmetric_key(
+            ctx.decrypt_key_into_store(
                 AsymmetricKeyId::UserPrivateKey,
                 SymmetricKeyId::Organization(org_id),
                 &org_enc_key,

--- a/crates/bitwarden-core/src/key_management/mod.rs
+++ b/crates/bitwarden-core/src/key_management/mod.rs
@@ -38,7 +38,7 @@ pub fn create_test_crypto_with_user_key(key: SymmetricCryptoKey) -> KeyStore<Key
     #[allow(deprecated)]
     store
         .context_mut()
-        .set_symmetric_key(SymmetricKeyId::User, key.clone())
+        .set_key(SymmetricKeyId::User, key.clone())
         .expect("Mutable context");
 
     store
@@ -58,13 +58,13 @@ pub fn create_test_crypto_with_user_and_org_key(
     #[allow(deprecated)]
     store
         .context_mut()
-        .set_symmetric_key(SymmetricKeyId::User, key.clone())
+        .set_key(SymmetricKeyId::User, key.clone())
         .expect("Mutable context");
 
     #[allow(deprecated)]
     store
         .context_mut()
-        .set_symmetric_key(SymmetricKeyId::Organization(org_id), org_key.clone())
+        .set_key(SymmetricKeyId::Organization(org_id), org_key.clone())
         .expect("Mutable context");
 
     store

--- a/crates/bitwarden-core/src/mobile/crypto.rs
+++ b/crates/bitwarden-core/src/mobile/crypto.rs
@@ -223,7 +223,7 @@ pub async fn get_user_encryption_key(client: &Client) -> Result<String, MobileCr
     let ctx = key_store.context();
     // This is needed because the mobile clients need access to the user encryption key
     #[allow(deprecated)]
-    let user_key = ctx.dangerous_get_symmetric_key(SymmetricKeyId::User)?;
+    let user_key = ctx.dangerous_get_key(SymmetricKeyId::User)?;
 
     Ok(user_key.to_base64())
 }
@@ -246,7 +246,7 @@ pub fn update_password(
     let ctx = key_store.context();
     // FIXME: [PM-18099] Once MasterKey deals with KeyIds, this should be updated
     #[allow(deprecated)]
-    let user_key = ctx.dangerous_get_symmetric_key(SymmetricKeyId::User)?;
+    let user_key = ctx.dangerous_get_key(SymmetricKeyId::User)?;
 
     let login_method = client
         .internal
@@ -294,7 +294,7 @@ pub fn derive_pin_key(
     let ctx = key_store.context();
     // FIXME: [PM-18099] Once PinKey deals with KeyIds, this should be updated
     #[allow(deprecated)]
-    let user_key = ctx.dangerous_get_symmetric_key(SymmetricKeyId::User)?;
+    let user_key = ctx.dangerous_get_key(SymmetricKeyId::User)?;
 
     let login_method = client
         .internal
@@ -317,7 +317,7 @@ pub fn derive_pin_user_key(
     let ctx = key_store.context();
     // FIXME: [PM-18099] Once PinKey deals with KeyIds, this should be updated
     #[allow(deprecated)]
-    let user_key = ctx.dangerous_get_symmetric_key(SymmetricKeyId::User)?;
+    let user_key = ctx.dangerous_get_key(SymmetricKeyId::User)?;
 
     let pin: String = encrypted_pin.decrypt_with_key(user_key)?;
     let login_method = client
@@ -370,7 +370,7 @@ pub(super) fn enroll_admin_password_reset(
     let ctx = key_store.context();
     // FIXME: [PM-18110] This should be removed once the key store can handle public key encryption
     #[allow(deprecated)]
-    let key = ctx.dangerous_get_symmetric_key(SymmetricKeyId::User)?;
+    let key = ctx.dangerous_get_key(SymmetricKeyId::User)?;
 
     Ok(AsymmetricEncString::encrypt_rsa2048_oaep_sha1(
         &key.to_vec(),
@@ -581,7 +581,7 @@ mod tests {
             let key_store = client.internal.get_key_store();
             let ctx = key_store.context();
             #[allow(deprecated)]
-            ctx.dangerous_get_symmetric_key(SymmetricKeyId::User)
+            ctx.dangerous_get_key(SymmetricKeyId::User)
                 .unwrap()
                 .to_base64()
         };
@@ -590,7 +590,7 @@ mod tests {
             let key_store = client2.internal.get_key_store();
             let ctx = key_store.context();
             #[allow(deprecated)]
-            ctx.dangerous_get_symmetric_key(SymmetricKeyId::User)
+            ctx.dangerous_get_key(SymmetricKeyId::User)
                 .unwrap()
                 .to_base64()
         };
@@ -646,7 +646,7 @@ mod tests {
             let key_store = client.internal.get_key_store();
             let ctx = key_store.context();
             #[allow(deprecated)]
-            ctx.dangerous_get_symmetric_key(SymmetricKeyId::User)
+            ctx.dangerous_get_key(SymmetricKeyId::User)
                 .unwrap()
                 .to_base64()
         };
@@ -655,7 +655,7 @@ mod tests {
             let key_store = client2.internal.get_key_store();
             let ctx = key_store.context();
             #[allow(deprecated)]
-            ctx.dangerous_get_symmetric_key(SymmetricKeyId::User)
+            ctx.dangerous_get_key(SymmetricKeyId::User)
                 .unwrap()
                 .to_base64()
         };
@@ -688,7 +688,7 @@ mod tests {
             let key_store = client.internal.get_key_store();
             let ctx = key_store.context();
             #[allow(deprecated)]
-            ctx.dangerous_get_symmetric_key(SymmetricKeyId::User)
+            ctx.dangerous_get_key(SymmetricKeyId::User)
                 .unwrap()
                 .to_base64()
         };
@@ -697,7 +697,7 @@ mod tests {
             let key_store = client3.internal.get_key_store();
             let ctx = key_store.context();
             #[allow(deprecated)]
-            ctx.dangerous_get_symmetric_key(SymmetricKeyId::User)
+            ctx.dangerous_get_key(SymmetricKeyId::User)
                 .unwrap()
                 .to_base64()
         };
@@ -740,9 +740,7 @@ mod tests {
         let key_store = client.internal.get_key_store();
         let ctx = key_store.context();
         #[allow(deprecated)]
-        let expected = ctx
-            .dangerous_get_symmetric_key(SymmetricKeyId::User)
-            .unwrap();
+        let expected = ctx.dangerous_get_key(SymmetricKeyId::User).unwrap();
 
         assert_eq!(&decrypted, &expected.to_vec());
     }

--- a/crates/bitwarden-core/src/platform/generate_fingerprint.rs
+++ b/crates/bitwarden-core/src/platform/generate_fingerprint.rs
@@ -66,7 +66,7 @@ pub(crate) fn generate_user_fingerprint(
     // FIXME: [PM-18110] This should be removed once the key store can handle public keys and
     // fingerprints
     #[allow(deprecated)]
-    let private_key = ctx.dangerous_get_asymmetric_key(AsymmetricKeyId::UserPrivateKey)?;
+    let private_key = ctx.dangerous_get_key(AsymmetricKeyId::UserPrivateKey)?;
 
     let public_key = private_key.to_public_der()?;
     let fingerprint = fingerprint(&fingerprint_material, &public_key)?;

--- a/crates/bitwarden-crypto/src/store/context.rs
+++ b/crates/bitwarden-crypto/src/store/context.rs
@@ -230,7 +230,8 @@ impl<Ids: KeyIds> KeyStoreContext<'_, Ids> {
     where
         Self: ContextHasKeys<DecryptedKeyId, DecryptedKeyId::KeyValue, Ids>,
         EncryptedKey: Decryptable<Ids, EncryptionKeyId, Vec<u8>>,
-        DecryptedKeyId: KeyId<KeyValue: KeyBytes>,
+        DecryptedKeyId: KeyId,
+        DecryptedKeyId::KeyValue: KeyBytes,
         EncryptionKeyId: KeyId,
     {
         let decrypted_key = encrypted_key.decrypt(self, encryption_key)?;
@@ -256,7 +257,8 @@ impl<Ids: KeyIds> KeyStoreContext<'_, Ids> {
     where
         Self: ContextHasKeys<DecryptedKeyId, DecryptedKeyId::KeyValue, Ids>,
         EncryptionKeyId: KeyId,
-        DecryptedKeyId: KeyId<KeyValue: KeyBytes>,
+        DecryptedKeyId: KeyId,
+        DecryptedKeyId::KeyValue: KeyBytes,
         for<'a> &'a [u8]: Encryptable<Ids, EncryptionKeyId, EncryptedKey>,
     {
         let key_to_encrypt: &DecryptedKeyId::KeyValue = self.internal_get_key(key_to_encrypt)?;

--- a/crates/bitwarden-crypto/src/store/mod.rs
+++ b/crates/bitwarden-crypto/src/store/mod.rs
@@ -65,7 +65,7 @@ pub use context::KeyStoreContext;
 /// let store: KeyStore<Ids> = KeyStore::default();
 ///
 /// #[allow(deprecated)]
-/// store.context_mut().set_symmetric_key(SymmKeyId::User, SymmetricCryptoKey::generate(rand::thread_rng()));
+/// store.context_mut().set_key(SymmKeyId::User, SymmetricCryptoKey::generate(rand::thread_rng()));
 ///
 /// // Define some data that needs to be encrypted
 /// struct Data(String);
@@ -355,7 +355,7 @@ pub(crate) mod tests {
             #[allow(deprecated)]
             store
                 .context_mut()
-                .set_symmetric_key(TestSymmKey::A(n), SymmetricCryptoKey::generate(&mut rng))
+                .set_key(TestSymmKey::A(n), SymmetricCryptoKey::generate(&mut rng))
                 .unwrap();
         }
 

--- a/crates/bitwarden-crypto/src/store/mod.rs
+++ b/crates/bitwarden-crypto/src/store/mod.rs
@@ -152,9 +152,7 @@ impl<Ids: KeyIds> KeyStore<Ids> {
     ///   lead to key material being leaked, but we need to support it for backwards compatibility.
     ///   If you want to access the key material to encrypt it or derive a new key from it, we
     ///   provide functions for that:
-    ///     - [KeyStoreContext::encrypt_symmetric_key_with_symmetric_key]
-    ///     - [KeyStoreContext::encrypt_symmetric_key_with_asymmetric_key]
-    ///     - [KeyStoreContext::encrypt_asymmetric_key_with_asymmetric_key]
+    ///     - [KeyStoreContext::encrypt_key_from_store]
     ///     - [KeyStoreContext::derive_shareable_key]
     pub fn context(&'_ self) -> KeyStoreContext<'_, Ids> {
         KeyStoreContext {

--- a/crates/bitwarden-crypto/src/traits/decryptable.rs
+++ b/crates/bitwarden-crypto/src/traits/decryptable.rs
@@ -87,7 +87,7 @@ mod tests {
         #[allow(deprecated)]
         store
             .context_mut()
-            .set_symmetric_key(TestSymmKey::A(0), key.clone())
+            .set_key(TestSymmKey::A(0), key.clone())
             .unwrap();
 
         store

--- a/crates/bitwarden-crypto/src/traits/encryptable.rs
+++ b/crates/bitwarden-crypto/src/traits/encryptable.rs
@@ -129,12 +129,12 @@ mod tests {
         #[allow(deprecated)]
         store
             .context_mut()
-            .set_symmetric_key(TestSymmKey::A(0), symm_key.clone())
+            .set_key(TestSymmKey::A(0), symm_key.clone())
             .unwrap();
         #[allow(deprecated)]
         store
             .context_mut()
-            .set_asymmetric_key(TestAsymmKey::A(0), asymm_key.clone())
+            .set_key(TestAsymmKey::A(0), asymm_key.clone())
             .unwrap();
 
         store

--- a/crates/bitwarden-send/src/send.rs
+++ b/crates/bitwarden-send/src/send.rs
@@ -429,7 +429,7 @@ mod tests {
         // Get the send key
         let send_key = Send::get_key(&mut ctx, &send_key, SymmetricKeyId::User).unwrap();
         #[allow(deprecated)]
-        let send_key = ctx.dangerous_get_symmetric_key(send_key).unwrap();
+        let send_key = ctx.dangerous_get_key(send_key).unwrap();
         let send_key_b64 = send_key.to_base64();
         assert_eq!(send_key_b64, "IR9ImHGm6rRuIjiN7csj94bcZR5WYTJj5GtNfx33zm6tJCHUl+QZlpNPba8g2yn70KnOHsAODLcR0um6E3MAlg==");
     }

--- a/crates/bitwarden-vault/src/cipher/attachment.rs
+++ b/crates/bitwarden-vault/src/cipher/attachment.rs
@@ -84,8 +84,7 @@ impl Encryptable<KeyIds, SymmetricKeyId, AttachmentEncryptResult> for Attachment
         // with it, and then encrypt the key with the cipher key
         let attachment_key = ctx.generate_symmetric_key(ATTACHMENT_KEY)?;
         let encrypted_contents = self.contents.encrypt(ctx, attachment_key)?;
-        attachment.key =
-            Some(ctx.encrypt_symmetric_key_with_symmetric_key(ciphers_key, attachment_key)?);
+        attachment.key = Some(ctx.encrypt_key_from_store(ciphers_key, attachment_key)?);
 
         let contents = encrypted_contents.to_buffer()?;
 
@@ -120,11 +119,8 @@ impl Decryptable<KeyIds, SymmetricKeyId, Vec<u8>> for AttachmentFile {
 
         // Version 2 or 3, `AttachmentKey` or `CipherKey(AttachmentKey)`
         if let Some(attachment_key) = &self.attachment.key {
-            let content_key = ctx.decrypt_symmetric_key_with_symmetric_key(
-                ciphers_key,
-                ATTACHMENT_KEY,
-                attachment_key,
-            )?;
+            let content_key =
+                ctx.decrypt_key_into_store(ciphers_key, ATTACHMENT_KEY, attachment_key)?;
             self.contents.decrypt(ctx, content_key)
         } else {
             // Legacy attachment version 1, use user/org key


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-18104

## 📔 Objective

Expanded a bit a POC I had to make all the key encryption and decryption methods in KeyStore generic, through the use of a `ContextHasKeys` trait that ensures the store knows how to handle each key type.

I've had to introduce a trait called `KeyBytes` to deal with how to parse each key from bytes and convert them to bytes, initially I planned to enforce that keys had a `TryFrom<Vec<u8>>` and `TryInto<Vec<u8>>`, but hit some errors with the trait solver. I'll see if there's a better way to do it, maybe Encodable/Decodable from #142?

~~This is using an associated type bound, which would require us to bump MSRV to 1.79~~ Fixed it in ce39bca

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation
  team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
