### PR TITLE
[PM-18382] Added has_fido2_credentials new property to CipherListView.

### DIFF
--- a/crates/bitwarden-vault/src/cipher/cipher.rs
+++ b/crates/bitwarden-vault/src/cipher/cipher.rs
@@ -623,7 +623,7 @@ impl Decryptable<KeyIds, SymmetricKeyId, CipherListView> for Cipher {
                         .unwrap_or_default()
                         .is_empty()
                 }
-                _ => false
+                _ => false,
             },
             creation_date: self.creation_date,
             deleted_date: self.deleted_date,
@@ -860,7 +860,7 @@ mod tests {
                 organization_use_totp: cipher.organization_use_totp,
                 edit: cipher.edit,
                 view_password: cipher.view_password,
-                attachments: 0, 
+                attachments: 0,
                 has_fido2_credentials: true,
                 creation_date: cipher.creation_date,
                 deleted_date: cipher.deleted_date,

--- a/crates/bitwarden-vault/src/cipher/cipher.rs
+++ b/crates/bitwarden-vault/src/cipher/cipher.rs
@@ -168,6 +168,7 @@ pub struct CipherListView {
 
     /// The number of attachments
     pub attachments: u32,
+    pub has_fido2_credentials: bool,
 
     pub creation_date: DateTime<Utc>,
     pub deleted_date: Option<DateTime<Utc>>,
@@ -610,6 +611,16 @@ impl Decryptable<KeyIds, SymmetricKeyId, CipherListView> for Cipher {
                 .as_ref()
                 .map(|a| a.len() as u32)
                 .unwrap_or(0),
+            has_fido2_credentials: match self.r#type {
+                CipherType::Login => {
+                    let login = self
+                        .login
+                        .as_ref()
+                        .ok_or(CryptoError::MissingField("login"))?;
+                    !login.fido2_credentials.as_deref().unwrap_or_default().is_empty()
+                }
+                _ => false
+            },
             creation_date: self.creation_date,
             deleted_date: self.deleted_date,
             revision_date: self.revision_date,
@@ -845,7 +856,8 @@ mod tests {
                 organization_use_totp: cipher.organization_use_totp,
                 edit: cipher.edit,
                 view_password: cipher.view_password,
-                attachments: 0,
+                attachments: 0, 
+                has_fido2_credentials: true,
                 creation_date: cipher.creation_date,
                 deleted_date: cipher.deleted_date,
                 revision_date: cipher.revision_date

--- a/crates/bitwarden-vault/src/cipher/cipher.rs
+++ b/crates/bitwarden-vault/src/cipher/cipher.rs
@@ -617,7 +617,11 @@ impl Decryptable<KeyIds, SymmetricKeyId, CipherListView> for Cipher {
                         .login
                         .as_ref()
                         .ok_or(CryptoError::MissingField("login"))?;
-                    !login.fido2_credentials.as_deref().unwrap_or_default().is_empty()
+                    !login
+                        .fido2_credentials
+                        .as_deref()
+                        .unwrap_or_default()
+                        .is_empty()
                 }
                 _ => false
             },

--- a/crates/bitwarden-vault/src/totp.rs
+++ b/crates/bitwarden-vault/src/totp.rs
@@ -737,6 +737,7 @@ mod tests {
             edit: true,
             view_password: true,
             attachments: 0,
+            has_fido2_credentials: false,
             creation_date: "2024-01-30T17:55:36.150Z".parse().unwrap(),
             deleted_date: None,
             revision_date: "2024-01-30T17:55:36.150Z".parse().unwrap(),


### PR DESCRIPTION
## 🎟️ Tracking

[PM-18382](https://bitwarden.atlassian.net/browse/PM-18382)

## 📔 Objective

Add `has_fido2_credentials` new property to `CipherListView` so it can be known if the login cipher has any Fido2 credentials in it.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation
  team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-18382]: https://bitwarden.atlassian.net/browse/PM-18382?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ