### PR TITLE
[PM-24243] Add load_flags method to wasm PlatformClient

### DIFF
--- a/crates/bitwarden-core/src/client/flags.rs
+++ b/crates/bitwarden-core/src/client/flags.rs
@@ -1,10 +1,18 @@
-#[derive(Debug, Default, Clone, serde::Deserialize)]
+/// Feature flags for the Bitwarden SDK client.
+#[derive(Debug, Default, Clone, serde::Deserialize, serde::Serialize)]
+#[cfg_attr(
+    feature = "wasm",
+    derive(tsify::Tsify),
+    tsify(into_wasm_abi, from_wasm_abi)
+)]
 pub struct Flags {
+    /// Enable cipher key encryption within the `CipherClient`
     #[serde(default, rename = "enableCipherKeyEncryption")]
     pub enable_cipher_key_encryption: bool,
 }
 
 impl Flags {
+    /// Create a new `Flags` instance from a map of flag names and values.
     pub fn load_from_map(map: std::collections::HashMap<String, bool>) -> Self {
         let map = map
             .into_iter()

--- a/crates/bitwarden-core/src/client/internal.rs
+++ b/crates/bitwarden-core/src/client/internal.rs
@@ -118,6 +118,12 @@ impl InternalClient {
 
     #[allow(missing_docs)]
     #[cfg(feature = "internal")]
+    pub fn set_flags(&self, flags: &Flags) {
+        *self.flags.write().expect("RwLock is not poisoned") = flags.clone();
+    }
+
+    #[allow(missing_docs)]
+    #[cfg(feature = "internal")]
     pub fn get_flags(&self) -> Flags {
         self.flags.read().expect("RwLock is not poisoned").clone()
     }

--- a/crates/bitwarden-core/src/client/mod.rs
+++ b/crates/bitwarden-core/src/client/mod.rs
@@ -19,6 +19,7 @@ mod flags;
 
 pub use client::Client;
 pub use client_settings::{ClientSettings, DeviceType};
+pub use flags::Flags;
 
 #[allow(missing_docs)]
 #[cfg(feature = "internal")]

--- a/crates/bitwarden-core/src/client/mod.rs
+++ b/crates/bitwarden-core/src/client/mod.rs
@@ -14,8 +14,8 @@ pub mod login_method;
 #[cfg(feature = "secrets")]
 pub(crate) use login_method::ServiceAccountLoginMethod;
 pub(crate) use login_method::{LoginMethod, UserLoginMethod};
-#[cfg(feature = "internal")]
-mod flags;
+#[allow(missing_docs)]
+pub mod flags;
 
 pub use client::Client;
 pub use client_settings::{ClientSettings, DeviceType};

--- a/crates/bitwarden-core/src/client/mod.rs
+++ b/crates/bitwarden-core/src/client/mod.rs
@@ -14,11 +14,12 @@ pub mod login_method;
 #[cfg(feature = "secrets")]
 pub(crate) use login_method::ServiceAccountLoginMethod;
 pub(crate) use login_method::{LoginMethod, UserLoginMethod};
-#[allow(missing_docs)]
-pub mod flags;
+#[cfg(feature = "internal")]
+mod flags;
 
 pub use client::Client;
 pub use client_settings::{ClientSettings, DeviceType};
+#[cfg(feature = "internal")]
 pub use flags::Flags;
 
 #[allow(missing_docs)]

--- a/crates/bitwarden-core/src/lib.rs
+++ b/crates/bitwarden-core/src/lib.rs
@@ -24,7 +24,7 @@ pub mod secrets_manager;
 mod util;
 
 pub use bitwarden_crypto::ZeroizingAllocator;
-pub use client::{Client, ClientSettings, DeviceType};
+pub use client::{Client, ClientSettings, DeviceType, Flags};
 
 mod ids;
 pub use ids::*;

--- a/crates/bitwarden-core/src/lib.rs
+++ b/crates/bitwarden-core/src/lib.rs
@@ -24,7 +24,9 @@ pub mod secrets_manager;
 mod util;
 
 pub use bitwarden_crypto::ZeroizingAllocator;
-pub use client::{Client, ClientSettings, DeviceType, Flags};
+#[cfg(feature = "internal")]
+pub use client::Flags;
+pub use client::{Client, ClientSettings, DeviceType};
 
 mod ids;
 pub use ids::*;

--- a/crates/bitwarden-wasm-internal/src/platform/mod.rs
+++ b/crates/bitwarden-wasm-internal/src/platform/mod.rs
@@ -1,9 +1,27 @@
 use bitwarden_core::Client;
 use bitwarden_vault::{Cipher, Folder};
-use wasm_bindgen::prelude::wasm_bindgen;
+use tsify::{serde_wasm_bindgen, Tsify};
+use wasm_bindgen::prelude::*;
 
 mod repository;
 pub mod token_provider;
+
+#[derive(serde::Serialize, serde::Deserialize, Tsify)]
+#[tsify(into_wasm_abi, from_wasm_abi)]
+pub struct FlagsInput {
+    #[serde(rename = "enableCipherKeyEncryption")]
+    pub enable_cipher_key_encryption: Option<bool>,
+}
+
+impl From<FlagsInput> for std::collections::HashMap<String, bool> {
+    fn from(flags: FlagsInput) -> Self {
+        let js_value = serde_wasm_bindgen::to_value(&flags)
+            .expect("FlagsInput should always serialize successfully");
+
+        serde_wasm_bindgen::from_value(js_value)
+            .unwrap_or_else(|_| std::collections::HashMap::new())
+    }
+}
 
 #[wasm_bindgen]
 pub struct PlatformClient(Client);
@@ -18,6 +36,12 @@ impl PlatformClient {
 impl PlatformClient {
     pub fn state(&self) -> StateClient {
         StateClient::new(self.0.clone())
+    }
+
+    /// Load feature flags into the client
+    pub fn load_flags(&self, flags: FlagsInput) -> Result<(), JsValue> {
+        self.0.internal.load_flags(flags.into());
+        Ok(())
     }
 }
 

--- a/crates/bitwarden-wasm-internal/src/platform/mod.rs
+++ b/crates/bitwarden-wasm-internal/src/platform/mod.rs
@@ -1,27 +1,9 @@
-use bitwarden_core::Client;
+use bitwarden_core::{Client, Flags};
 use bitwarden_vault::{Cipher, Folder};
-use tsify::{serde_wasm_bindgen, Tsify};
 use wasm_bindgen::prelude::*;
 
 mod repository;
 pub mod token_provider;
-
-#[derive(serde::Serialize, serde::Deserialize, Tsify)]
-#[tsify(into_wasm_abi, from_wasm_abi)]
-pub struct FlagsInput {
-    #[serde(rename = "enableCipherKeyEncryption")]
-    pub enable_cipher_key_encryption: Option<bool>,
-}
-
-impl From<FlagsInput> for std::collections::HashMap<String, bool> {
-    fn from(flags: FlagsInput) -> Self {
-        let js_value = serde_wasm_bindgen::to_value(&flags)
-            .expect("FlagsInput should always serialize successfully");
-
-        serde_wasm_bindgen::from_value(js_value)
-            .unwrap_or_else(|_| std::collections::HashMap::new())
-    }
-}
 
 #[wasm_bindgen]
 pub struct PlatformClient(Client);
@@ -39,8 +21,8 @@ impl PlatformClient {
     }
 
     /// Load feature flags into the client
-    pub fn load_flags(&self, flags: FlagsInput) -> Result<(), JsValue> {
-        self.0.internal.load_flags(flags.into());
+    pub fn load_flags(&self, flags: Flags) -> Result<(), JsValue> {
+        self.0.internal.set_flags(&flags);
         Ok(())
     }
 }


### PR DESCRIPTION
## 🎟️ Tracking

[PM-24243](https://bitwarden.atlassian.net/browse/PM-24243)

## 📔 Objective

Add `load_flags` method to the wasm `PlatformClient` to match parity with the uniffi `PlatformClient` so that the TS clients can set the SDK flags dynamically.

Related Clients PR: https://github.com/bitwarden/clients/pull/15855

~Added a `FlagsInput` struct that mimics the internal `Flags` struct but with tsify bindings.~

~Another potential option is to make the internal `Flags` struct public with wasm bindings to avoid duplicating the struct.~

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation
  team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-24243]: https://bitwarden.atlassian.net/browse/PM-24243?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ