### PR TITLE
`CipherListView` updates

### DIFF
--- a/crates/bitwarden-vault/src/cipher/card.rs
+++ b/crates/bitwarden-vault/src/cipher/card.rs
@@ -195,9 +195,8 @@ mod tests {
     use bitwarden_core::key_management::create_test_crypto_with_user_key;
     use bitwarden_crypto::SymmetricCryptoKey;
 
-    use crate::{CipherRepromptType, CipherType};
-
     use super::*;
+    use crate::{CipherRepromptType, CipherType};
 
     fn encrypt_test_string(string: &str) -> EncString {
         let key = SymmetricCryptoKey::try_from("hvBMMb1t79YssFZkpetYsM3deyVuQv4r88Uj9gvYe0+G8EwxvW3v1iywVmSl61iwzd17JW5C/ivzxSP2C9h7Tw==".to_string()).unwrap();

--- a/crates/bitwarden-vault/src/cipher/card.rs
+++ b/crates/bitwarden-vault/src/cipher/card.rs
@@ -192,19 +192,7 @@ fn build_subtitle_card(brand: Option<String>, number: Option<String>) -> String 
 
 #[cfg(test)]
 mod tests {
-    use bitwarden_core::key_management::create_test_crypto_with_user_key;
-    use bitwarden_crypto::SymmetricCryptoKey;
-
     use super::*;
-
-    fn encrypt_test_string(string: &str) -> EncString {
-        let key = SymmetricCryptoKey::try_from("hvBMMb1t79YssFZkpetYsM3deyVuQv4r88Uj9gvYe0+G8EwxvW3v1iywVmSl61iwzd17JW5C/ivzxSP2C9h7Tw==".to_string()).unwrap();
-        let key_store = create_test_crypto_with_user_key(key);
-        let key = SymmetricKeyId::User;
-        let mut ctx = key_store.context();
-
-        string.to_string().encrypt(&mut ctx, key).unwrap()
-    }
 
     #[test]
     fn test_build_subtitle_card_visa() {
@@ -265,7 +253,7 @@ mod tests {
             cardholder_name: None,
             exp_month: None,
             exp_year: None,
-            code: Some(encrypt_test_string("123")),
+            code: Some("2.6TpmzzaQHgYr+mXjdGLQlg==|vT8VhfvMlWSCN9hxGYftZ5rjKRsZ9ofjdlUCx5Gubnk=|uoD3/GEQBWKKx2O+/YhZUCzVkfhm8rFK3sUEVV84mv8=".parse().unwrap()),
             brand: None,
             number: None,
         };
@@ -286,7 +274,7 @@ mod tests {
             exp_year: None,
             code: None,
             brand: None,
-            number: Some(encrypt_test_string("4242424242424242")),
+            number: Some("2.6TpmzzaQHgYr+mXjdGLQlg==|vT8VhfvMlWSCN9hxGYftZ5rjKRsZ9ofjdlUCx5Gubnk=|uoD3/GEQBWKKx2O+/YhZUCzVkfhm8rFK3sUEVV84mv8=".parse().unwrap()),
         };
 
         let copyable_fields = card.get_copyable_fields(None);

--- a/crates/bitwarden-vault/src/cipher/card.rs
+++ b/crates/bitwarden-vault/src/cipher/card.rs
@@ -144,7 +144,7 @@ impl CipherKind for Card {
         Ok(build_subtitle_card(brand, number))
     }
 
-    fn get_copyable_fields(&self, _: &Cipher) -> Vec<CopyableCipherFields> {
+    fn get_copyable_fields(&self, _: Option<&Cipher>) -> Vec<CopyableCipherFields> {
         [
             self.number
                 .as_ref()
@@ -196,7 +196,6 @@ mod tests {
     use bitwarden_crypto::SymmetricCryptoKey;
 
     use super::*;
-    use crate::{CipherRepromptType, CipherType};
 
     fn encrypt_test_string(string: &str) -> EncString {
         let key = SymmetricCryptoKey::try_from("hvBMMb1t79YssFZkpetYsM3deyVuQv4r88Uj9gvYe0+G8EwxvW3v1iywVmSl61iwzd17JW5C/ivzxSP2C9h7Tw==".to_string()).unwrap();
@@ -205,37 +204,6 @@ mod tests {
         let mut ctx = key_store.context();
 
         string.to_string().encrypt(&mut ctx, key).unwrap()
-    }
-
-    fn create_cipher_for_card(card: Card) -> Cipher {
-        Cipher {
-            id: Some("090c19ea-a61a-4df6-8963-262b97bc6266".parse().unwrap()),
-            organization_id: None,
-            folder_id: None,
-            collection_ids: vec![],
-            r#type: CipherType::Login,
-            key: None,
-            name: encrypt_test_string("My test cipher"),
-            notes: None,
-            login: None,
-            identity: None,
-            card: Some(card),
-            secure_note: None,
-            ssh_key: None,
-            favorite: false,
-            reprompt: CipherRepromptType::None,
-            organization_use_totp: false,
-            edit: true,
-            permissions: None,
-            view_password: true,
-            local_data: None,
-            attachments: None,
-            fields: None,
-            password_history: None,
-            creation_date: "2024-01-01T00:00:00.000Z".parse().unwrap(),
-            deleted_date: None,
-            revision_date: "2024-01-01T00:00:00.000Z".parse().unwrap(),
-        }
     }
 
     #[test]
@@ -302,8 +270,7 @@ mod tests {
             number: None,
         };
 
-        let cipher = create_cipher_for_card(card.clone());
-        let copyable_fields = card.get_copyable_fields(&cipher);
+        let copyable_fields = card.get_copyable_fields(None);
 
         assert_eq!(
             copyable_fields,
@@ -322,8 +289,7 @@ mod tests {
             number: Some(encrypt_test_string("4242424242424242")),
         };
 
-        let cipher = create_cipher_for_card(card.clone());
-        let copyable_fields = card.get_copyable_fields(&cipher);
+        let copyable_fields = card.get_copyable_fields(None);
 
         assert_eq!(copyable_fields, vec![CopyableCipherFields::CardNumber]);
     }

--- a/crates/bitwarden-vault/src/cipher/cipher.rs
+++ b/crates/bitwarden-vault/src/cipher/cipher.rs
@@ -415,33 +415,9 @@ impl Cipher {
     /// Returns a list of copyable field names for this cipher,
     /// based on the cipher type and populated properties.
     fn get_copyable_fields(&self) -> Vec<CopyableCipherFields> {
-        match self.r#type {
-            CipherType::Login => self
-                .login
-                .as_ref()
-                .map(|login| login.get_copyable_fields(self))
-                .unwrap_or_default(),
-            CipherType::Card => self
-                .card
-                .as_ref()
-                .map(|card| card.get_copyable_fields(self))
-                .unwrap_or_default(),
-            CipherType::Identity => self
-                .identity
-                .as_ref()
-                .map(|identity| identity.get_copyable_fields(self))
-                .unwrap_or_default(),
-            CipherType::SshKey => self
-                .ssh_key
-                .as_ref()
-                .map(|ssh_key| ssh_key.get_copyable_fields(self))
-                .unwrap_or_default(),
-            CipherType::SecureNote => self
-                .secure_note
-                .as_ref()
-                .map(|secure_note| secure_note.get_copyable_fields(self))
-                .unwrap_or_default(),
-        }
+        self.get_kind()
+            .map(|kind| kind.get_copyable_fields(self))
+            .unwrap_or_default()
     }
 }
 

--- a/crates/bitwarden-vault/src/cipher/cipher.rs
+++ b/crates/bitwarden-vault/src/cipher/cipher.rs
@@ -55,7 +55,7 @@ pub(super) trait CipherKind {
     ) -> Result<String, CryptoError>;
 
     /// Returns a list of populated fields for the cipher.
-    fn get_copyable_fields(&self, cipher: &Cipher) -> Vec<CopyableCipherFields>;
+    fn get_copyable_fields(&self, cipher: Option<&Cipher>) -> Vec<CopyableCipherFields>;
 }
 
 #[allow(missing_docs)]
@@ -416,7 +416,7 @@ impl Cipher {
     /// based on the cipher type and populated properties.
     fn get_copyable_fields(&self) -> Vec<CopyableCipherFields> {
         self.get_kind()
-            .map(|kind| kind.get_copyable_fields(self))
+            .map(|kind| kind.get_copyable_fields(Some(self)))
             .unwrap_or_default()
     }
 }

--- a/crates/bitwarden-vault/src/cipher/cipher.rs
+++ b/crates/bitwarden-vault/src/cipher/cipher.rs
@@ -241,9 +241,7 @@ pub struct CipherListView {
     pub deleted_date: Option<DateTime<Utc>>,
     pub revision_date: DateTime<Utc>,
 
-    /// Fields on the cipher that are populated. This can be used in the
-    /// UI to determine the visibility of copy actions without needing
-    /// the full cipher details.
+    /// Hints for the presentation layer for which fields can be copied.
     pub copyable_fields: Vec<CopyableCipherFields>,
 
     /// Indicates if the cipher has old attachments that need to be re-uploaded

--- a/crates/bitwarden-vault/src/cipher/cipher.rs
+++ b/crates/bitwarden-vault/src/cipher/cipher.rs
@@ -219,6 +219,11 @@ pub struct CipherListView {
     pub creation_date: DateTime<Utc>,
     pub deleted_date: Option<DateTime<Utc>>,
     pub revision_date: DateTime<Utc>,
+
+    /// Fields on the cipher that are able to be copied. The fields
+    /// are not included on the CipherListView, but are available on the full
+    /// CipherView.
+    pub copiable_fields: Vec<String>,
 }
 
 impl CipherListView {
@@ -379,6 +384,65 @@ impl Cipher {
         self.get_kind()
             .map(|sub| sub.decrypt_subtitle(ctx, key))
             .unwrap_or_else(|| Ok(String::new()))
+    }
+
+    /// Adds the `field_name` to the `fields` vector if the value is populated.
+    fn push_if_populated(encs: &[&Option<EncString>], field_name: &str, fields: &mut Vec<String>) {
+        let any_populated = encs.iter().any(|enc| enc.is_some());
+        if any_populated {
+            fields.push(field_name.to_string());
+        }
+    }
+
+    /// Returns a list of copiable field names for this cipher, based on the type and populated content.
+    fn get_copiable_fields(&self) -> Vec<String> {
+        let mut fields = Vec::new();
+        match self.r#type {
+            CipherType::Login => {
+                if let Some(login) = &self.login {
+                    Self::push_if_populated(&[&login.username], "login_username", &mut fields);
+                    Self::push_if_populated(&[&login.password], "login_password", &mut fields);
+                    Self::push_if_populated(&[&login.totp], "login_totp", &mut fields);
+                }
+            }
+            CipherType::Card => {
+                if let Some(card) = &self.card {
+                    Self::push_if_populated(&[&card.number], "card_number", &mut fields);
+                    Self::push_if_populated(&[&card.number], "card_security_code", &mut fields);
+                }
+            }
+            CipherType::Identity => {
+                if let Some(identity) = &self.identity {
+                    Self::push_if_populated(
+                        &[&identity.username],
+                        "identity_username",
+                        &mut fields,
+                    );
+                    Self::push_if_populated(&[&identity.email], "identity_email", &mut fields);
+                    Self::push_if_populated(&[&identity.phone], "identity_phone", &mut fields);
+                    Self::push_if_populated(
+                        &[
+                            &identity.address1,
+                            &identity.address2,
+                            &identity.address3,
+                            &identity.city,
+                            &identity.state,
+                            &identity.postal_code,
+                        ],
+                        "identity_address",
+                        &mut fields,
+                    );
+                }
+            }
+            CipherType::SshKey => {
+                // All properties SSH Keys are required
+                fields.push("ssh_key".to_string());
+            }
+            CipherType::SecureNote => {
+                Self::push_if_populated(&[&self.notes], "secure_note_notes", &mut fields);
+            }
+        }
+        fields
     }
 }
 
@@ -589,6 +653,7 @@ impl Decryptable<KeyIds, SymmetricKeyId, CipherListView> for Cipher {
             creation_date: self.creation_date,
             deleted_date: self.deleted_date,
             revision_date: self.revision_date,
+            copiable_fields: self.get_copiable_fields(),
         })
     }
 }
@@ -839,7 +904,8 @@ mod tests {
                 attachments: 0,
                 creation_date: cipher.creation_date,
                 deleted_date: cipher.deleted_date,
-                revision_date: cipher.revision_date
+                revision_date: cipher.revision_date,
+                copiable_fields: vec!["login_username".to_string(), "login_totp".to_string()],
             }
         )
     }

--- a/crates/bitwarden-vault/src/cipher/cipher.rs
+++ b/crates/bitwarden-vault/src/cipher/cipher.rs
@@ -419,7 +419,8 @@ impl Cipher {
         }
     }
 
-    /// Returns a list of copiable field names for this cipher, based on the type and populated content.
+    /// Returns a list of copiable field names for this cipher,
+    /// based on the cipher type and populated properties.
     fn get_copiable_fields(&self) -> Vec<CopiableCipherFields> {
         let mut fields = Vec::new();
         match self.r#type {

--- a/crates/bitwarden-vault/src/cipher/cipher.rs
+++ b/crates/bitwarden-vault/src/cipher/cipher.rs
@@ -966,6 +966,7 @@ mod tests {
                 revision_date: cipher.revision_date,
                 copiable_fields: vec![
                     CopiableCipherFields::LoginUsername,
+                    CopiableCipherFields::LoginPassword,
                     CopiableCipherFields::LoginTotp
                 ],
                 local_data: None,
@@ -1415,9 +1416,9 @@ mod tests {
         assert_eq!(
             cipher.get_copiable_fields(),
             vec![
+                CopiableCipherFields::IdentityUsername,
                 CopiableCipherFields::IdentityEmail,
-                CopiableCipherFields::IdentityPhone,
-                CopiableCipherFields::IdentityUsername
+                CopiableCipherFields::IdentityPhone
             ],
         );
     }

--- a/crates/bitwarden-vault/src/cipher/cipher.rs
+++ b/crates/bitwarden-vault/src/cipher/cipher.rs
@@ -236,6 +236,8 @@ pub struct CipherListView {
 
     /// The number of attachments
     pub attachments: u32,
+    /// Indicates if the cipher has old attachments that need to be re-uploaded
+    pub has_old_attachments: bool,
 
     pub creation_date: DateTime<Utc>,
     pub deleted_date: Option<DateTime<Utc>>,
@@ -243,9 +245,6 @@ pub struct CipherListView {
 
     /// Hints for the presentation layer for which fields can be copied.
     pub copyable_fields: Vec<CopyableCipherFields>,
-
-    /// Indicates if the cipher has old attachments that need to be re-uploaded
-    pub has_old_attachments: bool,
 
     pub local_data: Option<LocalDataView>,
 }

--- a/crates/bitwarden-vault/src/cipher/cipher.rs
+++ b/crates/bitwarden-vault/src/cipher/cipher.rs
@@ -242,6 +242,9 @@ pub struct CipherListView {
     /// UI to determine the visibility of copy actions without needing
     /// the full cipher details.
     pub copiable_fields: Vec<CopiableCipherFields>,
+
+    // Only added to the list view for typing purposes, it won't be retrieved from the server
+    pub local_data: Option<LocalDataView>,
 }
 
 impl CipherListView {
@@ -708,6 +711,7 @@ impl Decryptable<KeyIds, SymmetricKeyId, CipherListView> for Cipher {
             deleted_date: self.deleted_date,
             revision_date: self.revision_date,
             copiable_fields: self.get_copiable_fields(),
+            local_data: None, // Not sent from server
         })
     }
 }
@@ -963,6 +967,7 @@ mod tests {
                     CopiableCipherFields::LoginUsername,
                     CopiableCipherFields::LoginTotp
                 ],
+                local_data: None,
             }
         )
     }

--- a/crates/bitwarden-vault/src/cipher/cipher.rs
+++ b/crates/bitwarden-vault/src/cipher/cipher.rs
@@ -243,7 +243,6 @@ pub struct CipherListView {
     /// the full cipher details.
     pub copiable_fields: Vec<CopiableCipherFields>,
 
-    // Only added to the list view for typing purposes, it won't be retrieved from the server
     pub local_data: Option<LocalDataView>,
 }
 
@@ -712,7 +711,7 @@ impl Decryptable<KeyIds, SymmetricKeyId, CipherListView> for Cipher {
             deleted_date: self.deleted_date,
             revision_date: self.revision_date,
             copiable_fields: self.get_copiable_fields(),
-            local_data: None, // Not sent from server
+            local_data: self.local_data.decrypt(ctx, ciphers_key)?,
         })
     }
 }

--- a/crates/bitwarden-vault/src/cipher/cipher.rs
+++ b/crates/bitwarden-vault/src/cipher/cipher.rs
@@ -246,6 +246,9 @@ pub struct CipherListView {
     /// the full cipher details.
     pub copyable_fields: Vec<CopyableCipherFields>,
 
+    /// Indicates if the cipher has old attachments that need to be re-uploaded
+    pub has_old_attachments: bool,
+
     pub local_data: Option<LocalDataView>,
 }
 
@@ -646,6 +649,11 @@ impl Decryptable<KeyIds, SymmetricKeyId, CipherListView> for Cipher {
                 .as_ref()
                 .map(|a| a.len() as u32)
                 .unwrap_or(0),
+            has_old_attachments: self
+                .attachments
+                .as_ref()
+                .map(|a| a.iter().any(|att| att.key.is_none()))
+                .unwrap_or(false),
             creation_date: self.creation_date,
             deleted_date: self.deleted_date,
             revision_date: self.revision_date,
@@ -899,6 +907,7 @@ mod tests {
                 permissions: cipher.permissions,
                 view_password: cipher.view_password,
                 attachments: 0,
+                has_old_attachments: false,
                 creation_date: cipher.creation_date,
                 deleted_date: cipher.deleted_date,
                 revision_date: cipher.revision_date,

--- a/crates/bitwarden-vault/src/cipher/identity.rs
+++ b/crates/bitwarden-vault/src/cipher/identity.rs
@@ -220,9 +220,8 @@ mod tests {
     use bitwarden_core::key_management::create_test_crypto_with_user_key;
     use bitwarden_crypto::SymmetricCryptoKey;
 
-    use crate::{cipher::cipher::CopyableCipherFields, Cipher, CipherRepromptType, CipherType};
-
     use super::*;
+    use crate::{cipher::cipher::CopyableCipherFields, Cipher, CipherRepromptType, CipherType};
 
     fn encrypt_test_string(string: &str) -> EncString {
         let key = SymmetricCryptoKey::try_from("hvBMMb1t79YssFZkpetYsM3deyVuQv4r88Uj9gvYe0+G8EwxvW3v1iywVmSl61iwzd17JW5C/ivzxSP2C9h7Tw==".to_string()).unwrap();

--- a/crates/bitwarden-vault/src/cipher/identity.rs
+++ b/crates/bitwarden-vault/src/cipher/identity.rs
@@ -164,7 +164,7 @@ impl CipherKind for Identity {
         Ok(build_subtitle_identity(first_name, last_name))
     }
 
-    fn get_copyable_fields(&self, _: &Cipher) -> Vec<CopyableCipherFields> {
+    fn get_copyable_fields(&self, _: Option<&Cipher>) -> Vec<CopyableCipherFields> {
         [
             self.username
                 .as_ref()
@@ -221,7 +221,7 @@ mod tests {
     use bitwarden_crypto::SymmetricCryptoKey;
 
     use super::*;
-    use crate::{cipher::cipher::CopyableCipherFields, Cipher, CipherRepromptType, CipherType};
+    use crate::cipher::cipher::CopyableCipherFields;
 
     fn encrypt_test_string(string: &str) -> EncString {
         let key = SymmetricCryptoKey::try_from("hvBMMb1t79YssFZkpetYsM3deyVuQv4r88Uj9gvYe0+G8EwxvW3v1iywVmSl61iwzd17JW5C/ivzxSP2C9h7Tw==".to_string()).unwrap();
@@ -230,37 +230,6 @@ mod tests {
         let mut ctx = key_store.context();
 
         string.to_string().encrypt(&mut ctx, key).unwrap()
-    }
-
-    fn create_cipher_for_identity(identity: Identity) -> Cipher {
-        Cipher {
-            id: Some("090c19ea-a61a-4df6-8963-262b97bc6266".parse().unwrap()),
-            organization_id: None,
-            folder_id: None,
-            collection_ids: vec![],
-            r#type: CipherType::Login,
-            key: None,
-            name: encrypt_test_string("My test cipher"),
-            notes: None,
-            login: None,
-            identity: Some(identity),
-            card: None,
-            secure_note: None,
-            ssh_key: None,
-            favorite: false,
-            reprompt: CipherRepromptType::None,
-            organization_use_totp: false,
-            edit: true,
-            permissions: None,
-            view_password: true,
-            local_data: None,
-            attachments: None,
-            fields: None,
-            password_history: None,
-            creation_date: "2024-01-01T00:00:00.000Z".parse().unwrap(),
-            deleted_date: None,
-            revision_date: "2024-01-01T00:00:00.000Z".parse().unwrap(),
-        }
     }
 
     fn create_identity() -> Identity {
@@ -326,9 +295,7 @@ mod tests {
     fn test_get_copyable_fields_identity_empty() {
         let identity = create_identity();
 
-        let cipher = create_cipher_for_identity(identity.clone());
-
-        let copyable_fields = identity.get_copyable_fields(&cipher);
+        let copyable_fields = identity.get_copyable_fields(None);
         assert_eq!(copyable_fields, vec![]);
     }
 
@@ -337,8 +304,7 @@ mod tests {
         let mut identity = create_identity();
         identity.username = Some(encrypt_test_string("username"));
 
-        let cipher = create_cipher_for_identity(identity.clone());
-        let copyable_fields = identity.get_copyable_fields(&cipher);
+        let copyable_fields = identity.get_copyable_fields(None);
         assert_eq!(
             copyable_fields,
             vec![CopyableCipherFields::IdentityUsername]
@@ -350,8 +316,7 @@ mod tests {
         let mut identity = create_identity();
         identity.email = Some(encrypt_test_string("email@example.com"));
 
-        let cipher = create_cipher_for_identity(identity.clone());
-        let copyable_fields = identity.get_copyable_fields(&cipher);
+        let copyable_fields = identity.get_copyable_fields(None);
         assert_eq!(copyable_fields, vec![CopyableCipherFields::IdentityEmail]);
     }
 
@@ -360,9 +325,7 @@ mod tests {
         let mut identity = create_identity();
         identity.phone = Some(encrypt_test_string("867-5309"));
 
-        let cipher = create_cipher_for_identity(identity.clone());
-
-        let copyable_fields = identity.get_copyable_fields(&cipher);
+        let copyable_fields = identity.get_copyable_fields(None);
         assert_eq!(copyable_fields, vec![CopyableCipherFields::IdentityPhone]);
     }
 
@@ -371,16 +334,15 @@ mod tests {
         let mut identity = create_identity();
 
         identity.address1 = Some(encrypt_test_string("123 Main St"));
-        let cipher = create_cipher_for_identity(identity.clone());
 
-        let mut copyable_fields = identity.get_copyable_fields(&cipher);
+        let mut copyable_fields = identity.get_copyable_fields(None);
 
         assert_eq!(copyable_fields, vec![CopyableCipherFields::IdentityAddress]);
 
         identity.state = Some(encrypt_test_string("CA"));
         identity.address1 = None;
 
-        copyable_fields = identity.get_copyable_fields(&cipher);
+        copyable_fields = identity.get_copyable_fields(None);
         assert_eq!(copyable_fields, vec![CopyableCipherFields::IdentityAddress]);
     }
 }

--- a/crates/bitwarden-vault/src/cipher/identity.rs
+++ b/crates/bitwarden-vault/src/cipher/identity.rs
@@ -217,20 +217,8 @@ fn build_subtitle_identity(first_name: Option<String>, last_name: Option<String>
 
 #[cfg(test)]
 mod tests {
-    use bitwarden_core::key_management::create_test_crypto_with_user_key;
-    use bitwarden_crypto::SymmetricCryptoKey;
-
     use super::*;
     use crate::cipher::cipher::CopyableCipherFields;
-
-    fn encrypt_test_string(string: &str) -> EncString {
-        let key = SymmetricCryptoKey::try_from("hvBMMb1t79YssFZkpetYsM3deyVuQv4r88Uj9gvYe0+G8EwxvW3v1iywVmSl61iwzd17JW5C/ivzxSP2C9h7Tw==".to_string()).unwrap();
-        let key_store = create_test_crypto_with_user_key(key);
-        let key = SymmetricKeyId::User;
-        let mut ctx = key_store.context();
-
-        string.to_string().encrypt(&mut ctx, key).unwrap()
-    }
 
     fn create_identity() -> Identity {
         Identity {
@@ -302,7 +290,7 @@ mod tests {
     #[test]
     fn test_get_copyable_fields_identity_has_username() {
         let mut identity = create_identity();
-        identity.username = Some(encrypt_test_string("username"));
+        identity.username = Some("2.yXXpPbsf6NZhLVkNe/i4Bw==|ol/HTI++aMO1peBBBhSR7Q==|awNmmj31efIXTzaru42/Ay+bQ6V+1MrKxXh1Uo5gca8=".parse().unwrap());
 
         let copyable_fields = identity.get_copyable_fields(None);
         assert_eq!(
@@ -314,7 +302,7 @@ mod tests {
     #[test]
     fn test_get_copyable_fields_identity_has_email() {
         let mut identity = create_identity();
-        identity.email = Some(encrypt_test_string("email@example.com"));
+        identity.email = Some("2.yXXpPbsf6NZhLVkNe/i4Bw==|ol/HTI++aMO1peBBBhSR7Q==|awNmmj31efIXTzaru42/Ay+bQ6V+1MrKxXh1Uo5gca8=".parse().unwrap());
 
         let copyable_fields = identity.get_copyable_fields(None);
         assert_eq!(copyable_fields, vec![CopyableCipherFields::IdentityEmail]);
@@ -323,7 +311,7 @@ mod tests {
     #[test]
     fn test_get_copyable_fields_identity_has_phone() {
         let mut identity = create_identity();
-        identity.phone = Some(encrypt_test_string("867-5309"));
+        identity.phone = Some("2.yXXpPbsf6NZhLVkNe/i4Bw==|ol/HTI++aMO1peBBBhSR7Q==|awNmmj31efIXTzaru42/Ay+bQ6V+1MrKxXh1Uo5gca8=".parse().unwrap());
 
         let copyable_fields = identity.get_copyable_fields(None);
         assert_eq!(copyable_fields, vec![CopyableCipherFields::IdentityPhone]);
@@ -333,13 +321,13 @@ mod tests {
     fn test_get_copyable_fields_identity_has_address() {
         let mut identity = create_identity();
 
-        identity.address1 = Some(encrypt_test_string("123 Main St"));
+        identity.address1 = Some("2.yXXpPbsf6NZhLVkNe/i4Bw==|ol/HTI++aMO1peBBBhSR7Q==|awNmmj31efIXTzaru42/Ay+bQ6V+1MrKxXh1Uo5gca8=".parse().unwrap());
 
         let mut copyable_fields = identity.get_copyable_fields(None);
 
         assert_eq!(copyable_fields, vec![CopyableCipherFields::IdentityAddress]);
 
-        identity.state = Some(encrypt_test_string("CA"));
+        identity.state = Some("2.yXXpPbsf6NZhLVkNe/i4Bw==|ol/HTI++aMO1peBBBhSR7Q==|awNmmj31efIXTzaru42/Ay+bQ6V+1MrKxXh1Uo5gca8=".parse().unwrap());
         identity.address1 = None;
 
         copyable_fields = identity.get_copyable_fields(None);

--- a/crates/bitwarden-vault/src/cipher/local_data.rs
+++ b/crates/bitwarden-vault/src/cipher/local_data.rs
@@ -14,7 +14,7 @@ pub struct LocalData {
     last_launched: Option<DateTime<Utc>>,
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 #[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
 #[cfg_attr(feature = "wasm", derive(Tsify), tsify(into_wasm_abi, from_wasm_abi))]

--- a/crates/bitwarden-vault/src/cipher/login.rs
+++ b/crates/bitwarden-vault/src/cipher/login.rs
@@ -585,22 +585,10 @@ impl CipherKind for Login {
 
 #[cfg(test)]
 mod tests {
-    use bitwarden_core::key_management::{create_test_crypto_with_user_key, SymmetricKeyId};
-    use bitwarden_crypto::{EncString, Encryptable, SymmetricCryptoKey};
-
     use crate::{
         cipher::cipher::{CipherKind, CopyableCipherFields},
         Login,
     };
-
-    fn encrypt_test_string(string: &str) -> EncString {
-        let key = SymmetricCryptoKey::try_from("hvBMMb1t79YssFZkpetYsM3deyVuQv4r88Uj9gvYe0+G8EwxvW3v1iywVmSl61iwzd17JW5C/ivzxSP2C9h7Tw==".to_string()).unwrap();
-        let key_store = create_test_crypto_with_user_key(key);
-        let key = SymmetricKeyId::User;
-        let mut ctx = key_store.context();
-
-        string.to_string().encrypt(&mut ctx, key).unwrap()
-    }
 
     #[test]
     fn test_valid_checksum() {
@@ -652,7 +640,7 @@ mod tests {
     fn test_get_copyable_fields_login_password() {
         let login_with_password = Login {
             username: None,
-            password: Some(encrypt_test_string("testPassword")),
+            password: Some("2.38t4E88QbQEkBdK+oZNHFg==|B3BiDcG3ZfEkD2BK+FMytQ==|2Dw1/f+LCfkCmCj4gKOxOu6CRnZj93qaBYUqbzy/reU=".parse().unwrap()),
             password_revision_date: None,
             uris: None,
             totp: None,
@@ -667,7 +655,7 @@ mod tests {
     #[test]
     fn test_get_copyable_fields_login_username() {
         let login_with_username = Login {
-            username: Some(encrypt_test_string("testUsername")),
+            username: Some("2.38t4E88QbQEkBdK+oZNHFg==|B3BiDcG3ZfEkD2BK+FMytQ==|2Dw1/f+LCfkCmCj4gKOxOu6CRnZj93qaBYUqbzy/reU=".parse().unwrap()),
             password: None,
             password_revision_date: None,
             uris: None,
@@ -683,11 +671,11 @@ mod tests {
     #[test]
     fn test_get_copyable_fields_login_everything() {
         let login = Login {
-            username: Some(encrypt_test_string("testUsername")),
-            password: Some(encrypt_test_string("testPassword")),
+            username: Some("2.38t4E88QbQEkBdK+oZNHFg==|B3BiDcG3ZfEkD2BK+FMytQ==|2Dw1/f+LCfkCmCj4gKOxOu6CRnZj93qaBYUqbzy/reU=".parse().unwrap()),
+            password: Some("2.38t4E88QbQEkBdK+oZNHFg==|B3BiDcG3ZfEkD2BK+FMytQ==|2Dw1/f+LCfkCmCj4gKOxOu6CRnZj93qaBYUqbzy/reU=".parse().unwrap()),
             password_revision_date: None,
             uris: None,
-            totp: Some(encrypt_test_string("totp")),
+            totp: Some("2.38t4E88QbQEkBdK+oZNHFg==|B3BiDcG3ZfEkD2BK+FMytQ==|2Dw1/f+LCfkCmCj4gKOxOu6CRnZj93qaBYUqbzy/reU=".parse().unwrap()),
             autofill_on_page_load: None,
             fido2_credentials: None,
         };

--- a/crates/bitwarden-vault/src/cipher/login.rs
+++ b/crates/bitwarden-vault/src/cipher/login.rs
@@ -567,7 +567,7 @@ impl CipherKind for Login {
         Ok(username.unwrap_or_default())
     }
 
-    fn get_copyable_fields(&self, _: &Cipher) -> Vec<CopyableCipherFields> {
+    fn get_copyable_fields(&self, _: Option<&Cipher>) -> Vec<CopyableCipherFields> {
         [
             self.username
                 .as_ref()
@@ -589,8 +589,8 @@ mod tests {
     use bitwarden_crypto::{EncString, Encryptable, SymmetricCryptoKey};
 
     use crate::{
-        cipher::cipher::{Cipher, CipherKind, CopyableCipherFields},
-        CipherRepromptType, CipherType, Login,
+        cipher::cipher::{CipherKind, CopyableCipherFields},
+        Login,
     };
 
     fn encrypt_test_string(string: &str) -> EncString {
@@ -600,37 +600,6 @@ mod tests {
         let mut ctx = key_store.context();
 
         string.to_string().encrypt(&mut ctx, key).unwrap()
-    }
-
-    fn create_cipher_for_login(login: Login) -> Cipher {
-        Cipher {
-            id: Some("090c19ea-a61a-4df6-8963-262b97bc6266".parse().unwrap()),
-            organization_id: None,
-            folder_id: None,
-            collection_ids: vec![],
-            r#type: CipherType::Login,
-            key: None,
-            name: encrypt_test_string("My test cipher"),
-            notes: None,
-            login: Some(login),
-            identity: None,
-            card: None,
-            secure_note: None,
-            ssh_key: None,
-            favorite: false,
-            reprompt: CipherRepromptType::None,
-            organization_use_totp: false,
-            edit: true,
-            permissions: None,
-            view_password: true,
-            local_data: None,
-            attachments: None,
-            fields: None,
-            password_history: None,
-            creation_date: "2024-01-01T00:00:00.000Z".parse().unwrap(),
-            deleted_date: None,
-            revision_date: "2024-01-01T00:00:00.000Z".parse().unwrap(),
-        }
     }
 
     #[test]
@@ -691,9 +660,7 @@ mod tests {
             fido2_credentials: None,
         };
 
-        let cipher = create_cipher_for_login(login_with_password.clone());
-
-        let copyable_fields = login_with_password.get_copyable_fields(&cipher);
+        let copyable_fields = login_with_password.get_copyable_fields(None);
         assert_eq!(copyable_fields, vec![CopyableCipherFields::LoginPassword]);
     }
 
@@ -709,9 +676,7 @@ mod tests {
             fido2_credentials: None,
         };
 
-        let cipher = create_cipher_for_login(login_with_username.clone());
-
-        let copyable_fields = login_with_username.get_copyable_fields(&cipher);
+        let copyable_fields = login_with_username.get_copyable_fields(None);
         assert_eq!(copyable_fields, vec![CopyableCipherFields::LoginUsername]);
     }
 
@@ -727,9 +692,7 @@ mod tests {
             fido2_credentials: None,
         };
 
-        let cipher = create_cipher_for_login(login.clone());
-
-        let copyable_fields = login.get_copyable_fields(&cipher);
+        let copyable_fields = login.get_copyable_fields(None);
         assert_eq!(
             copyable_fields,
             vec![

--- a/crates/bitwarden-vault/src/cipher/secure_note.rs
+++ b/crates/bitwarden-vault/src/cipher/secure_note.rs
@@ -85,10 +85,9 @@ impl From<bitwarden_api_api::models::SecureNoteType> for SecureNoteType {
 }
 
 impl CipherKind for SecureNote {
-    fn get_copyable_fields(&self, cipher: &Cipher) -> Vec<CopyableCipherFields> {
+    fn get_copyable_fields(&self, cipher: Option<&Cipher>) -> Vec<CopyableCipherFields> {
         [cipher
-            .notes
-            .as_ref()
+            .and_then(|c| c.notes.as_ref())
             .map(|_| CopyableCipherFields::SecureNotes)]
         .into_iter()
         .flatten()
@@ -163,7 +162,7 @@ mod tests {
 
         let cipher = create_cipher_for_note(secure_note.clone());
 
-        let copyable_fields = secure_note.get_copyable_fields(&cipher);
+        let copyable_fields = secure_note.get_copyable_fields(Some(&cipher));
         assert_eq!(copyable_fields, vec![]);
     }
 
@@ -178,7 +177,17 @@ mod tests {
             "This is a secure note with some content.",
         ));
 
-        let copyable_fields = secure_note.get_copyable_fields(&cipher);
+        let copyable_fields = secure_note.get_copyable_fields(Some(&cipher));
         assert_eq!(copyable_fields, vec![CopyableCipherFields::SecureNotes]);
+    }
+
+    #[test]
+    fn test_get_copyable_fields_secure_no_cipher() {
+        let secure_note = SecureNote {
+            r#type: SecureNoteType::Generic,
+        };
+
+        let copyable_fields = secure_note.get_copyable_fields(None);
+        assert_eq!(copyable_fields, vec![]);
     }
 }

--- a/crates/bitwarden-vault/src/cipher/secure_note.rs
+++ b/crates/bitwarden-vault/src/cipher/secure_note.rs
@@ -105,23 +105,11 @@ impl CipherKind for SecureNote {
 
 #[cfg(test)]
 mod tests {
-    use bitwarden_core::key_management::{create_test_crypto_with_user_key, SymmetricKeyId};
-    use bitwarden_crypto::{EncString, Encryptable, SymmetricCryptoKey};
-
     use crate::{
         cipher::cipher::{Cipher, CipherKind, CopyableCipherFields},
         secure_note::SecureNote,
         CipherRepromptType, CipherType, SecureNoteType,
     };
-
-    fn encrypt_test_string(string: &str) -> EncString {
-        let key = SymmetricCryptoKey::try_from("hvBMMb1t79YssFZkpetYsM3deyVuQv4r88Uj9gvYe0+G8EwxvW3v1iywVmSl61iwzd17JW5C/ivzxSP2C9h7Tw==".to_string()).unwrap();
-        let key_store = create_test_crypto_with_user_key(key);
-        let key = SymmetricKeyId::User;
-        let mut ctx = key_store.context();
-
-        string.to_string().encrypt(&mut ctx, key).unwrap()
-    }
 
     fn create_cipher_for_note(note: SecureNote) -> Cipher {
         Cipher {
@@ -131,7 +119,7 @@ mod tests {
             collection_ids: vec![],
             r#type: CipherType::Login,
             key: None,
-            name: encrypt_test_string("My test cipher"),
+            name: "2.iovOJUb186UXu+0AlQggjw==|LeWZhrT0B7rqFtDufOJMlJsftwmMGuaoBxf/Cig4D4A9XHhUqacd8uOYP7M5bd/k|++gmrHIyt8hvvPP9dwFS/CGd+POfzmeXzKOsuyJpDDc=".parse().unwrap(),
             notes: None,
             login: None,
             identity: None,
@@ -173,9 +161,7 @@ mod tests {
         };
 
         let mut cipher = create_cipher_for_note(secure_note.clone());
-        cipher.notes = Some(encrypt_test_string(
-            "This is a secure note with some content.",
-        ));
+        cipher.notes = Some("2.iovOJUb186UXu+0AlQggjw==|LeWZhrT0B7rqFtDufOJMlJsftwmMGuaoBxf/Cig4D4A9XHhUqacd8uOYP7M5bd/k|++gmrHIyt8hvvPP9dwFS/CGd+POfzmeXzKOsuyJpDDc=".parse().unwrap());
 
         let copyable_fields = secure_note.get_copyable_fields(Some(&cipher));
         assert_eq!(copyable_fields, vec![CopyableCipherFields::SecureNotes]);

--- a/crates/bitwarden-vault/src/cipher/ssh_key.rs
+++ b/crates/bitwarden-vault/src/cipher/ssh_key.rs
@@ -71,7 +71,7 @@ impl CipherKind for SshKey {
         self.fingerprint.decrypt(ctx, key)
     }
 
-    fn get_copyable_fields(&self, _: &Cipher) -> Vec<CopyableCipherFields> {
+    fn get_copyable_fields(&self, _: Option<&Cipher>) -> Vec<CopyableCipherFields> {
         [CopyableCipherFields::SshKey].into_iter().collect()
     }
 }
@@ -82,7 +82,7 @@ mod tests {
     use bitwarden_crypto::SymmetricCryptoKey;
 
     use super::*;
-    use crate::{cipher::cipher::CopyableCipherFields, Cipher, CipherRepromptType, CipherType};
+    use crate::cipher::cipher::CopyableCipherFields;
 
     #[test]
     fn test_subtitle_ssh_key() {
@@ -121,36 +121,7 @@ mod tests {
             fingerprint: "fingerprint".to_string().encrypt(&mut ctx, key).unwrap(),
         };
 
-        let cipher = Cipher {
-            id: Some("090c19ea-a61a-4df6-8963-262b97bc6266".parse().unwrap()),
-            organization_id: None,
-            folder_id: None,
-            collection_ids: vec![],
-            r#type: CipherType::SshKey,
-            key: None,
-            name: "My test cipher".to_string().encrypt(&mut ctx, key).unwrap(),
-            notes: None,
-            login: None,
-            identity: None,
-            card: None,
-            secure_note: None,
-            ssh_key: Some(ssh_key.clone()),
-            favorite: false,
-            reprompt: CipherRepromptType::None,
-            organization_use_totp: false,
-            edit: true,
-            permissions: None,
-            view_password: true,
-            local_data: None,
-            attachments: None,
-            fields: None,
-            password_history: None,
-            creation_date: "2024-01-01T00:00:00.000Z".parse().unwrap(),
-            deleted_date: None,
-            revision_date: "2024-01-01T00:00:00.000Z".parse().unwrap(),
-        };
-
-        let copyable_fields = ssh_key.get_copyable_fields(&cipher);
+        let copyable_fields = ssh_key.get_copyable_fields(None);
         assert_eq!(copyable_fields, vec![CopyableCipherFields::SshKey]);
     }
 }

--- a/crates/bitwarden-vault/src/cipher/ssh_key.rs
+++ b/crates/bitwarden-vault/src/cipher/ssh_key.rs
@@ -4,9 +4,8 @@ use serde::{Deserialize, Serialize};
 #[cfg(feature = "wasm")]
 use tsify_next::Tsify;
 
-use crate::{cipher::cipher::CopyableCipherFields, Cipher};
-
 use super::cipher::CipherKind;
+use crate::{cipher::cipher::CopyableCipherFields, Cipher};
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
@@ -82,9 +81,8 @@ mod tests {
     use bitwarden_core::key_management::create_test_crypto_with_user_key;
     use bitwarden_crypto::SymmetricCryptoKey;
 
-    use crate::{cipher::cipher::CopyableCipherFields, Cipher, CipherRepromptType, CipherType};
-
     use super::*;
+    use crate::{cipher::cipher::CopyableCipherFields, Cipher, CipherRepromptType, CipherType};
 
     #[test]
     fn test_subtitle_ssh_key() {

--- a/crates/bitwarden-vault/src/cipher/ssh_key.rs
+++ b/crates/bitwarden-vault/src/cipher/ssh_key.rs
@@ -110,15 +110,10 @@ mod tests {
 
     #[test]
     fn test_get_copyable_fields_sshkey() {
-        let key = SymmetricCryptoKey::try_from("hvBMMb1t79YssFZkpetYsM3deyVuQv4r88Uj9gvYe0+G8EwxvW3v1iywVmSl61iwzd17JW5C/ivzxSP2C9h7Tw==".to_string()).unwrap();
-        let key_store = create_test_crypto_with_user_key(key);
-        let key = SymmetricKeyId::User;
-        let mut ctx = key_store.context();
-
         let ssh_key = SshKey {
-            private_key: "private_key".to_string().encrypt(&mut ctx, key).unwrap(),
-            public_key: "public_key".to_string().encrypt(&mut ctx, key).unwrap(),
-            fingerprint: "fingerprint".to_string().encrypt(&mut ctx, key).unwrap(),
+            private_key: "2.tMIugb6zQOL+EuOizna1wQ==|W5dDLoNJtajN68yeOjrr6w==|qS4hwJB0B0gNLI0o+jxn+sKMBmvtVgJCRYNEXBZoGeE=".parse().unwrap(),
+            public_key: "2.tMIugb6zQOL+EuOizna1wQ==|W5dDLoNJtajN68yeOjrr6w==|qS4hwJB0B0gNLI0o+jxn+sKMBmvtVgJCRYNEXBZoGeE=".parse().unwrap(),
+            fingerprint: "2.tMIugb6zQOL+EuOizna1wQ==|W5dDLoNJtajN68yeOjrr6w==|qS4hwJB0B0gNLI0o+jxn+sKMBmvtVgJCRYNEXBZoGeE=".parse().unwrap(),
         };
 
         let copyable_fields = ssh_key.get_copyable_fields(None);

--- a/crates/bitwarden-vault/src/totp.rs
+++ b/crates/bitwarden-vault/src/totp.rs
@@ -747,6 +747,7 @@ mod tests {
             permissions: None,
             view_password: true,
             attachments: 0,
+            has_old_attachments: false,
             creation_date: "2024-01-30T17:55:36.150Z".parse().unwrap(),
             deleted_date: None,
             revision_date: "2024-01-30T17:55:36.150Z".parse().unwrap(),

--- a/crates/bitwarden-vault/src/totp.rs
+++ b/crates/bitwarden-vault/src/totp.rs
@@ -751,6 +751,7 @@ mod tests {
             deleted_date: None,
             revision_date: "2024-01-30T17:55:36.150Z".parse().unwrap(),
             copiable_fields: vec![CopiableCipherFields::LoginTotp],
+            local_data: None,
         };
 
         let key = SymmetricCryptoKey::try_from("w2LO+nwV4oxwswVYCxlOfRUseXfvU03VzvKQHrqeklPgiMZrspUe6sOBToCnDn9Ay0tuCBn8ykVVRb7PWhub2Q==".to_string()).unwrap();

--- a/crates/bitwarden-vault/src/totp.rs
+++ b/crates/bitwarden-vault/src/totp.rs
@@ -377,7 +377,11 @@ mod tests {
     use chrono::Utc;
 
     use super::*;
-    use crate::{cipher::cipher::CipherListViewType, login::LoginListView, CipherRepromptType};
+    use crate::{
+        cipher::cipher::{CipherListViewType, CopiableCipherFields},
+        login::LoginListView,
+        CipherRepromptType,
+    };
 
     #[test]
     fn test_decode_b32() {
@@ -746,6 +750,7 @@ mod tests {
             creation_date: "2024-01-30T17:55:36.150Z".parse().unwrap(),
             deleted_date: None,
             revision_date: "2024-01-30T17:55:36.150Z".parse().unwrap(),
+            copiable_fields: vec![CopiableCipherFields::LoginTotp],
         };
 
         let key = SymmetricCryptoKey::try_from("w2LO+nwV4oxwswVYCxlOfRUseXfvU03VzvKQHrqeklPgiMZrspUe6sOBToCnDn9Ay0tuCBn8ykVVRb7PWhub2Q==".to_string()).unwrap();

--- a/crates/bitwarden-vault/src/totp.rs
+++ b/crates/bitwarden-vault/src/totp.rs
@@ -378,7 +378,7 @@ mod tests {
 
     use super::*;
     use crate::{
-        cipher::cipher::{CipherListViewType, CopiableCipherFields},
+        cipher::cipher::{CipherListViewType, CopyableCipherFields},
         login::LoginListView,
         CipherRepromptType,
     };
@@ -750,7 +750,7 @@ mod tests {
             creation_date: "2024-01-30T17:55:36.150Z".parse().unwrap(),
             deleted_date: None,
             revision_date: "2024-01-30T17:55:36.150Z".parse().unwrap(),
-            copiable_fields: vec![CopiableCipherFields::LoginTotp],
+            copyable_fields: vec![CopyableCipherFields::LoginTotp],
             local_data: None,
         };
 


### PR DESCRIPTION
## 🎟️ Tracking

Tangential to [PM-22134](https://bitwarden.atlassian.net/browse/PM-22134)

## 📔 Objective

Two updates to ensure parity when migrating from `CipherView` to `CipherListView` on the clients repo
- Added `local_data` so the type propagates to the clients repo and can be set there.
- Added  `CopiableCipherFields` enum + property.
  - In the browser the copy menu / actions are dynamic based on the populated fields on the cipher.  The `CipherListView` doesn't contain these details. This array is filled with the available fields so the extension can still check their availability. When a value is needed the full cipher is decrypted. 
- Added `has_old_attachments` to identify attachments following old encryption methods. This populates UI signaling to the user that the attachment needs to be re-encrypted. 

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-22134]: https://bitwarden.atlassian.net/browse/PM-22134?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ