### PR TITLE
Replace deprecated gradle syntax

### DIFF
--- a/crates/bitwarden-uniffi/kotlin/app/build.gradle
+++ b/crates/bitwarden-uniffi/kotlin/app/build.gradle
@@ -6,40 +6,40 @@ plugins {
 }
 
 android {
-    namespace 'com.bitwarden.myapplication'
-    compileSdk 35
+    namespace = 'com.bitwarden.myapplication'
+    compileSdk = 35
 
     defaultConfig {
-        applicationId "com.bitwarden.myapplication"
-        minSdk 28
-        targetSdk 35
-        versionCode 1
-        versionName "1.0"
+        applicationId = "com.bitwarden.myapplication"
+        minSdk = 28
+        targetSdk = 35
+        versionCode = 1
+        versionName = "1.0"
 
-        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {
-            useSupportLibrary true
+            useSupportLibrary = true
         }
     }
 
     buildTypes {
         release {
-            minifyEnabled false
+            minifyEnabled = false
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
     }
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility = JavaVersion.VERSION_1_8
+        targetCompatibility = JavaVersion.VERSION_1_8
     }
     kotlinOptions {
         jvmTarget = '1.8'
     }
     buildFeatures {
-        compose true
+        compose = true
     }
     composeOptions {
-        kotlinCompilerExtensionVersion '1.5.12'
+        kotlinCompilerExtensionVersion = '1.5.12'
     }
     packagingOptions {
         resources {

--- a/crates/bitwarden-uniffi/kotlin/sdk/build.gradle
+++ b/crates/bitwarden-uniffi/kotlin/sdk/build.gradle
@@ -5,27 +5,27 @@ plugins {
 }
 
 android {
-    namespace 'com.bitwarden.sdk'
-    compileSdk 35
+    namespace = 'com.bitwarden.sdk'
+    compileSdk = 35
 
     defaultConfig {
-        minSdk 28
-        targetSdk 35
+        minSdk = 28
+        targetSdk = 35
 
-        testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
+        testInstrumentationRunner = 'androidx.test.runner.AndroidJUnitRunner'
         consumerProguardFiles 'consumer-rules.pro'
     }
 
     buildTypes {
         release {
-            minifyEnabled false
+            minifyEnabled = false
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
     }
 
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility = JavaVersion.VERSION_1_8
+        targetCompatibility = JavaVersion.VERSION_1_8
     }
 
     kotlinOptions {


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective

The space assignment syntax was deprecated in Gradle 8.0 and will be removed in Gradle 10.0: https://docs.gradle.org/8.12/userguide/upgrading_version_8.html#groovy_space_assignment_syntax

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation
  team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
