### PR TITLE
[PM-27530] Rename BitwardenClient to PasswordManagerClient

### DIFF
--- a/crates/bitwarden-wasm-internal/src/client.rs
+++ b/crates/bitwarden-wasm-internal/src/client.rs
@@ -3,7 +3,7 @@ use std::{fmt::Display, sync::Arc};
 
 use bitwarden_core::ClientSettings;
 use bitwarden_error::bitwarden_error;
-use bitwarden_pm::{PasswordManagerClient, clients::*};
+use bitwarden_pm::{PasswordManagerClient as InnerPasswordManagerClient, clients::*};
 use wasm_bindgen::prelude::*;
 
 use crate::platform::{
@@ -11,17 +11,25 @@ use crate::platform::{
     token_provider::{JsTokenProvider, WasmClientManagedTokens},
 };
 
+#[wasm_bindgen(typescript_custom_section)]
+const TOKEN_CUSTOM_TS_TYPE: &'static str = r#"
+/**
+ * @deprecated Use PasswordManagerClient instead
+ */
+export type BitwardenClient = PasswordManagerClient;
+"#;
+
 /// The main entry point for the Bitwarden SDK in WebAssembly environments
 #[wasm_bindgen]
-pub struct BitwardenClient(pub(crate) PasswordManagerClient);
+pub struct PasswordManagerClient(pub(crate) InnerPasswordManagerClient);
 
 #[wasm_bindgen]
-impl BitwardenClient {
+impl PasswordManagerClient {
     /// Initialize a new instance of the SDK client
     #[wasm_bindgen(constructor)]
     pub fn new(token_provider: JsTokenProvider, settings: Option<ClientSettings>) -> Self {
         let tokens = Arc::new(WasmClientManagedTokens::new(token_provider));
-        Self(PasswordManagerClient::new_with_client_tokens(
+        Self(InnerPasswordManagerClient::new_with_client_tokens(
             settings, tokens,
         ))
     }

--- a/crates/bitwarden-wasm-internal/src/lib.rs
+++ b/crates/bitwarden-wasm-internal/src/lib.rs
@@ -8,5 +8,5 @@ mod pure_crypto;
 mod ssh;
 
 pub use bitwarden_ipc::wasm::*;
-pub use client::BitwardenClient;
+pub use client::PasswordManagerClient;
 pub use init::init_sdk;


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective

Jira description: We renamed BitwardenClient to be PasswordManagerClient internally in the SDK, but the ones we exposed through FFI are still just called Client/BitwardenClient for backwards compatibility.

For consistency against our documentation, we shouldt rename and expose deprecated type aliases with the old name temporarily.

## 🚨 Breaking Changes

Breaks places where `BitwardenClient` is used as a value (e.g. `new BitwardenClient` or `typeof BitwardenClient`). Fixes can be found here: https://github.com/bitwarden/clients/pull/17578

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation
  team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
