### PR TITLE
Rename rustls-platform-verifier deprecated API

### DIFF
--- a/crates/bitwarden-uniffi/src/android_support.rs
+++ b/crates/bitwarden-uniffi/src/android_support.rs
@@ -92,7 +92,7 @@ fn init_verifier(env: &mut jni::JNIEnv<'_>) -> jni::errors::Result<()> {
         )?
         .l()?;
 
-    Ok(rustls_platform_verifier::android::init_hosted(
+    Ok(rustls_platform_verifier::android::init_with_env(
         env, context,
     )?)
 }


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective

This API was deprecated with the latest release of rustls-platform-verifier, but there is an equivalent with a different name

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation
  team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
