### PR TITLE
[PM-24051] OpenApi generated models with pascal-case alias for serde serialization

### DIFF
--- a/support/openapi-template/model.mustache
+++ b/support/openapi-template/model.mustache
@@ -87,7 +87,7 @@ pub enum {{{classname}}} {
         {{#description}}
         /// {{{.}}}
         {{/description}}
-        #[serde(rename = "{{{baseName}}}"{{^required}}, skip_serializing_if = "Option::is_none"{{/required}})]
+        #[serde(rename = "{{{baseName}}}", alias = "{{{nameInPascalCase}}}"{{^required}}, skip_serializing_if = "Option::is_none"{{/required}})]
         {{{name}}}: {{#required}}{{#isNullable}}Option<{{/isNullable}}{{/required}}{{^required}}Option<{{/required}}{{#isEnum}}{{{enumName}}}{{/isEnum}}{{^isEnum}}{{#isModel}}{{^avoidBoxedModels}}Box<{{/avoidBoxedModels}}{{{dataType}}}{{^avoidBoxedModels}}>{{/avoidBoxedModels}}{{/isModel}}{{^isModel}}{{{dataType}}}{{/isModel}}{{/isEnum}}{{#required}}{{#isNullable}}>{{/isNullable}}{{/required}}{{^required}}>{{/required}},
     {{/vars}}
     },
@@ -163,7 +163,7 @@ pub struct {{{classname}}} {
     {{#isByteArray}}
     {{#vendorExtensions.isMandatory}}#[serde_as(as = "serde_with::base64::Base64")]{{/vendorExtensions.isMandatory}}{{^vendorExtensions.isMandatory}}#[serde_as(as = "Option<serde_with::base64::Base64>")]{{/vendorExtensions.isMandatory}}
     {{/isByteArray}}
-    #[serde(rename = "{{{baseName}}}"{{^required}}, skip_serializing_if = "Option::is_none"{{/required}})]
+    #[serde(rename = "{{{baseName}}}", alias = "{{{nameInPascalCase}}}"{{^required}}, skip_serializing_if = "Option::is_none"{{/required}})]
     pub {{{name}}}: {{!
     ### Option Start
     }}{{#isNullable}}Option<{{/isNullable}}{{^required}}{{^isNullable}}Option<{{/isNullable}}{{/required}}{{!
@@ -218,7 +218,7 @@ pub struct {{{classname}}} {
     {{#isByteArray}}
     {{#vendorExtensions.isMandatory}}#[serde_as(as = "serde_with::base64::Base64")]{{/vendorExtensions.isMandatory}}{{^vendorExtensions.isMandatory}}#[serde_as(as = "Option<serde_with::base64::Base64>")]{{/vendorExtensions.isMandatory}}
     {{/isByteArray}}
-    #[serde(rename = "{{{baseName}}}"{{^required}}, skip_serializing_if = "Option::is_none"{{/required}})]
+    #[serde(rename = "{{{baseName}}}", alias = "{{{nameInPascalCase}}}"{{^required}}, skip_serializing_if = "Option::is_none"{{/required}})]
     pub {{{name}}}: {{!
     ### Option Start
     }}{{#isNullable}}Option<{{/isNullable}}{{^required}}{{^isNullable}}Option<{{/isNullable}}{{/required}}{{!


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-24051

## 📔 Objective

Added pascal-case serde serialisation alias for all OpenApi generated models.

Issue: The OpenApi generated models only contain the camel-case name of the field. This does not work during deserialisation of Bitwarden server responses, since most of them are in pascal-case.

Persistent models update will be taken care of by `Update API Bindings` GH workflow, once merged.

Example model updated:
```diff

 #[derive(Clone, Default, Debug, PartialEq, Serialize, Deserialize)]
 pub struct MasterPasswordUnlockResponseModel {
-    #[serde(rename = "kdf")]
+    #[serde(rename = "kdf", alias = "Kdf")]
     pub kdf: Box<models::MasterPasswordUnlockKdfResponseModel>,
-    #[serde(rename = "masterKeyEncryptedUserKey")]
+    #[serde(
+        rename = "masterKeyEncryptedUserKey",
+        alias = "MasterKeyEncryptedUserKey"
+    )]
     pub master_key_encrypted_user_key: Option<String>,
-    #[serde(rename = "salt")]
+    #[serde(rename = "salt", alias = "Salt")]
     pub salt: Option<String>,
 }
 ```


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation
  team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
