### PR TITLE
[PM-23641] Credential Exchange - CredentialScope

### DIFF
--- a/crates/bitwarden-exporters/src/cxf/import.rs
+++ b/crates/bitwarden-exporters/src/cxf/import.rs
@@ -5,7 +5,10 @@ use credential_exchange_format::{
 };
 
 use crate::{
-    cxf::{login::to_login, CxfError},
+    cxf::{
+        login::{to_fields, to_login},
+        CxfError,
+    },
     CipherType, ImportingCipher,
 };
 
@@ -33,12 +36,14 @@ fn parse_item(value: Item) -> Vec<ImportingCipher> {
 
     let mut output = vec![];
 
+    let scope = value.scope.as_ref();
+
     // Login credentials
     if !grouped.basic_auth.is_empty() || !grouped.passkey.is_empty() {
         let basic_auth = grouped.basic_auth.first();
         let passkey = grouped.passkey.first();
 
-        let login = to_login(creation_date, basic_auth, passkey, value.scope);
+        let login = to_login(creation_date, basic_auth, passkey, scope);
 
         output.push(ImportingCipher {
             folder_id: None, // TODO: Handle folders
@@ -67,7 +72,7 @@ fn parse_item(value: Item) -> Vec<ImportingCipher> {
             r#type: CipherType::Card(Box::new(credit_card.into())),
             favorite: false,
             reprompt: 0,
-            fields: vec![],
+            fields: scope.map(to_fields).unwrap_or_default(),
             revision_date,
             creation_date,
             deleted_date: None,

--- a/crates/bitwarden-exporters/src/cxf/login.rs
+++ b/crates/bitwarden-exporters/src/cxf/login.rs
@@ -16,7 +16,7 @@ use thiserror::Error;
 use crate::{Fido2Credential, Field, Login, LoginUri};
 
 /// Prefix that indicates the URL is an Android app scheme.
-const ANDROID_APP_SCHEME: &str = "androidapp";
+const ANDROID_APP_SCHEME: &str = "androidapp://";
 
 pub(super) fn to_login(
     creation_date: DateTime<Utc>,
@@ -59,7 +59,7 @@ fn to_uris(scope: &CredentialScope) -> Vec<LoginUri> {
     });
 
     let android_apps = scope.android_apps.iter().map(|a| LoginUri {
-        uri: Some(format!("{}://{}", ANDROID_APP_SCHEME, a.bundle_id)),
+        uri: Some(format!("{ANDROID_APP_SCHEME}{}", a.bundle_id)),
         r#match: None,
     });
 
@@ -102,12 +102,12 @@ impl From<Login> for CredentialScope {
             .login_uris
             .into_iter()
             .filter_map(|u| u.uri)
-            .partition(|uri| uri.starts_with(&format!("{}://", ANDROID_APP_SCHEME)));
+            .partition(|uri| uri.starts_with(ANDROID_APP_SCHEME));
 
         let android_apps = android_uris
             .into_iter()
             .map(|uri| {
-                let rest = uri.trim_start_matches(&format!("{}://", ANDROID_APP_SCHEME));
+                let rest = uri.trim_start_matches(ANDROID_APP_SCHEME);
                 AndroidAppIdCredential {
                     bundle_id: rest.to_string(),
                     certificate: None,

--- a/crates/bitwarden-exporters/src/cxf/login.rs
+++ b/crates/bitwarden-exporters/src/cxf/login.rs
@@ -71,14 +71,14 @@ fn to_uris(scope: &CredentialScope) -> Vec<LoginUri> {
 /// This is used for non-login credentials.
 pub(crate) fn to_fields(scope: &CredentialScope) -> Vec<Field> {
     let urls = scope.urls.iter().enumerate().map(|(i, u)| Field {
-        name: Some(format!("url_{}", i)),
+        name: Some(format!("Url {}", i + 1)),
         value: Some(u.clone()),
         r#type: FieldType::Text as u8,
         linked_id: None,
     });
 
     let android_apps = scope.android_apps.iter().enumerate().map(|(i, a)| Field {
-        name: Some(format!("android_app_{}", i)),
+        name: Some(format!("Android App {}", i + 1)),
         value: Some(a.bundle_id.clone()),
         r#type: FieldType::Text as u8,
         linked_id: None,
@@ -441,30 +441,31 @@ mod tests {
                 },
             ],
         };
+
         let fields = to_fields(&scope);
         assert_eq!(
             fields,
             vec![
                 Field {
-                    name: Some("url_0".to_string()),
+                    name: Some("Url 1".to_string()),
                     value: Some("https://vault.bitwarden.com".to_string()),
                     r#type: FieldType::Text as u8,
                     linked_id: None,
                 },
                 Field {
-                    name: Some("url_1".to_string()),
+                    name: Some("Url 2".to_string()),
                     value: Some("https://bitwarden.com".to_string()),
                     r#type: FieldType::Text as u8,
                     linked_id: None,
                 },
                 Field {
-                    name: Some("android_app_0".to_string()),
+                    name: Some("Android App 1".to_string()),
                     value: Some("com.bitwarden.app".to_string()),
                     r#type: FieldType::Text as u8,
                     linked_id: None,
                 },
                 Field {
-                    name: Some("android_app_1".to_string()),
+                    name: Some("Android App 2".to_string()),
                     value: Some("com.example.app".to_string()),
                     r#type: FieldType::Text as u8,
                     linked_id: None,

--- a/crates/bitwarden-exporters/src/cxf/login.rs
+++ b/crates/bitwarden-exporters/src/cxf/login.rs
@@ -7,10 +7,15 @@ use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
 use bitwarden_core::MissingFieldError;
 use bitwarden_fido::{string_to_guid_bytes, InvalidGuid};
 use chrono::{DateTime, Utc};
-use credential_exchange_format::{BasicAuthCredential, CredentialScope, PasskeyCredential};
+use credential_exchange_format::{
+    AndroidAppIdCredential, BasicAuthCredential, CredentialScope, PasskeyCredential,
+};
 use thiserror::Error;
 
 use crate::{Fido2Credential, Login, LoginUri};
+
+/// Prefix that indicates the URL is an Android app scheme.
+const ANDROID_APP_SCHEME: &str = "androidapp";
 
 pub(super) fn to_login(
     creation_date: DateTime<Utc>,
@@ -18,20 +23,10 @@ pub(super) fn to_login(
     passkey: Option<&PasskeyCredential>,
     scope: Option<CredentialScope>,
 ) -> Login {
-    let login = Login {
+    Login {
         username: basic_auth.and_then(|v| v.username.clone().map(|v| v.into())),
         password: basic_auth.and_then(|v| v.password.clone().map(|u| u.into())),
-        login_uris: scope
-            .map(|v| {
-                v.urls
-                    .iter()
-                    .map(|u| LoginUri {
-                        uri: Some(u.clone()),
-                        r#match: None,
-                    })
-                    .collect()
-            })
-            .unwrap_or_default(),
+        login_uris: scope.map(|s| to_uris(&s)).unwrap_or_default(),
         totp: None,
         fido2_credentials: passkey.map(|p| {
             vec![Fido2Credential {
@@ -50,8 +45,21 @@ pub(super) fn to_login(
                 creation_date,
             }]
         }),
-    };
-    login
+    }
+}
+
+fn to_uris(scope: &CredentialScope) -> Vec<LoginUri> {
+    let urls = scope.urls.iter().map(|u| LoginUri {
+        uri: Some(u.clone()),
+        r#match: None,
+    });
+
+    let android_apps = scope.android_apps.iter().map(|a| LoginUri {
+        uri: Some(format!("{}://{}", ANDROID_APP_SCHEME, a.bundle_id)),
+        r#match: None,
+    });
+
+    urls.chain(android_apps).collect()
 }
 
 impl From<Login> for BasicAuthCredential {
@@ -65,10 +73,25 @@ impl From<Login> for BasicAuthCredential {
 
 impl From<Login> for CredentialScope {
     fn from(login: Login) -> Self {
-        CredentialScope {
-            urls: login.login_uris.into_iter().filter_map(|u| u.uri).collect(),
-            android_apps: vec![],
-        }
+        let (android_uris, urls): (Vec<_>, Vec<_>) = login
+            .login_uris
+            .into_iter()
+            .filter_map(|u| u.uri)
+            .partition(|uri| uri.starts_with(&format!("{}://", ANDROID_APP_SCHEME)));
+
+        let android_apps = android_uris
+            .into_iter()
+            .map(|uri| {
+                let rest = uri.trim_start_matches(&format!("{}://", ANDROID_APP_SCHEME));
+                AndroidAppIdCredential {
+                    bundle_id: rest.to_string(),
+                    certificate: None,
+                    name: None,
+                }
+            })
+            .collect();
+
+        CredentialScope { urls, android_apps }
     }
 }
 
@@ -185,5 +208,191 @@ mod tests {
         assert_eq!(String::from(passkey.user_handle.clone()), "AAECAwQFBg");
         assert_eq!(String::from(passkey.key.clone()), "AAECAwQFBg");
         assert!(passkey.fido2_extensions.is_none());
+    }
+
+    #[test]
+    fn test_to_uris_with_urls_only() {
+        let scope = CredentialScope {
+            urls: vec![
+                "https://vault.bitwarden.com".to_string(),
+                "https://bitwarden.com".to_string(),
+            ],
+            android_apps: vec![],
+        };
+
+        let uris = to_uris(&scope);
+
+        assert_eq!(
+            uris,
+            vec![
+                LoginUri {
+                    uri: Some("https://vault.bitwarden.com".to_string()),
+                    r#match: None
+                },
+                LoginUri {
+                    uri: Some("https://bitwarden.com".to_string()),
+                    r#match: None
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn test_to_uris_with_android_apps_only() {
+        let scope = CredentialScope {
+            urls: vec![],
+            android_apps: vec![
+                credential_exchange_format::AndroidAppIdCredential {
+                    bundle_id: "com.bitwarden.app".to_string(),
+                    certificate: None,
+                    name: None,
+                },
+                credential_exchange_format::AndroidAppIdCredential {
+                    bundle_id: "com.example.app".to_string(),
+                    certificate: None,
+                    name: None,
+                },
+            ],
+        };
+
+        let uris = to_uris(&scope);
+
+        assert_eq!(
+            uris,
+            vec![
+                LoginUri {
+                    uri: Some("androidapp://com.bitwarden.app".to_string()),
+                    r#match: None
+                },
+                LoginUri {
+                    uri: Some("androidapp://com.example.app".to_string()),
+                    r#match: None
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn test_to_uris_with_mixed_urls_and_android_apps() {
+        let scope = CredentialScope {
+            urls: vec![
+                "https://vault.bitwarden.com".to_string(),
+                "https://bitwarden.com".to_string(),
+            ],
+            android_apps: vec![
+                credential_exchange_format::AndroidAppIdCredential {
+                    bundle_id: "com.bitwarden.app".to_string(),
+                    certificate: None,
+                    name: None,
+                },
+                credential_exchange_format::AndroidAppIdCredential {
+                    bundle_id: "com.example.app".to_string(),
+                    certificate: None,
+                    name: None,
+                },
+            ],
+        };
+
+        let uris = to_uris(&scope);
+
+        assert_eq!(
+            uris,
+            vec![
+                LoginUri {
+                    uri: Some("https://vault.bitwarden.com".to_string()),
+                    r#match: None
+                },
+                LoginUri {
+                    uri: Some("https://bitwarden.com".to_string()),
+                    r#match: None
+                },
+                LoginUri {
+                    uri: Some("androidapp://com.bitwarden.app".to_string()),
+                    r#match: None
+                },
+                LoginUri {
+                    uri: Some("androidapp://com.example.app".to_string()),
+                    r#match: None
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn test_to_uris_with_empty_scope() {
+        let scope = CredentialScope {
+            urls: vec![],
+            android_apps: vec![],
+        };
+
+        let uris = to_uris(&scope);
+
+        assert!(uris.is_empty());
+    }
+
+    #[test]
+    fn test_credential_scope_with_android_apps_only() {
+        let login = Login {
+            username: None,
+            password: None,
+            login_uris: vec![
+                LoginUri {
+                    uri: Some("androidapp://com.bitwarden.app".to_string()),
+                    r#match: None,
+                },
+                LoginUri {
+                    uri: Some("androidapp://com.example.app".to_string()),
+                    r#match: None,
+                },
+            ],
+            totp: None,
+            fido2_credentials: None,
+        };
+
+        let scope: CredentialScope = login.into();
+        assert!(scope.urls.is_empty());
+        assert_eq!(scope.android_apps.len(), 2);
+        assert_eq!(scope.android_apps[0].bundle_id, "com.bitwarden.app");
+        assert_eq!(scope.android_apps[1].bundle_id, "com.example.app");
+    }
+
+    #[test]
+    fn test_credential_scope_with_mixed_urls_and_android_apps() {
+        let login = Login {
+            username: None,
+            password: None,
+            login_uris: vec![
+                LoginUri {
+                    uri: Some("https://vault.bitwarden.com".to_string()),
+                    r#match: None,
+                },
+                LoginUri {
+                    uri: Some("androidapp://com.bitwarden.app".to_string()),
+                    r#match: None,
+                },
+                LoginUri {
+                    uri: Some("https://bitwarden.com".to_string()),
+                    r#match: None,
+                },
+                LoginUri {
+                    uri: Some("androidapp://com.example.app".to_string()),
+                    r#match: None,
+                },
+            ],
+            totp: None,
+            fido2_credentials: None,
+        };
+
+        let scope: CredentialScope = login.into();
+        assert_eq!(
+            scope.urls,
+            vec![
+                "https://vault.bitwarden.com".to_string(),
+                "https://bitwarden.com".to_string(),
+            ]
+        );
+        assert_eq!(scope.android_apps.len(), 2);
+        assert_eq!(scope.android_apps[0].bundle_id, "com.bitwarden.app");
+        assert_eq!(scope.android_apps[1].bundle_id, "com.example.app");
     }
 }

--- a/crates/bitwarden-exporters/src/lib.rs
+++ b/crates/bitwarden-exporters/src/lib.rs
@@ -170,7 +170,7 @@ impl From<LoginUri> for bitwarden_vault::LoginUriView {
 }
 
 #[allow(missing_docs)]
-#[derive(Clone)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct Field {
     pub name: Option<String>,
     pub value: Option<String>,

--- a/crates/bitwarden-exporters/src/lib.rs
+++ b/crates/bitwarden-exporters/src/lib.rs
@@ -212,7 +212,7 @@ pub struct Login {
 }
 
 #[allow(missing_docs)]
-#[derive(Clone)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct LoginUri {
     pub uri: Option<String>,
     pub r#match: Option<u8>,

--- a/crates/bitwarden-vault/src/cipher/field.rs
+++ b/crates/bitwarden-vault/src/cipher/field.rs
@@ -17,7 +17,7 @@ use wasm_bindgen::prelude::wasm_bindgen;
 use super::linked_id::LinkedIdType;
 use crate::VaultParseError;
 
-/// Represents the type of a [Field]
+/// Represents the type of a [FieldView].
 #[derive(Clone, Copy, Serialize_repr, Deserialize_repr, Debug)]
 #[repr(u8)]
 #[cfg_attr(feature = "uniffi", derive(uniffi::Enum))]

--- a/crates/bitwarden-vault/src/cipher/field.rs
+++ b/crates/bitwarden-vault/src/cipher/field.rs
@@ -17,14 +17,19 @@ use wasm_bindgen::prelude::wasm_bindgen;
 use super::linked_id::LinkedIdType;
 use crate::VaultParseError;
 
+/// Represents the type of a [Field]
 #[derive(Clone, Copy, Serialize_repr, Deserialize_repr, Debug)]
 #[repr(u8)]
 #[cfg_attr(feature = "uniffi", derive(uniffi::Enum))]
 #[cfg_attr(feature = "wasm", wasm_bindgen)]
 pub enum FieldType {
+    /// Text field
     Text = 0,
+    /// Hidden text field
     Hidden = 1,
+    /// Boolean field
     Boolean = 2,
+    /// Linked field
     Linked = 3,
 }
 

--- a/crates/bitwarden-vault/src/cipher/mod.rs
+++ b/crates/bitwarden-vault/src/cipher/mod.rs
@@ -23,7 +23,7 @@ pub use cipher::{
     CipherView, DecryptCipherListResult, EncryptionContext,
 };
 pub use cipher_client::CiphersClient;
-pub use field::FieldView;
+pub use field::{FieldType, FieldView};
 pub use identity::IdentityView;
 pub use login::{
     Fido2Credential, Fido2CredentialFullView, Fido2CredentialNewView, Fido2CredentialView, Login,


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

https://bitwarden.atlassian.net/browse/PM-23641

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Improves the `CredentialScope` import logic.

- Now handles `android_apps` appropriately.
- Supports mapping to `Fields` when importing a non Login credential.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation
  team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
