### PR TITLE
Preserve original encrypted OpenSSH/PKCS#8 PEM on import + on-demand decryption for SSH agent

### DIFF
--- a/crates/bitwarden-ssh/src/import.rs
+++ b/crates/bitwarden-ssh/src/import.rs
@@ -3,6 +3,8 @@ use ed25519;
 use pem_rfc7468::PemLabel;
 use pkcs8::{der::Decode, pkcs5, DecodePrivateKey, PrivateKeyInfo, SecretDocument};
 use ssh_key::private::{Ed25519Keypair, RsaKeypair};
+use ssh_key::HashAlg;
+use pkcs8::LineEnding;
 
 use crate::{error::SshKeyImportError, ssh_private_key_to_view};
 
@@ -36,20 +38,43 @@ fn import_pkcs8_key(
     encoded_key: String,
     password: Option<String>,
 ) -> Result<SshKeyView, SshKeyImportError> {
-    let doc = if let Some(password) = password {
-        SecretDocument::from_pkcs8_encrypted_pem(&encoded_key, password.as_bytes()).map_err(
-            |err| match err {
-                pkcs8::Error::EncryptedPrivateKey(pkcs5::Error::DecryptFailed) => {
-                    SshKeyImportError::WrongPassword
-                }
-                _ => SshKeyImportError::ParsingError,
-            },
-        )?
+    // Load the PKCS#8 document (decrypt if necessary)
+    let (doc, was_encrypted) = if let Some(ref pw) = password {
+        (
+            SecretDocument::from_pkcs8_encrypted_pem(&encoded_key, pw.as_bytes()).map_err(
+                |err| match err {
+                    pkcs8::Error::EncryptedPrivateKey(pkcs5::Error::DecryptFailed) => {
+                        SshKeyImportError::WrongPassword
+                    }
+                    _ => SshKeyImportError::ParsingError,
+                },
+            )?,
+            true,
+        )
     } else {
-        SecretDocument::from_pkcs8_pem(&encoded_key).map_err(|_| SshKeyImportError::ParsingError)?
+        (
+            SecretDocument::from_pkcs8_pem(&encoded_key)
+                .map_err(|_| SshKeyImportError::ParsingError)?,
+            false,
+        )
     };
 
-    import_pkcs8_der_key(doc.as_bytes())
+    // Reuse existing DER importer to compute public key and fingerprint
+    let base = import_pkcs8_der_key(doc.as_bytes())?;
+
+    // Preserve original PEM for round-trip fidelity; mark encryption status and passphrase (if provided)
+    Ok(SshKeyView {
+        private_key: if was_encrypted {
+            encoded_key.clone()
+        } else {
+            base.private_key
+        },
+        public_key: base.public_key,
+        fingerprint: base.fingerprint,
+        original_private_key: Some(encoded_key),
+        is_encrypted: was_encrypted,
+        ssh_key_passphrase: if was_encrypted { password } else { None },
+    })
 }
 
 /// Import a DER encoded private key, and returns a decoded [SshKeyView]. This is primarily used for
@@ -85,7 +110,8 @@ fn import_openssh_key(
     encoded_key: String,
     password: Option<String>,
 ) -> Result<SshKeyView, SshKeyImportError> {
-    let private_key =
+    // Parse the original OpenSSH PEM to determine encryption and to compute pub/fingerprint.
+    let parsed =
         ssh_key::private::PrivateKey::from_openssh(&encoded_key).map_err(|err| match err {
             ssh_key::Error::AlgorithmUnknown | ssh_key::Error::AlgorithmUnsupported { .. } => {
                 SshKeyImportError::UnsupportedKeyType
@@ -93,16 +119,146 @@ fn import_openssh_key(
             _ => SshKeyImportError::ParsingError,
         })?;
 
-    let private_key = if private_key.is_encrypted() {
+    if parsed.is_encrypted() {
+        // Encrypted: require password to decrypt for computing public key and fingerprint,
+        // but preserve the original PEM verbatim for storage/export.
         let password = password.ok_or(SshKeyImportError::PasswordRequired)?;
-        private_key
+        let decrypted = parsed
             .decrypt(password.as_bytes())
-            .map_err(|_| SshKeyImportError::WrongPassword)?
-    } else {
-        private_key
-    };
+            .map_err(|_| SshKeyImportError::WrongPassword)?;
 
-    ssh_private_key_to_view(private_key).map_err(|_| SshKeyImportError::ParsingError)
+        let public_key = decrypted.public_key().to_string();
+        let fingerprint = decrypted.fingerprint(HashAlg::Sha256).to_string();
+
+        Ok(SshKeyView {
+            private_key: encoded_key.clone(),
+            public_key,
+            fingerprint,
+            original_private_key: Some(encoded_key),
+            is_encrypted: true,
+            ssh_key_passphrase: Some(password),
+        })
+    } else {
+        // Unencrypted: compute public key and fingerprint as-is, preserve original PEM verbatim.
+        let public_key = parsed.public_key().to_string();
+        let fingerprint = parsed.fingerprint(HashAlg::Sha256).to_string();
+
+        Ok(SshKeyView {
+            private_key: encoded_key.clone(),
+            public_key,
+            fingerprint,
+            original_private_key: Some(encoded_key),
+            is_encrypted: false,
+            ssh_key_passphrase: None,
+        })
+    }
+}
+
+/**
+ * Decrypt a private key PEM into an unencrypted OpenSSH PEM for agent use.
+ * Supports both OpenSSH and PKCS#8 inputs. If already unencrypted OpenSSH, returns it verbatim.
+ */
+pub fn decrypt_openssh_key(
+    encoded_key: String,
+    password: String,
+) -> Result<String, SshKeyImportError> {
+    // Determine the PEM label so we can support OpenSSH and PKCS#8 inputs
+    let label = pem_rfc7468::decode_label(encoded_key.as_bytes())
+        .map_err(|_| SshKeyImportError::ParsingError)?;
+
+    match label {
+        // Encrypted PKCS#8
+        pkcs8::EncryptedPrivateKeyInfo::PEM_LABEL => {
+            let doc = SecretDocument::from_pkcs8_encrypted_pem(&encoded_key, password.as_bytes())
+                .map_err(|err| match err {
+                    pkcs8::Error::EncryptedPrivateKey(pkcs5::Error::DecryptFailed) => {
+                        SshKeyImportError::WrongPassword
+                    }
+                    _ => SshKeyImportError::ParsingError,
+                })?;
+
+            // Parse DER and convert to OpenSSH
+            let private_key_info =
+                PrivateKeyInfo::from_der(doc.as_bytes()).map_err(|_| SshKeyImportError::ParsingError)?;
+
+            let private_key = match private_key_info.algorithm.oid {
+                ed25519::pkcs8::ALGORITHM_OID => {
+                    let private_key: ed25519::KeypairBytes = private_key_info
+                        .try_into()
+                        .map_err(|_| SshKeyImportError::ParsingError)?;
+                    ssh_key::private::PrivateKey::from(Ed25519Keypair::from(&private_key.secret_key.into()))
+                }
+                rsa::pkcs1::ALGORITHM_OID => {
+                    let private_key: rsa::RsaPrivateKey = private_key_info
+                        .try_into()
+                        .map_err(|_| SshKeyImportError::ParsingError)?;
+                    ssh_key::private::PrivateKey::from(
+                        RsaKeypair::try_from(private_key).map_err(|_| SshKeyImportError::ParsingError)?,
+                    )
+                }
+                _ => return Err(SshKeyImportError::UnsupportedKeyType),
+            };
+
+            let pem = private_key
+                .to_openssh(LineEnding::LF)
+                .map_err(|_| SshKeyImportError::ParsingError)?;
+            Ok(pem.to_string())
+        }
+        // Unencrypted PKCS#8: convert directly to OpenSSH
+        pkcs8::PrivateKeyInfo::PEM_LABEL => {
+            let doc = SecretDocument::from_pkcs8_pem(&encoded_key)
+                .map_err(|_| SshKeyImportError::ParsingError)?;
+
+            let private_key_info =
+                PrivateKeyInfo::from_der(doc.as_bytes()).map_err(|_| SshKeyImportError::ParsingError)?;
+
+            let private_key = match private_key_info.algorithm.oid {
+                ed25519::pkcs8::ALGORITHM_OID => {
+                    let private_key: ed25519::KeypairBytes = private_key_info
+                        .try_into()
+                        .map_err(|_| SshKeyImportError::ParsingError)?;
+                    ssh_key::private::PrivateKey::from(Ed25519Keypair::from(&private_key.secret_key.into()))
+                }
+                rsa::pkcs1::ALGORITHM_OID => {
+                    let private_key: rsa::RsaPrivateKey = private_key_info
+                        .try_into()
+                        .map_err(|_| SshKeyImportError::ParsingError)?;
+                    ssh_key::private::PrivateKey::from(
+                        RsaKeypair::try_from(private_key).map_err(|_| SshKeyImportError::ParsingError)?,
+                    )
+                }
+                _ => return Err(SshKeyImportError::UnsupportedKeyType),
+            };
+
+            let pem = private_key
+                .to_openssh(LineEnding::LF)
+                .map_err(|_| SshKeyImportError::ParsingError)?;
+            Ok(pem.to_string())
+        }
+        // OpenSSH input
+        ssh_key::PrivateKey::PEM_LABEL => {
+            let parsed = ssh_key::private::PrivateKey::from_openssh(&encoded_key).map_err(|err| match err {
+                ssh_key::Error::AlgorithmUnknown | ssh_key::Error::AlgorithmUnsupported { .. } => {
+                    SshKeyImportError::UnsupportedKeyType
+                }
+                _ => SshKeyImportError::ParsingError,
+            })?;
+
+            if !parsed.is_encrypted() {
+                // Already unencrypted, return as-is
+                return Ok(encoded_key);
+            }
+
+            let decrypted = parsed
+                .decrypt(password.as_bytes())
+                .map_err(|_| SshKeyImportError::WrongPassword)?;
+            let pem = decrypted
+                .to_openssh(LineEnding::LF)
+                .map_err(|_| SshKeyImportError::ParsingError)?;
+            Ok(pem.to_string())
+        }
+        _ => Err(SshKeyImportError::UnsupportedKeyType),
+    }
 }
 
 #[cfg(test)]
@@ -226,5 +382,19 @@ mod tests {
         let private_key = include_str!("../resources/import/rsa_putty_pkcs1_unencrypted");
         let result = import_key(private_key.to_string(), Some("".to_string()));
         assert_eq!(result.unwrap_err(), SshKeyImportError::UnsupportedKeyType);
+    }
+
+    #[test]
+    fn import_key_openssh_encrypted_preserves_input() {
+        let original = include_str!("../resources/import/ed25519_openssh_encrypted");
+        let result = import_key(original.to_string(), Some("password".to_string())).unwrap();
+        assert_eq!(result.private_key, original);
+    }
+
+    #[test]
+    fn import_key_openssh_unencrypted_preserves_input() {
+        let original = include_str!("../resources/import/ed25519_openssh_unencrypted");
+        let result = import_key(original.to_string(), Some("".to_string())).unwrap();
+        assert_eq!(result.private_key, original);
     }
 }

--- a/crates/bitwarden-ssh/src/lib.rs
+++ b/crates/bitwarden-ssh/src/lib.rs
@@ -24,5 +24,8 @@ fn ssh_private_key_to_view(value: PrivateKey) -> Result<SshKeyView, SshKeyExport
         private_key: private_key_openssh.to_string(),
         public_key: value.public_key().to_string(),
         fingerprint: value.fingerprint(HashAlg::Sha256).to_string(),
+        original_private_key: None,
+        is_encrypted: false,
+        ssh_key_passphrase: None,
     })
 }

--- a/crates/bitwarden-uniffi/src/tool/ssh.rs
+++ b/crates/bitwarden-uniffi/src/tool/ssh.rs
@@ -26,4 +26,9 @@ impl SshClient {
         bitwarden_ssh::import::import_key(imported_key, password)
             .map_err(|e| BitwardenError::E(Error::SshImport(e)))
     }
+
+    pub fn decrypt_ssh_key_for_agent(&self, encrypted_pem: String, password: String) -> Result<String> {
+        bitwarden_ssh::import::decrypt_openssh_key(encrypted_pem, password)
+            .map_err(|e| BitwardenError::E(Error::SshImport(e)))
+    }
 }

--- a/crates/bitwarden-wasm-internal/src/ssh.rs
+++ b/crates/bitwarden-wasm-internal/src/ssh.rs
@@ -36,3 +36,17 @@ pub fn import_ssh_key(
 ) -> Result<SshKeyView, bitwarden_ssh::error::SshKeyImportError> {
     bitwarden_ssh::import::import_key(imported_key.to_string(), password)
 }
+
+/// Decrypt an encrypted OpenSSH private key PEM into an unencrypted OpenSSH PEM for agent use.
+/// If the input is already unencrypted, returns it verbatim.
+///
+/// # Arguments
+/// - `encrypted_pem` - The original OpenSSH private key PEM (possibly encrypted)
+/// - `password` - The passphrase to decrypt the key
+#[wasm_bindgen]
+pub fn decrypt_ssh_key_for_agent(
+    encrypted_pem: &str,
+    password: &str,
+) -> Result<String, bitwarden_ssh::error::SshKeyImportError> {
+    bitwarden_ssh::import::decrypt_openssh_key(encrypted_pem.to_string(), password.to_string())
+}


### PR DESCRIPTION
Summary
This change fixes loss of encryption headers when importing SSH private keys by preserving the exact original PEM (including bcrypt/aes header) and introducing a just-in-time decrypt function for SSH agent operations. It also plumbs new metadata through SshKeyView for clients to enable improved UX.

Linked PRs needed to work for this changes:
- clients: https://github.com/bitwarden/clients/pull/16121
- server: https://github.com/bitwarden/server/pull/6232
- sdk-internal: https://github.com/bitwarden/sdk-internal/pull/408

Linked Issue
- OpenSSH keys with passphrase not saving correctly (https://github.com/bitwarden/clients/issues/13878)
- SSH agent can't import RSA keys (PKCS#1 / PEM) (https://github.com/bitwarden/clients/issues/15088)
- unable to save SSH key with or without a passphrase from puttygen (https://github.com/bitwarden/clients/issues/13343)

Root Cause
Imported SSH keys were always re-encoded into unencrypted OpenSSH format (via to_openssh), stripping encrypted headers. Copying/using the key later did not match the original encrypted PEM.

Approach
- Lossless storage: Store the original imported PEM verbatim and expose it to clients.
- Metadata: SshKeyView now carries original_private_key, is_encrypted, and ssh_key_passphrase (optional).
- Just-in-time decryption: Provide decrypt_openssh_key that returns an unencrypted OpenSSH PEM in memory for agent use only.

Changes
- crates/bitwarden-ssh/src/import.rs
  - import_key now:
    - Detects PEM label (OpenSSH or PKCS#8; encrypted/unencrypted).
    - Preserves original PEM in SshKeyView.original_private_key.
    - Sets is_encrypted and optionally ssh_key_passphrase in SshKeyView.
  - New decrypt_openssh_key(encoded_key, password): Supports encrypted OpenSSH and PKCS#8 input; returns unencrypted OpenSSH PEM for transient use.
  - Added tests to ensure original OpenSSH PEM is preserved for encrypted/unencrypted keys.
- crates/bitwarden-ssh/src/lib.rs
  - ssh_private_key_to_view sets defaults for new SshKeyView fields (original_private_key: None, is_encrypted: false, ssh_key_passphrase: None).
- crates/bitwarden-vault/src/cipher/ssh_key.rs
  - Extend SshKey/SshKeyView with:
    - original_private_key: Option<String/EncString>
    - is_encrypted: bool
    - ssh_key_passphrase: Option<String/EncString>
  - Updated CompositeEncryptable/Decryptable implementations.
- crates/bitwarden-wasm-internal/src/ssh.rs
  - Export decrypt_ssh_key_for_agent(encrypted_pem, password) for web/TS clients.
- crates/bitwarden-uniffi/src/tool/ssh.rs
  - Add SshClient.decrypt_ssh_key_for_agent for native clients.

Backwards Compatibility
- New fields are optional; existing clients continue to function.
- Unencrypted keys behave as before.
- The decrypt function is additive and does not change previous interfaces.

Security Considerations
- OriginalPrivateKey and sshKeyPassphrase are encrypted-at-rest via existing model encryption mechanisms.
- Decryptions for agent operations occur in memory only; no plaintext persistence.

Testing
- cargo test -p bitwarden-ssh
- Added unit tests for preserving original OpenSSH PEM (encrypted/unencrypted).
- Recommended: add tests for PKCS#8 encrypted behavior.