### PR TITLE
Fix SM init crypto

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -409,7 +409,6 @@ dependencies = [
  "uniffi",
  "uuid",
  "wasm-bindgen",
- "wiremock",
  "zeroize",
  "zxcvbn",
 ]
@@ -597,6 +596,7 @@ dependencies = [
  "tokio",
  "uuid",
  "validator",
+ "wiremock",
 ]
 
 [[package]]

--- a/bitwarden_license/bitwarden-sm/Cargo.toml
+++ b/bitwarden_license/bitwarden-sm/Cargo.toml
@@ -15,7 +15,7 @@ keywords.workspace = true
 
 [dependencies]
 bitwarden-api-api = { workspace = true }
-bitwarden-core = { workspace = true }
+bitwarden-core = { workspace = true, features = ["secrets"] }
 bitwarden-crypto = { workspace = true }
 chrono = { workspace = true }
 log = { workspace = true }
@@ -28,6 +28,7 @@ validator = { workspace = true }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["rt"] }
+wiremock = "0.6.0"
 
 [lints]
 workspace = true

--- a/bitwarden_license/bitwarden-sm/src/client_secrets.rs
+++ b/bitwarden_license/bitwarden-sm/src/client_secrets.rs
@@ -104,7 +104,9 @@ impl SecretsClientExt for Client {
 
 #[cfg(test)]
 mod tests {
-    use bitwarden_core::{auth::login::AccessTokenLoginRequest, Client, ClientSettings, DeviceType};
+    use bitwarden_core::{
+        auth::login::AccessTokenLoginRequest, Client, ClientSettings, DeviceType,
+    };
 
     use crate::{
         secrets::{SecretGetRequest, SecretIdentifiersRequest},

--- a/bitwarden_license/bitwarden-sm/src/client_secrets.rs
+++ b/bitwarden_license/bitwarden-sm/src/client_secrets.rs
@@ -101,3 +101,119 @@ impl SecretsClientExt for Client {
         SecretsClient::new(self.clone())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use bitwarden_core::{auth::login::AccessTokenLoginRequest, Client, ClientSettings, DeviceType};
+
+    use crate::{
+        secrets::{SecretGetRequest, SecretIdentifiersRequest},
+        ClientSecretsExt,
+    };
+
+    async fn start_mock(mocks: Vec<wiremock::Mock>) -> (wiremock::MockServer, Client) {
+        let server = wiremock::MockServer::start().await;
+
+        for mock in mocks {
+            server.register(mock).await;
+        }
+
+        let settings = ClientSettings {
+            identity_url: format!("http://{}/identity", server.address()),
+            api_url: format!("http://{}/api", server.address()),
+            user_agent: "Bitwarden Rust-SDK [TEST]".into(),
+            device_type: DeviceType::SDK,
+        };
+
+        (server, Client::new(Some(settings)))
+    }
+
+    #[tokio::test]
+    async fn test_access_token_login() {
+        use wiremock::{matchers, Mock, ResponseTemplate};
+
+        // Create the mock server with the necessary routes for this test
+        let (_server, client) = start_mock(vec![
+            Mock::given(matchers::path("/identity/connect/token"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(
+                serde_json::json!({
+                    "access_token":"eyJhbGciOiJSUzI1NiIsImtpZCI6IjMwMURENkE1MEU4NEUxRDA5MUM4MUQzQjAwQkY5MDEwQzg1REJEOUFSUzI1NiIsInR5cCI6\
+                    ImF0K2p3dCIsIng1dCI6Ik1CM1dwUTZFNGRDUnlCMDdBTC1RRU1oZHZabyJ9.eyJuYmYiOjE2NzUxMDM3ODEsImV4cCI6MTY3NTEwNzM4MSwiaXNzIjo\
+                    iaHR0cDovL2xvY2FsaG9zdCIsImNsaWVudF9pZCI6ImVjMmMxZDQ2LTZhNGItNDc1MS1hMzEwLWFmOTYwMTMxN2YyZCIsInN1YiI6ImQzNDgwNGNhLTR\
+                    mNmMtNDM5Mi04NmI3LWFmOTYwMTMxNzVkMCIsIm9yZ2FuaXphdGlvbiI6ImY0ZTQ0YTdmLTExOTAtNDMyYS05ZDRhLWFmOTYwMTMxMjdjYiIsImp0aSI\
+                    6IjU3QUU0NzQ0MzIwNzk1RThGQkQ4MUIxNDA2RDQyNTQyIiwiaWF0IjoxNjc1MTAzNzgxLCJzY29wZSI6WyJhcGkuc2VjcmV0cyJdfQ.GRKYzqgJZHEE\
+                    ZHsJkhVZH8zjYhY3hUvM4rhdV3FU10WlCteZdKHrPIadCUh-Oz9DxIAA2HfALLhj1chL4JgwPmZgPcVS2G8gk8XeBmZXowpVWJ11TXS1gYrM9syXbv9j\
+                    0JUCdpeshH7e56WnlpVynyUwIum9hmYGZ_XJUfmGtlKLuNjYnawTwLEeR005uEjxq3qI1kti-WFnw8ciL4a6HLNulgiFw1dAvs4c7J0souShMfrnFO3g\
+                    SOHff5kKD3hBB9ynDBnJQSFYJ7dFWHIjhqs0Vj-9h0yXXCcHvu7dVGpaiNjNPxbh6YeXnY6UWcmHLDtFYsG2BWcNvVD4-VgGxXt3cMhrn7l3fSYuo32Z\
+                    Yk4Wop73XuxqF2fmfmBdZqGI1BafhENCcZw_bpPSfK2uHipfztrgYnrzwvzedz0rjFKbhDyrjzuRauX5dqVJ4ntPeT9g_I5n71gLxiP7eClyAx5RxdF6\
+                    He87NwC8i-hLBhugIvLTiDj-Sk9HvMth6zaD0ebxd56wDjq8-CMG_WcgusDqNzKFHqWNDHBXt8MLeTgZAR2rQMIMFZqFgsJlRflbig8YewmNUA9wAU74\
+                    TfxLY1foO7Xpg49vceB7C-PlvGi1VtX6F2i0tc_67lA5kWXnnKBPBUyspoIrmAUCwfms5nTTqA9xXAojMhRHAos_OdM",
+                    "expires_in":3600,
+                    "token_type":"Bearer",
+                    "scope":"api.secrets",
+                    "encrypted_payload":"2.E9fE8+M/VWMfhhim1KlCbQ==|eLsHR484S/tJbIkM6spnG/HP65tj9A6Tba7kAAvUp+rYuQmGLixiOCfMsqt5OvBctDfvvr/Aes\
+                    Bu7cZimPLyOEhqEAjn52jF0eaI38XZfeOG2VJl0LOf60Wkfh3ryAMvfvLj3G4ZCNYU8sNgoC2+IQ==|lNApuCQ4Pyakfo/wwuuajWNaEX/2MW8/3rjXB/V7n+k="})
+            )),
+            Mock::given(matchers::path("/api/organizations/f4e44a7f-1190-432a-9d4a-af96013127cb/secrets"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(
+                serde_json::json!({
+                    "secrets":[{
+                            "id":"15744a66-341a-4c62-af50-af960166b6bc",
+                            "organizationId":"f4e44a7f-1190-432a-9d4a-af96013127cb",
+                            "key":"2.pMS6/icTQABtulw52pq2lg==|XXbxKxDTh+mWiN1HjH2N1w==|Q6PkuT+KX/axrgN9ubD5Ajk2YNwxQkgs3WJM0S0wtG8=",
+                            "creationDate":"2023-01-26T21:46:02.2182556Z",
+                            "revisionDate":"2023-01-26T21:46:02.2182557Z"
+                    }],
+                    "projects":[],
+                    "object":"SecretsWithProjectsList"
+                })
+            )),
+            Mock::given(matchers::path("/api/secrets/15744a66-341a-4c62-af50-af960166b6bc"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(
+                serde_json::json!({
+                    "id":"15744a66-341a-4c62-af50-af960166b6bc",
+                    "organizationId":"f4e44a7f-1190-432a-9d4a-af96013127cb",
+                    "key":"2.pMS6/icTQABtulw52pq2lg==|XXbxKxDTh+mWiN1HjH2N1w==|Q6PkuT+KX/axrgN9ubD5Ajk2YNwxQkgs3WJM0S0wtG8=",
+                    "value":"2.Gl34n9JYABC7V21qHcBzHg==|c1Ds244pob7i+8+MXe4++w==|Shimz/qKMYZmzSFWdeBzFb9dFz7oF6Uv9oqkws7rEe0=",
+                    "note":"2.Cn9ABJy7+WfR4uUHwdYepg==|+nbJyU/6hSknoa5dcEJEUg==|1DTp/ZbwGO3L3RN+VMsCHz8XDr8egn/M5iSitGGysPA=",
+                    "creationDate":"2023-01-26T21:46:02.2182556Z",
+                    "revisionDate":"2023-01-26T21:46:02.2182557Z",
+                    "object":"secret"
+                })
+            ))
+        ]).await;
+
+        // Test the login is correct and we store the returned organization ID correctly
+        let res = client
+            .auth()
+            .login_access_token(&AccessTokenLoginRequest {
+                access_token: "0.ec2c1d46-6a4b-4751-a310-af9601317f2d.C2IgxjjLF7qSshsbwe8JGcbM075YXw:X8vbvA0bduihIDe/qrzIQQ==".into(),
+                state_file: None,
+            })
+            .await
+            .unwrap();
+        assert!(res.authenticated);
+
+        let organization_id = "f4e44a7f-1190-432a-9d4a-af96013127cb".try_into().unwrap();
+
+        // Test that we can retrieve the list of secrets correctly
+        let mut res = client
+            .secrets()
+            .list(&SecretIdentifiersRequest { organization_id })
+            .await
+            .unwrap();
+        assert_eq!(res.data.len(), 1);
+
+        // Test that given a secret ID we can get it's data
+        let res = client
+            .secrets()
+            .get(&SecretGetRequest {
+                id: res.data.remove(0).id,
+            })
+            .await
+            .unwrap();
+        assert_eq!(res.key, "TEST");
+        assert_eq!(res.note, "TEST");
+        assert_eq!(res.value, "TEST");
+    }
+}

--- a/crates/bitwarden-core/Cargo.toml
+++ b/crates/bitwarden-core/Cargo.toml
@@ -62,7 +62,6 @@ rustls-platform-verifier = "0.5.0"
 [dev-dependencies]
 rand_chacha = "0.3.1"
 tokio = { workspace = true, features = ["rt"] }
-wiremock = "0.6.0"
 zeroize = { version = ">=1.7.0, <2.0", features = ["derive", "aarch64"] }
 
 [lints]

--- a/crates/bitwarden-core/src/auth/auth_client.rs
+++ b/crates/bitwarden-core/src/auth/auth_client.rs
@@ -5,7 +5,6 @@ use bitwarden_crypto::{
 
 #[cfg(feature = "secrets")]
 use crate::auth::login::{login_access_token, AccessTokenLoginRequest, AccessTokenLoginResponse};
-use crate::{auth::renew::renew_token, Client};
 #[cfg(feature = "internal")]
 use crate::{
     auth::{
@@ -28,8 +27,10 @@ use crate::{
     },
     client::encryption_settings::EncryptionSettingsError,
 };
-
-use crate::auth::login::LoginError;
+use crate::{
+    auth::{login::LoginError, renew::renew_token},
+    Client,
+};
 
 pub struct AuthClient {
     pub(crate) client: crate::Client,

--- a/crates/bitwarden-core/src/auth/auth_client.rs
+++ b/crates/bitwarden-core/src/auth/auth_client.rs
@@ -13,7 +13,7 @@ use crate::{
         key_connector::{make_key_connector_keys, KeyConnectorResponse},
         login::{
             login_api_key, login_password, send_two_factor_email, ApiKeyLoginRequest,
-            ApiKeyLoginResponse, LoginError, NewAuthRequestResponse, PasswordLoginRequest,
+            ApiKeyLoginResponse, NewAuthRequestResponse, PasswordLoginRequest,
             PasswordLoginResponse, PreloginError, TwoFactorEmailError, TwoFactorEmailRequest,
         },
         password::{
@@ -28,6 +28,8 @@ use crate::{
     },
     client::encryption_settings::EncryptionSettingsError,
 };
+
+use crate::auth::login::LoginError;
 
 pub struct AuthClient {
     pub(crate) client: crate::Client,
@@ -212,104 +214,3 @@ impl Client {
         }
     }
 }
-
-/*
-#[cfg(test)]
-mod tests {
-
-    #[cfg(feature = "secrets")]
-    #[tokio::test]
-    async fn test_access_token_login() {
-        use wiremock::{matchers, Mock, ResponseTemplate};
-
-        use crate::{auth::login::AccessTokenLoginRequest, secrets_manager::secrets::*};
-
-        // Create the mock server with the necessary routes for this test
-        let (_server, client) = crate::util::start_mock(vec![
-            Mock::given(matchers::path("/identity/connect/token"))
-            .respond_with(ResponseTemplate::new(200).set_body_json(
-                serde_json::json!({
-                    "access_token":"eyJhbGciOiJSUzI1NiIsImtpZCI6IjMwMURENkE1MEU4NEUxRDA5MUM4MUQzQjAwQkY5MDEwQzg1REJEOUFSUzI1NiIsInR5cCI6\
-                    ImF0K2p3dCIsIng1dCI6Ik1CM1dwUTZFNGRDUnlCMDdBTC1RRU1oZHZabyJ9.eyJuYmYiOjE2NzUxMDM3ODEsImV4cCI6MTY3NTEwNzM4MSwiaXNzIjo\
-                    iaHR0cDovL2xvY2FsaG9zdCIsImNsaWVudF9pZCI6ImVjMmMxZDQ2LTZhNGItNDc1MS1hMzEwLWFmOTYwMTMxN2YyZCIsInN1YiI6ImQzNDgwNGNhLTR\
-                    mNmMtNDM5Mi04NmI3LWFmOTYwMTMxNzVkMCIsIm9yZ2FuaXphdGlvbiI6ImY0ZTQ0YTdmLTExOTAtNDMyYS05ZDRhLWFmOTYwMTMxMjdjYiIsImp0aSI\
-                    6IjU3QUU0NzQ0MzIwNzk1RThGQkQ4MUIxNDA2RDQyNTQyIiwiaWF0IjoxNjc1MTAzNzgxLCJzY29wZSI6WyJhcGkuc2VjcmV0cyJdfQ.GRKYzqgJZHEE\
-                    ZHsJkhVZH8zjYhY3hUvM4rhdV3FU10WlCteZdKHrPIadCUh-Oz9DxIAA2HfALLhj1chL4JgwPmZgPcVS2G8gk8XeBmZXowpVWJ11TXS1gYrM9syXbv9j\
-                    0JUCdpeshH7e56WnlpVynyUwIum9hmYGZ_XJUfmGtlKLuNjYnawTwLEeR005uEjxq3qI1kti-WFnw8ciL4a6HLNulgiFw1dAvs4c7J0souShMfrnFO3g\
-                    SOHff5kKD3hBB9ynDBnJQSFYJ7dFWHIjhqs0Vj-9h0yXXCcHvu7dVGpaiNjNPxbh6YeXnY6UWcmHLDtFYsG2BWcNvVD4-VgGxXt3cMhrn7l3fSYuo32Z\
-                    Yk4Wop73XuxqF2fmfmBdZqGI1BafhENCcZw_bpPSfK2uHipfztrgYnrzwvzedz0rjFKbhDyrjzuRauX5dqVJ4ntPeT9g_I5n71gLxiP7eClyAx5RxdF6\
-                    He87NwC8i-hLBhugIvLTiDj-Sk9HvMth6zaD0ebxd56wDjq8-CMG_WcgusDqNzKFHqWNDHBXt8MLeTgZAR2rQMIMFZqFgsJlRflbig8YewmNUA9wAU74\
-                    TfxLY1foO7Xpg49vceB7C-PlvGi1VtX6F2i0tc_67lA5kWXnnKBPBUyspoIrmAUCwfms5nTTqA9xXAojMhRHAos_OdM",
-                    "expires_in":3600,
-                    "token_type":"Bearer",
-                    "scope":"api.secrets",
-                    "encrypted_payload":"2.E9fE8+M/VWMfhhim1KlCbQ==|eLsHR484S/tJbIkM6spnG/HP65tj9A6Tba7kAAvUp+rYuQmGLixiOCfMsqt5OvBctDfvvr/Aes\
-                    Bu7cZimPLyOEhqEAjn52jF0eaI38XZfeOG2VJl0LOf60Wkfh3ryAMvfvLj3G4ZCNYU8sNgoC2+IQ==|lNApuCQ4Pyakfo/wwuuajWNaEX/2MW8/3rjXB/V7n+k="})
-            )),
-            Mock::given(matchers::path("/api/organizations/f4e44a7f-1190-432a-9d4a-af96013127cb/secrets"))
-            .respond_with(ResponseTemplate::new(200).set_body_json(
-                serde_json::json!({
-                    "secrets":[{
-                            "id":"15744a66-341a-4c62-af50-af960166b6bc",
-                            "organizationId":"f4e44a7f-1190-432a-9d4a-af96013127cb",
-                            "key":"2.pMS6/icTQABtulw52pq2lg==|XXbxKxDTh+mWiN1HjH2N1w==|Q6PkuT+KX/axrgN9ubD5Ajk2YNwxQkgs3WJM0S0wtG8=",
-                            "creationDate":"2023-01-26T21:46:02.2182556Z",
-                            "revisionDate":"2023-01-26T21:46:02.2182557Z"
-                    }],
-                    "projects":[],
-                    "object":"SecretsWithProjectsList"
-                })
-            )),
-            Mock::given(matchers::path("/api/secrets/15744a66-341a-4c62-af50-af960166b6bc"))
-            .respond_with(ResponseTemplate::new(200).set_body_json(
-                serde_json::json!({
-                    "id":"15744a66-341a-4c62-af50-af960166b6bc",
-                    "organizationId":"f4e44a7f-1190-432a-9d4a-af96013127cb",
-                    "key":"2.pMS6/icTQABtulw52pq2lg==|XXbxKxDTh+mWiN1HjH2N1w==|Q6PkuT+KX/axrgN9ubD5Ajk2YNwxQkgs3WJM0S0wtG8=",
-                    "value":"2.Gl34n9JYABC7V21qHcBzHg==|c1Ds244pob7i+8+MXe4++w==|Shimz/qKMYZmzSFWdeBzFb9dFz7oF6Uv9oqkws7rEe0=",
-                    "note":"2.Cn9ABJy7+WfR4uUHwdYepg==|+nbJyU/6hSknoa5dcEJEUg==|1DTp/ZbwGO3L3RN+VMsCHz8XDr8egn/M5iSitGGysPA=",
-                    "creationDate":"2023-01-26T21:46:02.2182556Z",
-                    "revisionDate":"2023-01-26T21:46:02.2182557Z",
-                    "object":"secret"
-                })
-            ))
-        ]).await;
-
-        // Test the login is correct and we store the returned organization ID correctly
-        let res = client
-            .auth()
-            .login_access_token(&AccessTokenLoginRequest {
-                access_token: "0.ec2c1d46-6a4b-4751-a310-af9601317f2d.C2IgxjjLF7qSshsbwe8JGcbM075YXw:X8vbvA0bduihIDe/qrzIQQ==".into(),
-                state_file: None,
-            })
-            .await
-            .unwrap();
-        assert!(res.authenticated);
-        let organization_id = client.get_access_token_organization().unwrap();
-        assert_eq!(
-            organization_id.to_string(),
-            "f4e44a7f-1190-432a-9d4a-af96013127cb"
-        );
-
-        // Test that we can retrieve the list of secrets correctly
-        let mut res = client
-            .secrets()
-            .list(&SecretIdentifiersRequest { organization_id })
-            .await
-            .unwrap();
-        assert_eq!(res.data.len(), 1);
-
-        // Test that given a secret ID we can get it's data
-        let res = client
-            .secrets()
-            .get(&SecretGetRequest {
-                id: res.data.remove(0).id,
-            })
-            .await
-            .unwrap();
-        assert_eq!(res.key, "TEST");
-        assert_eq!(res.note, "TEST");
-        assert_eq!(res.value, "TEST");
-    }
-}
- */

--- a/crates/bitwarden-core/src/auth/login/access_token.rs
+++ b/crates/bitwarden-core/src/auth/login/access_token.rs
@@ -96,7 +96,9 @@ pub(crate) async fn login_access_token(
                 },
             ));
 
-        client.internal.initialize_crypto_single_key(encryption_key);
+        client
+            .internal
+            .initialize_crypto_single_org_key(organization_id, encryption_key);
     }
 
     AccessTokenLoginResponse::process_response(response)

--- a/crates/bitwarden-core/src/auth/login/access_token.rs
+++ b/crates/bitwarden-core/src/auth/login/access_token.rs
@@ -135,7 +135,9 @@ fn load_tokens_from_state(
             client
                 .internal
                 .set_tokens(client_state.token, None, time_till_expiration as u64);
-            client.internal.initialize_crypto_single_key(encryption_key);
+            client
+                .internal
+                .initialize_crypto_single_org_key(organization_id, encryption_key);
 
             return Ok(organization_id);
         }

--- a/crates/bitwarden-core/src/auth/login/mod.rs
+++ b/crates/bitwarden-core/src/auth/login/mod.rs
@@ -7,7 +7,7 @@ pub use prelogin::*;
 
 #[cfg(any(feature = "internal", feature = "secrets"))]
 mod password;
-#[cfg(feature = "internal")]
+#[cfg(any(feature = "internal", feature = "secrets"))]
 pub use password::*;
 
 #[cfg(feature = "internal")]
@@ -49,6 +49,7 @@ pub enum LoginError {
     #[error("JWT token is missing email")]
     JwtTokenMissingEmail,
 
+    #[cfg(feature = "internal")]
     #[error(transparent)]
     Prelogin(#[from] PreloginError),
     #[error(transparent)]

--- a/crates/bitwarden-core/src/client/encryption_settings.rs
+++ b/crates/bitwarden-core/src/client/encryption_settings.rs
@@ -77,15 +77,19 @@ impl EncryptionSettings {
         Ok(())
     }
 
-    /// Initialize the encryption settings with only a single decrypted key.
+    /// Initialize the encryption settings with only a single decrypted organization key.
     /// This is used only for logging in Secrets Manager with an access token
     #[cfg(feature = "secrets")]
-    pub(crate) fn new_single_key(key: SymmetricCryptoKey, store: &KeyStore<KeyIds>) {
+    pub(crate) fn new_single_org_key(
+        organization_id: Uuid,
+        key: SymmetricCryptoKey,
+        store: &KeyStore<KeyIds>,
+    ) {
         // FIXME: [PM-18098] When this is part of crypto we won't need to use deprecated methods
         #[allow(deprecated)]
         store
             .context_mut()
-            .set_symmetric_key(SymmetricKeyId::User, key)
+            .set_symmetric_key(SymmetricKeyId::Organization(organization_id), key)
             .expect("Mutable context");
     }
 

--- a/crates/bitwarden-core/src/client/internal.rs
+++ b/crates/bitwarden-core/src/client/internal.rs
@@ -208,8 +208,12 @@ impl InternalClient {
     }
 
     #[cfg(feature = "secrets")]
-    pub(crate) fn initialize_crypto_single_key(&self, key: SymmetricCryptoKey) {
-        EncryptionSettings::new_single_key(key, &self.key_store);
+    pub(crate) fn initialize_crypto_single_org_key(
+        &self,
+        organization_id: Uuid,
+        key: SymmetricCryptoKey,
+    ) {
+        EncryptionSettings::new_single_org_key(organization_id, key, &self.key_store);
     }
 
     #[cfg(feature = "internal")]

--- a/crates/bitwarden-core/src/util.rs
+++ b/crates/bitwarden-core/src/util.rs
@@ -10,22 +10,3 @@ const INDIFFERENT: GeneralPurposeConfig =
 /// padding.
 pub const STANDARD_INDIFFERENT: GeneralPurpose =
     GeneralPurpose::new(&alphabet::STANDARD, INDIFFERENT);
-
-#[allow(dead_code)]
-#[cfg(test)]
-async fn start_mock(mocks: Vec<wiremock::Mock>) -> (wiremock::MockServer, crate::Client) {
-    let server = wiremock::MockServer::start().await;
-
-    for mock in mocks {
-        server.register(mock).await;
-    }
-
-    let settings = crate::ClientSettings {
-        identity_url: format!("http://{}/identity", server.address()),
-        api_url: format!("http://{}/api", server.address()),
-        user_agent: "Bitwarden Rust-SDK [TEST]".into(),
-        device_type: crate::DeviceType::SDK,
-    };
-
-    (server, crate::Client::new(Some(settings)))
-}


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective

Before the crypto refactor a user key was required to initialize crypto. Because secrets manager only has a single organization key, we used to set it as the user key and internally whenever an organization key was requested we'd return the user key if there was no private key.

With the crypto refactor, we removed this user key requirement and the code fallback when selecting a key, but we didn't change the initialization method to save the key as an organization key.

This PR changes the secrets manager initialization to do the correct thing here, and also brings a mocked test that was previously disabled in core to the bitwarden-sm crate. I've also fixed some compile time features that were incorrect and were causing compilation issues when running tests on bitwarden-sm.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation
  team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
