### PR TITLE
Accept AttachmentView in AttachmentFile

### DIFF
--- a/crates/bitwarden-uniffi/src/vault/attachments.rs
+++ b/crates/bitwarden-uniffi/src/vault/attachments.rs
@@ -44,7 +44,7 @@ impl AttachmentsClient {
     pub fn decrypt_buffer(
         &self,
         cipher: Cipher,
-        attachment: Attachment,
+        attachment: AttachmentView,
         buffer: Vec<u8>,
     ) -> Result<Vec<u8>> {
         Ok(self
@@ -57,7 +57,7 @@ impl AttachmentsClient {
     pub fn decrypt_file(
         &self,
         cipher: Cipher,
-        attachment: Attachment,
+        attachment: AttachmentView,
         encrypted_file_path: String,
         decrypted_file_path: String,
     ) -> Result<()> {

--- a/crates/bitwarden-vault/src/cipher/attachment.rs
+++ b/crates/bitwarden-vault/src/cipher/attachment.rs
@@ -47,17 +47,6 @@ pub struct AttachmentEncryptResult {
 
 pub struct AttachmentFile {
     pub cipher: Cipher,
-    pub attachment: Attachment,
-
-    /// There are three different ways attachments are encrypted.
-    /// 1. UserKey / OrgKey (Contents) - Legacy
-    /// 2. AttachmentKey(Contents) - Pre CipherKey
-    /// 3. CipherKey(AttachmentKey(Contents)) - Current
-    pub contents: EncString,
-}
-
-pub struct AttachmentFileData {
-    pub cipher: Cipher,
     pub attachment: AttachmentView,
 
     /// There are three different ways attachments are encrypted.
@@ -80,12 +69,6 @@ impl IdentifyKey<SymmetricKeyId> for AttachmentFileView<'_> {
     }
 }
 impl IdentifyKey<SymmetricKeyId> for AttachmentFile {
-    fn key_identifier(&self) -> SymmetricKeyId {
-        self.cipher.key_identifier()
-    }
-}
-
-impl IdentifyKey<SymmetricKeyId> for AttachmentFileData {
     fn key_identifier(&self) -> SymmetricKeyId {
         self.cipher.key_identifier()
     }
@@ -132,29 +115,6 @@ fn size_name(size: usize) -> String {
 }
 
 impl Decryptable<KeyIds, SymmetricKeyId, Vec<u8>> for AttachmentFile {
-    fn decrypt(
-        &self,
-        ctx: &mut KeyStoreContext<KeyIds>,
-        key: SymmetricKeyId,
-    ) -> Result<Vec<u8>, CryptoError> {
-        let ciphers_key = Cipher::decrypt_cipher_key(ctx, key, &self.cipher.key)?;
-
-        // Version 2 or 3, `AttachmentKey` or `CipherKey(AttachmentKey)`
-        if let Some(attachment_key) = &self.attachment.key {
-            let content_key = ctx.decrypt_symmetric_key_with_symmetric_key(
-                ciphers_key,
-                ATTACHMENT_KEY,
-                attachment_key,
-            )?;
-            self.contents.decrypt(ctx, content_key)
-        } else {
-            // Legacy attachment version 1, use user/org key
-            self.contents.decrypt(ctx, key)
-        }
-    }
-}
-
-impl Decryptable<KeyIds, SymmetricKeyId, Vec<u8>> for AttachmentFileData {
     fn decrypt(
         &self,
         ctx: &mut KeyStoreContext<KeyIds>,
@@ -231,12 +191,12 @@ impl TryFrom<bitwarden_api_api::models::AttachmentResponseModel> for Attachment 
 #[cfg(test)]
 mod tests {
     use base64::{engine::general_purpose::STANDARD, Engine};
-    use bitwarden_core::key_management::{create_test_crypto_with_user_key, SymmetricKeyId};
-    use bitwarden_crypto::{EncString, Encryptable, SymmetricCryptoKey};
+    use bitwarden_core::key_management::create_test_crypto_with_user_key;
+    use bitwarden_crypto::{EncString, SymmetricCryptoKey};
 
     use crate::{
         cipher::cipher::{CipherRepromptType, CipherType},
-        Attachment, AttachmentFile, AttachmentFileData, AttachmentFileView, AttachmentView, Cipher,
+        AttachmentFile, AttachmentFileView, AttachmentView, Cipher,
     };
 
     #[test]
@@ -312,13 +272,13 @@ mod tests {
         let user_key: SymmetricCryptoKey = "w2LO+nwV4oxwswVYCxlOfRUseXfvU03VzvKQHrqeklPgiMZrspUe6sOBToCnDn9Ay0tuCBn8ykVVRb7PWhub2Q==".to_string().try_into().unwrap();
         let key_store = create_test_crypto_with_user_key(user_key);
 
-        let attachment = Attachment {
+        let attachment = AttachmentView {
             id: None,
             url: None,
             size: Some("161".into()),
             size_name: Some("161 Bytes".into()),
-            file_name: Some("2.M3z1MOO9eBG9BWRTEUbPog==|jPw0By1AakHDfoaY8UOwOQ==|eP9/J1583OJpHsSM4ZnXZzdBHfqVTXnOXGlkkmAKSfA=".parse().unwrap()),
-            key: Some("2.r288/AOSPiaLFkW07EBGBw==|SAmnnCbOLFjX5lnURvoualOetQwuyPc54PAmHDTRrhT0gwO9ailna9U09q9bmBfI5XrjNNEsuXssgzNygRkezoVQvZQggZddOwHB6KQW5EQ=|erIMUJp8j+aTcmhdE50zEX+ipv/eR1sZ7EwULJm/6DY=".parse().unwrap())
+            file_name: Some("Test.txt".into()),
+            key: Some("2.r288/AOSPiaLFkW07EBGBw==|SAmnnCbOLFjX5lnURvoualOetQwuyPc54PAmHDTRrhT0gwO9ailna9U09q9bmBfI5XrjNNEsuXssgzNygRkezoVQvZQggZddOwHB6KQW5EQ=|erIMUJp8j+aTcmhdE50zEX+ipv/eR1sZ7EwULJm/6DY=".parse().unwrap()),
         };
 
         let cipher  = Cipher {
@@ -369,12 +329,12 @@ mod tests {
         let user_key: SymmetricCryptoKey = "w2LO+nwV4oxwswVYCxlOfRUseXfvU03VzvKQHrqeklPgiMZrspUe6sOBToCnDn9Ay0tuCBn8ykVVRb7PWhub2Q==".to_string().try_into().unwrap();
         let key_store = create_test_crypto_with_user_key(user_key);
 
-        let attachment = Attachment {
+        let attachment = AttachmentView {
             id: None,
             url: None,
             size: Some("161".into()),
             size_name: Some("161 Bytes".into()),
-            file_name: Some("2.qTJdrgQe+tLCHTlPHMJXLw==|0we9+uYJPEY3FU5SblX2hg==|+fL/wTF/WgpoV+BNzmsmi284O0QNdVBUYmfqqs0CG1E=".parse().unwrap()),
+            file_name: Some("Test.txt".into()),
             key: None,
         };
 
@@ -419,80 +379,5 @@ mod tests {
             .unwrap();
 
         assert_eq!(dec, original);
-    }
-
-    #[test]
-    fn test_attachment_file_data_decrypt() {
-        let user_key: SymmetricCryptoKey = "w2LO+nwV4oxwswVYCxlOfRUseXfvU03VzvKQHrqeklPgiMZrspUe6sOBToCnDn9Ay0tuCBn8ykVVRb7PWhub2Q==".to_string().try_into().unwrap();
-        let key_store = create_test_crypto_with_user_key(user_key.clone());
-        let mut ctx = key_store.context();
-
-        let cipher_key = ctx
-            .generate_symmetric_key(SymmetricKeyId::Local("test_cipher_key"))
-            .unwrap();
-        let cipher_key_enc = ctx
-            .encrypt_symmetric_key_with_symmetric_key(SymmetricKeyId::User, cipher_key)
-            .unwrap();
-
-        let encrypted_name = "Test".to_string().encrypt(&mut ctx, cipher_key).unwrap();
-
-        let attachment_key = ctx
-            .generate_symmetric_key(SymmetricKeyId::Local("test_attachment_key"))
-            .unwrap();
-        let attachment_key_enc = ctx
-            .encrypt_symmetric_key_with_symmetric_key(cipher_key, attachment_key)
-            .unwrap();
-
-        println!("attachment key {}", &attachment_key_enc);
-
-        let original_content = "AttachmentFileTest decrypt test content";
-        let encrypted_content = original_content.encrypt(&mut ctx, attachment_key).unwrap();
-
-        let cipher = Cipher {
-            id: None,
-            organization_id: None,
-            folder_id: None,
-            collection_ids: Vec::new(),
-            key: Some(cipher_key_enc),
-            name: encrypted_name,
-            notes: None,
-            r#type: CipherType::Login,
-            login: None,
-            identity: None,
-            card: None,
-            secure_note: None,
-            ssh_key: None,
-            favorite: false,
-            reprompt: CipherRepromptType::None,
-            organization_use_totp: false,
-            edit: true,
-            permissions: None,
-            view_password: true,
-            local_data: None,
-            attachments: None,
-            fields: None,
-            password_history: None,
-            creation_date: "2023-07-24T12:05:09.466666700Z".parse().unwrap(),
-            deleted_date: None,
-            revision_date: "2023-07-27T19:28:05.240Z".parse().unwrap(),
-        };
-
-        let attachment = AttachmentView {
-            id: Some("test-attachment-id".into()),
-            url: None,
-            size: Some(original_content.len().to_string()),
-            size_name: Some(format!("{} Bytes", original_content.len())),
-            file_name: Some("test.txt".into()),
-            key: Some(attachment_key_enc),
-        };
-
-        let file = AttachmentFileData {
-            cipher,
-            attachment,
-            contents: encrypted_content,
-        };
-
-        let decrypted = key_store.decrypt(&file).unwrap();
-        assert_eq!(decrypted, original_content.as_bytes());
     }
 }

--- a/crates/bitwarden-vault/src/cipher/attachment_client.rs
+++ b/crates/bitwarden-vault/src/cipher/attachment_client.rs
@@ -10,6 +10,8 @@ use crate::{
     Cipher, DecryptError, EncryptError, VaultClient,
 };
 
+use super::AttachmentFileData;
+
 pub struct AttachmentsClient {
     pub(crate) client: Client,
 }
@@ -74,6 +76,20 @@ impl AttachmentsClient {
         let key_store = self.client.internal.get_key_store();
 
         Ok(key_store.decrypt(&AttachmentFile {
+            cipher,
+            attachment,
+            contents: EncString::from_buffer(encrypted_buffer)?,
+        })?)
+    }
+    pub fn decrypt_buffer_view(
+        &self,
+        cipher: Cipher,
+        attachment: AttachmentView,
+        encrypted_buffer: &[u8],
+    ) -> Result<Vec<u8>, DecryptError> {
+        let key_store = self.client.internal.get_key_store();
+
+        Ok(key_store.decrypt(&AttachmentFileData {
             cipher,
             attachment,
             contents: EncString::from_buffer(encrypted_buffer)?,

--- a/crates/bitwarden-vault/src/cipher/attachment_client.rs
+++ b/crates/bitwarden-vault/src/cipher/attachment_client.rs
@@ -65,7 +65,6 @@ impl AttachmentsClient {
         Ok(attachment)
     }
 
-    #[deprecated(note = "Prefer decrypt_buffer_view, which accepts AttachmentView directly.")]
     pub fn decrypt_buffer(
         &self,
         cipher: Cipher,

--- a/crates/bitwarden-vault/src/cipher/attachment_client.rs
+++ b/crates/bitwarden-vault/src/cipher/attachment_client.rs
@@ -6,11 +6,9 @@ use bitwarden_error::bitwarden_error;
 use thiserror::Error;
 
 use crate::{
-    Attachment, AttachmentEncryptResult, AttachmentFile, AttachmentFileView, AttachmentView,
-    Cipher, DecryptError, EncryptError, VaultClient,
+    Attachment, AttachmentEncryptResult, AttachmentFile, AttachmentFileData, AttachmentFileView,
+    AttachmentView, Cipher, DecryptError, EncryptError, VaultClient,
 };
-
-use super::AttachmentFileData;
 
 pub struct AttachmentsClient {
     pub(crate) client: Client,

--- a/crates/bitwarden-vault/src/cipher/attachment_client.rs
+++ b/crates/bitwarden-vault/src/cipher/attachment_client.rs
@@ -65,6 +65,7 @@ impl AttachmentsClient {
         Ok(attachment)
     }
 
+    #[deprecated(note = "Prefer decrypt_buffer_view, which accepts AttachmentView directly.")]
     pub fn decrypt_buffer(
         &self,
         cipher: Cipher,

--- a/crates/bitwarden-vault/src/cipher/attachment_client.rs
+++ b/crates/bitwarden-vault/src/cipher/attachment_client.rs
@@ -6,8 +6,8 @@ use bitwarden_error::bitwarden_error;
 use thiserror::Error;
 
 use crate::{
-    Attachment, AttachmentEncryptResult, AttachmentFile, AttachmentFileData, AttachmentFileView,
-    AttachmentView, Cipher, DecryptError, EncryptError, VaultClient,
+    Attachment, AttachmentEncryptResult, AttachmentFile, AttachmentFileView, AttachmentView,
+    Cipher, DecryptError, EncryptError, VaultClient,
 };
 
 pub struct AttachmentsClient {
@@ -68,7 +68,7 @@ impl AttachmentsClient {
     pub fn decrypt_buffer(
         &self,
         cipher: Cipher,
-        attachment: Attachment,
+        attachment: AttachmentView,
         encrypted_buffer: &[u8],
     ) -> Result<Vec<u8>, DecryptError> {
         let key_store = self.client.internal.get_key_store();
@@ -79,24 +79,10 @@ impl AttachmentsClient {
             contents: EncString::from_buffer(encrypted_buffer)?,
         })?)
     }
-    pub fn decrypt_buffer_view(
-        &self,
-        cipher: Cipher,
-        attachment: AttachmentView,
-        encrypted_buffer: &[u8],
-    ) -> Result<Vec<u8>, DecryptError> {
-        let key_store = self.client.internal.get_key_store();
-
-        Ok(key_store.decrypt(&AttachmentFileData {
-            cipher,
-            attachment,
-            contents: EncString::from_buffer(encrypted_buffer)?,
-        })?)
-    }
     pub fn decrypt_file(
         &self,
         cipher: Cipher,
-        attachment: Attachment,
+        attachment: AttachmentView,
         encrypted_file_path: &Path,
         decrypted_file_path: &Path,
     ) -> Result<(), DecryptFileError> {

--- a/crates/bitwarden-vault/src/cipher/cipher_client.rs
+++ b/crates/bitwarden-vault/src/cipher/cipher_client.rs
@@ -233,7 +233,7 @@ mod tests {
         let attachment_view = attachments.first().unwrap().clone();
         assert!(attachment_view.key.is_none());
 
-        assert_eq!(attachment_view.file_name.unwrap(), "h.txt");
+        assert_eq!(attachment_view.file_name.as_deref(), Some("h.txt"));
 
         let buf = vec![
             2, 100, 205, 148, 152, 77, 184, 77, 53, 80, 38, 240, 83, 217, 251, 118, 254, 27, 117,
@@ -245,7 +245,7 @@ mod tests {
         let content = client
             .vault()
             .attachments()
-            .decrypt_buffer(cipher, attachment, buf.as_slice())
+            .decrypt_buffer(cipher, attachment_view.clone(), buf.as_slice())
             .unwrap();
 
         assert_eq!(content, b"Hello");
@@ -267,7 +267,11 @@ mod tests {
         let new_cipher = client.vault().ciphers().encrypt(view).unwrap();
         assert!(new_cipher.key.is_some());
 
-        let view = client.vault().ciphers().decrypt(new_cipher).unwrap();
+        let view = client
+            .vault()
+            .ciphers()
+            .decrypt(new_cipher.clone())
+            .unwrap();
         let attachments = view.clone().attachments.unwrap();
         let attachment_view = attachments.first().unwrap().clone();
         assert!(attachment_view.key.is_some());
@@ -278,7 +282,7 @@ mod tests {
             attachment_view.clone().key.unwrap().to_string()
         );
 
-        assert_eq!(attachment_view.file_name.unwrap(), "h.txt");
+        assert_eq!(attachment_view.file_name.as_deref(), Some("h.txt"));
 
         let buf = vec![
             2, 114, 53, 72, 20, 82, 18, 46, 48, 137, 97, 1, 100, 142, 120, 187, 28, 36, 180, 46,
@@ -290,7 +294,7 @@ mod tests {
         let content = client
             .vault()
             .attachments()
-            .decrypt_buffer(cipher, attachment, buf.as_slice())
+            .decrypt_buffer(new_cipher.clone(), attachment_view.clone(), buf.as_slice())
             .unwrap();
 
         assert_eq!(content, b"Hello");
@@ -316,14 +320,14 @@ mod tests {
 
         // Ensure attachment key is still the same since it's protected by the cipher key
         assert_eq!(
-            attachment.clone().key.unwrap().to_string(),
-            attachment_view.key.unwrap().to_string()
+            attachment.clone().key.as_ref().unwrap().to_string(),
+            attachment_view.key.as_ref().unwrap().to_string()
         );
 
         let content = client
             .vault()
             .attachments()
-            .decrypt_buffer(new_cipher, attachment, buf.as_slice())
+            .decrypt_buffer(new_cipher, attachment_view, buf.as_slice())
             .unwrap();
 
         assert_eq!(content, b"Hello");

--- a/crates/bitwarden-vault/src/cipher/mod.rs
+++ b/crates/bitwarden-vault/src/cipher/mod.rs
@@ -14,8 +14,7 @@ pub(crate) mod secure_note;
 pub(crate) mod ssh_key;
 
 pub use attachment::{
-    Attachment, AttachmentEncryptResult, AttachmentFile, AttachmentFileData, AttachmentFileView,
-    AttachmentView,
+    Attachment, AttachmentEncryptResult, AttachmentFile, AttachmentFileView, AttachmentView,
 };
 pub use attachment_client::{AttachmentsClient, DecryptFileError, EncryptFileError};
 pub use card::{CardBrand, CardView};

--- a/crates/bitwarden-vault/src/cipher/mod.rs
+++ b/crates/bitwarden-vault/src/cipher/mod.rs
@@ -14,7 +14,8 @@ pub(crate) mod secure_note;
 pub(crate) mod ssh_key;
 
 pub use attachment::{
-    Attachment, AttachmentEncryptResult, AttachmentFile, AttachmentFileView, AttachmentView,
+    Attachment, AttachmentEncryptResult, AttachmentFile, AttachmentFileData, AttachmentFileView,
+    AttachmentView,
 };
 pub use attachment_client::{AttachmentsClient, DecryptFileError, EncryptFileError};
 pub use card::{CardBrand, CardView};

--- a/crates/bitwarden-wasm-internal/src/vault/attachments.rs
+++ b/crates/bitwarden-wasm-internal/src/vault/attachments.rs
@@ -1,4 +1,4 @@
-use bitwarden_vault::{Attachment, AttachmentView, Cipher, DecryptError};
+use bitwarden_vault::{AttachmentView, Cipher, DecryptError};
 use wasm_bindgen::prelude::wasm_bindgen;
 
 #[wasm_bindgen]
@@ -16,20 +16,9 @@ impl AttachmentsClient {
     pub fn decrypt_buffer(
         &self,
         cipher: Cipher,
-        attachment: Attachment,
-        encrypted_buffer: &[u8],
-    ) -> Result<Vec<u8>, DecryptError> {
-        self.0.decrypt_buffer(cipher, attachment, encrypted_buffer)
-    }
-
-    /// Decrypts an attachment's encrypted content
-    pub fn decrypt_buffer_view(
-        &self,
-        cipher: Cipher,
         attachment: AttachmentView,
         encrypted_buffer: &[u8],
     ) -> Result<Vec<u8>, DecryptError> {
-        self.0
-            .decrypt_buffer_view(cipher, attachment, encrypted_buffer)
+        self.0.decrypt_buffer(cipher, attachment, encrypted_buffer)
     }
 }

--- a/crates/bitwarden-wasm-internal/src/vault/attachments.rs
+++ b/crates/bitwarden-wasm-internal/src/vault/attachments.rs
@@ -1,4 +1,4 @@
-use bitwarden_vault::{Attachment, Cipher, DecryptError};
+use bitwarden_vault::{Attachment, AttachmentView, Cipher, DecryptError};
 use wasm_bindgen::prelude::wasm_bindgen;
 
 #[wasm_bindgen]
@@ -20,5 +20,16 @@ impl AttachmentsClient {
         encrypted_buffer: &[u8],
     ) -> Result<Vec<u8>, DecryptError> {
         self.0.decrypt_buffer(cipher, attachment, encrypted_buffer)
+    }
+
+    /// Decrypts an attachment's encrypted content
+    pub fn decrypt_buffer_view(
+        &self,
+        cipher: Cipher,
+        attachment: AttachmentView,
+        encrypted_buffer: &[u8],
+    ) -> Result<Vec<u8>, DecryptError> {
+        self.0
+            .decrypt_buffer_view(cipher, attachment, encrypted_buffer)
     }
 }


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective
Previously, decrypting attachment content in clients required fetching the cipher, filtering to find the relevant attachment, and then passing the full encrypted attachment to the `decrypt_buffer` function, even when the decrypted `AttachmentView` was already available. This change reafctors `AttachmentFile` to uses the `AttachmentView` directly.
<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation
  team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
