### PR TITLE
Add card brand to the CipherListViewType

### DIFF
--- a/crates/bitwarden-vault/src/cipher/card.rs
+++ b/crates/bitwarden-vault/src/cipher/card.rs
@@ -34,6 +34,16 @@ pub struct CardView {
     pub number: Option<String>,
 }
 
+/// Minimal CardView only including the needed details for list views
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+#[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
+#[cfg_attr(feature = "wasm", derive(Tsify), tsify(into_wasm_abi, from_wasm_abi))]
+pub struct CardListView {
+    /// The brand of the card, e.g. Visa, Mastercard, etc.
+    pub brand: Option<String>,
+}
+
 #[allow(missing_docs)]
 #[derive(Serialize, Deserialize)]
 pub enum CardBrand {
@@ -65,6 +75,18 @@ impl Encryptable<KeyIds, SymmetricKeyId, Card> for CardView {
             code: self.code.encrypt(ctx, key)?,
             brand: self.brand.encrypt(ctx, key)?,
             number: self.number.encrypt(ctx, key)?,
+        })
+    }
+}
+
+impl Decryptable<KeyIds, SymmetricKeyId, CardListView> for Card {
+    fn decrypt(
+        &self,
+        ctx: &mut KeyStoreContext<KeyIds>,
+        key: SymmetricKeyId,
+    ) -> Result<CardListView, CryptoError> {
+        Ok(CardListView {
+            brand: self.brand.decrypt(ctx, key).ok().flatten(),
         })
     }
 }

--- a/crates/bitwarden-vault/src/cipher/cipher.rs
+++ b/crates/bitwarden-vault/src/cipher/cipher.rs
@@ -19,6 +19,7 @@ use wasm_bindgen::prelude::wasm_bindgen;
 
 use super::{
     attachment, card,
+    card::CardListView,
     cipher_permissions::CipherPermissions,
     field, identity,
     local_data::{LocalData, LocalDataView},
@@ -170,7 +171,7 @@ pub struct CipherView {
 pub enum CipherListViewType {
     Login(LoginListView),
     SecureNote,
-    Card,
+    Card(CardListView),
     Identity,
     SshKey,
 }
@@ -649,7 +650,13 @@ impl Decryptable<KeyIds, SymmetricKeyId, CipherListView> for Cipher {
                     CipherListViewType::Login(login.decrypt(ctx, ciphers_key)?)
                 }
                 CipherType::SecureNote => CipherListViewType::SecureNote,
-                CipherType::Card => CipherListViewType::Card,
+                CipherType::Card => {
+                    let card = self
+                        .card
+                        .as_ref()
+                        .ok_or(CryptoError::MissingField("card"))?;
+                    CipherListViewType::Card(card.decrypt(ctx, ciphers_key)?)
+                }
                 CipherType::Identity => CipherListViewType::Identity,
                 CipherType::SshKey => CipherListViewType::SshKey,
             },

--- a/crates/bitwarden-vault/src/cipher/mod.rs
+++ b/crates/bitwarden-vault/src/cipher/mod.rs
@@ -17,7 +17,7 @@ pub use attachment::{
     Attachment, AttachmentEncryptResult, AttachmentFile, AttachmentFileView, AttachmentView,
 };
 pub use attachment_client::{AttachmentsClient, DecryptFileError, EncryptFileError};
-pub use card::{CardBrand, CardView};
+pub use card::{CardBrand, CardListView, CardView};
 pub use cipher::{
     Cipher, CipherError, CipherListView, CipherListViewType, CipherRepromptType, CipherType,
     CipherView, EncryptionContext,


### PR DESCRIPTION
## 🎟️ Tracking

Related to [PM-22134](https://bitwarden.atlassian.net/browse/PM-22134)

## 📔 Objective

Add the card brand to the `CipherListViewType`
- This will be used to show the internal card icon when displayed in the list:
  <img width="600" alt="Screenshot 2025-06-09 at 8 50 43 AM" src="https://github.com/user-attachments/assets/f3cd7dc2-ff8f-4059-9607-8466e6f636e8" />

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-22134]: https://bitwarden.atlassian.net/browse/PM-22134?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ