### PR TITLE
Replace `log` with `tracing` in WASM crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -959,9 +959,10 @@ dependencies = [
  "bitwarden-threading",
  "bitwarden-vault",
  "console_error_panic_hook",
- "console_log",
- "log",
  "serde",
+ "tracing",
+ "tracing-subscriber",
+ "tracing-web",
  "tsify",
  "wasm-bindgen",
  "wasm-bindgen-futures",
@@ -1369,17 +1370,6 @@ checksum = "a06aeb73f470f66dcdbf7223caeebb85984942f22f1adb2a088cf9668146bbbc"
 dependencies = [
  "cfg-if",
  "wasm-bindgen",
-]
-
-[[package]]
-name = "console_log"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be8aed40e4edbf4d3b4431ab260b63fdc40f5780a4766824329ea0f1eefe3c0f"
-dependencies = [
- "log",
- "wasm-bindgen",
- "web-sys",
 ]
 
 [[package]]
@@ -3019,6 +3009,15 @@ name = "lru-slab"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
+]
 
 [[package]]
 name = "memchr"
@@ -5090,7 +5089,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
 dependencies = [
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81383ab64e72a7a8b8e13130c49e3dab29def6d0c7d76a03087b3cf71c5c6903"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -5114,14 +5125,46 @@ dependencies = [
 ]
 
 [[package]]
-name = "tracing-subscriber"
-version = "0.3.19"
+name = "tracing-log"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8189decb5ac0fa7bc8b96b7cb9b2701d60d48805aca84a238004d665fcc4008"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
 dependencies = [
- "sharded-slab",
- "thread_local",
+ "log",
+ "once_cell",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2054a14f5307d601f88daf0553e1cbf472acc4f2c51afab632431cdcd72124d5"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "time",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+]
+
+[[package]]
+name = "tracing-web"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e6a141feebd51f8d91ebfd785af50fca223c570b86852166caa3b141defe7c"
+dependencies = [
+ "js-sys",
+ "tracing-core",
+ "tracing-subscriber",
+ "wasm-bindgen",
+ "web-sys",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5148,7 +5148,6 @@ dependencies = [
  "sharded-slab",
  "smallvec",
  "thread_local",
- "time",
  "tracing",
  "tracing-core",
  "tracing-log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,7 +81,6 @@ tracing-subscriber = { version = "0.3.20", features = [
     "fmt",
     "env-filter",
     "tracing-log",
-    "time",
 ] }
 tsify = { version = ">=0.5.5, <0.6", features = [
     "js",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,6 +76,13 @@ serde-wasm-bindgen = ">=0.6.0, <0.7"
 syn = ">=2.0.87, <3"
 thiserror = ">=1.0.40, <3"
 tokio = { version = "1.36.0", features = ["macros"] }
+tracing = { version = "0.1.41" }
+tracing-subscriber = { version = "0.3.20", features = [
+    "fmt",
+    "env-filter",
+    "tracing-log",
+    "time",
+]}
 tsify = { version = ">=0.5.5, <0.6", features = [
     "js",
 ], default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,7 +82,7 @@ tracing-subscriber = { version = "0.3.20", features = [
     "env-filter",
     "tracing-log",
     "time",
-]}
+] }
 tsify = { version = ">=0.5.5, <0.6", features = [
     "js",
 ], default-features = false }

--- a/crates/bitwarden-wasm-internal/Cargo.toml
+++ b/crates/bitwarden-wasm-internal/Cargo.toml
@@ -33,9 +33,10 @@ bitwarden-state = { workspace = true, features = ["wasm"] }
 bitwarden-threading = { workspace = true }
 bitwarden-vault = { workspace = true, features = ["wasm"] }
 console_error_panic_hook = "0.1.7"
-console_log = { version = "1.0.0", features = ["color"] }
-log = "0.4.20"
 serde = { workspace = true }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true }
+tracing-web = { version = "0.1.3"}
 tsify = { workspace = true }
 # When upgrading wasm-bindgen, make sure to update the version in the workflows!
 wasm-bindgen = { version = "=0.2.105", features = ["serde-serialize"] }

--- a/crates/bitwarden-wasm-internal/Cargo.toml
+++ b/crates/bitwarden-wasm-internal/Cargo.toml
@@ -36,7 +36,7 @@ console_error_panic_hook = "0.1.7"
 serde = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
-tracing-web = { version = "0.1.3"}
+tracing-web = { version = "0.1.3" }
 tsify = { workspace = true }
 # When upgrading wasm-bindgen, make sure to update the version in the workflows!
 wasm-bindgen = { version = "=0.2.105", features = ["serde-serialize"] }

--- a/crates/bitwarden-wasm-internal/src/init.rs
+++ b/crates/bitwarden-wasm-internal/src/init.rs
@@ -1,4 +1,11 @@
-use log::{Level, set_max_level};
+use tracing::Level;
+use tracing_subscriber::{
+    EnvFilter,
+    fmt::{format::Pretty, time::UtcTime},
+    layer::SubscriberExt as _,
+    util::SubscriberInitExt as _,
+};
+use tracing_web::{MakeWebConsoleWriter, performance_layer};
 use wasm_bindgen::prelude::*;
 
 #[wasm_bindgen]
@@ -12,26 +19,35 @@ pub enum LogLevel {
 
 fn convert_level(level: LogLevel) -> Level {
     match level {
-        LogLevel::Trace => Level::Trace,
-        LogLevel::Debug => Level::Debug,
-        LogLevel::Info => Level::Info,
-        LogLevel::Warn => Level::Warn,
-        LogLevel::Error => Level::Error,
+        LogLevel::Trace => Level::TRACE,
+        LogLevel::Debug => Level::DEBUG,
+        LogLevel::Info => Level::INFO,
+        LogLevel::Warn => Level::WARN,
+        LogLevel::Error => Level::ERROR,
     }
-}
-
-#[wasm_bindgen]
-pub fn set_log_level(level: LogLevel) {
-    let log_level = convert_level(level);
-    set_max_level(log_level.to_level_filter());
 }
 
 #[allow(missing_docs)]
 #[wasm_bindgen]
 pub fn init_sdk(log_level: Option<LogLevel>) {
     console_error_panic_hook::set_once();
+
     let log_level = convert_level(log_level.unwrap_or(LogLevel::Info));
-    if let Err(_e) = console_log::init_with_level(log_level) {
-        set_max_level(log_level.to_level_filter())
-    }
+
+    let filter = EnvFilter::builder()
+        .with_default_directive(log_level.into())
+        .from_env_lossy();
+
+    let fmt = tracing_subscriber::fmt::layer()
+        .with_ansi(false) // Only partially supported across browsers
+        .with_timer(UtcTime::rfc_3339())
+        .with_writer(MakeWebConsoleWriter::new()); // write events to the console
+
+    let perf_layer = performance_layer().with_details_from_fields(Pretty::default());
+
+    tracing_subscriber::registry()
+        .with(perf_layer)
+        .with(filter)
+        .with(fmt)
+        .init();
 }

--- a/crates/bitwarden-wasm-internal/src/init.rs
+++ b/crates/bitwarden-wasm-internal/src/init.rs
@@ -1,9 +1,6 @@
 use tracing::Level;
 use tracing_subscriber::{
-    EnvFilter,
-    fmt::{format::Pretty, time::UtcTime},
-    layer::SubscriberExt as _,
-    util::SubscriberInitExt as _,
+    EnvFilter, fmt::format::Pretty, layer::SubscriberExt as _, util::SubscriberInitExt as _,
 };
 use tracing_web::{MakeWebConsoleWriter, performance_layer};
 use wasm_bindgen::prelude::*;
@@ -39,8 +36,8 @@ pub fn init_sdk(log_level: Option<LogLevel>) {
         .from_env_lossy();
 
     let fmt = tracing_subscriber::fmt::layer()
-        .with_ansi(false) // Only partially supported across browsers
-        .with_timer(UtcTime::rfc_3339())
+        .with_ansi(false) // only partially supported across browsers
+        .without_time() // time is not supported in wasm
         .with_writer(MakeWebConsoleWriter::new()); // write events to the console
 
     let perf_layer = performance_layer().with_details_from_fields(Pretty::default());


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective

Cascading the standardization of `tracing` crate from clients repo into the SDK, that was started per https://github.com/bitwarden/clients/pull/16321

, this change updates the WASM crate to use `tracing`.

## 📸 Screenshots

<img width="918" height="157" alt="Screenshot 2025-11-19 at 09 32 04" src="https://github.com/user-attachments/assets/d84d9563-3dbc-49a1-bc5e-8caec6988cb1" />


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation
  team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
