### PR TITLE
Ignore the error when setting the user id twice to the same value

### DIFF
--- a/crates/bitwarden-core/src/client/internal.rs
+++ b/crates/bitwarden-core/src/client/internal.rs
@@ -184,25 +184,15 @@ impl InternalClient {
 
     #[allow(missing_docs)]
     pub fn init_user_id(&self, user_id: Uuid) -> Result<(), UserIdAlreadySetError> {
-        let mut value = Some(user_id);
-        let set_uuid = self
-            .user_id
-            .get_or_init(|| value.take().expect("Value is Some"));
+        let set_uuid = self.user_id.get_or_init(|| user_id);
 
-        match value {
-            // If this is none, that means the user_id was not set before
-            None => Ok(()),
-            // If this is some, it means the user_id was already set
-            Some(_) => {
-                // Only return an error if the user_id is already set to a different value,
-                // as we want an SDK client to be tied to a single user_id.
-                // If it's the same value, we can just do nothing.
-                if *set_uuid != user_id {
-                    Err(UserIdAlreadySetError)
-                } else {
-                    Ok(())
-                }
-            }
+        // Only return an error if the user_id is already set to a different value,
+        // as we want an SDK client to be tied to a single user_id.
+        // If it's the same value, we can just do nothing.
+        if *set_uuid != user_id {
+            Err(UserIdAlreadySetError)
+        } else {
+            Ok(())
         }
     }
 


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective

The mobile clients will call `init_crypto` multiple times on the same client if the user types the wrong password/pin.

The simplest fix here is to make it so that `init_user_id` only errors when there is an attempted UUID change, and trying to set the same UUID is just ignored. The UUID will only be set the very first call either way.

Ideally we'd do as mentioned in  #278, and just provide this ID during initialization once we have a pure/user-bound client split, but that's a bigger API break.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation
  team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
