### PR TITLE
Make bindings ?Send only for WASM

### DIFF
--- a/crates/bitwarden-api-api/src/apis/access_policies_api.rs
+++ b/crates/bitwarden-api-api/src/apis/access_policies_api.rs
@@ -23,7 +23,8 @@ use crate::{
 };
 
 #[cfg_attr(feature = "mockall", automock)]
-#[async_trait(?Send)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 pub trait AccessPoliciesApi: Send + Sync {
     /// GET /organizations/{id}/access-policies/people/potential-grantees
     async fn get_people_potential_grantees<'a>(
@@ -149,7 +150,8 @@ impl AccessPoliciesApiClient {
     }
 }
 
-#[async_trait(?Send)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 impl AccessPoliciesApi for AccessPoliciesApiClient {
     async fn get_people_potential_grantees<'a>(
         &self,

--- a/crates/bitwarden-api-api/src/apis/account_billing_v_next_api.rs
+++ b/crates/bitwarden-api-api/src/apis/account_billing_v_next_api.rs
@@ -23,7 +23,8 @@ use crate::{
 };
 
 #[cfg_attr(feature = "mockall", automock)]
-#[async_trait(?Send)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 pub trait AccountBillingVNextApi: Send + Sync {
     /// POST /account/billing/vnext/credit/bitpay
     async fn add_credit_via_bit_pay<'a>(
@@ -281,7 +282,8 @@ impl AccountBillingVNextApiClient {
     }
 }
 
-#[async_trait(?Send)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 impl AccountBillingVNextApi for AccountBillingVNextApiClient {
     async fn add_credit_via_bit_pay<'a>(
         &self,

--- a/crates/bitwarden-api-api/src/apis/accounts_api.rs
+++ b/crates/bitwarden-api-api/src/apis/accounts_api.rs
@@ -23,7 +23,8 @@ use crate::{
 };
 
 #[cfg_attr(feature = "mockall", automock)]
-#[async_trait(?Send)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 pub trait AccountsApi: Send + Sync {
     /// POST /accounts/api-key
     async fn api_key<'a>(
@@ -258,7 +259,8 @@ impl AccountsApiClient {
     }
 }
 
-#[async_trait(?Send)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 impl AccountsApi for AccountsApiClient {
     async fn api_key<'a>(
         &self,

--- a/crates/bitwarden-api-api/src/apis/accounts_billing_api.rs
+++ b/crates/bitwarden-api-api/src/apis/accounts_billing_api.rs
@@ -23,7 +23,8 @@ use crate::{
 };
 
 #[cfg_attr(feature = "mockall", automock)]
-#[async_trait(?Send)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 pub trait AccountsBillingApi: Send + Sync {
     /// GET /accounts/billing/history
     async fn get_billing_history(
@@ -67,7 +68,8 @@ impl AccountsBillingApiClient {
     }
 }
 
-#[async_trait(?Send)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 impl AccountsBillingApi for AccountsBillingApiClient {
     async fn get_billing_history(
         &self,

--- a/crates/bitwarden-api-api/src/apis/accounts_key_management_api.rs
+++ b/crates/bitwarden-api-api/src/apis/accounts_key_management_api.rs
@@ -23,7 +23,8 @@ use crate::{
 };
 
 #[cfg_attr(feature = "mockall", automock)]
-#[async_trait(?Send)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 pub trait AccountsKeyManagementApi: Send + Sync {
     /// POST /accounts/convert-to-key-connector
     async fn post_convert_to_key_connector(
@@ -61,7 +62,8 @@ impl AccountsKeyManagementApiClient {
     }
 }
 
-#[async_trait(?Send)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 impl AccountsKeyManagementApi for AccountsKeyManagementApiClient {
     async fn post_convert_to_key_connector(
         &self,

--- a/crates/bitwarden-api-api/src/apis/auth_requests_api.rs
+++ b/crates/bitwarden-api-api/src/apis/auth_requests_api.rs
@@ -23,7 +23,8 @@ use crate::{
 };
 
 #[cfg_attr(feature = "mockall", automock)]
-#[async_trait(?Send)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 pub trait AuthRequestsApi: Send + Sync {
     /// GET /auth-requests/{id}
     async fn get<'a>(
@@ -81,7 +82,8 @@ impl AuthRequestsApiClient {
     }
 }
 
-#[async_trait(?Send)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 impl AuthRequestsApi for AuthRequestsApiClient {
     async fn get<'a>(
         &self,

--- a/crates/bitwarden-api-api/src/apis/ciphers_api.rs
+++ b/crates/bitwarden-api-api/src/apis/ciphers_api.rs
@@ -23,7 +23,8 @@ use crate::{
 };
 
 #[cfg_attr(feature = "mockall", automock)]
-#[async_trait(?Send)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 pub trait CiphersApi: Send + Sync {
     /// POST /ciphers/attachment/validate/azure
     async fn azure_validate_file(&self) -> Result<(), Error<AzureValidateFileError>>;
@@ -319,7 +320,8 @@ impl CiphersApiClient {
     }
 }
 
-#[async_trait(?Send)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 impl CiphersApi for CiphersApiClient {
     async fn azure_validate_file(&self) -> Result<(), Error<AzureValidateFileError>> {
         let local_var_configuration = &self.configuration;

--- a/crates/bitwarden-api-api/src/apis/collections_api.rs
+++ b/crates/bitwarden-api-api/src/apis/collections_api.rs
@@ -23,7 +23,8 @@ use crate::{
 };
 
 #[cfg_attr(feature = "mockall", automock)]
-#[async_trait(?Send)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 pub trait CollectionsApi: Send + Sync {
     /// DELETE /organizations/{orgId}/collections/{id}
     async fn delete<'a>(
@@ -113,7 +114,8 @@ impl CollectionsApiClient {
     }
 }
 
-#[async_trait(?Send)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 impl CollectionsApi for CollectionsApiClient {
     async fn delete<'a>(
         &self,

--- a/crates/bitwarden-api-api/src/apis/config_api.rs
+++ b/crates/bitwarden-api-api/src/apis/config_api.rs
@@ -23,7 +23,8 @@ use crate::{
 };
 
 #[cfg_attr(feature = "mockall", automock)]
-#[async_trait(?Send)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 pub trait ConfigApi: Send + Sync {
     /// GET /config
     async fn get_configs(&self) -> Result<models::ConfigResponseModel, Error<GetConfigsError>>;
@@ -39,7 +40,8 @@ impl ConfigApiClient {
     }
 }
 
-#[async_trait(?Send)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 impl ConfigApi for ConfigApiClient {
     async fn get_configs(&self) -> Result<models::ConfigResponseModel, Error<GetConfigsError>> {
         let local_var_configuration = &self.configuration;

--- a/crates/bitwarden-api-api/src/apis/counts_api.rs
+++ b/crates/bitwarden-api-api/src/apis/counts_api.rs
@@ -23,7 +23,8 @@ use crate::{
 };
 
 #[cfg_attr(feature = "mockall", automock)]
-#[async_trait(?Send)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 pub trait CountsApi: Send + Sync {
     /// GET /organizations/{organizationId}/sm-counts
     async fn get_by_organization<'a>(
@@ -54,7 +55,8 @@ impl CountsApiClient {
     }
 }
 
-#[async_trait(?Send)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 impl CountsApi for CountsApiClient {
     async fn get_by_organization<'a>(
         &self,

--- a/crates/bitwarden-api-api/src/apis/devices_api.rs
+++ b/crates/bitwarden-api-api/src/apis/devices_api.rs
@@ -23,7 +23,8 @@ use crate::{
 };
 
 #[cfg_attr(feature = "mockall", automock)]
-#[async_trait(?Send)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 pub trait DevicesApi: Send + Sync {
     /// DELETE /devices/{id}
     async fn deactivate<'a>(&self, id: &'a str) -> Result<(), Error<DeactivateError>>;
@@ -115,7 +116,8 @@ impl DevicesApiClient {
     }
 }
 
-#[async_trait(?Send)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 impl DevicesApi for DevicesApiClient {
     async fn deactivate<'a>(&self, id: &'a str) -> Result<(), Error<DeactivateError>> {
         let local_var_configuration = &self.configuration;

--- a/crates/bitwarden-api-api/src/apis/emergency_access_api.rs
+++ b/crates/bitwarden-api-api/src/apis/emergency_access_api.rs
@@ -23,7 +23,8 @@ use crate::{
 };
 
 #[cfg_attr(feature = "mockall", automock)]
-#[async_trait(?Send)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 pub trait EmergencyAccessApi: Send + Sync {
     /// POST /emergency-access/{id}/accept
     async fn accept<'a>(
@@ -137,7 +138,8 @@ impl EmergencyAccessApiClient {
     }
 }
 
-#[async_trait(?Send)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 impl EmergencyAccessApi for EmergencyAccessApiClient {
     async fn accept<'a>(
         &self,

--- a/crates/bitwarden-api-api/src/apis/events_api.rs
+++ b/crates/bitwarden-api-api/src/apis/events_api.rs
@@ -23,7 +23,8 @@ use crate::{
 };
 
 #[cfg_attr(feature = "mockall", automock)]
-#[async_trait(?Send)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 pub trait EventsApi: Send + Sync {
     /// GET /ciphers/{id}/events
     async fn get_cipher<'a>(
@@ -111,7 +112,8 @@ impl EventsApiClient {
     }
 }
 
-#[async_trait(?Send)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 impl EventsApi for EventsApiClient {
     async fn get_cipher<'a>(
         &self,

--- a/crates/bitwarden-api-api/src/apis/folders_api.rs
+++ b/crates/bitwarden-api-api/src/apis/folders_api.rs
@@ -23,7 +23,8 @@ use crate::{
 };
 
 #[cfg_attr(feature = "mockall", automock)]
-#[async_trait(?Send)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 pub trait FoldersApi: Send + Sync {
     /// DELETE /folders/{id}
     async fn delete<'a>(&self, id: &'a str) -> Result<(), Error<DeleteError>>;
@@ -63,7 +64,8 @@ impl FoldersApiClient {
     }
 }
 
-#[async_trait(?Send)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 impl FoldersApi for FoldersApiClient {
     async fn delete<'a>(&self, id: &'a str) -> Result<(), Error<DeleteError>> {
         let local_var_configuration = &self.configuration;

--- a/crates/bitwarden-api-api/src/apis/groups_api.rs
+++ b/crates/bitwarden-api-api/src/apis/groups_api.rs
@@ -23,7 +23,8 @@ use crate::{
 };
 
 #[cfg_attr(feature = "mockall", automock)]
-#[async_trait(?Send)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 pub trait GroupsApi: Send + Sync {
     /// DELETE /organizations/{orgId}/groups
     async fn bulk_delete<'a>(
@@ -105,7 +106,8 @@ impl GroupsApiClient {
     }
 }
 
-#[async_trait(?Send)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 impl GroupsApi for GroupsApiClient {
     async fn bulk_delete<'a>(
         &self,

--- a/crates/bitwarden-api-api/src/apis/hibp_api.rs
+++ b/crates/bitwarden-api-api/src/apis/hibp_api.rs
@@ -23,7 +23,8 @@ use crate::{
 };
 
 #[cfg_attr(feature = "mockall", automock)]
-#[async_trait(?Send)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 pub trait HibpApi: Send + Sync {
     /// GET /hibp/breach
     async fn get<'a>(&self, username: Option<&'a str>) -> Result<(), Error<GetError>>;
@@ -39,7 +40,8 @@ impl HibpApiClient {
     }
 }
 
-#[async_trait(?Send)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 impl HibpApi for HibpApiClient {
     async fn get<'a>(&self, username: Option<&'a str>) -> Result<(), Error<GetError>> {
         let local_var_configuration = &self.configuration;

--- a/crates/bitwarden-api-api/src/apis/import_ciphers_api.rs
+++ b/crates/bitwarden-api-api/src/apis/import_ciphers_api.rs
@@ -23,7 +23,8 @@ use crate::{
 };
 
 #[cfg_attr(feature = "mockall", automock)]
-#[async_trait(?Send)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 pub trait ImportCiphersApi: Send + Sync {
     /// POST /ciphers/import
     async fn post_import<'a>(
@@ -51,7 +52,8 @@ impl ImportCiphersApiClient {
     }
 }
 
-#[async_trait(?Send)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 impl ImportCiphersApi for ImportCiphersApiClient {
     async fn post_import<'a>(
         &self,

--- a/crates/bitwarden-api-api/src/apis/info_api.rs
+++ b/crates/bitwarden-api-api/src/apis/info_api.rs
@@ -23,7 +23,8 @@ use crate::{
 };
 
 #[cfg_attr(feature = "mockall", automock)]
-#[async_trait(?Send)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 pub trait InfoApi: Send + Sync {
     /// GET /alive
     async fn get_alive(&self) -> Result<String, Error<GetAliveError>>;
@@ -42,7 +43,8 @@ impl InfoApiClient {
     }
 }
 
-#[async_trait(?Send)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 impl InfoApi for InfoApiClient {
     async fn get_alive(&self) -> Result<String, Error<GetAliveError>> {
         let local_var_configuration = &self.configuration;

--- a/crates/bitwarden-api-api/src/apis/installations_api.rs
+++ b/crates/bitwarden-api-api/src/apis/installations_api.rs
@@ -23,7 +23,8 @@ use crate::{
 };
 
 #[cfg_attr(feature = "mockall", automock)]
-#[async_trait(?Send)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 pub trait InstallationsApi: Send + Sync {
     /// GET /installations/{id}
     async fn get<'a>(
@@ -48,7 +49,8 @@ impl InstallationsApiClient {
     }
 }
 
-#[async_trait(?Send)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 impl InstallationsApi for InstallationsApiClient {
     async fn get<'a>(
         &self,

--- a/crates/bitwarden-api-api/src/apis/invoices_api.rs
+++ b/crates/bitwarden-api-api/src/apis/invoices_api.rs
@@ -23,7 +23,8 @@ use crate::{
 };
 
 #[cfg_attr(feature = "mockall", automock)]
-#[async_trait(?Send)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 pub trait InvoicesApi: Send + Sync {
     /// POST /invoices/preview-organization
     async fn preview_invoice<'a>(
@@ -44,7 +45,8 @@ impl InvoicesApiClient {
     }
 }
 
-#[async_trait(?Send)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 impl InvoicesApi for InvoicesApiClient {
     async fn preview_invoice<'a>(
         &self,

--- a/crates/bitwarden-api-api/src/apis/licenses_api.rs
+++ b/crates/bitwarden-api-api/src/apis/licenses_api.rs
@@ -23,7 +23,8 @@ use crate::{
 };
 
 #[cfg_attr(feature = "mockall", automock)]
-#[async_trait(?Send)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 pub trait LicensesApi: Send + Sync {
     /// GET /licenses/user/{id}
     async fn get_user<'a>(
@@ -52,7 +53,8 @@ impl LicensesApiClient {
     }
 }
 
-#[async_trait(?Send)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 impl LicensesApi for LicensesApiClient {
     async fn get_user<'a>(
         &self,

--- a/crates/bitwarden-api-api/src/apis/misc_api.rs
+++ b/crates/bitwarden-api-api/src/apis/misc_api.rs
@@ -23,7 +23,8 @@ use crate::{
 };
 
 #[cfg_attr(feature = "mockall", automock)]
-#[async_trait(?Send)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 pub trait MiscApi: Send + Sync {
     /// POST /bitpay-invoice
     async fn post_bit_pay_invoice<'a>(
@@ -45,7 +46,8 @@ impl MiscApiClient {
     }
 }
 
-#[async_trait(?Send)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 impl MiscApi for MiscApiClient {
     async fn post_bit_pay_invoice<'a>(
         &self,

--- a/crates/bitwarden-api-api/src/apis/notifications_api.rs
+++ b/crates/bitwarden-api-api/src/apis/notifications_api.rs
@@ -23,7 +23,8 @@ use crate::{
 };
 
 #[cfg_attr(feature = "mockall", automock)]
-#[async_trait(?Send)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 pub trait NotificationsApi: Send + Sync {
     /// GET /notifications
     async fn list<'a>(
@@ -51,7 +52,8 @@ impl NotificationsApiClient {
     }
 }
 
-#[async_trait(?Send)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 impl NotificationsApi for NotificationsApiClient {
     async fn list<'a>(
         &self,

--- a/crates/bitwarden-api-api/src/apis/organization_auth_requests_api.rs
+++ b/crates/bitwarden-api-api/src/apis/organization_auth_requests_api.rs
@@ -23,7 +23,8 @@ use crate::{
 };
 
 #[cfg_attr(feature = "mockall", automock)]
-#[async_trait(?Send)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 pub trait OrganizationAuthRequestsApi: Send + Sync {
     /// POST /organizations/{orgId}/auth-requests/deny
     async fn bulk_deny_requests<'a>(
@@ -71,7 +72,8 @@ impl OrganizationAuthRequestsApiClient {
     }
 }
 
-#[async_trait(?Send)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 impl OrganizationAuthRequestsApi for OrganizationAuthRequestsApiClient {
     async fn bulk_deny_requests<'a>(
         &self,

--- a/crates/bitwarden-api-api/src/apis/organization_billing_api.rs
+++ b/crates/bitwarden-api-api/src/apis/organization_billing_api.rs
@@ -23,7 +23,8 @@ use crate::{
 };
 
 #[cfg_attr(feature = "mockall", automock)]
-#[async_trait(?Send)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 pub trait OrganizationBillingApi: Send + Sync {
     /// POST /organizations/{organizationId}/billing/change-frequency
     async fn change_plan_subscription_frequency<'a>(
@@ -123,7 +124,8 @@ impl OrganizationBillingApiClient {
     }
 }
 
-#[async_trait(?Send)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 impl OrganizationBillingApi for OrganizationBillingApiClient {
     async fn change_plan_subscription_frequency<'a>(
         &self,

--- a/crates/bitwarden-api-api/src/apis/organization_billing_v_next_api.rs
+++ b/crates/bitwarden-api-api/src/apis/organization_billing_v_next_api.rs
@@ -23,7 +23,8 @@ use crate::{
 };
 
 #[cfg_attr(feature = "mockall", automock)]
-#[async_trait(?Send)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 pub trait OrganizationBillingVNextApi: Send + Sync {
     /// POST /organizations/{organizationId}/billing/vnext/credit/bitpay
     async fn add_credit_via_bit_pay<'a>(
@@ -494,7 +495,8 @@ impl OrganizationBillingVNextApiClient {
     }
 }
 
-#[async_trait(?Send)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 impl OrganizationBillingVNextApi for OrganizationBillingVNextApiClient {
     async fn add_credit_via_bit_pay<'a>(
         &self,

--- a/crates/bitwarden-api-api/src/apis/organization_connections_api.rs
+++ b/crates/bitwarden-api-api/src/apis/organization_connections_api.rs
@@ -23,7 +23,8 @@ use crate::{
 };
 
 #[cfg_attr(feature = "mockall", automock)]
-#[async_trait(?Send)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 pub trait OrganizationConnectionsApi: Send + Sync {
     /// GET /organizations/connections/enabled
     async fn connections_enabled(&self) -> Result<bool, Error<ConnectionsEnabledError>>;
@@ -65,7 +66,8 @@ impl OrganizationConnectionsApiClient {
     }
 }
 
-#[async_trait(?Send)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 impl OrganizationConnectionsApi for OrganizationConnectionsApiClient {
     async fn connections_enabled(&self) -> Result<bool, Error<ConnectionsEnabledError>> {
         let local_var_configuration = &self.configuration;

--- a/crates/bitwarden-api-api/src/apis/organization_domain_api.rs
+++ b/crates/bitwarden-api-api/src/apis/organization_domain_api.rs
@@ -23,7 +23,8 @@ use crate::{
 };
 
 #[cfg_attr(feature = "mockall", automock)]
-#[async_trait(?Send)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 pub trait OrganizationDomainApi: Send + Sync {
     /// GET /organizations/{orgId}/domain/{id}
     async fn get<'a>(
@@ -89,7 +90,8 @@ impl OrganizationDomainApiClient {
     }
 }
 
-#[async_trait(?Send)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 impl OrganizationDomainApi for OrganizationDomainApiClient {
     async fn get<'a>(
         &self,

--- a/crates/bitwarden-api-api/src/apis/organization_export_api.rs
+++ b/crates/bitwarden-api-api/src/apis/organization_export_api.rs
@@ -23,7 +23,8 @@ use crate::{
 };
 
 #[cfg_attr(feature = "mockall", automock)]
-#[async_trait(?Send)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 pub trait OrganizationExportApi: Send + Sync {
     /// GET /organizations/{organizationId}/export
     async fn export<'a>(&self, organization_id: uuid::Uuid) -> Result<(), Error<ExportError>>;
@@ -39,7 +40,8 @@ impl OrganizationExportApiClient {
     }
 }
 
-#[async_trait(?Send)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 impl OrganizationExportApi for OrganizationExportApiClient {
     async fn export<'a>(&self, organization_id: uuid::Uuid) -> Result<(), Error<ExportError>> {
         let local_var_configuration = &self.configuration;

--- a/crates/bitwarden-api-api/src/apis/organization_integration_api.rs
+++ b/crates/bitwarden-api-api/src/apis/organization_integration_api.rs
@@ -23,7 +23,8 @@ use crate::{
 };
 
 #[cfg_attr(feature = "mockall", automock)]
-#[async_trait(?Send)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 pub trait OrganizationIntegrationApi: Send + Sync {
     /// POST /organizations/{organizationId}/integrations
     async fn create<'a>(
@@ -64,7 +65,8 @@ impl OrganizationIntegrationApiClient {
     }
 }
 
-#[async_trait(?Send)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 impl OrganizationIntegrationApi for OrganizationIntegrationApiClient {
     async fn create<'a>(
         &self,

--- a/crates/bitwarden-api-api/src/apis/organization_integration_configuration_api.rs
+++ b/crates/bitwarden-api-api/src/apis/organization_integration_configuration_api.rs
@@ -23,7 +23,8 @@ use crate::{
 };
 
 #[cfg_attr(feature = "mockall", automock)]
-#[async_trait(?Send)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 pub trait OrganizationIntegrationConfigurationApi: Send + Sync {
     /// POST /organizations/{organizationId}/integrations/{integrationId}/configurations
     async fn create<'a>(
@@ -74,7 +75,8 @@ impl OrganizationIntegrationConfigurationApiClient {
     }
 }
 
-#[async_trait(?Send)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 impl OrganizationIntegrationConfigurationApi for OrganizationIntegrationConfigurationApiClient {
     async fn create<'a>(
         &self,

--- a/crates/bitwarden-api-api/src/apis/organization_reports_api.rs
+++ b/crates/bitwarden-api-api/src/apis/organization_reports_api.rs
@@ -23,7 +23,8 @@ use crate::{
 };
 
 #[cfg_attr(feature = "mockall", automock)]
-#[async_trait(?Send)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 pub trait OrganizationReportsApi: Send + Sync {
     /// POST /reports/organizations/{organizationId}
     async fn create_organization_report<'a>(
@@ -123,7 +124,8 @@ impl OrganizationReportsApiClient {
     }
 }
 
-#[async_trait(?Send)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 impl OrganizationReportsApi for OrganizationReportsApiClient {
     async fn create_organization_report<'a>(
         &self,

--- a/crates/bitwarden-api-api/src/apis/organization_sponsorships_api.rs
+++ b/crates/bitwarden-api-api/src/apis/organization_sponsorships_api.rs
@@ -23,7 +23,8 @@ use crate::{
 };
 
 #[cfg_attr(feature = "mockall", automock)]
-#[async_trait(?Send)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 pub trait OrganizationSponsorshipsApi: Send + Sync {
     /// DELETE /organization/sponsorship/{sponsoringOrgId}/{sponsoredFriendlyName}/revoke
     async fn admin_initiated_revoke_sponsorship<'a>(
@@ -109,7 +110,8 @@ impl OrganizationSponsorshipsApiClient {
     }
 }
 
-#[async_trait(?Send)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 impl OrganizationSponsorshipsApi for OrganizationSponsorshipsApiClient {
     async fn admin_initiated_revoke_sponsorship<'a>(
         &self,

--- a/crates/bitwarden-api-api/src/apis/organization_users_api.rs
+++ b/crates/bitwarden-api-api/src/apis/organization_users_api.rs
@@ -23,7 +23,8 @@ use crate::{
 };
 
 #[cfg_attr(feature = "mockall", automock)]
-#[async_trait(?Send)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 pub trait OrganizationUsersApi: Send + Sync {
     /// POST /organizations/{orgId}/users/{organizationUserId}/accept
     async fn accept<'a>(
@@ -243,7 +244,8 @@ impl OrganizationUsersApiClient {
     }
 }
 
-#[async_trait(?Send)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 impl OrganizationUsersApi for OrganizationUsersApiClient {
     async fn accept<'a>(
         &self,

--- a/crates/bitwarden-api-api/src/apis/organizations_api.rs
+++ b/crates/bitwarden-api-api/src/apis/organizations_api.rs
@@ -23,7 +23,8 @@ use crate::{
 };
 
 #[cfg_attr(feature = "mockall", automock)]
-#[async_trait(?Send)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 pub trait OrganizationsApi: Send + Sync {
     /// POST /organizations/{id}/api-key
     async fn api_key<'a>(
@@ -246,7 +247,8 @@ impl OrganizationsApiClient {
     }
 }
 
-#[async_trait(?Send)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 impl OrganizationsApi for OrganizationsApiClient {
     async fn api_key<'a>(
         &self,

--- a/crates/bitwarden-api-api/src/apis/phishing_domains_api.rs
+++ b/crates/bitwarden-api-api/src/apis/phishing_domains_api.rs
@@ -23,7 +23,8 @@ use crate::{
 };
 
 #[cfg_attr(feature = "mockall", automock)]
-#[async_trait(?Send)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 pub trait PhishingDomainsApi: Send + Sync {
     /// GET /phishing-domains/checksum
     async fn get_checksum(&self) -> Result<String, Error<GetChecksumError>>;
@@ -42,7 +43,8 @@ impl PhishingDomainsApiClient {
     }
 }
 
-#[async_trait(?Send)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 impl PhishingDomainsApi for PhishingDomainsApiClient {
     async fn get_checksum(&self) -> Result<String, Error<GetChecksumError>> {
         let local_var_configuration = &self.configuration;

--- a/crates/bitwarden-api-api/src/apis/plans_api.rs
+++ b/crates/bitwarden-api-api/src/apis/plans_api.rs
@@ -23,7 +23,8 @@ use crate::{
 };
 
 #[cfg_attr(feature = "mockall", automock)]
-#[async_trait(?Send)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 pub trait PlansApi: Send + Sync {
     /// GET /plans
     async fn get(&self) -> Result<models::PlanResponseModelListResponseModel, Error<GetError>>;
@@ -39,7 +40,8 @@ impl PlansApiClient {
     }
 }
 
-#[async_trait(?Send)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 impl PlansApi for PlansApiClient {
     async fn get(&self) -> Result<models::PlanResponseModelListResponseModel, Error<GetError>> {
         let local_var_configuration = &self.configuration;

--- a/crates/bitwarden-api-api/src/apis/policies_api.rs
+++ b/crates/bitwarden-api-api/src/apis/policies_api.rs
@@ -23,7 +23,8 @@ use crate::{
 };
 
 #[cfg_attr(feature = "mockall", automock)]
-#[async_trait(?Send)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 pub trait PoliciesApi: Send + Sync {
     /// GET /organizations/{orgId}/policies/{type}
     async fn get<'a>(
@@ -80,7 +81,8 @@ impl PoliciesApiClient {
     }
 }
 
-#[async_trait(?Send)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 impl PoliciesApi for PoliciesApiClient {
     async fn get<'a>(
         &self,

--- a/crates/bitwarden-api-api/src/apis/projects_api.rs
+++ b/crates/bitwarden-api-api/src/apis/projects_api.rs
@@ -23,7 +23,8 @@ use crate::{
 };
 
 #[cfg_attr(feature = "mockall", automock)]
-#[async_trait(?Send)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 pub trait ProjectsApi: Send + Sync {
     /// POST /projects/delete
     async fn bulk_delete<'a>(
@@ -68,7 +69,8 @@ impl ProjectsApiClient {
     }
 }
 
-#[async_trait(?Send)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 impl ProjectsApi for ProjectsApiClient {
     async fn bulk_delete<'a>(
         &self,

--- a/crates/bitwarden-api-api/src/apis/provider_billing_api.rs
+++ b/crates/bitwarden-api-api/src/apis/provider_billing_api.rs
@@ -23,7 +23,8 @@ use crate::{
 };
 
 #[cfg_attr(feature = "mockall", automock)]
-#[async_trait(?Send)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 pub trait ProviderBillingApi: Send + Sync {
     /// GET /providers/{providerId}/billing/invoices/{invoiceId}
     async fn generate_client_invoice_report<'a>(
@@ -82,7 +83,8 @@ impl ProviderBillingApiClient {
     }
 }
 
-#[async_trait(?Send)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 impl ProviderBillingApi for ProviderBillingApiClient {
     async fn generate_client_invoice_report<'a>(
         &self,

--- a/crates/bitwarden-api-api/src/apis/provider_billing_v_next_api.rs
+++ b/crates/bitwarden-api-api/src/apis/provider_billing_v_next_api.rs
@@ -23,7 +23,8 @@ use crate::{
 };
 
 #[cfg_attr(feature = "mockall", automock)]
-#[async_trait(?Send)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 pub trait ProviderBillingVNextApi: Send + Sync {
     /// POST /providers/{providerId}/billing/vnext/credit/bitpay
     async fn add_credit_via_bit_pay<'a>(
@@ -221,7 +222,8 @@ impl ProviderBillingVNextApiClient {
     }
 }
 
-#[async_trait(?Send)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 impl ProviderBillingVNextApi for ProviderBillingVNextApiClient {
     async fn add_credit_via_bit_pay<'a>(
         &self,

--- a/crates/bitwarden-api-api/src/apis/provider_clients_api.rs
+++ b/crates/bitwarden-api-api/src/apis/provider_clients_api.rs
@@ -23,7 +23,8 @@ use crate::{
 };
 
 #[cfg_attr(feature = "mockall", automock)]
-#[async_trait(?Send)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 pub trait ProviderClientsApi: Send + Sync {
     /// POST /providers/{providerId}/clients/existing
     async fn add_existing_organization<'a>(
@@ -68,7 +69,8 @@ impl ProviderClientsApiClient {
     }
 }
 
-#[async_trait(?Send)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 impl ProviderClientsApi for ProviderClientsApiClient {
     async fn add_existing_organization<'a>(
         &self,

--- a/crates/bitwarden-api-api/src/apis/provider_organizations_api.rs
+++ b/crates/bitwarden-api-api/src/apis/provider_organizations_api.rs
@@ -23,7 +23,8 @@ use crate::{
 };
 
 #[cfg_attr(feature = "mockall", automock)]
-#[async_trait(?Send)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 pub trait ProviderOrganizationsApi: Send + Sync {
     /// POST /providers/{providerId}/organizations/add
     async fn add<'a>(
@@ -70,7 +71,8 @@ impl ProviderOrganizationsApiClient {
     }
 }
 
-#[async_trait(?Send)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 impl ProviderOrganizationsApi for ProviderOrganizationsApiClient {
     async fn add<'a>(
         &self,

--- a/crates/bitwarden-api-api/src/apis/provider_users_api.rs
+++ b/crates/bitwarden-api-api/src/apis/provider_users_api.rs
@@ -23,7 +23,8 @@ use crate::{
 };
 
 #[cfg_attr(feature = "mockall", automock)]
-#[async_trait(?Send)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 pub trait ProviderUsersApi: Send + Sync {
     /// POST /providers/{providerId}/users/{id}/accept
     async fn accept<'a>(
@@ -127,7 +128,8 @@ impl ProviderUsersApiClient {
     }
 }
 
-#[async_trait(?Send)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 impl ProviderUsersApi for ProviderUsersApiClient {
     async fn accept<'a>(
         &self,

--- a/crates/bitwarden-api-api/src/apis/providers_api.rs
+++ b/crates/bitwarden-api-api/src/apis/providers_api.rs
@@ -23,7 +23,8 @@ use crate::{
 };
 
 #[cfg_attr(feature = "mockall", automock)]
-#[async_trait(?Send)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 pub trait ProvidersApi: Send + Sync {
     /// DELETE /providers/{id}
     async fn delete<'a>(&self, id: uuid::Uuid) -> Result<(), Error<DeleteError>>;
@@ -68,7 +69,8 @@ impl ProvidersApiClient {
     }
 }
 
-#[async_trait(?Send)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 impl ProvidersApi for ProvidersApiClient {
     async fn delete<'a>(&self, id: uuid::Uuid) -> Result<(), Error<DeleteError>> {
         let local_var_configuration = &self.configuration;

--- a/crates/bitwarden-api-api/src/apis/push_api.rs
+++ b/crates/bitwarden-api-api/src/apis/push_api.rs
@@ -23,7 +23,8 @@ use crate::{
 };
 
 #[cfg_attr(feature = "mockall", automock)]
-#[async_trait(?Send)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 pub trait PushApi: Send + Sync {
     /// PUT /push/add-organization
     async fn add_organization<'a>(
@@ -66,7 +67,8 @@ impl PushApiClient {
     }
 }
 
-#[async_trait(?Send)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 impl PushApi for PushApiClient {
     async fn add_organization<'a>(
         &self,

--- a/crates/bitwarden-api-api/src/apis/reports_api.rs
+++ b/crates/bitwarden-api-api/src/apis/reports_api.rs
@@ -23,7 +23,8 @@ use crate::{
 };
 
 #[cfg_attr(feature = "mockall", automock)]
-#[async_trait(?Send)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 pub trait ReportsApi: Send + Sync {
     /// POST /reports/password-health-report-application
     async fn add_password_health_report_application<'a>(
@@ -87,7 +88,8 @@ impl ReportsApiClient {
     }
 }
 
-#[async_trait(?Send)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 impl ReportsApi for ReportsApiClient {
     async fn add_password_health_report_application<'a>(
         &self,

--- a/crates/bitwarden-api-api/src/apis/request_sm_access_api.rs
+++ b/crates/bitwarden-api-api/src/apis/request_sm_access_api.rs
@@ -23,7 +23,8 @@ use crate::{
 };
 
 #[cfg_attr(feature = "mockall", automock)]
-#[async_trait(?Send)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 pub trait RequestSmAccessApi: Send + Sync {
     /// POST /request-access/request-sm-access
     async fn request_sm_access_from_admins<'a>(
@@ -42,7 +43,8 @@ impl RequestSmAccessApiClient {
     }
 }
 
-#[async_trait(?Send)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 impl RequestSmAccessApi for RequestSmAccessApiClient {
     async fn request_sm_access_from_admins<'a>(
         &self,

--- a/crates/bitwarden-api-api/src/apis/secrets_api.rs
+++ b/crates/bitwarden-api-api/src/apis/secrets_api.rs
@@ -23,7 +23,8 @@ use crate::{
 };
 
 #[cfg_attr(feature = "mockall", automock)]
-#[async_trait(?Send)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 pub trait SecretsApi: Send + Sync {
     /// POST /secrets/delete
     async fn bulk_delete<'a>(
@@ -85,7 +86,8 @@ impl SecretsApiClient {
     }
 }
 
-#[async_trait(?Send)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 impl SecretsApi for SecretsApiClient {
     async fn bulk_delete<'a>(
         &self,

--- a/crates/bitwarden-api-api/src/apis/secrets_manager_events_api.rs
+++ b/crates/bitwarden-api-api/src/apis/secrets_manager_events_api.rs
@@ -23,7 +23,8 @@ use crate::{
 };
 
 #[cfg_attr(feature = "mockall", automock)]
-#[async_trait(?Send)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 pub trait SecretsManagerEventsApi: Send + Sync {
     /// GET /sm/events/service-accounts/{serviceAccountId}
     async fn get_service_account_events<'a>(
@@ -45,7 +46,8 @@ impl SecretsManagerEventsApiClient {
     }
 }
 
-#[async_trait(?Send)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 impl SecretsManagerEventsApi for SecretsManagerEventsApiClient {
     async fn get_service_account_events<'a>(
         &self,

--- a/crates/bitwarden-api-api/src/apis/secrets_manager_porting_api.rs
+++ b/crates/bitwarden-api-api/src/apis/secrets_manager_porting_api.rs
@@ -23,7 +23,8 @@ use crate::{
 };
 
 #[cfg_attr(feature = "mockall", automock)]
-#[async_trait(?Send)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 pub trait SecretsManagerPortingApi: Send + Sync {
     /// GET /sm/{organizationId}/export
     async fn export<'a>(
@@ -49,7 +50,8 @@ impl SecretsManagerPortingApiClient {
     }
 }
 
-#[async_trait(?Send)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 impl SecretsManagerPortingApi for SecretsManagerPortingApiClient {
     async fn export<'a>(
         &self,

--- a/crates/bitwarden-api-api/src/apis/security_task_api.rs
+++ b/crates/bitwarden-api-api/src/apis/security_task_api.rs
@@ -23,7 +23,8 @@ use crate::{
 };
 
 #[cfg_attr(feature = "mockall", automock)]
-#[async_trait(?Send)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 pub trait SecurityTaskApi: Send + Sync {
     /// POST /tasks/{orgId}/bulk-create
     async fn bulk_create_tasks<'a>(
@@ -67,7 +68,8 @@ impl SecurityTaskApiClient {
     }
 }
 
-#[async_trait(?Send)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 impl SecurityTaskApi for SecurityTaskApiClient {
     async fn bulk_create_tasks<'a>(
         &self,

--- a/crates/bitwarden-api-api/src/apis/self_hosted_account_billing_api.rs
+++ b/crates/bitwarden-api-api/src/apis/self_hosted_account_billing_api.rs
@@ -23,7 +23,8 @@ use crate::{
 };
 
 #[cfg_attr(feature = "mockall", automock)]
-#[async_trait(?Send)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 pub trait SelfHostedAccountBillingApi: Send + Sync {
     /// POST /account/billing/vnext/self-host/license
     async fn upload_license<'a>(
@@ -85,7 +86,8 @@ impl SelfHostedAccountBillingApiClient {
     }
 }
 
-#[async_trait(?Send)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 impl SelfHostedAccountBillingApi for SelfHostedAccountBillingApiClient {
     async fn upload_license<'a>(
         &self,

--- a/crates/bitwarden-api-api/src/apis/self_hosted_organization_licenses_api.rs
+++ b/crates/bitwarden-api-api/src/apis/self_hosted_organization_licenses_api.rs
@@ -23,7 +23,8 @@ use crate::{
 };
 
 #[cfg_attr(feature = "mockall", automock)]
-#[async_trait(?Send)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 pub trait SelfHostedOrganizationLicensesApi: Send + Sync {
     /// POST /organizations/licenses/self-hosted
     async fn create_license<'a>(
@@ -56,7 +57,8 @@ impl SelfHostedOrganizationLicensesApiClient {
     }
 }
 
-#[async_trait(?Send)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 impl SelfHostedOrganizationLicensesApi for SelfHostedOrganizationLicensesApiClient {
     async fn create_license<'a>(
         &self,

--- a/crates/bitwarden-api-api/src/apis/self_hosted_organization_sponsorships_api.rs
+++ b/crates/bitwarden-api-api/src/apis/self_hosted_organization_sponsorships_api.rs
@@ -23,7 +23,8 @@ use crate::{
 };
 
 #[cfg_attr(feature = "mockall", automock)]
-#[async_trait(?Send)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 pub trait SelfHostedOrganizationSponsorshipsApi: Send + Sync {
     /// DELETE /organization/sponsorship/self-hosted/{sponsoringOrgId}/{sponsoredFriendlyName}/
     /// revoke
@@ -68,7 +69,8 @@ impl SelfHostedOrganizationSponsorshipsApiClient {
     }
 }
 
-#[async_trait(?Send)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 impl SelfHostedOrganizationSponsorshipsApi for SelfHostedOrganizationSponsorshipsApiClient {
     async fn admin_initiated_revoke_sponsorship<'a>(
         &self,

--- a/crates/bitwarden-api-api/src/apis/sends_api.rs
+++ b/crates/bitwarden-api-api/src/apis/sends_api.rs
@@ -23,7 +23,8 @@ use crate::{
 };
 
 #[cfg_attr(feature = "mockall", automock)]
-#[async_trait(?Send)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 pub trait SendsApi: Send + Sync {
     /// POST /sends/access/{id}
     async fn access<'a>(
@@ -104,7 +105,8 @@ impl SendsApiClient {
     }
 }
 
-#[async_trait(?Send)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 impl SendsApi for SendsApiClient {
     async fn access<'a>(
         &self,

--- a/crates/bitwarden-api-api/src/apis/service_accounts_api.rs
+++ b/crates/bitwarden-api-api/src/apis/service_accounts_api.rs
@@ -23,7 +23,8 @@ use crate::{
 };
 
 #[cfg_attr(feature = "mockall", automock)]
-#[async_trait(?Send)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 pub trait ServiceAccountsApi: Send + Sync {
     /// POST /service-accounts/delete
     async fn bulk_delete<'a>(
@@ -92,7 +93,8 @@ impl ServiceAccountsApiClient {
     }
 }
 
-#[async_trait(?Send)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 impl ServiceAccountsApi for ServiceAccountsApiClient {
     async fn bulk_delete<'a>(
         &self,

--- a/crates/bitwarden-api-api/src/apis/settings_api.rs
+++ b/crates/bitwarden-api-api/src/apis/settings_api.rs
@@ -23,7 +23,8 @@ use crate::{
 };
 
 #[cfg_attr(feature = "mockall", automock)]
-#[async_trait(?Send)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 pub trait SettingsApi: Send + Sync {
     /// GET /settings/domains
     async fn get_domains<'a>(
@@ -48,7 +49,8 @@ impl SettingsApiClient {
     }
 }
 
-#[async_trait(?Send)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 impl SettingsApi for SettingsApiClient {
     async fn get_domains<'a>(
         &self,

--- a/crates/bitwarden-api-api/src/apis/slack_integration_api.rs
+++ b/crates/bitwarden-api-api/src/apis/slack_integration_api.rs
@@ -23,7 +23,8 @@ use crate::{
 };
 
 #[cfg_attr(feature = "mockall", automock)]
-#[async_trait(?Send)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 pub trait SlackIntegrationApi: Send + Sync {
     /// GET /organizations/{organizationId}/integrations/slack/create
     async fn create<'a>(
@@ -46,7 +47,8 @@ impl SlackIntegrationApiClient {
     }
 }
 
-#[async_trait(?Send)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 impl SlackIntegrationApi for SlackIntegrationApiClient {
     async fn create<'a>(
         &self,

--- a/crates/bitwarden-api-api/src/apis/stripe_api.rs
+++ b/crates/bitwarden-api-api/src/apis/stripe_api.rs
@@ -23,7 +23,8 @@ use crate::{
 };
 
 #[cfg_attr(feature = "mockall", automock)]
-#[async_trait(?Send)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 pub trait StripeApi: Send + Sync {
     /// POST /setup-intent/bank-account
     async fn create_setup_intent_for_bank_account(
@@ -52,7 +53,8 @@ impl StripeApiClient {
     }
 }
 
-#[async_trait(?Send)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 impl StripeApi for StripeApiClient {
     async fn create_setup_intent_for_bank_account(
         &self,

--- a/crates/bitwarden-api-api/src/apis/sync_api.rs
+++ b/crates/bitwarden-api-api/src/apis/sync_api.rs
@@ -23,7 +23,8 @@ use crate::{
 };
 
 #[cfg_attr(feature = "mockall", automock)]
-#[async_trait(?Send)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 pub trait SyncApi: Send + Sync {
     /// GET /sync
     async fn get<'a>(
@@ -42,7 +43,8 @@ impl SyncApiClient {
     }
 }
 
-#[async_trait(?Send)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 impl SyncApi for SyncApiClient {
     async fn get<'a>(
         &self,

--- a/crates/bitwarden-api-api/src/apis/tax_api.rs
+++ b/crates/bitwarden-api-api/src/apis/tax_api.rs
@@ -23,7 +23,8 @@ use crate::{
 };
 
 #[cfg_attr(feature = "mockall", automock)]
-#[async_trait(?Send)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 pub trait TaxApi: Send + Sync {
     /// POST /tax/preview-amount/organization-trial
     async fn preview_tax_amount_for_organization_trial<'a>(
@@ -44,7 +45,8 @@ impl TaxApiClient {
     }
 }
 
-#[async_trait(?Send)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 impl TaxApi for TaxApiClient {
     async fn preview_tax_amount_for_organization_trial<'a>(
         &self,

--- a/crates/bitwarden-api-api/src/apis/trash_api.rs
+++ b/crates/bitwarden-api-api/src/apis/trash_api.rs
@@ -23,7 +23,8 @@ use crate::{
 };
 
 #[cfg_attr(feature = "mockall", automock)]
-#[async_trait(?Send)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 pub trait TrashApi: Send + Sync {
     /// POST /secrets/{organizationId}/trash/empty
     async fn empty_trash<'a>(
@@ -56,7 +57,8 @@ impl TrashApiClient {
     }
 }
 
-#[async_trait(?Send)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 impl TrashApi for TrashApiClient {
     async fn empty_trash<'a>(
         &self,

--- a/crates/bitwarden-api-api/src/apis/two_factor_api.rs
+++ b/crates/bitwarden-api-api/src/apis/two_factor_api.rs
@@ -23,7 +23,8 @@ use crate::{
 };
 
 #[cfg_attr(feature = "mockall", automock)]
-#[async_trait(?Send)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 pub trait TwoFactorApi: Send + Sync {
     /// DELETE /two-factor/webauthn
     async fn delete_web_authn<'a>(
@@ -172,7 +173,8 @@ impl TwoFactorApiClient {
     }
 }
 
-#[async_trait(?Send)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 impl TwoFactorApi for TwoFactorApiClient {
     async fn delete_web_authn<'a>(
         &self,

--- a/crates/bitwarden-api-api/src/apis/users_api.rs
+++ b/crates/bitwarden-api-api/src/apis/users_api.rs
@@ -23,7 +23,8 @@ use crate::{
 };
 
 #[cfg_attr(feature = "mockall", automock)]
-#[async_trait(?Send)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 pub trait UsersApi: Send + Sync {
     /// GET /users/{id}/public-key
     async fn get<'a>(&self, id: &'a str) -> Result<models::UserKeyResponseModel, Error<GetError>>;
@@ -39,7 +40,8 @@ impl UsersApiClient {
     }
 }
 
-#[async_trait(?Send)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 impl UsersApi for UsersApiClient {
     async fn get<'a>(&self, id: &'a str) -> Result<models::UserKeyResponseModel, Error<GetError>> {
         let local_var_configuration = &self.configuration;

--- a/crates/bitwarden-api-api/src/apis/web_authn_api.rs
+++ b/crates/bitwarden-api-api/src/apis/web_authn_api.rs
@@ -23,7 +23,8 @@ use crate::{
 };
 
 #[cfg_attr(feature = "mockall", automock)]
-#[async_trait(?Send)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 pub trait WebAuthnApi: Send + Sync {
     /// POST /webauthn/assertion-options
     async fn assertion_options<'a>(
@@ -76,7 +77,8 @@ impl WebAuthnApiClient {
     }
 }
 
-#[async_trait(?Send)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 impl WebAuthnApi for WebAuthnApiClient {
     async fn assertion_options<'a>(
         &self,

--- a/crates/bitwarden-api-identity/src/apis/accounts_api.rs
+++ b/crates/bitwarden-api-identity/src/apis/accounts_api.rs
@@ -23,7 +23,8 @@ use crate::{
 };
 
 #[cfg_attr(feature = "mockall", automock)]
-#[async_trait(?Send)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 pub trait AccountsApi: Send + Sync {
     /// GET /accounts/webauthn/assertion-options
     async fn get_web_authn_login_assertion_options(
@@ -80,7 +81,8 @@ impl AccountsApiClient {
     }
 }
 
-#[async_trait(?Send)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 impl AccountsApi for AccountsApiClient {
     async fn get_web_authn_login_assertion_options(
         &self,

--- a/crates/bitwarden-api-identity/src/apis/info_api.rs
+++ b/crates/bitwarden-api-identity/src/apis/info_api.rs
@@ -23,7 +23,8 @@ use crate::{
 };
 
 #[cfg_attr(feature = "mockall", automock)]
-#[async_trait(?Send)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 pub trait InfoApi: Send + Sync {
     /// GET /alive
     async fn get_alive(&self) -> Result<String, Error<GetAliveError>>;
@@ -42,7 +43,8 @@ impl InfoApiClient {
     }
 }
 
-#[async_trait(?Send)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 impl InfoApi for InfoApiClient {
     async fn get_alive(&self) -> Result<String, Error<GetAliveError>> {
         let local_var_configuration = &self.configuration;

--- a/crates/bitwarden-api-identity/src/apis/sso_api.rs
+++ b/crates/bitwarden-api-identity/src/apis/sso_api.rs
@@ -23,7 +23,8 @@ use crate::{
 };
 
 #[cfg_attr(feature = "mockall", automock)]
-#[async_trait(?Send)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 pub trait SsoApi: Send + Sync {
     /// GET /sso/ExternalCallback
     async fn external_callback(&self) -> Result<(), Error<ExternalCallbackError>>;
@@ -57,7 +58,8 @@ impl SsoApiClient {
     }
 }
 
-#[async_trait(?Send)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 impl SsoApi for SsoApiClient {
     async fn external_callback(&self) -> Result<(), Error<ExternalCallbackError>> {
         let local_var_configuration = &self.configuration;

--- a/support/openapi-template/reqwest-trait/api.mustache
+++ b/support/openapi-template/reqwest-trait/api.mustache
@@ -15,7 +15,8 @@ use crate::apis::ContentType;
 {{#mockall}}
 #[cfg_attr(feature = "mockall", automock)]
 {{/mockall}}
-#[async_trait(?Send)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 pub trait {{{classname}}}: Send + Sync {
 {{#operations}}
 {{#operation}}
@@ -118,7 +119,8 @@ pub struct {{{vendorExtensions.x-action-name}}}Params {
 {{/operation}}
 {{/operations}}
 
-#[async_trait(?Send)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 impl {{classname}} for {{classname}}Client {
     {{#operations}}
     {{#operation}}


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective

In #343 I've made the bindings traits always ?Send as the `reqwest` client on WASM is  not Send. The issue is that this introduces problems for other SDK clients where that require the code to be Send, for example NAPI, which is used by Secrets Manager.

This PR updates the bindings to be ?Send only for the WASM architecture.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation
  team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
