### PR TITLE
Fix Clippy 1.88 warnings

### DIFF
--- a/bitwarden_license/bitwarden-sm/src/error.rs
+++ b/bitwarden_license/bitwarden-sm/src/error.rs
@@ -47,7 +47,7 @@ pub fn validate_only_whitespaces(value: &str) -> Result<(), validator::Validatio
 
 impl From<ValidationErrors> for ValidationError {
     fn from(e: ValidationErrors) -> Self {
-        debug!("Validation errors: {:#?}", e);
+        debug!("Validation errors: {e:#?}");
         for (field_name, errors) in e.field_errors() {
             for error in errors {
                 match error.code.as_ref() {
@@ -74,7 +74,7 @@ impl From<ValidationErrors> for ValidationError {
                 }
             }
         }
-        ValidationError::Unknown(format!("{:#?}", e))
+        ValidationError::Unknown(format!("{e:#?}"))
     }
 }
 

--- a/crates/bitwarden-api-api/src/lib.rs
+++ b/crates/bitwarden-api-api/src/lib.rs
@@ -3,7 +3,8 @@
     clippy::too_many_arguments,
     clippy::empty_docs,
     clippy::to_string_in_format_args,
-    clippy::needless_return
+    clippy::needless_return,
+    clippy::uninlined_format_args
 )]
 
 extern crate reqwest;

--- a/crates/bitwarden-api-identity/src/lib.rs
+++ b/crates/bitwarden-api-identity/src/lib.rs
@@ -3,7 +3,8 @@
     clippy::too_many_arguments,
     clippy::empty_docs,
     clippy::to_string_in_format_args,
-    clippy::needless_return
+    clippy::needless_return,
+    clippy::uninlined_format_args
 )]
 
 extern crate reqwest;

--- a/crates/bitwarden-core/src/auth/api/request/access_token_request.rs
+++ b/crates/bitwarden-core/src/auth/api/request/access_token_request.rs
@@ -23,7 +23,7 @@ impl AccessTokenRequest {
             client_secret: client_secret.to_string(),
             grant_type: "client_credentials".to_string(),
         };
-        debug!("initializing {:?}", obj);
+        debug!("initializing {obj:?}");
         obj
     }
 

--- a/crates/bitwarden-core/src/auth/api/request/api_token_request.rs
+++ b/crates/bitwarden-core/src/auth/api/request/api_token_request.rs
@@ -31,7 +31,7 @@ impl ApiTokenRequest {
             device_name: "firefox".to_string(),
             grant_type: "client_credentials".to_string(),
         };
-        debug!("initializing {:?}", obj);
+        debug!("initializing {obj:?}");
         obj
     }
 

--- a/crates/bitwarden-core/src/auth/api/request/auth_request_token_request.rs
+++ b/crates/bitwarden-core/src/auth/api/request/auth_request_token_request.rs
@@ -47,7 +47,7 @@ impl AuthRequestTokenRequest {
             auth_request_id: *auth_request_id,
             access_code: access_code.to_string(),
         };
-        debug!("initializing {:?}", obj);
+        debug!("initializing {obj:?}");
         obj
     }
 

--- a/crates/bitwarden-core/src/auth/api/request/password_token_request.rs
+++ b/crates/bitwarden-core/src/auth/api/request/password_token_request.rs
@@ -56,7 +56,7 @@ impl PasswordTokenRequest {
             two_factor_provider: tf.map(|t| t.provider.clone()),
             two_factor_remember: tf.map(|t| t.remember),
         };
-        debug!("initializing {:?}", obj);
+        debug!("initializing {obj:?}");
         obj
     }
 

--- a/crates/bitwarden-core/src/auth/api/response/identity_token_fail_response.rs
+++ b/crates/bitwarden-core/src/auth/api/response/identity_token_fail_response.rs
@@ -17,7 +17,7 @@ impl fmt::Display for IdentityTokenFailResponse {
             false => self.error_model.message.clone(),
         };
 
-        write!(f, "{}", msg)
+        write!(f, "{msg}")
     }
 }
 

--- a/crates/bitwarden-core/src/client/internal.rs
+++ b/crates/bitwarden-core/src/client/internal.rs
@@ -112,7 +112,7 @@ impl InternalClient {
     pub(crate) fn set_login_method(&self, login_method: LoginMethod) {
         use log::debug;
 
-        debug! {"setting login method: {:#?}", login_method}
+        debug! {"setting login method: {login_method:#?}"}
         *self.login_method.write().expect("RwLock is not poisoned") = Some(Arc::new(login_method));
     }
 

--- a/crates/bitwarden-core/src/key_management/crypto.rs
+++ b/crates/bitwarden-core/src/key_management/crypto.rs
@@ -560,7 +560,7 @@ pub(super) fn verify_asymmetric_keys(
             valid_private_key: true,
         },
         Err(e) => {
-            log::debug!("User asymmetric keys verification: {}", e);
+            log::debug!("User asymmetric keys verification: {e}");
 
             VerifyAsymmetricKeysResponse {
                 private_key_decryptable: !matches!(e, VerifyError::DecryptFailed(_)),

--- a/crates/bitwarden-core/src/platform/get_user_api_key.rs
+++ b/crates/bitwarden-core/src/platform/get_user_api_key.rs
@@ -50,7 +50,7 @@ pub(crate) async fn get_user_api_key(
     input: &SecretVerificationRequest,
 ) -> Result<UserApiKeyResponse, UserApiKeyError> {
     info!("Getting Api Key");
-    debug!("{:?}", input);
+    debug!("{input:?}");
 
     let auth_settings = get_login_method(client)?;
     let config = client.internal.get_api_configurations().await;

--- a/crates/bitwarden-crypto/src/enc_string/asymmetric.rs
+++ b/crates/bitwarden-crypto/src/enc_string/asymmetric.rs
@@ -345,7 +345,7 @@ XKZBokBGnjFnTnKcs7nv/O8=
         let enc_str: &str = "4.ZheRb3PCfAunyFdQYPfyrFqpuvmln9H9w5nDjt88i5A7ug1XE0LJdQHCIYJl0YOZ1gCOGkhFu/CRY2StiLmT3iRKrrVBbC1+qRMjNNyDvRcFi91LWsmRXhONVSPjywzrJJXglsztDqGkLO93dKXNhuKpcmtBLsvgkphk/aFvxbaOvJ/FHdK/iV0dMGNhc/9tbys8laTdwBlI5xIChpRcrfH+XpSFM88+Bu03uK67N9G6eU1UmET+pISJwJvMuIDMqH+qkT7OOzgL3t6I0H2LDj+CnsumnQmDsvQzDiNfTR0IgjpoE9YH2LvPXVP2wVUkiTwXD9cG/E7XeoiduHyHjw==";
         let enc_string: UnsignedSharedKey = enc_str.parse().unwrap();
 
-        let debug_string = format!("{:?}", enc_string);
+        let debug_string = format!("{enc_string:?}");
         assert_eq!(debug_string, "UnsignedSharedKey");
     }
 

--- a/crates/bitwarden-crypto/src/enc_string/symmetric.rs
+++ b/crates/bitwarden-crypto/src/enc_string/symmetric.rs
@@ -223,9 +223,9 @@ impl std::fmt::Debug for EncString {
             }
             EncString::Cose_Encrypt0_B64 { data } => {
                 let msg = coset::CoseEncrypt0::from_slice(data.as_slice())
-                    .map(|msg| format!("{:?}", msg))
+                    .map(|msg| format!("{msg:?}"))
                     .unwrap_or_else(|_| "INVALID_COSE".to_string());
-                write!(f, "{}.{}", enc_type, msg)
+                write!(f, "{enc_type}.{msg}")
             }
         }
     }
@@ -498,7 +498,7 @@ mod tests {
         let enc_str  = "2.pMS6/icTQABtulw52pq2lg==|XXbxKxDTh+mWiN1HjH2N1w==|Q6PkuT+KX/axrgN9ubD5Ajk2YNwxQkgs3WJM0S0wtG8=";
         let enc_string: EncString = enc_str.parse().unwrap();
 
-        let debug_string = format!("{:?}", enc_string);
+        let debug_string = format!("{enc_string:?}");
         assert_eq!(debug_string, enc_str);
     }
 

--- a/crates/bitwarden-crypto/src/keys/shareable_key.rs
+++ b/crates/bitwarden-crypto/src/keys/shareable_key.rs
@@ -19,7 +19,7 @@ pub fn derive_shareable_key(
 ) -> Aes256CbcHmacKey {
     // Because all inputs are fixed size, we can unwrap all errors here without issue
     let res = Zeroizing::new(
-        PbkdfSha256Hmac::new_from_slice(format!("bitwarden-{}", name).as_bytes())
+        PbkdfSha256Hmac::new_from_slice(format!("bitwarden-{name}").as_bytes())
             .expect("hmac new_from_slice should not fail")
             .chain_update(secret)
             .finalize()

--- a/crates/bitwarden-crypto/src/store/mod.rs
+++ b/crates/bitwarden-crypto/src/store/mod.rs
@@ -371,7 +371,7 @@ pub(crate) mod tests {
 
         // Create some test data
         let data: Vec<_> = (0..300usize)
-            .map(|n| DataView(format!("Test {}", n), TestSymmKey::A((n % 15) as u8)))
+            .map(|n| DataView(format!("Test {n}"), TestSymmKey::A((n % 15) as u8)))
             .collect();
 
         // Encrypt the data

--- a/crates/bitwarden-crypto/src/util.rs
+++ b/crates/bitwarden-crypto/src/util.rs
@@ -73,7 +73,7 @@ where
     where
         E: serde::de::Error,
     {
-        T::from_str(v).map_err(|e| E::custom(format!("{:?}", e)))
+        T::from_str(v).map_err(|e| E::custom(format!("{e:?}")))
     }
 }
 

--- a/crates/bitwarden-error-macro/src/basic/attribute.rs
+++ b/crates/bitwarden-error-macro/src/basic/attribute.rs
@@ -20,7 +20,7 @@ fn basic_error_wasm(
     export_as_identifier: &proc_macro2::Ident,
 ) -> proc_macro2::TokenStream {
     let export_as_identifier_str = export_as_identifier.to_string();
-    let is_error_function_name = format!("is{}", export_as_identifier);
+    let is_error_function_name = format!("is{export_as_identifier}");
     let ts_code_str = format!(
         r##"r#"
             export interface {export_as_identifier} extends Error {{

--- a/crates/bitwarden-error-macro/src/flat/attribute.rs
+++ b/crates/bitwarden-error-macro/src/flat/attribute.rs
@@ -67,7 +67,7 @@ fn flat_error_wasm(
     variant_names: &[&proc_macro2::Ident],
 ) -> proc_macro2::TokenStream {
     let export_as_identifier_str = export_as_identifier.to_string();
-    let is_error_function_name = format!("is{}", export_as_identifier);
+    let is_error_function_name = format!("is{export_as_identifier}");
     let ts_variant_names = variant_names
         .iter()
         .map(|vn| format!(r#""{vn}""#))

--- a/crates/bitwarden-fido/src/crypto.rs
+++ b/crates/bitwarden-fido/src/crypto.rs
@@ -17,14 +17,14 @@ pub enum CoseKeyToPkcs8Error {
 pub(crate) fn cose_key_to_pkcs8(cose_key: &CoseKey) -> Result<Vec<u8>, CoseKeyToPkcs8Error> {
     // cose_key.
     let secret_key = private_key_from_cose_key(cose_key).map_err(|error| {
-        log::error!("Failed to extract private key from cose_key: {:?}", error);
+        log::error!("Failed to extract private key from cose_key: {error:?}");
         CoseKeyToPkcs8Error::FailedToExtractPrivateKeyFromCoseKey
     })?;
 
     let vec = secret_key
         .to_pkcs8_der()
         .map_err(|error| {
-            log::error!("Failed to convert P256 private key to PKC8: {:?}", error);
+            log::error!("Failed to convert P256 private key to PKC8: {error:?}");
             CoseKeyToPkcs8Error::FailedToConvertP256PrivateKeyToPkcs8
         })?
         .as_bytes()
@@ -39,7 +39,7 @@ pub struct PrivateKeyFromSecretKeyError;
 
 pub fn pkcs8_to_cose_key(secret_key: &[u8]) -> Result<CoseKey, PrivateKeyFromSecretKeyError> {
     let secret_key = SecretKey::from_pkcs8_der(secret_key).map_err(|error| {
-        log::error!("Failed to extract private key from secret_key: {:?}", error);
+        log::error!("Failed to extract private key from secret_key: {error:?}");
         PrivateKeyFromSecretKeyError
     })?;
 

--- a/crates/bitwarden-fido/src/lib.rs
+++ b/crates/bitwarden-fido/src/lib.rs
@@ -256,7 +256,7 @@ pub struct UnknownEnum;
 
 // Some utilities to convert back and forth between enums and strings
 fn get_enum_from_string_name<T: serde::de::DeserializeOwned>(s: &str) -> Result<T, UnknownEnum> {
-    let serialized = format!(r#""{}""#, s);
+    let serialized = format!(r#""{s}""#);
     let deserialized: T = serde_json::from_str(&serialized).map_err(|_| UnknownEnum)?;
     Ok(deserialized)
 }

--- a/crates/bitwarden-fido/src/types.rs
+++ b/crates/bitwarden-fido/src/types.rs
@@ -449,7 +449,7 @@ impl TryFrom<Origin> for passkey::client::Origin<'_> {
     fn try_from(value: Origin) -> Result<Self, Self::Error> {
         Ok(match value {
             Origin::Web(url) => {
-                let url = Url::parse(&url).map_err(|e| InvalidOriginError(format!("{}", e)))?;
+                let url = Url::parse(&url).map_err(|e| InvalidOriginError(format!("{e}")))?;
                 passkey::client::Origin::Web(Cow::Owned(url))
             }
             Origin::Android(link) => passkey::client::Origin::Android(link.try_into()?),
@@ -462,7 +462,7 @@ impl TryFrom<UnverifiedAssetLink> for passkey::client::UnverifiedAssetLink<'_> {
 
     fn try_from(value: UnverifiedAssetLink) -> Result<Self, Self::Error> {
         let asset_link_url = match value.asset_link_url {
-            Some(url) => Some(Url::parse(&url).map_err(|e| InvalidOriginError(format!("{}", e)))?),
+            Some(url) => Some(Url::parse(&url).map_err(|e| InvalidOriginError(format!("{e}")))?),
             None => None,
         };
 
@@ -472,7 +472,7 @@ impl TryFrom<UnverifiedAssetLink> for passkey::client::UnverifiedAssetLink<'_> {
             Cow::from(value.host),
             asset_link_url,
         )
-        .map_err(|e| InvalidOriginError(format!("{:?}", e)))
+        .map_err(|e| InvalidOriginError(format!("{e:?}")))
     }
 }
 

--- a/crates/bitwarden-generators/src/username.rs
+++ b/crates/bitwarden-generators/src/username.rs
@@ -212,7 +212,7 @@ fn username_subaddress(mut rng: impl RngCore, r#type: AppendType, email: String)
         AppendType::WebsiteName { website } => website,
     };
 
-    format!("{}+{}@{}", email_begin, email_middle, email_end)
+    format!("{email_begin}+{email_middle}@{email_end}")
 }
 
 /// Generate a username using a catchall email address
@@ -227,7 +227,7 @@ fn username_catchall(mut rng: impl RngCore, r#type: AppendType, domain: String) 
         AppendType::WebsiteName { website } => website,
     };
 
-    format!("{}@{}", email_start, domain)
+    format!("{email_start}@{domain}")
 }
 
 fn random_lowercase_string(mut rng: impl RngCore, length: usize) -> String {

--- a/crates/bitwarden-generators/src/username_forwarders/simplelogin.rs
+++ b/crates/bitwarden-generators/src/username_forwarders/simplelogin.rs
@@ -19,7 +19,7 @@ async fn generate_with_api_url(
 ) -> Result<String, UsernameError> {
     let query = website
         .as_ref()
-        .map(|w| format!("?hostname={}", w))
+        .map(|w| format!("?hostname={w}"))
         .unwrap_or_default();
 
     let note = super::format_description(&website);

--- a/crates/bitwarden-ipc/src/ipc_client.rs
+++ b/crates/bitwarden-ipc/src/ipc_client.rs
@@ -190,7 +190,7 @@ where
                                 };
                             }
                             Err(e) => {
-                                log::error!("Error receiving message: {:?}", e);
+                                log::error!("Error receiving message: {e:?}");
                                 break;
                             }
                         }
@@ -244,7 +244,7 @@ where
             .await;
 
         if result.is_err() {
-            log::error!("Error sending message: {:?}", result);
+            log::error!("Error sending message: {result:?}");
             self.stop().await;
         }
 
@@ -318,7 +318,7 @@ where
 
         self.send(message)
             .await
-            .map_err(|e| RequestError::Send(format!("{:?}", e)))?;
+            .map_err(|e| RequestError::Send(format!("{e:?}")))?;
 
         let response = loop {
             let received = response_subscription
@@ -382,7 +382,7 @@ where
                     }
                 }
                 Err(e) => {
-                    log::error!("Error handling RPC request: {:?}", e);
+                    log::error!("Error handling RPC request: {e:?}");
                 }
             }
         };

--- a/crates/bitwarden-ipc/src/wasm/communication_backend.rs
+++ b/crates/bitwarden-ipc/src/wasm/communication_backend.rs
@@ -96,7 +96,7 @@ impl CommunicationBackend for JsCommunicationBackend {
         let result = self
             .sender
             .run_in_thread(|sender| async move {
-                sender.send(message).await.map_err(|e| format!("{:?}", e))
+                sender.send(message).await.map_err(|e| format!("{e:?}"))
             })
             .await;
 

--- a/crates/bitwarden-uuid-macro/src/lib.rs
+++ b/crates/bitwarden-uuid-macro/src/lib.rs
@@ -16,8 +16,8 @@ pub fn uuid(input: TokenStream) -> TokenStream {
     let vis = input.vis;
     let name_str = ident.to_string();
 
-    let tsify_type = format!("Tagged<Uuid, \"{}\">", name_str);
-    let doc_string = format!(" NewType wrapper for `{}`", name_str);
+    let tsify_type = format!("Tagged<Uuid, \"{name_str}\">");
+    let doc_string = format!(" NewType wrapper for `{name_str}`");
 
     let expanded = quote! {
         #[doc = #doc_string]

--- a/crates/bitwarden-vault/src/totp.rs
+++ b/crates/bitwarden-vault/src/totp.rs
@@ -269,7 +269,7 @@ impl fmt::Display for Totp {
         let secret_b32 = BASE32_NOPAD.encode(&self.secret);
 
         if let TotpAlgorithm::Steam = self.algorithm {
-            return write!(f, "steam://{}", secret_b32);
+            return write!(f, "steam://{secret_b32}");
         }
 
         let mut url = Url::parse("otpauth://totp").map_err(|_| fmt::Error)?;
@@ -290,7 +290,7 @@ impl fmt::Display for Totp {
             .map(|account| percent_encode(account.as_bytes(), NON_ALPHANUMERIC));
 
         let label = match (&encoded_issuer, &encoded_account) {
-            (Some(issuer), Some(account)) => format!("{}:{}", issuer, account),
+            (Some(issuer), Some(account)) => format!("{issuer}:{account}"),
             (None, Some(account)) => account.to_string(),
             _ => String::new(),
         };
@@ -298,10 +298,10 @@ impl fmt::Display for Totp {
         url.set_path(&label);
 
         let mut query_params = Vec::new();
-        query_params.push(format!("secret={}", secret_b32));
+        query_params.push(format!("secret={secret_b32}"));
 
         if let Some(issuer) = &encoded_issuer {
-            query_params.push(format!("issuer={}", issuer));
+            query_params.push(format!("issuer={issuer}"));
         }
 
         if self.period != DEFAULT_PERIOD {
@@ -356,7 +356,7 @@ fn decode_b32(s: &str) -> Vec<u8> {
     let mut bits = String::new();
     for c in s.chars() {
         if let Some(i) = BASE32_CHARS.find(c) {
-            bits.push_str(&format!("{:05b}", i));
+            bits.push_str(&format!("{i:05b}"));
         }
     }
     let mut bytes = Vec::new();
@@ -720,7 +720,7 @@ mod tests {
             secret: vec![1, 2, 3, 4],
         };
         let secret_b32 = BASE32_NOPAD.encode(&totp.secret);
-        assert_eq!(totp.to_string(), format!("steam://{}", secret_b32));
+        assert_eq!(totp.to_string(), format!("steam://{secret_b32}"));
     }
 
     #[test]

--- a/crates/bw/src/auth/login.rs
+++ b/crates/bw/src/auth/login.rs
@@ -32,10 +32,10 @@ pub(crate) async fn login_password(client: Client, email: Option<String>) -> Res
         // TODO: We should build a web captcha solution
         error!("Captcha required");
     } else if let Some(two_factor) = result.two_factor {
-        error!("{:?}", two_factor);
+        error!("{two_factor:?}");
 
         let two_factor = if let Some(tf) = two_factor.authenticator {
-            debug!("{:?}", tf);
+            debug!("{tf:?}");
 
             let token = Text::new("Authenticator code").prompt()?;
 
@@ -54,7 +54,7 @@ pub(crate) async fn login_password(client: Client, email: Option<String>) -> Res
                 })
                 .await?;
 
-            info!("Two factor code sent to {:?}", tf);
+            info!("Two factor code sent to {tf:?}");
             let token = Text::new("Two factor code").prompt()?;
 
             Some(TwoFactorRequest {
@@ -76,9 +76,9 @@ pub(crate) async fn login_password(client: Client, email: Option<String>) -> Res
             })
             .await?;
 
-        debug!("{:?}", result);
+        debug!("{result:?}");
     } else {
-        debug!("{:?}", result);
+        debug!("{result:?}");
     }
 
     let res = client
@@ -87,7 +87,7 @@ pub(crate) async fn login_password(client: Client, email: Option<String>) -> Res
             exclude_subdomains: Some(true),
         })
         .await?;
-    info!("{:#?}", res);
+    info!("{res:#?}");
 
     Ok(())
 }
@@ -111,7 +111,7 @@ pub(crate) async fn login_api_key(
         })
         .await?;
 
-    debug!("{:?}", result);
+    debug!("{result:?}");
 
     Ok(())
 }

--- a/crates/bw/src/main.rs
+++ b/crates/bw/src/main.rs
@@ -154,8 +154,8 @@ async fn process_commands() -> Result<()> {
     match command.clone() {
         Commands::Login(args) => {
             let settings = args.server.map(|server| ClientSettings {
-                api_url: format!("{}/api", server),
-                identity_url: format!("{}/identity", server),
+                api_url: format!("{server}/api"),
+                identity_url: format!("{server}/identity"),
                 ..Default::default()
             });
             let client = bitwarden_core::Client::new(settings);
@@ -185,8 +185,8 @@ async fn process_commands() -> Result<()> {
             server,
         } => {
             let settings = server.map(|server| ClientSettings {
-                api_url: format!("{}/api", server),
-                identity_url: format!("{}/identity", server),
+                api_url: format!("{server}/api"),
+                identity_url: format!("{server}/identity"),
                 ..Default::default()
             });
             let client = bitwarden_core::Client::new(settings);
@@ -227,7 +227,7 @@ async fn process_commands() -> Result<()> {
                     ..Default::default()
                 })?;
 
-                println!("{}", password);
+                println!("{password}");
             }
             GeneratorCommands::Passphrase(args) => {
                 let passphrase = client.generator().passphrase(PassphraseGeneratorRequest {
@@ -237,7 +237,7 @@ async fn process_commands() -> Result<()> {
                     include_number: args.include_number,
                 })?;
 
-                println!("{}", passphrase);
+                println!("{passphrase}");
             }
         },
     };

--- a/crates/memory-testing/src/bin/capture-dumps.rs
+++ b/crates/memory-testing/src/bin/capture-dumps.rs
@@ -12,12 +12,11 @@ fn dump_process_to_bytearray(pid: u32, output_dir: &Path, output_name: &Path) ->
 
     if !output.status.success() {
         return io::Result::Err(io::Error::other(format!(
-            "Failed to dump process: {:?}",
-            output
+            "Failed to dump process: {output:?}"
         )));
     }
 
-    let core_path = format!("core.{}", pid);
+    let core_path = format!("core.{pid}");
     let output_path = output_dir.join(output_name);
     let len = fs::copy(&core_path, output_path)?;
     fs::remove_file(&core_path)?;
@@ -48,7 +47,7 @@ fn wait_dump_and_continue(
         }
     }
     let dump_size = dump_process_to_bytearray(id, &base_dir.join("output"), name)?;
-    println!("Got memory dump of file size: {}", dump_size);
+    println!("Got memory dump of file size: {dump_size}");
 
     stdin.write_all(b".")?;
     stdin.flush()?;
@@ -72,7 +71,7 @@ fn main() -> io::Result<()> {
         .stdin(Stdio::piped())
         .spawn()?;
     let id = proc.id();
-    println!("Started memory testing process with PID: {}", id);
+    println!("Started memory testing process with PID: {id}");
 
     let stdin = proc.stdin.as_mut().expect("Valid stdin");
     let stdout = proc.stdout.as_mut().expect("Valid stdin");
@@ -82,7 +81,7 @@ fn main() -> io::Result<()> {
 
     // Wait for the process to finish and print the output
     let output = proc.wait()?;
-    println!("Return code: {}", output);
+    println!("Return code: {output}");
 
     std::process::exit(output.code().unwrap_or(1));
 }

--- a/support/openapi-template/lib.mustache
+++ b/support/openapi-template/lib.mustache
@@ -4,6 +4,7 @@
     clippy::empty_docs,
     clippy::to_string_in_format_args,
     clippy::needless_return,
+    clippy::uninlined_format_args
 )]
 
 extern crate serde_repr;


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective

Clippy in Rust 1.88 comes with a warning about uninlined format arguments, this PR just runs `cargo clippy --fix` to resolve them, and also excludes the warning from the generated code in the `bitwarden-api-*` crates.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation
  team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
