### PR TITLE
[PM-26542] Add listing items functionality with session-based authentication with environment variable support for API key login

### DIFF
--- a/crates/bitwarden-cli/src/lib.rs
+++ b/crates/bitwarden-cli/src/lib.rs
@@ -15,3 +15,29 @@ pub fn text_prompt_when_none(prompt: &str, val: Option<String>) -> InquireResult
         Text::new(prompt).prompt()?
     })
 }
+
+/// Try to get a value from CLI arg, then from environment variables, then prompt
+///
+/// Checks multiple environment variable names in order (e.g., BW_CLIENTID, BW_CLIENT_ID)
+pub fn text_or_env_prompt(
+    prompt: &str,
+    cli_val: Option<String>,
+    env_var_names: &[&str],
+) -> InquireResult<String> {
+    // First check if provided via CLI
+    if let Some(val) = cli_val {
+        return Ok(val);
+    }
+
+    // Then check environment variables
+    for env_var in env_var_names {
+        if let Ok(val) = std::env::var(env_var) {
+            if !val.is_empty() {
+                return Ok(val);
+            }
+        }
+    }
+
+    // Finally, prompt the user
+    Text::new(prompt).prompt()
+}

--- a/crates/bitwarden-cli/src/lib.rs
+++ b/crates/bitwarden-cli/src/lib.rs
@@ -19,7 +19,7 @@ pub fn text_prompt_when_none(prompt: &str, val: Option<String>) -> InquireResult
 /// Try to get a value from CLI arg, then from environment variables, then prompt
 ///
 /// Checks multiple environment variable names in order (e.g., BW_CLIENTID, BW_CLIENT_ID)
-pub fn text_or_env_prompt(
+pub fn resolve_user_input_value(
     prompt: &str,
     cli_val: Option<String>,
     env_var_names: &[&str],

--- a/crates/bitwarden-core/src/client/internal.rs
+++ b/crates/bitwarden-core/src/client/internal.rs
@@ -289,8 +289,8 @@ impl InternalClient {
     /// This includes the user key, tokens, and encrypted private/signing keys
     #[cfg(feature = "internal")]
     pub fn export_session(&self) -> Result<String, CryptoError> {
-        use bitwarden_encoding::B64;
         use crate::key_management::{AsymmetricKeyId, SymmetricKeyId};
+        use bitwarden_encoding::B64;
         use serde::{Deserialize, Serialize};
 
         #[derive(Serialize, Deserialize)]
@@ -336,8 +336,7 @@ impl InternalClient {
         };
 
         // Serialize to JSON and then base64 encode
-        let json = serde_json::to_string(&session_data)
-            .map_err(|_| CryptoError::InvalidKey)?;
+        let json = serde_json::to_string(&session_data).map_err(|_| CryptoError::InvalidKey)?;
         let encoded = bitwarden_encoding::B64::from(json.as_bytes());
 
         Ok(encoded.to_string())
@@ -347,9 +346,9 @@ impl InternalClient {
     /// This includes restoring the user key, private key, and setting tokens
     #[cfg(feature = "internal")]
     pub fn import_session(&self, session: &str) -> Result<(), CryptoError> {
+        use crate::key_management::{AsymmetricKeyId, SymmetricKeyId};
         use bitwarden_crypto::{AsymmetricCryptoKey, Pkcs8PrivateKeyBytes};
         use bitwarden_encoding::B64;
-        use crate::key_management::{AsymmetricKeyId, SymmetricKeyId};
         use serde::{Deserialize, Serialize};
 
         #[derive(Serialize, Deserialize)]
@@ -362,12 +361,11 @@ impl InternalClient {
         }
 
         // Decode from base64 and parse JSON
-        let decoded = B64::try_from(session.to_string())
-            .map_err(|_| CryptoError::InvalidKey)?;
-        let json_str = String::from_utf8(decoded.as_bytes().to_vec())
-            .map_err(|_| CryptoError::InvalidKey)?;
-        let session_data: SessionData = serde_json::from_str(&json_str)
-            .map_err(|_| CryptoError::InvalidKey)?;
+        let decoded = B64::try_from(session.to_string()).map_err(|_| CryptoError::InvalidKey)?;
+        let json_str =
+            String::from_utf8(decoded.as_bytes().to_vec()).map_err(|_| CryptoError::InvalidKey)?;
+        let session_data: SessionData =
+            serde_json::from_str(&json_str).map_err(|_| CryptoError::InvalidKey)?;
 
         // Restore the user key and private key
         let user_key = SymmetricCryptoKey::try_from(session_data.user_key)?;
@@ -379,8 +377,8 @@ impl InternalClient {
 
             // Restore private key if present
             if let Some(private_key_b64) = session_data.private_key {
-                let private_key_b64_parsed = B64::try_from(private_key_b64)
-                    .map_err(|_| CryptoError::InvalidKey)?;
+                let private_key_b64_parsed =
+                    B64::try_from(private_key_b64).map_err(|_| CryptoError::InvalidKey)?;
                 let private_key_der = Pkcs8PrivateKeyBytes::from(private_key_b64_parsed.as_bytes());
                 let private_key = AsymmetricCryptoKey::from_der(&private_key_der)?;
                 ctx.set_asymmetric_key(AsymmetricKeyId::UserPrivateKey, private_key)?;

--- a/crates/bitwarden-core/src/client/internal.rs
+++ b/crates/bitwarden-core/src/client/internal.rs
@@ -289,9 +289,10 @@ impl InternalClient {
     /// This includes the user key, tokens, and encrypted private/signing keys
     #[cfg(feature = "internal")]
     pub fn export_session(&self) -> Result<String, CryptoError> {
-        use crate::key_management::{AsymmetricKeyId, SymmetricKeyId};
         use bitwarden_encoding::B64;
         use serde::{Deserialize, Serialize};
+
+        use crate::key_management::{AsymmetricKeyId, SymmetricKeyId};
 
         #[derive(Serialize, Deserialize)]
         struct SessionData {
@@ -346,10 +347,11 @@ impl InternalClient {
     /// This includes restoring the user key, private key, and setting tokens
     #[cfg(feature = "internal")]
     pub fn import_session(&self, session: &str) -> Result<(), CryptoError> {
-        use crate::key_management::{AsymmetricKeyId, SymmetricKeyId};
         use bitwarden_crypto::{AsymmetricCryptoKey, Pkcs8PrivateKeyBytes};
         use bitwarden_encoding::B64;
         use serde::{Deserialize, Serialize};
+
+        use crate::key_management::{AsymmetricKeyId, SymmetricKeyId};
 
         #[derive(Serialize, Deserialize)]
         struct SessionData {

--- a/crates/bitwarden-core/src/client/internal.rs
+++ b/crates/bitwarden-core/src/client/internal.rs
@@ -285,6 +285,22 @@ impl InternalClient {
         self.user_id.get().copied()
     }
 
+    /// Export the user encryption key as a base64-encoded session string
+    /// This is used to return a session key that can be used with --session or BW_SESSION
+    #[cfg(feature = "internal")]
+    pub fn export_user_key_as_session(&self) -> Result<String, CryptoError> {
+        use crate::key_management::SymmetricKeyId;
+
+        #[allow(deprecated)]
+        let session = {
+            let ctx = self.key_store.context();
+            let user_key = ctx.dangerous_get_symmetric_key(SymmetricKeyId::User)?;
+            user_key.to_base64().to_string()
+        };
+
+        Ok(session)
+    }
+
     #[cfg(feature = "internal")]
     pub(crate) fn initialize_user_crypto_master_key(
         &self,

--- a/crates/bw/README.md
+++ b/crates/bw/README.md
@@ -1,3 +1,50 @@
 # Bitwarden CLI (testing)
 
 A testing CLI for the Bitwarden Password Manager SDK.
+
+## Authentication
+
+### Login with API Key
+
+```bash
+# With environment variables
+export BW_CLIENTID="user.xxx"
+export BW_CLIENTSECRET="xxx"
+export BW_PASSWORD="xxx"
+bw login api-key
+
+# Or with interactive prompts
+bw login api-key
+```
+
+The login command returns a session key that can be used for subsequent commands.
+
+### Using Sessions
+
+```bash
+# Save session to environment variable
+export BW_SESSION="<session-key-from-login>"
+
+# Or pass directly to commands
+bw list items --session "<session-key>"
+```
+
+## Commands
+
+### List Items
+
+```bash
+# List all items
+bw list items
+
+# Search items
+bw list items --search "github"
+
+# Filter by folder, collection, or organization
+bw list items --folderid "<folder-id>"
+bw list items --collectionid "<collection-id>"
+bw list items --organizationid "<org-id>"
+
+# Show deleted items
+bw list items --trash
+```

--- a/crates/bw/src/auth/login.rs
+++ b/crates/bw/src/auth/login.rs
@@ -94,7 +94,8 @@ pub(crate) async fn login_api_key(
     client_id: Option<String>,
     client_secret: Option<String>,
 ) -> Result<String> {
-    let client_id = resolve_user_input_value("Client ID", client_id, &["BW_CLIENTID", "BW_CLIENT_ID"])?;
+    let client_id =
+        resolve_user_input_value("Client ID", client_id, &["BW_CLIENTID", "BW_CLIENT_ID"])?;
     let client_secret = resolve_user_input_value(
         "Client Secret",
         client_secret,

--- a/crates/bw/src/auth/login.rs
+++ b/crates/bw/src/auth/login.rs
@@ -1,4 +1,4 @@
-use bitwarden_cli::{text_or_env_prompt, text_prompt_when_none};
+use bitwarden_cli::{resolve_user_input_value, text_prompt_when_none};
 use bitwarden_core::{
     Client,
     auth::login::{
@@ -94,8 +94,8 @@ pub(crate) async fn login_api_key(
     client_id: Option<String>,
     client_secret: Option<String>,
 ) -> Result<String> {
-    let client_id = text_or_env_prompt("Client ID", client_id, &["BW_CLIENTID", "BW_CLIENT_ID"])?;
-    let client_secret = text_or_env_prompt(
+    let client_id = resolve_user_input_value("Client ID", client_id, &["BW_CLIENTID", "BW_CLIENT_ID"])?;
+    let client_secret = resolve_user_input_value(
         "Client Secret",
         client_secret,
         &["BW_CLIENTSECRET", "BW_CLIENT_SECRET"],

--- a/crates/bw/src/auth/login.rs
+++ b/crates/bw/src/auth/login.rs
@@ -123,8 +123,17 @@ pub(crate) async fn login_api_key(
 
     debug!("{result:?}");
 
-    // Export the user key as a session string
-    let session = client.internal.export_user_key_as_session()?;
+    // Sync vault data after successful login
+    let sync_result = client
+        .vault()
+        .sync(&SyncRequest {
+            exclude_subdomains: Some(true),
+        })
+        .await?;
+    info!("Synced {} ciphers", sync_result.ciphers.len());
+
+    // Export the full session (user key + tokens)
+    let session = client.internal.export_session()?;
 
     Ok(session)
 }

--- a/crates/bw/src/auth/mod.rs
+++ b/crates/bw/src/auth/mod.rs
@@ -47,19 +47,23 @@ impl LoginArgs {
             // FIXME: Rust CLI will not support password login!
             LoginCommands::Password { email } => {
                 login::login_password(client, email).await?;
+                Ok("Successfully logged in!".into())
             }
             LoginCommands::ApiKey {
                 client_id,
                 client_secret,
-            } => login::login_api_key(client, client_id, client_secret).await?,
+            } => {
+                let session = login::login_api_key(client, client_id, client_secret).await?;
+                Ok(session.into())
+            }
             LoginCommands::Device {
                 email,
                 device_identifier,
             } => {
                 login::login_device(client, email, device_identifier).await?;
+                Ok("Successfully logged in!".into())
             }
         }
-        Ok("Successfully logged in!".into())
     }
 }
 

--- a/crates/bw/src/command.rs
+++ b/crates/bw/src/command.rs
@@ -145,7 +145,25 @@ Notes:
     // These are the old style action-name commands, to be replaced by name-action commands in the
     // future
     #[command(long_about = "List an array of objects from the vault.")]
-    List,
+    List {
+        /// Object type to list (items, folders, collections, etc.)
+        object: String,
+
+        #[arg(long, help = "Perform a search on the listed objects")]
+        search: Option<String>,
+
+        #[arg(long, help = "Filter items by folder id")]
+        folderid: Option<String>,
+
+        #[arg(long, help = "Filter items by collection id")]
+        collectionid: Option<String>,
+
+        #[arg(long, help = "Filter items by organization id")]
+        organizationid: Option<String>,
+
+        #[arg(long, help = "Filter items that are deleted and in the trash")]
+        trash: bool,
+    },
     #[command(long_about = "Get an object from the vault.")]
     Get,
     #[command(long_about = "Create an object in the vault.")]

--- a/crates/bw/src/command.rs
+++ b/crates/bw/src/command.rs
@@ -147,7 +147,7 @@ Notes:
     #[command(long_about = "List an array of objects from the vault.")]
     List {
         /// Object type to list (items, folders, collections, etc.)
-        object: String,
+        object: crate::vault::ObjectType,
 
         #[arg(long, help = "Perform a search on the listed objects")]
         search: Option<String>,

--- a/crates/bw/src/command.rs
+++ b/crates/bw/src/command.rs
@@ -163,6 +163,9 @@ Notes:
 
         #[arg(long, help = "Filter items that are deleted and in the trash")]
         trash: bool,
+
+        #[arg(long, help = "Filter items that are archived")]
+        archived: bool,
     },
     #[command(long_about = "Get an object from the vault.")]
     Get,
@@ -174,6 +177,8 @@ Notes:
     Delete,
     #[command(long_about = "Restores an object from the trash.")]
     Restore,
+    #[command(long_about = "Archive an object from the vault.")]
+    Archive,
     #[command(long_about = "Move an item to an organization.")]
     Move,
 

--- a/crates/bw/src/main.rs
+++ b/crates/bw/src/main.rs
@@ -110,6 +110,7 @@ async fn process_commands(command: Commands, session: Option<String>) -> Command
             collectionid,
             organizationid,
             trash,
+            archived,
         } => {
             vault::list(
                 &client.0,
@@ -120,6 +121,7 @@ async fn process_commands(command: Commands, session: Option<String>) -> Command
                     collectionid,
                     organizationid,
                     trash,
+                    archived,
                 },
             )
             .await
@@ -129,6 +131,7 @@ async fn process_commands(command: Commands, session: Option<String>) -> Command
         Commands::Edit => todo!(),
         Commands::Delete => todo!(),
         Commands::Restore => todo!(),
+        Commands::Archive => todo!(),
         Commands::Move => todo!(),
 
         // Admin console commands

--- a/crates/bw/src/vault/list.rs
+++ b/crates/bw/src/vault/list.rs
@@ -24,6 +24,7 @@ pub struct ListOptions {
     pub collectionid: Option<String>,
     pub organizationid: Option<String>,
     pub trash: bool,
+    pub archived: bool,
 }
 
 pub async fn list(client: &Client, options: ListOptions) -> Result<CommandOutput> {

--- a/crates/bw/src/vault/list.rs
+++ b/crates/bw/src/vault/list.rs
@@ -1,0 +1,111 @@
+use bitwarden_core::Client;
+use bitwarden_vault::{CipherListView, SyncRequest, VaultClientExt};
+use color_eyre::eyre::{Result, bail};
+
+use crate::render::CommandOutput;
+
+#[derive(Debug)]
+pub struct ListOptions {
+    pub object: String,
+    pub search: Option<String>,
+    pub folderid: Option<String>,
+    pub collectionid: Option<String>,
+    pub organizationid: Option<String>,
+    pub trash: bool,
+}
+
+pub async fn list(client: &Client, options: ListOptions) -> Result<CommandOutput> {
+    match options.object.as_str() {
+        "items" => list_items(client, options).await,
+        "folders" => {
+            bail!("Listing folders is not yet implemented")
+        }
+        "collections" => {
+            bail!("Listing collections is not yet implemented")
+        }
+        "organizations" => {
+            bail!("Listing organizations is not yet implemented")
+        }
+        "org-collections" => {
+            bail!("Listing org-collections is not yet implemented")
+        }
+        "org-members" => {
+            bail!("Listing org-members is not yet implemented")
+        }
+        _ => {
+            bail!(
+                "Invalid object type '{}'. Valid objects are: items, folders, collections, \
+                 organizations, org-collections, org-members",
+                options.object
+            )
+        }
+    }
+}
+
+async fn list_items(client: &Client, options: ListOptions) -> Result<CommandOutput> {
+    // Sync to get the latest vault data
+    let sync_response = client
+        .vault()
+        .sync(&SyncRequest {
+            exclude_subdomains: Some(true),
+        })
+        .await?;
+
+    // Decrypt the ciphers
+    let mut cipher_views: Vec<CipherListView> = client
+        .vault()
+        .ciphers()
+        .decrypt_list(sync_response.ciphers)?;
+
+    // Apply filters (retaining matching items)
+    cipher_views.retain(|item| {
+        // Filter by trash status
+        if options.trash {
+            if item.deleted_date.is_none() {
+                return false;
+            }
+        } else if item.deleted_date.is_some() {
+            return false;
+        }
+
+        // Filter by folder
+        if let Some(ref folder_id) = options.folderid {
+            if item.folder_id.as_ref().map(|id| id.to_string()) != Some(folder_id.clone()) {
+                return false;
+            }
+        }
+
+        // Filter by collection
+        if let Some(ref collection_id) = options.collectionid {
+            if !item
+                .collection_ids
+                .iter()
+                .any(|id| id.to_string() == *collection_id)
+            {
+                return false;
+            }
+        }
+
+        // Filter by organization
+        if let Some(ref org_id) = options.organizationid {
+            if item.organization_id.as_ref().map(|id| id.to_string()) != Some(org_id.clone()) {
+                return false;
+            }
+        }
+
+        // Search filter (case-insensitive search in name)
+        if let Some(ref search_term) = options.search {
+            let search_lower = search_term.to_lowercase();
+            if !item.name.to_lowercase().contains(&search_lower) {
+                return false;
+            }
+        }
+
+        true
+    });
+
+    // Sort by name for consistent output
+    cipher_views.sort_by(|a, b| a.name.cmp(&b.name));
+
+    Ok(CommandOutput::Object(Box::new(cipher_views)))
+}

--- a/crates/bw/src/vault/list.rs
+++ b/crates/bw/src/vault/list.rs
@@ -1,12 +1,24 @@
 use bitwarden_core::Client;
 use bitwarden_vault::{CipherListView, SyncRequest, VaultClientExt};
+use clap::ValueEnum;
 use color_eyre::eyre::{Result, bail};
 
 use crate::render::CommandOutput;
 
+#[derive(Debug, Clone, Copy, ValueEnum)]
+#[value(rename_all = "kebab-case")]
+pub enum ObjectType {
+    Items,
+    Folders,
+    Collections,
+    Organizations,
+    OrgCollections,
+    OrgMembers,
+}
+
 #[derive(Debug)]
 pub struct ListOptions {
-    pub object: String,
+    pub object: ObjectType,
     pub search: Option<String>,
     pub folderid: Option<String>,
     pub collectionid: Option<String>,
@@ -15,29 +27,22 @@ pub struct ListOptions {
 }
 
 pub async fn list(client: &Client, options: ListOptions) -> Result<CommandOutput> {
-    match options.object.as_str() {
-        "items" => list_items(client, options).await,
-        "folders" => {
+    match options.object {
+        ObjectType::Items => list_items(client, options).await,
+        ObjectType::Folders => {
             bail!("Listing folders is not yet implemented")
         }
-        "collections" => {
+        ObjectType::Collections => {
             bail!("Listing collections is not yet implemented")
         }
-        "organizations" => {
+        ObjectType::Organizations => {
             bail!("Listing organizations is not yet implemented")
         }
-        "org-collections" => {
+        ObjectType::OrgCollections => {
             bail!("Listing org-collections is not yet implemented")
         }
-        "org-members" => {
+        ObjectType::OrgMembers => {
             bail!("Listing org-members is not yet implemented")
-        }
-        _ => {
-            bail!(
-                "Invalid object type '{}'. Valid objects are: items, folders, collections, \
-                 organizations, org-collections, org-members",
-                options.object
-            )
         }
     }
 }

--- a/crates/bw/src/vault/mod.rs
+++ b/crates/bw/src/vault/mod.rs
@@ -3,7 +3,7 @@ use clap::Subcommand;
 use crate::render::{CommandOutput, CommandResult};
 
 pub mod list;
-pub use list::{ListOptions, list};
+pub use list::{ListOptions, ObjectType, list};
 
 #[derive(Subcommand, Clone)]
 pub enum ItemCommands {

--- a/crates/bw/src/vault/mod.rs
+++ b/crates/bw/src/vault/mod.rs
@@ -2,6 +2,9 @@ use clap::Subcommand;
 
 use crate::render::{CommandOutput, CommandResult};
 
+pub mod list;
+pub use list::{ListOptions, list};
+
 #[derive(Subcommand, Clone)]
 pub enum ItemCommands {
     Get { id: String },


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

https://bitwarden.atlassian.net/browse/PM-26542

## 📔 Objective

Implements session-based authentication for the Rust Bitwarden CLI, enabling stateless command execution similar to the Node.js CLI. Users can now authenticate once with `bw login api-key` and reuse the session for subsequent commands.

![demo](https://github.com/user-attachments/assets/d947d068-dc50-4d88-b542-1be86da487c9)

Added environment variable support (`BW_CLIENTID`, `BW_CLIENTSECRET`, `BW_PASSWORD`) to the `bw login api-key` command and made it return a base64-encoded session key (like the Node.js CLI, **although this one is reaally long**) that can be potentially used with --session (or `BW_SESSION`) for subsequent vault operations.


### Session Management

- **Session Export**: Added `export_session()` to serialize full client state
- **Session Import**: Added `import_session()` to restore complete authenticated state from session string
- **Session Format**: Base64-encoded JSON containing all crypto keys and OAuth tokens needed for vault operations

### Environment Variable Support
Added support for environment variables in `bw login api-key`:
- `BW_CLIENTID` (or `BW_CLIENT_ID`): API client ID
- `BW_CLIENTSECRET` (or `BW_CLIENT_SECRET`): API client secret
- `BW_PASSWORD`: Master password
- Environment variables take precedence over interactive prompts

### List Command Implementation
- Implemented `bw list items` with filtering options:
  - `--search`: Text search across items
  - `--folderid`: Filter by folder
  - `--collectionid`: Filter by collection
  - `--organizationid`: Filter by organization
  - `--trash`: Show deleted items
- Returns decrypted vault items as JSON

### Session Usage
The global `--session` flag and `BW_SESSION` environment variable now work across all commands, automatically restoring client state before execution.

## Usage Example
```bash
# Set credentials via environment variables
export BW_CLIENTID="user.xxx"
export BW_CLIENTSECRET="xxx"
export BW_PASSWORD="xxx"

# Login and capture session
SESSION=$(bw login api-key)

# Use session for subsequent commands
bw list items --session "$SESSION"

# Or via environment variable
export BW_SESSION="$SESSION"
bw list items
```

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation
  team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
