### PR TITLE
Fix wasm gated features in bitwarden-vault crate

### DIFF
--- a/crates/bitwarden-vault/src/cipher/attachment.rs
+++ b/crates/bitwarden-vault/src/cipher/attachment.rs
@@ -288,6 +288,7 @@ mod tests {
             size_name: Some("100 Bytes".into()),
             file_name: Some("Test.txt".into()),
             key: None,
+            #[cfg(feature = "wasm")]
             decrypted_key: None,
         };
 
@@ -346,6 +347,7 @@ mod tests {
             size_name: Some("161 Bytes".into()),
             file_name: Some("Test.txt".into()),
             key: Some("2.r288/AOSPiaLFkW07EBGBw==|SAmnnCbOLFjX5lnURvoualOetQwuyPc54PAmHDTRrhT0gwO9ailna9U09q9bmBfI5XrjNNEsuXssgzNygRkezoVQvZQggZddOwHB6KQW5EQ=|erIMUJp8j+aTcmhdE50zEX+ipv/eR1sZ7EwULJm/6DY=".parse().unwrap()),
+            #[cfg(feature = "wasm")]
             decrypted_key: None,
         };
 
@@ -405,6 +407,7 @@ mod tests {
             size_name: Some("161 Bytes".into()),
             file_name: Some("Test.txt".into()),
             key: None,
+            #[cfg(feature = "wasm")]
             decrypted_key: None,
         };
 

--- a/crates/bitwarden-vault/src/cipher/cipher.rs
+++ b/crates/bitwarden-vault/src/cipher/cipher.rs
@@ -1091,6 +1091,7 @@ mod tests {
             size_name: None,
             file_name: Some("Attachment test name".into()),
             key: None,
+            #[cfg(feature = "wasm")]
             decrypted_key: None,
         };
         cipher.attachments = Some(vec![attachment]);
@@ -1203,6 +1204,7 @@ mod tests {
             size_name: None,
             file_name: Some("Attachment test name".into()),
             key: None,
+            #[cfg(feature = "wasm")]
             decrypted_key: None,
         };
         cipher.attachments = Some(vec![attachment]);
@@ -1247,6 +1249,7 @@ mod tests {
             size_name: None,
             file_name: Some("Attachment test name".into()),
             key: Some(attachment_key_enc),
+            #[cfg(feature = "wasm")]
             decrypted_key: None,
         };
         cipher.attachments = Some(vec![attachment]);
@@ -1315,6 +1318,7 @@ mod tests {
             size_name: None,
             file_name: Some("Attachment test name".into()),
             key: Some(attachment_key_enc.clone()),
+            #[cfg(feature = "wasm")]
             decrypted_key: None,
         };
         cipher.attachments = Some(vec![attachment]);

--- a/crates/bitwarden-vault/src/cipher/cipher_client/mod.rs
+++ b/crates/bitwarden-vault/src/cipher/cipher_client/mod.rs
@@ -531,6 +531,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[cfg(feature = "wasm")]
     async fn test_encrypt_cipher_for_rotation() {
         let client = Client::init_test_account(test_bitwarden_com_account()).await;
 

--- a/crates/bitwarden-vault/src/cipher/cipher_client/mod.rs
+++ b/crates/bitwarden-vault/src/cipher/cipher_client/mod.rs
@@ -1,7 +1,9 @@
 use std::sync::Arc;
 
 use bitwarden_core::{Client, OrganizationId};
-use bitwarden_crypto::{CompositeEncryptable, IdentifyKey, SymmetricCryptoKey};
+use bitwarden_crypto::IdentifyKey;
+#[cfg(feature = "wasm")]
+use bitwarden_crypto::{CompositeEncryptable, SymmetricCryptoKey};
 #[cfg(feature = "wasm")]
 use bitwarden_encoding::B64;
 use bitwarden_state::repository::{Repository, RepositoryError};
@@ -11,8 +13,10 @@ use wasm_bindgen::prelude::*;
 use super::EncryptionContext;
 use crate::{
     Cipher, CipherError, CipherListView, CipherView, DecryptError, EncryptError,
-    Fido2CredentialFullView, cipher::cipher::DecryptCipherListResult,
+    cipher::cipher::DecryptCipherListResult,
 };
+#[cfg(feature = "wasm")]
+use crate::Fido2CredentialFullView;
 
 mod create;
 mod edit;
@@ -195,6 +199,7 @@ impl CiphersClient {
 mod tests {
 
     use bitwarden_core::client::test_accounts::test_bitwarden_com_account;
+    #[cfg(feature = "wasm")]
     use bitwarden_crypto::CryptoError;
 
     use super::*;

--- a/crates/bitwarden-vault/src/cipher/cipher_client/mod.rs
+++ b/crates/bitwarden-vault/src/cipher/cipher_client/mod.rs
@@ -11,12 +11,12 @@ use bitwarden_state::repository::{Repository, RepositoryError};
 use wasm_bindgen::prelude::*;
 
 use super::EncryptionContext;
+#[cfg(feature = "wasm")]
+use crate::Fido2CredentialFullView;
 use crate::{
     Cipher, CipherError, CipherListView, CipherView, DecryptError, EncryptError,
     cipher::cipher::DecryptCipherListResult,
 };
-#[cfg(feature = "wasm")]
-use crate::Fido2CredentialFullView;
 
 mod create;
 mod edit;

--- a/crates/bitwarden-vault/src/collection_client.rs
+++ b/crates/bitwarden-vault/src/collection_client.rs
@@ -5,6 +5,7 @@ use bitwarden_collections::{
     tree::{NodeItem, Tree},
 };
 use bitwarden_core::Client;
+#[cfg(feature = "wasm")]
 use serde::{Deserialize, Serialize};
 #[cfg(feature = "wasm")]
 use tsify::Tsify;


### PR DESCRIPTION
## 🎟️ Tracking

N/A

## 📔 Objective

Several tests referenced fields and methods only available with the `wasm` feature. Gate these code sections with `#[cfg(feature = "wasm")]` to allow tests to compile without the `wasm` feature.

This fixes `cargo test --package bitwarden-vault` which previously failed due to feature resolution differences between workspace and package-specific testing.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation
  team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
