### PR TITLE
[PM-22136] Expose encrypt_fido2_credentials to support cipher encryption in TS clients

### DIFF
--- a/crates/bitwarden-vault/src/cipher/cipher_client.rs
+++ b/crates/bitwarden-vault/src/cipher/cipher_client.rs
@@ -6,7 +6,7 @@ use wasm_bindgen::prelude::*;
 use super::EncryptionContext;
 use crate::{
     Cipher, CipherError, CipherListView, CipherView, DecryptError, EncryptError,
-    Fido2CredentialFullView, Fido2CredentialView,
+    Fido2CredentialFullView,
 };
 
 #[allow(missing_docs)]

--- a/crates/bitwarden-vault/src/cipher/cipher_client.rs
+++ b/crates/bitwarden-vault/src/cipher/cipher_client.rs
@@ -1,10 +1,10 @@
 use bitwarden_core::{Client, OrganizationId};
-use bitwarden_crypto::IdentifyKey;
+use bitwarden_crypto::{Encryptable, IdentifyKey};
 #[cfg(feature = "wasm")]
 use wasm_bindgen::prelude::*;
 
 use super::EncryptionContext;
-use crate::{Cipher, CipherError, CipherListView, CipherView, DecryptError, EncryptError};
+use crate::{Cipher, CipherError, CipherListView, CipherView, DecryptError, EncryptError, Fido2CredentialFullView, Fido2CredentialView};
 
 #[allow(missing_docs)]
 #[cfg_attr(feature = "wasm", wasm_bindgen)]
@@ -65,6 +65,24 @@ impl CiphersClient {
         let key_store = self.client.internal.get_key_store();
         let credentials = cipher_view.decrypt_fido2_credentials(&mut key_store.context())?;
         Ok(credentials)
+    }
+    
+    /// Temporary method used to re-encrypt FIDO2 credentials for a cipher view. 
+    /// Necessary while the FIDO2 credentials remain in the LoginView in an encrypted form.
+    /// Used by the TS clients to encrypt FIDO2 credentials separately before encrypting the remaining cipher view.
+    /// TODO: Remove once FIDO2 credentials have been removed from the LoginView.
+    pub fn encrypt_fido2_credentials(
+        &self,
+        cipher_view: CipherView,
+        fido2_credentials: Fido2CredentialFullView,
+    ) -> Result<crate::Fido2Credential, EncryptError> {
+        let key_store = self.client.internal.get_key_store();
+        let key = cipher_view.key_identifier();
+        let cipher_key = Cipher::decrypt_cipher_key(&mut key_store.context(), key, &cipher_view.key)?;
+        
+        let fido2_credential = fido2_credentials.encrypt(&mut key_store.context(), cipher_key)?;
+        
+        Ok(fido2_credential)
     }
 
     #[allow(missing_docs)]

--- a/crates/bitwarden-vault/src/cipher/cipher_client.rs
+++ b/crates/bitwarden-vault/src/cipher/cipher_client.rs
@@ -1,5 +1,5 @@
 use bitwarden_core::{Client, OrganizationId};
-use bitwarden_crypto::{CompositeEncryptable, IdentifyKey};
+use bitwarden_crypto::IdentifyKey;
 #[cfg(feature = "wasm")]
 use wasm_bindgen::prelude::*;
 

--- a/crates/bitwarden-vault/src/cipher/cipher_client.rs
+++ b/crates/bitwarden-vault/src/cipher/cipher_client.rs
@@ -4,7 +4,10 @@ use bitwarden_crypto::{Encryptable, IdentifyKey};
 use wasm_bindgen::prelude::*;
 
 use super::EncryptionContext;
-use crate::{Cipher, CipherError, CipherListView, CipherView, DecryptError, EncryptError, Fido2CredentialFullView, Fido2CredentialView};
+use crate::{
+    Cipher, CipherError, CipherListView, CipherView, DecryptError, EncryptError,
+    Fido2CredentialFullView, Fido2CredentialView,
+};
 
 #[allow(missing_docs)]
 #[cfg_attr(feature = "wasm", wasm_bindgen)]
@@ -66,8 +69,8 @@ impl CiphersClient {
         let credentials = cipher_view.decrypt_fido2_credentials(&mut key_store.context())?;
         Ok(credentials)
     }
-    
-    /// Temporary method used to re-encrypt FIDO2 credentials for a cipher view. 
+
+    /// Temporary method used to re-encrypt FIDO2 credentials for a cipher view.
     /// Necessary while the FIDO2 credentials remain in the LoginView in an encrypted form.
     /// Used by the TS clients to encrypt FIDO2 credentials separately before encrypting the remaining cipher view.
     /// TODO: Remove once FIDO2 credentials have been removed from the LoginView.
@@ -78,10 +81,11 @@ impl CiphersClient {
     ) -> Result<crate::Fido2Credential, EncryptError> {
         let key_store = self.client.internal.get_key_store();
         let key = cipher_view.key_identifier();
-        let cipher_key = Cipher::decrypt_cipher_key(&mut key_store.context(), key, &cipher_view.key)?;
-        
+        let cipher_key =
+            Cipher::decrypt_cipher_key(&mut key_store.context(), key, &cipher_view.key)?;
+
         let fido2_credential = fido2_credentials.encrypt(&mut key_store.context(), cipher_key)?;
-        
+
         Ok(fido2_credential)
     }
 

--- a/crates/bitwarden-vault/src/cipher/cipher_client.rs
+++ b/crates/bitwarden-vault/src/cipher/cipher_client.rs
@@ -71,10 +71,11 @@ impl CiphersClient {
     }
 
     /// Temporary method used to re-encrypt FIDO2 credentials for a cipher view.
-    /// Necessary while the FIDO2 credentials remain in the LoginView in an encrypted form.
-    /// Used by the TS clients to encrypt FIDO2 credentials separately before encrypting the
-    /// remaining cipher view. TODO: Remove once FIDO2 credentials have been removed from the
-    /// LoginView.
+    /// Necessary until the TS clients utilize the SDK entirely for FIDO2 credentials management.
+    /// TS clients create decrypted FIDO2 credentials that need to be encrypted manually when encrypting
+    /// the rest of the CipherView. 
+    /// TODO: Remove once TS passkey provider implementation uses SDK - PM-8313
+    #[cfg(feature = "wasm")]
     pub fn encrypt_fido2_credentials(
         &self,
         cipher_view: CipherView,

--- a/crates/bitwarden-vault/src/cipher/cipher_client.rs
+++ b/crates/bitwarden-vault/src/cipher/cipher_client.rs
@@ -88,19 +88,16 @@ impl CiphersClient {
     /// the rest of the CipherView.
     /// TODO: Remove once TS passkey provider implementation uses SDK - PM-8313
     #[cfg(feature = "wasm")]
-    pub fn encrypt_fido2_credentials(
+    pub fn set_fido2_credentials(
         &self,
-        cipher_view: CipherView,
-        fido2_credentials: Fido2CredentialFullView,
-    ) -> Result<crate::Fido2Credential, EncryptError> {
+        mut cipher_view: CipherView,
+        fido2_credentials: Vec<Fido2CredentialFullView>,
+    ) -> Result<CipherView, CipherError> {
         let key_store = self.client.internal.get_key_store();
-        let key = cipher_view.key_identifier();
-        let cipher_key =
-            Cipher::decrypt_cipher_key(&mut key_store.context(), key, &cipher_view.key)?;
 
-        let fido2_credential = fido2_credentials.encrypt_composite(&mut key_store.context(), cipher_key)?;
+        cipher_view.set_new_fido2_credentials(&mut key_store.context(), fido2_credentials)?;
 
-        Ok(fido2_credential)
+        Ok(cipher_view)
     }
 
     #[allow(missing_docs)]

--- a/crates/bitwarden-vault/src/cipher/cipher_client.rs
+++ b/crates/bitwarden-vault/src/cipher/cipher_client.rs
@@ -6,7 +6,7 @@ use wasm_bindgen::prelude::*;
 use super::EncryptionContext;
 use crate::{
     cipher::cipher::DecryptCipherListResult, Cipher, CipherError, CipherListView, CipherView,
-    DecryptError, EncryptError, Fido2CredentialFullView
+    DecryptError, EncryptError, Fido2CredentialFullView,
 };
 
 #[allow(missing_docs)]
@@ -84,8 +84,8 @@ impl CiphersClient {
 
     /// Temporary method used to re-encrypt FIDO2 credentials for a cipher view.
     /// Necessary until the TS clients utilize the SDK entirely for FIDO2 credentials management.
-    /// TS clients create decrypted FIDO2 credentials that need to be encrypted manually when encrypting
-    /// the rest of the CipherView.
+    /// TS clients create decrypted FIDO2 credentials that need to be encrypted manually when
+    /// encrypting the rest of the CipherView.
     /// TODO: Remove once TS passkey provider implementation uses SDK - PM-8313
     #[cfg(feature = "wasm")]
     pub fn set_fido2_credentials(

--- a/crates/bitwarden-vault/src/cipher/cipher_client.rs
+++ b/crates/bitwarden-vault/src/cipher/cipher_client.rs
@@ -72,8 +72,9 @@ impl CiphersClient {
 
     /// Temporary method used to re-encrypt FIDO2 credentials for a cipher view.
     /// Necessary while the FIDO2 credentials remain in the LoginView in an encrypted form.
-    /// Used by the TS clients to encrypt FIDO2 credentials separately before encrypting the remaining cipher view.
-    /// TODO: Remove once FIDO2 credentials have been removed from the LoginView.
+    /// Used by the TS clients to encrypt FIDO2 credentials separately before encrypting the
+    /// remaining cipher view. TODO: Remove once FIDO2 credentials have been removed from the
+    /// LoginView.
     pub fn encrypt_fido2_credentials(
         &self,
         cipher_view: CipherView,

--- a/crates/bitwarden-vault/src/cipher/cipher_client.rs
+++ b/crates/bitwarden-vault/src/cipher/cipher_client.rs
@@ -1,5 +1,5 @@
 use bitwarden_core::{Client, OrganizationId};
-use bitwarden_crypto::{Encryptable, IdentifyKey};
+use bitwarden_crypto::{CompositeEncryptable, IdentifyKey};
 #[cfg(feature = "wasm")]
 use wasm_bindgen::prelude::*;
 
@@ -85,7 +85,7 @@ impl CiphersClient {
         let cipher_key =
             Cipher::decrypt_cipher_key(&mut key_store.context(), key, &cipher_view.key)?;
 
-        let fido2_credential = fido2_credentials.encrypt(&mut key_store.context(), cipher_key)?;
+        let fido2_credential = fido2_credentials.encrypt_composite(&mut key_store.context(), cipher_key)?;
 
         Ok(fido2_credential)
     }

--- a/crates/bitwarden-vault/src/cipher/login.rs
+++ b/crates/bitwarden-vault/src/cipher/login.rs
@@ -141,6 +141,7 @@ pub struct Fido2CredentialView {
 #[allow(missing_docs)]
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
+#[cfg_attr(feature = "wasm", derive(Tsify), tsify(into_wasm_abi, from_wasm_abi))]
 pub struct Fido2CredentialFullView {
     pub credential_id: String,
     pub key_type: String,


### PR DESCRIPTION
## 🎟️ Tracking

[PM-22136](https://bitwarden.atlassian.net/browse/PM-22136)

## 📔 Objective

The TS clients use fully decrypted FIDO2 credentials which need to be re-encrypted separately before using the SDK to encrypt the rest of the Cipher. Otherwise, the FIDO2 credential encryption key will be lost.

Once the decrypted FIDO2 Credentials are removed from the LoginView in TS, this method can be removed.

Related Clients PR: https://github.com/bitwarden/clients/pull/15337

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation
  team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-22136]: https://bitwarden.atlassian.net/browse/PM-22136?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ