### PR TITLE
Fix sensitive leak after enabling opt-z

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -109,6 +109,12 @@ codegen-units = 1
 lto = true
 opt-level = "z"
 
+# Enable optimization for the bitwarden-crypto crate. This will increase the binary size slightly (~0.1MB),
+# but it will more aggressively inline functions. This will help us avoid extra stack copies of keys and
+# other sensitive values being left behind without cleanup.
+[profile.release.package.bitwarden-crypto]
+opt-level = 3
+
 # Stripping the binary reduces the size by ~30%, but the stacktraces won't be usable anymore.
 # This is fine as long as we don't have any unhandled panics, but let's keep it disabled for now
 # strip = true


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective

Discovered in #356, the recent PR #353 has made some [sensitive memory leak tests fail](https://github.com/bitwarden/sdk-internal/actions/runs/16499844362/job/46655074711?pr=356). I've had to do two things to fix this:
- In the `argon2` implementation, we used to hash into a fixed size array, and then box it. I've rewritten this code to store the value into the box directly, avoiding stack copies. This fixes the `Master Key Argon2 / Key` test case.
- I've set the opt level for the crypto crate specifically to level 3, overriding the z level from the workspace. This is to ensure the compiler is able to inline functions as needed to avoid stack copies of values. This increases the WASM bundle size by around 0.1MB, but seems worth it in this case, as the code in bitwarden-crypto is more performance and security sensitive than the rest of the application. This fixes the `Master Key Argon2 / Hash bytes` test case.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation
  team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
