### PR TITLE
Add PRF passkey authenticator support and external passkeys

### DIFF
--- a/crates/bitwarden-api-api/src/models/cipher_fido2_credential_model.rs
+++ b/crates/bitwarden-api-api/src/models/cipher_fido2_credential_model.rs
@@ -88,6 +88,8 @@ pub struct CipherFido2CredentialModel {
     pub discoverable: Option<String>,
     #[serde(rename = "creationDate", alias = "CreationDate")]
     pub creation_date: String,
+    #[serde(rename = "hmac_secret", skip_serializing_if = "Option::is_none")]
+    pub hmac_secret: Option<String>,
 }
 
 impl CipherFido2CredentialModel {
@@ -105,6 +107,7 @@ impl CipherFido2CredentialModel {
             user_display_name: None,
             counter: None,
             discoverable: None,
+            hmac_secret: None,
             creation_date,
         }
     }

--- a/crates/bitwarden-exporters/src/cxf/export.rs
+++ b/crates/bitwarden-exporters/src/cxf/export.rs
@@ -210,6 +210,7 @@ mod tests {
                     rp_name: None,
                     user_display_name: None,
                     discoverable: "true".to_string(),
+                    hmac_secret: Some("AAECAwQFBg".to_string()),
                     creation_date: "2024-06-07T14:12:36.150Z".parse().unwrap(),
                 }]),
             })),

--- a/crates/bitwarden-exporters/src/cxf/login.rs
+++ b/crates/bitwarden-exporters/src/cxf/login.rs
@@ -89,6 +89,11 @@ pub(super) fn to_login(
                 rp_name: Some(p.rp_id.clone()),
                 user_display_name: Some(p.user_display_name.clone()),
                 discoverable: "true".to_string(),
+                hmac_secret: p
+                    .fido2_extensions
+                    .as_ref()
+                    .and_then(|ext| ext.hmac_credentials.as_ref())
+                    .map(|s| s.cred_with_uv.to_string()),
                 creation_date,
             }]
         }),
@@ -283,6 +288,7 @@ mod tests {
             rp_name: None,
             user_display_name: None,
             discoverable: "true".to_string(),
+            hmac_secret: Some("AAECAwQFBg".to_string()),
             creation_date: "2024-06-07T14:12:36.150Z".parse().unwrap(),
         };
 

--- a/crates/bitwarden-exporters/src/export.rs
+++ b/crates/bitwarden-exporters/src/export.rs
@@ -78,7 +78,7 @@ fn encrypt_import(
     if let Some(passkey) = passkey {
         let passkeys = passkey.into_iter().map(|p| p.into()).collect();
 
-        view.set_new_fido2_credentials(ctx, passkeys)?;
+        view.set_new_fido2_credentials(ctx, None, passkeys)?;
     }
 
     let new_cipher = view.encrypt_composite(ctx, view.key_identifier())?;

--- a/crates/bitwarden-exporters/src/lib.rs
+++ b/crates/bitwarden-exporters/src/lib.rs
@@ -345,6 +345,7 @@ pub struct Fido2Credential {
     pub rp_name: Option<String>,
     pub user_display_name: Option<String>,
     pub discoverable: String,
+    pub hmac_secret: Option<String>,
     pub creation_date: DateTime<Utc>,
 }
 
@@ -363,6 +364,7 @@ impl From<Fido2Credential> for Fido2CredentialFullView {
             rp_name: value.rp_name,
             user_display_name: value.user_display_name,
             discoverable: value.discoverable,
+            hmac_secret: value.hmac_secret,
             creation_date: value.creation_date,
         }
     }

--- a/crates/bitwarden-exporters/src/models.rs
+++ b/crates/bitwarden-exporters/src/models.rs
@@ -82,7 +82,9 @@ fn from_login(
             .collect(),
         totp: l.totp,
         fido2_credentials: l.fido2_credentials.as_ref().and_then(|_| {
-            let credentials = view.get_fido2_credentials(&mut key_store.context()).ok()?;
+            let credentials = view
+                .get_fido2_credentials(&mut key_store.context(), None)
+                .ok()?;
             if credentials.is_empty() {
                 None
             } else {

--- a/crates/bitwarden-exporters/src/models.rs
+++ b/crates/bitwarden-exporters/src/models.rs
@@ -116,6 +116,7 @@ impl From<Fido2CredentialFullView> for crate::Fido2Credential {
             rp_name: value.rp_name,
             user_display_name: value.user_display_name,
             discoverable: value.discoverable,
+            hmac_secret: value.hmac_secret,
             creation_date: value.creation_date,
         }
     }

--- a/crates/bitwarden-fido/src/authenticator.rs
+++ b/crates/bitwarden-fido/src/authenticator.rs
@@ -120,17 +120,16 @@ impl<'a> Fido2Authenticator<'a> {
         client: &'a Client,
         user_interface: &'a dyn Fido2UserInterface,
         credential_store: &'a dyn Fido2CredentialStore,
-        enable_hmac_secret: bool,
-        encryption_key: Option<SymmetricCryptoKey>,
+        options: Fido2AuthenticatorOptions,
     ) -> Fido2Authenticator<'a> {
         Fido2Authenticator {
             client,
             user_interface,
             credential_store,
-            encryption_key,
+            encryption_key: options.external_encryption_key,
+            enable_hmac_secret: options.enable_hmac_secret,
             selected_cipher: Mutex::new(None),
             requested_uv: Mutex::new(None),
-            enable_hmac_secret,
         }
     }
 
@@ -365,6 +364,18 @@ impl<'a> Fido2Authenticator<'a> {
 
         Ok(SelectedCredential { cipher, credential })
     }
+}
+
+/// Options for configuring FIDO2 authenticator behavior.
+#[derive(Debug, Clone)]
+pub struct Fido2AuthenticatorOptions {
+    /// Whether to enable hmac-secret extension support on the authenticator.
+    pub enable_hmac_secret: bool,
+
+    /// External encryption key provided by the consumer. If specified, this key
+    /// will be used to encrypt any credentials created with the authenticator
+    /// instead of the user key.
+    pub external_encryption_key: Option<SymmetricCryptoKey>,
 }
 
 pub(super) struct CredentialStoreImpl<'a> {

--- a/crates/bitwarden-fido/src/client_fido.rs
+++ b/crates/bitwarden-fido/src/client_fido.rs
@@ -11,6 +11,7 @@ use crate::{
 #[derive(Clone)]
 pub struct ClientFido2 {
     pub(crate) client: Client,
+    enable_hmac_secret: bool,
 }
 
 #[allow(missing_docs)]
@@ -23,8 +24,11 @@ pub enum DecryptFido2AutofillCredentialsError {
 
 impl ClientFido2 {
     #[allow(missing_docs)]
-    pub fn new(client: Client) -> Self {
-        Self { client }
+    pub fn new(client: Client, enable_hmac_secret: bool) -> Self {
+        Self {
+            client,
+            enable_hmac_secret,
+        }
     }
 
     #[allow(missing_docs)]
@@ -33,7 +37,12 @@ impl ClientFido2 {
         user_interface: &'a dyn Fido2UserInterface,
         credential_store: &'a dyn Fido2CredentialStore,
     ) -> Fido2Authenticator<'a> {
-        Fido2Authenticator::new(&self.client, user_interface, credential_store)
+        Fido2Authenticator::new(
+            &self.client,
+            user_interface,
+            credential_store,
+            self.enable_hmac_secret,
+        )
     }
 
     #[allow(missing_docs)]
@@ -63,11 +72,11 @@ impl ClientFido2 {
 
 #[allow(missing_docs)]
 pub trait ClientFido2Ext {
-    fn fido2(&self) -> ClientFido2;
+    fn fido2(&self, enable_hmac_secret: bool) -> ClientFido2;
 }
 
 impl ClientFido2Ext for Client {
-    fn fido2(&self) -> ClientFido2 {
-        ClientFido2::new(self.clone())
+    fn fido2(&self, enable_hmac_secret: bool) -> ClientFido2 {
+        ClientFido2::new(self.clone(), enable_hmac_secret)
     }
 }

--- a/crates/bitwarden-fido/src/lib.rs
+++ b/crates/bitwarden-fido/src/lib.rs
@@ -1,6 +1,6 @@
 #![doc = include_str!("../README.md")]
 
-use bitwarden_core::key_management::KeyIds;
+use bitwarden_core::key_management::{KeyIds, SymmetricKeyId};
 use bitwarden_crypto::KeyStoreContext;
 use bitwarden_encoding::{B64Url, NotB64UrlEncodedError};
 use bitwarden_vault::{
@@ -65,8 +65,12 @@ pub(crate) struct CipherViewContainer {
 }
 
 impl CipherViewContainer {
-    fn new(cipher: CipherView, ctx: &mut KeyStoreContext<KeyIds>) -> Result<Self, CipherError> {
-        let fido2_credentials = cipher.get_fido2_credentials(ctx)?;
+    fn new(
+        cipher: CipherView,
+        ctx: &mut KeyStoreContext<KeyIds>,
+        key_id: Option<SymmetricKeyId>,
+    ) -> Result<Self, CipherError> {
+        let fido2_credentials = cipher.get_fido2_credentials(ctx, key_id)?;
         Ok(Self {
             cipher,
             fido2_credentials,

--- a/crates/bitwarden-fido/src/lib.rs
+++ b/crates/bitwarden-fido/src/lib.rs
@@ -7,7 +7,7 @@ use bitwarden_vault::{
     CipherError, CipherView, Fido2CredentialFullView, Fido2CredentialNewView, Fido2CredentialView,
 };
 use crypto::{CoseKeyToPkcs8Error, PrivateKeyFromSecretKeyError};
-use passkey::types::{CredentialExtensions, Passkey, ctap2::Aaguid};
+use passkey::types::{CredentialExtensions, Passkey, StoredHmacSecret, ctap2::Aaguid};
 
 #[cfg(feature = "uniffi")]
 uniffi::setup_scaffolding!();
@@ -117,6 +117,17 @@ fn try_from_credential_full_view(value: Fido2CredentialFullView) -> Result<Passk
     let counter = (counter != 0).then_some(counter);
     let key_value = B64Url::try_from(value.key_value)?;
     let user_handle = value.user_handle.map(B64Url::try_from).transpose()?;
+    let hmac_secret = value
+        .hmac_secret
+        .map(B64Url::try_from)
+        .transpose()?
+        .map(|s| s.as_bytes().to_vec());
+    let extensions = CredentialExtensions {
+        hmac_secret: hmac_secret.map(|cred_with_uv| StoredHmacSecret {
+            cred_with_uv,
+            cred_without_uv: None,
+        }),
+    };
 
     let key = pkcs8_to_cose_key(key_value.as_bytes())?;
 
@@ -126,7 +137,7 @@ fn try_from_credential_full_view(value: Fido2CredentialFullView) -> Result<Passk
         rp_id: value.rp_id.clone(),
         user_handle: user_handle.map(|u| u.into_bytes().into()),
         counter,
-        extensions: CredentialExtensions { hmac_secret: None },
+        extensions,
     })
 }
 
@@ -148,6 +159,11 @@ pub fn fill_with_credential(
     let user_handle = value
         .user_handle
         .map(|u| B64Url::from(u.to_vec()).to_string());
+    let hmac_secret = value
+        .extensions
+        .hmac_secret
+        .as_ref()
+        .map(|s| B64Url::from(s.cred_with_uv.as_ref()).to_string());
     let key_value = B64Url::from(cose_key_to_pkcs8(&value.key)?).to_string();
 
     Ok(Fido2CredentialFullView {
@@ -164,6 +180,7 @@ pub fn fill_with_credential(
         user_name: view.user_name.clone(),
         user_display_name: view.user_display_name.clone(),
         discoverable: "true".to_owned(),
+        hmac_secret,
         creation_date: chrono::offset::Utc::now(),
     })
 }
@@ -201,6 +218,11 @@ pub(crate) fn try_from_credential_full(
     let cred_id: Vec<u8> = value.credential_id.into();
     let key_value = B64Url::from(cose_key_to_pkcs8(&value.key)?).to_string();
     let user_handle = B64Url::from(user.id.to_vec()).to_string();
+    let hmac_secret = value
+        .extensions
+        .hmac_secret
+        .as_ref()
+        .map(|s| B64Url::from(s.cred_with_uv.as_ref()).to_string());
 
     Ok(Fido2CredentialFullView {
         credential_id: guid_bytes_to_string(&cred_id)?,
@@ -216,6 +238,7 @@ pub(crate) fn try_from_credential_full(
         user_name: user.name,
         user_display_name: user.display_name,
         discoverable: options.rk.to_string(),
+        hmac_secret,
         creation_date: chrono::offset::Utc::now(),
     })
 }

--- a/crates/bitwarden-fido/src/lib.rs
+++ b/crates/bitwarden-fido/src/lib.rs
@@ -21,8 +21,8 @@ mod crypto;
 mod traits;
 mod types;
 pub use authenticator::{
-    CredentialsForAutofillError, Fido2Authenticator, GetAssertionError, MakeCredentialError,
-    SilentlyDiscoverCredentialsError,
+    CredentialsForAutofillError, Fido2Authenticator, Fido2AuthenticatorOptions, GetAssertionError,
+    MakeCredentialError, SilentlyDiscoverCredentialsError,
 };
 pub use client::{Fido2Client, Fido2ClientError};
 pub use client_fido::{ClientFido2, ClientFido2Ext, DecryptFido2AutofillCredentialsError};

--- a/crates/bitwarden-fido/src/types.rs
+++ b/crates/bitwarden-fido/src/types.rs
@@ -1,6 +1,6 @@
 use std::{borrow::Cow, collections::HashMap};
 
-use bitwarden_core::key_management::KeyIds;
+use bitwarden_core::key_management::{KeyIds, SymmetricKeyId};
 use bitwarden_crypto::{CryptoError, KeyStoreContext};
 use bitwarden_encoding::{B64Url, NotB64UrlEncodedError};
 use bitwarden_vault::{CipherListView, CipherListViewType, CipherView, LoginListView};
@@ -79,8 +79,9 @@ impl Fido2CredentialAutofillView {
     pub fn from_cipher_view(
         cipher: &CipherView,
         ctx: &mut KeyStoreContext<KeyIds>,
+        key_id: Option<SymmetricKeyId>,
     ) -> Result<Vec<Fido2CredentialAutofillView>, Fido2CredentialAutofillViewError> {
-        let credentials = cipher.decrypt_fido2_credentials(ctx)?;
+        let credentials = cipher.decrypt_fido2_credentials(ctx, key_id)?;
 
         credentials
             .iter()

--- a/crates/bitwarden-fido/src/types.rs
+++ b/crates/bitwarden-fido/src/types.rs
@@ -1,11 +1,16 @@
-use std::borrow::Cow;
+use std::{borrow::Cow, collections::HashMap};
 
 use bitwarden_core::key_management::KeyIds;
 use bitwarden_crypto::{CryptoError, KeyStoreContext};
 use bitwarden_encoding::{B64Url, NotB64UrlEncodedError};
 use bitwarden_vault::{CipherListView, CipherListViewType, CipherView, LoginListView};
 use passkey::types::{
-    ctap2::{get_assertion, make_credential},
+    Bytes,
+    crypto::sha256,
+    ctap2::{
+        extensions::{AuthenticatorPrfInputs, AuthenticatorPrfValues},
+        get_assertion, make_credential,
+    },
     webauthn::UserVerificationRequirement,
 };
 use reqwest::Url;
@@ -252,16 +257,18 @@ pub struct MakeCredentialResult {
 #[allow(missing_docs)]
 #[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
 #[derive(Debug)]
-pub struct MakeCredentialExtensionsInput {}
+pub struct MakeCredentialExtensionsInput {
+    prf: Option<MakeCredentialPrfInput>,
+}
 
 impl From<MakeCredentialExtensionsInput>
     for passkey::types::ctap2::make_credential::ExtensionInputs
 {
-    fn from(_value: MakeCredentialExtensionsInput) -> Self {
+    fn from(value: MakeCredentialExtensionsInput) -> Self {
         Self {
             hmac_secret: None,
             hmac_secret_mc: None,
-            prf: None,
+            prf: value.prf.map(AuthenticatorPrfInputs::from),
         }
     }
 }
@@ -269,12 +276,55 @@ impl From<MakeCredentialExtensionsInput>
 #[allow(missing_docs)]
 #[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
 #[derive(Debug)]
-pub struct MakeCredentialExtensionsOutput {}
+pub struct MakeCredentialExtensionsOutput {
+    pub prf: Option<MakeCredentialPrfOutput>,
+}
+
+impl From<Option<make_credential::UnsignedExtensionOutputs>> for MakeCredentialExtensionsOutput {
+    fn from(value: Option<make_credential::UnsignedExtensionOutputs>) -> Self {
+        if let Some(ext) = value {
+            MakeCredentialExtensionsOutput::from(ext)
+        } else {
+            MakeCredentialExtensionsOutput { prf: None }
+        }
+    }
+}
 
 impl From<make_credential::UnsignedExtensionOutputs> for MakeCredentialExtensionsOutput {
-    fn from(_value: make_credential::UnsignedExtensionOutputs) -> Self {
-        MakeCredentialExtensionsOutput {}
+    fn from(value: make_credential::UnsignedExtensionOutputs) -> Self {
+        let prf = value.prf.map(|prf| MakeCredentialPrfOutput {
+            enabled: prf.enabled,
+            results: prf.results.map(|v| PrfValues {
+                first: v.first.to_vec(),
+                second: v.second.map(|second| second.to_vec()),
+            }),
+        });
+        MakeCredentialExtensionsOutput { prf }
     }
+}
+
+#[allow(missing_docs)]
+#[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
+#[derive(Debug)]
+pub struct MakeCredentialPrfInput {
+    eval: Option<PrfValues>,
+}
+
+impl From<MakeCredentialPrfInput> for AuthenticatorPrfInputs {
+    fn from(value: MakeCredentialPrfInput) -> Self {
+        Self {
+            eval: value.eval.map(AuthenticatorPrfValues::from),
+            eval_by_credential: None,
+        }
+    }
+}
+
+#[allow(missing_docs)]
+#[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
+#[derive(Debug)]
+pub struct MakeCredentialPrfOutput {
+    pub enabled: bool,
+    pub results: Option<PrfValues>,
 }
 
 #[allow(missing_docs)]
@@ -367,13 +417,15 @@ pub struct GetAssertionResult {
 #[allow(missing_docs)]
 #[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
 #[derive(Debug)]
-pub struct GetAssertionExtensionsInput {}
+pub struct GetAssertionExtensionsInput {
+    prf: Option<GetAssertionPrfInput>,
+}
 
 impl From<GetAssertionExtensionsInput> for get_assertion::ExtensionInputs {
-    fn from(_value: GetAssertionExtensionsInput) -> Self {
+    fn from(value: GetAssertionExtensionsInput) -> Self {
         Self {
             hmac_secret: None,
-            prf: None,
+            prf: value.prf.map(AuthenticatorPrfInputs::from),
         }
     }
 }
@@ -381,12 +433,63 @@ impl From<GetAssertionExtensionsInput> for get_assertion::ExtensionInputs {
 #[allow(missing_docs)]
 #[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
 #[derive(Debug)]
-pub struct GetAssertionExtensionsOutput {}
+pub struct GetAssertionExtensionsOutput {
+    pub prf: Option<GetAssertionPrfOutput>,
+}
+
+impl From<Option<get_assertion::UnsignedExtensionOutputs>> for GetAssertionExtensionsOutput {
+    fn from(value: Option<get_assertion::UnsignedExtensionOutputs>) -> Self {
+        if let Some(value) = value {
+            value.into()
+        } else {
+            Self { prf: None }
+        }
+    }
+}
 
 impl From<get_assertion::UnsignedExtensionOutputs> for GetAssertionExtensionsOutput {
-    fn from(_value: get_assertion::UnsignedExtensionOutputs) -> Self {
-        Self {}
+    fn from(value: get_assertion::UnsignedExtensionOutputs) -> Self {
+        let prf = value.prf.map(|prf| GetAssertionPrfOutput {
+            results: PrfValues {
+                first: prf.results.first.to_vec(),
+                second: prf.results.second.map(|second| second.to_vec()),
+            },
+        });
+        GetAssertionExtensionsOutput { prf }
     }
+}
+
+#[allow(missing_docs)]
+#[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
+#[derive(Debug)]
+pub struct GetAssertionPrfInput {
+    eval: Option<PrfValues>,
+    eval_by_credential: Option<HashMap<Vec<u8>, PrfValues>>,
+}
+
+impl From<GetAssertionPrfInput> for AuthenticatorPrfInputs {
+    fn from(value: GetAssertionPrfInput) -> Self {
+        let eval_by_credential = if let Some(values) = value.eval_by_credential {
+            let map: HashMap<Bytes, AuthenticatorPrfValues> = values
+                .into_iter()
+                .map(|(k, v)| (k.into(), v.into()))
+                .collect();
+            Some(map)
+        } else {
+            None
+        };
+        Self {
+            eval: value.eval.map(AuthenticatorPrfValues::from),
+            eval_by_credential,
+        }
+    }
+}
+
+#[allow(missing_docs)]
+#[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
+#[derive(Debug)]
+pub struct GetAssertionPrfOutput {
+    pub results: PrfValues,
 }
 
 #[allow(missing_docs)]
@@ -419,6 +522,27 @@ impl passkey::client::ClientData<Option<AndroidClientData>> for ClientData {
             ClientData::DefaultWithExtraData { .. } => None,
             ClientData::DefaultWithCustomHash { hash } => Some(hash.clone()),
         }
+    }
+}
+
+#[allow(missing_docs)]
+#[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
+#[derive(Debug)]
+pub struct PrfValues {
+    pub first: Vec<u8>,
+    pub second: Option<Vec<u8>>,
+}
+
+impl From<PrfValues> for AuthenticatorPrfValues {
+    fn from(value: PrfValues) -> Self {
+        // passkey-rs expects the salt to be hashed already according to
+        // WebAuthn PRF extension client processing rules.
+        let prefix = b"WebAuthn PRF\0".as_slice();
+        let first = sha256(&[prefix, value.first.as_ref()].concat());
+        let second = value
+            .second
+            .map(|second| sha256(&[prefix, second.as_ref()].concat()));
+        Self { first, second }
     }
 }
 
@@ -549,9 +673,20 @@ impl TryFrom<UnverifiedAssetLink> for passkey::client::UnverifiedAssetLink<'_> {
 
 #[cfg(test)]
 mod tests {
+    use passkey::types::ctap2::{
+        extensions::{
+            AuthenticatorPrfGetOutputs, AuthenticatorPrfMakeOutputs, AuthenticatorPrfValues,
+        },
+        get_assertion, make_credential,
+    };
     use serde::{Deserialize, Serialize};
 
     use super::AndroidClientData;
+    use crate::types::{
+        GetAssertionExtensionsInput, GetAssertionExtensionsOutput, GetAssertionPrfInput,
+        MakeCredentialExtensionsInput, MakeCredentialExtensionsOutput, MakeCredentialPrfInput,
+        PrfValues,
+    };
 
     // This is a stripped down of the passkey-rs implementation, to test the
     // serialization of the `ClientData` enum, and to make sure that () and None
@@ -604,5 +739,122 @@ mod tests {
             serialized,
             r#"{"origin":"https://example.com","androidPackageName":"com.example.app"}"#
         );
+    }
+
+    #[test]
+    fn test_transform_make_credential_extension_input() {
+        let salt1 = b"salt1".to_vec();
+        let salt2 = b"salt2".to_vec();
+        let input = MakeCredentialExtensionsInput {
+            prf: Some(MakeCredentialPrfInput {
+                eval: Some(PrfValues {
+                    first: salt1.clone(),
+                    second: Some(salt2.clone()),
+                }),
+            }),
+        };
+        let transformed = make_credential::ExtensionInputs::from(input);
+        // SHA-256(UTF-8("WebAuthn PRF") || 0x00 || salt1)
+        let hashed_first = [
+            0x2A, 0x19, 0x90, 0xF9, 0xC9, 0xBB, 0xFE, 0x1B, 0xBF, 0x56, 0xAB, 0xEE, 0x2B, 0x5A,
+            0x0F, 0x59, 0xBE, 0x5F, 0x63, 0x3A, 0x35, 0xC2, 0xA5, 0xF0, 0x7D, 0x85, 0x53, 0x3E,
+            0xEE, 0xCB, 0xDD, 0x3C,
+        ];
+        assert_eq!(
+            hashed_first,
+            transformed
+                .prf
+                .as_ref()
+                .unwrap()
+                .eval
+                .as_ref()
+                .unwrap()
+                .first
+        );
+        // SHA-256(UTF-8("WebAuthn PRF") || 0x00 || salt2)
+        let hashed_second = [
+            0xA6, 0x42, 0xFA, 0x8B, 0x6E, 0xAC, 0x68, 0xD3, 0x73, 0xCF, 0x08, 0xEA, 0xC8, 0x5E,
+            0x1D, 0x62, 0x9B, 0x50, 0x10, 0x6D, 0x60, 0xEB, 0x92, 0x48, 0xEC, 0xB6, 0x54, 0xE2,
+            0x94, 0x9A, 0xDD, 0x65,
+        ];
+        assert_eq!(
+            hashed_second,
+            transformed.prf.unwrap().eval.unwrap().second.unwrap()
+        );
+    }
+
+    #[test]
+    fn test_transform_make_credential_extension_output() {
+        let prf1: Vec<u8> = (0..32).collect();
+        let output = make_credential::UnsignedExtensionOutputs {
+            prf: Some(AuthenticatorPrfMakeOutputs {
+                enabled: true,
+                results: Some(AuthenticatorPrfValues {
+                    first: prf1.clone().try_into().unwrap(),
+                    second: None,
+                }),
+            }),
+        };
+        let transformed = MakeCredentialExtensionsOutput::from(output);
+        assert!(transformed.prf.as_ref().unwrap().enabled);
+        assert_eq!(prf1, transformed.prf.unwrap().results.unwrap().first);
+    }
+
+    #[test]
+    fn test_transform_get_assertion_extension_input() {
+        let salt1 = b"salt1".to_vec();
+        let salt2 = b"salt2".to_vec();
+        let input = GetAssertionExtensionsInput {
+            prf: Some(GetAssertionPrfInput {
+                eval: Some(PrfValues {
+                    first: salt1.clone(),
+                    second: Some(salt2.clone()),
+                }),
+                eval_by_credential: None,
+            }),
+        };
+        let transformed = get_assertion::ExtensionInputs::from(input);
+        // SHA-256(UTF-8("WebAuthn PRF") || 0x00 || salt1)
+        let hashed_first = [
+            0x2A, 0x19, 0x90, 0xF9, 0xC9, 0xBB, 0xFE, 0x1B, 0xBF, 0x56, 0xAB, 0xEE, 0x2B, 0x5A,
+            0x0F, 0x59, 0xBE, 0x5F, 0x63, 0x3A, 0x35, 0xC2, 0xA5, 0xF0, 0x7D, 0x85, 0x53, 0x3E,
+            0xEE, 0xCB, 0xDD, 0x3C,
+        ];
+        assert_eq!(
+            hashed_first,
+            transformed
+                .prf
+                .as_ref()
+                .unwrap()
+                .eval
+                .as_ref()
+                .unwrap()
+                .first
+        );
+        // SHA-256(UTF-8("WebAuthn PRF") || 0x00 || salt2)
+        let hashed_second = [
+            0xA6, 0x42, 0xFA, 0x8B, 0x6E, 0xAC, 0x68, 0xD3, 0x73, 0xCF, 0x08, 0xEA, 0xC8, 0x5E,
+            0x1D, 0x62, 0x9B, 0x50, 0x10, 0x6D, 0x60, 0xEB, 0x92, 0x48, 0xEC, 0xB6, 0x54, 0xE2,
+            0x94, 0x9A, 0xDD, 0x65,
+        ];
+        assert_eq!(
+            hashed_second,
+            transformed.prf.unwrap().eval.unwrap().second.unwrap()
+        );
+    }
+
+    #[test]
+    fn test_transform_get_assertion_extension_output() {
+        let prf1: Vec<u8> = (0..32).collect();
+        let output = get_assertion::UnsignedExtensionOutputs {
+            prf: Some(AuthenticatorPrfGetOutputs {
+                results: AuthenticatorPrfValues {
+                    first: prf1.clone().try_into().unwrap(),
+                    second: None,
+                },
+            }),
+        };
+        let transformed = GetAssertionExtensionsOutput::from(output);
+        assert_eq!(prf1, transformed.prf.unwrap().results.first);
     }
 }

--- a/crates/bitwarden-uniffi/src/platform/fido2.rs
+++ b/crates/bitwarden-uniffi/src/platform/fido2.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use bitwarden_crypto::{BitwardenLegacyKeyBytes, SymmetricCryptoKey};
+use bitwarden_crypto::{BitwardenLegacyKeyBytes, CryptoError, SymmetricCryptoKey};
 use bitwarden_fido::{
     CheckUserOptions, ClientData, Fido2AuthenticatorOptions,
     Fido2CallbackError as BitFido2CallbackError, Fido2CredentialAutofillView, GetAssertionRequest,
@@ -47,10 +47,9 @@ impl ClientFido2 {
         user_interface: Arc<dyn Fido2UserInterface>,
         credential_store: Arc<dyn Fido2CredentialStore>,
         encryption_key: Vec<u8>,
-    ) -> Arc<ClientFido2Authenticator> {
-        let key =
-            SymmetricCryptoKey::try_from(&BitwardenLegacyKeyBytes::from(encryption_key)).unwrap();
-        Arc::new(ClientFido2Authenticator(
+    ) -> Result<Arc<ClientFido2Authenticator>, CryptoError> {
+        let key = SymmetricCryptoKey::try_from(&BitwardenLegacyKeyBytes::from(encryption_key))?;
+        Ok(Arc::new(ClientFido2Authenticator(
             self.0.clone(),
             user_interface,
             credential_store,
@@ -58,7 +57,7 @@ impl ClientFido2 {
                 enable_hmac_secret: true,
                 external_encryption_key: Some(key),
             },
-        ))
+        )))
     }
 
     pub fn client(

--- a/crates/bitwarden-uniffi/src/platform/fido2.rs
+++ b/crates/bitwarden-uniffi/src/platform/fido2.rs
@@ -18,6 +18,7 @@ pub struct ClientFido2(pub(crate) bitwarden_fido::ClientFido2);
 
 #[uniffi::export]
 impl ClientFido2 {
+    /// FIDO2 authenticator for interacting with credentials stored in the vault.
     pub fn vault_authenticator(
         &self,
         user_interface: Arc<dyn Fido2UserInterface>,
@@ -34,6 +35,13 @@ impl ClientFido2 {
         ))
     }
 
+    /// FIDO2 authenticator for interacting with credentials stored on the
+    /// device.
+    ///
+    /// The credentials created with this authenticator are encrypted
+    /// with the given external encryption key, not the user key, so the same
+    /// device-specific key must be given to use credentials created with this
+    /// authenticator.
     pub fn device_authenticator(
         &self,
         user_interface: Arc<dyn Fido2UserInterface>,

--- a/crates/bitwarden-uniffi/src/platform/mod.rs
+++ b/crates/bitwarden-uniffi/src/platform/mod.rs
@@ -35,9 +35,7 @@ impl PlatformClient {
 
     /// FIDO2 operations
     pub fn fido2(&self) -> fido2::ClientFido2 {
-        // Do not expose HMAC secret to vault authenticator yet.
-        let enable_hmac_secret = false;
-        fido2::ClientFido2(self.0.fido2(enable_hmac_secret))
+        fido2::ClientFido2(self.0.fido2())
     }
 
     pub fn state(&self) -> StateClient {

--- a/crates/bitwarden-uniffi/src/platform/mod.rs
+++ b/crates/bitwarden-uniffi/src/platform/mod.rs
@@ -35,7 +35,9 @@ impl PlatformClient {
 
     /// FIDO2 operations
     pub fn fido2(&self) -> fido2::ClientFido2 {
-        fido2::ClientFido2(self.0.fido2())
+        // Do not expose HMAC secret to vault authenticator yet.
+        let enable_hmac_secret = false;
+        fido2::ClientFido2(self.0.fido2(enable_hmac_secret))
     }
 
     pub fn state(&self) -> StateClient {

--- a/crates/bitwarden-uniffi/src/vault/ciphers.rs
+++ b/crates/bitwarden-uniffi/src/vault/ciphers.rs
@@ -42,8 +42,11 @@ impl CiphersClient {
     pub fn decrypt_fido2_credentials(
         &self,
         cipher_view: CipherView,
+        encryption_key: Option<Vec<u8>>,
     ) -> Result<Vec<Fido2CredentialView>> {
-        Ok(self.0.decrypt_fido2_credentials(cipher_view)?)
+        Ok(self
+            .0
+            .decrypt_fido2_credentials(cipher_view, encryption_key)?)
     }
 
     /// Move a cipher to an organization, reencrypting the cipher key if necessary

--- a/crates/bitwarden-uniffi/swift/iOS/App/ContentView.swift
+++ b/crates/bitwarden-uniffi/swift/iOS/App/ContentView.swift
@@ -345,7 +345,7 @@ struct ContentView: View {
     func authenticatorTest(clientFido: ClientFido2) async throws {
         let ui = Fido2UserInterfaceImpl()
         let cs = Fido2CredentialStoreImpl()
-        let authenticator = clientFido.authenticator(userInterface: ui, credentialStore: cs)
+        let authenticator = clientFido.vaultAuthenticator(userInterface: ui, credentialStore: cs)
 
         // Make credential
         let _ = try await authenticator.makeCredential(request: MakeCredentialRequest(

--- a/crates/bitwarden-uniffi/swift/iOS/App/ContentView.swift
+++ b/crates/bitwarden-uniffi/swift/iOS/App/ContentView.swift
@@ -345,7 +345,7 @@ struct ContentView: View {
     func authenticatorTest(clientFido: ClientFido2) async throws {
         let ui = Fido2UserInterfaceImpl()
         let cs = Fido2CredentialStoreImpl()
-        let authenticator = clientFido.vaultAuthenticator(userInterface: ui, credentialStore: cs)
+        let authenticator = try clientFido.vaultAuthenticator(userInterface: ui, credentialStore: cs)
 
         // Make credential
         let _ = try await authenticator.makeCredential(request: MakeCredentialRequest(

--- a/crates/bitwarden-vault/src/cipher/cipher.rs
+++ b/crates/bitwarden-vault/src/cipher/cipher.rs
@@ -694,8 +694,9 @@ impl CipherView {
     pub fn decrypt_fido2_credentials(
         &self,
         ctx: &mut KeyStoreContext<KeyIds>,
+        key_id: Option<SymmetricKeyId>,
     ) -> Result<Vec<Fido2CredentialView>, CryptoError> {
-        let key = self.key_identifier();
+        let key = key_id.unwrap_or_else(|| self.key_identifier());
         let ciphers_key = Cipher::decrypt_cipher_key(ctx, key, &self.key)?;
 
         Ok(self
@@ -775,9 +776,10 @@ impl CipherView {
     pub fn set_new_fido2_credentials(
         &mut self,
         ctx: &mut KeyStoreContext<KeyIds>,
+        key_id: Option<SymmetricKeyId>,
         creds: Vec<Fido2CredentialFullView>,
     ) -> Result<(), CipherError> {
-        let key = self.key_identifier();
+        let key = key_id.unwrap_or_else(|| self.key_identifier());
 
         let ciphers_key = Cipher::decrypt_cipher_key(ctx, key, &self.key)?;
 
@@ -791,8 +793,9 @@ impl CipherView {
     pub fn get_fido2_credentials(
         &self,
         ctx: &mut KeyStoreContext<KeyIds>,
+        key_id: Option<SymmetricKeyId>,
     ) -> Result<Vec<Fido2CredentialFullView>, CipherError> {
-        let key = self.key_identifier();
+        let key = key_id.unwrap_or_else(|| self.key_identifier());
 
         let ciphers_key = Cipher::decrypt_cipher_key(ctx, key, &self.key)?;
 
@@ -806,8 +809,9 @@ impl CipherView {
     pub fn decrypt_fido2_private_key(
         &self,
         ctx: &mut KeyStoreContext<KeyIds>,
+        key_id: Option<SymmetricKeyId>,
     ) -> Result<String, CipherError> {
-        let fido2_credential = self.get_fido2_credentials(ctx)?;
+        let fido2_credential = self.get_fido2_credentials(ctx, key_id)?;
 
         Ok(fido2_credential[0].key_value.clone())
     }
@@ -1738,7 +1742,9 @@ mod tests {
         cipher_view.login.as_mut().unwrap().fido2_credentials =
             Some(vec![fido2_credential.clone()]);
 
-        let decrypted_key_value = cipher_view.decrypt_fido2_private_key(&mut ctx).unwrap();
+        let decrypted_key_value = cipher_view
+            .decrypt_fido2_private_key(&mut ctx, None)
+            .unwrap();
         assert_eq!(decrypted_key_value, "123");
     }
 

--- a/crates/bitwarden-vault/src/cipher/cipher.rs
+++ b/crates/bitwarden-vault/src/cipher/cipher.rs
@@ -1279,6 +1279,7 @@ mod tests {
             rp_name: None,
             user_display_name: None,
             discoverable: "true".to_string().encrypt(ctx, key).unwrap(),
+            hmac_secret: Some("123".to_string().encrypt(ctx, key).unwrap()),
             creation_date: "2024-06-07T14:12:36.150Z".parse().unwrap(),
         }
     }

--- a/crates/bitwarden-vault/src/cipher/login.rs
+++ b/crates/bitwarden-vault/src/cipher/login.rs
@@ -675,6 +675,7 @@ impl From<Fido2Credential> for bitwarden_api_api::models::CipherFido2CredentialM
             user_display_name: cred.user_display_name.map(|n| n.to_string()),
             discoverable: Some(cred.discoverable.to_string()),
             creation_date: cred.creation_date.to_rfc3339(),
+            hmac_secret: cred.hmac_secret.map(|h| h.to_string()),
         }
     }
 }

--- a/crates/bitwarden-vault/src/cipher/login.rs
+++ b/crates/bitwarden-vault/src/cipher/login.rs
@@ -102,6 +102,7 @@ pub struct Fido2Credential {
     pub rp_name: Option<EncString>,
     pub user_display_name: Option<EncString>,
     pub discoverable: EncString,
+    pub hmac_secret: Option<EncString>,
     pub creation_date: DateTime<Utc>,
 }
 
@@ -138,6 +139,9 @@ pub struct Fido2CredentialView {
     pub rp_name: Option<String>,
     pub user_display_name: Option<String>,
     pub discoverable: String,
+    // This value doesn't need to be returned to the client
+    // so we keep it encrypted until we need it
+    pub hmac_secret: Option<EncString>,
     pub creation_date: DateTime<Utc>,
 }
 
@@ -160,6 +164,7 @@ pub struct Fido2CredentialFullView {
     pub rp_name: Option<String>,
     pub user_display_name: Option<String>,
     pub discoverable: String,
+    pub hmac_secret: Option<String>,
     pub creation_date: DateTime<Utc>,
 }
 
@@ -226,6 +231,11 @@ impl CompositeEncryptable<KeyIds, SymmetricKeyId, Fido2Credential> for Fido2Cred
             rp_name: self.rp_name.encrypt(ctx, key)?,
             user_display_name: self.user_display_name.encrypt(ctx, key)?,
             discoverable: self.discoverable.encrypt(ctx, key)?,
+            hmac_secret: self
+                .hmac_secret
+                .as_ref()
+                .map(|s| s.encrypt(ctx, key))
+                .transpose()?,
             creation_date: self.creation_date,
         })
     }
@@ -250,6 +260,7 @@ impl Decryptable<KeyIds, SymmetricKeyId, Fido2CredentialFullView> for Fido2Crede
             rp_name: self.rp_name.decrypt(ctx, key)?,
             user_display_name: self.user_display_name.decrypt(ctx, key)?,
             discoverable: self.discoverable.decrypt(ctx, key)?,
+            hmac_secret: self.hmac_secret.decrypt(ctx, key)?,
             creation_date: self.creation_date,
         })
     }
@@ -274,6 +285,7 @@ impl Decryptable<KeyIds, SymmetricKeyId, Fido2CredentialFullView> for Fido2Crede
             rp_name: self.rp_name.clone(),
             user_display_name: self.user_display_name.clone(),
             discoverable: self.discoverable.clone(),
+            hmac_secret: self.hmac_secret.decrypt(ctx, key)?,
             creation_date: self.creation_date,
         })
     }
@@ -493,6 +505,7 @@ impl CompositeEncryptable<KeyIds, SymmetricKeyId, Fido2Credential> for Fido2Cred
             rp_name: self.rp_name.encrypt(ctx, key)?,
             user_display_name: self.user_display_name.encrypt(ctx, key)?,
             discoverable: self.discoverable.encrypt(ctx, key)?,
+            hmac_secret: self.hmac_secret.clone(),
             creation_date: self.creation_date,
         })
     }
@@ -517,6 +530,7 @@ impl Decryptable<KeyIds, SymmetricKeyId, Fido2CredentialView> for Fido2Credentia
             rp_name: self.rp_name.decrypt(ctx, key)?,
             user_display_name: self.user_display_name.decrypt(ctx, key)?,
             discoverable: self.discoverable.decrypt(ctx, key)?,
+            hmac_secret: self.hmac_secret.clone(),
             creation_date: self.creation_date,
         })
     }
@@ -612,6 +626,9 @@ impl TryFrom<bitwarden_api_api::models::CipherFido2CredentialModel> for Fido2Cre
                 .ok()
                 .flatten(),
             discoverable: require!(value.discoverable).parse()?,
+            hmac_secret: EncString::try_from_optional(value.hmac_secret)
+                .ok()
+                .flatten(),
             creation_date: value.creation_date.parse()?,
         })
     }


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-27582
https://bitwarden.atlassian.net/browse/PM-26177

## 📔 Objective

This adds the ability to use PRF for passkeys and authenticate using key material tied to a device, not the user key. (We're calling this the "device auth key.") This will effectively allow native clients to act as login+unlock passkeys without requiring vault unlock.

- Incorporates upstream passkey-rs changes
- Adds separate "vault authenticator" and "device authenticator" to distinguish between device-bound flow
- Allows encrypting passkey using a provided external key (device binding key)
- Adds hmacSecret field to FIDO2 credential models

Depends on #494.

# Breaking Changes

- This renames the current `authenticator()` method to `vault_authenticator()` to clarify that this authenticator will operate on vault items, as opposed to the new `device_authenticator()` method, which operates on items stored on the device with a caller-provided encryption key.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation
  team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
