### PR TITLE
Exposed temporary function to decrypt Key

### DIFF
--- a/crates/bitwarden-vault/src/cipher/cipher.rs
+++ b/crates/bitwarden-vault/src/cipher/cipher.rs
@@ -587,8 +587,7 @@ impl CipherView {
 
     /// Decrypts an encrypted key value using the cipher's key
     ///
-    /// This method is a temporary solution to allow typescript client access to decrypted key
-    /// values, particularly for FIDO2 credentials.
+    /// This method is a temporary solution to allow typescript client access to decrypted key values, particularly for FIDO2 credentials.
     ///
     /// # Arguments
     /// * `enc_key` - The encrypted key value to decrypt
@@ -597,7 +596,7 @@ impl CipherView {
     /// # Returns
     /// * `Ok(String)` - The decrypted key value
     /// * `Err(CryptoError)` - An error occurred during decryption
-    pub fn decrypt_key(
+    pub fn decrypt_fido2_private_key(
         &self,
         enc_key: EncString,
         ctx: &mut KeyStoreContext<KeyIds>,
@@ -1372,7 +1371,7 @@ mod tests {
             Some(vec![fido2_credential.clone()]);
 
         let decrypted_key_value = cipher_view
-            .decrypt_key(fido2_credential.key_value, &mut ctx)
+            .decrypt_fido2_private_key(fido2_credential.key_value, &mut ctx)
             .unwrap();
         assert_eq!(decrypted_key_value, "123");
     }

--- a/crates/bitwarden-vault/src/cipher/cipher.rs
+++ b/crates/bitwarden-vault/src/cipher/cipher.rs
@@ -587,7 +587,8 @@ impl CipherView {
 
     /// Decrypts an encrypted key value using the cipher's key
     ///
-    /// This method is a temporary solution to allow typescript client access to decrypted key values, particularly for FIDO2 credentials.
+    /// This method is a temporary solution to allow typescript client access to decrypted key
+    /// values, particularly for FIDO2 credentials.
     ///
     /// # Arguments
     /// * `enc_key` - The encrypted key value to decrypt

--- a/crates/bitwarden-vault/src/mobile/cipher_client.rs
+++ b/crates/bitwarden-vault/src/mobile/cipher_client.rs
@@ -62,14 +62,15 @@ impl ClientCiphers<'_> {
         Ok(cipher_view)
     }
 
-    pub fn decrypt_key(
+    pub fn decrypt_fido2_private_key(
         &self,
         cipher_view: CipherView,
         key: String,
     ) -> Result<String, DecryptError> {
         let key_store = self.client.internal.get_key_store();
         let enc_key: EncString = key.parse()?;
-        let decrypted_key = cipher_view.decrypt_key(enc_key, &mut key_store.context())?;
+        let decrypted_key =
+            cipher_view.decrypt_fido2_private_key(enc_key, &mut key_store.context())?;
         Ok(decrypted_key)
     }
 }

--- a/crates/bitwarden-vault/src/mobile/cipher_client.rs
+++ b/crates/bitwarden-vault/src/mobile/cipher_client.rs
@@ -1,5 +1,5 @@
 use bitwarden_core::Client;
-use bitwarden_crypto::{EncString, IdentifyKey};
+use bitwarden_crypto::IdentifyKey;
 use uuid::Uuid;
 
 use crate::{
@@ -65,12 +65,9 @@ impl ClientCiphers<'_> {
     pub fn decrypt_fido2_private_key(
         &self,
         cipher_view: CipherView,
-        key: String,
-    ) -> Result<String, DecryptError> {
+    ) -> Result<String, CipherError> {
         let key_store = self.client.internal.get_key_store();
-        let enc_key: EncString = key.parse()?;
-        let decrypted_key =
-            cipher_view.decrypt_fido2_private_key(enc_key, &mut key_store.context())?;
+        let decrypted_key = cipher_view.decrypt_fido2_private_key(&mut key_store.context())?;
         Ok(decrypted_key)
     }
 }

--- a/crates/bitwarden-vault/src/mobile/cipher_client.rs
+++ b/crates/bitwarden-vault/src/mobile/cipher_client.rs
@@ -1,5 +1,5 @@
 use bitwarden_core::Client;
-use bitwarden_crypto::IdentifyKey;
+use bitwarden_crypto::{EncString, IdentifyKey};
 use uuid::Uuid;
 
 use crate::{
@@ -60,6 +60,17 @@ impl ClientCiphers<'_> {
         let key_store = self.client.internal.get_key_store();
         cipher_view.move_to_organization(&mut key_store.context(), organization_id)?;
         Ok(cipher_view)
+    }
+
+    pub fn decrypt_key(
+        &self,
+        cipher_view: CipherView,
+        key: String,
+    ) -> Result<String, DecryptError> {
+        let key_store = self.client.internal.get_key_store();
+        let enc_key: EncString = key.parse()?;
+        let decrypted_key = cipher_view.decrypt_key(enc_key, &mut key_store.context())?;
+        Ok(decrypted_key)
     }
 }
 

--- a/crates/bitwarden-wasm-internal/src/vault/ciphers.rs
+++ b/crates/bitwarden-wasm-internal/src/vault/ciphers.rs
@@ -71,4 +71,23 @@ impl ClientCiphers {
             .ciphers()
             .decrypt_fido2_credentials(cipher_view)
     }
+
+    /// Decrypt key
+    ///
+    /// This method is a temporary solution to allow typescript client access to decrypted key values, particularly for FIDO2 credentials.
+    ///
+    /// # Arguments
+    /// - `cipher_view` - Decrypted cipher containing the key
+    /// - `key` - The encrypted key to decrypt
+    ///
+    /// # Returns
+    /// - `Ok(String)` containing the decrypted key
+    /// - `Err(DecryptError)` if decryption fails
+    pub fn decrypt_key(
+        &self,
+        cipher_view: CipherView,
+        key: String,
+    ) -> Result<String, DecryptError> {
+        self.0.vault().ciphers().decrypt_key(cipher_view, key)
+    }
 }

--- a/crates/bitwarden-wasm-internal/src/vault/ciphers.rs
+++ b/crates/bitwarden-wasm-internal/src/vault/ciphers.rs
@@ -2,8 +2,8 @@ use std::rc::Rc;
 
 use bitwarden_core::Client;
 use bitwarden_vault::{
-    Cipher, CipherListView, CipherView, DecryptError, EncryptError, Fido2CredentialView,
-    VaultClientExt,
+    Cipher, CipherError, CipherListView, CipherView, DecryptError, EncryptError,
+    Fido2CredentialView, VaultClientExt,
 };
 use wasm_bindgen::prelude::wasm_bindgen;
 
@@ -72,26 +72,24 @@ impl ClientCiphers {
             .decrypt_fido2_credentials(cipher_view)
     }
 
-    /// Decrypt Fido2 private key
+    /// Decrypt key
     ///
     /// This method is a temporary solution to allow typescript client access to decrypted key
     /// values, particularly for FIDO2 credentials.
     ///
     /// # Arguments
     /// - `cipher_view` - Decrypted cipher containing the key
-    /// - `key` - The encrypted key to decrypt
     ///
     /// # Returns
     /// - `Ok(String)` containing the decrypted key
-    /// - `Err(DecryptError)` if decryption fails
+    /// - `Err(CipherError)`
     pub fn decrypt_fido2_private_key(
         &self,
         cipher_view: CipherView,
-        key: String,
-    ) -> Result<String, DecryptError> {
+    ) -> Result<String, CipherError> {
         self.0
             .vault()
             .ciphers()
-            .decrypt_fido2_private_key(cipher_view, key)
+            .decrypt_fido2_private_key(cipher_view)
     }
 }

--- a/crates/bitwarden-wasm-internal/src/vault/ciphers.rs
+++ b/crates/bitwarden-wasm-internal/src/vault/ciphers.rs
@@ -72,7 +72,7 @@ impl ClientCiphers {
             .decrypt_fido2_credentials(cipher_view)
     }
 
-    /// Decrypt key
+    /// Decrypt Fido2 private key
     ///
     /// This method is a temporary solution to allow typescript client access to decrypted key
     /// values, particularly for FIDO2 credentials.
@@ -84,11 +84,14 @@ impl ClientCiphers {
     /// # Returns
     /// - `Ok(String)` containing the decrypted key
     /// - `Err(DecryptError)` if decryption fails
-    pub fn decrypt_key(
+    pub fn decrypt_fido2_private_key(
         &self,
         cipher_view: CipherView,
         key: String,
     ) -> Result<String, DecryptError> {
-        self.0.vault().ciphers().decrypt_key(cipher_view, key)
+        self.0
+            .vault()
+            .ciphers()
+            .decrypt_fido2_private_key(cipher_view, key)
     }
 }

--- a/crates/bitwarden-wasm-internal/src/vault/ciphers.rs
+++ b/crates/bitwarden-wasm-internal/src/vault/ciphers.rs
@@ -74,7 +74,8 @@ impl ClientCiphers {
 
     /// Decrypt key
     ///
-    /// This method is a temporary solution to allow typescript client access to decrypted key values, particularly for FIDO2 credentials.
+    /// This method is a temporary solution to allow typescript client access to decrypted key
+    /// values, particularly for FIDO2 credentials.
     ///
     /// # Arguments
     /// - `cipher_view` - Decrypted cipher containing the key


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective
`decrypt_fido2_private_key` is exposed temporarily because the typescript clients still use the internal Fido2 authentication logic. As a result,  we need the `keyValue` on the Fido2CredentialsView to remain in the decrypted state. This workaround will be removed once the migration to the SDK-based  Fido2 Authentication is done.
<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation
  team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
