### PR TITLE
[PM-23638] Fix URI checksums not being generated when cipherkey is not present

### DIFF
--- a/crates/bitwarden-vault/src/cipher/cipher.rs
+++ b/crates/bitwarden-vault/src/cipher/cipher.rs
@@ -296,11 +296,7 @@ impl CompositeEncryptable<KeyIds, SymmetricKeyId, Cipher> for CipherView {
         let ciphers_key = Cipher::decrypt_cipher_key(ctx, key, &self.key)?;
 
         let mut cipher_view = self.clone();
-
-        // For compatibility reasons, we only create checksums for ciphers that have a key
-        if cipher_view.key.is_some() {
-            cipher_view.generate_checksums();
-        }
+        cipher_view.generate_checksums();
 
         Ok(Cipher {
             id: cipher_view.id,


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-23638

## 📔 Objective

While we only enforce decrypting correct checksums when a cipherkey is present for that cipher, we must always upgrade to url checksums for newly encrypted ciphers, regardless of whether the cipherkey is present or not.

This is the case on Typescript (https://github.com/bitwarden/clients/blob/682f1f83d9c211e886d6f05fc557eddb25c4c5c2/libs/common/src/vault/services/cipher.service.ts#L1660). This allows us to enforce the presence of icon URLs after users went through the key-rotation for v2 encryption based on the account security version *instead of* being based on cipherkeys.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation
  team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
