### PR TITLE
PM-25311: CXF Map all custom fields to a CustomFieldsCredential

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1200,7 +1200,7 @@ dependencies = [
 [[package]]
 name = "credential-exchange-format"
 version = "0.2.0"
-source = "git+https://github.com/bitwarden/credential-exchange?rev=38e8a013c13644f832c457555baaa536fe481b77#38e8a013c13644f832c457555baaa536fe481b77"
+source = "git+https://github.com/bitwarden/credential-exchange?rev=12702ad62ccc2a1e3cd9bdea40fc0f6399e1fffa#12702ad62ccc2a1e3cd9bdea40fc0f6399e1fffa"
 dependencies = [
  "chrono",
  "data-encoding",

--- a/crates/bitwarden-exporters/Cargo.toml
+++ b/crates/bitwarden-exporters/Cargo.toml
@@ -34,7 +34,7 @@ bitwarden-fido = { workspace = true }
 bitwarden-ssh = { workspace = true }
 bitwarden-vault = { workspace = true }
 chrono = { workspace = true, features = ["std"] }
-credential-exchange-format = { git = "https://github.com/bitwarden/credential-exchange", rev = "38e8a013c13644f832c457555baaa536fe481b77" }
+credential-exchange-format = { git = "https://github.com/bitwarden/credential-exchange", rev = "12702ad62ccc2a1e3cd9bdea40fc0f6399e1fffa" }
 csv = "1.3.0"
 num-traits = ">=0.2, <0.3"
 serde = { workspace = true }

--- a/crates/bitwarden-exporters/src/cxf/editable_field.rs
+++ b/crates/bitwarden-exporters/src/cxf/editable_field.rs
@@ -24,7 +24,6 @@ where
     }
 }
 
-
 /// Helper function to create an EditableField with common properties
 fn create_editable_field<T>(name: String, value: T) -> EditableField<T> {
     EditableField {

--- a/crates/bitwarden-exporters/src/cxf/export.rs
+++ b/crates/bitwarden-exporters/src/cxf/export.rs
@@ -9,7 +9,7 @@ use {tsify::Tsify, wasm_bindgen::prelude::*};
 
 use crate::{
     cxf::{editable_field::field_to_editable_field_value, CxfError},
-    Cipher, CipherType, Field, Login,
+    Cipher, CipherType, Login,
 };
 
 /// Temporary struct to hold metadata related to current account

--- a/crates/bitwarden-exporters/src/cxf/import.rs
+++ b/crates/bitwarden-exporters/src/cxf/import.rs
@@ -1,9 +1,9 @@
 use chrono::{DateTime, Utc};
 use credential_exchange_format::{
     Account as CxfAccount, AddressCredential, ApiKeyCredential, BasicAuthCredential, Credential,
-    CreditCardCredential, CustomFieldsCredential, DriversLicenseCredential,
-    IdentityDocumentCredential, Item, NoteCredential, PasskeyCredential, PassportCredential,
-    PersonNameCredential, SshKeyCredential, TotpCredential, WifiCredential,
+    CreditCardCredential, CustomFieldsCredential, DriversLicenseCredential, EditableField,
+    EditableFieldString, IdentityDocumentCredential, Item, NoteCredential, PasskeyCredential,
+    PassportCredential, PersonNameCredential, SshKeyCredential, TotpCredential, WifiCredential,
 };
 
 use crate::{
@@ -49,7 +49,41 @@ fn custom_fields_to_fields(custom_fields: &CustomFieldsCredential) -> Vec<Field>
     custom_fields
         .fields
         .iter()
-        .map(|f| create_field(f, None::<String>))
+        .map(|field_value| match field_value {
+            credential_exchange_format::EditableFieldValue::String(field) => {
+                create_field(field, None::<String>)
+            }
+            credential_exchange_format::EditableFieldValue::ConcealedString(field) => {
+                create_field(field, None::<String>)
+            }
+            credential_exchange_format::EditableFieldValue::Boolean(field) => {
+                create_field(field, None::<String>)
+            }
+            credential_exchange_format::EditableFieldValue::Date(field) => {
+                create_field(field, None::<String>)
+            }
+            credential_exchange_format::EditableFieldValue::YearMonth(field) => {
+                create_field(field, None::<String>)
+            }
+            credential_exchange_format::EditableFieldValue::SubdivisionCode(field) => {
+                create_field(field, None::<String>)
+            }
+            credential_exchange_format::EditableFieldValue::CountryCode(field) => {
+                create_field(field, None::<String>)
+            }
+            credential_exchange_format::EditableFieldValue::WifiNetworkSecurityType(field) => {
+                create_field(field, None::<String>)
+            }
+            _ => create_field(
+                &EditableField {
+                    id: None,
+                    label: Some("Unknown Field".to_string()),
+                    value: EditableFieldString("".to_string()),
+                    extensions: None,
+                },
+                None::<String>,
+            ),
+        })
         .collect()
 }
 

--- a/crates/bitwarden-exporters/src/cxf/import.rs
+++ b/crates/bitwarden-exporters/src/cxf/import.rs
@@ -2,8 +2,9 @@ use chrono::{DateTime, Utc};
 use credential_exchange_format::{
     Account as CxfAccount, AddressCredential, ApiKeyCredential, BasicAuthCredential, Credential,
     CreditCardCredential, CustomFieldsCredential, DriversLicenseCredential, EditableField,
-    EditableFieldString, IdentityDocumentCredential, Item, NoteCredential, PasskeyCredential,
-    PassportCredential, PersonNameCredential, SshKeyCredential, TotpCredential, WifiCredential,
+    EditableFieldString, EditableFieldValue, IdentityDocumentCredential, Item, NoteCredential,
+    PasskeyCredential, PassportCredential, PersonNameCredential, SshKeyCredential, TotpCredential,
+    WifiCredential,
 };
 
 use crate::{
@@ -50,28 +51,14 @@ fn custom_fields_to_fields(custom_fields: &CustomFieldsCredential) -> Vec<Field>
         .fields
         .iter()
         .map(|field_value| match field_value {
-            credential_exchange_format::EditableFieldValue::String(field) => {
-                create_field(field, None::<String>)
-            }
-            credential_exchange_format::EditableFieldValue::ConcealedString(field) => {
-                create_field(field, None::<String>)
-            }
-            credential_exchange_format::EditableFieldValue::Boolean(field) => {
-                create_field(field, None::<String>)
-            }
-            credential_exchange_format::EditableFieldValue::Date(field) => {
-                create_field(field, None::<String>)
-            }
-            credential_exchange_format::EditableFieldValue::YearMonth(field) => {
-                create_field(field, None::<String>)
-            }
-            credential_exchange_format::EditableFieldValue::SubdivisionCode(field) => {
-                create_field(field, None::<String>)
-            }
-            credential_exchange_format::EditableFieldValue::CountryCode(field) => {
-                create_field(field, None::<String>)
-            }
-            credential_exchange_format::EditableFieldValue::WifiNetworkSecurityType(field) => {
+            EditableFieldValue::String(field) => create_field(field, None::<String>),
+            EditableFieldValue::ConcealedString(field) => create_field(field, None::<String>),
+            EditableFieldValue::Boolean(field) => create_field(field, None::<String>),
+            EditableFieldValue::Date(field) => create_field(field, None::<String>),
+            EditableFieldValue::YearMonth(field) => create_field(field, None::<String>),
+            EditableFieldValue::SubdivisionCode(field) => create_field(field, None::<String>),
+            EditableFieldValue::CountryCode(field) => create_field(field, None::<String>),
+            EditableFieldValue::WifiNetworkSecurityType(field) => {
                 create_field(field, None::<String>)
             }
             _ => create_field(


### PR DESCRIPTION
## 🎟️ Tracking
https://bitwarden.atlassian.net/browse/PM-25311
<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective

This PR is a quick stab at mapping all custom fields on a cipher to a single CustomFieldCredential.

I'm not 100% sure about how to parse this from the spec:

> If the [exporting provider](https://fidoalliance.org/specs/cx/cxf-v1.0-ps-20250814.html#exporting-provider) allows custom fields to be added to items but does not have a grouping concept, it SHOULD use this object without setting the label or id fields.

From: https://fidoalliance.org/specs/cx/cxf-v1.0-ps-20250814.html#dict-custom-fields



<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation
  team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
