### PR TITLE
Remove unused asymmetric key methods

### DIFF
--- a/crates/bitwarden-crypto/src/store/context.rs
+++ b/crates/bitwarden-crypto/src/store/context.rs
@@ -217,56 +217,6 @@ impl<Ids: KeyIds> KeyStoreContext<'_, Ids> {
         self.encrypt_data_with_asymmetric_key(encryption_key, &key_to_encrypt.to_vec())
     }
 
-    /// Decrypt an asymmetric key into the context by using an already existing asymmetric key
-    ///
-    /// # Arguments
-    ///
-    /// * `encryption_key` - The key id used to decrypt the `encrypted_key`. It must already exist
-    ///   in the context
-    /// * `new_key_id` - The key id where the decrypted key will be stored. If it already exists, it
-    ///   will be overwritten
-    /// * `encrypted_key` - The key to decrypt
-    pub fn decrypt_asymmetric_key_with_asymmetric_key(
-        &mut self,
-        encryption_key: Ids::Asymmetric,
-        new_key_id: Ids::Asymmetric,
-        encrypted_key: &AsymmetricEncString,
-    ) -> Result<Ids::Asymmetric> {
-        let new_key_material =
-            self.decrypt_data_with_asymmetric_key(encryption_key, encrypted_key)?;
-
-        #[allow(deprecated)]
-        self.set_asymmetric_key(
-            new_key_id,
-            AsymmetricCryptoKey::from_der(&new_key_material)?,
-        )?;
-
-        // Returning the new key identifier for convenience
-        Ok(new_key_id)
-    }
-
-    /// Encrypt and return an asymmetric key from the context by using an already existing
-    /// asymmetric key
-    ///
-    /// # Arguments
-    ///
-    /// * `encryption_key` - The key id used to encrypt the `key_to_encrypt`. It must already exist
-    ///   in the context
-    /// * `key_to_encrypt` - The key id to encrypt. It must already exist in the context
-    pub fn encrypt_asymmetric_key_with_asymmetric_key(
-        &self,
-        encryption_key: Ids::Asymmetric,
-        key_to_encrypt: Ids::Asymmetric,
-    ) -> Result<AsymmetricEncString> {
-        let encryption_key = self.get_asymmetric_key(encryption_key)?;
-        let key_to_encrypt = self.get_asymmetric_key(key_to_encrypt)?;
-
-        AsymmetricEncString::encrypt_rsa2048_oaep_sha1(
-            key_to_encrypt.to_der()?.as_slice(),
-            encryption_key,
-        )
-    }
-
     /// Returns `true` if the context has a symmetric key with the given identifier
     pub fn has_symmetric_key(&self, key_id: Ids::Symmetric) -> bool {
         self.get_symmetric_key(key_id).is_ok()

--- a/crates/bitwarden-crypto/src/store/mod.rs
+++ b/crates/bitwarden-crypto/src/store/mod.rs
@@ -154,7 +154,6 @@ impl<Ids: KeyIds> KeyStore<Ids> {
     ///   provide functions for that:
     ///     - [KeyStoreContext::encrypt_symmetric_key_with_symmetric_key]
     ///     - [KeyStoreContext::encrypt_symmetric_key_with_asymmetric_key]
-    ///     - [KeyStoreContext::encrypt_asymmetric_key_with_asymmetric_key]
     ///     - [KeyStoreContext::derive_shareable_key]
     pub fn context(&'_ self) -> KeyStoreContext<'_, Ids> {
         KeyStoreContext {


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.slack.com/archives/C08CS047UPL/p1739281434358939

## 📔 Objective

The encrypt asymmetric with asymmetric / decrypt asymmetric with asymmetric methods are not something that is currently used by the application. Further, these should not be publicly exposed because they are not a pattern of encryption that should be used by any other crate - the only way should be sharing symmetric keys to asymmetric keys (and later on, signed).

For this reason, this PR removes the two unused methods.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation
  team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
