### PR TITLE
Force HTTPS on release builds

### DIFF
--- a/crates/bitwarden-core/src/client/client.rs
+++ b/crates/bitwarden-core/src/client/client.rs
@@ -53,6 +53,11 @@ impl Client {
                     ClientConfig::with_platform_verifier()
                         .expect("Failed to create platform verifier"),
                 );
+
+                #[cfg(not(debug_assertions))]
+                {
+                    client_builder = client_builder.https_only(true);
+                }
             }
 
             client_builder

--- a/crates/bitwarden-core/src/client/client.rs
+++ b/crates/bitwarden-core/src/client/client.rs
@@ -54,6 +54,7 @@ impl Client {
                         .expect("Failed to create platform verifier"),
                 );
 
+                // Enforce HTTPS for all requests in non-debug builds
                 #[cfg(not(debug_assertions))]
                 {
                     client_builder = client_builder.https_only(true);


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective

In prod builds, we should enforce that all the requests that we do are HTTPS. This will also protect against redirects to HTTP that would cause a downgrade. 

Note that this is only applicable to non-WASM builds, as the HTTP client for WASM is just a thin layer over `fetch`

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation
  team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
