### PR TITLE
[PM-21377] Add missing purecrypto functions

### DIFF
--- a/crates/bitwarden-wasm-internal/src/pure_crypto.rs
+++ b/crates/bitwarden-wasm-internal/src/pure_crypto.rs
@@ -188,8 +188,8 @@ impl PureCrypto {
             SymmetricCryptoKey::try_from(wrapping_key)?,
         )?;
         // Note: The order of arguments is different here, and should probably be refactored
-        Ok(EncString::from_str(wrapped_key.as_str())?
-            .decrypt(&mut context, SymmetricKeyId::Local("wrapping_key"))?)
+        EncString::from_str(wrapped_key.as_str())?
+            .decrypt(&mut context, SymmetricKeyId::Local("wrapping_key"))
     }
 
     pub fn wrap_decapsulation_key(
@@ -221,8 +221,8 @@ impl PureCrypto {
             SymmetricCryptoKey::try_from(wrapping_key)?,
         )?;
         // Note: The order of arguments is different here, and should probably be refactored
-        Ok(EncString::from_str(wrapped_key.as_str())?
-            .decrypt(&mut context, SymmetricKeyId::Local("wrapping_key"))?)
+        EncString::from_str(wrapped_key.as_str())?
+            .decrypt(&mut context, SymmetricKeyId::Local("wrapping_key"))
     }
 
     // Key encapsulation

--- a/crates/bitwarden-wasm-internal/src/pure_crypto.rs
+++ b/crates/bitwarden-wasm-internal/src/pure_crypto.rs
@@ -2,7 +2,9 @@ use std::str::FromStr;
 
 use bitwarden_core::key_management::{KeyIds, SymmetricKeyId};
 use bitwarden_crypto::{
-    AsymmetricCryptoKey, AsymmetricPublicCryptoKey, CryptoError, Decryptable, EncString, Encryptable, Kdf, KeyDecryptable, KeyEncryptable, KeyStore, MasterKey, SymmetricCryptoKey, UnsignedSharedKey
+    AsymmetricCryptoKey, AsymmetricPublicCryptoKey, CryptoError, Decryptable, EncString,
+    Encryptable, Kdf, KeyDecryptable, KeyEncryptable, KeyStore, MasterKey, SymmetricCryptoKey,
+    UnsignedSharedKey,
 };
 use wasm_bindgen::prelude::*;
 
@@ -117,15 +119,22 @@ impl PureCrypto {
         let tmp_store: KeyStore<KeyIds> = KeyStore::default();
         let mut context = tmp_store.context();
         #[allow(deprecated)]
-        context.set_symmetric_key(SymmetricKeyId::Local("wrapping_key"), SymmetricCryptoKey::try_from(wrapping_key)?)?;
-        #[allow(deprecated)]
-        context.set_symmetric_key(SymmetricKeyId::Local("key_to_wrap"), SymmetricCryptoKey::try_from(key_to_be_wrapped)?)?;
-        // Note: The order of arguments is different here, and should probably be refactored
-        Ok(context.wrap_symmetric_key(
+        context.set_symmetric_key(
             SymmetricKeyId::Local("wrapping_key"),
+            SymmetricCryptoKey::try_from(wrapping_key)?,
+        )?;
+        #[allow(deprecated)]
+        context.set_symmetric_key(
             SymmetricKeyId::Local("key_to_wrap"),
-        )?
-        .to_string())
+            SymmetricCryptoKey::try_from(key_to_be_wrapped)?,
+        )?;
+        // Note: The order of arguments is different here, and should probably be refactored
+        Ok(context
+            .wrap_symmetric_key(
+                SymmetricKeyId::Local("wrapping_key"),
+                SymmetricKeyId::Local("key_to_wrap"),
+            )?
+            .to_string())
     }
 
     pub fn unwrap_symmetric_key(
@@ -135,7 +144,10 @@ impl PureCrypto {
         let tmp_store: KeyStore<KeyIds> = KeyStore::default();
         let mut context = tmp_store.context();
         #[allow(deprecated)]
-        context.set_symmetric_key(SymmetricKeyId::Local("wrapping_key"), SymmetricCryptoKey::try_from(wrapping_key)?)?;
+        context.set_symmetric_key(
+            SymmetricKeyId::Local("wrapping_key"),
+            SymmetricCryptoKey::try_from(wrapping_key)?,
+        )?;
         // Note: The order of arguments is different here, and should probably be refactored
         context.unwrap_symmetric_key(
             SymmetricKeyId::Local("wrapping_key"),
@@ -143,8 +155,7 @@ impl PureCrypto {
             &EncString::from_str(wrapped_key.as_str())?,
         )?;
         #[allow(deprecated)]
-        let key = context
-            .dangerous_get_symmetric_key(SymmetricKeyId::Local("wrapped_key"))?;
+        let key = context.dangerous_get_symmetric_key(SymmetricKeyId::Local("wrapped_key"))?;
         Ok(key.to_encoded())
     }
 
@@ -155,9 +166,14 @@ impl PureCrypto {
         let tmp_store: KeyStore<KeyIds> = KeyStore::default();
         let mut context = tmp_store.context();
         #[allow(deprecated)]
-        context.set_symmetric_key(SymmetricKeyId::Local("wrapping_key"), SymmetricCryptoKey::try_from(wrapping_key)?)?;
+        context.set_symmetric_key(
+            SymmetricKeyId::Local("wrapping_key"),
+            SymmetricCryptoKey::try_from(wrapping_key)?,
+        )?;
         // Note: The order of arguments is different here, and should probably be refactored
-        Ok(encapsulation_key.encrypt(&mut context, SymmetricKeyId::Local("wrapping_key"))?.to_string())
+        Ok(encapsulation_key
+            .encrypt(&mut context, SymmetricKeyId::Local("wrapping_key"))?
+            .to_string())
     }
 
     pub fn unwrap_encapsulation_key(
@@ -167,9 +183,13 @@ impl PureCrypto {
         let tmp_store: KeyStore<KeyIds> = KeyStore::default();
         let mut context = tmp_store.context();
         #[allow(deprecated)]
-        context.set_symmetric_key(SymmetricKeyId::Local("wrapping_key"), SymmetricCryptoKey::try_from(wrapping_key)?)?;
+        context.set_symmetric_key(
+            SymmetricKeyId::Local("wrapping_key"),
+            SymmetricCryptoKey::try_from(wrapping_key)?,
+        )?;
         // Note: The order of arguments is different here, and should probably be refactored
-        Ok(EncString::from_str(wrapped_key.as_str())?.decrypt(&mut context, SymmetricKeyId::Local("wrapping_key"))?)
+        Ok(EncString::from_str(wrapped_key.as_str())?
+            .decrypt(&mut context, SymmetricKeyId::Local("wrapping_key"))?)
     }
 
     pub fn wrap_decapsulation_key(
@@ -179,9 +199,14 @@ impl PureCrypto {
         let tmp_store: KeyStore<KeyIds> = KeyStore::default();
         let mut context = tmp_store.context();
         #[allow(deprecated)]
-        context.set_symmetric_key(SymmetricKeyId::Local("wrapping_key"), SymmetricCryptoKey::try_from(wrapping_key)?)?;
+        context.set_symmetric_key(
+            SymmetricKeyId::Local("wrapping_key"),
+            SymmetricCryptoKey::try_from(wrapping_key)?,
+        )?;
         // Note: The order of arguments is different here, and should probably be refactored
-        Ok(decapsulation_key.encrypt(&mut context, SymmetricKeyId::Local("wrapping_key"))?.to_string())
+        Ok(decapsulation_key
+            .encrypt(&mut context, SymmetricKeyId::Local("wrapping_key"))?
+            .to_string())
     }
 
     pub fn unwrap_decapsulation_key(
@@ -191,26 +216,37 @@ impl PureCrypto {
         let tmp_store: KeyStore<KeyIds> = KeyStore::default();
         let mut context = tmp_store.context();
         #[allow(deprecated)]
-        context.set_symmetric_key(SymmetricKeyId::Local("wrapping_key"), SymmetricCryptoKey::try_from(wrapping_key)?)?;
+        context.set_symmetric_key(
+            SymmetricKeyId::Local("wrapping_key"),
+            SymmetricCryptoKey::try_from(wrapping_key)?,
+        )?;
         // Note: The order of arguments is different here, and should probably be refactored
-        Ok(EncString::from_str(wrapped_key.as_str())?.decrypt(&mut context, SymmetricKeyId::Local("wrapping_key"))?)
+        Ok(EncString::from_str(wrapped_key.as_str())?
+            .decrypt(&mut context, SymmetricKeyId::Local("wrapping_key"))?)
     }
 
     // Key encapsulation
     pub fn encapsulate_key_unsigned(
         shared_key: Vec<u8>,
-        encapsulation_key: Vec<u8>
+        encapsulation_key: Vec<u8>,
     ) -> Result<String, CryptoError> {
         let encapsulation_key = AsymmetricPublicCryptoKey::from_der(encapsulation_key.as_slice())?;
-        Ok(UnsignedSharedKey::encapsulate_key_unsigned(&SymmetricCryptoKey::try_from(shared_key)?, &encapsulation_key)?.to_string())
+        Ok(UnsignedSharedKey::encapsulate_key_unsigned(
+            &SymmetricCryptoKey::try_from(shared_key)?,
+            &encapsulation_key,
+        )?
+        .to_string())
     }
 
     pub fn decapsulate_key_unsigned(
         encapsulated_key: String,
-        decapsulation_key: Vec<u8>
+        decapsulation_key: Vec<u8>,
     ) -> Result<Vec<u8>, CryptoError> {
         Ok(UnsignedSharedKey::from_str(encapsulated_key.as_str())?
-            .decapsulate_key_unsigned(&AsymmetricCryptoKey::from_der(decapsulation_key.as_slice())?)?.to_encoded())
+            .decapsulate_key_unsigned(&AsymmetricCryptoKey::from_der(
+                decapsulation_key.as_slice(),
+            )?)?
+            .to_encoded())
     }
 }
 
@@ -238,7 +274,7 @@ mod tests {
         2, 89, 112, 178, 83, 25, 77, 130, 187, 127, 85, 179, 211, 159, 186, 111, 44, 109, 211, 18,
         120, 104, 144, 4, 76, 3,
     ];
-    
+
     const PEM_KEY: &str = "-----BEGIN PRIVATE KEY-----
 MIIEwAIBADANBgkqhkiG9w0BAQEFAASCBKowggSmAgEAAoIBAQDiTQVuzhdygFz5
 qv14i+XFDGTnDravzUQT1hPKPGUZOUSZ1gwdNgkWqOIaOnR65BHEnL0sp4bnuiYc
@@ -367,11 +403,9 @@ DnqOsltgPomWZ7xVfMkm9niL2OA=
     fn test_wrap_unwrap_symmetric_key() {
         let key_to_be_wrapped = PureCrypto::generate_user_key_aes256_cbc_hmac();
         let wrapping_key = PureCrypto::generate_user_key_aes256_cbc_hmac();
-        let wrapped_key = PureCrypto::wrap_symmetric_key(
-            key_to_be_wrapped.clone(),
-            wrapping_key.clone(),
-        )
-        .unwrap();
+        let wrapped_key =
+            PureCrypto::wrap_symmetric_key(key_to_be_wrapped.clone(), wrapping_key.clone())
+                .unwrap();
         let unwrapped_key = PureCrypto::unwrap_symmetric_key(wrapped_key, wrapping_key).unwrap();
         assert_eq!(key_to_be_wrapped, unwrapped_key);
     }
@@ -381,12 +415,11 @@ DnqOsltgPomWZ7xVfMkm9niL2OA=
         let decapsulation_key = AsymmetricCryptoKey::from_pem(PEM_KEY).unwrap();
         let encapsulation_key = decapsulation_key.to_public_der().unwrap();
         let wrapping_key = PureCrypto::generate_user_key_aes256_cbc_hmac();
-        let wrapped_key = PureCrypto::wrap_encapsulation_key(
-            encapsulation_key.clone(),
-            wrapping_key.clone(),
-        )
-        .unwrap();
-        let unwrapped_key = PureCrypto::unwrap_encapsulation_key(wrapped_key, wrapping_key).unwrap();
+        let wrapped_key =
+            PureCrypto::wrap_encapsulation_key(encapsulation_key.clone(), wrapping_key.clone())
+                .unwrap();
+        let unwrapped_key =
+            PureCrypto::unwrap_encapsulation_key(wrapped_key, wrapping_key).unwrap();
         assert_eq!(encapsulation_key, unwrapped_key);
     }
 
@@ -399,7 +432,8 @@ DnqOsltgPomWZ7xVfMkm9niL2OA=
             wrapping_key.clone(),
         )
         .unwrap();
-        let unwrapped_key = PureCrypto::unwrap_decapsulation_key(wrapped_key, wrapping_key).unwrap();
+        let unwrapped_key =
+            PureCrypto::unwrap_decapsulation_key(wrapped_key, wrapping_key).unwrap();
         assert_eq!(decapsulation_key.to_der().unwrap(), unwrapped_key);
     }
 
@@ -408,12 +442,14 @@ DnqOsltgPomWZ7xVfMkm9niL2OA=
         let shared_key = PureCrypto::generate_user_key_aes256_cbc_hmac();
         let decapsulation_key = AsymmetricCryptoKey::from_pem(PEM_KEY).unwrap();
         let encapsulation_key = decapsulation_key.to_public_der().unwrap();
-        let encapsulated_key = PureCrypto::encapsulate_key_unsigned(
-            shared_key.clone(),
-            encapsulation_key.clone(),
+        let encapsulated_key =
+            PureCrypto::encapsulate_key_unsigned(shared_key.clone(), encapsulation_key.clone())
+                .unwrap();
+        let unwrapped_key = PureCrypto::decapsulate_key_unsigned(
+            encapsulated_key,
+            decapsulation_key.to_der().unwrap(),
         )
         .unwrap();
-        let unwrapped_key = PureCrypto::decapsulate_key_unsigned(encapsulated_key, decapsulation_key.to_der().unwrap()).unwrap();
         assert_eq!(shared_key, unwrapped_key);
     }
 }

--- a/crates/bitwarden-wasm-internal/src/pure_crypto.rs
+++ b/crates/bitwarden-wasm-internal/src/pure_crypto.rs
@@ -1,7 +1,8 @@
 use std::str::FromStr;
 
+use bitwarden_core::key_management::{KeyIds, SymmetricKeyId};
 use bitwarden_crypto::{
-    CryptoError, EncString, Kdf, KeyDecryptable, KeyEncryptable, MasterKey, SymmetricCryptoKey,
+    AsymmetricCryptoKey, AsymmetricPublicCryptoKey, CryptoError, Decryptable, EncString, Encryptable, Kdf, KeyDecryptable, KeyEncryptable, KeyStore, MasterKey, SymmetricCryptoKey, UnsignedSharedKey
 };
 use wasm_bindgen::prelude::*;
 
@@ -107,6 +108,110 @@ impl PureCrypto {
     pub fn generate_user_key_xchacha20_poly1305() -> Vec<u8> {
         SymmetricCryptoKey::make_xchacha20_poly1305_key().to_encoded()
     }
+
+    // Key wrap
+    pub fn wrap_symmetric_key(
+        key_to_be_wrapped: Vec<u8>,
+        wrapping_key: Vec<u8>,
+    ) -> Result<String, CryptoError> {
+        let tmp_store: KeyStore<KeyIds> = KeyStore::default();
+        let mut context = tmp_store.context();
+        #[allow(deprecated)]
+        context.set_symmetric_key(SymmetricKeyId::Local("wrapping_key"), SymmetricCryptoKey::try_from(wrapping_key)?)?;
+        #[allow(deprecated)]
+        context.set_symmetric_key(SymmetricKeyId::Local("key_to_wrap"), SymmetricCryptoKey::try_from(key_to_be_wrapped)?)?;
+        // Note: The order of arguments is different here, and should probably be refactored
+        Ok(context.wrap_symmetric_key(
+            SymmetricKeyId::Local("wrapping_key"),
+            SymmetricKeyId::Local("key_to_wrap"),
+        )?
+        .to_string())
+    }
+
+    pub fn unwrap_symmetric_key(
+        wrapped_key: String,
+        wrapping_key: Vec<u8>,
+    ) -> Result<Vec<u8>, CryptoError> {
+        let tmp_store: KeyStore<KeyIds> = KeyStore::default();
+        let mut context = tmp_store.context();
+        #[allow(deprecated)]
+        context.set_symmetric_key(SymmetricKeyId::Local("wrapping_key"), SymmetricCryptoKey::try_from(wrapping_key)?)?;
+        // Note: The order of arguments is different here, and should probably be refactored
+        context.unwrap_symmetric_key(
+            SymmetricKeyId::Local("wrapping_key"),
+            SymmetricKeyId::Local("wrapped_key"),
+            &EncString::from_str(wrapped_key.as_str())?,
+        )?;
+        #[allow(deprecated)]
+        let key = context
+            .dangerous_get_symmetric_key(SymmetricKeyId::Local("wrapped_key"))?;
+        Ok(key.to_encoded())
+    }
+
+    pub fn wrap_encapsulation_key(
+        encapsulation_key: Vec<u8>,
+        wrapping_key: Vec<u8>,
+    ) -> Result<String, CryptoError> {
+        let tmp_store: KeyStore<KeyIds> = KeyStore::default();
+        let mut context = tmp_store.context();
+        #[allow(deprecated)]
+        context.set_symmetric_key(SymmetricKeyId::Local("wrapping_key"), SymmetricCryptoKey::try_from(wrapping_key)?)?;
+        // Note: The order of arguments is different here, and should probably be refactored
+        Ok(encapsulation_key.encrypt(&mut context, SymmetricKeyId::Local("wrapping_key"))?.to_string())
+    }
+
+    pub fn unwrap_encapsulation_key(
+        wrapped_key: String,
+        wrapping_key: Vec<u8>,
+    ) -> Result<Vec<u8>, CryptoError> {
+        let tmp_store: KeyStore<KeyIds> = KeyStore::default();
+        let mut context = tmp_store.context();
+        #[allow(deprecated)]
+        context.set_symmetric_key(SymmetricKeyId::Local("wrapping_key"), SymmetricCryptoKey::try_from(wrapping_key)?)?;
+        // Note: The order of arguments is different here, and should probably be refactored
+        Ok(EncString::from_str(wrapped_key.as_str())?.decrypt(&mut context, SymmetricKeyId::Local("wrapping_key"))?)
+    }
+
+    pub fn wrap_decapsulation_key(
+        decapsulation_key: Vec<u8>,
+        wrapping_key: Vec<u8>,
+    ) -> Result<String, CryptoError> {
+        let tmp_store: KeyStore<KeyIds> = KeyStore::default();
+        let mut context = tmp_store.context();
+        #[allow(deprecated)]
+        context.set_symmetric_key(SymmetricKeyId::Local("wrapping_key"), SymmetricCryptoKey::try_from(wrapping_key)?)?;
+        // Note: The order of arguments is different here, and should probably be refactored
+        Ok(decapsulation_key.encrypt(&mut context, SymmetricKeyId::Local("wrapping_key"))?.to_string())
+    }
+
+    pub fn unwrap_decapsulation_key(
+        wrapped_key: String,
+        wrapping_key: Vec<u8>,
+    ) -> Result<Vec<u8>, CryptoError> {
+        let tmp_store: KeyStore<KeyIds> = KeyStore::default();
+        let mut context = tmp_store.context();
+        #[allow(deprecated)]
+        context.set_symmetric_key(SymmetricKeyId::Local("wrapping_key"), SymmetricCryptoKey::try_from(wrapping_key)?)?;
+        // Note: The order of arguments is different here, and should probably be refactored
+        Ok(EncString::from_str(wrapped_key.as_str())?.decrypt(&mut context, SymmetricKeyId::Local("wrapping_key"))?)
+    }
+
+    // Key encapsulation
+    pub fn encapsulate_key_unsigned(
+        shared_key: Vec<u8>,
+        encapsulation_key: Vec<u8>
+    ) -> Result<String, CryptoError> {
+        let encapsulation_key = AsymmetricPublicCryptoKey::from_der(encapsulation_key.as_slice())?;
+        Ok(UnsignedSharedKey::encapsulate_key_unsigned(&SymmetricCryptoKey::try_from(shared_key)?, &encapsulation_key)?.to_string())
+    }
+
+    pub fn decapsulate_key_unsigned(
+        encapsulated_key: String,
+        decapsulation_key: Vec<u8>
+    ) -> Result<Vec<u8>, CryptoError> {
+        Ok(UnsignedSharedKey::from_str(encapsulated_key.as_str())?
+            .decapsulate_key_unsigned(&AsymmetricCryptoKey::from_der(decapsulation_key.as_slice())?)?.to_encoded())
+    }
 }
 
 #[cfg(test)]
@@ -133,6 +238,35 @@ mod tests {
         2, 89, 112, 178, 83, 25, 77, 130, 187, 127, 85, 179, 211, 159, 186, 111, 44, 109, 211, 18,
         120, 104, 144, 4, 76, 3,
     ];
+    
+    const PEM_KEY: &str = "-----BEGIN PRIVATE KEY-----
+MIIEwAIBADANBgkqhkiG9w0BAQEFAASCBKowggSmAgEAAoIBAQDiTQVuzhdygFz5
+qv14i+XFDGTnDravzUQT1hPKPGUZOUSZ1gwdNgkWqOIaOnR65BHEnL0sp4bnuiYc
+afeK2JAW5Sc8Z7IxBNSuAwhQmuKx3RochMIiuCkI2/p+JvUQoJu6FBNm8OoJ4Cwm
+qqHGZESMfnpQDCuDrB3JdJEdXhtmnl0C48sGjOk3WaBMcgGqn8LbJDUlyu1zdqyv
+b0waJf0iV4PJm2fkUl7+57D/2TkpbCqURVnZK1FFIEg8mr6FzSN1F2pOfktkNYZw
+P7MSNR7o81CkRSCMr7EkIVa+MZYMBx106BMK7FXgWB7nbSpsWKxBk7ZDHkID2fam
+rEcVtrzDAgMBAAECggEBAKwq9OssGGKgjhvUnyrLJHAZ0dqIMyzk+dotkLjX4gKi
+szJmyqiep6N5sStLNbsZMPtoU/RZMCW0VbJgXFhiEp2YkZU/Py5UAoqw++53J+kx
+0d/IkPphKbb3xUec0+1mg5O6GljDCQuiZXS1dIa/WfeZcezclW6Dz9WovY6ePjJ+
+8vEBR1icbNKzyeINd6MtPtpcgQPHtDwHvhPyUDbKDYGbLvjh9nui8h4+ZUlXKuVR
+jB0ChxiKV1xJRjkrEVoulOOicd5r597WfB2ghax3pvRZ4MdXemCXm3gQYqPVKach
+vGU+1cPQR/MBJZpxT+EZA97xwtFS3gqwbxJaNFcoE8ECgYEA9OaeYZhQPDo485tI
+1u/Z7L/3PNape9hBQIXoW7+MgcQ5NiWqYh8Jnj43EIYa0wM/ECQINr1Za8Q5e6KR
+J30FcU+kfyjuQ0jeXdNELGU/fx5XXNg/vV8GevHwxRlwzqZTCg6UExUZzbYEQqd7
+l+wPyETGeua5xCEywA1nX/D101kCgYEA7I6aMFjhEjO71RmzNhqjKJt6DOghoOfQ
+TjhaaanNEhLYSbenFz1mlb21mW67ulmz162saKdIYLxQNJIP8ZPmxh4ummOJI8w9
+ClHfo8WuCI2hCjJ19xbQJocSbTA5aJg6lA1IDVZMDbQwsnAByPRGpaLHBT/Q9Bye
+KvCMB+9amXsCgYEAx65yXSkP4sumPBrVHUub6MntERIGRxBgw/drKcPZEMWp0FiN
+wEuGUBxyUWrG3F69QK/gcqGZE6F/LSu0JvptQaKqgXQiMYJsrRvhbkFvsHpQyUcZ
+UZL1ebFjm5HOxPAgrQaN/bEqxOwwNRjSUWEMzUImg3c06JIZCzbinvudtKECgYEA
+kY3JF/iIPI/yglP27lKDlCfeeHSYxI3+oTKRhzSAxx8rUGidenJAXeDGDauR/T7W
+pt3pGNfddBBK9Z3uC4Iq3DqUCFE4f/taj7ADAJ1Q0Vh7/28/IJM77ojr8J1cpZwN
+Zy2o6PPxhfkagaDjqEeN9Lrs5LD4nEvDkr5CG1vOjmMCgYEAvIBFKRm31NyF8jLi
+CVuPwC5PzrW5iThDmsWTaXFpB3esUsbICO2pEz872oeQS+Em4GO5vXUlpbbFPzup
+PFhA8iMJ8TAvemhvc7oM0OZqpU6p3K4seHf6BkwLxumoA3vDJfovu9RuXVcJVOnf
+DnqOsltgPomWZ7xVfMkm9niL2OA=
+-----END PRIVATE KEY-----";
 
     #[test]
     fn test_symmetric_decrypt() {
@@ -227,5 +361,59 @@ mod tests {
         )
         .unwrap();
         assert_eq!(user_key, decrypted_user_key);
+    }
+
+    #[test]
+    fn test_wrap_unwrap_symmetric_key() {
+        let key_to_be_wrapped = PureCrypto::generate_user_key_aes256_cbc_hmac();
+        let wrapping_key = PureCrypto::generate_user_key_aes256_cbc_hmac();
+        let wrapped_key = PureCrypto::wrap_symmetric_key(
+            key_to_be_wrapped.clone(),
+            wrapping_key.clone(),
+        )
+        .unwrap();
+        let unwrapped_key = PureCrypto::unwrap_symmetric_key(wrapped_key, wrapping_key).unwrap();
+        assert_eq!(key_to_be_wrapped, unwrapped_key);
+    }
+
+    #[test]
+    fn test_wrap_encapsulation_key() {
+        let decapsulation_key = AsymmetricCryptoKey::from_pem(PEM_KEY).unwrap();
+        let encapsulation_key = decapsulation_key.to_public_der().unwrap();
+        let wrapping_key = PureCrypto::generate_user_key_aes256_cbc_hmac();
+        let wrapped_key = PureCrypto::wrap_encapsulation_key(
+            encapsulation_key.clone(),
+            wrapping_key.clone(),
+        )
+        .unwrap();
+        let unwrapped_key = PureCrypto::unwrap_encapsulation_key(wrapped_key, wrapping_key).unwrap();
+        assert_eq!(encapsulation_key, unwrapped_key);
+    }
+
+    #[test]
+    fn test_wrap_decapsulation_key() {
+        let decapsulation_key = AsymmetricCryptoKey::from_pem(PEM_KEY).unwrap();
+        let wrapping_key = PureCrypto::generate_user_key_aes256_cbc_hmac();
+        let wrapped_key = PureCrypto::wrap_decapsulation_key(
+            decapsulation_key.to_der().unwrap(),
+            wrapping_key.clone(),
+        )
+        .unwrap();
+        let unwrapped_key = PureCrypto::unwrap_decapsulation_key(wrapped_key, wrapping_key).unwrap();
+        assert_eq!(decapsulation_key.to_der().unwrap(), unwrapped_key);
+    }
+
+    #[test]
+    fn test_encapsulate_key_unsigned() {
+        let shared_key = PureCrypto::generate_user_key_aes256_cbc_hmac();
+        let decapsulation_key = AsymmetricCryptoKey::from_pem(PEM_KEY).unwrap();
+        let encapsulation_key = decapsulation_key.to_public_der().unwrap();
+        let encapsulated_key = PureCrypto::encapsulate_key_unsigned(
+            shared_key.clone(),
+            encapsulation_key.clone(),
+        )
+        .unwrap();
+        let unwrapped_key = PureCrypto::decapsulate_key_unsigned(encapsulated_key, decapsulation_key.to_der().unwrap()).unwrap();
+        assert_eq!(shared_key, unwrapped_key);
     }
 }


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-21377

## 📔 Objective

Add remaining missing functions needed to port encrypt service to sdk.
Ref: https://github.com/bitwarden/clients/blob/87a1f4e8ac928edfb05a283372550d0792c71827/libs/common/src/key-management/crypto/abstractions/encrypt.service.ts#L105-L188

Note: The way that this uses the key context is not ideal, but this should not be handled in this PR. This PR is to make the public interface available to unblock clients changes. Follow-up work (such as https://github.com/bitwarden/sdk-internal/pull/221) can expose better apis from bitwarden-crypto and move PureCrypto to it.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation
  team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
