### PR TITLE
[PM-22515] Update cipher decrypt list to return successful decryptions and failure metadata

### DIFF
--- a/crates/bitwarden-crypto/src/store/mod.rs
+++ b/crates/bitwarden-crypto/src/store/mod.rs
@@ -284,18 +284,16 @@ impl<Ids: KeyIds> KeyStore<Ids> {
             .map(|chunk| {
                 let mut ctx = self.context();
 
-                let mut result = Vec::with_capacity(chunk.len());
-
-                for item in chunk {
-                    let key = item.key_identifier();
-                    result.push(
-                        item.decrypt(&mut ctx, key)
-                            .map_err(|_| ErrorView::from(item)),
-                    );
-                    ctx.clear_local();
-                }
-
-                result
+                chunk
+                    .iter()
+                    .map(|item| {
+                        let result = item
+                            .decrypt(&mut ctx, item.key_identifier())
+                            .map_err(|_| ErrorView::from(item));
+                        ctx.clear_local();
+                        result
+                    })
+                    .collect::<Vec<_>>()
             })
             .flatten()
             .partition_map(|result| match result {

--- a/crates/bitwarden-crypto/src/store/mod.rs
+++ b/crates/bitwarden-crypto/src/store/mod.rs
@@ -284,7 +284,7 @@ impl<Ids: KeyIds> KeyStore<Ids> {
             .map(|chunk| {
                 let mut ctx = self.context();
 
-                let mut result = Vec::with_capacity(data.len());
+                let mut result = Vec::with_capacity(chunk.len());
 
                 for item in chunk {
                     let key = item.key_identifier();

--- a/crates/bitwarden-crypto/src/store/mod.rs
+++ b/crates/bitwarden-crypto/src/store/mod.rs
@@ -281,7 +281,7 @@ impl<Ids: KeyIds> KeyStore<Ids> {
     ) -> (Vec<Output>, Vec<ErrorView>) {
         let results: (Vec<_>, Vec<_>) = data
             .par_chunks(batch_chunk_size(data.len()))
-            .map(|chunk| {
+            .flat_map(|chunk| {
                 let mut ctx = self.context();
 
                 chunk
@@ -295,7 +295,6 @@ impl<Ids: KeyIds> KeyStore<Ids> {
                     })
                     .collect::<Vec<_>>()
             })
-            .flatten()
             .partition_map(|result| match result {
                 Ok(output) => Either::Left(output),
                 Err(err) => Either::Right(err),

--- a/crates/bitwarden-crypto/src/store/mod.rs
+++ b/crates/bitwarden-crypto/src/store/mod.rs
@@ -259,14 +259,16 @@ impl<Ids: KeyIds> KeyStore<Ids> {
         res
     }
 
-    /// Decrypt a list of items using this key store, returning a tuple of successful and failed items.
+    /// Decrypt a list of items using this key store, returning a tuple of successful and failed
+    /// items.
     ///
     /// # Arguments
     /// * `data` - The list of items to decrypt.
     ///
     /// # Returns
     /// A tuple containing two vectors: the first vector contains the successfully decrypted items,
-    /// and the second vector contains the items that failed to decrypt along with their error views.
+    /// and the second vector contains the items that failed to decrypt along with their error
+    /// views.
     pub fn decrypt_list_with_failures<
         'a,
         Key: KeyId,

--- a/crates/bitwarden-uniffi/src/vault/ciphers.rs
+++ b/crates/bitwarden-uniffi/src/vault/ciphers.rs
@@ -1,5 +1,8 @@
 use bitwarden_core::OrganizationId;
-use bitwarden_vault::{Cipher, CipherListView, CipherView, EncryptionContext, Fido2CredentialView};
+use bitwarden_vault::{
+    Cipher, CipherListView, CipherView, DecryptCipherListResult, EncryptionContext,
+    Fido2CredentialView,
+};
 use uuid::Uuid;
 
 use crate::{error::Error, Result};
@@ -23,6 +26,12 @@ impl CiphersClient {
     /// Decrypt cipher list
     pub fn decrypt_list(&self, ciphers: Vec<Cipher>) -> Result<Vec<CipherListView>> {
         Ok(self.0.decrypt_list(ciphers).map_err(Error::Decrypt)?)
+    }
+
+    /// Decrypt cipher list with failures
+    /// Returns both successfully decrypted ciphers and any that failed to decrypt
+    pub fn decrypt_list_with_failures(&self, ciphers: Vec<Cipher>) -> DecryptCipherListResult {
+        self.0.decrypt_list_with_failures(ciphers)
     }
 
     pub fn decrypt_fido2_credentials(

--- a/crates/bitwarden-vault/src/cipher/cipher.rs
+++ b/crates/bitwarden-vault/src/cipher/cipher.rs
@@ -249,13 +249,19 @@ pub struct CipherListView {
     pub local_data: Option<LocalDataView>,
 }
 
-#[allow(missing_docs)]
+/// Represents the result of decrypting a list of ciphers.
+///
+/// This struct contains two vectors: `successes` and `failures`.
+/// `successes` contains the decrypted `CipherListView` objects,
+/// while `failures` contains the original `Cipher` objects that failed to decrypt.
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 #[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
 #[cfg_attr(feature = "wasm", derive(Tsify), tsify(into_wasm_abi, from_wasm_abi))]
 pub struct DecryptCipherListResult {
+    /// The decrypted `CipherListView` objects.
     pub successes: Vec<CipherListView>,
+    /// The original `Cipher` objects that failed to decrypt.
     pub failures: Vec<Cipher>,
 }
 

--- a/crates/bitwarden-vault/src/cipher/cipher.rs
+++ b/crates/bitwarden-vault/src/cipher/cipher.rs
@@ -250,61 +250,13 @@ pub struct CipherListView {
 }
 
 #[allow(missing_docs)]
-#[derive(Serialize, Deserialize, Debug, PartialEq)]
-#[serde(rename_all = "camelCase", deny_unknown_fields)]
-#[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
-#[cfg_attr(feature = "wasm", derive(Tsify), tsify(into_wasm_abi, from_wasm_abi))]
-pub struct CipherDecryptionErrorView {
-    pub id: Option<Uuid>,
-    pub organization_id: Option<Uuid>,
-    pub folder_id: Option<Uuid>,
-    pub collection_ids: Vec<Uuid>,
-    pub r#type: CipherType,
-    pub favorite: bool,
-    pub organization_use_totp: bool,
-    pub has_fido2: bool,
-    pub has_totp: bool,
-    pub deleted_date: Option<DateTime<Utc>>,
-}
-
-#[allow(missing_docs)]
-#[derive(Serialize, Deserialize, Debug, PartialEq)]
+#[derive(Serialize, Deserialize, Debug)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 #[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
 #[cfg_attr(feature = "wasm", derive(Tsify), tsify(into_wasm_abi, from_wasm_abi))]
 pub struct DecryptCipherListResult {
     pub successes: Vec<CipherListView>,
-    pub failures: Vec<CipherDecryptionErrorView>,
-}
-
-impl From<&Cipher> for CipherDecryptionErrorView {
-    fn from(cipher: &Cipher) -> Self {
-        let has_totp = cipher
-            .login
-            .as_ref()
-            .and_then(|c| c.totp.as_ref())
-            .is_some();
-
-        let has_fido2 = cipher
-            .login
-            .as_ref()
-            .and_then(|c| c.fido2_credentials.as_ref())
-            .map(|fido_vec| !fido_vec.is_empty())
-            .unwrap_or(false);
-
-        Self {
-            id: cipher.id,
-            organization_id: cipher.organization_id,
-            folder_id: cipher.folder_id,
-            collection_ids: cipher.collection_ids.clone(),
-            r#type: cipher.r#type,
-            favorite: cipher.favorite,
-            organization_use_totp: cipher.organization_use_totp,
-            has_fido2,
-            has_totp,
-            deleted_date: cipher.deleted_date,
-        }
-    }
+    pub failures: Vec<Cipher>,
 }
 
 impl CipherListView {

--- a/crates/bitwarden-vault/src/cipher/cipher.rs
+++ b/crates/bitwarden-vault/src/cipher/cipher.rs
@@ -249,6 +249,64 @@ pub struct CipherListView {
     pub local_data: Option<LocalDataView>,
 }
 
+#[allow(missing_docs)]
+#[derive(Serialize, Deserialize, Debug, PartialEq)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+#[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
+#[cfg_attr(feature = "wasm", derive(Tsify), tsify(into_wasm_abi, from_wasm_abi))]
+pub struct CipherDecryptionErrorView {
+    pub id: Option<Uuid>,
+    pub organization_id: Option<Uuid>,
+    pub folder_id: Option<Uuid>,
+    pub collection_ids: Vec<Uuid>,
+    pub r#type: CipherType,
+    pub favorite: bool,
+    pub organization_use_totp: bool,
+    pub has_fido2: bool,
+    pub has_totp: bool,
+    pub deleted_date: Option<DateTime<Utc>>,
+}
+
+#[allow(missing_docs)]
+#[derive(Serialize, Deserialize, Debug, PartialEq)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+#[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
+#[cfg_attr(feature = "wasm", derive(Tsify), tsify(into_wasm_abi, from_wasm_abi))]
+pub struct DecryptCipherListResult {
+    pub successes: Vec<CipherListView>,
+    pub failures: Vec<CipherDecryptionErrorView>,
+}
+
+impl From<&Cipher> for CipherDecryptionErrorView {
+    fn from(cipher: &Cipher) -> Self {
+        let has_totp = cipher
+            .login
+            .as_ref()
+            .and_then(|c| c.totp.as_ref())
+            .is_some();
+
+        let has_fido2 = cipher
+            .login
+            .as_ref()
+            .and_then(|c| c.fido2_credentials.as_ref())
+            .map(|fido_vec| !fido_vec.is_empty())
+            .unwrap_or(false);
+
+        Self {
+            id: cipher.id,
+            organization_id: cipher.organization_id,
+            folder_id: cipher.folder_id,
+            collection_ids: cipher.collection_ids.clone(),
+            r#type: cipher.r#type,
+            favorite: cipher.favorite,
+            organization_use_totp: cipher.organization_use_totp,
+            has_fido2,
+            has_totp,
+            deleted_date: cipher.deleted_date,
+        }
+    }
+}
+
 impl CipherListView {
     pub(crate) fn get_totp_key(
         self,

--- a/crates/bitwarden-vault/src/cipher/cipher_client.rs
+++ b/crates/bitwarden-vault/src/cipher/cipher_client.rs
@@ -234,6 +234,24 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_decrypt_list_with_failures_mixed_results() {
+        let client = Client::init_test_account(test_bitwarden_com_account()).await;
+        let valid_cipher = test_cipher();
+        let mut invalid_cipher = test_cipher();
+        // Set an invalid encryptedkey to cause decryption failure
+        invalid_cipher.key = Some("2.Gg8yCM4IIgykCZyq0O4+cA==|GJLBtfvSJTDJh/F7X4cJPkzI6ccnzJm5DYl3yxOW2iUn7DgkkmzoOe61sUhC5dgVdV0kFqsZPcQ0yehlN1DDsFIFtrb4x7LwzJNIkMgxNyg=|1rGkGJ8zcM5o5D0aIIwAyLsjMLrPsP3EWm3CctBO3Fw=".parse().unwrap());
+
+        let ciphers = vec![valid_cipher, invalid_cipher];
+
+        let result = client.vault().ciphers().decrypt_list_with_failures(ciphers);
+
+        assert_eq!(result.successes.len(), 1);
+        assert_eq!(result.failures.len(), 1);
+
+        assert_eq!(result.successes[0].name, "234234");
+    }
+
+    #[tokio::test]
     async fn test_move_user_cipher_with_attachment_without_key_to_org_fails() {
         let client = Client::init_test_account(test_bitwarden_com_account()).await;
 

--- a/crates/bitwarden-vault/src/cipher/cipher_client.rs
+++ b/crates/bitwarden-vault/src/cipher/cipher_client.rs
@@ -60,7 +60,8 @@ impl CiphersClient {
         Ok(cipher_views)
     }
 
-    #[allow(missing_docs)]
+    /// Decrypt cipher list with failures
+    /// Returns both successfully decrypted ciphers and any that failed to decrypt
     pub fn decrypt_list_with_failures(&self, ciphers: Vec<Cipher>) -> DecryptCipherListResult {
         let key_store = self.client.internal.get_key_store();
         let (successes, failures) = key_store.decrypt_list_with_failures(&ciphers);

--- a/crates/bitwarden-vault/src/cipher/cipher_client.rs
+++ b/crates/bitwarden-vault/src/cipher/cipher_client.rs
@@ -68,7 +68,7 @@ impl CiphersClient {
 
         DecryptCipherListResult {
             successes,
-            failures,
+            failures: failures.into_iter().cloned().collect(),
         }
     }
 
@@ -242,7 +242,7 @@ mod tests {
         // Set an invalid encryptedkey to cause decryption failure
         invalid_cipher.key = Some("2.Gg8yCM4IIgykCZyq0O4+cA==|GJLBtfvSJTDJh/F7X4cJPkzI6ccnzJm5DYl3yxOW2iUn7DgkkmzoOe61sUhC5dgVdV0kFqsZPcQ0yehlN1DDsFIFtrb4x7LwzJNIkMgxNyg=|1rGkGJ8zcM5o5D0aIIwAyLsjMLrPsP3EWm3CctBO3Fw=".parse().unwrap());
 
-        let ciphers = vec![valid_cipher, invalid_cipher];
+        let ciphers = vec![valid_cipher, invalid_cipher.clone()];
 
         let result = client.vault().ciphers().decrypt_list_with_failures(ciphers);
 

--- a/crates/bitwarden-vault/src/cipher/cipher_client.rs
+++ b/crates/bitwarden-vault/src/cipher/cipher_client.rs
@@ -4,7 +4,10 @@ use bitwarden_crypto::IdentifyKey;
 use wasm_bindgen::prelude::*;
 
 use super::EncryptionContext;
-use crate::{Cipher, CipherError, CipherListView, CipherView, DecryptError, EncryptError};
+use crate::{
+    cipher::cipher::DecryptCipherListResult, Cipher, CipherError, CipherListView, CipherView,
+    DecryptError, EncryptError,
+};
 
 #[allow(missing_docs)]
 #[cfg_attr(feature = "wasm", wasm_bindgen)]
@@ -58,6 +61,17 @@ impl CiphersClient {
     }
 
     #[allow(missing_docs)]
+    pub fn decrypt_list_with_failures(&self, ciphers: Vec<Cipher>) -> DecryptCipherListResult {
+        let key_store = self.client.internal.get_key_store();
+        let (successes, failures) = key_store.decrypt_list_with_failures(&ciphers);
+
+        DecryptCipherListResult {
+            successes,
+            failures,
+        }
+    }
+
+    #[allow(missing_docs)]
     pub fn decrypt_fido2_credentials(
         &self,
         cipher_view: CipherView,
@@ -97,50 +111,6 @@ mod tests {
 
     use super::*;
     use crate::{Attachment, CipherRepromptType, CipherType, Login, VaultClientExt};
-
-    #[tokio::test]
-    async fn test_decrypt_list() {
-        let client = Client::init_test_account(test_bitwarden_com_account()).await;
-
-        let dec = client
-            .vault()
-            .ciphers()
-            .decrypt_list(vec![Cipher {
-                id: Some("a1569f46-0797-4d3f-b859-b181009e2e49".parse().unwrap()),
-                organization_id: Some("1bc9ac1e-f5aa-45f2-94bf-b181009709b8".parse().unwrap()),
-                folder_id: None,
-                collection_ids: vec!["66c5ca57-0868-4c7e-902f-b181009709c0".parse().unwrap()],
-                key: None,
-                name: "2.RTdUGVWYl/OZHUMoy68CMg==|sCaT5qHx8i0rIvzVrtJKww==|jB8DsRws6bXBtXNfNXUmFJ0JLDlB6GON6Y87q0jgJ+0=".parse().unwrap(),
-                notes: None,
-                r#type: CipherType::Login,
-                login: Some(Login{
-                    username: Some("2.ouEYEk+SViUtqncesfe9Ag==|iXzEJq1zBeNdDbumFO1dUA==|RqMoo9soSwz/yB99g6YPqk8+ASWRcSdXsKjbwWzyy9U=".parse().unwrap()),
-                    password: Some("2.6yXnOz31o20Z2kiYDnXueA==|rBxTb6NK9lkbfdhrArmacw==|ogZir8Z8nLgiqlaLjHH+8qweAtItS4P2iPv1TELo5a0=".parse().unwrap()),
-                    password_revision_date: None, uris:None, totp: None, autofill_on_page_load: None, fido2_credentials: None }),
-                identity: None,
-                card: None,
-                secure_note: None,
-                ssh_key: None,
-                favorite: false,
-                reprompt: CipherRepromptType::None,
-                organization_use_totp: true,
-                edit: true,
-                permissions: None,
-                view_password: true,
-                local_data: None,
-                attachments: None,
-                fields:  None,
-                password_history: None,
-                creation_date: "2024-05-31T09:35:55.12Z".parse().unwrap(),
-                deleted_date: None,
-                revision_date: "2024-05-31T09:35:55.12Z".parse().unwrap(),
-            }])
-
-            .unwrap();
-
-        assert_eq!(dec[0].name, "Test item");
-    }
 
     fn test_cipher() -> Cipher {
         Cipher {
@@ -201,6 +171,66 @@ mod tests {
             size: Some("65".to_string()),
             size_name: Some("65 Bytes".to_string()),
         }
+    }
+
+    #[tokio::test]
+    async fn test_decrypt_list() {
+        let client = Client::init_test_account(test_bitwarden_com_account()).await;
+
+        let dec = client
+            .vault()
+            .ciphers()
+            .decrypt_list(vec![Cipher {
+                id: Some("a1569f46-0797-4d3f-b859-b181009e2e49".parse().unwrap()),
+                organization_id: Some("1bc9ac1e-f5aa-45f2-94bf-b181009709b8".parse().unwrap()),
+                folder_id: None,
+                collection_ids: vec!["66c5ca57-0868-4c7e-902f-b181009709c0".parse().unwrap()],
+                key: None,
+                name: "2.RTdUGVWYl/OZHUMoy68CMg==|sCaT5qHx8i0rIvzVrtJKww==|jB8DsRws6bXBtXNfNXUmFJ0JLDlB6GON6Y87q0jgJ+0=".parse().unwrap(),
+                notes: None,
+                r#type: CipherType::Login,
+                login: Some(Login{
+                    username: Some("2.ouEYEk+SViUtqncesfe9Ag==|iXzEJq1zBeNdDbumFO1dUA==|RqMoo9soSwz/yB99g6YPqk8+ASWRcSdXsKjbwWzyy9U=".parse().unwrap()),
+                    password: Some("2.6yXnOz31o20Z2kiYDnXueA==|rBxTb6NK9lkbfdhrArmacw==|ogZir8Z8nLgiqlaLjHH+8qweAtItS4P2iPv1TELo5a0=".parse().unwrap()),
+                    password_revision_date: None, uris:None, totp: None, autofill_on_page_load: None, fido2_credentials: None }),
+                identity: None,
+                card: None,
+                secure_note: None,
+                ssh_key: None,
+                favorite: false,
+                reprompt: CipherRepromptType::None,
+                organization_use_totp: true,
+                edit: true,
+                permissions: None,
+                view_password: true,
+                local_data: None,
+                attachments: None,
+                fields:  None,
+                password_history: None,
+                creation_date: "2024-05-31T09:35:55.12Z".parse().unwrap(),
+                deleted_date: None,
+                revision_date: "2024-05-31T09:35:55.12Z".parse().unwrap(),
+            }])
+
+            .unwrap();
+
+        assert_eq!(dec[0].name, "Test item");
+    }
+
+    #[tokio::test]
+    async fn test_decrypt_list_with_failures_all_success() {
+        let client = Client::init_test_account(test_bitwarden_com_account()).await;
+
+        let valid_cipher = test_cipher();
+
+        let result = client
+            .vault()
+            .ciphers()
+            .decrypt_list_with_failures(vec![valid_cipher]);
+
+        assert_eq!(result.successes.len(), 1);
+        assert!(result.failures.is_empty());
+        assert_eq!(result.successes[0].name, "234234");
     }
 
     #[tokio::test]

--- a/crates/bitwarden-vault/src/cipher/mod.rs
+++ b/crates/bitwarden-vault/src/cipher/mod.rs
@@ -20,7 +20,7 @@ pub use attachment_client::{AttachmentsClient, DecryptFileError, EncryptFileErro
 pub use card::{CardBrand, CardListView, CardView};
 pub use cipher::{
     Cipher, CipherError, CipherListView, CipherListViewType, CipherRepromptType, CipherType,
-    CipherView, EncryptionContext,
+    CipherView, DecryptCipherListResult, EncryptionContext,
 };
 pub use cipher_client::CiphersClient;
 pub use field::FieldView;


### PR DESCRIPTION
## 🎟️ Tracking
https://bitwarden.atlassian.net/browse/PM-22515
<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective
Currently, calling ClientCiphers.decryptList(ciphers:) is an all-or-nothing operation. You’ll either get back a list decrypted ciphers if everything was successful or a single error if any cipher is unable to be decrypted. We’d like to get back anything that was successfully decrypted along with a list of any ciphers which failed to decrypt.
<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation
  team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
