### PR TITLE
[RFC] Add parse fuzzing via cargo fuzz

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -54,6 +54,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "afl"
+version = "0.15.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2e868a49dcc54f7edcec970721ba68c4b5cc5f1e478393ae2dd2d475efd752e"
+dependencies = [
+ "home",
+ "libc",
+ "rustc_version",
+ "xdg",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -155,6 +167,15 @@ name = "anyhow"
 version = "1.0.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
+
+[[package]]
+name = "arbitrary"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dde20b3d026af13f561bdd0f15edf01fc734f0dafcedbaf42bba506a9517f223"
+dependencies = [
+ "derive_arbitrary",
+]
 
 [[package]]
 name = "argon2"
@@ -653,6 +674,7 @@ dependencies = [
 name = "bitwarden-vault"
 version = "1.0.0"
 dependencies = [
+ "arbitrary",
  "base64",
  "bitwarden-api-api",
  "bitwarden-core",
@@ -824,6 +846,8 @@ version = "1.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04da6a0d40b948dfc4fa8f5bbf402b0fc1a64a28dbf7d12ffd683550f2c1b63a"
 dependencies = [
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -1368,6 +1392,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_arbitrary"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30542c1ad912e0e3d22a1935c290e12e8a29d704a420177a31faad4a601a0800"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "derive_builder"
 version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1682,6 +1717,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "fuzz"
+version = "0.0.0"
+dependencies = [
+ "afl",
+ "bitwarden-crypto",
+ "bitwarden-exporters",
+ "bitwarden-fido",
+ "bitwarden-vault",
+ "chrono",
+ "libfuzzer-sys",
+]
+
+[[package]]
 name = "fuzzy-matcher"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1874,6 +1922,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
  "digest",
+]
+
+[[package]]
+name = "home"
+version = "0.5.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3d1354bf6b7235cb4a0576c2619fd4ed18183f689b12b006a0ee7329eeff9a5"
+dependencies = [
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2323,6 +2380,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
 
 [[package]]
+name = "jobserver"
+version = "0.1.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38f262f097c174adebe41eb73d66ae9c06b2844fb0da69969647bbddd9b0538a"
+dependencies = [
+ "getrandom 0.3.2",
+ "libc",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2346,6 +2413,16 @@ name = "libc"
 version = "0.2.172"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
+
+[[package]]
+name = "libfuzzer-sys"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5037190e1f70cbeef565bd267599242926f724d3b8a9f510fd7e0b540cfa4404"
+dependencies = [
+ "arbitrary",
+ "cc",
+]
 
 [[package]]
 name = "libloading"
@@ -5129,6 +5206,12 @@ name = "writeable"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
+
+[[package]]
+name = "xdg"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fb433233f2df9344722454bc7e96465c9d03bff9d77c248f9e7523fe79585b5"
 
 [[package]]
 name = "yoke"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 resolver = "2"
-members = ["bitwarden_license/*", "crates/*"]
+members = ["bitwarden_license/*", "crates/*", "fuzz"]
 
 # Global settings for all crates should be defined here
 [workspace.package]
@@ -34,6 +34,8 @@ bitwarden-ssh = { path = "crates/bitwarden-ssh", version = "=1.0.0" }
 bitwarden-vault = { path = "crates/bitwarden-vault", version = "=1.0.0" }
 bitwarden-error = { path = "crates/bitwarden-error", version = "=1.0.0" }
 bitwarden-error-macro = { path = "crates/bitwarden-error-macro", version = "=1.0.0" }
+
+fuzz = { path = "fuzz", version = "=0.0.0" }
 
 # External crates that are expected to maintain a consistent version across all crates
 chrono = { version = ">=0.4.26, <0.5", features = [

--- a/crates/bitwarden-crypto/src/aes.rs
+++ b/crates/bitwarden-crypto/src/aes.rs
@@ -91,7 +91,7 @@ fn encrypt_aes256_internal(
 }
 
 /// Generate a MAC using HMAC-SHA256.
-fn generate_mac(mac_key: &[u8], iv: &[u8], data: &[u8]) -> Result<[u8; 32]> {
+pub fn generate_mac(mac_key: &[u8], iv: &[u8], data: &[u8]) -> Result<[u8; 32]> {
     let mut hmac =
         PbkdfSha256Hmac::new_from_slice(mac_key).expect("hmac new_from_slice should not fail");
     hmac.update(iv);

--- a/crates/bitwarden-crypto/src/enc_string/symmetric.rs
+++ b/crates/bitwarden-crypto/src/enc_string/symmetric.rs
@@ -352,6 +352,12 @@ mod tests {
     };
 
     #[test]
+    fn from_buffer() {
+        let a = EncString::from_buffer(&[7]);
+        println!("{:?}", a);
+    }
+
+    #[test]
     fn test_enc_roundtrip_xchacha20() {
         let key_id = [0u8; KEY_ID_SIZE];
         let enc_key = [0u8; 32];

--- a/crates/bitwarden-crypto/src/lib.rs
+++ b/crates/bitwarden-crypto/src/lib.rs
@@ -13,6 +13,7 @@
 static ALLOC: ZeroizingAllocator<std::alloc::System> = ZeroizingAllocator(std::alloc::System);
 
 mod aes;
+pub use aes::generate_mac;
 mod enc_string;
 pub use enc_string::{EncString, UnsignedSharedKey};
 mod error;

--- a/crates/bitwarden-exporters/src/cxf/import.rs
+++ b/crates/bitwarden-exporters/src/cxf/import.rs
@@ -9,7 +9,7 @@ use crate::{
     CipherType, ImportingCipher,
 };
 
-pub(crate) fn parse_cxf(payload: String) -> Result<Vec<ImportingCipher>, CxfError> {
+pub fn parse_cxf(payload: String) -> Result<Vec<ImportingCipher>, CxfError> {
     let account: CxfAccount = serde_json::from_str(&payload)?;
 
     let items: Vec<ImportingCipher> = account.items.into_iter().flat_map(parse_item).collect();

--- a/crates/bitwarden-exporters/src/cxf/mod.rs
+++ b/crates/bitwarden-exporters/src/cxf/mod.rs
@@ -11,6 +11,6 @@ mod export;
 pub(crate) use export::build_cxf;
 pub use export::Account;
 mod import;
-pub(crate) use import::parse_cxf;
+pub use import::parse_cxf;
 mod card;
 mod login;

--- a/crates/bitwarden-exporters/src/lib.rs
+++ b/crates/bitwarden-exporters/src/lib.rs
@@ -13,7 +13,7 @@ mod uniffi_support;
 
 mod csv;
 mod cxf;
-pub use cxf::Account;
+pub use cxf::{parse_cxf, Account};
 mod encrypted_json;
 mod exporter_client;
 mod json;

--- a/crates/bitwarden-fido/src/lib.rs
+++ b/crates/bitwarden-fido/src/lib.rs
@@ -105,7 +105,9 @@ impl TryFrom<CipherViewContainer> for Passkey {
     }
 }
 
-fn try_from_credential_full_view(value: Fido2CredentialFullView) -> Result<Passkey, Fido2Error> {
+pub fn try_from_credential_full_view(
+    value: Fido2CredentialFullView,
+) -> Result<Passkey, Fido2Error> {
     let counter: u32 = value.counter.parse().expect("Invalid counter");
     let counter = (counter != 0).then_some(counter);
     let key_value = URL_SAFE_NO_PAD.decode(value.key_value)?;

--- a/crates/bitwarden-generators/src/lib.rs
+++ b/crates/bitwarden-generators/src/lib.rs
@@ -6,7 +6,7 @@ pub use generator_client::{GeneratorClient, GeneratorClientsExt};
 pub(crate) mod passphrase;
 pub use passphrase::{PassphraseError, PassphraseGeneratorRequest};
 pub(crate) mod password;
-pub use password::{PasswordError, PasswordGeneratorRequest};
+pub use password::{password, PasswordError, PasswordGeneratorOptions, PasswordGeneratorRequest};
 pub(crate) mod username;
 pub use username::{ForwarderServiceType, UsernameError, UsernameGeneratorRequest};
 mod util;

--- a/crates/bitwarden-generators/src/password.rs
+++ b/crates/bitwarden-generators/src/password.rs
@@ -130,7 +130,7 @@ impl Distribution<char> for CharSet {
 /// Represents a set of valid options to generate a password with.
 /// To get an instance of it, use
 /// [`PasswordGeneratorRequest::validate_options`](PasswordGeneratorRequest::validate_options)
-struct PasswordGeneratorOptions {
+pub struct PasswordGeneratorOptions {
     pub(super) lower: (CharSet, usize),
     pub(super) upper: (CharSet, usize),
     pub(super) number: (CharSet, usize),
@@ -224,7 +224,7 @@ impl PasswordGeneratorRequest {
 }
 
 /// Implementation of the random password generator.
-pub(crate) fn password(input: PasswordGeneratorRequest) -> Result<String, PasswordError> {
+pub fn password(input: PasswordGeneratorRequest) -> Result<String, PasswordError> {
     let options = input.validate_options()?;
     Ok(password_with_rng(rand::thread_rng(), options))
 }

--- a/crates/bitwarden-vault/Cargo.toml
+++ b/crates/bitwarden-vault/Cargo.toml
@@ -23,6 +23,7 @@ uniffi = [
 wasm = ["dep:tsify-next", "dep:wasm-bindgen"] # WASM support
 
 [dependencies]
+arbitrary = { version = "1.4.1", features = ["derive_arbitrary"] }
 base64 = ">=0.22.1, <0.23"
 bitwarden-api-api = { workspace = true }
 bitwarden-core = { workspace = true, features = ["internal"] }

--- a/crates/bitwarden-vault/src/cipher/login.rs
+++ b/crates/bitwarden-vault/src/cipher/login.rs
@@ -5,7 +5,7 @@ use bitwarden_core::{
     require,
 };
 use bitwarden_crypto::{CryptoError, Decryptable, EncString, Encryptable, KeyStoreContext};
-use chrono::{DateTime, Utc};
+use chrono::{Date, DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use serde_repr::{Deserialize_repr, Serialize_repr};
 #[cfg(feature = "wasm")]
@@ -149,6 +149,26 @@ pub struct Fido2CredentialFullView {
     pub user_display_name: Option<String>,
     pub discoverable: String,
     pub creation_date: DateTime<Utc>,
+}
+
+impl<'a> arbitrary::Arbitrary<'a> for Fido2CredentialFullView {
+    fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
+        Ok(Fido2CredentialFullView {
+            credential_id: u.arbitrary()?,
+            key_type: u.arbitrary()?,
+            key_algorithm: u.arbitrary()?,
+            key_curve: u.arbitrary()?,
+            key_value: u.arbitrary()?,
+            rp_id: u.arbitrary()?,
+            user_handle: u.arbitrary()?,
+            user_name: u.arbitrary()?,
+            counter: u.arbitrary()?,
+            rp_name: u.arbitrary()?,
+            user_display_name: u.arbitrary()?,
+            discoverable: u.arbitrary()?,
+            creation_date: DateTime::<Utc>::from_timestamp_nanos(u.arbitrary::<i64>()?),
+        })
+    }
 }
 
 // This is mostly a copy of the Fido2CredentialView, meant to be exposed to the clients

--- a/fuzz/.gitignore
+++ b/fuzz/.gitignore
@@ -1,0 +1,4 @@
+target
+corpus
+artifacts
+coverage

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -1,0 +1,66 @@
+[package]
+name = "fuzz"
+version = "0.0.0"
+publish = false
+edition = "2021"
+
+[package.metadata]
+cargo-fuzz = true
+
+[dependencies]
+libfuzzer-sys = "0.4"
+bitwarden-crypto = { workspace = true }
+bitwarden-exporters = { workspace = true }
+bitwarden-fido = { workspace = true }
+bitwarden-vault = { workspace = true }
+chrono = { workspace = true }
+afl = "0.15.19"
+
+[[bin]]
+name = "parse_enc_buffer"
+path = "fuzz_targets/parse_enc_buffer.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "parse_enc_string"
+path = "fuzz_targets/parse_enc_string.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "parse_symmetric_crypto_key"
+path = "fuzz_targets/parse_symmetric_crypto_key.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "parse_unsigned_shared_key"
+path = "fuzz_targets/parse_unsigned_shared_key.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "parse_cxf"
+path = "fuzz_targets/parse_cxf.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "parse_passkey"
+path = "fuzz_targets/parse_passkey.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "generate_mac"
+path = "fuzz_targets/generate_mac.rs"
+test = false
+doc = false
+bench = false

--- a/fuzz/fuzz_targets/generate_mac.rs
+++ b/fuzz/fuzz_targets/generate_mac.rs
@@ -1,0 +1,9 @@
+#![no_main]
+
+use bitwarden_crypto::generate_mac;
+use libfuzzer_sys::fuzz_target;
+
+// EncString parsing should never panic
+fuzz_target!(|data: &[u8]| {
+    let _ = generate_mac(data, &[], &[]);
+});

--- a/fuzz/fuzz_targets/parse_cxf.rs
+++ b/fuzz/fuzz_targets/parse_cxf.rs
@@ -1,0 +1,14 @@
+#![no_main]
+
+use bitwarden_exporters::parse_cxf;
+use libfuzzer_sys::fuzz_target;
+
+// SymmetricCryptoKey parsing should never panic
+fuzz_target!(|data: &[u8]| {
+    let payload = match String::from_utf8(data.to_vec()) {
+        Ok(s) => s,
+        Err(_) => return, // Skip invalid UTF-8 data
+    };
+    let _ = parse_cxf(payload);
+});
+

--- a/fuzz/fuzz_targets/parse_enc_buffer.rs
+++ b/fuzz/fuzz_targets/parse_enc_buffer.rs
@@ -1,0 +1,9 @@
+#![no_main]
+
+use bitwarden_crypto::EncString;
+use libfuzzer_sys::fuzz_target;
+
+// EncBuffer parsing should never panic
+fuzz_target!(|data: &[u8]| {
+    let _ = EncString::from_buffer(data);
+});

--- a/fuzz/fuzz_targets/parse_enc_string.rs
+++ b/fuzz/fuzz_targets/parse_enc_string.rs
@@ -1,0 +1,15 @@
+#![no_main]
+
+use std::str::FromStr;
+
+use bitwarden_crypto::EncString;
+use libfuzzer_sys::fuzz_target;
+
+// EncString parsing should never panic
+fuzz_target!(|data: &[u8]| {
+    let data_string = match std::str::from_utf8(data) {
+        Ok(s) => s,
+        Err(_) => return,
+    };
+    let _ = EncString::from_str(data_string);
+});

--- a/fuzz/fuzz_targets/parse_passkey.rs
+++ b/fuzz/fuzz_targets/parse_passkey.rs
@@ -1,0 +1,10 @@
+#![no_main]
+
+use bitwarden_fido::try_from_credential_full_view;
+use bitwarden_vault::Fido2CredentialFullView;
+use libfuzzer_sys::fuzz_target;
+
+// EncString parsing should never panic
+fuzz_target!(|data: Fido2CredentialFullView| {
+    let _ = try_from_credential_full_view(data);
+});

--- a/fuzz/fuzz_targets/parse_symmetric_crypto_key.rs
+++ b/fuzz/fuzz_targets/parse_symmetric_crypto_key.rs
@@ -1,0 +1,9 @@
+#![no_main]
+
+use bitwarden_crypto::SymmetricCryptoKey;
+use libfuzzer_sys::fuzz_target;
+
+// SymmetricCryptoKey parsing should never panic
+fuzz_target!(|data: &[u8]| {
+    let _ = SymmetricCryptoKey::try_from(data.to_vec());
+});

--- a/fuzz/fuzz_targets/parse_unsigned_shared_key.rs
+++ b/fuzz/fuzz_targets/parse_unsigned_shared_key.rs
@@ -1,0 +1,15 @@
+#![no_main]
+
+use std::str::FromStr;
+
+use bitwarden_crypto::UnsignedSharedKey;
+use libfuzzer_sys::fuzz_target;
+
+// UnsignedSharedKey parsing should never panic
+fuzz_target!(|data: &[u8]| {
+    let data_string = match std::str::from_utf8(data) {
+        Ok(s) => s,
+        Err(_) => return,
+    };
+    let _ = UnsignedSharedKey::from_str(data_string);
+});


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective

Adds fuzzing. In this case, the test cases would only detect panic(unwrap/expect). For `parse_passkey`, the following failing input is discovered:
```
        Fido2CredentialFullView {
            credential_id: "",
            key_type: "",
            key_algorithm: "",
            key_curve: "",
            key_value: "",
            rp_id: "",
            user_handle: None,
            user_name: None,
            counter: "",
            rp_name: None,
            user_display_name: None,
            discoverable: "",
            creation_date: 1970-01-01T00:00:00Z,
        }
```
from this expect: https://github.com/bitwarden/sdk-internal/blob/f2bc7084ffa2a0a427b2b215bd0d39944f9cb705/crates/bitwarden-fido/src/lib.rs#L110.

Fix in: https://github.com/bitwarden/sdk-internal/pull/346


I have not further audited where this is called.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation
  team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
