### PR TITLE
[PM-18248] Generator: Support custom API URL for SimpleLogin aliases

### DIFF
--- a/crates/bitwarden-generators/src/username.rs
+++ b/crates/bitwarden-generators/src/username.rs
@@ -124,7 +124,7 @@ impl ForwarderServiceType {
                 forwardemail::generate(http, api_token, domain, website).await
             }
             SimpleLogin { api_key, base_url } => {
-                simplelogin::generate(http, api_key, website, base_url).await
+                simplelogin::generate(http, api_key, base_url, website).await
             }
         }
     }

--- a/crates/bitwarden-generators/src/username.rs
+++ b/crates/bitwarden-generators/src/username.rs
@@ -59,6 +59,7 @@ pub enum ForwarderServiceType {
     },
     SimpleLogin {
         api_key: String,
+        base_url: String,
     },
 }
 
@@ -122,7 +123,9 @@ impl ForwarderServiceType {
             ForwardEmail { api_token, domain } => {
                 forwardemail::generate(http, api_token, domain, website).await
             }
-            SimpleLogin { api_key } => simplelogin::generate(http, api_key, website).await,
+            SimpleLogin { api_key, base_url } => {
+                simplelogin::generate(http, api_key, website, base_url).await
+            }
         }
     }
 }

--- a/crates/bitwarden-generators/src/username_forwarders/simplelogin.rs
+++ b/crates/bitwarden-generators/src/username_forwarders/simplelogin.rs
@@ -5,17 +5,17 @@ use crate::username::UsernameError;
 pub async fn generate(
     http: &reqwest::Client,
     api_key: String,
-    website: Option<String>,
     base_url: String,
+    website: Option<String>,
 ) -> Result<String, UsernameError> {
-    generate_with_api_url(http, api_key, website, base_url).await
+    generate_with_api_url(http, api_key, base_url, website).await
 }
 
 async fn generate_with_api_url(
     http: &reqwest::Client,
     api_key: String,
-    website: Option<String>,
     api_url: String,
+    website: Option<String>,
 ) -> Result<String, UsernameError> {
     let query = website
         .as_ref()
@@ -100,8 +100,8 @@ mod tests {
         let address = super::generate_with_api_url(
             &reqwest::Client::new(),
             "MY_TOKEN".into(),
-            Some("example.com".into()),
             format!("http://{}", server.address()),
+            Some("example.com".into()),
         )
         .await
         .unwrap();
@@ -110,8 +110,8 @@ mod tests {
         let fake_token_error = super::generate_with_api_url(
             &reqwest::Client::new(),
             "MY_FAKE_TOKEN".into(),
-            Some("example.com".into()),
             format!("http://{}", server.address()),
+            Some("example.com".into()),
         )
         .await
         .unwrap_err();

--- a/crates/bitwarden-generators/src/username_forwarders/simplelogin.rs
+++ b/crates/bitwarden-generators/src/username_forwarders/simplelogin.rs
@@ -6,8 +6,9 @@ pub async fn generate(
     http: &reqwest::Client,
     api_key: String,
     website: Option<String>,
+    base_url: String,
 ) -> Result<String, UsernameError> {
-    generate_with_api_url(http, api_key, website, "https://app.simplelogin.io".into()).await
+    generate_with_api_url(http, api_key, website, base_url).await
 }
 
 async fn generate_with_api_url(


### PR DESCRIPTION
## 🎟️ Tracking

[PM-18248](https://bitwarden.atlassian.net/browse/PM-18248)

## 📔 Objective

This PR adds a `base_url` param to the SimpleLogin alias generator in order to support self-hosted instances.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation
  team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-18248]: https://bitwarden.atlassian.net/browse/PM-18248?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ