### PR TITLE
Simplify use of io::Error::other

### DIFF
--- a/crates/bitwarden-wasm-internal/build.rs
+++ b/crates/bitwarden-wasm-internal/build.rs
@@ -11,13 +11,13 @@ fn main() {
 }
 
 fn run(args: &[&str]) -> Result<String, std::io::Error> {
-    use std::io::{Error, ErrorKind};
+    use std::io::Error;
     let out = Command::new(args[0]).args(&args[1..]).output()?;
     if !out.status.success() {
-        return Err(Error::new(ErrorKind::Other, "Command not successful"));
+        return Err(Error::other("Command not successful"));
     }
     Ok(String::from_utf8(out.stdout)
-        .map_err(|e| Error::new(ErrorKind::Other, e.to_string()))?
+        .map_err(Error::other)?
         .trim()
         .to_string())
 }

--- a/crates/memory-testing/src/bin/capture-dumps.rs
+++ b/crates/memory-testing/src/bin/capture-dumps.rs
@@ -11,10 +11,10 @@ fn dump_process_to_bytearray(pid: u32, output_dir: &Path, output_name: &Path) ->
         .output()?;
 
     if !output.status.success() {
-        return io::Result::Err(io::Error::new(
-            io::ErrorKind::Other,
-            format!("Failed to dump process: {:?}", output),
-        ));
+        return io::Result::Err(io::Error::other(format!(
+            "Failed to dump process: {:?}",
+            output
+        )));
     }
 
     let core_path = format!("core.{}", pid);


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective

The new `io::Error::other` function to create an `Other` variant is available since rust 1.74 and clippy was linting it as a recommendation.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation
  team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
