### PR TITLE
[PM-22812] Attachments get corrupted when downgrading from cipherkeys

### DIFF
--- a/crates/bitwarden-vault/src/cipher/attachment.rs
+++ b/crates/bitwarden-vault/src/cipher/attachment.rs
@@ -172,6 +172,7 @@ impl Decryptable<KeyIds, SymmetricKeyId, AttachmentView> for Attachment {
         ctx: &mut KeyStoreContext<KeyIds>,
         key: SymmetricKeyId,
     ) -> Result<AttachmentView, CryptoError> {
+        #[cfg(feature = "wasm")]
         let decrypted_key = if let Some(attachment_key) = &self.key {
             let content_key_id = ctx.unwrap_symmetric_key(key, ATTACHMENT_KEY, attachment_key)?;
 

--- a/crates/bitwarden-vault/src/cipher/attachment.rs
+++ b/crates/bitwarden-vault/src/cipher/attachment.rs
@@ -43,7 +43,7 @@ pub struct AttachmentView {
     /// process. It will be removed once the encryption/decryption logic is
     /// fully migrated to the SDK.
     ///
-    /// **Ticket**: https://bitwarden.atlassian.net/browse/PM-23005
+    /// **Ticket**: <https://bitwarden.atlassian.net/browse/PM-23005>
     ///
     /// Do not rely on this field for long-term use.
     #[cfg(feature = "wasm")]

--- a/crates/bitwarden-vault/src/cipher/attachment.rs
+++ b/crates/bitwarden-vault/src/cipher/attachment.rs
@@ -36,6 +36,18 @@ pub struct AttachmentView {
     pub size_name: Option<String>,
     pub file_name: Option<String>,
     pub key: Option<EncString>,
+    /// The decrypted attachmentkey in base64 format.
+    ///
+    /// **TEMPORARY FIELD**: This field is a temporary workaround to provide
+    /// decrypted attachment keys to the TypeScript client during the migration
+    /// process. It will be removed once the encryption/decryption logic is
+    /// fully migrated to the SDK.
+    ///
+    /// **Ticket**: https://bitwarden.atlassian.net/browse/PM-23005
+    ///
+    /// Do not rely on this field for long-term use.
+    #[cfg(feature = "wasm")]
+    pub decrypted_key: Option<String>,
 }
 
 #[allow(missing_docs)]
@@ -160,6 +172,17 @@ impl Decryptable<KeyIds, SymmetricKeyId, AttachmentView> for Attachment {
         ctx: &mut KeyStoreContext<KeyIds>,
         key: SymmetricKeyId,
     ) -> Result<AttachmentView, CryptoError> {
+        let decrypted_key = if let Some(attachment_key) = &self.key {
+            let content_key_id = ctx.unwrap_symmetric_key(key, ATTACHMENT_KEY, attachment_key)?;
+
+            #[allow(deprecated)]
+            let actual_key = ctx.dangerous_get_symmetric_key(content_key_id)?;
+
+            Some(actual_key.to_base64())
+        } else {
+            None
+        };
+
         Ok(AttachmentView {
             id: self.id.clone(),
             url: self.url.clone(),
@@ -167,6 +190,8 @@ impl Decryptable<KeyIds, SymmetricKeyId, AttachmentView> for Attachment {
             size_name: self.size_name.clone(),
             file_name: self.file_name.decrypt(ctx, key)?,
             key: self.key.clone(),
+            #[cfg(feature = "wasm")]
+            decrypted_key,
         })
     }
 }
@@ -223,6 +248,7 @@ mod tests {
             size_name: Some("100 Bytes".into()),
             file_name: Some("Test.txt".into()),
             key: None,
+            decrypted_key: None,
         };
 
         let contents = b"This is a test file that we will encrypt. It's 100 bytes long, the encrypted version will be longer!";
@@ -279,6 +305,7 @@ mod tests {
             size_name: Some("161 Bytes".into()),
             file_name: Some("Test.txt".into()),
             key: Some("2.r288/AOSPiaLFkW07EBGBw==|SAmnnCbOLFjX5lnURvoualOetQwuyPc54PAmHDTRrhT0gwO9ailna9U09q9bmBfI5XrjNNEsuXssgzNygRkezoVQvZQggZddOwHB6KQW5EQ=|erIMUJp8j+aTcmhdE50zEX+ipv/eR1sZ7EwULJm/6DY=".parse().unwrap()),
+            decrypted_key: None,
         };
 
         let cipher  = Cipher {
@@ -336,6 +363,7 @@ mod tests {
             size_name: Some("161 Bytes".into()),
             file_name: Some("Test.txt".into()),
             key: None,
+            decrypted_key: None,
         };
 
         let cipher  = Cipher {

--- a/crates/bitwarden-vault/src/cipher/cipher.rs
+++ b/crates/bitwarden-vault/src/cipher/cipher.rs
@@ -343,7 +343,7 @@ impl Decryptable<KeyIds, SymmetricKeyId, CipherView> for Cipher {
             permissions: self.permissions,
             view_password: self.view_password,
             local_data: self.local_data.decrypt(ctx, ciphers_key).ok().flatten(),
-            attachments: self.attachments.decrypt(ctx, ciphers_key).ok().flatten(),
+            attachments: self.attachments.decrypt(ctx, ciphers_key)?,
             fields: self.fields.decrypt(ctx, ciphers_key).ok().flatten(),
             password_history: self
                 .password_history
@@ -962,6 +962,7 @@ mod tests {
             size_name: None,
             file_name: Some("Attachment test name".into()),
             key: None,
+            decrypted_key: None,
         };
         cipher.attachments = Some(vec![attachment]);
 
@@ -1031,6 +1032,7 @@ mod tests {
             size_name: None,
             file_name: Some("Attachment test name".into()),
             key: None,
+            decrypted_key: None,
         };
         cipher.attachments = Some(vec![attachment]);
 
@@ -1074,6 +1076,7 @@ mod tests {
             size_name: None,
             file_name: Some("Attachment test name".into()),
             key: Some(attachment_key_enc),
+            decrypted_key: None,
         };
         cipher.attachments = Some(vec![attachment]);
         let cred = generate_fido2(&mut key_store.context(), SymmetricKeyId::User);
@@ -1141,6 +1144,7 @@ mod tests {
             size_name: None,
             file_name: Some("Attachment test name".into()),
             key: Some(attachment_key_enc.clone()),
+            decrypted_key: None,
         };
         cipher.attachments = Some(vec![attachment]);
 

--- a/crates/bitwarden-vault/src/cipher/cipher.rs
+++ b/crates/bitwarden-vault/src/cipher/cipher.rs
@@ -343,7 +343,7 @@ impl Decryptable<KeyIds, SymmetricKeyId, CipherView> for Cipher {
             permissions: self.permissions,
             view_password: self.view_password,
             local_data: self.local_data.decrypt(ctx, ciphers_key).ok().flatten(),
-            attachments: self.attachments.decrypt(ctx, ciphers_key)?,
+            attachments: self.attachments.decrypt(ctx, ciphers_key).ok().flatten(),
             fields: self.fields.decrypt(ctx, ciphers_key).ok().flatten(),
             password_history: self
                 .password_history


### PR DESCRIPTION
## 🎟️ Tracking
https://bitwarden.atlassian.net/browse/PM-22812
<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective
Editing a cipher with attachments causes attachment corruption when switching between cipher-key encryption and user-key encryption in either direction. The SDK's AttachmentView was not providing the decrypted attachment key needed for re-encryption scenarios. When the cipher gets re-encrypted between different encryption contexts (cipher-key ↔ user-key) during save, the client needs the decrypted attachment key to properly re-encrypt it under the new encryption context. Without this, null gets posted for the attachment key, breaking decryption.

This is a temporary solution during the migration from TypeScript to the SDK. The decrypted_key field should be removed once all encryption logic is handled within the SDK.

Cleanup tracked in: https://bitwarden.atlassian.net/browse/PM-23005
<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation
  team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
