### PR TITLE
[no ticket] Fix wasm being imported on UNIFFI builds

### DIFF
--- a/crates/bitwarden-exporters/Cargo.toml
+++ b/crates/bitwarden-exporters/Cargo.toml
@@ -19,13 +19,14 @@ keywords.workspace = true
 uniffi = ["dep:uniffi", "bitwarden-core/uniffi"] # Uniffi bindings
 wasm = [
     "bitwarden-vault/wasm",
+    "bitwarden-collections/wasm",
     "dep:tsify",
     "dep:wasm-bindgen"
 ] # WebAssembly bindings
 
 [dependencies]
 base64 = ">=0.22.1, <0.23"
-bitwarden-collections = { workspace = true, features = ["wasm"] }
+bitwarden-collections = { workspace = true }
 bitwarden-core = { workspace = true }
 bitwarden-crypto = { workspace = true }
 bitwarden-error = { workspace = true }

--- a/crates/bitwarden-exporters/Cargo.toml
+++ b/crates/bitwarden-exporters/Cargo.toml
@@ -18,8 +18,8 @@ keywords.workspace = true
 [features]
 uniffi = ["dep:uniffi", "bitwarden-core/uniffi"] # Uniffi bindings
 wasm = [
-    "bitwarden-vault/wasm",
     "bitwarden-collections/wasm",
+    "bitwarden-vault/wasm",
     "dep:tsify",
     "dep:wasm-bindgen"
 ] # WebAssembly bindings

--- a/crates/bitwarden-vault/Cargo.toml
+++ b/crates/bitwarden-vault/Cargo.toml
@@ -21,8 +21,8 @@ uniffi = [
     "dep:uniffi"
 ] # Uniffi bindings
 wasm = [
-    "bitwarden-core/wasm",
     "bitwarden-collections/wasm",
+    "bitwarden-core/wasm",
     "dep:tsify",
     "dep:wasm-bindgen",
     "dep:wasm-bindgen-futures"

--- a/crates/bitwarden-vault/Cargo.toml
+++ b/crates/bitwarden-vault/Cargo.toml
@@ -22,6 +22,7 @@ uniffi = [
 ] # Uniffi bindings
 wasm = [
     "bitwarden-core/wasm",
+    "bitwarden-collections/wasm",
     "dep:tsify",
     "dep:wasm-bindgen",
     "dep:wasm-bindgen-futures"
@@ -30,7 +31,7 @@ wasm = [
 [dependencies]
 base64 = ">=0.22.1, <0.23"
 bitwarden-api-api = { workspace = true }
-bitwarden-collections = { workspace = true, features = ["wasm"] }
+bitwarden-collections = { workspace = true }
 bitwarden-core = { workspace = true, features = ["internal"] }
 bitwarden-crypto = { workspace = true }
 bitwarden-error = { workspace = true }

--- a/crates/bitwarden-vault/src/collection_client.rs
+++ b/crates/bitwarden-vault/src/collection_client.rs
@@ -3,6 +3,7 @@ use bitwarden_collections::{
     tree::{NodeItem, Tree},
 };
 use bitwarden_core::Client;
+#[cfg(feature = "wasm")]
 use bitwarden_error::js_sys::Map;
 #[cfg(feature = "wasm")]
 use wasm_bindgen::prelude::wasm_bindgen;
@@ -69,6 +70,7 @@ impl CollectionViewNodeItem {
         self.node_item.children.clone()
     }
 
+    #[cfg(feature = "wasm")]
     pub fn get_ancestors(&self) -> Map {
         self.node_item
             .ancestors


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.slack.com/archives/C054ZQSBS49/p1755188403409309

## 📔 Objective

It seems https://github.com/bitwarden/sdk-internal/pull/279 accidentally required wasm in all uniffi builds via `bitwarden-vault` -> `bitwarden-collections` -> `bitwarden-core`. Since it is only required on core, this leads to build issues on anything where an impl is tagged with wasm-bindgen, but uses a struct from a third package - such as `bitwarden-crypto` that does not have the wasm feature enabled.

Attempts to fix the build errors of: https://github.com/bitwarden/sdk-internal/pull/383

Note: This flags out a function from the collections client. This has to be fixed by the owning team and updated, this PR just unblocks builds and fixes the imports.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation
  team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
