### PR TITLE
Accept SecureNote with Type 1 and set to 0

### DIFF
--- a/crates/bitwarden-vault/src/cipher/secure_note.rs
+++ b/crates/bitwarden-vault/src/cipher/secure_note.rs
@@ -4,8 +4,8 @@ use bitwarden_core::{
     require,
 };
 use bitwarden_crypto::{CompositeEncryptable, CryptoError, Decryptable, KeyStoreContext};
-use serde::{Deserialize, Serialize};
-use serde_repr::{Deserialize_repr, Serialize_repr};
+use serde::{Deserialize, Deserializer, Serialize};
+use serde_repr::Serialize_repr;
 #[cfg(feature = "wasm")]
 use tsify::Tsify;
 #[cfg(feature = "wasm")]
@@ -17,7 +17,7 @@ use crate::{
 };
 
 #[allow(missing_docs)]
-#[derive(Clone, Copy, Serialize_repr, Deserialize_repr, Debug)]
+#[derive(Clone, Copy, Serialize_repr, Debug)]
 #[repr(u8)]
 #[cfg_attr(feature = "uniffi", derive(uniffi::Enum))]
 #[cfg_attr(feature = "wasm", wasm_bindgen)]
@@ -31,6 +31,25 @@ pub enum SecureNoteType {
 #[cfg_attr(feature = "wasm", derive(Tsify), tsify(into_wasm_abi, from_wasm_abi))]
 pub struct SecureNote {
     r#type: SecureNoteType,
+}
+
+/// Use the custom deserializer for SecureNoteType
+/// Older notes may have a Type greater than 0. If so set them to Generic
+impl<'de> Deserialize<'de> for SecureNoteType {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        match u8::deserialize(deserializer) {
+            Ok(0) => Ok(SecureNoteType::Generic),
+            Ok(_) => {
+                // Any unknown type (like type 1) defaults to Generic
+                // This allows the SDK to handle future secure note types gracefully
+                Ok(SecureNoteType::Generic)
+            }
+            Err(_) => Ok(SecureNoteType::Generic),
+        }
+    }
 }
 
 #[allow(missing_docs)]

--- a/crates/bitwarden-vault/src/cipher/secure_note.rs
+++ b/crates/bitwarden-vault/src/cipher/secure_note.rs
@@ -44,7 +44,6 @@ impl<'de> Deserialize<'de> for SecureNoteType {
             Ok(0) => Ok(SecureNoteType::Generic),
             Ok(_) => {
                 // Any unknown type (like type 1) defaults to Generic
-                // This allows the SDK to handle future secure note types gracefully
                 Ok(SecureNoteType::Generic)
             }
             Err(_) => Ok(SecureNoteType::Generic),


### PR DESCRIPTION
## 🎟️ Tracking

[PM-27214](https://bitwarden.atlassian.net/browse/PM-27214)

## 📔 Objective

Some users have Notes with a `Type:1` in their data. This was breaking some vaults as failures were returning. Changes allow for Cipher Notes to have Type:1 and setting them to 0

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation
  team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-27214]: https://bitwarden.atlassian.net/browse/PM-27214?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ