### PR TITLE
Add Vault as co-owners of the bitwarden-vault crate

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,6 +7,8 @@
 # Platform is the default owner for all files
 * @bitwarden/team-platform-dev
 
+crates/bitwarden-vault/** @bitwarden/team-vault-dev @bitwarden/team-platform-dev
+
 # BRE for publish workflow changes
 .github/workflows/publish-*.yml @bitwarden/dept-bre
 .github/workflows/release-rust-crates.yml @bitwarden/dept-bre


### PR DESCRIPTION
## 📔 Objective

Tag `team-vault-dev` as co-owners of the `bitwarden-vault` crate.  This will allow either Platform or Vault to perform reviews.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation
  team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
