### PR TITLE
Swap to using FolderId for the new folder methods

### DIFF
--- a/crates/bitwarden-vault/src/folder/folder_client.rs
+++ b/crates/bitwarden-vault/src/folder/folder_client.rs
@@ -8,7 +8,8 @@ use wasm_bindgen::prelude::*;
 use crate::{
     error::{DecryptError, EncryptError},
     folder::{create_folder, edit_folder, get_folder, list_folders},
-    CreateFolderError, EditFolderError, Folder, FolderAddEditRequest, FolderView, GetFolderError,
+    CreateFolderError, EditFolderError, Folder, FolderAddEditRequest, FolderId, FolderView,
+    GetFolderError,
 };
 
 /// Wrapper for folder specific functionality.
@@ -49,7 +50,7 @@ impl FoldersClient {
     }
 
     /// Get a specific [Folder] by its ID from state and decrypt it to a [FolderView].
-    pub async fn get(&self, folder_id: &str) -> Result<FolderView, GetFolderError> {
+    pub async fn get(&self, folder_id: FolderId) -> Result<FolderView, GetFolderError> {
         let key_store = self.client.internal.get_key_store();
         let repository = self.get_repository()?;
 
@@ -71,7 +72,7 @@ impl FoldersClient {
     /// Edit the [Folder] and save it to the server.
     pub async fn edit(
         &self,
-        folder_id: &str,
+        folder_id: FolderId,
         request: FolderAddEditRequest,
     ) -> Result<FolderView, EditFolderError> {
         let key_store = self.client.internal.get_key_store();

--- a/crates/bitwarden-vault/src/folder/get_list.rs
+++ b/crates/bitwarden-vault/src/folder/get_list.rs
@@ -4,7 +4,7 @@ use bitwarden_error::bitwarden_error;
 use bitwarden_state::repository::{Repository, RepositoryError};
 use thiserror::Error;
 
-use crate::{Folder, FolderView, ItemNotFoundError};
+use crate::{Folder, FolderId, FolderView, ItemNotFoundError};
 
 #[allow(missing_docs)]
 #[bitwarden_error(flat)]
@@ -21,7 +21,7 @@ pub enum GetFolderError {
 pub(super) async fn get_folder(
     store: &KeyStore<KeyIds>,
     repository: &dyn Repository<Folder>,
-    id: &str,
+    id: FolderId,
 ) -> Result<FolderView, GetFolderError> {
     let folder = repository
         .get(id.to_string())


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

I noticed we missed updating a few places to use `FolderId` instead of `str` or `uuid`.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation
  team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
