### PR TITLE
[PM-23512] Rename FFI client to PMClient

### DIFF
--- a/crates/bitwarden-uniffi/kotlin/app/src/main/java/com/bitwarden/myapplication/MainActivity.kt
+++ b/crates/bitwarden-uniffi/kotlin/app/src/main/java/com/bitwarden/myapplication/MainActivity.kt
@@ -31,7 +31,7 @@ import com.bitwarden.core.Uuid
 import com.bitwarden.crypto.HashPurpose
 import com.bitwarden.crypto.Kdf
 import com.bitwarden.myapplication.ui.theme.MyApplicationTheme
-import com.bitwarden.sdk.Client
+import com.bitwarden.sdk.PasswordManagerClient
 import io.ktor.client.HttpClient
 import io.ktor.client.call.body
 import io.ktor.client.engine.cio.CIO
@@ -84,7 +84,7 @@ const val BIOMETRIC_KEY = "biometric_key"
 
 class MainActivity : FragmentActivity() {
     private lateinit var biometric: Biometric
-    private lateinit var client: Client
+    private lateinit var client: PasswordManagerClient
     private lateinit var http: HttpClient
 
     private var accessToken = ""
@@ -98,7 +98,7 @@ class MainActivity : FragmentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         biometric = Biometric(this)
-        client = Client(null)
+        client = PasswordManagerClient(null)
         http = httpClient()
 
         setContent {
@@ -172,7 +172,7 @@ class MainActivity : FragmentActivity() {
                         Button({
                             GlobalScope.launch {
                                 client.destroy()
-                                client = Client(null)
+                                client = PasswordManagerClient(null)
                                 outputText.value = "OK"
                             }
                         }) {
@@ -190,7 +190,7 @@ class MainActivity : FragmentActivity() {
     }
 
     private suspend fun clientExamplePassword(
-        client: Client,
+        client: PasswordManagerClient,
         http: HttpClient,
         outputText: MutableState<String>,
         setupBiometrics: Boolean,
@@ -309,7 +309,7 @@ class MainActivity : FragmentActivity() {
     }
 
     private suspend fun clientExampleBiometrics(
-        client: Client, http: HttpClient, outputText: MutableState<String>
+        client: PasswordManagerClient, http: HttpClient, outputText: MutableState<String>
     ) {
         println("### Unlocking with Biometrics ###")
 
@@ -352,7 +352,7 @@ class MainActivity : FragmentActivity() {
     }
 
     private suspend fun clientExamplePin(
-        client: Client, http: HttpClient, outputText: MutableState<String>
+        client: PasswordManagerClient, http: HttpClient, outputText: MutableState<String>
     ) {
         println("### Unlocking with PIN ###")
 
@@ -392,7 +392,7 @@ class MainActivity : FragmentActivity() {
         }
     }
 
-    suspend fun decryptVault(client: Client, http: HttpClient, outputText: MutableState<String>) {
+    suspend fun decryptVault(client: PasswordManagerClient, http: HttpClient, outputText: MutableState<String>) {
         ///////////////////////////// Sync /////////////////////////////
 
         val syncBody = http.get(API_URL + "sync?excludeDomains=true") {

--- a/crates/bitwarden-uniffi/kotlin/build-schemas.sh
+++ b/crates/bitwarden-uniffi/kotlin/build-schemas.sh
@@ -6,6 +6,7 @@ cargo run -p uniffi-bindgen generate \
   --out-dir sdk/src/main/java
 
 # Insert a temporary alias for the deprecated Client type
+# TODO(PM-23512): Remove this alias in the future once the clients are updated
 ALIAS='
 @Deprecated("Use PasswordManagerClient instead", ReplaceWith("PasswordManagerClient"))
 typealias Client = PasswordManagerClient

--- a/crates/bitwarden-uniffi/kotlin/build-schemas.sh
+++ b/crates/bitwarden-uniffi/kotlin/build-schemas.sh
@@ -4,3 +4,10 @@ cargo run -p uniffi-bindgen generate \
   --language kotlin \
   --no-format \
   --out-dir sdk/src/main/java
+
+# Insert a temporary alias for the deprecated Client type
+ALIAS='
+@Deprecated("Use PasswordManagerClient instead", ReplaceWith("PasswordManagerClient"))
+typealias Client = PasswordManagerClient
+'
+echo -e "$ALIAS" >> ./sdk/src/main/java/com/bitwarden/sdk/bitwarden_uniffi.kt

--- a/crates/bitwarden-uniffi/kotlin/gradle/wrapper/gradle-wrapper.properties
+++ b/crates/bitwarden-uniffi/kotlin/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Mon Jul 24 14:16:42 CEST 2023
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.12-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.0.0-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/crates/bitwarden-uniffi/src/lib.rs
+++ b/crates/bitwarden-uniffi/src/lib.rs
@@ -33,10 +33,10 @@ use vault::VaultClient;
 
 #[allow(missing_docs)]
 #[derive(uniffi::Object)]
-pub struct Client(pub(crate) bitwarden_core::Client);
+pub struct PasswordManagerClient(pub(crate) bitwarden_core::Client);
 
 #[uniffi::export(async_runtime = "tokio")]
-impl Client {
+impl PasswordManagerClient {
     /// Initialize a new instance of the SDK client
     #[uniffi::constructor]
     pub fn new(settings: Option<ClientSettings>) -> Self {

--- a/crates/bitwarden-uniffi/swift/build.sh
+++ b/crates/bitwarden-uniffi/swift/build.sh
@@ -31,6 +31,13 @@ cargo run -p uniffi-bindgen generate \
   --no-format \
   --out-dir tmp/bindings
 
+# Insert a temporary alias for the deprecated Client type
+ALIAS='
+@available(*, deprecated, message: "Use PasswordManagerClient instead")
+public typealias Client = PasswordManagerClient
+'
+echo -e "$ALIAS" >> ./tmp/bindings/BitwardenSDK.swift
+
 # Move generated swift bindings
 mv ./tmp/bindings/*.swift ./Sources/BitwardenSdk/
 

--- a/crates/bitwarden-uniffi/swift/build.sh
+++ b/crates/bitwarden-uniffi/swift/build.sh
@@ -32,6 +32,7 @@ cargo run -p uniffi-bindgen generate \
   --out-dir tmp/bindings
 
 # Insert a temporary alias for the deprecated Client type
+# TODO(PM-23512): Remove this alias in the future once the clients are updated
 ALIAS='
 @available(*, deprecated, message: "Use PasswordManagerClient instead")
 public typealias Client = PasswordManagerClient

--- a/crates/bitwarden-uniffi/swift/iOS/App/ContentView.swift
+++ b/crates/bitwarden-uniffi/swift/iOS/App/ContentView.swift
@@ -28,7 +28,7 @@ let PIN = "1234"
 struct ContentView: View {
     private var http: URLSession
 
-    @State private var client: Client
+    @State private var client: PasswordManagerClient
 
     @State private var accessToken: String = ""
 
@@ -38,7 +38,7 @@ struct ContentView: View {
             configuration: URLSessionConfiguration.default, delegate: IgnoreHttpsDelegate(),
             delegateQueue: nil)
 
-        client = Client(settings: nil)
+        client = PasswordManagerClient(settings: nil)
     }
 
     @State var setupBiometrics: Bool = true
@@ -104,7 +104,7 @@ struct ContentView: View {
             })
 
             Button(action: {
-                client = Client(settings: nil)
+                client = PasswordManagerClient(settings: nil)
             }, label: {
                 Text("Lock & reset client")
             }).padding()

--- a/crates/bitwarden-wasm-internal/src/client.rs
+++ b/crates/bitwarden-wasm-internal/src/client.rs
@@ -14,6 +14,8 @@ use crate::platform::{
     PlatformClient,
 };
 
+// Insert a temporary alias for the deprecated BitwardenClient type
+// TODO(PM-23512): Remove this alias in the future once the clients are updated
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_COMPAT_TYPE: &'static str = r#"
 /**

--- a/crates/bitwarden-wasm-internal/src/client.rs
+++ b/crates/bitwarden-wasm-internal/src/client.rs
@@ -14,12 +14,20 @@ use crate::platform::{
     PlatformClient,
 };
 
+#[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
+const TS_COMPAT_TYPE: &'static str = r#"
+/**
+ * @deprecated Use PasswordManagerClient instead.
+ */
+export type BitwardenClient = PasswordManagerClient;
+"#;
+
 #[allow(missing_docs)]
 #[wasm_bindgen]
-pub struct BitwardenClient(pub(crate) Client);
+pub struct PasswordManagerClient(pub(crate) Client);
 
 #[wasm_bindgen]
-impl BitwardenClient {
+impl PasswordManagerClient {
     #[allow(missing_docs)]
     #[wasm_bindgen(constructor)]
     pub fn new(token_provider: JsTokenProvider, settings: Option<ClientSettings>) -> Self {

--- a/crates/bitwarden-wasm-internal/src/lib.rs
+++ b/crates/bitwarden-wasm-internal/src/lib.rs
@@ -8,5 +8,5 @@ mod pure_crypto;
 mod ssh;
 
 pub use bitwarden_ipc::wasm::*;
-pub use client::BitwardenClient;
+pub use client::PasswordManagerClient;
 pub use init::init_sdk;


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-23512

## 📔 Objective

Rename the FFI client (WASM/UniFFI) to PasswordManagerClient, unifying both names and opening the posibility of non-pm clients in the future.

As the client names are used a lot, specially on mobile, I've added type aliases for backwards compatibility. UniFFI doesn't provide a way to add snipets like wasm-bindgen does, so I've just appended them to the file. TODO: Make a ticket to remove this in the future

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation
  team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
