### PR TITLE
Mark auth api as pub(crate) but private within auth

### DIFF
--- a/crates/bitwarden-core/src/auth/api/mod.rs
+++ b/crates/bitwarden-core/src/auth/api/mod.rs
@@ -1,2 +1,2 @@
-pub mod request;
-pub mod response;
+pub(crate) mod request;
+pub(crate) mod response;

--- a/crates/bitwarden-core/src/auth/api/request/access_token_request.rs
+++ b/crates/bitwarden-core/src/auth/api/request/access_token_request.rs
@@ -8,7 +8,7 @@ use crate::{
 };
 
 #[derive(Serialize, Deserialize, Debug)]
-pub struct AccessTokenRequest {
+pub(crate) struct AccessTokenRequest {
     scope: String,
     client_id: String,
     client_secret: String,
@@ -16,7 +16,7 @@ pub struct AccessTokenRequest {
 }
 
 impl AccessTokenRequest {
-    pub fn new(access_token_id: Uuid, client_secret: &String) -> Self {
+    pub(crate) fn new(access_token_id: Uuid, client_secret: &String) -> Self {
         let obj = Self {
             scope: "api.secrets".to_string(),
             client_id: access_token_id.to_string(),

--- a/crates/bitwarden-core/src/auth/api/request/api_token_request.rs
+++ b/crates/bitwarden-core/src/auth/api/request/api_token_request.rs
@@ -7,7 +7,7 @@ use crate::{
 };
 
 #[derive(Serialize, Deserialize, Debug)]
-pub struct ApiTokenRequest {
+pub(crate) struct ApiTokenRequest {
     scope: String,
     client_id: String,
     client_secret: String,
@@ -21,7 +21,7 @@ pub struct ApiTokenRequest {
 }
 
 impl ApiTokenRequest {
-    pub fn new(client_id: &String, client_secret: &String) -> Self {
+    pub(crate) fn new(client_id: &String, client_secret: &String) -> Self {
         let obj = Self {
             scope: "api".to_string(),
             client_id: client_id.to_string(),

--- a/crates/bitwarden-core/src/auth/api/request/auth_request_token_request.rs
+++ b/crates/bitwarden-core/src/auth/api/request/auth_request_token_request.rs
@@ -9,7 +9,7 @@ use crate::{
 };
 
 #[derive(Serialize, Deserialize, Debug)]
-pub struct AuthRequestTokenRequest {
+pub(crate) struct AuthRequestTokenRequest {
     scope: String,
     client_id: String,
     #[serde(rename = "deviceType")]
@@ -29,7 +29,7 @@ pub struct AuthRequestTokenRequest {
 
 #[allow(dead_code)]
 impl AuthRequestTokenRequest {
-    pub fn new(
+    pub(crate) fn new(
         email: &str,
         auth_request_id: &Uuid,
         access_code: &str,

--- a/crates/bitwarden-core/src/auth/api/request/mod.rs
+++ b/crates/bitwarden-core/src/auth/api/request/mod.rs
@@ -27,7 +27,7 @@ use crate::{
     ApiError,
 };
 
-async fn send_identity_connect_request(
+pub(crate) async fn send_identity_connect_request(
     configurations: &ApiConfigurations,
     body: impl serde::Serialize,
 ) -> Result<IdentityTokenResponse, LoginError> {

--- a/crates/bitwarden-core/src/auth/api/request/password_token_request.rs
+++ b/crates/bitwarden-core/src/auth/api/request/password_token_request.rs
@@ -11,7 +11,7 @@ use crate::{
 };
 
 #[derive(Serialize, Deserialize, Debug)]
-pub struct PasswordTokenRequest {
+pub(crate) struct PasswordTokenRequest {
     scope: String,
     client_id: String,
     #[serde(rename = "deviceType")]
@@ -35,7 +35,7 @@ pub struct PasswordTokenRequest {
 }
 
 impl PasswordTokenRequest {
-    pub fn new(
+    pub(crate) fn new(
         email: &str,
         password_hash: &str,
         device_type: DeviceType,

--- a/crates/bitwarden-core/src/auth/api/request/renew_token_request.rs
+++ b/crates/bitwarden-core/src/auth/api/request/renew_token_request.rs
@@ -6,14 +6,14 @@ use crate::{
 };
 
 #[derive(Serialize, Deserialize, Debug)]
-pub struct RenewTokenRequest {
+pub(crate) struct RenewTokenRequest {
     grant_type: String,
     refresh_token: String,
     client_id: String,
 }
 
 impl RenewTokenRequest {
-    pub fn new(refresh_token: String, client_id: String) -> Self {
+    pub(crate) fn new(refresh_token: String, client_id: String) -> Self {
         Self {
             refresh_token,
             client_id,

--- a/crates/bitwarden-core/src/auth/api/response/identity_payload_response.rs
+++ b/crates/bitwarden-core/src/auth/api/response/identity_payload_response.rs
@@ -2,7 +2,7 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Debug, PartialEq)]
 #[cfg_attr(test, derive(Default))]
-pub struct IdentityTokenPayloadResponse {
+pub(crate) struct IdentityTokenPayloadResponse {
     pub access_token: String,
     pub expires_in: u64,
     pub refresh_token: Option<String>,

--- a/crates/bitwarden-core/src/auth/api/response/identity_refresh_response.rs
+++ b/crates/bitwarden-core/src/auth/api/response/identity_refresh_response.rs
@@ -2,7 +2,7 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Debug, PartialEq)]
 #[cfg_attr(test, derive(Default))]
-pub struct IdentityTokenRefreshResponse {
+pub(crate) struct IdentityTokenRefreshResponse {
     pub access_token: String,
     pub expires_in: u64,
     pub refresh_token: Option<String>,

--- a/crates/bitwarden-core/src/auth/api/response/identity_success_response.rs
+++ b/crates/bitwarden-core/src/auth/api/response/identity_success_response.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
 #[derive(Serialize, Deserialize, Debug, PartialEq)]
-pub struct IdentityTokenSuccessResponse {
+pub(crate) struct IdentityTokenSuccessResponse {
     pub access_token: String,
     pub expires_in: u64,
     pub refresh_token: Option<String>,

--- a/crates/bitwarden-core/src/auth/api/response/identity_token_response.rs
+++ b/crates/bitwarden-core/src/auth/api/response/identity_token_response.rs
@@ -13,14 +13,14 @@ use crate::{
 };
 
 #[derive(Debug, Serialize, Deserialize, PartialEq)]
-pub enum IdentityTokenResponse {
+pub(crate) enum IdentityTokenResponse {
     Authenticated(IdentityTokenSuccessResponse),
     Payload(IdentityTokenPayloadResponse),
     Refreshed(IdentityTokenRefreshResponse),
     TwoFactorRequired(Box<IdentityTwoFactorResponse>),
 }
 
-pub fn parse_identity_response(
+pub(crate) fn parse_identity_response(
     status: StatusCode,
     response: String,
 ) -> Result<IdentityTokenResponse, LoginError> {

--- a/crates/bitwarden-core/src/auth/api/response/identity_two_factor_response.rs
+++ b/crates/bitwarden-core/src/auth/api/response/identity_two_factor_response.rs
@@ -6,7 +6,7 @@ use serde_json::Value;
 use crate::auth::api::response::two_factor_providers::TwoFactorProviders;
 
 #[derive(Serialize, Deserialize, Debug, PartialEq)]
-pub struct IdentityTwoFactorResponse {
+pub(crate) struct IdentityTwoFactorResponse {
     pub error: String,
     pub error_description: String,
     #[serde(rename = "twoFactorProviders2", alias = "TwoFactorProviders2")]

--- a/crates/bitwarden-core/src/auth/api/response/two_factor_providers.rs
+++ b/crates/bitwarden-core/src/auth/api/response/two_factor_providers.rs
@@ -9,7 +9,7 @@ use crate::auth::api::response::two_factor_provider_data::{
 };
 
 #[derive(Serialize, Deserialize, Debug, PartialEq)]
-pub struct TwoFactorProviders {
+pub(crate) struct TwoFactorProviders {
     #[serde(rename = "0", default, deserialize_with = "double_option")]
     pub authenticator: Option<Option<Authenticator>>,
     #[serde(rename = "1")]

--- a/crates/bitwarden-core/src/auth/mod.rs
+++ b/crates/bitwarden-core/src/auth/mod.rs
@@ -7,7 +7,8 @@ use thiserror::Error;
 use crate::{NotAuthenticatedError, VaultLockedError, WrongPasswordError};
 
 mod access_token;
-pub(super) mod api;
+// API is intentionally not visible outside of `auth` as these should be considered private.
+mod api;
 #[allow(missing_docs)]
 pub mod auth_client;
 mod jwt_token;


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

There is no reason for auth api request/responses to be public. This changes them to `pub(crate)` for simplicity, but they are never publicly exposed outside of `auth`.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation
  team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
