### PR TITLE
[PM-28026] Lint when holding KeyStoreContext across await points

### DIFF
--- a/clippy.toml
+++ b/clippy.toml
@@ -1,2 +1,10 @@
-allow-unwrap-in-tests=true
-allow-expect-in-tests=true
+allow-unwrap-in-tests = true
+allow-expect-in-tests = true
+
+await-holding-invalid-types = [
+    { path = "bitwarden_crypto::KeyStoreContext", reason = """
+Contains a RwLock guard that will limit concurrency and even deadlock when held across await points.
+Instead, prefer to hold a reference to bitwarden_core::KeyStore and use its encrypt/decrypt methods directly.
+If you require access to KeyStoreContext, create short-lived KeyStoreContext instances as needed.
+""" },
+]

--- a/crates/bitwarden-vault/src/cipher/cipher_client/edit.rs
+++ b/crates/bitwarden-vault/src/cipher/cipher_client/edit.rs
@@ -462,58 +462,56 @@ mod tests {
         cipher_id: CipherId,
         name: &str,
     ) {
-        let mut ctx = store.context();
+        let cipher = {
+            let mut ctx = store.context();
 
-        repository
-            .set(
-                cipher_id.to_string(),
-                Cipher {
-                    id: Some(cipher_id),
-                    organization_id: None,
-                    folder_id: None,
-                    collection_ids: vec![],
-                    key: None,
-                    name: name.encrypt(&mut ctx, SymmetricKeyId::User).unwrap(),
-                    notes: None,
-                    r#type: CipherType::Login,
-                    login: Some(Login {
-                        username: Some("test@example.com")
-                            .map(|u| u.encrypt(&mut ctx, SymmetricKeyId::User))
-                            .transpose()
-                            .unwrap(),
-                        password: Some("password123")
-                            .map(|p| p.encrypt(&mut ctx, SymmetricKeyId::User))
-                            .transpose()
-                            .unwrap(),
-                        password_revision_date: None,
-                        uris: None,
-                        totp: None,
-                        autofill_on_page_load: None,
-                        fido2_credentials: None,
-                    }),
-                    identity: None,
-                    card: None,
-                    secure_note: None,
-                    ssh_key: None,
-                    favorite: false,
-                    reprompt: CipherRepromptType::None,
-                    organization_use_totp: true,
-                    edit: true,
-                    permissions: None,
-                    view_password: true,
-                    local_data: None,
-                    attachments: None,
-                    fields: None,
-                    password_history: None,
-                    creation_date: "2024-01-01T00:00:00Z".parse().unwrap(),
-                    deleted_date: None,
-                    revision_date: "2024-01-01T00:00:00Z".parse().unwrap(),
-                    archived_date: None,
-                    data: None,
-                },
-            )
-            .await
-            .unwrap();
+            Cipher {
+                id: Some(cipher_id),
+                organization_id: None,
+                folder_id: None,
+                collection_ids: vec![],
+                key: None,
+                name: name.encrypt(&mut ctx, SymmetricKeyId::User).unwrap(),
+                notes: None,
+                r#type: CipherType::Login,
+                login: Some(Login {
+                    username: Some("test@example.com")
+                        .map(|u| u.encrypt(&mut ctx, SymmetricKeyId::User))
+                        .transpose()
+                        .unwrap(),
+                    password: Some("password123")
+                        .map(|p| p.encrypt(&mut ctx, SymmetricKeyId::User))
+                        .transpose()
+                        .unwrap(),
+                    password_revision_date: None,
+                    uris: None,
+                    totp: None,
+                    autofill_on_page_load: None,
+                    fido2_credentials: None,
+                }),
+                identity: None,
+                card: None,
+                secure_note: None,
+                ssh_key: None,
+                favorite: false,
+                reprompt: CipherRepromptType::None,
+                organization_use_totp: true,
+                edit: true,
+                permissions: None,
+                view_password: true,
+                local_data: None,
+                attachments: None,
+                fields: None,
+                password_history: None,
+                creation_date: "2024-01-01T00:00:00Z".parse().unwrap(),
+                deleted_date: None,
+                revision_date: "2024-01-01T00:00:00Z".parse().unwrap(),
+                archived_date: None,
+                data: None,
+            }
+        };
+
+        repository.set(cipher_id.to_string(), cipher).await.unwrap();
     }
 
     #[tokio::test]

--- a/crates/bitwarden-vault/src/folder/edit.rs
+++ b/crates/bitwarden-vault/src/folder/edit.rs
@@ -76,19 +76,14 @@ mod tests {
         folder_id: FolderId,
         name: &str,
     ) {
-        repository
-            .set(
-                folder_id.to_string(),
-                Folder {
-                    id: Some(folder_id),
-                    name: name
-                        .encrypt(&mut store.context(), SymmetricKeyId::User)
-                        .unwrap(),
-                    revision_date: "2024-01-01T00:00:00Z".parse().unwrap(),
-                },
-            )
-            .await
-            .unwrap();
+        let folder = Folder {
+            id: Some(folder_id),
+            name: name
+                .encrypt(&mut store.context(), SymmetricKeyId::User)
+                .unwrap(),
+            revision_date: "2024-01-01T00:00:00Z".parse().unwrap(),
+        };
+        repository.set(folder_id.to_string(), folder).await.unwrap();
     }
 
     #[tokio::test]


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-28026

## 📔 Objective

Clippy by default lints when trying to hold an RwLock/Mutex guard across an await point, but that doesn't apply to custom types by default. This PR configures clippy to also apply that lint to our own types that wrap lock guards, which at the moment is only `KeyStoreContext`.

We only have two instances that needed fixing and both were in tests, but some of the SM code I wrote already had to deal with it by creating short lived contexts, so I assume it might be a problem in the future as well:
https://github.com/bitwarden/sdk-internal/blob/main/bitwarden_license/bitwarden-sm/src/secrets/create.rs#L41-L64

The lint docs:
https://rust-lang.github.io/rust-clippy/master/index.html#await_holding_invalid_type

This is what the lint looks like:
<img width="1011" height="262" alt="image" src="https://github.com/user-attachments/assets/77f9eaa2-f46b-460a-81b7-627e440e3f7a" />


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation
  team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
