### PR TITLE
Add rsa extract public key

### DIFF
--- a/crates/bitwarden-crypto/src/enc_string/symmetric.rs
+++ b/crates/bitwarden-crypto/src/enc_string/symmetric.rs
@@ -3,6 +3,8 @@ use std::{borrow::Cow, str::FromStr};
 use bitwarden_encoding::{B64, FromStrVisitor};
 use coset::{CborSerializable, iana::KeyOperation};
 use serde::Deserialize;
+#[cfg(feature = "wasm")]
+use wasm_bindgen::convert::FromWasmAbi;
 
 use super::{check_length, from_b64, from_b64_vec, split_enc_string};
 use crate::{
@@ -73,6 +75,25 @@ pub enum EncString {
     Cose_Encrypt0_B64 {
         data: Vec<u8>,
     },
+}
+
+#[cfg(feature = "wasm")]
+impl wasm_bindgen::describe::WasmDescribe for EncString {
+    fn describe() {
+        <String as wasm_bindgen::describe::WasmDescribe>::describe();
+    }
+}
+
+#[cfg(feature = "wasm")]
+impl FromWasmAbi for EncString {
+    type Abi = <String as FromWasmAbi>::Abi;
+
+    unsafe fn from_abi(abi: Self::Abi) -> Self {
+        use wasm_bindgen::UnwrapThrowExt;
+
+        let s = unsafe { String::from_abi(abi) };
+        Self::from_str(&s).unwrap_throw()
+    }
 }
 
 /// Deserializes an [EncString] from a string.

--- a/crates/bitwarden-wasm-internal/src/pure_crypto.rs
+++ b/crates/bitwarden-wasm-internal/src/pure_crypto.rs
@@ -319,6 +319,8 @@ impl PureCrypto {
         Ok(result.to_encoded().to_vec())
     }
 
+    /// Given an encrypted private RSA key and the symmetric key it is wrapped with, this returns
+    /// the corresponding public RSA key in DER format.
     pub fn rsa_extract_public_key(
         encrypted_private_key: EncString,
         wrapping_key: Vec<u8>,

--- a/crates/bitwarden-wasm-internal/src/pure_crypto.rs
+++ b/crates/bitwarden-wasm-internal/src/pure_crypto.rs
@@ -318,6 +318,21 @@ impl PureCrypto {
             .map_err(|_| CryptoError::InvalidKey)?;
         Ok(result.to_encoded().to_vec())
     }
+
+    pub fn rsa_extract_public_key(
+        encrypted_private_key: EncString,
+        wrapping_key: Vec<u8>,
+    ) -> Result<Vec<u8>, CryptoError> {
+        let wrapping_key = SymmetricCryptoKey::try_from(
+            &BitwardenLegacyKeyBytes::from(wrapping_key),
+        )?;
+        let decrypted_private_key: Vec<u8> = encrypted_private_key.decrypt_with_key(&wrapping_key)?;
+        let private_key = AsymmetricCryptoKey::from_der(&Pkcs8PrivateKeyBytes::from(
+            decrypted_private_key,
+        ))?;
+        let public_key = private_key.to_public_key();
+        Ok(public_key.to_der()?.to_vec())
+    }
 }
 
 #[cfg(test)]

--- a/crates/bitwarden-wasm-internal/src/pure_crypto.rs
+++ b/crates/bitwarden-wasm-internal/src/pure_crypto.rs
@@ -323,13 +323,12 @@ impl PureCrypto {
         encrypted_private_key: EncString,
         wrapping_key: Vec<u8>,
     ) -> Result<Vec<u8>, CryptoError> {
-        let wrapping_key = SymmetricCryptoKey::try_from(
-            &BitwardenLegacyKeyBytes::from(wrapping_key),
-        )?;
-        let decrypted_private_key: Vec<u8> = encrypted_private_key.decrypt_with_key(&wrapping_key)?;
-        let private_key = AsymmetricCryptoKey::from_der(&Pkcs8PrivateKeyBytes::from(
-            decrypted_private_key,
-        ))?;
+        let wrapping_key =
+            SymmetricCryptoKey::try_from(&BitwardenLegacyKeyBytes::from(wrapping_key))?;
+        let decrypted_private_key: Vec<u8> =
+            encrypted_private_key.decrypt_with_key(&wrapping_key)?;
+        let private_key =
+            AsymmetricCryptoKey::from_der(&Pkcs8PrivateKeyBytes::from(decrypted_private_key))?;
         let public_key = private_key.to_public_key();
         Ok(public_key.to_der()?.to_vec())
     }


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Webcrypto provides non-useful errors when private keys are corrupt (invalid content on undecryptable wrapping decryption). This PR introduces a temporary function to immediately replace the derive_public_key function in `clients` so that the error logs become useful.

## 🚨 Breaking Changes

<!-- Does this PR introduce any breaking changes? If so, please describe the impact and migration path for clients.

If you're unsure, the automated TypeScript compatibility check will run when you open/update this PR and provide feedback.

For breaking changes:
1. Describe what changed in the client interface
2. Explain why the change was necessary
3. Provide migration steps for client developers
4. Link to any paired client PRs if needed

Otherwise, you can remove this section. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation
  team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
