### PR TITLE
Fix MSRV build failures during CI

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -23,11 +23,7 @@ jobs:
         id: toolchain
         shell: bash
         run: |
-          if [[ "${{ matrix.channel }}" == 'rust-toolchain' ]]; then
-            RUST_TOOLCHAIN="$(grep -oP '^channel.*"(\K.*?)(?=")' rust-toolchain.toml)"
-          else
-            RUST_TOOLCHAIN="${{ matrix.channel }}"
-          fi
+          RUST_TOOLCHAIN="$(grep -oP '^channel.*"(\K.*?)(?=")' rust-toolchain.toml)"
           echo "RUST_TOOLCHAIN=${RUST_TOOLCHAIN}" | tee -a "${GITHUB_OUTPUT}"
 
       - name: Set Rust Nightly Toolchain

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -48,7 +48,6 @@ jobs:
 
       - name: Install rust
         uses: dtolnay/rust-toolchain@a54c7afa936fefeb4456b2dd8068152669aa8203 # stable
-        if: ${{ matrix.channel == 'rust-toolchain' }}
         with:
           toolchain: "${{ steps.toolchain.outputs.RUST_TOOLCHAIN }}"
           components: clippy, rustfmt

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,13 +15,6 @@ jobs:
 
     runs-on: ubuntu-24.04
 
-    strategy:
-      fail-fast: false
-      matrix:
-        channel:
-          - "rust-toolchain" # The version defined in rust-toolchain
-          - "msrv" # The supported MSRV
-
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -32,8 +25,6 @@ jobs:
         run: |
           if [[ "${{ matrix.channel }}" == 'rust-toolchain' ]]; then
             RUST_TOOLCHAIN="$(grep -oP '^channel.*"(\K.*?)(?=")' rust-toolchain.toml)"
-          elif [[ "${{ matrix.channel }}" == 'msrv' ]]; then
-            RUST_TOOLCHAIN="$(grep -oP '^rust-version.*"(\K.*?)(?=")' Cargo.toml)"
           else
             RUST_TOOLCHAIN="${{ matrix.channel }}"
           fi

--- a/.github/workflows/minimum-rust-version.yml
+++ b/.github/workflows/minimum-rust-version.yml
@@ -35,13 +35,6 @@ jobs:
           RUST_TOOLCHAIN="$(grep -oP '^rust-version.*"(\K.*?)(?=")' Cargo.toml)"
           echo "RUST_TOOLCHAIN=${RUST_TOOLCHAIN}" | tee -a "${GITHUB_OUTPUT}"
 
-      - name: Set Rust Nightly Toolchain
-        id: nightly-toolchain
-        shell: bash
-        run: |
-          RUST_NIGHTLY_TOOLCHAIN="$(grep -oP '^nightly-channel.*"(\K.*?)(?=")' rust-toolchain.toml)"
-          echo "RUST_NIGHTLY_TOOLCHAIN=${RUST_NIGHTLY_TOOLCHAIN}" | tee -a "${GITHUB_OUTPUT}"
-
       - name: Install rust
         uses: dtolnay/rust-toolchain@a54c7afa936fefeb4456b2dd8068152669aa8203 # stable
         with:
@@ -54,4 +47,4 @@ jobs:
           key: msrv-${{ matrix.settings.target }}-cargo-${{ matrix.settings.os }}
 
       - name: Cargo check MSRV
-        run: cargo check --all-features
+        run: cargo +"${{ steps.toolchain.outputs.RUST_TOOLCHAIN }}" check --all-features


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective

I've removed the MSRV from the clippy workflow. It wasn't working correctly as the toolchain file was overriding the manually provided rust version, and with the newest rustup it was erroring as the toolchain wasn't installed (and the latest rustup won't do it automatically like before).

MSRV is still being checked by the `minimum-rust-version.yml` workflow, which I've also updated to use an explicit rust version in case the toolchain was also overriding it.


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation
  team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
