### PR TITLE
[PM-22844] Fix enrollment of signing keys

### DIFF
--- a/crates/bitwarden-core/src/key_management/crypto.rs
+++ b/crates/bitwarden-core/src/key_management/crypto.rs
@@ -595,9 +595,12 @@ pub fn make_user_signing_keys_for_enrollment(
 
     // Make new keypair and sign the public key with it
     let signature_keypair = SigningKey::make(SignatureAlgorithm::Ed25519);
+    let temporary_signature_keypair_id = SigningKeyId::Local("temporary_key_for_rotation");
+    #[allow(deprecated)]
+    ctx.set_signing_key(temporary_signature_keypair_id, signature_keypair.clone())?;
     let signed_public_key = ctx.make_signed_public_key(
         AsymmetricKeyId::UserPrivateKey,
-        SigningKeyId::UserSigningKey,
+        temporary_signature_keypair_id,
     )?;
 
     Ok(MakeUserSigningKeysResponse {

--- a/crates/bitwarden-core/src/key_management/mod.rs
+++ b/crates/bitwarden-core/src/key_management/mod.rs
@@ -34,6 +34,8 @@ key_ids! {
     #[signing]
     pub enum SigningKeyId {
         UserSigningKey,
+        #[local]
+        Local(&'static str),
     }
 
     pub KeyIds => SymmetricKeyId, AsymmetricKeyId, SigningKeyId;


### PR DESCRIPTION
## 🎟️ Tracking
https://bitwarden.atlassian.net/browse/PM-22844

## 📔 Objective

Enrollment of signing keys used the user state's signature keypair to create a signed public key. However, this is not available at the time of enrolling into signing keys yet, and thus creation fails. This PR fixes this by setting the just-created signature key to the local context, and using this local key.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation
  team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
