### PR TITLE
[PM-20288] Fix GitHub Release creation in sdk-swift repo

### DIFF
--- a/.github/workflows/release-swift.yml
+++ b/.github/workflows/release-swift.yml
@@ -217,7 +217,6 @@ jobs:
           _RELEASE_NAME: ${{ steps.set-release-name.outputs.release_name }}
           _PKG_VERSION: ${{ steps.version.outputs.version }}
           _SDK_INTERNAL_SHORT_REF: ${{ steps.get-sdk-internal-ref.outputs.short_sha }}
-        working-directory: sdk
         run: |
           gh release create "v$_RELEASE_NAME" \
             --repo bitwarden/sdk-swift \


### PR DESCRIPTION
## 🎟️ Tracking

PM-20288

## 📔 Objective

Fix GitHub Release creation in sdk-swift repo. The BitwardenFFI zip wasn't being found due to running in the wrong path.

Test runs:

* https://github.com/bitwarden/sdk-internal/actions/runs/17779143466
* https://github.com/bitwarden/ios/actions/runs/17779169149
* https://github.com/bitwarden/ios/pull/1944

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation
  team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
