### PR TITLE
[PM-20288] Automate iOS repo update and improve release-swift process

### DIFF
--- a/.github/workflows/build-swift.yml
+++ b/.github/workflows/build-swift.yml
@@ -133,7 +133,7 @@ jobs:
               inputs: {
                 'build-run-id': '${{ github.run_id }}',
                 'build-run-number': '${{ github.run_number }}',
-                'branch-name': 'unstable',
+                'sdk-swift-branch-name': 'unstable',
                 'update-ios-repo': 'true',
               }
             })

--- a/.github/workflows/build-swift.yml
+++ b/.github/workflows/build-swift.yml
@@ -132,6 +132,8 @@ jobs:
               ref: 'main',
               inputs: {
                 'build-run-id': '${{ github.run_id }}',
-                'pre-release': 'true'
+                'pre-release': 'true',
+                'update-ios-repo': 'true',
+                'build-run-number': '${{ github.run_number }}'
               }
             })

--- a/.github/workflows/build-swift.yml
+++ b/.github/workflows/build-swift.yml
@@ -132,7 +132,6 @@ jobs:
               ref: 'main',
               inputs: {
                 'build-run-id': '${{ github.run_id }}',
-                'pre-release': 'true',
                 'update-ios-repo': 'true',
                 'build-run-number': '${{ github.run_number }}'
               }

--- a/.github/workflows/build-swift.yml
+++ b/.github/workflows/build-swift.yml
@@ -132,7 +132,8 @@ jobs:
               ref: 'main',
               inputs: {
                 'build-run-id': '${{ github.run_id }}',
+                'build-run-number': '${{ github.run_number }}',
+                'branch-name': 'unstable',
                 'update-ios-repo': 'true',
-                'build-run-number': '${{ github.run_number }}'
               }
             })

--- a/.github/workflows/release-swift.yml
+++ b/.github/workflows/release-swift.yml
@@ -54,11 +54,16 @@ jobs:
         working-directory: sdk
         run: |
           COMMIT_SHA=$(gh run view $_RUN_ID --json headSha --jq '.headSha')
+          COMMIT_MSG=$(gh api repos/bitwarden/sdk-internal/commits/$COMMIT_SHA --jq '.commit.message' | head -n1)
+          COMMIT_MSG=$(echo "$COMMIT_MSG" | sed 's/(#\([0-9]*\))/(bitwarden\/sdk-internal#\1)/') # formats the PR ID for github autolink
           SHORT_SHA=$(echo $COMMIT_SHA | cut -c1-7)
+
           echo "sha=$COMMIT_SHA" >> $GITHUB_OUTPUT
           echo "short_sha=$SHORT_SHA" >> $GITHUB_OUTPUT
+          echo "commit_message=$COMMIT_MSG" >> $GITHUB_OUTPUT
           echo "👀 Commit SHA: $COMMIT_SHA"
           echo "👀 Short SHA: $SHORT_SHA"
+          echo "👀 Commit Message: $COMMIT_MSG"
 
       - name: Set release name
         id: set-release-name
@@ -187,10 +192,12 @@ jobs:
         env:
           _RELEASE_NAME: ${{ steps.set-release-name.outputs.release_name }}
           _SDK_INTERNAL_REF: ${{ steps.get-sdk-internal-ref.outputs.sha }}
+          _SDK_INTERNAL_COMMIT_MSG: ${{ steps.get-sdk-internal-ref.outputs.commit_message }}
           _BRANCH_NAME: ${{ inputs.branch-name }}
         run: |
+          # NOTE: bitwarden/ios repo expects the full sdk-internal commit hash in sdk-swift commit message
           git add .
-          git commit -m "Update Swift SDK to $_SDK_INTERNAL_REF"
+          git commit -m "bitwarden/sdk-internal@$_SDK_INTERNAL_REF $_RELEASE_NAME - $_SDK_INTERNAL_COMMIT_MSG"
           git push origin $_BRANCH_NAME
           COMMIT_HASH=$(git rev-parse HEAD)
           echo "👀 Commit hash: $COMMIT_HASH"

--- a/.github/workflows/release-swift.yml
+++ b/.github/workflows/release-swift.yml
@@ -50,25 +50,30 @@ jobs:
 
       - name: Set SHA
         id: set-sha
+        env:
+          _ARTIFACT_BUILD_COMMIT: ${{ steps.download-artifact.outputs.artifact-build-commit }}
         run: |
-          echo "sha=${{ steps.download-artifact.outputs.artifact-build-commit }}" >> $GITHUB_OUTPUT
-          echo "short_sha=$(echo ${{ steps.download-artifact.outputs.artifact-build-commit }} | cut -c1-7)" >> $GITHUB_OUTPUT
+          echo "sha=$_ARTIFACT_BUILD_COMMIT" >> $GITHUB_OUTPUT
+          echo "short_sha=$(echo $_ARTIFACT_BUILD_COMMIT | cut -c1-7)" >> $GITHUB_OUTPUT
 
       - name: Set release name
         id: set-release-name
         env:
           _BUILD_RUN_NUMBER: ${{ inputs.build-run-number }}
-          _SHORT_SHA: ${{ steps.set-sha.outputs.short_sha }}
+          _SDK_INTERNAL_SHORT_REF: ${{ steps.set-sha.outputs.short_sha }}
           _VERSION: ${{ steps.version.outputs.version }}
         run: |
-          RELEASE_NAME="$_VERSION-$_BUILD_RUN_NUMBER-$_SHORT_SHA"
+          RELEASE_NAME="$_VERSION-$_BUILD_RUN_NUMBER-$_SDK_INTERNAL_SHORT_REF"
           echo "👀 Release name: $RELEASE_NAME"
           echo "release_name=$RELEASE_NAME" >> $GITHUB_OUTPUT
 
       - name: Calculate swift file checksum
         id: calculate-swift-checksum
+        env:
+          _VERSION: ${{ steps.version.outputs.version }}
+          _SDK_INTERNAL_SHORT_REF: ${{ steps.set-sha.outputs.short_sha }}
         run: |
-          CHECKSUM=$(swift package compute-checksum BitwardenFFI-${{ steps.version.outputs.version }}-${{ steps.set-sha.outputs.short_sha }}.xcframework.zip)
+          CHECKSUM=$(swift package compute-checksum BitwardenFFI-$_VERSION-$_SDK_INTERNAL_SHORT_REF.xcframework.zip)
           echo "checksum=$CHECKSUM" >> $GITHUB_OUTPUT
 
   repo-sync:
@@ -86,6 +91,8 @@ jobs:
       _SWIFT_CHECKSUM: ${{ needs.validate.outputs.swift_checksum }}
       _BUILD_RUN_ID: ${{ inputs.build-run-id }}
       _BRANCH_NAME: TEST_BRANCH # TODO: replace with unstable before merging
+      _SDK_INTERNAL_SHORT_REF: ${{ needs.validate.outputs.short_sha }}
+      _SDK_INTERNAL_REF: ${{ needs.validate.outputs.sha }}
     steps:
       - name: Checkout SDK repo
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -139,7 +146,7 @@ jobs:
         with:
           workflow: build-swift.yml
           workflow_conclusion: success
-          artifacts: "BitwardenSdk-${{ env._PKG_VERSION }}-${{ needs.validate.outputs.short_sha }}-sources"
+          artifacts: "BitwardenSdk-${{ env._PKG_VERSION }}-${{ env._SDK_INTERNAL_SHORT_REF }}-sources"
           run_id: ${{ env._BUILD_RUN_ID }}
           path: sdk/crates/bitwarden-uniffi/swift/Sources/BitwardenSdk
 
@@ -155,8 +162,8 @@ jobs:
           # Update BitwardenFFI path
           sed -i 's|.binaryTarget(name: "BitwardenFFI", path: "BitwardenFFI.xcframework")|.binaryTarget(\
             name: "BitwardenFFI",\
-            url: "https://github.com/bitwarden/sdk-swift/releases/download/v${{ env._RELEASE_NAME }}/BitwardenFFI-${{ env._PKG_VERSION }}-${{ needs.validate.outputs.short_sha }}.xcframework.zip",\
-            checksum: "${{ env._SWIFT_CHECKSUM }}" )|' sdk/crates/bitwarden-uniffi/swift/Package.swift
+            url: "https://github.com/bitwarden/sdk-swift/releases/download/v$_RELEASE_NAME/BitwardenFFI-$_PKG_VERSION-$_SDK_INTERNAL_SHORT_REF.xcframework.zip",\
+            checksum: "$_SWIFT_CHECKSUM" )|' sdk/crates/bitwarden-uniffi/swift/Package.swift
 
           # Run swiftformat
           swiftformat sdk/crates/bitwarden-uniffi/swift/Package.swift
@@ -177,8 +184,8 @@ jobs:
         working-directory: sdk-swift
         run: |
           git add .
-          git commit -m "Update Swift SDK to ${{ needs.validate.outputs.sha }}"
-          git push origin ${{ env._BRANCH_NAME }}
+          git commit -m "Update Swift SDK to $_SDK_INTERNAL_REF"
+          git push origin $_BRANCH_NAME
           COMMIT_HASH=$(git rev-parse HEAD)
           echo "👀 Commit hash: $COMMIT_HASH"
           echo "commit-hash=$COMMIT_HASH" >> $GITHUB_OUTPUT
@@ -186,8 +193,8 @@ jobs:
       - name: Create release tag on SDK Swift repo
         working-directory: sdk-swift
         run: |
-          git tag v${{ env._RELEASE_NAME }}
-          git push origin v${{ env._RELEASE_NAME }}
+          git tag v$_RELEASE_NAME
+          git push origin v$_RELEASE_NAME
 
       - name: Download BitwardenFFI artifact
         uses: bitwarden/gh-actions/download-artifacts@main
@@ -195,23 +202,20 @@ jobs:
         with:
           workflow: build-swift.yml
           workflow_conclusion: success
-          artifacts: "BitwardenFFI-${{ env._PKG_VERSION }}-${{ needs.validate.outputs.short_sha }}.xcframework"
+          artifacts: "BitwardenFFI-${{ env._PKG_VERSION }}-${{ env._SDK_INTERNAL_SHORT_REF }}.xcframework"
           run_id: ${{ env._BUILD_RUN_ID }}
           skip_unpack: true
 
       - name: Create release
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
-          _RELEASE_NAME: ${{ env._RELEASE_NAME }}
-          _PKG_VERSION: ${{ env._PKG_VERSION }}
-          _SHORT_SHA: ${{ needs.validate.outputs.short_sha }}
         run: |
           gh release create "v$_RELEASE_NAME" \
             --repo bitwarden/sdk-swift \
             --title "v$_RELEASE_NAME" \
             --notes "" \
             --prerelease \
-            "BitwardenFFI-$_PKG_VERSION-$_SHORT_SHA.xcframework.zip"
+            "BitwardenFFI-$_PKG_VERSION-$_SDK_INTERNAL_SHORT_REF.xcframework.zip"
 
       - name: Trigger SDK Update in iOS repo
         if: inputs.update-ios-repo

--- a/.github/workflows/release-swift.yml
+++ b/.github/workflows/release-swift.yml
@@ -183,11 +183,9 @@ jobs:
           echo "👀 Commit hash: $COMMIT_HASH"
           echo "commit-hash=$COMMIT_HASH" >> $GITHUB_OUTPUT
 
-      - name: Create release tag on SDK Swift repo
-        working-directory: sdk-swift
-        run: |
-          git tag v$_RELEASE_NAME
-          git push origin v$_RELEASE_NAME
+          # git tag v$_RELEASE_NAME
+          # git push origin v$_RELEASE_NAME
+          # echo "👀 Release Tag: v$_RELEASE_NAME"
 
       - name: Download BitwardenFFI artifact
         uses: bitwarden/gh-actions/download-artifacts@main

--- a/.github/workflows/release-swift.yml
+++ b/.github/workflows/release-swift.yml
@@ -5,26 +5,24 @@ on:
   workflow_dispatch:
     inputs:
       build-run-id:
-        description: "Workflow Run ID to use for artifact download. If not provided the latest build from the selected branch will be used."
+        description: "Build Swift Workflow Run ID"
         type: string
         required: true
       build-run-number:
-        description: "Build Run Number"
+        description: "Build Swift Workflow Run Number - used for workflow run-name"
         type: string
         required: true
+      branch-name:
+          description: "Branch Name - can be used for testing purposes"
+          type: string
+          required: true
       update-ios-repo:
         description: "Update iOS Repo - Opens a PR updating the SDK in bitwarden/ios"
         type: boolean
-        default: false
-      branch-name:
-        description: "Branch Name - can be used for testing purposes"
-        type: string
-        required: true
-        default: "WORKFLOW_TEST" # TODO: replace with unstable before merging
 
 jobs:
   release:
-    name: Push changed files to SDK Swift repo and create GitHub
+    name: Release to sdk-swift
     runs-on: ubuntu-24.04
     permissions:
       contents: read
@@ -251,7 +249,8 @@ jobs:
 
           echo "# 📱 **iOS SDK Update Triggered!**" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo "🔗 **Links:**" >> $GITHUB_STEP_SUMMARY
+          echo "👀 **Release Name:** $_RELEASE_NAME" >> $GITHUB_STEP_SUMMARY
+          echo "🔗 **Quick Links:**" >> $GITHUB_STEP_SUMMARY
           echo "- [Workflow Runs](https://github.com/bitwarden/ios/actions/workflows/sdlc-sdk-update.yml)" >> $GITHUB_STEP_SUMMARY
           echo "- [Pull Requests](https://github.com/bitwarden/ios/pulls?q=head:sdlc/sdk-update)" >> $GITHUB_STEP_SUMMARY
 

--- a/.github/workflows/release-swift.yml
+++ b/.github/workflows/release-swift.yml
@@ -103,12 +103,14 @@ jobs:
 
       - name: Set release name
         id: set-release-name
+        env:
+          _BUILD_RUN_NUMBER: ${{ inputs.build-run-number }}
+          _SHORT_SHA: ${{ steps.set-sha.outputs.short_sha }}
+          _VERSION: ${{ steps.version.outputs.version }}
         run: |
-          if [[ ${{ inputs.pre-release }} == true ]]; then
-            echo "release_name=${{ steps.version.outputs.version }}-unstable-${{ steps.set-sha.outputs.short_sha }}" >> $GITHUB_OUTPUT
-          else
-            echo "release_name=${{ steps.version.outputs.version }}" >> $GITHUB_OUTPUT
-          fi
+          RELEASE_NAME="$_VERSION-$_BUILD_RUN_NUMBER-$_SHORT_SHA"
+          echo "👀 Release name: $RELEASE_NAME"
+          echo "release_name=$RELEASE_NAME" >> $GITHUB_OUTPUT
 
       - name: Calculate swift file checksum
         id: calculate-swift-checksum

--- a/.github/workflows/release-swift.yml
+++ b/.github/workflows/release-swift.yml
@@ -12,10 +12,10 @@ on:
         description: "Build Swift Run Number - used for workflow run-name"
         type: string
         required: true
-      branch-name:
-          description: "Branch Name - can be used for testing purposes"
-          type: string
-          required: true
+      sdk-swift-branch-name:
+        description: "sdk-swift Branch Name"
+        type: string
+        required: true
       update-ios-repo:
         description: "Update iOS Repo - Opens a PR updating the SDK in bitwarden/ios"
         type: boolean
@@ -133,7 +133,7 @@ jobs:
         with:
           repository: bitwarden/sdk-swift
           path: sdk-swift
-          ref: ${{ inputs.branch-name }}
+          ref: ${{ inputs.sdk-swift-branch-name }}
           token: ${{ steps.app-token-sdk-swift.outputs.token }}
 
       - name: Import GPG key
@@ -192,7 +192,7 @@ jobs:
           _RELEASE_NAME: ${{ steps.set-release-name.outputs.release_name }}
           _SDK_INTERNAL_REF: ${{ steps.get-sdk-internal-ref.outputs.sha }}
           _SDK_INTERNAL_COMMIT_MSG: ${{ steps.get-sdk-internal-ref.outputs.commit_message }}
-          _BRANCH_NAME: ${{ inputs.branch-name }}
+          _BRANCH_NAME: ${{ inputs.sdk-swift-branch-name }}
         run: |
           # NOTE: bitwarden/ios repo expects the full sdk-internal commit hash in sdk-swift commit message
           git add .
@@ -253,4 +253,3 @@ jobs:
           echo "🔗 **Quick Links:**" >> $GITHUB_STEP_SUMMARY
           echo "- [Workflow Runs](https://github.com/bitwarden/ios/actions/workflows/sdlc-sdk-update.yml)" >> $GITHUB_STEP_SUMMARY
           echo "- [Pull Requests](https://github.com/bitwarden/ios/pulls?q=head:sdlc/sdk-update)" >> $GITHUB_STEP_SUMMARY
-

--- a/.github/workflows/release-swift.yml
+++ b/.github/workflows/release-swift.yml
@@ -17,9 +17,6 @@ on:
         type: boolean
         default: false
 
-env:
-  _KEY_VAULT: "bitwarden-ci"
-
 jobs:
   validate:
     name: Set Version and SHA
@@ -222,41 +219,9 @@ jobs:
           git tag v${{ env._RELEASE_NAME }}
           git push origin v${{ env._RELEASE_NAME }}
 
-  github-release:
-    name: GitHub Release
-    runs-on: ubuntu-24.04
-    needs:
-      - validate
-      - repo-sync
-    permissions:
-      actions: read
-      contents: write
-      id-token: write
-    env:
-      _PKG_VERSION: ${{ needs.validate.outputs.version }}
-      _RELEASE_NAME: ${{ needs.validate.outputs.release_name }}
-      _BUILD_RUN_ID: ${{ needs.validate.outputs.run_id }}
-    steps:
-      - name: Log in to Azure
-        uses: bitwarden/gh-actions/azure-login@main
-        with:
-          subscription_id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
-          tenant_id: ${{ secrets.AZURE_TENANT_ID }}
-          client_id: ${{ secrets.AZURE_CLIENT_ID }}
-
-      - name: Retrieve secrets
-        id: retrieve-secrets
-        uses: bitwarden/gh-actions/get-keyvault-secrets@main
-        with:
-          keyvault: ${{ env._KEY_VAULT }}
-          secrets: "github-pat-bitwarden-devops-bot-repo-scope"
-
-      - name: Log out from Azure
-        uses: bitwarden/gh-actions/azure-logout@main
-
-      - name: Download BitwardenEFI artifact
+      - name: Download BitwardenFFI artifact
         uses: bitwarden/gh-actions/download-artifacts@main
-        id: download-artifact
+        id: download-artifact-ffi
         with:
           workflow: build-swift.yml
           workflow_conclusion: success
@@ -265,14 +230,15 @@ jobs:
           skip_unpack: true
 
       - name: Create release
-        uses: ncipollo/release-action@cdcc88a9acf3ca41c16c37bb7d21b9ad48560d87 # v1.15.0
-        with:
-          tag: v${{ env._RELEASE_NAME }}
-          name: v${{ env._RELEASE_NAME }}
-          body: ""
-          token: ${{ steps.retrieve-secrets.outputs.github-pat-bitwarden-devops-bot-repo-scope }}
-          draft: false
-          repo: sdk-swift
-          owner: bitwarden
-          artifacts: "BitwardenFFI-${{ env._PKG_VERSION }}-${{ needs.validate.outputs.short_sha }}.xcframework.zip"
-          prerelease: ${{ inputs.pre-release }}
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          _RELEASE_NAME: ${{ env._RELEASE_NAME }}
+          _PKG_VERSION: ${{ env._PKG_VERSION }}
+          _SHORT_SHA: ${{ needs.validate.outputs.short_sha }}
+        run: |
+          gh release create "v$_RELEASE_NAME" \
+            --repo bitwarden/sdk-swift \
+            --title "v$_RELEASE_NAME" \
+            --notes "" \
+            --prerelease \
+            "BitwardenFFI-$_PKG_VERSION-$_SHORT_SHA.xcframework.zip"

--- a/.github/workflows/release-swift.yml
+++ b/.github/workflows/release-swift.yml
@@ -243,3 +243,10 @@ jobs:
         run: |
           echo "🚀 Triggering sdlc-sdk-update.yml workflow in bitwarden/ios repo..."
           gh workflow run sdlc-sdk-update.yml --repo bitwarden/ios --ref main -f run-mode=Update -f sdk-version=$_RELEASE_NAME -f sdk-swift-ref=$_SDK_SWIFT_REF
+
+          echo "# 📱 **iOS SDK Update Triggered!**" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "🔗 **Links:**" >> $GITHUB_STEP_SUMMARY
+          echo "- [Workflow Runs](https://github.com/bitwarden/ios/actions/workflows/sdlc-sdk-update.yml)" >> $GITHUB_STEP_SUMMARY
+          echo "- [Pull Requests](https://github.com/bitwarden/ios/pulls?q=head:sdlc/sdk-update)" >> $GITHUB_STEP_SUMMARY
+

--- a/.github/workflows/release-swift.yml
+++ b/.github/workflows/release-swift.yml
@@ -37,6 +37,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           path: sdk
+          persist-credentials: false
 
       - name: Get version
         id: version

--- a/.github/workflows/release-swift.yml
+++ b/.github/workflows/release-swift.yml
@@ -126,8 +126,8 @@ jobs:
       contents: read
       id-token: write
     env:
-      _BOT_EMAIL: 106330231+bitwarden-devops-bot@users.noreply.github.com
-      _BOT_NAME: bitwarden-devops-bot
+      _BOT_EMAIL: 178206702+bw-ghapp[bot]@users.noreply.github.com
+      _BOT_NAME: bw-ghapp[bot]
       _PKG_VERSION: ${{ needs.validate.outputs.version }}
       _PRE_RELEASE: ${{ inputs.pre-release }}
       _RELEASE_NAME: ${{ needs.validate.outputs.release_name }}
@@ -155,17 +155,25 @@ jobs:
           tenant_id: ${{ secrets.AZURE_TENANT_ID }}
           client_id: ${{ secrets.AZURE_CLIENT_ID }}
 
-      - name: Retrieve secrets
-        id: retrieve-secrets
+      - name: Get Azure Key Vault secrets
+        id: get-kv-secrets
         uses: bitwarden/gh-actions/get-keyvault-secrets@main
         with:
-          keyvault: "bitwarden-ci"
-          secrets: "github-gpg-private-key,
-            github-gpg-private-key-passphrase,
-            github-pat-bitwarden-devops-bot-repo-scope"
+          keyvault: gh-org-bitwarden
+          secrets: "BW-GHAPP-ID,BW-GHAPP-KEY"
 
       - name: Log out from Azure
         uses: bitwarden/gh-actions/azure-logout@main
+
+      - name: Generate GH App token
+        uses: actions/create-github-app-token@0f859bf9e69e887678d5bbfbee594437cb440ffe # v2.1.1
+        id: app-token
+        with:
+          app-id: ${{ steps.get-kv-secrets.outputs.BW-GHAPP-ID }}
+          private-key: ${{ steps.get-kv-secrets.outputs.BW-GHAPP-KEY }}
+          owner: bitwarden
+          repositories: sdk-swift
+          permission-contents: write # used to: push code; create github release
 
       - name: Checkout SDK-Swift repo
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -173,16 +181,7 @@ jobs:
           repository: bitwarden/sdk-swift
           path: sdk-swift
           ref: ${{ steps.get-ref.outputs.ref }}
-          token: ${{ steps.retrieve-secrets.outputs.github-pat-bitwarden-devops-bot-repo-scope }}
-
-      - name: Import GPG key
-        uses: crazy-max/ghaction-import-gpg@cb9bde2e2525e640591a934b1fd28eef1dcaf5e5 # v6.2.0
-        with:
-          gpg_private_key: ${{ steps.retrieve-secrets.outputs.github-gpg-private-key }}
-          passphrase: ${{ steps.retrieve-secrets.outputs.github-gpg-private-key-passphrase }}
-          git_user_signingkey: true
-          git_commit_gpgsign: true
-          workdir: sdk-swift
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Setup Git
         working-directory: sdk-swift

--- a/.github/workflows/release-swift.yml
+++ b/.github/workflows/release-swift.yml
@@ -85,7 +85,7 @@ jobs:
       _RELEASE_NAME: ${{ needs.validate.outputs.release_name }}
       _SWIFT_CHECKSUM: ${{ needs.validate.outputs.swift_checksum }}
       _BUILD_RUN_ID: ${{ inputs.build-run-id }}
-      _BRANCH_NAME: unstable
+      _BRANCH_NAME: TEST_BRANCH # TODO: replace with unstable before merging
     steps:
       - name: Checkout SDK repo
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/release-swift.yml
+++ b/.github/workflows/release-swift.yml
@@ -121,7 +121,7 @@ jobs:
 
       - name: Generate GH App token
         uses: actions/create-github-app-token@0f859bf9e69e887678d5bbfbee594437cb440ffe # v2.1.1
-        id: app-token
+        id: app-token-sdk-swift
         with:
           app-id: ${{ steps.get-kv-secrets.outputs.BW-GHAPP-ID }}
           private-key: ${{ steps.get-kv-secrets.outputs.BW-GHAPP-KEY }}
@@ -135,7 +135,7 @@ jobs:
           repository: bitwarden/sdk-swift
           path: sdk-swift
           ref: ${{ inputs.branch-name }}
-          token: ${{ steps.app-token.outputs.token }}
+          token: ${{ steps.app-token-sdk-swift.outputs.token }}
 
       - name: Import GPG key
         uses: crazy-max/ghaction-import-gpg@e89d40939c28e39f97cf32126055eeae86ba74ec # v6.3.0
@@ -214,7 +214,7 @@ jobs:
 
       # - name: Create release
       #   env:
-      #     GH_TOKEN: ${{ steps.app-token.outputs.token }}
+      #     GH_TOKEN: ${{ steps.app-token-sdk-swift.outputs.token }}
       #   working-directory: sdk
       #   run: |
       #     gh release create "v$_RELEASE_NAME" \
@@ -224,10 +224,20 @@ jobs:
       #       --prerelease \
       #       "BitwardenFFI-$_PKG_VERSION-$_SDK_INTERNAL_SHORT_REF.xcframework.zip"
 
+      - name: Generate GH App token
+        uses: actions/create-github-app-token@0f859bf9e69e887678d5bbfbee594437cb440ffe # v2.1.1
+        id: app-token-ios
+        with:
+          app-id: ${{ steps.get-kv-secrets.outputs.BW-GHAPP-ID }}
+          private-key: ${{ steps.get-kv-secrets.outputs.BW-GHAPP-KEY }}
+          owner: bitwarden
+          repositories: ios
+          permission-actions: write # used for: trigger update workflow
+
       - name: Trigger SDK Update in iOS repo
         if: inputs.update-ios-repo
         env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          GH_TOKEN: ${{ steps.app-token-ios.outputs.token }}
           _SDK_SWIFT_REF: ${{ steps.push-changes.outputs.commit-hash }}
         working-directory: sdk
         run: |

--- a/.github/workflows/release-swift.yml
+++ b/.github/workflows/release-swift.yml
@@ -72,7 +72,7 @@ jobs:
           echo "checksum=$CHECKSUM" >> $GITHUB_OUTPUT
 
   repo-sync:
-    name: Push changed files to SDK Swift repo
+    name: Push changed files to SDK Swift repo and create GitHub
     runs-on: ubuntu-24.04
     needs: validate
     permissions:

--- a/.github/workflows/release-swift.yml
+++ b/.github/workflows/release-swift.yml
@@ -157,13 +157,6 @@ jobs:
           run_id: ${{ inputs.build-run-id }}
           path: sdk/crates/bitwarden-uniffi/swift/Sources/BitwardenSdk
 
-      - name: Install Swift formatter
-        run: |
-          git clone https://github.com/nicklockwood/SwiftFormat
-          cd SwiftFormat
-          swift build -c release
-          cp -f .build/release/swiftformat /usr/local/bin/swiftformat
-
       - name: Update files
         env:
           _RELEASE_NAME: ${{ steps.set-release-name.outputs.release_name }}
@@ -176,9 +169,6 @@ jobs:
             name: "BitwardenFFI",\
             url: "https://github.com/bitwarden/sdk-swift/releases/download/v'$_RELEASE_NAME'/BitwardenFFI-'$_PKG_VERSION'-'$_SDK_INTERNAL_SHORT_REF'.xcframework.zip",\
             checksum: "'$_SWIFT_CHECKSUM'")|' sdk/crates/bitwarden-uniffi/swift/Package.swift
-
-          # Run swiftformat
-          swiftformat sdk/crates/bitwarden-uniffi/swift/Package.swift
 
           find sdk/crates/bitwarden-uniffi/swift/Sources/ -name ".gitignore" -exec rm -f {} \;
 

--- a/.github/workflows/release-swift.yml
+++ b/.github/workflows/release-swift.yml
@@ -155,8 +155,8 @@ jobs:
           # Update BitwardenFFI path
           sed -i 's|.binaryTarget(name: "BitwardenFFI", path: "BitwardenFFI.xcframework")|.binaryTarget(\
             name: "BitwardenFFI",\
-            url: "https://github.com/bitwarden/sdk-swift/releases/download/v$_RELEASE_NAME/BitwardenFFI-$_PKG_VERSION-$_SDK_INTERNAL_SHORT_REF.xcframework.zip",\
-            checksum: "$_SWIFT_CHECKSUM" )|' sdk/crates/bitwarden-uniffi/swift/Package.swift
+            url: "https://github.com/bitwarden/sdk-swift/releases/download/v'$_RELEASE_NAME'/BitwardenFFI-'$_PKG_VERSION'-'$_SDK_INTERNAL_SHORT_REF'.xcframework.zip",\
+            checksum: "'$_SWIFT_CHECKSUM'")|' sdk/crates/bitwarden-uniffi/swift/Package.swift
 
           # Run swiftformat
           swiftformat sdk/crates/bitwarden-uniffi/swift/Package.swift

--- a/.github/workflows/release-swift.yml
+++ b/.github/workflows/release-swift.yml
@@ -7,15 +7,11 @@ on:
       build-run-id:
         description: "Workflow Run ID to use for artifact download. If not provided the latest build from the selected branch will be used."
         type: string
-        required: false
-      pre-release:
-        description: "Create a pre-release"
-        type: boolean
-        required: false
-        default: false
+        required: true
       build-run-number:
         description: "Build Run Number"
         type: string
+        required: true
       update-ios-repo:
         description: "Update iOS Repo - Opens a PR updating the SDK in bitwarden/ios"
         type: boolean

--- a/.github/workflows/release-swift.yml
+++ b/.github/workflows/release-swift.yml
@@ -90,7 +90,7 @@ jobs:
       _RELEASE_NAME: ${{ needs.validate.outputs.release_name }}
       _SWIFT_CHECKSUM: ${{ needs.validate.outputs.swift_checksum }}
       _BUILD_RUN_ID: ${{ inputs.build-run-id }}
-      _BRANCH_NAME: TEST_BRANCH # TODO: replace with unstable before merging
+      _BRANCH_NAME: WORKFLOW_TEST # TODO: replace with unstable before merging
       _SDK_INTERNAL_SHORT_REF: ${{ needs.validate.outputs.short_sha }}
       _SDK_INTERNAL_REF: ${{ needs.validate.outputs.sha }}
     steps:

--- a/.github/workflows/release-swift.yml
+++ b/.github/workflows/release-swift.yml
@@ -2,25 +2,6 @@ name: Release Swift Package
 run-name: Release Swift Build ${{ inputs.build-run-number }}
 
 on:
-  workflow_call:
-    inputs:
-      build-run-id:
-        description: "Workflow Run ID to use for artifact download. If not provided the latest build from the selected branch will be used."
-        type: string
-        required: false
-      pre-release:
-        description: "Create a pre-release"
-        type: boolean
-        required: false
-        default: false
-      build-run-number:
-        description: "Build Run Number"
-        type: string
-      update-ios-repo:
-        description: "Update iOS Repo - Opens a PR updating the SDK in bitwarden/ios"
-        type: boolean
-        default: false
-
   workflow_dispatch:
     inputs:
       build-run-id:

--- a/.github/workflows/release-swift.yml
+++ b/.github/workflows/release-swift.yml
@@ -1,4 +1,5 @@
 name: Release Swift Package
+run-name: Release Swift Build ${{ inputs.build-run-number }}
 
 on:
   workflow_call:
@@ -12,6 +13,13 @@ on:
         type: boolean
         required: false
         default: false
+      build-run-number:
+        description: "Build Run Number"
+        type: string
+      update-ios-repo:
+        description: "Update iOS Repo - Opens a PR updating the SDK in bitwarden/ios"
+        type: boolean
+        default: false
 
   workflow_dispatch:
     inputs:
@@ -23,6 +31,13 @@ on:
         description: "Create a pre-release"
         type: boolean
         required: false
+        default: false
+      build-run-number:
+        description: "Build Run Number"
+        type: string
+      update-ios-repo:
+        description: "Update iOS Repo - Opens a PR updating the SDK in bitwarden/ios"
+        type: boolean
         default: false
 
 env:

--- a/.github/workflows/release-swift.yml
+++ b/.github/workflows/release-swift.yml
@@ -197,22 +197,22 @@ jobs:
           run_id: ${{ env._BUILD_RUN_ID }}
           skip_unpack: true
 
-      - name: Create release
-        env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
-        run: |
-          gh release create "v$_RELEASE_NAME" \
-            --repo bitwarden/sdk-swift \
-            --title "v$_RELEASE_NAME" \
-            --notes "" \
-            --prerelease \
-            "BitwardenFFI-$_PKG_VERSION-$_SDK_INTERNAL_SHORT_REF.xcframework.zip"
+      # - name: Create release
+      #   env:
+      #     GH_TOKEN: ${{ steps.app-token.outputs.token }}
+      #   run: |
+      #     gh release create "v$_RELEASE_NAME" \
+      #       --repo bitwarden/sdk-swift \
+      #       --title "v$_RELEASE_NAME" \
+      #       --notes "" \
+      #       --prerelease \
+      #       "BitwardenFFI-$_PKG_VERSION-$_SDK_INTERNAL_SHORT_REF.xcframework.zip"
 
-      - name: Trigger SDK Update in iOS repo
-        if: inputs.update-ios-repo
-        env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
-          _SDK_SWIFT_REF: ${{ steps.push-changes.outputs.commit-hash }}
-        run: |
-          echo "🚀 Triggering sdlc-sdk-update.yml workflow in bitwarden/ios repo..."
-          gh workflow run sdlc-sdk-update.yml --repo bitwarden/ios --ref main -f run-mode=Update -f sdk-version=$_RELEASE_NAME -f sdk-swift-ref=$_SDK_SWIFT_REF
+      # - name: Trigger SDK Update in iOS repo
+      #   if: inputs.update-ios-repo
+      #   env:
+      #     GH_TOKEN: ${{ steps.app-token.outputs.token }}
+      #     _SDK_SWIFT_REF: ${{ steps.push-changes.outputs.commit-hash }}
+      #   run: |
+      #     echo "🚀 Triggering sdlc-sdk-update.yml workflow in bitwarden/ios repo..."
+      #     gh workflow run sdlc-sdk-update.yml --repo bitwarden/ios --ref main -f run-mode=Update -f sdk-version=$_RELEASE_NAME -f sdk-swift-ref=$_SDK_SWIFT_REF

--- a/.github/workflows/release-swift.yml
+++ b/.github/workflows/release-swift.yml
@@ -30,8 +30,8 @@ jobs:
       contents: read
       id-token: write
     env:
-      _BOT_EMAIL: 178206702+bw-ghapp[bot]@users.noreply.github.com
-      _BOT_NAME: bw-ghapp[bot]
+      _BOT_EMAIL: 106330231+bitwarden-devops-bot@users.noreply.github.com
+      _BOT_NAME: bitwarden-devops-bot
     steps:
       - name: Checkout SDK repo
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/release-swift.yml
+++ b/.github/workflows/release-swift.yml
@@ -210,11 +210,15 @@ jobs:
           cp --verbose -rf sdk/crates/bitwarden-uniffi/swift/Tests sdk-swift
 
       - name: Push changes
+        id: push-changes
         working-directory: sdk-swift
         run: |
           git add .
           git commit -m "Update Swift SDK to ${{ needs.validate.outputs.sha }}"
           git push origin ${{ steps.get-ref.outputs.ref }}
+          COMMIT_HASH=$(git rev-parse HEAD)
+          echo "👀 Commit hash: $COMMIT_HASH"
+          echo "commit-hash=$COMMIT_HASH" >> $GITHUB_OUTPUT
 
       - name: Create release tag on SDK Swift repo
         working-directory: sdk-swift

--- a/.github/workflows/release-swift.yml
+++ b/.github/workflows/release-swift.yml
@@ -204,26 +204,29 @@ jobs:
           echo "👀 Commit hash: $COMMIT_HASH"
           echo "commit-hash=$COMMIT_HASH" >> $GITHUB_OUTPUT
 
-          # git tag v$_RELEASE_NAME
-          # git push origin v$_RELEASE_NAME
-          # echo "👀 Release Tag: v$_RELEASE_NAME"
+          git tag v$_RELEASE_NAME
+          git push origin v$_RELEASE_NAME
+          echo "👀 Release Tag: v$_RELEASE_NAME"
 
           echo "# 🚀 Swift SDK Updated Successfully!" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "📋 **Branch:** [\`$_BRANCH_NAME\`](https://github.com/bitwarden/sdk-swift/commits/$_BRANCH_NAME)" >> $GITHUB_STEP_SUMMARY
           echo "📝 **Commit:** bitwarden/sdk-swift@$COMMIT_HASH" >> $GITHUB_STEP_SUMMARY
 
-      # - name: Create release
-      #   env:
-      #     GH_TOKEN: ${{ steps.app-token-sdk-swift.outputs.token }}
-      #   working-directory: sdk
-      #   run: |
-      #     gh release create "v$_RELEASE_NAME" \
-      #       --repo bitwarden/sdk-swift \
-      #       --title "v$_RELEASE_NAME" \
-      #       --notes "" \
-      #       --prerelease \
-      #       "BitwardenFFI-$_PKG_VERSION-$_SDK_INTERNAL_SHORT_REF.xcframework.zip"
+      - name: Create release
+        env:
+          GH_TOKEN: ${{ steps.app-token-sdk-swift.outputs.token }}
+          _RELEASE_NAME: ${{ steps.set-release-name.outputs.release_name }}
+          _PKG_VERSION: ${{ steps.version.outputs.version }}
+          _SDK_INTERNAL_SHORT_REF: ${{ steps.get-sdk-internal-ref.outputs.short_sha }}
+        working-directory: sdk
+        run: |
+          gh release create "v$_RELEASE_NAME" \
+            --repo bitwarden/sdk-swift \
+            --title "v$_RELEASE_NAME" \
+            --notes "" \
+            --prerelease \
+            "BitwardenFFI-$_PKG_VERSION-$_SDK_INTERNAL_SHORT_REF.xcframework.zip"
 
       - name: Generate GH App token
         uses: actions/create-github-app-token@0f859bf9e69e887678d5bbfbee594437cb440ffe # v2.1.1

--- a/.github/workflows/release-swift.yml
+++ b/.github/workflows/release-swift.yml
@@ -28,7 +28,6 @@ jobs:
       sha: ${{ steps.set-sha.outputs.sha }}
       short_sha: ${{ steps.set-sha.outputs.short_sha }}
       release_name: ${{ steps.set-release-name.outputs.release_name }}
-      run_id: ${{ steps.get-run-id.outputs.build-run-id }}
       swift_checksum: ${{ steps.calculate-swift-checksum.outputs.checksum }}
     steps:
       - name: Checkout repo
@@ -40,26 +39,6 @@ jobs:
           VERSION=$(grep -o '^version = ".*"' Cargo.toml | grep -Eo "[0-9]+\.[0-9]+\.[0-9]+")
           echo "version=$VERSION" >> $GITHUB_OUTPUT
 
-      - name: Get run id
-        id: get-run-id
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          OWNER: ${{ github.repository_owner }}
-          REPO: ${{ github.event.repository.name }}
-        run: |
-          if [ -z ${{ inputs.build-run-id }} ]; then
-            BRANCH=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}
-            RUN_ID=$(gh api \
-              -H "Accept: application/vnd.github+json" \
-              -H "X-GitHub-Api-Version: 2022-11-28" \
-              /repos/$OWNER/$REPO/actions/workflows/build-swift.yml/runs \
-              | jq -r "[.workflow_runs[] | select(.head_branch == \"$BRANCH\").id ] | first")
-          else
-            RUN_ID=${{ inputs.build-run-id }}
-          fi
-
-          echo "build-run-id=$RUN_ID" >> $GITHUB_OUTPUT
-
       - name: Download BitwardenEFI artifact
         uses: bitwarden/gh-actions/download-artifacts@main
         id: download-artifact
@@ -67,7 +46,7 @@ jobs:
           workflow: build-swift.yml
           workflow_conclusion: success
           skip_unpack: true
-          run_id: ${{ steps.get-run-id.outputs.build-run-id }}
+          run_id: ${{ inputs.build-run-id }}
 
       - name: Set SHA
         id: set-sha
@@ -105,7 +84,7 @@ jobs:
       _PKG_VERSION: ${{ needs.validate.outputs.version }}
       _RELEASE_NAME: ${{ needs.validate.outputs.release_name }}
       _SWIFT_CHECKSUM: ${{ needs.validate.outputs.swift_checksum }}
-      _BUILD_RUN_ID: ${{ needs.validate.outputs.run_id }}
+      _BUILD_RUN_ID: ${{ inputs.build-run-id }}
       _BRANCH_NAME: unstable
     steps:
       - name: Checkout SDK repo

--- a/.github/workflows/release-swift.yml
+++ b/.github/workflows/release-swift.yml
@@ -130,8 +130,8 @@ jobs:
       - name: Setup Git
         working-directory: sdk-swift
         run: |
-          git config --local user.email "${{ env._BOT_EMAIL }}"
-          git config --local user.name "${{ env._BOT_NAME }}"
+          git config --local user.email "$_BOT_EMAIL"
+          git config --local user.name "$_BOT_NAME"
 
       - name: Download BitwardenSdk sources artifact
         uses: bitwarden/gh-actions/download-artifacts@main

--- a/.github/workflows/release-swift.yml
+++ b/.github/workflows/release-swift.yml
@@ -5,11 +5,11 @@ on:
   workflow_dispatch:
     inputs:
       build-run-id:
-        description: "Build Swift Workflow Run ID"
+        description: "Build Swift Run ID"
         type: string
         required: true
       build-run-number:
-        description: "Build Swift Workflow Run Number - used for workflow run-name"
+        description: "Build Swift Run Number - used for workflow run-name"
         type: string
         required: true
       branch-name:

--- a/.github/workflows/release-swift.yml
+++ b/.github/workflows/release-swift.yml
@@ -103,24 +103,15 @@ jobs:
       _BOT_EMAIL: 178206702+bw-ghapp[bot]@users.noreply.github.com
       _BOT_NAME: bw-ghapp[bot]
       _PKG_VERSION: ${{ needs.validate.outputs.version }}
-      _PRE_RELEASE: ${{ inputs.pre-release }}
       _RELEASE_NAME: ${{ needs.validate.outputs.release_name }}
       _SWIFT_CHECKSUM: ${{ needs.validate.outputs.swift_checksum }}
       _BUILD_RUN_ID: ${{ needs.validate.outputs.run_id }}
+      _BRANCH_NAME: unstable
     steps:
       - name: Checkout SDK repo
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           path: sdk
-
-      - name: Get ref from SDK repo
-        id: get-ref
-        run: |
-          if [[ $_PRE_RELEASE == true ]]; then
-            echo "ref=unstable" >> $GITHUB_OUTPUT
-          else
-            echo "ref=main" >> $GITHUB_OUTPUT
-          fi
 
       - name: Log in to Azure
         uses: bitwarden/gh-actions/azure-login@main
@@ -154,7 +145,7 @@ jobs:
         with:
           repository: bitwarden/sdk-swift
           path: sdk-swift
-          ref: ${{ steps.get-ref.outputs.ref }}
+          ref: ${{ env._BRANCH_NAME }}
           token: ${{ steps.app-token.outputs.token }}
 
       - name: Setup Git
@@ -208,7 +199,7 @@ jobs:
         run: |
           git add .
           git commit -m "Update Swift SDK to ${{ needs.validate.outputs.sha }}"
-          git push origin ${{ steps.get-ref.outputs.ref }}
+          git push origin ${{ env._BRANCH_NAME }}
           COMMIT_HASH=$(git rev-parse HEAD)
           echo "👀 Commit hash: $COMMIT_HASH"
           echo "commit-hash=$COMMIT_HASH" >> $GITHUB_OUTPUT

--- a/.github/workflows/release-swift.yml
+++ b/.github/workflows/release-swift.yml
@@ -200,6 +200,10 @@ jobs:
           # git push origin v$_RELEASE_NAME
           # echo "👀 Release Tag: v$_RELEASE_NAME"
 
+          echo "# 🚀 Swift SDK Updated Successfully!" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "📋 **Branch:** [\`$_BRANCH_NAME\`](https://github.com/bitwarden/sdk-swift/commits/$_BRANCH_NAME)" >> $GITHUB_STEP_SUMMARY
+          echo "📝 **Commit:** bitwarden/sdk-swift@$COMMIT_HASH" >> $GITHUB_STEP_SUMMARY
 
       # - name: Create release
       #   env:

--- a/.github/workflows/release-swift.yml
+++ b/.github/workflows/release-swift.yml
@@ -239,10 +239,11 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.app-token-ios.outputs.token }}
           _SDK_SWIFT_REF: ${{ steps.push-changes.outputs.commit-hash }}
+          _RELEASE_NAME: ${{ steps.set-release-name.outputs.release_name }}
         working-directory: sdk
         run: |
           echo "🚀 Triggering sdlc-sdk-update.yml workflow in bitwarden/ios repo..."
-          gh workflow run sdlc-sdk-update.yml --repo bitwarden/ios --ref main -f run-mode=Update -f sdk-version=$_RELEASE_NAME -f sdk-swift-ref=$_SDK_SWIFT_REF
+          gh workflow run sdlc-sdk-update.yml --repo bitwarden/ios --ref main -f run-mode="Update" -f sdk-version="$_RELEASE_NAME" -f sdk-swift-ref="$_SDK_SWIFT_REF"
 
           echo "# 📱 **iOS SDK Update Triggered!**" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/release-swift.yml
+++ b/.github/workflows/release-swift.yml
@@ -97,12 +97,19 @@ jobs:
           tenant_id: ${{ secrets.AZURE_TENANT_ID }}
           client_id: ${{ secrets.AZURE_CLIENT_ID }}
 
-      - name: Get Azure Key Vault secrets
+      - name: Get Azure Key Vault secrets - GH Org
         id: get-kv-secrets
         uses: bitwarden/gh-actions/get-keyvault-secrets@main
         with:
           keyvault: gh-org-bitwarden
           secrets: "BW-GHAPP-ID,BW-GHAPP-KEY"
+
+      - name: Get Azure Key Vault secrets - BW CI
+        id: get-kv-secrets-ci
+        uses: bitwarden/gh-actions/get-keyvault-secrets@main
+        with:
+          keyvault: "bitwarden-ci"
+          secrets: "github-gpg-private-key,github-gpg-private-key-passphrase"
 
       - name: Log out from Azure
         uses: bitwarden/gh-actions/azure-logout@main
@@ -124,6 +131,15 @@ jobs:
           path: sdk-swift
           ref: ${{ inputs.branch-name }}
           token: ${{ steps.app-token.outputs.token }}
+
+      - name: Import GPG key
+        uses: crazy-max/ghaction-import-gpg@cb9bde2e2525e640591a934b1fd28eef1dcaf5e5 # v6.2.0
+        with:
+          gpg_private_key: ${{ steps.get-kv-secrets-ci.outputs.github-gpg-private-key }}
+          passphrase: ${{ steps.get-kv-secrets-ci.outputs.github-gpg-private-key-passphrase }}
+          git_user_signingkey: true
+          git_commit_gpgsign: true
+          workdir: sdk-swift
 
       - name: Setup Git
         working-directory: sdk-swift

--- a/.github/workflows/release-swift.yml
+++ b/.github/workflows/release-swift.yml
@@ -25,8 +25,8 @@ jobs:
       contents: read
     outputs:
       version: ${{ steps.version.outputs.version }}
-      sha: ${{ steps.set-sha.outputs.sha }}
-      short_sha: ${{ steps.set-sha.outputs.short_sha }}
+      sha: ${{ steps.get-sdk-internal-ref.outputs.sha }}
+      short_sha: ${{ steps.get-sdk-internal-ref.outputs.short_sha }}
       release_name: ${{ steps.set-release-name.outputs.release_name }}
       swift_checksum: ${{ steps.calculate-swift-checksum.outputs.checksum }}
     steps:
@@ -39,28 +39,21 @@ jobs:
           VERSION=$(grep -o '^version = ".*"' Cargo.toml | grep -Eo "[0-9]+\.[0-9]+\.[0-9]+")
           echo "version=$VERSION" >> $GITHUB_OUTPUT
 
-      - name: Download BitwardenEFI artifact
-        uses: bitwarden/gh-actions/download-artifacts@main
-        id: download-artifact
-        with:
-          workflow: build-swift.yml
-          workflow_conclusion: success
-          skip_unpack: true
-          run_id: ${{ inputs.build-run-id }}
-
-      - name: Set SHA
-        id: set-sha
+      - name: Get workflow run commit ref
+        id: get-sdk-internal-ref
         env:
-          _ARTIFACT_BUILD_COMMIT: ${{ steps.download-artifact.outputs.artifact-build-commit }}
+          GH_TOKEN: ${{ github.token }}
+          _RUN_ID: ${{ inputs.build-run-id }}
         run: |
-          echo "sha=$_ARTIFACT_BUILD_COMMIT" >> $GITHUB_OUTPUT
-          echo "short_sha=$(echo $_ARTIFACT_BUILD_COMMIT | cut -c1-7)" >> $GITHUB_OUTPUT
+          COMMIT_SHA=$(gh run view $_RUN_ID --json headSha --jq '.headSha')
+          echo "sha=$COMMIT_SHA" >> $GITHUB_OUTPUT
+          echo "short_sha=$(echo $COMMIT_SHA | cut -c1-7)" >> $GITHUB_OUTPUT
 
       - name: Set release name
         id: set-release-name
         env:
           _BUILD_RUN_NUMBER: ${{ inputs.build-run-number }}
-          _SDK_INTERNAL_SHORT_REF: ${{ steps.set-sha.outputs.short_sha }}
+          _SDK_INTERNAL_SHORT_REF: ${{ steps.get-sdk-internal-ref.outputs.short_sha }}
           _VERSION: ${{ steps.version.outputs.version }}
         run: |
           RELEASE_NAME="$_VERSION-$_BUILD_RUN_NUMBER-$_SDK_INTERNAL_SHORT_REF"
@@ -71,7 +64,7 @@ jobs:
         id: calculate-swift-checksum
         env:
           _VERSION: ${{ steps.version.outputs.version }}
-          _SDK_INTERNAL_SHORT_REF: ${{ steps.set-sha.outputs.short_sha }}
+          _SDK_INTERNAL_SHORT_REF: ${{ steps.get-sdk-internal-ref.outputs.short_sha }}
         run: |
           CHECKSUM=$(swift package compute-checksum BitwardenFFI-$_VERSION-$_SDK_INTERNAL_SHORT_REF.xcframework.zip)
           echo "checksum=$CHECKSUM" >> $GITHUB_OUTPUT

--- a/.github/workflows/release-swift.yml
+++ b/.github/workflows/release-swift.yml
@@ -16,38 +16,49 @@ on:
         description: "Update iOS Repo - Opens a PR updating the SDK in bitwarden/ios"
         type: boolean
         default: false
+      branch-name:
+        description: "Branch Name - can be used for testing purposes"
+        type: string
+        required: true
+        default: "WORKFLOW_TEST" # TODO: replace with unstable before merging
 
 jobs:
-  validate:
-    name: Set Version and SHA
+  release:
+    name: Push changed files to SDK Swift repo and create GitHub
     runs-on: ubuntu-24.04
     permissions:
       contents: read
-    outputs:
-      version: ${{ steps.version.outputs.version }}
-      sha: ${{ steps.get-sdk-internal-ref.outputs.sha }}
-      short_sha: ${{ steps.get-sdk-internal-ref.outputs.short_sha }}
-      release_name: ${{ steps.set-release-name.outputs.release_name }}
-      swift_checksum: ${{ steps.calculate-swift-checksum.outputs.checksum }}
+      id-token: write
+    env:
+      _BOT_EMAIL: 178206702+bw-ghapp[bot]@users.noreply.github.com
+      _BOT_NAME: bw-ghapp[bot]
     steps:
-      - name: Checkout repo
+      - name: Checkout SDK repo
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          path: sdk
 
       - name: Get version
         id: version
+        working-directory: sdk
         run: |
           VERSION=$(grep -o '^version = ".*"' Cargo.toml | grep -Eo "[0-9]+\.[0-9]+\.[0-9]+")
           echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "👀 Version: $VERSION"
 
       - name: Get workflow run commit ref
         id: get-sdk-internal-ref
         env:
           GH_TOKEN: ${{ github.token }}
           _RUN_ID: ${{ inputs.build-run-id }}
+        working-directory: sdk
         run: |
           COMMIT_SHA=$(gh run view $_RUN_ID --json headSha --jq '.headSha')
+          SHORT_SHA=$(echo $COMMIT_SHA | cut -c1-7)
           echo "sha=$COMMIT_SHA" >> $GITHUB_OUTPUT
-          echo "short_sha=$(echo $COMMIT_SHA | cut -c1-7)" >> $GITHUB_OUTPUT
+          echo "short_sha=$SHORT_SHA" >> $GITHUB_OUTPUT
+          echo "👀 Commit SHA: $COMMIT_SHA"
+          echo "👀 Short SHA: $SHORT_SHA"
 
       - name: Set release name
         id: set-release-name
@@ -60,6 +71,16 @@ jobs:
           echo "👀 Release name: $RELEASE_NAME"
           echo "release_name=$RELEASE_NAME" >> $GITHUB_OUTPUT
 
+      - name: Download BitwardenFFI artifact
+        uses: bitwarden/gh-actions/download-artifacts@main
+        id: download-artifact-ffi
+        with:
+          workflow: build-swift.yml
+          workflow_conclusion: success
+          artifacts: "BitwardenFFI-${{ steps.version.outputs.version }}-${{ steps.get-sdk-internal-ref.outputs.short_sha }}.xcframework"
+          run_id: ${{ inputs.build-run-id }}
+          skip_unpack: true
+
       - name: Calculate swift file checksum
         id: calculate-swift-checksum
         env:
@@ -68,29 +89,6 @@ jobs:
         run: |
           CHECKSUM=$(swift package compute-checksum BitwardenFFI-$_VERSION-$_SDK_INTERNAL_SHORT_REF.xcframework.zip)
           echo "checksum=$CHECKSUM" >> $GITHUB_OUTPUT
-
-  repo-sync:
-    name: Push changed files to SDK Swift repo and create GitHub
-    runs-on: ubuntu-24.04
-    needs: validate
-    permissions:
-      contents: read
-      id-token: write
-    env:
-      _BOT_EMAIL: 178206702+bw-ghapp[bot]@users.noreply.github.com
-      _BOT_NAME: bw-ghapp[bot]
-      _PKG_VERSION: ${{ needs.validate.outputs.version }}
-      _RELEASE_NAME: ${{ needs.validate.outputs.release_name }}
-      _SWIFT_CHECKSUM: ${{ needs.validate.outputs.swift_checksum }}
-      _BUILD_RUN_ID: ${{ inputs.build-run-id }}
-      _BRANCH_NAME: WORKFLOW_TEST # TODO: replace with unstable before merging
-      _SDK_INTERNAL_SHORT_REF: ${{ needs.validate.outputs.short_sha }}
-      _SDK_INTERNAL_REF: ${{ needs.validate.outputs.sha }}
-    steps:
-      - name: Checkout SDK repo
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          path: sdk
 
       - name: Log in to Azure
         uses: bitwarden/gh-actions/azure-login@main
@@ -124,7 +122,7 @@ jobs:
         with:
           repository: bitwarden/sdk-swift
           path: sdk-swift
-          ref: ${{ env._BRANCH_NAME }}
+          ref: ${{ inputs.branch-name }}
           token: ${{ steps.app-token.outputs.token }}
 
       - name: Setup Git
@@ -139,8 +137,8 @@ jobs:
         with:
           workflow: build-swift.yml
           workflow_conclusion: success
-          artifacts: "BitwardenSdk-${{ env._PKG_VERSION }}-${{ env._SDK_INTERNAL_SHORT_REF }}-sources"
-          run_id: ${{ env._BUILD_RUN_ID }}
+          artifacts: "BitwardenSdk-${{ steps.version.outputs.version }}-${{ steps.get-sdk-internal-ref.outputs.short_sha }}-sources"
+          run_id: ${{ inputs.build-run-id }}
           path: sdk/crates/bitwarden-uniffi/swift/Sources/BitwardenSdk
 
       - name: Install Swift formatter
@@ -151,6 +149,11 @@ jobs:
           cp -f .build/release/swiftformat /usr/local/bin/swiftformat
 
       - name: Update files
+        env:
+          _RELEASE_NAME: ${{ steps.set-release-name.outputs.release_name }}
+          _PKG_VERSION: ${{ steps.version.outputs.version }}
+          _SDK_INTERNAL_SHORT_REF: ${{ steps.get-sdk-internal-ref.outputs.short_sha }}
+          _SWIFT_CHECKSUM: ${{ steps.calculate-swift-checksum.outputs.checksum }}
         run: |
           # Update BitwardenFFI path
           sed -i 's|.binaryTarget(name: "BitwardenFFI", path: "BitwardenFFI.xcframework")|.binaryTarget(\
@@ -175,6 +178,10 @@ jobs:
       - name: Push changes
         id: push-changes
         working-directory: sdk-swift
+        env:
+          _RELEASE_NAME: ${{ steps.set-release-name.outputs.release_name }}
+          _SDK_INTERNAL_REF: ${{ steps.get-sdk-internal-ref.outputs.sha }}
+          _BRANCH_NAME: ${{ inputs.branch-name }}
         run: |
           git add .
           git commit -m "Update Swift SDK to $_SDK_INTERNAL_REF"
@@ -187,19 +194,11 @@ jobs:
           # git push origin v$_RELEASE_NAME
           # echo "👀 Release Tag: v$_RELEASE_NAME"
 
-      - name: Download BitwardenFFI artifact
-        uses: bitwarden/gh-actions/download-artifacts@main
-        id: download-artifact-ffi
-        with:
-          workflow: build-swift.yml
-          workflow_conclusion: success
-          artifacts: "BitwardenFFI-${{ env._PKG_VERSION }}-${{ env._SDK_INTERNAL_SHORT_REF }}.xcframework"
-          run_id: ${{ env._BUILD_RUN_ID }}
-          skip_unpack: true
 
       # - name: Create release
       #   env:
       #     GH_TOKEN: ${{ steps.app-token.outputs.token }}
+      #   working-directory: sdk
       #   run: |
       #     gh release create "v$_RELEASE_NAME" \
       #       --repo bitwarden/sdk-swift \
@@ -213,6 +212,7 @@ jobs:
       #   env:
       #     GH_TOKEN: ${{ steps.app-token.outputs.token }}
       #     _SDK_SWIFT_REF: ${{ steps.push-changes.outputs.commit-hash }}
+      #   working-directory: sdk
       #   run: |
       #     echo "🚀 Triggering sdlc-sdk-update.yml workflow in bitwarden/ios repo..."
       #     gh workflow run sdlc-sdk-update.yml --repo bitwarden/ios --ref main -f run-mode=Update -f sdk-version=$_RELEASE_NAME -f sdk-swift-ref=$_SDK_SWIFT_REF

--- a/.github/workflows/release-swift.yml
+++ b/.github/workflows/release-swift.yml
@@ -242,3 +242,12 @@ jobs:
             --notes "" \
             --prerelease \
             "BitwardenFFI-$_PKG_VERSION-$_SHORT_SHA.xcframework.zip"
+
+      - name: Trigger SDK Update in iOS repo
+        if: inputs.update-ios-repo
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          _SDK_SWIFT_REF: ${{ steps.push-changes.outputs.commit-hash }}
+        run: |
+          echo "🚀 Triggering sdlc-sdk-update.yml workflow in bitwarden/ios repo..."
+          gh workflow run sdlc-sdk-update.yml --repo bitwarden/ios --ref main -f run-mode=Update -f sdk-version=$_RELEASE_NAME -f sdk-swift-ref=$_SDK_SWIFT_REF

--- a/.github/workflows/release-swift.yml
+++ b/.github/workflows/release-swift.yml
@@ -224,12 +224,12 @@ jobs:
       #       --prerelease \
       #       "BitwardenFFI-$_PKG_VERSION-$_SDK_INTERNAL_SHORT_REF.xcframework.zip"
 
-      # - name: Trigger SDK Update in iOS repo
-      #   if: inputs.update-ios-repo
-      #   env:
-      #     GH_TOKEN: ${{ steps.app-token.outputs.token }}
-      #     _SDK_SWIFT_REF: ${{ steps.push-changes.outputs.commit-hash }}
-      #   working-directory: sdk
-      #   run: |
-      #     echo "🚀 Triggering sdlc-sdk-update.yml workflow in bitwarden/ios repo..."
-      #     gh workflow run sdlc-sdk-update.yml --repo bitwarden/ios --ref main -f run-mode=Update -f sdk-version=$_RELEASE_NAME -f sdk-swift-ref=$_SDK_SWIFT_REF
+      - name: Trigger SDK Update in iOS repo
+        if: inputs.update-ios-repo
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          _SDK_SWIFT_REF: ${{ steps.push-changes.outputs.commit-hash }}
+        working-directory: sdk
+        run: |
+          echo "🚀 Triggering sdlc-sdk-update.yml workflow in bitwarden/ios repo..."
+          gh workflow run sdlc-sdk-update.yml --repo bitwarden/ios --ref main -f run-mode=Update -f sdk-version=$_RELEASE_NAME -f sdk-swift-ref=$_SDK_SWIFT_REF

--- a/.github/workflows/release-swift.yml
+++ b/.github/workflows/release-swift.yml
@@ -133,7 +133,7 @@ jobs:
           token: ${{ steps.app-token.outputs.token }}
 
       - name: Import GPG key
-        uses: crazy-max/ghaction-import-gpg@cb9bde2e2525e640591a934b1fd28eef1dcaf5e5 # v6.2.0
+        uses: crazy-max/ghaction-import-gpg@e89d40939c28e39f97cf32126055eeae86ba74ec # v6.3.0
         with:
           gpg_private_key: ${{ steps.get-kv-secrets-ci.outputs.github-gpg-private-key }}
           passphrase: ${{ steps.get-kv-secrets-ci.outputs.github-gpg-private-key-passphrase }}


### PR DESCRIPTION
## 🎟️ Tracking

PM-20288

## 📔 Objective

The initial goal was to trigger an iOS repo SDK update when sdk-internal `main` is updated, implementing that led to hard to maintain duplicate steps that were also slowing down the whole process even further, ended up refactoring multiple bits that would be hard to review independently. My suggestion for reviewers is to go through it as a new file instead of change-by-change. With that, here's a summary of updates:

### Structural

1. Consolidated jobs into a single one to reduce duplicate steps
1. Removed duplicated / unused steps like retrieving secrets, retrieving a run-id if missing, downloading BitwardenFFI file
1. Use the new BW App pattern for github authentication - still using the devops bot for commit signing
1. Removed swiftformat clone and build - took 50-60% of the average runtime just to format [Package.swift](https://github.com/bitwarden/sdk-internal/blob/main/crates/bitwarden-uniffi/swift/Package.swift) on each run, we should instead format it in this repo once.
1. Moved inline github template variables to env vars to mitigate script injections
1. Following @mandreko-bitwarden pro-tip, ran zizmor and addressed feedback like `persist-credentials: false` on `action/checkout` when we just need to checkout the repo
1. Update crazy-max/ghaction-import-gpg to 6.3.0

## Functional

1. Average runtime reduced from 4m45s to 1m10s. 
3. Triggers an iOS SDK update when new sdk-internal PRs are merged to `main`
4. Updates the sdk-swift commit message with additional sdk-internal info using [GitHub Autolink ](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/autolinked-references-and-urls) patterns, enabling ios devs to quickly go to the original commit or PR. [screenshot#1]
5. Added step logs and quick links to the Action Summary [screenshot#2]
6. Sets `run-as` to communicate the Build we're releasing. [screenshot#3 - old vs new]
7. Branch Name input added to enable testing and set us up to support publishing feature branches in the future, like we've been doing for [Android](https://github.com/bitwarden/sdk-internal/packages/2591890), enabling quick feature branch testing. 

Test Run:
* https://github.com/bitwarden/sdk-internal/actions/runs/17655035226
* triggered -> https://github.com/bitwarden/ios/actions/runs/17655061169
* opened -> https://github.com/bitwarden/ios/pull/1928


[screenshot#1 - sdk-swift new commit message format]
<img width="823" height="101" alt="image" src="https://github.com/user-attachments/assets/25aa2668-123f-46a2-9470-e3be2c4c94ab" />

[screenshot#2 - Action Summary]
<img width="568" height="322" alt="image" src="https://github.com/user-attachments/assets/796589b4-0897-4952-a15a-1cf756395380" />

[screenshot#3 - Action `run-as`]
<img width="447" height="151" alt="image" src="https://github.com/user-attachments/assets/f6bf1872-61c3-406b-9840-7a0c22154d0d" />


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation
  team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
