### PR TITLE
[BRE-848] Add Workflow Permissions

### DIFF
--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -23,6 +23,9 @@ jobs:
           - target: armv7-linux-androideabi
           - target: x86_64-linux-android
           - target: i686-linux-android
+    permissions:
+      contents: read
+
     steps:
       - name: Checkout repo
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -56,6 +59,10 @@ jobs:
     name: Combine
     runs-on: ubuntu-24.04
     needs: build
+    permissions:
+      contents: read
+      packages: write
+
     steps:
       - name: Checkout repo (PR)
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/build-rust-crates.yml
+++ b/.github/workflows/build-rust-crates.yml
@@ -10,6 +10,9 @@ on:
 env:
   CARGO_TERM_COLOR: always
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Building ${{matrix.package}} for - ${{ matrix.os }}

--- a/.github/workflows/check-powerset.yml
+++ b/.github/workflows/check-powerset.yml
@@ -6,6 +6,9 @@ on:
 env:
   CARGO_TERM_COLOR: always
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Building for ${{ matrix.os }}

--- a/.github/workflows/cloc.yml
+++ b/.github/workflows/cloc.yml
@@ -6,6 +6,9 @@ on:
     branches: ["main"]
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   cloc:
     name: CLOC

--- a/.github/workflows/direct-minimal-versions.yml
+++ b/.github/workflows/direct-minimal-versions.yml
@@ -13,6 +13,9 @@ defaults:
   run:
     shell: bash
 
+permissions:
+  contents: read
+
 jobs:
   direct-minimal-versions:
     name: Check dependencies minimal versions for - ${{ matrix.settings.os }} - ${{ matrix.settings.target }}

--- a/.github/workflows/enforce-labels.yml
+++ b/.github/workflows/enforce-labels.yml
@@ -4,6 +4,11 @@ on:
   workflow_call:
   pull_request:
     types: [labeled, unlabeled, opened, edited, synchronize]
+
+permissions:
+  contents: read
+  pull-requests: read
+
 jobs:
   enforce-label:
     name: EnforceLabel

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,6 +9,9 @@ on:
 env:
   CARGO_TERM_COLOR: always
 
+permissions:
+  contents: read
+
 jobs:
   style:
     name: Check Style

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,9 +11,6 @@ permissions: {}
 env:
   CARGO_TERM_COLOR: always
 
-permissions:
-  contents: read
-
 jobs:
   style:
     name: Check Style

--- a/.github/workflows/memory-testing.yml
+++ b/.github/workflows/memory-testing.yml
@@ -14,6 +14,9 @@ on:
       - "rc"
       - "hotfix-rc"
 
+permissions:
+  contents: read
+
 jobs:
   memory-test:
     name: Testing

--- a/.github/workflows/minimum-rust-version.yml
+++ b/.github/workflows/minimum-rust-version.yml
@@ -13,6 +13,9 @@ defaults:
   run:
     shell: bash
 
+permissions:
+  contents: read
+
 jobs:
   msrv:
     name: Check MSRV for - ${{ matrix.settings.os }} - ${{ matrix.settings.target }}

--- a/.github/workflows/release-rust-crates.yml
+++ b/.github/workflows/release-rust-crates.yml
@@ -17,6 +17,8 @@ jobs:
   setup:
     name: Setup
     runs-on: ubuntu-24.04
+    permissions:
+      contents: write
     outputs:
       release-version: ${{ steps.version.outputs.version }}
     steps:

--- a/.github/workflows/rust-test.yml
+++ b/.github/workflows/rust-test.yml
@@ -10,6 +10,9 @@ on:
 env:
   CARGO_TERM_COLOR: always
 
+permissions:
+  contents: read
+
 jobs:
   ci-pass:
     name: Check if tests passed


### PR DESCRIPTION
## 🎟️ Tracking

[BRE-848](https://bitwarden.atlassian.net/browse/BRE-848)

## 📔 Objective

Adding permissions to all workflows not being updated by [BRE-831](https://bitwarden.atlassian.net/browse/BRE-831)
This will prepare for changing the org wide GitHub actions setting to `contents:read` and `packages:read` as the default permissions provided to workflows.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes

[BRE-848]: https://bitwarden.atlassian.net/browse/BRE-848?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BRE-831]: https://bitwarden.atlassian.net/browse/BRE-831?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ