### PR TITLE
Expose counter to support more efficient sync

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -87,7 +87,7 @@ jobs:
         run: cargo sort --workspace --check
 
       - name: Install cargo-udeps
-        run: cargo install cargo-udeps --version 0.1.53 --locked
+        run: cargo install cargo-udeps --version 0.1.57 --locked
 
       - name: Cargo udeps
         run: cargo +"${{ steps.nightly-toolchain.outputs.RUST_NIGHTLY_TOOLCHAIN }}" udeps --workspace --all-features

--- a/crates/bitwarden-crypto/src/keys/asymmetric_crypto_key.rs
+++ b/crates/bitwarden-crypto/src/keys/asymmetric_crypto_key.rs
@@ -76,11 +76,9 @@ pub struct AsymmetricCryptoKey {
 
 // Note that RsaPrivateKey already implements ZeroizeOnDrop, so we don't need to do anything
 // We add this assertion to make sure that this is still true in the future
-const _: () = {
+const _: fn() = || {
     fn assert_zeroize_on_drop<T: zeroize::ZeroizeOnDrop>() {}
-    fn assert_all() {
-        assert_zeroize_on_drop::<RsaPrivateKey>();
-    }
+    assert_zeroize_on_drop::<RsaPrivateKey>();
 };
 impl zeroize::ZeroizeOnDrop for AsymmetricCryptoKey {}
 impl CryptoKey for AsymmetricCryptoKey {}

--- a/crates/bitwarden-crypto/src/signing/signing_key.rs
+++ b/crates/bitwarden-crypto/src/signing/signing_key.rs
@@ -38,11 +38,9 @@ pub struct SigningKey {
 // Note that `SigningKey` already implements ZeroizeOnDrop, so we don't need to do anything
 // We add this assertion to make sure that this is still true in the future
 // For any new keys, this needs to be checked
-const _: () = {
+const _: fn() = || {
     fn assert_zeroize_on_drop<T: zeroize::ZeroizeOnDrop>() {}
-    fn assert_all() {
-        assert_zeroize_on_drop::<ed25519_dalek::SigningKey>();
-    }
+    assert_zeroize_on_drop::<ed25519_dalek::SigningKey>();
 };
 impl zeroize::ZeroizeOnDrop for SigningKey {}
 impl CryptoKey for SigningKey {}

--- a/crates/bitwarden-fido/src/authenticator.rs
+++ b/crates/bitwarden-fido/src/authenticator.rs
@@ -294,7 +294,7 @@ impl<'a> Fido2Authenticator<'a> {
     pub(super) fn get_authenticator(
         &self,
         create_credential: bool,
-    ) -> Authenticator<CredentialStoreImpl, UserValidationMethodImpl> {
+    ) -> Authenticator<CredentialStoreImpl<'_>, UserValidationMethodImpl<'_>> {
         Authenticator::new(
             AAGUID,
             CredentialStoreImpl {

--- a/crates/bitwarden-fido/src/types.rs
+++ b/crates/bitwarden-fido/src/types.rs
@@ -97,9 +97,7 @@ impl Fido2CredentialAutofillView {
                                     .as_ref()
                                     .and_then(|l| l.username.none_whitespace()))
                                 .or(cipher.name.none_whitespace()),
-                            has_counter: c.counter.none_whitespace().is_some_and(|counter_str| {
-                                counter_str.parse::<u64>().is_ok_and(|counter| counter > 0)
-                            }),
+                            has_counter: Self::has_signature_counter(&c.counter),
                         })
                     })
             })
@@ -136,15 +134,18 @@ impl Fido2CredentialAutofillView {
                                     .or(c.user_display_name.none_whitespace())
                                     .or(username.none_whitespace())
                                     .or(cipher.name.none_whitespace()),
-                                // `Fido2CredentialListView` doesn't expose the counter property, so
-                                // assume there is not one.
-                                has_counter: false,
+                                has_counter: Self::has_signature_counter(&c.counter),
                             })
                         })
                 })
                 .collect(),
             _ => Ok(vec![]),
         }
+    }
+
+    fn has_signature_counter(str: &String) -> bool {
+        str.none_whitespace()
+            .is_some_and(|counter_str| counter_str.parse::<u64>().is_ok_and(|counter| counter > 0))
     }
 }
 

--- a/crates/bitwarden-fido/src/types.rs
+++ b/crates/bitwarden-fido/src/types.rs
@@ -24,6 +24,9 @@ pub struct Fido2CredentialAutofillView {
     pub rp_id: String,
     pub user_name_for_ui: Option<String>,
     pub user_handle: Vec<u8>,
+    /// Indicates if this credential uses a signature counter (legacy passkeys).
+    /// When true, mobile clients must sync before authentication to ensure
+    /// counter values are current. Modern passkeys (counter = 0) can work offline.
     pub has_counter: bool,
 }
 

--- a/crates/bitwarden-fido/src/types.rs
+++ b/crates/bitwarden-fido/src/types.rs
@@ -24,6 +24,7 @@ pub struct Fido2CredentialAutofillView {
     pub rp_id: String,
     pub user_name_for_ui: Option<String>,
     pub user_handle: Vec<u8>,
+    pub has_counter: bool,
 }
 
 trait NoneWhitespace {
@@ -96,6 +97,9 @@ impl Fido2CredentialAutofillView {
                                     .as_ref()
                                     .and_then(|l| l.username.none_whitespace()))
                                 .or(cipher.name.none_whitespace()),
+                            has_counter: c.counter.none_whitespace().is_some_and(|counter_str| {
+                                counter_str.parse::<u64>().is_ok_and(|counter| counter > 0)
+                            }),
                         })
                     })
             })
@@ -132,6 +136,9 @@ impl Fido2CredentialAutofillView {
                                     .or(c.user_display_name.none_whitespace())
                                     .or(username.none_whitespace())
                                     .or(cipher.name.none_whitespace()),
+                                // `Fido2CredentialListView` doesn't expose the counter property, so
+                                // assume there is not one.
+                                has_counter: false,
                             })
                         })
                 })

--- a/crates/bitwarden-vault/src/cipher/cipher.rs
+++ b/crates/bitwarden-vault/src/cipher/cipher.rs
@@ -924,6 +924,7 @@ mod tests {
                         user_handle: None,
                         user_name: None,
                         user_display_name: None,
+                        counter: "123".to_string(),
                     }]),
                     has_fido2: true,
                     username: Some("test_username".to_string()),

--- a/crates/bitwarden-vault/src/cipher/login.rs
+++ b/crates/bitwarden-vault/src/cipher/login.rs
@@ -114,6 +114,7 @@ pub struct Fido2CredentialListView {
     pub user_handle: Option<String>,
     pub user_name: Option<String>,
     pub user_display_name: Option<String>,
+    pub counter: String,
 }
 
 #[allow(missing_docs)]
@@ -478,6 +479,7 @@ impl Decryptable<KeyIds, SymmetricKeyId, Fido2CredentialListView> for Fido2Crede
             user_handle: self.user_handle.decrypt(ctx, key)?,
             user_name: self.user_name.decrypt(ctx, key)?,
             user_display_name: self.user_display_name.decrypt(ctx, key)?,
+            counter: self.counter.decrypt(ctx, key)?,
         })
     }
 }


### PR DESCRIPTION
## 🎟️ Tracking

[PM-22201][PM-22201]

## 📔 Objective

Mobile clients need to know if the FIDO 2 counter property is nonzero in order to determine if sync is required before performing authentication.

Updates `cargo-udeps` in `lint.yml` to version `0.1.57`. Previous version was 9 months old. Locally, I was experiencing a bug where `cargo-udeps` was considering `#[cfg(test)]` to be invalid.

Updates a couple static assertions that were showing up as unused when running `cargo +nightly udeps --workspace --all-features` locally. Unsure why this wasn't previously showing up in CI.

Added an explicit lifetime to fix a `mismatched-lifetime-syntax` error, again when running the `udeps` check locally.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation
  team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-22201]: https://bitwarden.atlassian.net/browse/PM-22201?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ