### PR TITLE
[PM-26177] Add methods to create rotateable key set (2/3)

### DIFF
--- a/crates/bitwarden-core/src/key_management/crypto.rs
+++ b/crates/bitwarden-core/src/key_management/crypto.rs
@@ -594,9 +594,8 @@ pub(super) fn make_key_pair(user_key: B64) -> Result<MakeKeyPairResponse, Crypto
 /// and the `PublicKey` is protected by the `UserKey`. This setup allows:
 ///
 ///   - Access to `UserKey` by knowing the `ExternalKey`
-///   - Rotation to a `NewUserKey` by knowing the current `UserKey`,
-///     without needing access to the `ExternalKey`
-
+///   - Rotation to a `NewUserKey` by knowing the current `UserKey`, without needing access to the
+///     `ExternalKey`
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 #[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
@@ -612,6 +611,7 @@ pub struct RotateableKeySet {
 
 /// Create a set of keys to allow access to the user key via the provided
 /// symmetric wrapping key while allowing the user key to be rotated.
+#[allow(dead_code)]
 fn create_rotateable_key_set(
     client: &Client,
     wrapping_key: SymmetricCryptoKey,
@@ -1577,14 +1577,9 @@ mod tests {
     #[tokio::test]
     async fn test_rotateable_key_set() {
         let client = Client::new(None);
-        let original_user_key = SymmetricCryptoKey::make_aes256_cbc_hmac_key();
-        #[allow(deprecated)]
-        client
-            .internal
-            .get_key_store()
-            .context_mut()
-            .set_symmetric_key(SymmetricKeyId::User, original_user_key.clone())
-            .unwrap();
+
+        let original_user_key =
+            SymmetricCryptoKey::try_from(TEST_VECTOR_USER_KEY_V2_B64.to_string()).unwrap();
         initialize_user_crypto(
             &client,
             InitUserCryptoRequest {


### PR DESCRIPTION
## 🎟️ Tracking

[PM-26177](https://bitwarden.atlassian.net/browse/PM-26177)

## 📔 Objective

In order to set up PRF passkeys on mobile clients, we need to create a rotateable key set. This adds an internal method to the SDK that can be used by a future PRF derivation method.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation
  team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-26177]: https://bitwarden.atlassian.net/browse/PM-26177?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ