### PR TITLE
[PM-22256] Add type and default_user_collection_email to collection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -378,6 +378,7 @@ dependencies = [
  "bitwarden-crypto",
  "bitwarden-error",
  "serde",
+ "serde_repr",
  "thiserror 1.0.69",
  "tsify",
  "uniffi",

--- a/crates/bitwarden-collections/Cargo.toml
+++ b/crates/bitwarden-collections/Cargo.toml
@@ -28,6 +28,7 @@ bitwarden-core = { workspace = true, features = ["internal"] }
 bitwarden-crypto = { workspace = true }
 bitwarden-error = { workspace = true }
 serde = { workspace = true }
+serde_repr = { workspace = true }
 thiserror = { workspace = true }
 tsify = { workspace = true, optional = true }
 uniffi = { workspace = true, optional = true }

--- a/crates/bitwarden-collections/src/collection.rs
+++ b/crates/bitwarden-collections/src/collection.rs
@@ -205,7 +205,7 @@ mod tests {
         let key = SymmetricKeyId::Organization(org_id);
 
         let collection_name: &str = "Collection Name";
-        let default_user_collection_email= String::from("test-user@bitwarden.com");
+        let default_user_collection_email = String::from("test-user@bitwarden.com");
 
         let collection = Collection {
             id: Some(Uuid::parse_str(COLLECTION_ID).unwrap()),

--- a/crates/bitwarden-collections/src/collection.rs
+++ b/crates/bitwarden-collections/src/collection.rs
@@ -128,7 +128,7 @@ mod tests {
     // Helper function to create a test key store with a symmetric key
     fn create_test_key_store() -> KeyStore<KeyIds> {
         let store = KeyStore::<KeyIds>::default();
-        let key = SymmetricCryptoKey::try_from("sJnO8rVi0dTwND43n0T9x7665s8mVUYNAaJ4nm7gx1iia1I7947URL60nwfIHaf9QJePO4VkNN0oT9jh4iC6aA==".to_string()).unwrap();
+        let key = SymmetricCryptoKey::make_aes256_cbc_hmac_key();
         let org_id = Uuid::parse_str(ORGANIZATION_ID).unwrap();
 
         #[allow(deprecated)]

--- a/crates/bitwarden-vault/src/collection_client.rs
+++ b/crates/bitwarden-vault/src/collection_client.rs
@@ -127,6 +127,7 @@ mod tests {
             hide_passwords: false,
             read_only: false,
             manage: false,
+            default_user_collection_email: None
         }]).unwrap();
 
         assert_eq!(dec[0].name, "Default collection");
@@ -144,6 +145,7 @@ mod tests {
             hide_passwords: false,
             read_only: false,
             manage: false,
+            default_user_collection_email: None
         }).unwrap();
 
         assert_eq!(dec.name, "Default collection");

--- a/crates/bitwarden-vault/src/collection_client.rs
+++ b/crates/bitwarden-vault/src/collection_client.rs
@@ -110,6 +110,7 @@ impl CollectionViewTree {
 
 #[cfg(test)]
 mod tests {
+    use bitwarden_collections::collection::CollectionType;
     use bitwarden_core::client::test_accounts::test_bitwarden_com_account;
 
     use super::*;
@@ -127,7 +128,8 @@ mod tests {
             hide_passwords: false,
             read_only: false,
             manage: false,
-            default_user_collection_email: None
+            default_user_collection_email: None,
+            r#type: CollectionType::SharedCollection,
         }]).unwrap();
 
         assert_eq!(dec[0].name, "Default collection");
@@ -145,7 +147,8 @@ mod tests {
             hide_passwords: false,
             read_only: false,
             manage: false,
-            default_user_collection_email: None
+            default_user_collection_email: None,
+            r#type: CollectionType::SharedCollection,
         }).unwrap();
 
         assert_eq!(dec.name, "Default collection");


### PR DESCRIPTION
## 🎟️ Tracking
[PM-22256](https://bitwarden.atlassian.net/browse/PM-22256)

## 📔 Objective
This adds type and default user collection email to the Collection struct. Type is only added to CollectionView. Name is now computed by the decrypt function of Collection as it is unneeded on the CollectionView.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation
  team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-22256]: https://bitwarden.atlassian.net/browse/PM-22256?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ