### PR TITLE
Extract init logic to separate function

### DIFF
--- a/crates/bitwarden-wasm-internal/src/client.rs
+++ b/crates/bitwarden-wasm-internal/src/client.rs
@@ -3,29 +3,9 @@ use std::{fmt::Display, rc::Rc};
 
 use bitwarden_core::{Client, ClientSettings};
 use bitwarden_error::bitwarden_error;
-use log::{set_max_level, Level};
 use wasm_bindgen::prelude::*;
 
 use crate::{vault::VaultClient, CryptoClient};
-
-#[wasm_bindgen]
-pub enum LogLevel {
-    Trace,
-    Debug,
-    Info,
-    Warn,
-    Error,
-}
-
-fn convert_level(level: LogLevel) -> Level {
-    match level {
-        LogLevel::Trace => Level::Trace,
-        LogLevel::Debug => Level::Debug,
-        LogLevel::Info => Level::Info,
-        LogLevel::Warn => Level::Warn,
-        LogLevel::Error => Level::Error,
-    }
-}
 
 // Rc<...> is to avoid needing to take ownership of the Client during our async run_command
 // function https://github.com/rustwasm/wasm-bindgen/issues/2195#issuecomment-799588401
@@ -35,13 +15,7 @@ pub struct BitwardenClient(pub(crate) Rc<Client>);
 #[wasm_bindgen]
 impl BitwardenClient {
     #[wasm_bindgen(constructor)]
-    pub fn new(settings: Option<ClientSettings>, log_level: Option<LogLevel>) -> Self {
-        console_error_panic_hook::set_once();
-        let log_level = convert_level(log_level.unwrap_or(LogLevel::Info));
-        if let Err(_e) = console_log::init_with_level(log_level) {
-            set_max_level(log_level.to_level_filter())
-        }
-
+    pub fn new(settings: Option<ClientSettings>) -> Self {
         Self(Rc::new(Client::new(settings)))
     }
 

--- a/crates/bitwarden-wasm-internal/src/init.rs
+++ b/crates/bitwarden-wasm-internal/src/init.rs
@@ -1,0 +1,30 @@
+use log::{set_max_level, Level};
+use wasm_bindgen::prelude::*;
+
+#[wasm_bindgen]
+pub enum LogLevel {
+    Trace,
+    Debug,
+    Info,
+    Warn,
+    Error,
+}
+
+fn convert_level(level: LogLevel) -> Level {
+    match level {
+        LogLevel::Trace => Level::Trace,
+        LogLevel::Debug => Level::Debug,
+        LogLevel::Info => Level::Info,
+        LogLevel::Warn => Level::Warn,
+        LogLevel::Error => Level::Error,
+    }
+}
+
+#[wasm_bindgen]
+pub fn init_sdk(log_level: Option<LogLevel>) {
+    console_error_panic_hook::set_once();
+    let log_level = convert_level(log_level.unwrap_or(LogLevel::Info));
+    if let Err(_e) = console_log::init_with_level(log_level) {
+        set_max_level(log_level.to_level_filter())
+    }
+}

--- a/crates/bitwarden-wasm-internal/src/lib.rs
+++ b/crates/bitwarden-wasm-internal/src/lib.rs
@@ -1,9 +1,11 @@
 mod client;
 mod crypto;
 mod custom_types;
+mod init;
 mod ssh;
 mod vault;
 
 pub use client::BitwardenClient;
 pub use crypto::CryptoClient;
+pub use init::init_sdk;
 pub use vault::{folders::ClientFolders, VaultClient};


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective

This PR moves the logging and panic handling initialization into a separate function so that it can be called without creating a `BitwardenClient`

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation
  team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
