### PR TITLE
Prevent panic in bitwarden-fido crate

### DIFF
--- a/crates/bitwarden-fido/src/lib.rs
+++ b/crates/bitwarden-fido/src/lib.rs
@@ -91,6 +91,9 @@ pub enum Fido2Error {
 
     #[error("No Fido2 credentials found")]
     NoFido2CredentialsFound,
+
+    #[error("Invalid counter")]
+    InvalidCounter,
 }
 
 impl TryFrom<CipherViewContainer> for Passkey {
@@ -107,7 +110,10 @@ impl TryFrom<CipherViewContainer> for Passkey {
 }
 
 fn try_from_credential_full_view(value: Fido2CredentialFullView) -> Result<Passkey, Fido2Error> {
-    let counter: u32 = value.counter.parse().expect("Invalid counter");
+    let counter: u32 = value
+        .counter
+        .parse()
+        .map_err(|_| Fido2Error::InvalidCounter)?;
     let counter = (counter != 0).then_some(counter);
     let key_value = URL_SAFE_NO_PAD.decode(value.key_value)?;
     let user_handle = value


### PR DESCRIPTION
## 🎟️ Tracking

- 

## 📔 Objective

```
       Fido2CredentialFullView {
            credential_id: "",
            key_type: "",
            key_algorithm: "",
            key_curve: "",
            key_value: "",
            rp_id: "",
            user_handle: None,
            user_name: None,
            counter: "",
            rp_name: None,
            user_display_name: None,
            discoverable: "",
            creation_date: 1970-01-01T00:00:00Z,
        }

```

will result in the expect to panic the SDK. This PR instead maps to a newly created error.
## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation
  team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
