### PR TITLE
README Space Fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ are:
 ## API Bindings
 
 We autogenerate the server bindings
-using[openapi-generator](https://github.com/OpenAPITools/openapi-generator). To do this, we first
+using [openapi-generator](https://github.com/OpenAPITools/openapi-generator). To do this, we first
 need to build the internal swagger documentation.
 
 ### Swagger generation

--- a/README.md
+++ b/README.md
@@ -63,9 +63,9 @@ are:
 
 ## API Bindings
 
-We autogenerate the server bindings
-using [openapi-generator](https://github.com/OpenAPITools/openapi-generator). To do this, we first
-need to build the internal swagger documentation.
+We autogenerate the server bindings using
+[openapi-generator](https://github.com/OpenAPITools/openapi-generator). To do this, we first need to
+build the internal swagger documentation.
 
 ### Swagger generation
 


### PR DESCRIPTION
## 📔 Objective

Adds a space in the README.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation
  team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
