### PR TITLE
Clippy disallow log crate macros

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -109,6 +109,7 @@ uniffi_bindgen = { git = "https://github.com/mozilla/uniffi-rs", rev = "6d46b3f7
 uniffi_build = { git = "https://github.com/mozilla/uniffi-rs", rev = "6d46b3f756dde3213357c477d86771a0fc5da7b4" }
 
 [workspace.lints.clippy]
+disallowed-macros = "deny"
 unused_async = "deny"
 unwrap_used = "deny"
 string_slice = "warn"

--- a/clippy.toml
+++ b/clippy.toml
@@ -8,3 +8,11 @@ Instead, prefer to hold a reference to bitwarden_core::KeyStore and use its encr
 If you require access to KeyStoreContext, create short-lived KeyStoreContext instances as needed.
 """ },
 ]
+
+disallowed-macros = [
+  { path = "log::trace", reason = "Use tracing for logging needs", replacement = "tracing::trace" },
+  { path = "log::debug", reason = "Use tracing for logging needs", replacement = "tracing::debug" },
+  { path = "log::info", reason = "Use tracing for logging needs", replacement = "tracing::info" },
+  { path = "log::warn", reason = "Use tracing for logging needs", replacement = "tracing::warn" },
+  { path = "log::error", reason = "Use tracing for logging needs", replacement = "tracing::error" },
+]


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-28762

## 📔 Objective

Now that the SDK is using `tracing` instead of `log`, add the same clippy lint to disallow the log crate's macros as we have in clients repo.

## 🚨 Breaking Changes

<!-- Does this PR introduce any breaking changes? If so, please describe the impact and migration path for clients.

If you're unsure, the automated TypeScript compatibility check will run when you open/update this PR and provide feedback.

For breaking changes:
1. Describe what changed in the client interface
2. Explain why the change was necessary
3. Provide migration steps for client developers
4. Link to any paired client PRs if needed

Otherwise, you can remove this section. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation
  team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
