### PR TITLE
[PM-25330] Fix B64 type

### DIFF
--- a/crates/bitwarden-encoding/src/b64.rs
+++ b/crates/bitwarden-encoding/src/b64.rs
@@ -16,7 +16,7 @@ use crate::FromStrVisitor;
 #[serde(into = "String")]
 #[derive(Tsify)]
 #[tsify(into_wasm_abi, from_wasm_abi)]
-pub struct B64(#[tsify(type = "String")] Vec<u8>);
+pub struct B64(#[tsify(type = "string")] Vec<u8>);
 
 /// Base64 encoded data
 ///


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-25330

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Currently `bitwarden_wasm_internal.d.ts` produces: 
```
export type B64 = String;
```

This PR makes it produce:

```
export type B64 = string;
```

In TypeScript the `string` primitive is case sensitive. This was causing breaking changes to TS clients.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation
  team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
