### PR TITLE
Always use WASM MVP

### DIFF
--- a/crates/bitwarden-wasm-internal/build.sh
+++ b/crates/bitwarden-wasm-internal/build.sh
@@ -19,17 +19,15 @@ else
   BUILD_FOLDER="release"
 fi
 
-# Build normally
-cargo build -p bitwarden-wasm-internal --target wasm32-unknown-unknown ${RELEASE_FLAG}
-wasm-bindgen --target bundler --out-dir crates/bitwarden-wasm-internal/npm ./target/wasm32-unknown-unknown/${BUILD_FOLDER}/bitwarden_wasm_internal.wasm
-wasm-bindgen --target nodejs --out-dir crates/bitwarden-wasm-internal/npm/node ./target/wasm32-unknown-unknown/${BUILD_FOLDER}/bitwarden_wasm_internal.wasm
-
-# Build with MVP CPU target, for wasm2js support
+# Build with MVP CPU target, two reasons:
+# 1. It is required for wasm2js support
+# 2. While webpack supports it, it has some compatibility issues that lead to strange results
 # Note that this requirest build-std which is an unstable feature,
 # this normally requires a nightly build, but we can also use the 
 # RUSTC_BOOTSTRAP hack to use the same stable version as the normal build
 RUSTFLAGS=-Ctarget-cpu=mvp RUSTC_BOOTSTRAP=1 cargo build -p bitwarden-wasm-internal -Zbuild-std=panic_abort,std --target wasm32-unknown-unknown ${RELEASE_FLAG}
-wasm-bindgen --target bundler --out-dir crates/bitwarden-wasm-internal/npm/mvp ./target/wasm32-unknown-unknown/${BUILD_FOLDER}/bitwarden_wasm_internal.wasm
+wasm-bindgen --target bundler --out-dir crates/bitwarden-wasm-internal/npm ./target/wasm32-unknown-unknown/${BUILD_FOLDER}/bitwarden_wasm_internal.wasm
+wasm-bindgen --target nodejs --out-dir crates/bitwarden-wasm-internal/npm/node ./target/wasm32-unknown-unknown/${BUILD_FOLDER}/bitwarden_wasm_internal.wasm
 
 # Format
 npx prettier --write ./crates/bitwarden-wasm-internal/npm
@@ -37,11 +35,7 @@ npx prettier --write ./crates/bitwarden-wasm-internal/npm
 # Optimize size
 wasm-opt -Os ./crates/bitwarden-wasm-internal/npm/bitwarden_wasm_internal_bg.wasm -o ./crates/bitwarden-wasm-internal/npm/bitwarden_wasm_internal_bg.wasm
 wasm-opt -Os ./crates/bitwarden-wasm-internal/npm/node/bitwarden_wasm_internal_bg.wasm -o ./crates/bitwarden-wasm-internal/npm/node/bitwarden_wasm_internal_bg.wasm
-wasm-opt -Os crates/bitwarden-wasm-internal/npm/mvp/bitwarden_wasm_internal_bg.wasm -o ./crates/bitwarden-wasm-internal/npm/bitwarden_wasm_internal_bg.mvp.wasm
 
 # Transpile to JS
-wasm2js ./crates/bitwarden-wasm-internal/npm/bitwarden_wasm_internal_bg.mvp.wasm -o ./crates/bitwarden-wasm-internal/npm/bitwarden_wasm_internal_bg.wasm.js
+wasm2js ./crates/bitwarden-wasm-internal/npm/bitwarden_wasm_internal_bg.wasm -o ./crates/bitwarden-wasm-internal/npm/bitwarden_wasm_internal_bg.wasm.js
 npx terser ./crates/bitwarden-wasm-internal/npm/bitwarden_wasm_internal_bg.wasm.js -o ./crates/bitwarden-wasm-internal/npm/bitwarden_wasm_internal_bg.wasm.js
-
-# Remove unneeded files
-rm -rf ./crates/bitwarden-wasm-internal/npm/mvp


### PR DESCRIPTION
## 🎟️ Tracking

## 📔 Objective

Webpack seems to be having some compatibility issues with the reference types feature of WASM that was enabled with Rust 1.82.0, leading to some strange results:
The `verify_asymmetric_keys` function should be returning two booleans:
```
{privateKeyDecryptable: true, validPrivateKey: true}
```
and is instead returning two strings with value `identityUrl`:
```
{privateKeyDecryptable: "identityUrl", validPrivateKey: "identityUrl"}
```
I've tried to reproduce the error in a Jest test and I can't, which is what leads me to blame webpack. By using the MVP builds for both the WASM artifact and the WASM2JS build it seems to fix the issue for me.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation
  team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
