### PR TITLE
Update sdk-internal CODEOWNERS to give more team ownership

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,12 +7,16 @@
 # Platform is the default owner for all files
 * @bitwarden/team-platform-dev
 
+# Team-owned crates
 crates/bitwarden-auth/** @bitwarden/team-auth-dev @bitwarden/team-platform-dev
+crates/bitwarden-crypto/** @bitwarden/team-key-management-dev @bitwarden/team-platform-dev @bitwarden/dept-architecture 
+crates/bitwarden-vault/** @bitwarden/team-vault-dev @bitwarden/team-sdk-sme
 
-crates/bitwarden-vault/** @bitwarden/team-vault-dev @bitwarden/team-platform-dev
-
-# Temporarily owned by multiple teams
-/crates/bitwarden-crypto/ @bitwarden/team-platform-dev @bitwarden/dept-architecture @bitwarden/team-key-management-dev
+# BW CLI
+crates/bw/src/admin_console/** @bitwarden/team-admin-console-dev @bitwarden/team-platform-dev
+crates/bw/src/auth/** @bitwarden/team-auth-dev @bitwarden/team-platform-dev
+crates/bw/src/tools/** @bitwarden/team-tools-dev @bitwarden/team-platform-dev
+crates/bw/src/vault/** @bitwarden/team-vault-dev @bitwarden/team-sdk-sme
 
 # BRE for publish workflow changes
 .github/workflows/publish-*.yml @bitwarden/dept-bre

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,6 +4,12 @@
 #
 # https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
 
+# We have a few ownership models in use here, applied to team-owned crates as well as CLI code:
+# 1. Full ownership by team-platform-dev, for cases where teams have not yet onboarded at all.
+# 2. Joint team ownership with team-platform-dev, as a team onboards into SDK development and close guidance is necessary.
+# 3. Joint team ownership with team-sdk-sme, once a team is comfortable with SDK development but still would benefit from architectural oversight.
+# 4. Full team ownership, once a team is comfortable with SDK development and has enough shared experience to  ensure alignment with SDK architecture.
+
 # Platform is the default owner for all files
 * @bitwarden/team-platform-dev
 
@@ -13,9 +19,9 @@ crates/bitwarden-crypto/** @bitwarden/team-key-management-dev @bitwarden/team-pl
 crates/bitwarden-vault/** @bitwarden/team-vault-dev @bitwarden/team-sdk-sme
 
 # BW CLI
-crates/bw/src/admin_console/** @bitwarden/team-admin-console-dev @bitwarden/team-platform-dev
+crates/bw/src/admin_console/** @bitwarden/team-platform-dev
 crates/bw/src/auth/** @bitwarden/team-auth-dev @bitwarden/team-platform-dev
-crates/bw/src/tools/** @bitwarden/team-tools-dev @bitwarden/team-platform-dev
+crates/bw/src/tools/** @bitwarden/team-platform-dev
 crates/bw/src/vault/** @bitwarden/team-vault-dev @bitwarden/team-sdk-sme
 
 # BRE for publish workflow changes


### PR DESCRIPTION
## 📔 Objective

Makes several changes to `CODEOWNERS` to reflect maturity in `sdk-internal` code ownership and clarity of ownership definitions:
1. Changed joint ownership of the `bitwarden-vault` crate from `team-platform-dev` to `team-sdk-sme`.
2. Added non-Platform co-owners for all `bw` CLI folders, with all except Vault using `team-platform-dev` and Vault using `team-sdk-sme`, reflecting the change in item 1 above.
3. Moved `bitwarden-crypto` to be grouped with the other joint team-owned crates, as it felt the same as the others (currently shared, with a goal of team-owned), and therefore was OK to group together.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation
  team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
