### PR TITLE
Fix card substring

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,6 +83,7 @@ pkcs5 = { git = "https://github.com/bitwarden/rustcrypto-formats.git", rev = "2b
 [workspace.lints.clippy]
 unused_async = "deny"
 unwrap_used = "deny"
+string_slice = "warn"
 
 [workspace.lints.rust]
 missing_docs = "warn"

--- a/crates/bitwarden-vault/src/cipher/card.rs
+++ b/crates/bitwarden-vault/src/cipher/card.rs
@@ -173,20 +173,21 @@ fn build_subtitle_card(brand: Option<String>, number: Option<String>) -> String 
     }
 
     if let Some(number) = number {
-        let number_len = number.len();
+        let number_chars: Vec<_> = number.chars().collect();
+        let number_len = number_chars.len();
         if number_len > 4 {
             if !subtitle.is_empty() {
                 subtitle.push_str(", ");
             }
 
             // On AMEX cards we show 5 digits instead of 4
-            let digit_count = match &number[0..2] {
-                "34" | "37" => 5,
+            let digit_count = match number_chars[0..2] {
+                ['3', '4'] | ['3', '7'] => 5,
                 _ => 4,
             };
 
             subtitle.push('*');
-            subtitle.push_str(&number[(number_len - digit_count)..]);
+            subtitle.extend(number_chars.iter().skip(number_len - digit_count));
         }
     }
 
@@ -267,6 +268,15 @@ mod tests {
             copyable_fields,
             vec![CopyableCipherFields::CardSecurityCode]
         );
+    }
+
+    #[test]
+    fn test_build_subtitle_card_unicode() {
+        let brand = Some("Visa".to_owned());
+        let number = Some("•••• 3278".to_owned());
+
+        let subtitle = build_subtitle_card(brand, number);
+        assert_eq!(subtitle, "Visa, *3278");
     }
 
     #[test]


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective

The string subslicing would panic when the subslice would split a multibyte unicode char in two. Using the .chars() API respects the unicode character boundaries.

Also enabled a lint to warn against string slicing in the future.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation
  team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
