### PR TITLE
Rename duplicate ssh key struct

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -584,6 +584,7 @@ name = "bitwarden-ssh"
 version = "1.0.0"
 dependencies = [
  "bitwarden-error",
+ "bitwarden-vault",
  "ed25519",
  "pem-rfc7468",
  "pkcs8",

--- a/crates/bitwarden-ssh/Cargo.toml
+++ b/crates/bitwarden-ssh/Cargo.toml
@@ -24,7 +24,7 @@ uniffi = ["dep:uniffi"] # Uniffi bindings
 
 [dependencies]
 bitwarden-error = { workspace = true }
-bitwarden-vault.workspace = true
+bitwarden-vault = { workspace = true }
 ed25519 = { version = ">=2.2.3, <3.0", features = ["pkcs8"] }
 pem-rfc7468 = "0.7.0"
 pkcs8 = { version = ">=0.10.2, <0.11", features = ["encryption"] }

--- a/crates/bitwarden-ssh/Cargo.toml
+++ b/crates/bitwarden-ssh/Cargo.toml
@@ -24,6 +24,7 @@ uniffi = ["dep:uniffi"] # Uniffi bindings
 
 [dependencies]
 bitwarden-error = { workspace = true }
+bitwarden-vault.workspace = true
 ed25519 = { version = ">=2.2.3, <3.0", features = ["pkcs8"] }
 pem-rfc7468 = "0.7.0"
 pkcs8 = { version = ">=0.10.2, <0.11", features = ["encryption"] }

--- a/crates/bitwarden-ssh/src/generator.rs
+++ b/crates/bitwarden-ssh/src/generator.rs
@@ -16,7 +16,7 @@ pub enum KeyAlgorithm {
 
 /**
  * Generate a new SSH key pair, for the provided key algorithm, returning
- * an [SshKey] struct containing the private key, public key, and key fingerprint,
+ * an [UnencryptedSshKey] struct containing the private key, public key, and key fingerprint,
  * with the private key in OpenSSH format.
  */
 pub fn generate_sshkey(

--- a/crates/bitwarden-ssh/src/generator.rs
+++ b/crates/bitwarden-ssh/src/generator.rs
@@ -1,9 +1,10 @@
+use bitwarden_vault::SshKeyView;
 use serde::{Deserialize, Serialize};
 use ssh_key::{rand_core::CryptoRngCore, Algorithm};
 #[cfg(feature = "wasm")]
 use tsify_next::Tsify;
 
-use crate::{error, error::KeyGenerationError, UnencryptedSshKey};
+use crate::{error::{self, KeyGenerationError}, ssh_private_key_to_view};
 
 #[derive(Serialize, Deserialize)]
 #[cfg_attr(feature = "wasm", derive(Tsify), tsify(into_wasm_abi, from_wasm_abi))]
@@ -16,12 +17,12 @@ pub enum KeyAlgorithm {
 
 /**
  * Generate a new SSH key pair, for the provided key algorithm, returning
- * an [UnencryptedSshKey] struct containing the private key, public key, and key fingerprint,
+ * an [SshKeyView] struct containing the private key, public key, and key fingerprint,
  * with the private key in OpenSSH format.
  */
 pub fn generate_sshkey(
     key_algorithm: KeyAlgorithm,
-) -> Result<UnencryptedSshKey, error::KeyGenerationError> {
+) -> Result<SshKeyView, error::KeyGenerationError> {
     let rng = rand::thread_rng();
     generate_sshkey_internal(key_algorithm, rng)
 }
@@ -29,7 +30,7 @@ pub fn generate_sshkey(
 fn generate_sshkey_internal(
     key_algorithm: KeyAlgorithm,
     mut rng: impl CryptoRngCore,
-) -> Result<UnencryptedSshKey, error::KeyGenerationError> {
+) -> Result<SshKeyView, error::KeyGenerationError> {
     let private_key = match key_algorithm {
         KeyAlgorithm::Ed25519 => ssh_key::PrivateKey::random(&mut rng, Algorithm::Ed25519)
             .map_err(KeyGenerationError::KeyGenerationError),
@@ -37,8 +38,7 @@ fn generate_sshkey_internal(
         KeyAlgorithm::Rsa4096 => create_rsa_key(&mut rng, 4096),
     }?;
 
-    private_key
-        .try_into()
+    ssh_private_key_to_view(private_key)
         .map_err(|_| KeyGenerationError::KeyConversionError)
 }
 

--- a/crates/bitwarden-ssh/src/generator.rs
+++ b/crates/bitwarden-ssh/src/generator.rs
@@ -3,7 +3,7 @@ use ssh_key::{rand_core::CryptoRngCore, Algorithm};
 #[cfg(feature = "wasm")]
 use tsify_next::Tsify;
 
-use crate::{error, error::KeyGenerationError, SshKey};
+use crate::{error, error::KeyGenerationError, UnencryptedSshKey};
 
 #[derive(Serialize, Deserialize)]
 #[cfg_attr(feature = "wasm", derive(Tsify), tsify(into_wasm_abi, from_wasm_abi))]
@@ -19,7 +19,9 @@ pub enum KeyAlgorithm {
  * an [SshKey] struct containing the private key, public key, and key fingerprint,
  * with the private key in OpenSSH format.
  */
-pub fn generate_sshkey(key_algorithm: KeyAlgorithm) -> Result<SshKey, error::KeyGenerationError> {
+pub fn generate_sshkey(
+    key_algorithm: KeyAlgorithm,
+) -> Result<UnencryptedSshKey, error::KeyGenerationError> {
     let rng = rand::thread_rng();
     generate_sshkey_internal(key_algorithm, rng)
 }
@@ -27,7 +29,7 @@ pub fn generate_sshkey(key_algorithm: KeyAlgorithm) -> Result<SshKey, error::Key
 fn generate_sshkey_internal(
     key_algorithm: KeyAlgorithm,
     mut rng: impl CryptoRngCore,
-) -> Result<SshKey, error::KeyGenerationError> {
+) -> Result<UnencryptedSshKey, error::KeyGenerationError> {
     let private_key = match key_algorithm {
         KeyAlgorithm::Ed25519 => ssh_key::PrivateKey::random(&mut rng, Algorithm::Ed25519)
             .map_err(KeyGenerationError::KeyGenerationError),

--- a/crates/bitwarden-ssh/src/generator.rs
+++ b/crates/bitwarden-ssh/src/generator.rs
@@ -4,7 +4,10 @@ use ssh_key::{rand_core::CryptoRngCore, Algorithm};
 #[cfg(feature = "wasm")]
 use tsify_next::Tsify;
 
-use crate::{error::{self, KeyGenerationError}, ssh_private_key_to_view};
+use crate::{
+    error::{self, KeyGenerationError},
+    ssh_private_key_to_view,
+};
 
 #[derive(Serialize, Deserialize)]
 #[cfg_attr(feature = "wasm", derive(Tsify), tsify(into_wasm_abi, from_wasm_abi))]
@@ -38,8 +41,7 @@ fn generate_sshkey_internal(
         KeyAlgorithm::Rsa4096 => create_rsa_key(&mut rng, 4096),
     }?;
 
-    ssh_private_key_to_view(private_key)
-        .map_err(|_| KeyGenerationError::KeyConversionError)
+    ssh_private_key_to_view(private_key).map_err(|_| KeyGenerationError::KeyConversionError)
 }
 
 fn create_rsa_key(

--- a/crates/bitwarden-ssh/src/import.rs
+++ b/crates/bitwarden-ssh/src/import.rs
@@ -72,8 +72,7 @@ fn import_pkcs8_key(
         _ => return Err(SshKeyImportError::UnsupportedKeyType),
     };
 
-    ssh_private_key_to_view(private_key)
-        .map_err(|_| SshKeyImportError::ParsingError)
+    ssh_private_key_to_view(private_key).map_err(|_| SshKeyImportError::ParsingError)
 }
 
 fn import_openssh_key(
@@ -97,8 +96,7 @@ fn import_openssh_key(
         private_key
     };
 
-    ssh_private_key_to_view(private_key)
-        .map_err(|_| SshKeyImportError::ParsingError)
+    ssh_private_key_to_view(private_key).map_err(|_| SshKeyImportError::ParsingError)
 }
 
 #[cfg(test)]

--- a/crates/bitwarden-ssh/src/import.rs
+++ b/crates/bitwarden-ssh/src/import.rs
@@ -3,7 +3,7 @@ use pem_rfc7468::PemLabel;
 use pkcs8::{der::Decode, pkcs5, DecodePrivateKey, PrivateKeyInfo, SecretDocument};
 use ssh_key::private::{Ed25519Keypair, RsaKeypair};
 
-use crate::{error::SshKeyImportError, SshKey};
+use crate::{error::SshKeyImportError, UnencryptedSshKey};
 
 /// Import a PKCS8 or OpenSSH encoded private key, and returns a decoded [SshKey],
 /// with the public key and fingerprint, and the private key in OpenSSH format.
@@ -16,7 +16,7 @@ use crate::{error::SshKeyImportError, SshKey};
 pub fn import_key(
     encoded_key: String,
     password: Option<String>,
-) -> Result<SshKey, SshKeyImportError> {
+) -> Result<UnencryptedSshKey, SshKeyImportError> {
     let label = pem_rfc7468::decode_label(encoded_key.as_bytes())
         .map_err(|_| SshKeyImportError::ParsingError)?;
 
@@ -34,7 +34,7 @@ pub fn import_key(
 fn import_pkcs8_key(
     encoded_key: String,
     password: Option<String>,
-) -> Result<SshKey, SshKeyImportError> {
+) -> Result<UnencryptedSshKey, SshKeyImportError> {
     let doc = if let Some(password) = password {
         SecretDocument::from_pkcs8_encrypted_pem(&encoded_key, password.as_bytes()).map_err(
             |err| match err {
@@ -79,7 +79,7 @@ fn import_pkcs8_key(
 fn import_openssh_key(
     encoded_key: String,
     password: Option<String>,
-) -> Result<SshKey, SshKeyImportError> {
+) -> Result<UnencryptedSshKey, SshKeyImportError> {
     let private_key =
         ssh_key::private::PrivateKey::from_openssh(&encoded_key).map_err(|err| match err {
             ssh_key::Error::AlgorithmUnknown | ssh_key::Error::AlgorithmUnsupported { .. } => {

--- a/crates/bitwarden-ssh/src/import.rs
+++ b/crates/bitwarden-ssh/src/import.rs
@@ -5,7 +5,7 @@ use ssh_key::private::{Ed25519Keypair, RsaKeypair};
 
 use crate::{error::SshKeyImportError, UnencryptedSshKey};
 
-/// Import a PKCS8 or OpenSSH encoded private key, and returns a decoded [SshKey],
+/// Import a PKCS8 or OpenSSH encoded private key, and returns a decoded [UnencryptedSshKey],
 /// with the public key and fingerprint, and the private key in OpenSSH format.
 /// A password can be provided for encrypted keys.
 /// # Returns

--- a/crates/bitwarden-ssh/src/import.rs
+++ b/crates/bitwarden-ssh/src/import.rs
@@ -1,11 +1,12 @@
+use bitwarden_vault::SshKeyView;
 use ed25519;
 use pem_rfc7468::PemLabel;
 use pkcs8::{der::Decode, pkcs5, DecodePrivateKey, PrivateKeyInfo, SecretDocument};
 use ssh_key::private::{Ed25519Keypair, RsaKeypair};
 
-use crate::{error::SshKeyImportError, UnencryptedSshKey};
+use crate::{error::SshKeyImportError, ssh_private_key_to_view};
 
-/// Import a PKCS8 or OpenSSH encoded private key, and returns a decoded [UnencryptedSshKey],
+/// Import a PKCS8 or OpenSSH encoded private key, and returns a decoded [SshKeyView],
 /// with the public key and fingerprint, and the private key in OpenSSH format.
 /// A password can be provided for encrypted keys.
 /// # Returns
@@ -16,7 +17,7 @@ use crate::{error::SshKeyImportError, UnencryptedSshKey};
 pub fn import_key(
     encoded_key: String,
     password: Option<String>,
-) -> Result<UnencryptedSshKey, SshKeyImportError> {
+) -> Result<SshKeyView, SshKeyImportError> {
     let label = pem_rfc7468::decode_label(encoded_key.as_bytes())
         .map_err(|_| SshKeyImportError::ParsingError)?;
 
@@ -34,7 +35,7 @@ pub fn import_key(
 fn import_pkcs8_key(
     encoded_key: String,
     password: Option<String>,
-) -> Result<UnencryptedSshKey, SshKeyImportError> {
+) -> Result<SshKeyView, SshKeyImportError> {
     let doc = if let Some(password) = password {
         SecretDocument::from_pkcs8_encrypted_pem(&encoded_key, password.as_bytes()).map_err(
             |err| match err {
@@ -71,15 +72,14 @@ fn import_pkcs8_key(
         _ => return Err(SshKeyImportError::UnsupportedKeyType),
     };
 
-    private_key
-        .try_into()
+    ssh_private_key_to_view(private_key)
         .map_err(|_| SshKeyImportError::ParsingError)
 }
 
 fn import_openssh_key(
     encoded_key: String,
     password: Option<String>,
-) -> Result<UnencryptedSshKey, SshKeyImportError> {
+) -> Result<SshKeyView, SshKeyImportError> {
     let private_key =
         ssh_key::private::PrivateKey::from_openssh(&encoded_key).map_err(|err| match err {
             ssh_key::Error::AlgorithmUnknown | ssh_key::Error::AlgorithmUnsupported { .. } => {
@@ -97,8 +97,7 @@ fn import_openssh_key(
         private_key
     };
 
-    private_key
-        .try_into()
+    ssh_private_key_to_view(private_key)
         .map_err(|_| SshKeyImportError::ParsingError)
 }
 

--- a/crates/bitwarden-ssh/src/lib.rs
+++ b/crates/bitwarden-ssh/src/lib.rs
@@ -2,38 +2,22 @@ pub mod error;
 pub mod generator;
 pub mod import;
 
+use bitwarden_vault::SshKeyView;
 use error::SshKeyExportError;
 use pkcs8::LineEnding;
-use serde::{Deserialize, Serialize};
 use ssh_key::{HashAlg, PrivateKey};
-#[cfg(feature = "wasm")]
-use tsify_next::Tsify;
 
 #[cfg(feature = "uniffi")]
 uniffi::setup_scaffolding!();
 
-#[derive(Serialize, Deserialize, Debug)]
-#[cfg_attr(feature = "wasm", derive(Tsify), tsify(into_wasm_abi, from_wasm_abi))]
-#[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
-pub struct UnencryptedSshKey {
-    /// The private key in OpenSSH format
-    pub private_key: String,
-    pub public_key: String,
-    pub key_fingerprint: String,
-}
+fn ssh_private_key_to_view(value: PrivateKey) -> Result<SshKeyView, SshKeyExportError> {
+    let private_key_openssh = value
+        .to_openssh(LineEnding::LF)
+        .map_err(|_| SshKeyExportError::KeyConversionError)?;
 
-impl TryFrom<PrivateKey> for UnencryptedSshKey {
-    type Error = SshKeyExportError;
-
-    fn try_from(value: PrivateKey) -> Result<Self, Self::Error> {
-        let private_key_openssh = value
-            .to_openssh(LineEnding::LF)
-            .map_err(|_| SshKeyExportError::KeyConversionError)?;
-
-        Ok(UnencryptedSshKey {
-            private_key: private_key_openssh.to_string(),
-            public_key: value.public_key().to_string(),
-            key_fingerprint: value.fingerprint(HashAlg::Sha256).to_string(),
-        })
-    }
+    Ok(SshKeyView {
+        private_key: private_key_openssh.to_string(),
+        public_key: value.public_key().to_string(),
+        fingerprint: value.fingerprint(HashAlg::Sha256).to_string(),
+    })
 }

--- a/crates/bitwarden-ssh/src/lib.rs
+++ b/crates/bitwarden-ssh/src/lib.rs
@@ -15,14 +15,14 @@ uniffi::setup_scaffolding!();
 #[derive(Serialize, Deserialize, Debug)]
 #[cfg_attr(feature = "wasm", derive(Tsify), tsify(into_wasm_abi, from_wasm_abi))]
 #[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
-pub struct SshKey {
+pub struct UnencryptedSshKey {
     /// The private key in OpenSSH format
     pub private_key: String,
     pub public_key: String,
     pub key_fingerprint: String,
 }
 
-impl TryFrom<PrivateKey> for SshKey {
+impl TryFrom<PrivateKey> for UnencryptedSshKey {
     type Error = SshKeyExportError;
 
     fn try_from(value: PrivateKey) -> Result<Self, Self::Error> {
@@ -30,7 +30,7 @@ impl TryFrom<PrivateKey> for SshKey {
             .to_openssh(LineEnding::LF)
             .map_err(|_| SshKeyExportError::KeyConversionError)?;
 
-        Ok(SshKey {
+        Ok(UnencryptedSshKey {
             private_key: private_key_openssh.to_string(),
             public_key: value.public_key().to_string(),
             key_fingerprint: value.fingerprint(HashAlg::Sha256).to_string(),

--- a/crates/bitwarden-uniffi/src/tool/ssh.rs
+++ b/crates/bitwarden-uniffi/src/tool/ssh.rs
@@ -13,7 +13,7 @@ impl SshClient {
     pub fn generate_ssh_key(
         &self,
         key_algorithm: bitwarden_ssh::generator::KeyAlgorithm,
-    ) -> Result<bitwarden_ssh::SshKey> {
+    ) -> Result<bitwarden_ssh::UnencryptedSshKey> {
         bitwarden_ssh::generator::generate_sshkey(key_algorithm)
             .map_err(|e| BitwardenError::E(Error::SshGeneration(e)))
     }
@@ -22,7 +22,7 @@ impl SshClient {
         &self,
         imported_key: String,
         password: Option<String>,
-    ) -> Result<bitwarden_ssh::SshKey> {
+    ) -> Result<bitwarden_ssh::UnencryptedSshKey> {
         bitwarden_ssh::import::import_key(imported_key, password)
             .map_err(|e| BitwardenError::E(Error::SshImport(e)))
     }

--- a/crates/bitwarden-uniffi/src/tool/ssh.rs
+++ b/crates/bitwarden-uniffi/src/tool/ssh.rs
@@ -1,5 +1,7 @@
 use std::sync::Arc;
 
+use bitwarden_vault::SshKeyView;
+
 use crate::{
     error::{BitwardenError, Error},
     Client, Result,
@@ -13,7 +15,7 @@ impl SshClient {
     pub fn generate_ssh_key(
         &self,
         key_algorithm: bitwarden_ssh::generator::KeyAlgorithm,
-    ) -> Result<bitwarden_ssh::UnencryptedSshKey> {
+    ) -> Result<SshKeyView> {
         bitwarden_ssh::generator::generate_sshkey(key_algorithm)
             .map_err(|e| BitwardenError::E(Error::SshGeneration(e)))
     }
@@ -22,7 +24,7 @@ impl SshClient {
         &self,
         imported_key: String,
         password: Option<String>,
-    ) -> Result<bitwarden_ssh::UnencryptedSshKey> {
+    ) -> Result<SshKeyView> {
         bitwarden_ssh::import::import_key(imported_key, password)
             .map_err(|e| BitwardenError::E(Error::SshImport(e)))
     }

--- a/crates/bitwarden-vault/src/cipher/ssh_key.rs
+++ b/crates/bitwarden-vault/src/cipher/ssh_key.rs
@@ -2,7 +2,6 @@ use bitwarden_core::key_management::{KeyIds, SymmetricKeyId};
 use bitwarden_crypto::{CryptoError, Decryptable, EncString, Encryptable, KeyStoreContext};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
-
 #[cfg(feature = "wasm")]
 use tsify_next::Tsify;
 

--- a/crates/bitwarden-vault/src/cipher/ssh_key.rs
+++ b/crates/bitwarden-vault/src/cipher/ssh_key.rs
@@ -2,6 +2,7 @@ use bitwarden_core::key_management::{KeyIds, SymmetricKeyId};
 use bitwarden_crypto::{CryptoError, Decryptable, EncString, Encryptable, KeyStoreContext};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
+use tsify_next::Tsify;
 
 #[derive(Serialize, Deserialize, Debug, JsonSchema, Clone)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
@@ -18,6 +19,7 @@ pub struct SshKey {
 #[derive(Serialize, Deserialize, Debug, JsonSchema, Clone)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 #[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
+#[cfg_attr(feature = "wasm", derive(Tsify), tsify(into_wasm_abi, from_wasm_abi))]
 pub struct SshKeyView {
     /// SSH private key (ed25519/rsa) in unencrypted openssh private key format [OpenSSH private key](https://github.com/openssh/openssh-portable/blob/master/PROTOCOL.key)
     pub private_key: String,

--- a/crates/bitwarden-vault/src/cipher/ssh_key.rs
+++ b/crates/bitwarden-vault/src/cipher/ssh_key.rs
@@ -2,6 +2,8 @@ use bitwarden_core::key_management::{KeyIds, SymmetricKeyId};
 use bitwarden_crypto::{CryptoError, Decryptable, EncString, Encryptable, KeyStoreContext};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
+
+#[cfg(feature = "wasm")]
 use tsify_next::Tsify;
 
 #[derive(Serialize, Deserialize, Debug, JsonSchema, Clone)]

--- a/crates/bitwarden-wasm-internal/src/ssh.rs
+++ b/crates/bitwarden-wasm-internal/src/ssh.rs
@@ -1,3 +1,4 @@
+use bitwarden_vault::SshKeyView;
 use wasm_bindgen::prelude::*;
 
 /// Generate a new SSH key pair
@@ -11,7 +12,7 @@ use wasm_bindgen::prelude::*;
 #[wasm_bindgen]
 pub fn generate_ssh_key(
     key_algorithm: bitwarden_ssh::generator::KeyAlgorithm,
-) -> Result<bitwarden_ssh::UnencryptedSshKey, bitwarden_ssh::error::KeyGenerationError> {
+) -> Result<SshKeyView, bitwarden_ssh::error::KeyGenerationError> {
     bitwarden_ssh::generator::generate_sshkey(key_algorithm)
 }
 
@@ -32,6 +33,6 @@ pub fn generate_ssh_key(
 pub fn import_ssh_key(
     imported_key: &str,
     password: Option<String>,
-) -> Result<bitwarden_ssh::UnencryptedSshKey, bitwarden_ssh::error::SshKeyImportError> {
+) -> Result<SshKeyView, bitwarden_ssh::error::SshKeyImportError> {
     bitwarden_ssh::import::import_key(imported_key.to_string(), password)
 }

--- a/crates/bitwarden-wasm-internal/src/ssh.rs
+++ b/crates/bitwarden-wasm-internal/src/ssh.rs
@@ -11,7 +11,7 @@ use wasm_bindgen::prelude::*;
 #[wasm_bindgen]
 pub fn generate_ssh_key(
     key_algorithm: bitwarden_ssh::generator::KeyAlgorithm,
-) -> Result<bitwarden_ssh::SshKey, bitwarden_ssh::error::KeyGenerationError> {
+) -> Result<bitwarden_ssh::UnencryptedSshKey, bitwarden_ssh::error::KeyGenerationError> {
     bitwarden_ssh::generator::generate_sshkey(key_algorithm)
 }
 
@@ -32,6 +32,6 @@ pub fn generate_ssh_key(
 pub fn import_ssh_key(
     imported_key: &str,
     password: Option<String>,
-) -> Result<bitwarden_ssh::SshKey, bitwarden_ssh::error::SshKeyImportError> {
+) -> Result<bitwarden_ssh::UnencryptedSshKey, bitwarden_ssh::error::SshKeyImportError> {
     bitwarden_ssh::import::import_key(imported_key.to_string(), password)
 }


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.slack.com/archives/C054ZQSBS49/p1739385839914989

## 📔 Objective

Renames the bitwarden-ssh ssh-key struct into `UnencryptedSshKey` to fix duplication.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation
  team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
