### PR TITLE
Create bitwarden-auth crate

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,6 +7,8 @@
 # Platform is the default owner for all files
 * @bitwarden/team-platform-dev
 
+crates/bitwarden-auth/** @bitwarden/team-auth-dev @bitwarden/team-platform-dev
+
 crates/bitwarden-vault/** @bitwarden/team-vault-dev @bitwarden/team-platform-dev
 
 # Temporarily owned by multiple teams

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -344,6 +344,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "bitwarden-auth"
+version = "1.0.0"
+dependencies = [
+ "bitwarden-core",
+ "bitwarden-error",
+ "serde",
+ "serde_json",
+ "serde_qs",
+ "thiserror 1.0.69",
+ "tsify",
+ "uniffi",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+]
+
+[[package]]
 name = "bitwarden-cli"
 version = "1.0.0"
 dependencies = [
@@ -730,6 +746,7 @@ version = "0.1.0"
 dependencies = [
  "async-trait",
  "base64",
+ "bitwarden-auth",
  "bitwarden-core",
  "bitwarden-crypto",
  "bitwarden-error",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ keywords = ["bitwarden"]
 bitwarden = { path = "crates/bitwarden", version = "=1.0.0" }
 bitwarden-api-api = { path = "crates/bitwarden-api-api", version = "=1.0.0" }
 bitwarden-api-identity = { path = "crates/bitwarden-api-identity", version = "=1.0.0" }
+bitwarden-auth = { path = "crates/bitwarden-auth", version = "=1.0.0" }
 bitwarden-cli = { path = "crates/bitwarden-cli", version = "=1.0.0" }
 bitwarden-core = { path = "crates/bitwarden-core", version = "=1.0.0" }
 bitwarden-crypto = { path = "crates/bitwarden-crypto", version = "=1.0.0" }

--- a/crates/bitwarden-auth/Cargo.toml
+++ b/crates/bitwarden-auth/Cargo.toml
@@ -1,0 +1,42 @@
+[package]
+name = "bitwarden-auth"
+description = """
+Internal crate for the bitwarden crate. Do not use.
+"""
+
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+readme.workspace = true
+homepage.workspace = true
+repository.workspace = true
+license-file.workspace = true
+keywords.workspace = true
+
+[features]
+uniffi = [
+    "bitwarden-core/uniffi",
+    "dep:uniffi"
+] # Uniffi bindings
+wasm = [
+    "bitwarden-core/wasm",
+    "dep:tsify",
+    "dep:wasm-bindgen",
+    "dep:wasm-bindgen-futures"
+] # WASM support
+
+[dependencies]
+bitwarden-core = { workspace = true, features = ["internal"] }
+bitwarden-error = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+serde_qs = { workspace = true }
+thiserror = { workspace = true }
+tsify = { workspace = true, optional = true }
+uniffi = { workspace = true, optional = true }
+wasm-bindgen = { workspace = true, optional = true }
+wasm-bindgen-futures = { workspace = true, optional = true }
+
+[lints]
+workspace = true

--- a/crates/bitwarden-auth/Cargo.toml
+++ b/crates/bitwarden-auth/Cargo.toml
@@ -15,10 +15,7 @@ license-file.workspace = true
 keywords.workspace = true
 
 [features]
-uniffi = [
-    "bitwarden-core/uniffi",
-    "dep:uniffi"
-] # Uniffi bindings
+uniffi = ["bitwarden-core/uniffi", "dep:uniffi"] # Uniffi bindings
 wasm = [
     "bitwarden-core/wasm",
     "dep:tsify",

--- a/crates/bitwarden-auth/README.md
+++ b/crates/bitwarden-auth/README.md
@@ -1,0 +1,3 @@
+# Bitwarden Auth
+
+Contains the implementation of the auth functionality for the Bitwarden Password Manager.

--- a/crates/bitwarden-auth/src/auth_client.rs
+++ b/crates/bitwarden-auth/src/auth_client.rs
@@ -1,0 +1,44 @@
+use bitwarden_core::Client;
+#[cfg(feature = "wasm")]
+use wasm_bindgen::prelude::*;
+
+use crate::send_access::SendAccessClient;
+
+/// Subclient containing auth functionality.
+#[derive(Clone)]
+#[cfg_attr(feature = "wasm", wasm_bindgen)]
+pub struct AuthClient {
+    // TODO: The AuthClient should probably not contain the whole bitwarden-core client.
+    // Instead, it should contain the ApiConfigurations and Tokens struct to do API requests and
+    // handle token renewals, and those structs should be shared between core and auth.
+    pub(crate) client: Client,
+}
+
+impl AuthClient {
+    /// Constructs a new `AuthClient` with the given `Client`.
+    pub fn new(client: Client) -> Self {
+        Self { client }
+    }
+}
+
+#[cfg_attr(feature = "wasm", wasm_bindgen)]
+impl AuthClient {
+    /// Client for send access functionality
+    pub fn send_access(&self) -> SendAccessClient {
+        SendAccessClient::new(self.client.clone())
+    }
+}
+
+/// Extension trait for `Client` to provide access to the `AuthClient`.
+pub trait AuthClientExt {
+    /// Creates a new `AuthClient` instance.
+    fn auth_new(&self) -> AuthClient;
+}
+
+impl AuthClientExt for Client {
+    fn auth_new(&self) -> AuthClient {
+        AuthClient {
+            client: self.clone(),
+        }
+    }
+}

--- a/crates/bitwarden-auth/src/lib.rs
+++ b/crates/bitwarden-auth/src/lib.rs
@@ -1,0 +1,6 @@
+#![doc = include_str!("../README.md")]
+
+mod auth_client;
+mod send_access;
+
+pub use auth_client::{AuthClient, AuthClientExt};

--- a/crates/bitwarden-auth/src/send_access/client.rs
+++ b/crates/bitwarden-auth/src/send_access/client.rs
@@ -1,0 +1,25 @@
+use bitwarden_core::Client;
+#[cfg(feature = "wasm")]
+use wasm_bindgen::prelude::*;
+
+#[derive(Clone)]
+#[cfg_attr(feature = "wasm", wasm_bindgen)]
+pub struct SendAccessClient {
+    pub(crate) client: Client,
+}
+
+impl SendAccessClient {
+    pub(crate) fn new(client: Client) -> Self {
+        Self { client }
+    }
+}
+
+#[cfg_attr(feature = "wasm", wasm_bindgen)]
+impl SendAccessClient {
+    /// Request an access token for the provided send
+    pub async fn request_send_access_token(&self, request: String) -> String {
+        // TODO: This is just here to silence some warnings
+        let _config = self.client.internal.get_api_configurations().await;
+        request
+    }
+}

--- a/crates/bitwarden-auth/src/send_access/mod.rs
+++ b/crates/bitwarden-auth/src/send_access/mod.rs
@@ -1,0 +1,2 @@
+mod client;
+pub use client::SendAccessClient;

--- a/crates/bitwarden-wasm-internal/Cargo.toml
+++ b/crates/bitwarden-wasm-internal/Cargo.toml
@@ -18,6 +18,7 @@ crate-type = ["cdylib"]
 [dependencies]
 async-trait = { workspace = true }
 base64 = ">=0.22.1, <0.23.0"
+bitwarden-auth = { workspace = true, features = ["wasm"] }
 bitwarden-core = { workspace = true, features = ["wasm", "internal"] }
 bitwarden-crypto = { workspace = true, features = ["wasm"] }
 bitwarden-error = { workspace = true }

--- a/crates/bitwarden-wasm-internal/src/client.rs
+++ b/crates/bitwarden-wasm-internal/src/client.rs
@@ -1,6 +1,7 @@
 extern crate console_error_panic_hook;
 use std::{fmt::Display, sync::Arc};
 
+use bitwarden_auth::{AuthClient, AuthClientExt};
 use bitwarden_core::{key_management::CryptoClient, Client, ClientSettings};
 use bitwarden_error::bitwarden_error;
 use bitwarden_exporters::ExporterClientExt;
@@ -47,6 +48,11 @@ impl BitwardenClient {
         let res = client.get(&url).send().await.map_err(|e| e.to_string())?;
 
         res.text().await.map_err(|e| e.to_string())
+    }
+
+    /// Auth related operations.
+    pub fn auth(&self) -> AuthClient {
+        self.0.auth_new()
     }
 
     #[allow(missing_docs)]


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective

Created a new auth crate for the work that auth is moving to the SDK, and defined the WASM API for the send access functionality as a basic skeleton.

Some things left open:
- We already have an `AuthClient` in `bitwarden-core`, it's not used for WASM but it is for UniFFI. This PR leaves both clients in place but the goal is to migrate the older clients functionality over to the auth crate or somewhere else, and keep it out of core.
- Because we already have the `AuthClient` in core, I've made the extension trait for auth use a function name like `auth_new`, this is to avoid conflicts with the other function and should be renamed once the older `AuthClient` is deleted.
- Currently `AuthClient` is wrapping a bitwarden-core `Client`, so it can reuse the `ApiConfigurations` defined in core, this seems like it would complicate the usage of the auth crate, so I'm thinking we should extract the `ApiConfigurations` and maybe part of the token handling code to a separate bitwarden-api crate that both core and auth can use without depending on eachother?

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation
  team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
