### PR TITLE
Lift in user_id into login method

### DIFF
--- a/crates/bitwarden-core/src/auth/auth_client.rs
+++ b/crates/bitwarden-core/src/auth/auth_client.rs
@@ -2,6 +2,8 @@
 use bitwarden_crypto::{
     CryptoError, DeviceKey, EncString, Kdf, TrustDeviceResponse, UnsignedSharedKey,
 };
+#[cfg(feature = "internal")]
+use uuid::Uuid;
 
 #[cfg(feature = "secrets")]
 use crate::auth::login::{login_access_token, AccessTokenLoginRequest, AccessTokenLoginResponse};
@@ -91,8 +93,15 @@ impl AuthClient {
         email: String,
         org_public_key: String,
         remember_device: bool,
+        user_id: Uuid,
     ) -> Result<RegisterTdeKeyResponse, EncryptionSettingsError> {
-        make_register_tde_keys(&self.client, email, org_public_key, remember_device)
+        make_register_tde_keys(
+            &self.client,
+            email,
+            org_public_key,
+            remember_device,
+            user_id,
+        )
     }
 
     #[allow(missing_docs)]

--- a/crates/bitwarden-core/src/auth/auth_request.rs
+++ b/crates/bitwarden-core/src/auth/auth_request.rs
@@ -241,7 +241,7 @@ mod tests {
         new_device
             .crypto()
             .initialize_user_crypto(InitUserCryptoRequest {
-                user_id: Some(uuid::Uuid::new_v4()),
+                user_id: uuid::Uuid::new_v4(),
                 kdf_params: kdf,
                 email: email.to_owned(),
                 private_key,

--- a/crates/bitwarden-core/src/auth/login/api_key.rs
+++ b/crates/bitwarden-core/src/auth/login/api_key.rs
@@ -39,14 +39,15 @@ pub(crate) async fn login_api_key(
 
         let master_key = MasterKey::derive(&input.password, &email, &kdf)?;
 
-        client
-            .internal
-            .set_login_method(LoginMethod::User(UserLoginMethod::ApiKey {
+        client.internal.set_login_method(LoginMethod::User {
+            method: UserLoginMethod::ApiKey {
                 client_id: input.client_id.to_owned(),
                 client_secret: input.client_secret.to_owned(),
                 email,
                 kdf,
-            }));
+            },
+            user_id: access_token_obj.sub.parse()?,
+        });
 
         let user_key: EncString = require!(r.key.as_deref()).parse()?;
         let private_key: EncString = require!(r.private_key.as_deref()).parse()?;

--- a/crates/bitwarden-core/src/auth/login/mod.rs
+++ b/crates/bitwarden-core/src/auth/login/mod.rs
@@ -42,6 +42,8 @@ pub enum LoginError {
     Serde(#[from] serde_json::Error),
     #[error(transparent)]
     InvalidBase64(#[from] base64::DecodeError),
+    #[error(transparent)]
+    Uuid(#[from] uuid::Error),
 
     #[error(transparent)]
     MissingField(#[from] crate::MissingFieldError),

--- a/crates/bitwarden-core/src/auth/password/validate.rs
+++ b/crates/bitwarden-core/src/auth/password/validate.rs
@@ -53,6 +53,7 @@ pub(crate) fn validate_password_user_key(
         .get_login_method()
         .ok_or(NotAuthenticatedError)?;
 
+    #[allow(irrefutable_let_patterns)]
     if let LoginMethod::User {
         method: login_method,
         ..

--- a/crates/bitwarden-core/src/auth/password/validate.rs
+++ b/crates/bitwarden-core/src/auth/password/validate.rs
@@ -18,7 +18,11 @@ pub(crate) fn validate_password(
         .ok_or(NotAuthenticatedError)?;
 
     #[allow(irrefutable_let_patterns)]
-    if let LoginMethod::User(login_method) = login_method.as_ref() {
+    if let LoginMethod::User {
+        method: login_method,
+        ..
+    } = login_method.as_ref()
+    {
         match login_method {
             UserLoginMethod::Username { email, kdf, .. }
             | UserLoginMethod::ApiKey { email, kdf, .. } => {
@@ -49,8 +53,11 @@ pub(crate) fn validate_password_user_key(
         .get_login_method()
         .ok_or(NotAuthenticatedError)?;
 
-    #[allow(irrefutable_let_patterns)]
-    if let LoginMethod::User(login_method) = login_method.as_ref() {
+    if let LoginMethod::User {
+        method: login_method,
+        ..
+    } = login_method.as_ref()
+    {
         match login_method {
             UserLoginMethod::Username { email, kdf, .. }
             | UserLoginMethod::ApiKey { email, kdf, .. } => {
@@ -91,15 +98,16 @@ mod tests {
         use crate::client::{Client, LoginMethod, UserLoginMethod};
 
         let client = Client::new(None);
-        client
-            .internal
-            .set_login_method(LoginMethod::User(UserLoginMethod::Username {
+        client.internal.set_login_method(LoginMethod::User {
+            method: UserLoginMethod::Username {
                 email: "test@bitwarden.com".to_string(),
                 kdf: Kdf::PBKDF2 {
                     iterations: NonZeroU32::new(100_000).unwrap(),
                 },
                 client_id: "1".to_string(),
-            }));
+            },
+            user_id: uuid::Uuid::new_v4(),
+        });
 
         let password = "password123".to_string();
         let password_hash = "7kTqkF1pY/3JeOu73N9kR99fDDe9O1JOZaVc7KH3lsU=".to_string();
@@ -125,13 +133,14 @@ mod tests {
             iterations: NonZeroU32::new(600_000).unwrap(),
         };
 
-        client
-            .internal
-            .set_login_method(LoginMethod::User(UserLoginMethod::Username {
+        client.internal.set_login_method(LoginMethod::User {
+            method: UserLoginMethod::Username {
                 email: email.to_string(),
                 kdf: kdf.clone(),
                 client_id: "1".to_string(),
-            }));
+            },
+            user_id: uuid::Uuid::new_v4(),
+        });
 
         let master_key = MasterKey::derive(password, email, &kdf).unwrap();
 
@@ -173,13 +182,14 @@ mod tests {
             iterations: NonZeroU32::new(600_000).unwrap(),
         };
 
-        client
-            .internal
-            .set_login_method(LoginMethod::User(UserLoginMethod::Username {
+        client.internal.set_login_method(LoginMethod::User {
+            method: UserLoginMethod::Username {
                 email: email.to_string(),
                 kdf: kdf.clone(),
                 client_id: "1".to_string(),
-            }));
+            },
+            user_id: uuid::Uuid::new_v4(),
+        });
 
         let master_key = MasterKey::derive(password, email, &kdf).unwrap();
 

--- a/crates/bitwarden-core/src/auth/pin.rs
+++ b/crates/bitwarden-core/src/auth/pin.rs
@@ -18,7 +18,11 @@ pub(crate) fn validate_pin(
         .ok_or(NotAuthenticatedError)?;
 
     #[allow(irrefutable_let_patterns)]
-    let LoginMethod::User(login_method) = login_method.as_ref() else {
+    let LoginMethod::User {
+        method: login_method,
+        ..
+    } = login_method.as_ref()
+    else {
         return Err(NotAuthenticatedError)?;
     };
 
@@ -47,6 +51,7 @@ mod tests {
     use std::num::NonZeroU32;
 
     use bitwarden_crypto::{Kdf, MasterKey};
+    use uuid::Uuid;
 
     use super::*;
     use crate::client::{Client, LoginMethod, UserLoginMethod};
@@ -60,13 +65,14 @@ mod tests {
             iterations: NonZeroU32::new(600_000).unwrap(),
         };
 
-        client
-            .internal
-            .set_login_method(LoginMethod::User(UserLoginMethod::Username {
+        client.internal.set_login_method(LoginMethod::User {
+            method: UserLoginMethod::Username {
                 email: email.to_string(),
                 kdf: kdf.clone(),
                 client_id: "1".to_string(),
-            }));
+            },
+            user_id: Uuid::new_v4(),
+        });
 
         let master_key = MasterKey::derive(password, email, &kdf).unwrap();
 

--- a/crates/bitwarden-core/src/auth/renew.rs
+++ b/crates/bitwarden-core/src/auth/renew.rs
@@ -40,7 +40,7 @@ pub(crate) async fn renew_token(client: &InternalClient) -> Result<(), LoginErro
             .clone();
 
         let res = match login_method.as_ref() {
-            LoginMethod::User(u) => match u {
+            LoginMethod::User { method: u, .. } => match u {
                 UserLoginMethod::Username { client_id, .. } => {
                     let refresh = tokens.refresh_token.ok_or(NotAuthenticatedError)?;
 

--- a/crates/bitwarden-core/src/auth/tde.rs
+++ b/crates/bitwarden-core/src/auth/tde.rs
@@ -3,6 +3,7 @@ use bitwarden_crypto::{
     AsymmetricPublicCryptoKey, DeviceKey, EncString, Kdf, SymmetricCryptoKey, TrustDeviceResponse,
     UnsignedSharedKey, UserKey,
 };
+use uuid::Uuid;
 
 use crate::{client::encryption_settings::EncryptionSettingsError, Client};
 
@@ -14,6 +15,7 @@ pub(super) fn make_register_tde_keys(
     email: String,
     org_public_key: String,
     remember_device: bool,
+    user_id: Uuid,
 ) -> Result<RegisterTdeKeyResponse, EncryptionSettingsError> {
     let public_key = AsymmetricPublicCryptoKey::from_der(&STANDARD.decode(org_public_key)?)?;
 
@@ -30,13 +32,14 @@ pub(super) fn make_register_tde_keys(
 
     client
         .internal
-        .set_login_method(crate::client::LoginMethod::User(
-            crate::client::UserLoginMethod::Username {
+        .set_login_method(crate::client::LoginMethod::User {
+            user_id,
+            method: crate::client::UserLoginMethod::Username {
                 client_id: "".to_owned(),
                 email,
                 kdf: Kdf::default(),
             },
-        ));
+        });
     client.internal.initialize_user_crypto_decrypted_key(
         user_key.0,
         key_pair.private.clone(),

--- a/crates/bitwarden-core/src/client/client.rs
+++ b/crates/bitwarden-core/src/client/client.rs
@@ -1,4 +1,4 @@
-use std::sync::{Arc, OnceLock, RwLock};
+use std::sync::{Arc, RwLock};
 
 use bitwarden_crypto::KeyStore;
 use reqwest::header::{self, HeaderValue};
@@ -76,7 +76,6 @@ impl Client {
 
         Self {
             internal: Arc::new(InternalClient {
-                user_id: OnceLock::new(),
                 tokens: RwLock::new(Tokens::default()),
                 login_method: RwLock::new(None),
                 #[cfg(feature = "internal")]

--- a/crates/bitwarden-core/src/client/encryption_settings.rs
+++ b/crates/bitwarden-core/src/client/encryption_settings.rs
@@ -9,7 +9,7 @@ use uuid::Uuid;
 
 #[cfg(any(feature = "internal", feature = "secrets"))]
 use crate::key_management::{KeyIds, SymmetricKeyId};
-use crate::{error::UserIdAlreadySetError, MissingPrivateKeyError, VaultLockedError};
+use crate::{MissingPrivateKeyError, VaultLockedError};
 
 #[allow(missing_docs)]
 #[bitwarden_error(flat)]
@@ -29,9 +29,6 @@ pub enum EncryptionSettingsError {
 
     #[error(transparent)]
     MissingPrivateKey(#[from] MissingPrivateKeyError),
-
-    #[error(transparent)]
-    UserIdAlreadySetError(#[from] UserIdAlreadySetError),
 }
 
 #[allow(missing_docs)]

--- a/crates/bitwarden-core/src/client/internal.rs
+++ b/crates/bitwarden-core/src/client/internal.rs
@@ -181,7 +181,7 @@ impl InternalClient {
         &self.key_store
     }
 
-    #[allow(missing_docs)]
+    /// Returns the user's ID if logged in as a user.
     pub fn get_user_id(&self) -> Option<Uuid> {
         match self
             .login_method

--- a/crates/bitwarden-core/src/client/login_method.rs
+++ b/crates/bitwarden-core/src/client/login_method.rs
@@ -2,7 +2,6 @@
 use std::path::PathBuf;
 
 use bitwarden_crypto::Kdf;
-#[cfg(feature = "secrets")]
 use uuid::Uuid;
 
 #[cfg(feature = "secrets")]

--- a/crates/bitwarden-core/src/client/login_method.rs
+++ b/crates/bitwarden-core/src/client/login_method.rs
@@ -11,7 +11,10 @@ use crate::auth::AccessToken;
 #[derive(Debug)]
 pub(crate) enum LoginMethod {
     #[allow(dead_code)]
-    User(UserLoginMethod),
+    User {
+        user_id: Uuid,
+        method: UserLoginMethod,
+    },
     // TODO: Organizations supports api key
     // Organization(OrganizationLoginMethod),
     #[cfg(feature = "secrets")]

--- a/crates/bitwarden-core/src/client/test_accounts.rs
+++ b/crates/bitwarden-core/src/client/test_accounts.rs
@@ -118,7 +118,7 @@ pub struct TestAccount {
 pub fn test_bitwarden_com_account() -> TestAccount {
     TestAccount {
         user: InitUserCryptoRequest {
-            user_id: Some(uuid::uuid!("060000fb-0922-4dd3-b170-6e15cb5df8c8")),
+            user_id: uuid::uuid!("060000fb-0922-4dd3-b170-6e15cb5df8c8"),
             kdf_params: Kdf::PBKDF2 {
                 iterations: 600_000.try_into().unwrap(),
             },
@@ -178,7 +178,7 @@ pub fn test_bitwarden_com_account() -> TestAccount {
 pub fn test_legacy_user_key_account() -> TestAccount {
     TestAccount {
         user: InitUserCryptoRequest {
-            user_id: Some(uuid::uuid!("060000fb-0922-4dd3-b170-6e15cb5df8c8")),
+            user_id: uuid::uuid!("060000fb-0922-4dd3-b170-6e15cb5df8c8"),
             kdf_params: Kdf::PBKDF2 {
                 iterations: 600_000.try_into().unwrap(),
             },

--- a/crates/bitwarden-core/src/error.rs
+++ b/crates/bitwarden-core/src/error.rs
@@ -48,11 +48,6 @@ impl_bitwarden_error!(IdentityError, ApiError);
 #[error("The client is not authenticated or the session has expired")]
 pub struct NotAuthenticatedError;
 
-/// Client's user ID is already set.
-#[derive(Debug, Error)]
-#[error("The client user ID is already set")]
-pub struct UserIdAlreadySetError;
-
 /// Missing required field.
 #[derive(Debug, Error)]
 #[error("The response received was missing a required field: {0}")]

--- a/crates/bitwarden-core/src/platform/get_user_api_key.rs
+++ b/crates/bitwarden-core/src/platform/get_user_api_key.rs
@@ -78,7 +78,11 @@ fn build_secret_verification_request(
     login_method: &LoginMethod,
     input: &SecretVerificationRequest,
 ) -> Result<SecretVerificationRequestModel, UserApiKeyError> {
-    if let LoginMethod::User(UserLoginMethod::Username { email, kdf, .. }) = login_method {
+    if let LoginMethod::User {
+        method: UserLoginMethod::Username { email, kdf, .. },
+        ..
+    } = login_method
+    {
         let master_password_hash = input
             .master_password
             .as_ref()

--- a/crates/bitwarden-core/tests/register.rs
+++ b/crates/bitwarden-core/tests/register.rs
@@ -29,7 +29,7 @@ async fn test_register_initialize_crypto() {
     client
         .crypto()
         .initialize_user_crypto(InitUserCryptoRequest {
-            user_id: Some(uuid::Uuid::new_v4()),
+            user_id: uuid::Uuid::new_v4(),
             kdf_params: kdf,
             email: email.to_owned(),
             private_key: register_response.keys.private,

--- a/crates/bitwarden-uniffi/kotlin/app/src/main/java/com/bitwarden/myapplication/MainActivity.kt
+++ b/crates/bitwarden-uniffi/kotlin/app/src/main/java/com/bitwarden/myapplication/MainActivity.kt
@@ -250,7 +250,7 @@ class MainActivity : FragmentActivity() {
 
         client.crypto().initializeUserCrypto(
             InitUserCryptoRequest(
-                userId = null,
+                userId = "fc0243b7-38f8-4f9c-af7e-e459298eefc3",
                 kdfParams = kdf,
                 email = EMAIL,
                 privateKey = loginBody.PrivateKey,
@@ -336,7 +336,7 @@ class MainActivity : FragmentActivity() {
             GlobalScope.launch {
                 client.crypto().initializeUserCrypto(
                     InitUserCryptoRequest(
-                        userId = null,
+                        userId = "fc0243b7-38f8-4f9c-af7e-e459298eefc3",
                         kdfParams = kdf,
                         email = EMAIL,
                         privateKey = privateKey!!,
@@ -375,7 +375,7 @@ class MainActivity : FragmentActivity() {
         GlobalScope.launch {
             client.crypto().initializeUserCrypto(
                 InitUserCryptoRequest(
-                    userId = null,
+                    userId = "fc0243b7-38f8-4f9c-af7e-e459298eefc3",
                     kdfParams = kdf,
                     email = EMAIL,
                     privateKey = privateKey!!,

--- a/crates/bitwarden-uniffi/src/auth/mod.rs
+++ b/crates/bitwarden-uniffi/src/auth/mod.rs
@@ -3,6 +3,7 @@ use bitwarden_core::auth::{
     RegisterKeyResponse, RegisterTdeKeyResponse,
 };
 use bitwarden_crypto::{EncString, HashPurpose, Kdf, TrustDeviceResponse, UnsignedSharedKey};
+use uuid::Uuid;
 
 use crate::error::{Error, Result};
 
@@ -69,11 +70,12 @@ impl AuthClient {
         email: String,
         org_public_key: String,
         remember_device: bool,
+        user_id: Uuid,
     ) -> Result<RegisterTdeKeyResponse> {
         Ok(self
             .0
             .auth()
-            .make_register_tde_keys(email, org_public_key, remember_device)
+            .make_register_tde_keys(email, org_public_key, remember_device, user_id)
             .map_err(Error::EncryptionSettings)?)
     }
 

--- a/crates/bitwarden-uniffi/swift/iOS/App/ContentView.swift
+++ b/crates/bitwarden-uniffi/swift/iOS/App/ContentView.swift
@@ -189,7 +189,7 @@ struct ContentView: View {
 
         try await clientCrypto.initializeUserCrypto(
             req: InitUserCryptoRequest(
-                userId: nil,
+                userId: "fc0243b7-38f8-4f9c-af7e-e459298eefc3",
                 kdfParams: kdf,
                 email: EMAIL,
                 privateKey: loginData.PrivateKey,
@@ -248,7 +248,7 @@ struct ContentView: View {
         let key = biometricRetrieveValue()!
 
         try await clientCrypto.initializeUserCrypto(req: InitUserCryptoRequest(
-            userId: nil,
+            userId: "fc0243b7-38f8-4f9c-af7e-e459298eefc3",
             kdfParams: kdf,
             email: EMAIL,
             privateKey: privateKey,
@@ -276,7 +276,7 @@ struct ContentView: View {
         let pinProtectedUserKey = defaults.string(forKey: "pinProtectedUserKey")!
 
         try await clientCrypto.initializeUserCrypto(req: InitUserCryptoRequest(
-            userId: nil,
+            userId: "fc0243b7-38f8-4f9c-af7e-e459298eefc3",
             kdfParams: kdf,
             email: EMAIL,
             privateKey: privateKey,


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Refactors `user_id` to be part of the Login Method. This seems like a more logical place to put it since in a fully SDK based flow you can always get the id as part of the access token. And it decreases us from three states to two.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation
  team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
