### PR TITLE
Change LocalData timestamp fields from u32 to DateTime<Utc> to support JavaScript timestamps

### DIFF
--- a/crates/bitwarden-vault/src/cipher/local_data.rs
+++ b/crates/bitwarden-vault/src/cipher/local_data.rs
@@ -1,5 +1,6 @@
 use bitwarden_core::key_management::{KeyIds, SymmetricKeyId};
 use bitwarden_crypto::{CryptoError, Decryptable, Encryptable, KeyStoreContext};
+use chrono::{DateTime, Utc};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 #[cfg(feature = "wasm")]
@@ -10,8 +11,8 @@ use tsify_next::Tsify;
 #[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
 #[cfg_attr(feature = "wasm", derive(Tsify), tsify(into_wasm_abi, from_wasm_abi))]
 pub struct LocalData {
-    last_used_date: Option<u64>,
-    last_launched: Option<u64>,
+    last_used_date: Option<DateTime<Utc>>,
+    last_launched: Option<DateTime<Utc>>,
 }
 
 #[derive(Serialize, Deserialize, Debug, JsonSchema, Clone)]
@@ -19,8 +20,8 @@ pub struct LocalData {
 #[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
 #[cfg_attr(feature = "wasm", derive(Tsify), tsify(into_wasm_abi, from_wasm_abi))]
 pub struct LocalDataView {
-    last_used_date: Option<u64>,
-    last_launched: Option<u64>,
+    last_used_date: Option<DateTime<Utc>>,
+    last_launched: Option<DateTime<Utc>>,
 }
 
 impl Encryptable<KeyIds, SymmetricKeyId, LocalData> for LocalDataView {
@@ -46,19 +47,5 @@ impl Decryptable<KeyIds, SymmetricKeyId, LocalDataView> for LocalData {
             last_used_date: self.last_used_date,
             last_launched: self.last_launched,
         })
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::LocalData;
-
-    #[test]
-    fn test_large_timestamps() {
-        // This JSON would have caused overflow with u32
-        let overflow_json = r#"{ "lastUsedDate": 1744662575875, "lastLaunched": null }"#;
-
-        let result = serde_json::from_str::<LocalData>(overflow_json);
-        assert!(result.is_ok());
     }
 }

--- a/crates/bitwarden-vault/src/cipher/local_data.rs
+++ b/crates/bitwarden-vault/src/cipher/local_data.rs
@@ -10,8 +10,8 @@ use tsify_next::Tsify;
 #[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
 #[cfg_attr(feature = "wasm", derive(Tsify), tsify(into_wasm_abi, from_wasm_abi))]
 pub struct LocalData {
-    last_used_date: Option<u32>,
-    last_launched: Option<u32>,
+    last_used_date: Option<u64>,
+    last_launched: Option<u64>,
 }
 
 #[derive(Serialize, Deserialize, Debug, JsonSchema, Clone)]
@@ -19,8 +19,8 @@ pub struct LocalData {
 #[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
 #[cfg_attr(feature = "wasm", derive(Tsify), tsify(into_wasm_abi, from_wasm_abi))]
 pub struct LocalDataView {
-    last_used_date: Option<u32>,
-    last_launched: Option<u32>,
+    last_used_date: Option<u64>,
+    last_launched: Option<u64>,
 }
 
 impl Encryptable<KeyIds, SymmetricKeyId, LocalData> for LocalDataView {
@@ -46,5 +46,19 @@ impl Decryptable<KeyIds, SymmetricKeyId, LocalDataView> for LocalData {
             last_used_date: self.last_used_date,
             last_launched: self.last_launched,
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::LocalData;
+
+    #[test]
+    fn test_large_timestamps() {
+        // This JSON would have caused overflow with u32
+        let overflow_json = r#"{ "lastUsedDate": 1744662575875, "lastLaunched": null }"#;
+
+        let result = serde_json::from_str::<LocalData>(overflow_json);
+        assert!(result.is_ok());
     }
 }


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective
This PR updates the LocalData and LocalDataView structs to use DateTime<Utc> instead of u32 for timestamp fields (lastUsedDate and lastLaunched). The timestamp sent from the TS client can exceed the u32 max value, which throws an error.
<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation
  team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
