### PR TITLE
[bre-1104] update npm publish workflow to add latest tag

### DIFF
--- a/.github/workflows/publish-wasm-internal.yml
+++ b/.github/workflows/publish-wasm-internal.yml
@@ -91,4 +91,4 @@ jobs:
 
       - name: Publish NPM
         if: ${{ inputs.release_type != 'Dry Run' }}
-        run: npm publish --access public
+        run: npm publish --access public --tag latest


### PR DESCRIPTION
## 🎟️ Tracking

[bre-1104](https://bitwarden.atlassian.net/browse/bre-1104)
## 📔 Objective
after merging #415 , based off moving to npm version 11 a `--tag` must be provided for all pre-releases in NPM. our releases are considered pre-release bc of the dashes and suffixes in the naming convention.

failure example: https://github.com/bitwarden/sdk-internal/actions/runs/17653063030/job/50172366269

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes