### PR TITLE
SRE-2330 cleanup references to auth-email

### DIFF
--- a/crates/bitwarden-core/src/auth/api/request/access_token_request.rs
+++ b/crates/bitwarden-core/src/auth/api/request/access_token_request.rs
@@ -31,6 +31,6 @@ impl AccessTokenRequest {
         &self,
         configurations: &ApiConfigurations,
     ) -> Result<IdentityTokenResponse, LoginError> {
-        super::send_identity_connect_request(configurations, None, &self).await
+        super::send_identity_connect_request(configurations, &self).await
     }
 }

--- a/crates/bitwarden-core/src/auth/api/request/api_token_request.rs
+++ b/crates/bitwarden-core/src/auth/api/request/api_token_request.rs
@@ -39,6 +39,6 @@ impl ApiTokenRequest {
         &self,
         configurations: &ApiConfigurations,
     ) -> Result<IdentityTokenResponse, LoginError> {
-        super::send_identity_connect_request(configurations, None, &self).await
+        super::send_identity_connect_request(configurations, &self).await
     }
 }

--- a/crates/bitwarden-core/src/auth/api/request/auth_request_token_request.rs
+++ b/crates/bitwarden-core/src/auth/api/request/auth_request_token_request.rs
@@ -55,6 +55,6 @@ impl AuthRequestTokenRequest {
         &self,
         configurations: &ApiConfigurations,
     ) -> Result<IdentityTokenResponse, LoginError> {
-        super::send_identity_connect_request(configurations, Some(&self.email), &self).await
+        super::send_identity_connect_request(configurations, &self).await
     }
 }

--- a/crates/bitwarden-core/src/auth/api/request/mod.rs
+++ b/crates/bitwarden-core/src/auth/api/request/mod.rs
@@ -30,7 +30,6 @@ use crate::{
 
 async fn send_identity_connect_request(
     configurations: &ApiConfigurations,
-    email: Option<&str>,
     body: impl serde::Serialize,
 ) -> Result<IdentityTokenResponse, LoginError> {
     let mut request = configurations

--- a/crates/bitwarden-core/src/auth/api/request/mod.rs
+++ b/crates/bitwarden-core/src/auth/api/request/mod.rs
@@ -51,10 +51,6 @@ async fn send_identity_connect_request(
         request = request.header(reqwest::header::USER_AGENT, user_agent.clone());
     }
 
-    if let Some(email) = email {
-        request = request.header("Auth-Email", URL_SAFE_NO_PAD.encode(email.as_bytes()));
-    }
-
     let response = request
         .body(serde_qs::to_string(&body).expect("Serialize should be infallible"))
         .send()

--- a/crates/bitwarden-core/src/auth/api/request/mod.rs
+++ b/crates/bitwarden-core/src/auth/api/request/mod.rs
@@ -12,7 +12,6 @@ mod password_token_request;
 pub(crate) use password_token_request::*;
 
 mod renew_token_request;
-use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
 pub(crate) use renew_token_request::*;
 
 mod auth_request_token_request;

--- a/crates/bitwarden-core/src/auth/api/request/password_token_request.rs
+++ b/crates/bitwarden-core/src/auth/api/request/password_token_request.rs
@@ -64,6 +64,6 @@ impl PasswordTokenRequest {
         &self,
         configurations: &ApiConfigurations,
     ) -> Result<IdentityTokenResponse, LoginError> {
-        super::send_identity_connect_request(configurations, Some(&self.email), &self).await
+        super::send_identity_connect_request(configurations, &self).await
     }
 }

--- a/crates/bitwarden-core/src/auth/api/request/renew_token_request.rs
+++ b/crates/bitwarden-core/src/auth/api/request/renew_token_request.rs
@@ -25,6 +25,6 @@ impl RenewTokenRequest {
         &self,
         configurations: &ApiConfigurations,
     ) -> Result<IdentityTokenResponse, LoginError> {
-        super::send_identity_connect_request(configurations, None, &self).await
+        super::send_identity_connect_request(configurations, &self).await
     }
 }

--- a/crates/bitwarden-uniffi/kotlin/app/src/main/java/com/bitwarden/myapplication/MainActivity.kt
+++ b/crates/bitwarden-uniffi/kotlin/app/src/main/java/com/bitwarden/myapplication/MainActivity.kt
@@ -234,7 +234,6 @@ class MainActivity : FragmentActivity() {
 
         val loginBody = http.post(IDENTITY_URL + "connect/token") {
             contentType(ContentType.Application.Json)
-            header("Auth-Email", Base64.getEncoder().encodeToString(EMAIL.toByteArray()))
             setBody(FormDataContent(Parameters.build {
                 append("scope", "api offline_access")
                 append("client_id", "web")

--- a/crates/bitwarden-uniffi/swift/iOS/App/ContentView.swift
+++ b/crates/bitwarden-uniffi/swift/iOS/App/ContentView.swift
@@ -160,13 +160,7 @@ struct ContentView: View {
         let (loginDataJson, _) = try await http.data(
             for: request(
                 method: "POST", url: IDENTITY_URL + "connect/token",
-                fn: { r in
-                    r.setValue(
-                        EMAIL.data(using: .utf8)?.base64EncodedString(),
-                        forHTTPHeaderField: "Auth-Email")
-                    r.setValue(
-                        "application/x-www-form-urlencoded", forHTTPHeaderField: "Content-Type")
-
+                fn: {
                     var comp = URLComponents()
                     comp.queryItems = [
                         URLQueryItem(name: "scope", value: "api offline_access"),

--- a/crates/bitwarden-uniffi/swift/iOS/App/ContentView.swift
+++ b/crates/bitwarden-uniffi/swift/iOS/App/ContentView.swift
@@ -163,7 +163,6 @@ struct ContentView: View {
                 fn: { r in 
                     r.setValue(
                         "application/x-www-form-urlencoded", forHTTPHeaderField: "Content-Type")
-                    
                     var comp = URLComponents()
                     comp.queryItems = [
                         URLQueryItem(name: "scope", value: "api offline_access"),

--- a/crates/bitwarden-uniffi/swift/iOS/App/ContentView.swift
+++ b/crates/bitwarden-uniffi/swift/iOS/App/ContentView.swift
@@ -160,7 +160,10 @@ struct ContentView: View {
         let (loginDataJson, _) = try await http.data(
             for: request(
                 method: "POST", url: IDENTITY_URL + "connect/token",
-                fn: {
+                fn: { r in 
+                    r.setValue(
+                        "application/x-www-form-urlencoded", forHTTPHeaderField: "Content-Type")
+                    
                     var comp = URLComponents()
                     comp.queryItems = [
                         URLQueryItem(name: "scope", value: "api offline_access"),


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/SRE-2330

## 📔 Objective

Part of overall effort to deprecate auth-email header

Server side changes: https://github.com/bitwarden/server/pull/5709

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation
  team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
