### PR TITLE
[PM-22647] Move build subtitle into cipher types

### DIFF
--- a/crates/bitwarden-vault/src/cipher/login.rs
+++ b/crates/bitwarden-vault/src/cipher/login.rs
@@ -13,6 +13,7 @@ use tsify_next::Tsify;
 #[cfg(feature = "wasm")]
 use wasm_bindgen::prelude::wasm_bindgen;
 
+use super::cipher::CipherKind;
 use crate::VaultParseError;
 
 #[allow(missing_docs)]
@@ -552,6 +553,18 @@ impl TryFrom<bitwarden_api_api::models::CipherFido2CredentialModel> for Fido2Cre
             discoverable: require!(value.discoverable).parse()?,
             creation_date: value.creation_date.parse()?,
         })
+    }
+}
+
+impl CipherKind for Login {
+    fn decrypt_subtitle(
+        &self,
+        ctx: &mut KeyStoreContext<KeyIds>,
+        key: SymmetricKeyId,
+    ) -> Result<String, CryptoError> {
+        let username: Option<String> = self.username.decrypt(ctx, key)?;
+
+        Ok(username.unwrap_or_default())
     }
 }
 


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

https://bitwarden.atlassian.net/browse/PM-22647

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

`Cipher` is currently non idiomatic rust due to a desire to simplify the conversion layers and to accurately replicate existing behaviour. This has some disadvantages such as `Cipher` having to own all business logic even if it really belongs to one of the cipher types.

This PR introduces a `CipherKind` enum which should be implemented by all cipher types. It also introduces a `get_kind` helper on `Cipher` which resolves the accurate `CipherKind` depending on cipher type. This allows us to delegate implementations to the relevant cipher kind avoiding complex match statements in `Cipher`.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation
  team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
