### PR TITLE
[PM-26177] Derive rotateable key set from PRF (3/3)

### DIFF
--- a/crates/bitwarden-core/src/key_management/crypto_client.rs
+++ b/crates/bitwarden-core/src/key_management/crypto_client.rs
@@ -26,9 +26,9 @@ use crate::{
     client::encryption_settings::EncryptionSettingsError,
     error::StatefulCryptoError,
     key_management::crypto::{
-        CryptoClientError, EnrollPinResponse, UpdateKdfResponse, UserCryptoV2KeysResponse,
-        enroll_pin, get_v2_rotated_account_keys, make_update_kdf, make_update_password,
-        make_v2_keys_for_v1_user,
+        CryptoClientError, EnrollPinResponse, RotateableKeySet, UpdateKdfResponse,
+        UserCryptoV2KeysResponse, derive_prf_key, enroll_pin, get_v2_rotated_account_keys,
+        make_update_kdf, make_update_password, make_v2_keys_for_v1_user,
     },
 };
 
@@ -170,6 +170,13 @@ impl CryptoClient {
         encrypted_pin: EncString,
     ) -> Result<EncString, CryptoClientError> {
         derive_pin_user_key(&self.client, encrypted_pin)
+    }
+
+    /// Generates a PRF-protected user key from the provided PRF secret. The result can be stored
+    /// and later used to initialize another client instance by using the PRF and the PRF key
+    /// with `initialize_user_crypto`.
+    pub fn derive_prf_key(&self, prf: B64) -> Result<RotateableKeySet, CryptoClientError> {
+        derive_prf_key(&self.client, prf)
     }
 
     /// Prepares the account for being enrolled in the admin password reset feature. This encrypts

--- a/crates/bitwarden-crypto/src/keys/mod.rs
+++ b/crates/bitwarden-crypto/src/keys/mod.rs
@@ -34,3 +34,6 @@ pub use kdf::{
 };
 pub(crate) use key_id::{KEY_ID_SIZE, KeyId};
 pub(crate) mod utils;
+
+mod prf;
+pub use prf::derive_symmetric_key_from_prf;

--- a/crates/bitwarden-crypto/src/keys/prf.rs
+++ b/crates/bitwarden-crypto/src/keys/prf.rs
@@ -1,0 +1,44 @@
+use crate::{utils::stretch_key, CryptoError, SymmetricCryptoKey};
+
+/// Takes the output of a PRF and derives a symmetric key
+pub fn derive_symmetric_key_from_prf(prf: &[u8]) -> Result<SymmetricCryptoKey, CryptoError> {
+    let (secret, _) = prf
+        .split_at_checked(32)
+        .ok_or_else(|| CryptoError::InvalidKeyLen)?;
+    let secret: [u8; 32] = secret.try_into().unwrap();
+    if secret.iter().all(|b| *b == b'\0') {
+        return Err(CryptoError::ZeroNumber);
+    }
+    Ok(SymmetricCryptoKey::Aes256CbcHmacKey(stretch_key(
+        &Box::pin(secret.into()),
+    )?))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn test_prf_succeeds() {
+        let prf = [
+            0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23,
+            24, 25, 26, 27, 28, 29, 30, 31,
+        ];
+        derive_symmetric_key_from_prf(&prf).unwrap();
+    }
+
+    #[test]
+    fn test_zero_key_fails() {
+        let prf = [
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0,
+        ];
+        let err = derive_symmetric_key_from_prf(&prf).unwrap_err();
+        assert!(matches!(err, CryptoError::ZeroNumber));
+    }
+    #[test]
+    fn test_short_prf_fails() {
+        let prf = [0, 1, 2, 3, 4, 5, 6, 7, 8];
+        let err = derive_symmetric_key_from_prf(&prf).unwrap_err();
+        assert!(matches!(err, CryptoError::InvalidKeyLen));
+    }
+}

--- a/crates/bitwarden-uniffi/src/crypto.rs
+++ b/crates/bitwarden-uniffi/src/crypto.rs
@@ -1,6 +1,6 @@
 use bitwarden_core::key_management::crypto::{
     DeriveKeyConnectorRequest, DerivePinKeyResponse, EnrollPinResponse, InitOrgCryptoRequest,
-    InitUserCryptoRequest, UpdateKdfResponse, UpdatePasswordResponse,
+    InitUserCryptoRequest, RotateableKeySet, UpdateKdfResponse, UpdatePasswordResponse,
 };
 use bitwarden_crypto::{EncString, Kdf, UnsignedSharedKey};
 use bitwarden_encoding::B64;
@@ -65,6 +65,10 @@ impl CryptoClient {
     /// `initialize_user_crypto`.
     pub fn enroll_pin(&self, pin: String) -> Result<EnrollPinResponse> {
         Ok(self.0.enroll_pin(pin)?)
+    }
+
+    pub fn derive_prf_key(&self, prf: B64) -> Result<RotateableKeySet> {
+        Ok(self.0.derive_prf_key(prf)?)
     }
 
     /// Protects the current user key with the provided PIN. The result can be stored and later


### PR DESCRIPTION
## 🎟️ Tracking

[PM-26177](https://bitwarden.atlassian.net/browse/PM-26177)

## 📔 Objective

In order to set up PRF passkeys on mobile clients, this adds a method to the SDK that derives the rotateable key set from a PRF value received by a passkey.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation
  team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-26177]: https://bitwarden.atlassian.net/browse/PM-26177?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ