### PR TITLE
[BEEEP] Bitwarden-crypto: update rustcrypto deps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -540,7 +540,6 @@ dependencies = [
  "log",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
- "rand_core 0.9.3",
  "reqwest",
  "rustls",
  "rustls-platform-verifier",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -942,7 +942,6 @@ dependencies = [
  "chrono",
  "data-encoding",
  "futures",
- "hmac",
  "hmac 0.12.1",
  "percent-encoding",
  "reqwest",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -23,8 +23,18 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.6",
  "generic-array",
+]
+
+[[package]]
+name = "aead"
+version = "0.6.0-rc.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac8202ab55fcbf46ca829833f347a82a2a4ce0596f0304ac322c2d100030cd56"
+dependencies = [
+ "crypto-common 0.2.0-rc.4",
+ "inout 0.2.1",
 ]
 
 [[package]]
@@ -34,7 +44,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
 dependencies = [
  "cfg-if",
- "cipher",
+ "cipher 0.4.4",
  "cpufeatures",
  "zeroize",
 ]
@@ -45,9 +55,9 @@ version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1"
 dependencies = [
- "aead",
+ "aead 0.5.2",
  "aes",
- "cipher",
+ "cipher 0.4.4",
  "ctr",
  "ghash",
  "subtle",
@@ -310,6 +320,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
 
 [[package]]
+name = "base16ct"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8b59d472eab27ade8d770dcb11da7201c11234bef9f82ce7aa517be028d462b"
+
+[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -374,8 +390,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6aeac2e1fe888769f34f05ac343bbef98b14d1ffb292ab69d4608b3abc86f2a2"
 dependencies = [
  "blowfish",
- "pbkdf2",
- "sha2",
+ "pbkdf2 0.12.2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -524,6 +540,7 @@ dependencies = [
  "log",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
+ "rand_core 0.9.3",
  "reqwest",
  "rustls",
  "rustls-platform-verifier",
@@ -558,24 +575,27 @@ dependencies = [
  "ciborium",
  "coset",
  "criterion",
- "ed25519-dalek",
+ "digest 0.11.0-rc.3",
+ "ed25519-dalek 3.0.0-pre.1",
  "generic-array",
  "hkdf",
- "hmac",
+ "hmac 0.13.0-rc.2",
  "num-bigint",
  "num-traits",
- "pbkdf2",
- "rand 0.8.5",
+ "pbkdf2 0.13.0-rc.1",
+ "rand 0.9.2",
  "rand_chacha 0.3.1",
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.3",
  "rayon",
- "rsa",
+ "rsa 0.10.0-rc.9",
  "schemars 1.0.0",
  "serde",
  "serde_bytes",
  "serde_json",
  "serde_repr",
- "sha1",
- "sha2",
+ "sha1 0.11.0-rc.2",
+ "sha2 0.11.0-rc.2",
  "subtle",
  "thiserror 2.0.12",
  "tsify",
@@ -784,13 +804,13 @@ version = "1.0.0"
 dependencies = [
  "bitwarden-error",
  "bitwarden-vault",
- "ed25519",
- "ed25519-dalek",
- "pem-rfc7468",
- "pkcs8",
+ "ed25519 2.2.3",
+ "ed25519-dalek 2.1.1",
+ "pem-rfc7468 0.7.0",
+ "pkcs8 0.10.2",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
- "rsa",
+ "rsa 0.9.8",
  "serde",
  "ssh-key",
  "thiserror 2.0.12",
@@ -922,14 +942,14 @@ dependencies = [
  "bitwarden-uuid",
  "chrono",
  "data-encoding",
- "hmac",
+ "hmac 0.12.1",
  "percent-encoding",
  "reqwest",
  "serde",
  "serde_json",
  "serde_repr",
- "sha1",
- "sha2",
+ "sha1 0.10.6",
+ "sha2 0.10.9",
  "thiserror 2.0.12",
  "tokio",
  "tsify",
@@ -970,7 +990,7 @@ version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
 dependencies = [
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -980,6 +1000,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.11.0-rc.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9ef36a6fcdb072aa548f3da057640ec10859eb4e91ddf526ee648d50c76a949"
+dependencies = [
+ "hybrid-array",
 ]
 
 [[package]]
@@ -998,7 +1027,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e412e2cd0f2b2d93e02543ceae7917b3c70331573df19ee046bcbc35e45e87d7"
 dependencies = [
  "byteorder",
- "cipher",
+ "cipher 0.4.4",
 ]
 
 [[package]]
@@ -1042,7 +1071,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
- "thiserror 1.0.69",
+ "thiserror 2.0.12",
  "tokio",
  "uuid",
  "wiremock",
@@ -1116,7 +1145,7 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26b52a9543ae338f279b96b0b9fed9c8093744685043739079ce85cd58f289a6"
 dependencies = [
- "cipher",
+ "cipher 0.4.4",
 ]
 
 [[package]]
@@ -1153,21 +1182,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818"
 dependencies = [
  "cfg-if",
- "cipher",
+ "cipher 0.4.4",
+ "cpufeatures",
+]
+
+[[package]]
+name = "chacha20"
+version = "0.10.0-rc.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9bd162f2b8af3e0639d83f28a637e4e55657b7a74508dba5a9bf4da523d5c9e9"
+dependencies = [
+ "cfg-if",
+ "cipher 0.5.0-rc.1",
  "cpufeatures",
 ]
 
 [[package]]
 name = "chacha20poly1305"
-version = "0.10.1"
+version = "0.11.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10cd79432192d1c0f4e1a0fef9527696cc039165d729fb41b3f4f4f354c2dc35"
+checksum = "ecc260dd2c69bf5581e9603fff348843363a649edde02768e84c0088f21c3f52"
 dependencies = [
- "aead",
- "chacha20",
- "cipher",
- "poly1305",
- "zeroize",
+ "aead 0.6.0-rc.2",
+ "chacha20 0.10.0-rc.2",
+ "cipher 0.5.0-rc.1",
+ "poly1305 0.9.0-rc.2",
 ]
 
 [[package]]
@@ -1218,9 +1257,20 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
- "crypto-common",
- "inout",
+ "crypto-common 0.1.6",
+ "inout 0.1.4",
  "zeroize",
+]
+
+[[package]]
+name = "cipher"
+version = "0.5.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e12a13eb01ded5d32ee9658d94f553a19e804204f2dc811df69ab4d9e0cb8c7"
+dependencies = [
+ "block-buffer 0.11.0-rc.5",
+ "crypto-common 0.2.0-rc.4",
+ "inout 0.2.1",
 ]
 
 [[package]]
@@ -1375,6 +1425,12 @@ name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
+name = "const-oid"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dabb6555f92fb9ee4140454eb5dcd14c7960e1225c6d1a6cc361f032947713e"
 
 [[package]]
 name = "content_inspector"
@@ -1583,14 +1639,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-bigint"
+version = "0.7.0-rc.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f4b0fda9462026d53a3ef37c5ec283639ee8494a1a5401109c0e2a3fb4d490c"
+dependencies = [
+ "num-traits",
+ "rand_core 0.9.3",
+ "serdect 0.4.1",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "crypto-common"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
- "rand_core 0.6.4",
  "typenum",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.2.0-rc.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8235645834fbc6832939736ce2f2d08192652269e11010a6240f61b908a1c6"
+dependencies = [
+ "hybrid-array",
+ "rand_core 0.9.3",
+]
+
+[[package]]
+name = "crypto-primes"
+version = "0.7.0-pre.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25f2523fbb68811c8710829417ad488086720a6349e337c38d12fa81e09e50bf"
+dependencies = [
+ "crypto-bigint 0.7.0-rc.9",
+ "libm",
+ "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -1620,7 +1709,7 @@ version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
 dependencies = [
- "cipher",
+ "cipher 0.4.4",
 ]
 
 [[package]]
@@ -1632,8 +1721,24 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "curve25519-dalek-derive",
- "digest",
- "fiat-crypto",
+ "digest 0.10.7",
+ "fiat-crypto 0.2.9",
+ "rustc_version",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek"
+version = "5.0.0-pre.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f9200d1d13637f15a6acb71e758f64624048d85b31a5fdbfd8eca1e2687d0b7"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "curve25519-dalek-derive",
+ "digest 0.11.0-rc.3",
+ "fiat-crypto 0.3.0",
  "rustc_version",
  "subtle",
  "zeroize",
@@ -1748,8 +1853,19 @@ version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
- "const-oid",
- "pem-rfc7468",
+ "const-oid 0.9.6",
+ "pem-rfc7468 0.7.0",
+ "zeroize",
+]
+
+[[package]]
+name = "der"
+version = "0.8.0-rc.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9d8dd2f26c86b27a2a8ea2767ec7f9df7a89516e4794e54ac01ee618dda3aa4"
+dependencies = [
+ "const-oid 0.10.1",
+ "pem-rfc7468 1.0.0-rc.3",
  "zeroize",
 ]
 
@@ -1821,9 +1937,21 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
- "const-oid",
- "crypto-common",
+ "block-buffer 0.10.4",
+ "const-oid 0.9.6",
+ "crypto-common 0.1.6",
+ "subtle",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.0-rc.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dac89f8a64533a9b0eaa73a68e424db0fb1fd6271c74cc0125336a05f090568d"
+dependencies = [
+ "block-buffer 0.11.0-rc.5",
+ "const-oid 0.10.1",
+ "crypto-common 0.2.0-rc.4",
  "subtle",
 ]
 
@@ -1865,12 +1993,12 @@ version = "0.16.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
 dependencies = [
- "der",
- "digest",
+ "der 0.7.10",
+ "digest 0.10.7",
  "elliptic-curve",
  "rfc6979",
- "signature",
- "spki",
+ "signature 2.2.0",
+ "spki 0.7.3",
 ]
 
 [[package]]
@@ -1879,8 +2007,17 @@ version = "2.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
 dependencies = [
- "pkcs8",
- "signature",
+ "pkcs8 0.10.2",
+ "signature 2.2.0",
+]
+
+[[package]]
+name = "ed25519"
+version = "3.0.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ef49c0b20c0ad088893ad2a790a29c06a012b3f05bcfc66661fd22a94b32129"
+dependencies = [
+ "signature 3.0.0-rc.4",
 ]
 
 [[package]]
@@ -1889,11 +2026,24 @@ version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a3daa8e81a3963a60642bcc1f90a670680bd4a77535faa384e9d1c79d620871"
 dependencies = [
- "curve25519-dalek",
- "ed25519",
- "rand_core 0.6.4",
+ "curve25519-dalek 4.1.3",
+ "ed25519 2.2.3",
  "serde",
- "sha2",
+ "sha2 0.10.9",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "ed25519-dalek"
+version = "3.0.0-pre.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad207ed88a133091f83224265eac21109930db09bedcad05d5252f2af2de20a1"
+dependencies = [
+ "curve25519-dalek 5.0.0-pre.1",
+ "ed25519 3.0.0-rc.1",
+ "rand_core 0.9.3",
+ "sha2 0.11.0-rc.2",
  "subtle",
  "zeroize",
 ]
@@ -1910,19 +2060,19 @@ version = "0.13.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
 dependencies = [
- "base16ct",
+ "base16ct 0.2.0",
  "base64ct",
- "crypto-bigint",
- "digest",
+ "crypto-bigint 0.5.5",
+ "digest 0.10.7",
  "ff",
  "generic-array",
  "group",
- "pem-rfc7468",
- "pkcs8",
+ "pem-rfc7468 0.7.0",
+ "pkcs8 0.10.2",
  "rand_core 0.6.4",
  "sec1",
  "serde_json",
- "serdect",
+ "serdect 0.2.0",
  "subtle",
  "zeroize",
 ]
@@ -2055,6 +2205,12 @@ name = "fiat-crypto"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
+
+[[package]]
+name = "fiat-crypto"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64cd1e32ddd350061ae6edb1b082d7c54915b5c672c389143b9a63403a109f24"
 
 [[package]]
 name = "flate2"
@@ -2401,11 +2557,11 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hkdf"
-version = "0.12.4"
+version = "0.13.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
+checksum = "d8ef30358b03ca095a5b910547f4f8d4b9f163e4057669c5233ef595b1ecf008"
 dependencies = [
- "hmac",
+ "hmac 0.13.0-rc.2",
 ]
 
 [[package]]
@@ -2414,7 +2570,16 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "hmac"
+version = "0.13.0-rc.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3fd4dc94c318c1ede8a2a48341c250d6ddecd3ba793da2820301a9f92417ad9"
+dependencies = [
+ "digest 0.11.0-rc.3",
 ]
 
 [[package]]
@@ -2471,6 +2636,15 @@ name = "httpdate"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f471e0a81b2f90ffc0cb2f951ae04da57de8baa46fa99112b062a5173a5088d0"
+dependencies = [
+ "typenum",
+]
 
 [[package]]
 name = "hyper"
@@ -2730,6 +2904,15 @@ checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
 dependencies = [
  "block-padding",
  "generic-array",
+]
+
+[[package]]
+name = "inout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7357b6e7aa75618c7864ebd0634b115a7218b0615f4cb1df33ac3eca23943d4"
+dependencies = [
+ "hybrid-array",
 ]
 
 [[package]]
@@ -3254,7 +3437,7 @@ dependencies = [
  "ecdsa",
  "elliptic-curve",
  "primeorder",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -3340,7 +3523,7 @@ dependencies = [
  "rand 0.8.5",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "strum",
 ]
 
@@ -3370,8 +3553,17 @@ version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
 dependencies = [
- "digest",
- "hmac",
+ "digest 0.10.7",
+ "hmac 0.12.1",
+]
+
+[[package]]
+name = "pbkdf2"
+version = "0.13.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca3fc18bb4460ac250ba6b75dfa7cf9d0b2273e3e623f660bd6ce2c3e902342e"
+dependencies = [
+ "digest 0.11.0-rc.3",
 ]
 
 [[package]]
@@ -3379,6 +3571,15 @@ name = "pem-rfc7468"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
+dependencies = [
+ "base64ct",
+]
+
+[[package]]
+name = "pem-rfc7468"
+version = "1.0.0-rc.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8e58fab693c712c0d4e88f8eb3087b6521d060bcaf76aeb20cb192d809115ba"
 dependencies = [
  "base64ct",
 ]
@@ -3407,9 +3608,19 @@ version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
 dependencies = [
- "der",
- "pkcs8",
- "spki",
+ "der 0.7.10",
+ "pkcs8 0.10.2",
+ "spki 0.7.3",
+]
+
+[[package]]
+name = "pkcs1"
+version = "0.8.0-rc.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "986d2e952779af96ea048f160fd9194e1751b4faea78bcf3ceb456efe008088e"
+dependencies = [
+ "der 0.8.0-rc.9",
+ "spki 0.8.0-rc.4",
 ]
 
 [[package]]
@@ -3419,11 +3630,11 @@ source = "git+https://github.com/bitwarden/rustcrypto-formats.git?rev=2b27c63034
 dependencies = [
  "aes",
  "cbc",
- "der",
- "pbkdf2",
+ "der 0.7.10",
+ "pbkdf2 0.12.2",
  "scrypt",
- "sha2",
- "spki",
+ "sha2 0.10.9",
+ "spki 0.7.3",
 ]
 
 [[package]]
@@ -3432,10 +3643,20 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
 dependencies = [
- "der",
+ "der 0.7.10",
  "pkcs5",
  "rand_core 0.6.4",
- "spki",
+ "spki 0.7.3",
+]
+
+[[package]]
+name = "pkcs8"
+version = "0.11.0-rc.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93eac55f10aceed84769df670ea4a32d2ffad7399400d41ee1c13b1cd8e1b478"
+dependencies = [
+ "der 0.8.0-rc.9",
+ "spki 0.8.0-rc.4",
 ]
 
 [[package]]
@@ -3499,7 +3720,17 @@ checksum = "8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf"
 dependencies = [
  "cpufeatures",
  "opaque-debug",
- "universal-hash",
+ "universal-hash 0.5.1",
+]
+
+[[package]]
+name = "poly1305"
+version = "0.9.0-rc.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb78a635f75d76d856374961deecf61031c0b6f928c83dc9c0924ab6c019c298"
+dependencies = [
+ "cpufeatures",
+ "universal-hash 0.6.0-rc.2",
 ]
 
 [[package]]
@@ -3511,7 +3742,7 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "opaque-debug",
- "universal-hash",
+ "universal-hash 0.5.1",
 ]
 
 [[package]]
@@ -3662,7 +3893,7 @@ dependencies = [
  "bytes",
  "getrandom 0.3.3",
  "lru-slab",
- "rand 0.9.1",
+ "rand 0.9.2",
  "ring",
  "rustc-hash",
  "rustls",
@@ -3716,9 +3947,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.1"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fbfd9d094a40bf3ae768db9361049ace4c0e04a4fd6b359518bd7b73a73dd97"
+checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.3",
@@ -3886,7 +4117,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
 dependencies = [
- "hmac",
+ "hmac 0.12.1",
  "subtle",
 ]
 
@@ -3919,17 +4150,36 @@ version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78928ac1ed176a5ca1d17e578a1825f3d81ca54cf41053a592584b020cfd691b"
 dependencies = [
- "const-oid",
- "digest",
+ "const-oid 0.9.6",
+ "digest 0.10.7",
  "num-bigint-dig",
  "num-integer",
  "num-traits",
- "pkcs1",
- "pkcs8",
+ "pkcs1 0.7.5",
+ "pkcs8 0.10.2",
  "rand_core 0.6.4",
- "sha2",
- "signature",
- "spki",
+ "sha2 0.10.9",
+ "signature 2.2.0",
+ "spki 0.7.3",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rsa"
+version = "0.10.0-rc.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf8955ab399f6426998fde6b76ae27233cce950705e758a6c17afd2f6d0e5d52"
+dependencies = [
+ "const-oid 0.10.1",
+ "crypto-bigint 0.7.0-rc.9",
+ "crypto-primes",
+ "digest 0.11.0-rc.3",
+ "pkcs1 0.8.0-rc.4",
+ "pkcs8 0.11.0-rc.7",
+ "rand_core 0.9.3",
+ "signature 3.0.0-rc.4",
+ "spki 0.8.0-rc.4",
  "subtle",
  "zeroize",
 ]
@@ -4087,7 +4337,7 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97a22f5af31f73a954c10289c93e8a50cc23d971e80ee446f1f6f7137a088213"
 dependencies = [
- "cipher",
+ "cipher 0.4.4",
 ]
 
 [[package]]
@@ -4185,9 +4435,9 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0516a385866c09368f0b5bcd1caff3366aace790fcd46e2bb032697bb172fd1f"
 dependencies = [
- "pbkdf2",
+ "pbkdf2 0.12.2",
  "salsa20",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -4196,11 +4446,11 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
 dependencies = [
- "base16ct",
- "der",
+ "base16ct 0.2.0",
+ "der 0.7.10",
  "generic-array",
- "pkcs8",
- "serdect",
+ "pkcs8 0.10.2",
+ "serdect 0.2.0",
  "subtle",
  "zeroize",
 ]
@@ -4394,7 +4644,17 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a84f14a19e9a014bb9f4512488d9829a68e04ecabffb0f9904cd1ace94598177"
 dependencies = [
- "base16ct",
+ "base16ct 0.2.0",
+ "serde",
+]
+
+[[package]]
+name = "serdect"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3ef0e35b322ddfaecbc60f34ab448e157e48531288ee49fafbb053696b8ffe2"
+dependencies = [
+ "base16ct 0.3.0",
  "serde",
 ]
 
@@ -4406,7 +4666,18 @@ checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "digest",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha1"
+version = "0.11.0-rc.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5e046edf639aa2e7afb285589e5405de2ef7e61d4b0ac1e30256e3eab911af9"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest 0.11.0-rc.3",
 ]
 
 [[package]]
@@ -4417,7 +4688,18 @@ checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "digest",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0-rc.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1e3878ab0f98e35b2df35fe53201d088299b41a6bb63e3e34dada2ac4abd924"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest 0.11.0-rc.3",
 ]
 
 [[package]]
@@ -4472,8 +4754,18 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
- "digest",
+ "digest 0.10.7",
  "rand_core 0.6.4",
+]
+
+[[package]]
+name = "signature"
+version = "3.0.0-rc.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc280a6ff65c79fbd6622f64d7127f32b85563bca8c53cd2e9141d6744a9056d"
+dependencies = [
+ "digest 0.11.0-rc.3",
+ "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -4533,7 +4825,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
 dependencies = [
  "base64ct",
- "der",
+ "der 0.7.10",
+]
+
+[[package]]
+name = "spki"
+version = "0.8.0-rc.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8baeff88f34ed0691978ec34440140e1572b68c7dd4a495fd14a3dc1944daa80"
+dependencies = [
+ "base64ct",
+ "der 0.8.0-rc.9",
 ]
 
 [[package]]
@@ -4545,10 +4847,10 @@ dependencies = [
  "aes",
  "aes-gcm",
  "cbc",
- "chacha20",
- "cipher",
+ "chacha20 0.9.1",
+ "cipher 0.4.4",
  "ctr",
- "poly1305",
+ "poly1305 0.8.0",
  "ssh-encoding",
  "subtle",
 ]
@@ -4560,8 +4862,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb9242b9ef4108a78e8cd1a2c98e193ef372437f8c22be363075233321dd4a15"
 dependencies = [
  "base64ct",
- "pem-rfc7468",
- "sha2",
+ "pem-rfc7468 0.7.0",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -4571,12 +4873,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b86f5297f0f04d08cabaa0f6bff7cb6aec4d9c3b49d87990d63da9d9156a8c3"
 dependencies = [
  "bcrypt-pbkdf",
- "ed25519-dalek",
+ "ed25519-dalek 2.1.1",
  "num-bigint-dig",
  "rand_core 0.6.4",
- "rsa",
- "sha2",
- "signature",
+ "rsa 0.9.8",
+ "sha2 0.10.9",
+ "signature 2.2.0",
  "ssh-cipher",
  "ssh-encoding",
  "subtle",
@@ -5323,7 +5625,17 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.6",
+ "subtle",
+]
+
+[[package]]
+name = "universal-hash"
+version = "0.6.0-rc.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a55be643b40a21558f44806b53ee9319595bc7ca6896372e4e08e5d7d83c9cd6"
+dependencies = [
+ "crypto-common 0.2.0-rc.4",
  "subtle",
 ]
 
@@ -5612,7 +5924,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/crates/bitwarden-core/Cargo.toml
+++ b/crates/bitwarden-core/Cargo.toml
@@ -51,6 +51,7 @@ chrono = { workspace = true, features = ["std"] }
 getrandom = { version = ">=0.2.9, <0.3", features = ["js"] }
 log = { workspace = true }
 rand = ">=0.8.5, <0.9"
+rand_core = { version = "0.9.3", features = ["os_rng"] }
 reqwest = { workspace = true }
 schemars = { workspace = true }
 serde = { workspace = true }

--- a/crates/bitwarden-core/Cargo.toml
+++ b/crates/bitwarden-core/Cargo.toml
@@ -51,7 +51,6 @@ chrono = { workspace = true, features = ["std"] }
 getrandom = { version = ">=0.2.9, <0.3", features = ["js"] }
 log = { workspace = true }
 rand = ">=0.8.5, <0.9"
-rand_core = { version = "0.9.3", features = ["os_rng"] }
 reqwest = { workspace = true }
 schemars = { workspace = true }
 serde = { workspace = true }

--- a/crates/bitwarden-core/src/auth/auth_client.rs
+++ b/crates/bitwarden-core/src/auth/auth_client.rs
@@ -98,8 +98,7 @@ impl AuthClient {
 
     #[allow(missing_docs)]
     pub fn make_key_connector_keys(&self) -> Result<KeyConnectorResponse, CryptoError> {
-        let mut rng = rand::thread_rng();
-        make_key_connector_keys(&mut rng)
+        make_key_connector_keys()
     }
 
     #[allow(missing_docs)]

--- a/crates/bitwarden-core/src/auth/key_connector.rs
+++ b/crates/bitwarden-core/src/auth/key_connector.rs
@@ -9,10 +9,8 @@ pub struct KeyConnectorResponse {
     pub keys: RsaKeyPair,
 }
 
-pub(super) fn make_key_connector_keys(
-    mut rng: impl rand::RngCore,
-) -> Result<KeyConnectorResponse, CryptoError> {
-    let master_key = MasterKey::generate(&mut rng);
+pub(super) fn make_key_connector_keys() -> Result<KeyConnectorResponse, CryptoError> {
+    let master_key = MasterKey::generate();
     let (user_key, encrypted_user_key) = master_key.make_user_key()?;
     let keys = user_key.make_key_pair()?;
 
@@ -21,24 +19,4 @@ pub(super) fn make_key_connector_keys(
         encrypted_user_key: encrypted_user_key.to_string(),
         keys,
     })
-}
-
-#[cfg(test)]
-mod tests {
-    use rand::SeedableRng;
-    use rand_chacha::ChaCha8Rng;
-
-    use super::*;
-
-    #[test]
-    fn test_make_key_connector_keys() {
-        let mut rng = ChaCha8Rng::from_seed([0u8; 32]);
-
-        let result = make_key_connector_keys(&mut rng).unwrap();
-
-        assert_eq!(
-            result.master_key.to_string(),
-            "PgDvL4lfQNZ/W7joHwmloSyEDsPOmn87GBvhiO9xGh4="
-        );
-    }
 }

--- a/crates/bitwarden-crypto/Cargo.toml
+++ b/crates/bitwarden-crypto/Cargo.toml
@@ -34,26 +34,28 @@ bitwarden-encoding = { workspace = true }
 bitwarden-error = { workspace = true }
 bitwarden-uniffi-error = { workspace = true, optional = true }
 cbc = { version = ">=0.1.2, <0.2", features = ["alloc", "zeroize"] }
-chacha20poly1305 = { version = "0.10.1" }
+chacha20poly1305 = { version = "0.11.0-rc.1" }
 ciborium = { version = ">=0.2.2, <0.3" }
 coset = { version = ">=0.3.8, <0.4" }
-ed25519-dalek = { workspace = true, features = ["rand_core"] }
+digest = { version = "=0.11.0-rc.3" }
+ed25519-dalek = { version = "=3.0.0-pre.1", features = ["rand_core"] }
 generic-array = { version = ">=0.14.7, <1.0", features = ["zeroize"] }
-hkdf = ">=0.12.3, <0.13"
-hmac = ">=0.12.1, <0.13"
+hkdf = "=0.13.0-rc.2"
+hmac = "=0.13.0-rc.2"
 num-bigint = ">=0.4, <0.5"
 num-traits = ">=0.2.15, <0.3"
-pbkdf2 = { version = ">=0.12.1, <0.13", default-features = false }
-rand = ">=0.8.5, <0.9"
-rand_chacha = ">=0.3.1, <0.4.0"
+pbkdf2 = { version = "=0.13.0-rc.1", default-features = false }
+rand = "0.9.2"
+rand_chacha = "=0.9.0"
+rand_core = { version = "0.9.3", features = ["os_rng"] }
 rayon = ">=1.8.1, <2.0"
-rsa = ">=0.9.2, <0.10"
+rsa = "=0.10.0-rc.9"
 schemars = { workspace = true }
 serde = { workspace = true }
 serde_bytes = { workspace = true }
 serde_repr.workspace = true
-sha1 = ">=0.10.5, <0.11"
-sha2 = ">=0.10.6, <0.11"
+sha1 = "=0.11.0-rc.2"
+sha2 = "=0.11.0-rc.2"
 subtle = ">=2.5.0, <3.0"
 thiserror = { workspace = true }
 tsify = { workspace = true, optional = true }

--- a/crates/bitwarden-crypto/src/aes.rs
+++ b/crates/bitwarden-crypto/src/aes.rs
@@ -7,7 +7,7 @@
 
 use aes::cipher::{BlockDecryptMut, BlockEncryptMut, KeyIvInit, block_padding::Pkcs7};
 use generic_array::GenericArray;
-use hmac::Mac;
+use hmac::{KeyInit, Mac};
 use subtle::ConstantTimeEq;
 use typenum::U32;
 
@@ -66,7 +66,7 @@ pub(crate) fn encrypt_aes256_hmac(
     mac_key: &GenericArray<u8, U32>,
     key: &GenericArray<u8, U32>,
 ) -> Result<([u8; 16], [u8; 32], Vec<u8>)> {
-    let rng = rand::thread_rng();
+    let rng = rand::rng();
     let (iv, data) = encrypt_aes256_internal(rng, data_dec, key);
     let mac = generate_mac(mac_key, &iv, &data)?;
 

--- a/crates/bitwarden-crypto/src/keys/asymmetric_crypto_key.rs
+++ b/crates/bitwarden-crypto/src/keys/asymmetric_crypto_key.rs
@@ -86,7 +86,7 @@ impl CryptoKey for AsymmetricCryptoKey {}
 impl AsymmetricCryptoKey {
     /// Generate a random AsymmetricCryptoKey (RSA-2048).
     pub fn make(algorithm: PublicKeyEncryptionAlgorithm) -> Self {
-        Self::make_internal(algorithm, &mut rand::thread_rng())
+        Self::make_internal(algorithm, &mut rand::rng())
     }
 
     fn make_internal<R: rand::CryptoRng + rand::RngCore>(

--- a/crates/bitwarden-crypto/src/keys/key_id.rs
+++ b/crates/bitwarden-crypto/src/keys/key_id.rs
@@ -24,7 +24,7 @@ impl KeyId {
         // We do not use the uuid crate's random generation functionality here to make sure the
         // entropy sampling aligns with the rest of this crates usage of CSPRNGs.
         let mut random_seed = [0u8; UUID_SEED_SIZE];
-        rand::thread_rng().fill_bytes(&mut random_seed);
+        rand::rng().fill_bytes(&mut random_seed);
 
         let uuid = uuid::Builder::from_random_bytes(random_seed)
             .with_version(uuid::Version::Random)

--- a/crates/bitwarden-crypto/src/keys/shareable_key.rs
+++ b/crates/bitwarden-crypto/src/keys/shareable_key.rs
@@ -1,7 +1,7 @@
 use std::pin::Pin;
 
 use generic_array::GenericArray;
-use hmac::Mac;
+use hmac::{KeyInit, Mac};
 use typenum::{U32, U64};
 use zeroize::{Zeroize, Zeroizing};
 
@@ -18,13 +18,11 @@ pub fn derive_shareable_key(
     info: Option<&str>,
 ) -> Aes256CbcHmacKey {
     // Because all inputs are fixed size, we can unwrap all errors here without issue
-    let res = Zeroizing::new(
-        PbkdfSha256Hmac::new_from_slice(format!("bitwarden-{name}").as_bytes())
-            .expect("hmac new_from_slice should not fail")
-            .chain_update(secret)
-            .finalize()
-            .into_bytes(),
-    );
+    let res = PbkdfSha256Hmac::new_from_slice(format!("bitwarden-{name}").as_bytes())
+        .expect("hmac new_from_slice should not fail")
+        .chain_update(secret)
+        .finalize()
+        .into_bytes();
 
     let mut key: Pin<Box<GenericArray<u8, U64>>> =
         hkdf_expand(&res, info).expect("Input is a valid size");

--- a/crates/bitwarden-crypto/src/keys/symmetric_crypto_key.rs
+++ b/crates/bitwarden-crypto/src/keys/symmetric_crypto_key.rs
@@ -122,13 +122,13 @@ impl SymmetricCryptoKey {
 
     /// Generate a new random AES256_CBC_HMAC [SymmetricCryptoKey]
     pub fn make_aes256_cbc_hmac_key() -> Self {
-        let rng = rand::thread_rng();
+        let rng = rand::rng();
         Self::make_aes256_cbc_hmac_key_internal(rng)
     }
 
     /// Generate a new random XChaCha20Poly1305 [SymmetricCryptoKey]
     pub fn make_xchacha20_poly1305_key() -> Self {
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
         let mut enc_key = Box::pin(GenericArray::<u8, U32>::default());
         rng.fill(enc_key.as_mut_slice());
         Self::XChaCha20Poly1305Key(XChaCha20Poly1305Key {

--- a/crates/bitwarden-crypto/src/keys/symmetric_crypto_key.rs
+++ b/crates/bitwarden-crypto/src/keys/symmetric_crypto_key.rs
@@ -82,7 +82,7 @@ pub struct XChaCha20Poly1305Key {
 impl XChaCha20Poly1305Key {
     /// Creates a new XChaCha20Poly1305Key with a securely sampled cryptographic key and key id.
     pub fn make() -> Self {
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
         let mut enc_key = Box::pin(GenericArray::<u8, U32>::default());
         rng.fill(enc_key.as_mut_slice());
         let mut key_id = [0u8; KEY_ID_SIZE];

--- a/crates/bitwarden-crypto/src/rsa.rs
+++ b/crates/bitwarden-crypto/src/rsa.rs
@@ -23,7 +23,7 @@ pub struct RsaKeyPair {
 
 /// Generate a new RSA key pair of 2048 bits
 pub(crate) fn make_key_pair(key: &SymmetricCryptoKey) -> Result<RsaKeyPair> {
-    let mut rng = rand::thread_rng();
+    let mut rng = rand::rng();
     let bits = 2048;
     let priv_key = RsaPrivateKey::new(&mut rng, bits).expect("failed to generate a key");
     let pub_key = RsaPublicKey::from(&priv_key);
@@ -56,7 +56,7 @@ pub(crate) fn make_key_pair(key: &SymmetricCryptoKey) -> Result<RsaKeyPair> {
 
 /// Encrypt data using RSA-OAEP-SHA1 with a 2048 bit key
 pub(super) fn encrypt_rsa2048_oaep_sha1(public_key: &RsaPublicKey, data: &[u8]) -> Result<Vec<u8>> {
-    let mut rng = rand::thread_rng();
+    let mut rng = rand::rng();
 
     let padding = Oaep::new::<Sha1>();
     public_key

--- a/crates/bitwarden-crypto/src/safe/password_protected_key_envelope.rs
+++ b/crates/bitwarden-crypto/src/safe/password_protected_key_envelope.rs
@@ -382,7 +382,7 @@ impl TryInto<Argon2RawSettings> for &Header {
 
 fn make_salt() -> [u8; ENVELOPE_ARGON2_SALT_SIZE] {
     let mut salt = [0u8; ENVELOPE_ARGON2_SALT_SIZE];
-    rand::thread_rng().fill_bytes(&mut salt);
+    rand::rng().fill_bytes(&mut salt);
     salt
 }
 

--- a/crates/bitwarden-crypto/src/signing/signing_key.rs
+++ b/crates/bitwarden-crypto/src/signing/signing_key.rs
@@ -51,7 +51,7 @@ impl SigningKey {
             SignatureAlgorithm::Ed25519 => SigningKey {
                 id: KeyId::make(),
                 inner: RawSigningKey::Ed25519(Box::pin(ed25519_dalek::SigningKey::generate(
-                    &mut rand::thread_rng(),
+                    &mut rand::rng(),
                 ))),
             },
         }

--- a/crates/bitwarden-crypto/src/util.rs
+++ b/crates/bitwarden-crypto/src/util.rs
@@ -5,7 +5,7 @@ use generic_array::GenericArray;
 use hmac::digest::OutputSizeUser;
 use rand::{
     Rng,
-    distributions::{Alphanumeric, DistString, Distribution, Standard},
+    distr::{Alphanumeric, Distribution, SampleString, StandardUniform},
 };
 use zeroize::{Zeroize, Zeroizing};
 
@@ -33,10 +33,10 @@ pub(crate) fn hkdf_expand<T: ArrayLength<u8>>(
 /// Generate random bytes that are cryptographically secure
 pub fn generate_random_bytes<T>() -> Zeroizing<T>
 where
-    Standard: Distribution<T>,
+    StandardUniform: Distribution<T>,
     T: Zeroize,
 {
-    Zeroizing::new(rand::thread_rng().r#gen::<T>())
+    Zeroizing::new(rand::rng().random())
 }
 
 /// Generate a random alphanumeric string of a given length
@@ -44,7 +44,7 @@ where
 /// Note: Do not use this generating user facing passwords. Use the `bitwarden-generator` crate for
 /// that.
 pub fn generate_random_alphanumeric(len: usize) -> String {
-    Alphanumeric.sample_string(&mut rand::thread_rng(), len)
+    Alphanumeric.sample_string(&mut rand::rng(), len)
 }
 
 /// Derive pbkdf2 of a given password and salt

--- a/crates/bitwarden-crypto/src/xchacha20.rs
+++ b/crates/bitwarden-crypto/src/xchacha20.rs
@@ -18,7 +18,6 @@ use chacha20poly1305::{
     AeadCore, KeyInit, XChaCha20Poly1305,
     aead::{AeadInOut, array::Array},
 };
-use rand::{CryptoRng, RngCore};
 use typenum::Unsigned;
 
 use crate::CryptoError;
@@ -42,16 +41,6 @@ impl XChaCha20Poly1305Ciphertext {
 }
 
 pub(crate) fn encrypt_xchacha20_poly1305(
-    key: &[u8; KEY_SIZE],
-    plaintext_secret_data: &[u8],
-    associated_data: &[u8],
-) -> XChaCha20Poly1305Ciphertext {
-    let rng = rand::rng();
-    encrypt_xchacha20_poly1305_internal(rng, key, plaintext_secret_data, associated_data)
-}
-
-fn encrypt_xchacha20_poly1305_internal(
-    _rng: impl RngCore + CryptoRng,
     key: &[u8; KEY_SIZE],
     plaintext_secret_data: &[u8],
     associated_data: &[u8],


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective

Bumps at `rsa`, `rand`, to the release candidates / stable releases. This fixes a non-constant timing vulnerability in the rsa function. This requires bumping a few other crates within `bitwarden-crypto` as they depend transitively on `rand`, or `rsa` depends on them. Within the same crate, we cannot have different versions.

This unblocks using any newer rustcrypto library, or other rust cyrpto library, including `hpke`, `xwing`, `ml-dsa`, which are required for the move to pq-crypto.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation
  team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
