### PR TITLE
Fix WASM MVP

### DIFF
--- a/crates/bitwarden-wasm-internal/build.sh
+++ b/crates/bitwarden-wasm-internal/build.sh
@@ -29,7 +29,7 @@ wasm-bindgen --target nodejs --out-dir crates/bitwarden-wasm-internal/npm/node .
 # this normally requires a nightly build, but we can also use the 
 # RUSTC_BOOTSTRAP hack to use the same stable version as the normal build
 RUSTFLAGS=-Ctarget-cpu=mvp RUSTC_BOOTSTRAP=1 cargo build -p bitwarden-wasm-internal -Zbuild-std=panic_abort,std --target wasm32-unknown-unknown ${RELEASE_FLAG}
-cp ./target/wasm32-unknown-unknown/${BUILD_FOLDER}/bitwarden_wasm_internal.wasm ./crates/bitwarden-wasm-internal/npm/bitwarden_wasm_internal_bg.mvp.wasm
+wasm-bindgen --target bundler --out-dir crates/bitwarden-wasm-internal/npm/mvp ./target/wasm32-unknown-unknown/${BUILD_FOLDER}/bitwarden_wasm_internal.wasm
 
 # Format
 npx prettier --write ./crates/bitwarden-wasm-internal/npm
@@ -37,11 +37,11 @@ npx prettier --write ./crates/bitwarden-wasm-internal/npm
 # Optimize size
 wasm-opt -Os ./crates/bitwarden-wasm-internal/npm/bitwarden_wasm_internal_bg.wasm -o ./crates/bitwarden-wasm-internal/npm/bitwarden_wasm_internal_bg.wasm
 wasm-opt -Os ./crates/bitwarden-wasm-internal/npm/node/bitwarden_wasm_internal_bg.wasm -o ./crates/bitwarden-wasm-internal/npm/node/bitwarden_wasm_internal_bg.wasm
-wasm-opt -Os ./crates/bitwarden-wasm-internal/npm/bitwarden_wasm_internal_bg.mvp.wasm -o ./crates/bitwarden-wasm-internal/npm/bitwarden_wasm_internal_bg.mvp.wasm
+wasm-opt -Os crates/bitwarden-wasm-internal/npm/mvp/bitwarden_wasm_internal_bg.wasm -o ./crates/bitwarden-wasm-internal/npm/bitwarden_wasm_internal_bg.mvp.wasm
 
 # Transpile to JS
 wasm2js ./crates/bitwarden-wasm-internal/npm/bitwarden_wasm_internal_bg.mvp.wasm -o ./crates/bitwarden-wasm-internal/npm/bitwarden_wasm_internal_bg.wasm.js
 npx terser ./crates/bitwarden-wasm-internal/npm/bitwarden_wasm_internal_bg.wasm.js -o ./crates/bitwarden-wasm-internal/npm/bitwarden_wasm_internal_bg.wasm.js
 
 # Remove unneeded files
-rm ./crates/bitwarden-wasm-internal/npm/bitwarden_wasm_internal_bg.mvp.wasm
+rm -rf ./crates/bitwarden-wasm-internal/npm/mvp


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective
 
 After we compile the MVP WASM build for wasm2js, we need to run wasm-bindgen to do it's thing, otherwise the build completes but it's not useable in webpack.

As wasm-bindgen generates a whole folder with duplicate support scripts, I've pointed it to a temp folder that is then deleted at the end.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation
  team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
