### PR TITLE
fix(ci): Use locked version of Cargo CLI tools

### DIFF
--- a/.github/workflows/build-rust-crates.yml
+++ b/.github/workflows/build-rust-crates.yml
@@ -70,7 +70,7 @@ jobs:
         uses: Swatinem/rust-cache@f0deed1e0edfc6a9be95417288c0e1099b1eeec3 # v2.7.7
 
       - name: Install cargo-release
-        run: cargo install cargo-release
+        run: cargo install cargo-release --version 0.25.20 --locked
 
       - name: Cargo release dry run
         run: cargo-release release publish --no-publish -p bitwarden-api-api -p bitwarden-api-identity -p bitwarden

--- a/.github/workflows/build-wasm-internal.yml
+++ b/.github/workflows/build-wasm-internal.yml
@@ -90,7 +90,7 @@ jobs:
           key: wasm-cargo-cache
 
       - name: Install wasm-bindgen-cli
-        run: cargo install wasm-bindgen-cli --version 0.2.100
+        run: cargo install wasm-bindgen-cli --version 0.2.100 --locked
 
       - name: Build
         run: ./build.sh -r ${{ matrix.license_type.build_flags }}

--- a/.github/workflows/publish-rust-crates.yml
+++ b/.github/workflows/publish-rust-crates.yml
@@ -98,7 +98,7 @@ jobs:
         uses: Swatinem/rust-cache@f0deed1e0edfc6a9be95417288c0e1099b1eeec3 # v2.7.7
 
       - name: Install cargo-release
-        run: cargo install cargo-release
+        run: cargo install cargo-release --version 0.25.20 --locked
 
       - name: Create GitHub deployment
         if: ${{ inputs.release_type != 'Dry Run' }}

--- a/.github/workflows/rust-test.yml
+++ b/.github/workflows/rust-test.yml
@@ -97,7 +97,7 @@ jobs:
         uses: Swatinem/rust-cache@f0deed1e0edfc6a9be95417288c0e1099b1eeec3 # v2.7.7
 
       - name: Install cargo-llvm-cov
-        run: cargo install cargo-llvm-cov --version 0.5.38
+        run: cargo install cargo-llvm-cov --version 0.5.38 --locked
 
       - name: Generate coverage
         run: cargo llvm-cov --all-features --lcov --output-path lcov.info --ignore-filename-regex "crates/bitwarden-api-"

--- a/.github/workflows/rust-test.yml
+++ b/.github/workflows/rust-test.yml
@@ -74,7 +74,7 @@ jobs:
         uses: Swatinem/rust-cache@f0deed1e0edfc6a9be95417288c0e1099b1eeec3 # v2.7.7
 
       - name: Install wasm-bindgen-cli
-        run: cargo install wasm-bindgen-cli --version 0.2.100
+        run: cargo install wasm-bindgen-cli --version 0.2.100 --locked
 
       - name: Test WASM
         run: cargo test --target wasm32-unknown-unknown -p bitwarden-wasm-internal -p bitwarden-threading -p bitwarden-error -p bitwarden-uuid --all-features


### PR DESCRIPTION
## 🎟️ Tracking

Cf. recent GitHub Actions checks failing, e.g. https://github.com/bitwarden/sdk-internal/actions/runs/18876687408/job/53868218878?pr=494#step:5:68

## 📔 Objective

A transitive dependency of llvm-cov was published 2025-10-23 that is incompatible with our current Rust version, 1.87. This adds the `--locked` flag so that the tool can successfully install.

Also updates other CLI tools in this repo with locked versions.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation
  team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
