### PR TITLE
[PM-22271] Expose KDF calculation in PureCrypto

### DIFF
--- a/crates/bitwarden-crypto/src/keys/kdf.rs
+++ b/crates/bitwarden-crypto/src/keys/kdf.rs
@@ -113,7 +113,6 @@ pub fn dangerous_derive_kdf_key(
 ) -> Result<Vec<u8>, CryptoError> {
     KdfDerivedKeyMaterial::derive_kdf_key(password, email, kdf)
         .map(|kdf_key| kdf_key.0.to_vec())
-        .map_err(|e| e.into())
 }
 
 /// Key Derivation Function for Bitwarden Account

--- a/crates/bitwarden-crypto/src/keys/kdf.rs
+++ b/crates/bitwarden-crypto/src/keys/kdf.rs
@@ -98,6 +98,24 @@ impl KdfDerivedKeyMaterial {
     }
 }
 
+#[deprecated(
+    note = "This function is only meant as a temporary stop-gap to expose KDF derivation in PureCrypto until the higher-level consumers are moved to the SDK directly. DO NOT USE THIS OUTSIDE OF PureCrypto!"
+)]
+/// Derives KDF material given a password, email and kdf configuration. This function is
+/// a stop-gap solution and should not be used outside of PureCrypto.
+///
+/// The clean-up ticket is tracked here:
+/// `https://bitwarden.atlassian.net/browse/PM-23168`
+pub fn dangerous_derive_kdf_key(
+    password: &[u8],
+    email: &[u8],
+    kdf: &Kdf,
+) -> Result<Vec<u8>, CryptoError> {
+    KdfDerivedKeyMaterial::derive_kdf_key(password, email, kdf)
+        .map(|kdf_key| kdf_key.0.to_vec())
+        .map_err(|e| e.into())
+}
+
 /// Key Derivation Function for Bitwarden Account
 ///
 /// In Bitwarden accounts can use multiple KDFs to derive their master key from their password. This

--- a/crates/bitwarden-crypto/src/keys/kdf.rs
+++ b/crates/bitwarden-crypto/src/keys/kdf.rs
@@ -106,7 +106,7 @@ impl KdfDerivedKeyMaterial {
 ///
 /// The clean-up ticket is tracked here:
 /// `https://bitwarden.atlassian.net/browse/PM-23168`
-pub fn dangerous_derive_kdf_key(
+pub fn dangerous_derive_kdf_output(
     password: &[u8],
     salt: &[u8],
     kdf: &Kdf,

--- a/crates/bitwarden-crypto/src/keys/kdf.rs
+++ b/crates/bitwarden-crypto/src/keys/kdf.rs
@@ -101,7 +101,7 @@ impl KdfDerivedKeyMaterial {
 #[deprecated(
     note = "This function is only meant as a temporary stop-gap to expose KDF derivation in PureCrypto until the higher-level consumers are moved to the SDK directly. DO NOT USE THIS OUTSIDE OF PureCrypto!"
 )]
-/// Derives KDF material given a password, email and kdf configuration. This function is
+/// Derives KDF material given a password, salt and kdf configuration. This function is
 /// a stop-gap solution and should not be used outside of PureCrypto.
 ///
 /// The clean-up ticket is tracked here:

--- a/crates/bitwarden-crypto/src/keys/kdf.rs
+++ b/crates/bitwarden-crypto/src/keys/kdf.rs
@@ -108,11 +108,10 @@ impl KdfDerivedKeyMaterial {
 /// `https://bitwarden.atlassian.net/browse/PM-23168`
 pub fn dangerous_derive_kdf_key(
     password: &[u8],
-    email: &[u8],
+    salt: &[u8],
     kdf: &Kdf,
 ) -> Result<Vec<u8>, CryptoError> {
-    KdfDerivedKeyMaterial::derive_kdf_key(password, email, kdf)
-        .map(|kdf_key| kdf_key.0.to_vec())
+    KdfDerivedKeyMaterial::derive_kdf_key(password, salt, kdf).map(|kdf_key| kdf_key.0.to_vec())
 }
 
 /// Key Derivation Function for Bitwarden Account

--- a/crates/bitwarden-crypto/src/keys/kdf.rs
+++ b/crates/bitwarden-crypto/src/keys/kdf.rs
@@ -106,7 +106,7 @@ impl KdfDerivedKeyMaterial {
 ///
 /// The clean-up ticket is tracked here:
 /// `https://bitwarden.atlassian.net/browse/PM-23168`
-pub fn dangerous_derive_kdf_output(
+pub fn dangerous_derive_kdf_material(
     password: &[u8],
     salt: &[u8],
     kdf: &Kdf,

--- a/crates/bitwarden-crypto/src/keys/mod.rs
+++ b/crates/bitwarden-crypto/src/keys/mod.rs
@@ -26,7 +26,7 @@ mod pin_key;
 pub use pin_key::PinKey;
 mod kdf;
 #[allow(deprecated)]
-pub use kdf::dangerous_derive_kdf_output;
+pub use kdf::dangerous_derive_kdf_material;
 mod key_id;
 pub use kdf::{
     default_argon2_iterations, default_argon2_memory, default_argon2_parallelism,

--- a/crates/bitwarden-crypto/src/keys/mod.rs
+++ b/crates/bitwarden-crypto/src/keys/mod.rs
@@ -25,6 +25,8 @@ pub use device_key::{DeviceKey, TrustDeviceResponse};
 mod pin_key;
 pub use pin_key::PinKey;
 mod kdf;
+#[allow(deprecated)]
+pub use kdf::dangerous_derive_kdf_key;
 mod key_id;
 pub use kdf::{
     default_argon2_iterations, default_argon2_memory, default_argon2_parallelism,

--- a/crates/bitwarden-crypto/src/keys/mod.rs
+++ b/crates/bitwarden-crypto/src/keys/mod.rs
@@ -26,7 +26,7 @@ mod pin_key;
 pub use pin_key::PinKey;
 mod kdf;
 #[allow(deprecated)]
-pub use kdf::dangerous_derive_kdf_key;
+pub use kdf::dangerous_derive_kdf_output;
 mod key_id;
 pub use kdf::{
     default_argon2_iterations, default_argon2_memory, default_argon2_parallelism,

--- a/crates/bitwarden-wasm-internal/src/pure_crypto.rs
+++ b/crates/bitwarden-wasm-internal/src/pure_crypto.rs
@@ -2,7 +2,7 @@ use std::str::FromStr;
 
 use bitwarden_core::key_management::{KeyIds, SymmetricKeyId};
 #[allow(deprecated)]
-use bitwarden_crypto::dangerous_derive_kdf_output;
+use bitwarden_crypto::dangerous_derive_kdf_material;
 use bitwarden_crypto::{
     AsymmetricCryptoKey, AsymmetricPublicCryptoKey, BitwardenLegacyKeyBytes, CoseKeyBytes,
     CoseSerializable, CoseSign1Bytes, CryptoError, Decryptable, EncString, Kdf, KeyDecryptable,
@@ -313,14 +313,14 @@ impl PureCrypto {
             .map(|pk| pk.to_vec())
     }
 
-    /// Derive the KDF output for a [bitwarden_crypto::Kdf] configuration.
-    pub fn derive_kdf_output(
+    /// Derive output of the KDF for a [bitwarden_crypto::Kdf] configuration.
+    pub fn derive_kdf_material(
         password: &[u8],
         salt: &[u8],
         kdf: Kdf,
     ) -> Result<Vec<u8>, CryptoError> {
         #[allow(deprecated)]
-        dangerous_derive_kdf_output(password, salt, &kdf)
+        dangerous_derive_kdf_material(password, salt, &kdf)
     }
 }
 
@@ -648,7 +648,7 @@ DnqOsltgPomWZ7xVfMkm9niL2OA=
         let kdf = Kdf::PBKDF2 {
             iterations: NonZero::try_from(600000).unwrap(),
         };
-        let derived_key = PureCrypto::derive_kdf_output(password, email, kdf).unwrap();
+        let derived_key = PureCrypto::derive_kdf_material(password, email, kdf).unwrap();
         assert_eq!(derived_key, DERIVED_KDF_MATERIAL_PBKDF2);
     }
 
@@ -661,7 +661,7 @@ DnqOsltgPomWZ7xVfMkm9niL2OA=
             memory: NonZero::try_from(64).unwrap(),
             parallelism: NonZero::try_from(4).unwrap(),
         };
-        let derived_key = PureCrypto::derive_kdf_output(password, email, kdf).unwrap();
+        let derived_key = PureCrypto::derive_kdf_material(password, email, kdf).unwrap();
         assert_eq!(derived_key, DERIVED_KDF_MATERIAL_ARGON2ID);
     }
 }

--- a/crates/bitwarden-wasm-internal/src/pure_crypto.rs
+++ b/crates/bitwarden-wasm-internal/src/pure_crypto.rs
@@ -315,12 +315,12 @@ impl PureCrypto {
 
     /// Derive the KDF output for a [bitwarden_crypto::Kdf] configuration.
     pub fn derive_kdf_output(
-        password: String,
-        email: String,
+        password: &[u8],
+        salt: &[u8],
         kdf: Kdf,
     ) -> Result<Vec<u8>, CryptoError> {
         #[allow(deprecated)]
-        dangerous_derive_kdf_key(password.as_bytes(), email.as_bytes(), &kdf)
+        dangerous_derive_kdf_key(password, salt, &kdf)
     }
 }
 
@@ -643,8 +643,8 @@ DnqOsltgPomWZ7xVfMkm9niL2OA=
 
     #[test]
     fn test_derive_pbkdf2_output() {
-        let password = "test_password".to_string();
-        let email = "test_email@example.com".to_string();
+        let password = "test_password".as_bytes();
+        let email = "test_email@example.com".as_bytes();
         let kdf = Kdf::PBKDF2 {
             iterations: NonZero::try_from(600000).unwrap(),
         };
@@ -654,8 +654,8 @@ DnqOsltgPomWZ7xVfMkm9niL2OA=
 
     #[test]
     fn test_derived_argon2_output() {
-        let password = "test_password".to_string();
-        let email = "test_email@example.com".to_string();
+        let password = "test_password".as_bytes();
+        let email = "test_email@example.com".as_bytes();
         let kdf = Kdf::Argon2id {
             iterations: NonZero::try_from(3).unwrap(),
             memory: NonZero::try_from(64).unwrap(),

--- a/crates/bitwarden-wasm-internal/src/pure_crypto.rs
+++ b/crates/bitwarden-wasm-internal/src/pure_crypto.rs
@@ -314,7 +314,7 @@ impl PureCrypto {
     }
 
     /// Derive the KDF output for a [bitwarden_crypto::Kdf] configuration.
-    pub fn derive_kdf_output(
+    pub fn dangerous_derive_kdf_output(
         password: &[u8],
         salt: &[u8],
         kdf: Kdf,
@@ -648,7 +648,7 @@ DnqOsltgPomWZ7xVfMkm9niL2OA=
         let kdf = Kdf::PBKDF2 {
             iterations: NonZero::try_from(600000).unwrap(),
         };
-        let derived_key = PureCrypto::derive_kdf_output(password, email, kdf).unwrap();
+        let derived_key = PureCrypto::dangerous_derive_kdf_output(password, email, kdf).unwrap();
         assert_eq!(derived_key, DERIVED_KDF_MATERIAL_PBKDF2);
     }
 
@@ -661,7 +661,7 @@ DnqOsltgPomWZ7xVfMkm9niL2OA=
             memory: NonZero::try_from(64).unwrap(),
             parallelism: NonZero::try_from(4).unwrap(),
         };
-        let derived_key = PureCrypto::derive_kdf_output(password, email, kdf).unwrap();
+        let derived_key = PureCrypto::dangerous_derive_kdf_output(password, email, kdf).unwrap();
         assert_eq!(derived_key, DERIVED_KDF_MATERIAL_ARGON2ID);
     }
 }

--- a/crates/bitwarden-wasm-internal/src/pure_crypto.rs
+++ b/crates/bitwarden-wasm-internal/src/pure_crypto.rs
@@ -1,6 +1,8 @@
 use std::str::FromStr;
 
 use bitwarden_core::key_management::{KeyIds, SymmetricKeyId};
+#[allow(deprecated)]
+use bitwarden_crypto::dangerous_derive_kdf_key;
 use bitwarden_crypto::{
     AsymmetricCryptoKey, AsymmetricPublicCryptoKey, BitwardenLegacyKeyBytes, CoseKeyBytes,
     CoseSerializable, CoseSign1Bytes, CryptoError, Decryptable, EncString, Kdf, KeyDecryptable,
@@ -310,6 +312,16 @@ impl PureCrypto {
             .map(|public_key| public_key.to_der())?
             .map(|pk| pk.to_vec())
     }
+
+    /// Derive the KDF output for a [bitwarden_crypto::Kdf] configuration.
+    pub fn derive_kdf_output(
+        password: String,
+        email: String,
+        kdf: Kdf,
+    ) -> Result<Vec<u8>, CryptoError> {
+        #[allow(deprecated)]
+        dangerous_derive_kdf_key(password.as_bytes(), email.as_bytes(), &kdf)
+    }
 }
 
 #[cfg(test)]
@@ -425,6 +437,16 @@ DnqOsltgPomWZ7xVfMkm9niL2OA=
         73, 4, 134, 242, 24, 56, 54, 38, 178, 59, 11, 118, 230, 159, 87, 91, 20, 237, 188, 186,
         216, 86, 189, 50, 46, 173, 117, 36, 54, 105, 216, 9,
     ];
+
+    const DERIVED_KDF_MATERIAL_PBKDF2: &[u8] = &[
+        129, 57, 137, 140, 156, 220, 110, 212, 201, 255, 52, 182, 22, 206, 221, 66, 136, 199, 181,
+        89, 252, 175, 82, 168, 79, 204, 88, 174, 166, 60, 52, 79,
+    ];
+    const DERIVED_KDF_MATERIAL_ARGON2ID: &[u8] = &[
+        221, 57, 158, 206, 27, 154, 188, 170, 33, 198, 250, 144, 191, 231, 29, 74, 201, 102, 253,
+        77, 8, 128, 173, 111, 217, 41, 125, 9, 156, 52, 112, 140,
+    ];
+
     #[test]
     fn test_symmetric_decrypt() {
         let enc_string = EncString::from_str(ENCRYPTED).unwrap();
@@ -617,5 +639,29 @@ DnqOsltgPomWZ7xVfMkm9niL2OA=
         )
         .unwrap();
         assert_eq!(public_key, PUBLIC_KEY);
+    }
+
+    #[test]
+    fn test_derive_pbkdf2_output() {
+        let password = "test_password".to_string();
+        let email = "test_email@example.com".to_string();
+        let kdf = Kdf::PBKDF2 {
+            iterations: NonZero::try_from(600000).unwrap(),
+        };
+        let derived_key = PureCrypto::derive_kdf_output(password, email, kdf).unwrap();
+        assert_eq!(derived_key, DERIVED_KDF_MATERIAL_PBKDF2);
+    }
+
+    #[test]
+    fn test_derived_argon2_output() {
+        let password = "test_password".to_string();
+        let email = "test_email@example.com".to_string();
+        let kdf = Kdf::Argon2id {
+            iterations: NonZero::try_from(3).unwrap(),
+            memory: NonZero::try_from(64).unwrap(),
+            parallelism: NonZero::try_from(4).unwrap(),
+        };
+        let derived_key = PureCrypto::derive_kdf_output(password, email, kdf).unwrap();
+        assert_eq!(derived_key, DERIVED_KDF_MATERIAL_ARGON2ID);
     }
 }

--- a/crates/bitwarden-wasm-internal/src/pure_crypto.rs
+++ b/crates/bitwarden-wasm-internal/src/pure_crypto.rs
@@ -2,7 +2,7 @@ use std::str::FromStr;
 
 use bitwarden_core::key_management::{KeyIds, SymmetricKeyId};
 #[allow(deprecated)]
-use bitwarden_crypto::dangerous_derive_kdf_key;
+use bitwarden_crypto::dangerous_derive_kdf_output;
 use bitwarden_crypto::{
     AsymmetricCryptoKey, AsymmetricPublicCryptoKey, BitwardenLegacyKeyBytes, CoseKeyBytes,
     CoseSerializable, CoseSign1Bytes, CryptoError, Decryptable, EncString, Kdf, KeyDecryptable,
@@ -314,13 +314,13 @@ impl PureCrypto {
     }
 
     /// Derive the KDF output for a [bitwarden_crypto::Kdf] configuration.
-    pub fn dangerous_derive_kdf_output(
+    pub fn derive_kdf_output(
         password: &[u8],
         salt: &[u8],
         kdf: Kdf,
     ) -> Result<Vec<u8>, CryptoError> {
         #[allow(deprecated)]
-        dangerous_derive_kdf_key(password, salt, &kdf)
+        dangerous_derive_kdf_output(password, salt, &kdf)
     }
 }
 
@@ -648,7 +648,7 @@ DnqOsltgPomWZ7xVfMkm9niL2OA=
         let kdf = Kdf::PBKDF2 {
             iterations: NonZero::try_from(600000).unwrap(),
         };
-        let derived_key = PureCrypto::dangerous_derive_kdf_output(password, email, kdf).unwrap();
+        let derived_key = PureCrypto::derive_kdf_output(password, email, kdf).unwrap();
         assert_eq!(derived_key, DERIVED_KDF_MATERIAL_PBKDF2);
     }
 
@@ -661,7 +661,7 @@ DnqOsltgPomWZ7xVfMkm9niL2OA=
             memory: NonZero::try_from(64).unwrap(),
             parallelism: NonZero::try_from(4).unwrap(),
         };
-        let derived_key = PureCrypto::dangerous_derive_kdf_output(password, email, kdf).unwrap();
+        let derived_key = PureCrypto::derive_kdf_output(password, email, kdf).unwrap();
         assert_eq!(derived_key, DERIVED_KDF_MATERIAL_ARGON2ID);
     }
 }


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-22271
https://github.com/bitwarden/clients/pull/15401

## 📔 Objective

We want to drop our three different argon2 implementations on `clients` (desktop-native rustcrypto, patched argon2-browser WASM, native C++ module on cli). Each of these have impactful bugs (https://bitwarden.atlassian.net/browse/PM-17450, https://bitwarden.atlassian.net/browse/PM-22217), and tech debt (dependency updates, and the patching scripts for node modules) associated.

In this case, there is a small amount of tech debt introduced in the SDK because we introduce a deprecated function on PureCrypto. This small amount of tech debt introduced is far outweight by the dependencies that can be dropped on ts. (The clients PR: <img width="128" alt="image" src="https://github.com/user-attachments/assets/642c6ee8-2df3-406c-aba1-167a1647b65d" />)


Specifically, since we want to fix immediate bugs, we do not yet do the work of porting all higher-level usages (masterpassword-unlock, masterkeyhash auth, pin unlock/enrollment, send password "key"(hash) deriving) to the SDK. This is follow-up feature work, and larger in scope, and involves other teams (auth,tools). Once this follow-up feature-work is complete, the tech-debt function introduced in this ticket will be removed, and a tech-debt ticket for this is linked. 

The tech debt function is clearly marked as `dangerous_` and `deprecated` with a note.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation
  team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
