### PR TITLE
[bre-1104] add repo url designation in sdk-internal wasm crate

### DIFF
--- a/crates/bitwarden-wasm-internal/npm/package.json
+++ b/crates/bitwarden-wasm-internal/npm/package.json
@@ -2,6 +2,10 @@
   "name": "@bitwarden/sdk-internal",
   "version": "0.1.0",
   "license": "GPL-3.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/bitwarden/sdk-internal.git"
+  },
   "files": [
     "bitwarden_wasm_internal_bg.js",
     "bitwarden_wasm_internal_bg.wasm.d.ts",

--- a/crates/bitwarden-wasm-internal/npm/package.json
+++ b/crates/bitwarden-wasm-internal/npm/package.json
@@ -4,7 +4,7 @@
   "license": "GPL-3.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/bitwarden/sdk-internal.git"
+    "url": "git+https://github.com/bitwarden/sdk-internal.git"
   },
   "files": [
     "bitwarden_wasm_internal_bg.js",


### PR DESCRIPTION
## 🎟️ Tracking
[bre-1104](https://bitwarden.atlassian.net/browse/bre-1104)

## 📔 Objective
related to #415 and #437 
example failure after moving to oidc npm publish -> https://github.com/bitwarden/sdk-internal/actions/runs/17654697060/job/50174358624

it is searching for provenance information in the package.json file but the repository url is not defined there

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes