### PR TITLE
Update wasm to use the same method as mobile for feature flags

### DIFF
--- a/crates/bitwarden-core/src/client/flags.rs
+++ b/crates/bitwarden-core/src/client/flags.rs
@@ -1,3 +1,7 @@
+/// Internal Feature flag representation for the Bitwarden SDK client.
+///
+/// **Note:** This struct while public, is intended for internal use and may change in future
+/// releases.
 #[derive(Debug, Default, Clone, serde::Deserialize)]
 pub struct Flags {
     /// Enable cipher key encryption.

--- a/crates/bitwarden-core/src/client/flags.rs
+++ b/crates/bitwarden-core/src/client/flags.rs
@@ -1,10 +1,12 @@
 #[derive(Debug, Default, Clone, serde::Deserialize)]
 pub struct Flags {
+    /// Enable cipher key encryption.
     #[serde(default, rename = "enableCipherKeyEncryption")]
     pub enable_cipher_key_encryption: bool,
 }
 
 impl Flags {
+    /// Create a new `Flags` instance from a map of flag names and values.
     pub fn load_from_map(map: std::collections::HashMap<String, bool>) -> Self {
         let map = map
             .into_iter()

--- a/crates/bitwarden-core/src/client/flags.rs
+++ b/crates/bitwarden-core/src/client/flags.rs
@@ -1,18 +1,10 @@
-/// Feature flags for the Bitwarden SDK client.
-#[derive(Debug, Default, Clone, serde::Deserialize, serde::Serialize)]
-#[cfg_attr(
-    feature = "wasm",
-    derive(tsify::Tsify),
-    tsify(into_wasm_abi, from_wasm_abi)
-)]
+#[derive(Debug, Default, Clone, serde::Deserialize)]
 pub struct Flags {
-    /// Enable cipher key encryption within the `CipherClient`
     #[serde(default, rename = "enableCipherKeyEncryption")]
     pub enable_cipher_key_encryption: bool,
 }
 
 impl Flags {
-    /// Create a new `Flags` instance from a map of flag names and values.
     pub fn load_from_map(map: std::collections::HashMap<String, bool>) -> Self {
         let map = map
             .into_iter()

--- a/crates/bitwarden-core/src/client/flags.rs
+++ b/crates/bitwarden-core/src/client/flags.rs
@@ -1,11 +1,16 @@
 /// Internal Feature flag representation for the Bitwarden SDK client.
 ///
+/// **Note:** The struct should be deserialized directly from the `api/config` endpoint. Take care
+/// to ensure any appropriate aliases are used. By default we use `kebab-schema` but there may be
+/// value in having shorter names.
+///
 /// **Note:** This struct while public, is intended for internal use and may change in future
 /// releases.
 #[derive(Debug, Default, Clone, serde::Deserialize)]
+#[serde(default, rename_all = "kebab-case")]
 pub struct Flags {
     /// Enable cipher key encryption.
-    #[serde(default, rename = "enableCipherKeyEncryption")]
+    #[serde(alias = "enableCipherKeyEncryption", alias = "cipher-key-encryption")]
     pub enable_cipher_key_encryption: bool,
 }
 
@@ -35,6 +40,14 @@ mod tests {
     fn test_load_valid_map() {
         let mut map = std::collections::HashMap::new();
         map.insert("enableCipherKeyEncryption".into(), true);
+        let flags = Flags::load_from_map(map);
+        assert!(flags.enable_cipher_key_encryption);
+    }
+
+    #[test]
+    fn test_load_valid_map_alias() {
+        let mut map = std::collections::HashMap::new();
+        map.insert("cipher-key-encryption".into(), true);
         let flags = Flags::load_from_map(map);
         assert!(flags.enable_cipher_key_encryption);
     }

--- a/crates/bitwarden-core/src/client/internal.rs
+++ b/crates/bitwarden-core/src/client/internal.rs
@@ -110,13 +110,14 @@ pub struct InternalClient {
 }
 
 impl InternalClient {
-    #[allow(missing_docs)]
+    /// Load feature flags. This is intentionally a collection and not the internal `Flag` enum as
+    /// we want to avoid changes in feature flags from being a breaking change.
     #[cfg(feature = "internal")]
     pub fn load_flags(&self, flags: std::collections::HashMap<String, bool>) {
         *self.flags.write().expect("RwLock is not poisoned") = Flags::load_from_map(flags);
     }
 
-    #[allow(missing_docs)]
+    /// Retrieve the active feature flags.
     #[cfg(feature = "internal")]
     pub fn get_flags(&self) -> Flags {
         self.flags.read().expect("RwLock is not poisoned").clone()

--- a/crates/bitwarden-core/src/client/internal.rs
+++ b/crates/bitwarden-core/src/client/internal.rs
@@ -118,12 +118,6 @@ impl InternalClient {
 
     #[allow(missing_docs)]
     #[cfg(feature = "internal")]
-    pub fn set_flags(&self, flags: &Flags) {
-        *self.flags.write().expect("RwLock is not poisoned") = flags.clone();
-    }
-
-    #[allow(missing_docs)]
-    #[cfg(feature = "internal")]
     pub fn get_flags(&self) -> Flags {
         self.flags.read().expect("RwLock is not poisoned").clone()
     }

--- a/crates/bitwarden-core/src/client/mod.rs
+++ b/crates/bitwarden-core/src/client/mod.rs
@@ -19,8 +19,6 @@ mod flags;
 
 pub use client::Client;
 pub use client_settings::{ClientSettings, DeviceType};
-#[cfg(feature = "internal")]
-pub use flags::Flags;
 
 #[allow(missing_docs)]
 #[cfg(feature = "internal")]

--- a/crates/bitwarden-core/src/lib.rs
+++ b/crates/bitwarden-core/src/lib.rs
@@ -24,8 +24,6 @@ pub mod secrets_manager;
 mod util;
 
 pub use bitwarden_crypto::ZeroizingAllocator;
-#[cfg(feature = "internal")]
-pub use client::Flags;
 pub use client::{Client, ClientSettings, DeviceType};
 
 mod ids;

--- a/crates/bitwarden-wasm-internal/src/platform/mod.rs
+++ b/crates/bitwarden-wasm-internal/src/platform/mod.rs
@@ -1,6 +1,6 @@
-use bitwarden_core::{Client, Flags};
+use bitwarden_core::Client;
 use bitwarden_vault::{Cipher, Folder};
-use wasm_bindgen::prelude::*;
+use wasm_bindgen::prelude::wasm_bindgen;
 
 mod repository;
 pub mod token_provider;
@@ -18,12 +18,6 @@ impl PlatformClient {
 impl PlatformClient {
     pub fn state(&self) -> StateClient {
         StateClient::new(self.0.clone())
-    }
-
-    /// Load feature flags into the client
-    pub fn load_flags(&self, flags: Flags) -> Result<(), JsValue> {
-        self.0.internal.set_flags(&flags);
-        Ok(())
     }
 }
 

--- a/crates/bitwarden-wasm-internal/src/platform/mod.rs
+++ b/crates/bitwarden-wasm-internal/src/platform/mod.rs
@@ -1,9 +1,20 @@
 use bitwarden_core::Client;
 use bitwarden_vault::{Cipher, Folder};
-use wasm_bindgen::prelude::wasm_bindgen;
+use serde::{Deserialize, Serialize};
+use tsify::Tsify;
+use wasm_bindgen::{prelude::wasm_bindgen, JsValue};
 
 mod repository;
 pub mod token_provider;
+
+/// Active feature flags for the SDK.
+#[derive(Serialize, Deserialize, Tsify)]
+#[tsify(into_wasm_abi, from_wasm_abi)]
+pub struct FeatureFlags {
+    /// We intentionally use a loose type here to allow for future flags without breaking changes.
+    #[serde(flatten)]
+    flags: std::collections::HashMap<String, bool>,
+}
 
 #[wasm_bindgen]
 pub struct PlatformClient(Client);
@@ -18,6 +29,13 @@ impl PlatformClient {
 impl PlatformClient {
     pub fn state(&self) -> StateClient {
         StateClient::new(self.0.clone())
+    }
+
+    /// Load feature flags into the client
+    #[wasm_bindgen(js_name = load_flags)]
+    pub fn load_flags(&self, flags: FeatureFlags) -> Result<(), JsValue> {
+        self.0.internal.load_flags(flags.flags);
+        Ok(())
     }
 }
 

--- a/crates/bitwarden-wasm-internal/src/platform/mod.rs
+++ b/crates/bitwarden-wasm-internal/src/platform/mod.rs
@@ -32,7 +32,6 @@ impl PlatformClient {
     }
 
     /// Load feature flags into the client
-    #[wasm_bindgen(js_name = load_flags)]
     pub fn load_flags(&self, flags: FeatureFlags) -> Result<(), JsValue> {
         self.0.internal.load_flags(flags.flags);
         Ok(())


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Updates wasm to use the same implementation as mobile, i.e. `load_flags`. This uses a hashmap instead of the internal `Flags` enum as we want to prevent additions or removal of flags to be a breaking change.

Consumers should pass in the full flag object they get from the config endpoint and let the SDK handle the rest.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation
  team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes 