### PR TITLE
style: use #[expect] instead of #[allow]

### DIFF
--- a/bitwarden_license/bitwarden-commercial-vault/src/vault_client.rs
+++ b/bitwarden_license/bitwarden-commercial-vault/src/vault_client.rs
@@ -2,11 +2,11 @@ use bitwarden_core::Client;
 #[cfg(feature = "wasm")]
 use wasm_bindgen::prelude::*;
 
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 #[derive(Clone)]
 #[cfg_attr(feature = "wasm", wasm_bindgen)]
 pub struct CommercialVaultClient {
-    #[allow(unused)]
+    #[expect(unused)]
     pub(crate) client: Client,
 }
 
@@ -19,7 +19,7 @@ impl CommercialVaultClient {
 #[cfg_attr(feature = "wasm", wasm_bindgen)]
 impl CommercialVaultClient {}
 
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 pub trait CommercialVaultClientExt {
     fn vault(&self) -> CommercialVaultClient;
 }

--- a/bitwarden_license/bitwarden-sm/src/client_projects.rs
+++ b/bitwarden_license/bitwarden-sm/src/client_projects.rs
@@ -12,18 +12,18 @@ use crate::{
 /// Aliases to maintain backward compatibility
 pub type ClientProjects = ProjectsClient;
 
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 pub struct ProjectsClient {
     pub client: Client,
 }
 
 impl ProjectsClient {
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub fn new(client: Client) -> Self {
         Self { client }
     }
 
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub async fn get(
         &self,
         input: &ProjectGetRequest,
@@ -31,7 +31,7 @@ impl ProjectsClient {
         get_project(&self.client, input).await
     }
 
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub async fn create(
         &self,
         input: &ProjectCreateRequest,
@@ -39,7 +39,7 @@ impl ProjectsClient {
         create_project(&self.client, input).await
     }
 
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub async fn list(
         &self,
         input: &ProjectsListRequest,
@@ -47,7 +47,7 @@ impl ProjectsClient {
         list_projects(&self.client, input).await
     }
 
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub async fn update(
         &self,
         input: &ProjectPutRequest,
@@ -55,7 +55,7 @@ impl ProjectsClient {
         update_project(&self.client, input).await
     }
 
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub async fn delete(
         &self,
         input: ProjectsDeleteRequest,
@@ -66,7 +66,7 @@ impl ProjectsClient {
 
 /// This trait is for backward compatibility
 pub trait ClientProjectsExt {
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     fn projects(&self) -> ClientProjects;
 }
 
@@ -76,9 +76,9 @@ impl ClientProjectsExt for Client {
     }
 }
 
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 pub trait ProjectsClientExt {
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     fn projects(&self) -> ProjectsClient;
 }
 

--- a/bitwarden_license/bitwarden-sm/src/client_secrets.rs
+++ b/bitwarden_license/bitwarden-sm/src/client_secrets.rs
@@ -14,18 +14,18 @@ use crate::{
 /// Aliases to maintain backward compatibility
 pub type ClientSecrets = SecretsClient;
 
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 pub struct SecretsClient {
     client: Client,
 }
 
 impl SecretsClient {
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub fn new(client: Client) -> Self {
         Self { client }
     }
 
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub async fn get(
         &self,
         input: &SecretGetRequest,
@@ -33,7 +33,7 @@ impl SecretsClient {
         get_secret(&self.client, input).await
     }
 
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub async fn get_by_ids(
         &self,
         input: SecretsGetRequest,
@@ -41,7 +41,7 @@ impl SecretsClient {
         get_secrets_by_ids(&self.client, input).await
     }
 
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub async fn create(
         &self,
         input: &SecretCreateRequest,
@@ -49,7 +49,7 @@ impl SecretsClient {
         create_secret(&self.client, input).await
     }
 
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub async fn list(
         &self,
         input: &SecretIdentifiersRequest,
@@ -57,7 +57,7 @@ impl SecretsClient {
         list_secrets(&self.client, input).await
     }
 
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub async fn list_by_project(
         &self,
         input: &SecretIdentifiersByProjectRequest,
@@ -65,7 +65,7 @@ impl SecretsClient {
         list_secrets_by_project(&self.client, input).await
     }
 
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub async fn update(
         &self,
         input: &SecretPutRequest,
@@ -73,7 +73,7 @@ impl SecretsClient {
         update_secret(&self.client, input).await
     }
 
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub async fn delete(
         &self,
         input: SecretsDeleteRequest,
@@ -81,7 +81,7 @@ impl SecretsClient {
         delete_secrets(&self.client, input).await
     }
 
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub async fn sync(
         &self,
         input: &SecretsSyncRequest,
@@ -92,7 +92,7 @@ impl SecretsClient {
 
 /// This trait is for backward compatibility
 pub trait ClientSecretsExt {
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     fn secrets(&self) -> ClientSecrets;
 }
 
@@ -102,9 +102,9 @@ impl ClientSecretsExt for Client {
     }
 }
 
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 pub trait SecretsClientExt {
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     fn secrets(&self) -> SecretsClient;
 }
 

--- a/bitwarden_license/bitwarden-sm/src/lib.rs
+++ b/bitwarden_license/bitwarden-sm/src/lib.rs
@@ -3,9 +3,9 @@
 mod client_projects;
 mod client_secrets;
 mod error;
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 pub mod projects;
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 pub mod secrets;
 
 pub use client_projects::{ClientProjects, ClientProjectsExt, ProjectsClient, ProjectsClientExt};

--- a/bitwarden_license/bitwarden-sm/src/projects/create.rs
+++ b/bitwarden_license/bitwarden-sm/src/projects/create.rs
@@ -11,7 +11,7 @@ use crate::{
     projects::ProjectResponse,
 };
 
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 #[derive(Serialize, Deserialize, Debug, JsonSchema, Validate)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct ProjectCreateRequest {

--- a/bitwarden_license/bitwarden-sm/src/projects/delete.rs
+++ b/bitwarden_license/bitwarden-sm/src/projects/delete.rs
@@ -8,7 +8,7 @@ use uuid::Uuid;
 
 use crate::error::SecretsManagerError;
 
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 #[derive(Serialize, Deserialize, Debug, JsonSchema)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct ProjectsDeleteRequest {
@@ -30,7 +30,7 @@ pub(crate) async fn delete_projects(
     ProjectsDeleteResponse::process_response(res)
 }
 
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 #[derive(Serialize, Deserialize, Debug, JsonSchema)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct ProjectsDeleteResponse {

--- a/bitwarden_license/bitwarden-sm/src/projects/get.rs
+++ b/bitwarden_license/bitwarden-sm/src/projects/get.rs
@@ -5,7 +5,7 @@ use uuid::Uuid;
 
 use crate::{error::SecretsManagerError, projects::ProjectResponse};
 
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 #[derive(Serialize, Deserialize, Debug, JsonSchema)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct ProjectGetRequest {

--- a/bitwarden_license/bitwarden-sm/src/projects/list.rs
+++ b/bitwarden_license/bitwarden-sm/src/projects/list.rs
@@ -7,7 +7,7 @@ use uuid::Uuid;
 
 use crate::{error::SecretsManagerError, projects::ProjectResponse};
 
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 #[derive(Serialize, Deserialize, Debug, JsonSchema)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct ProjectsListRequest {
@@ -31,7 +31,7 @@ pub(crate) async fn list_projects(
     ProjectsResponse::process_response(res, &mut key_store.context())
 }
 
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 #[derive(Serialize, Deserialize, Debug, JsonSchema)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct ProjectsResponse {

--- a/bitwarden_license/bitwarden-sm/src/projects/project_response.rs
+++ b/bitwarden_license/bitwarden-sm/src/projects/project_response.rs
@@ -12,7 +12,7 @@ use uuid::Uuid;
 
 use crate::error::SecretsManagerError;
 
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 #[derive(Serialize, Deserialize, Debug, JsonSchema)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct ProjectResponse {

--- a/bitwarden_license/bitwarden-sm/src/projects/update.rs
+++ b/bitwarden_license/bitwarden-sm/src/projects/update.rs
@@ -11,7 +11,7 @@ use crate::{
     projects::ProjectResponse,
 };
 
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 #[derive(Serialize, Deserialize, Debug, JsonSchema, Validate)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct ProjectPutRequest {

--- a/bitwarden_license/bitwarden-sm/src/secrets/create.rs
+++ b/bitwarden_license/bitwarden-sm/src/secrets/create.rs
@@ -11,7 +11,7 @@ use crate::{
     secrets::SecretResponse,
 };
 
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 #[derive(Serialize, Deserialize, Debug, JsonSchema, Validate)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct SecretCreateRequest {

--- a/bitwarden_license/bitwarden-sm/src/secrets/delete.rs
+++ b/bitwarden_license/bitwarden-sm/src/secrets/delete.rs
@@ -8,7 +8,7 @@ use uuid::Uuid;
 
 use crate::error::SecretsManagerError;
 
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 #[derive(Serialize, Deserialize, Debug, JsonSchema)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct SecretsDeleteRequest {
@@ -30,7 +30,7 @@ pub(crate) async fn delete_secrets(
     SecretsDeleteResponse::process_response(res)
 }
 
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 #[derive(Serialize, Deserialize, Debug, JsonSchema)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct SecretsDeleteResponse {

--- a/bitwarden_license/bitwarden-sm/src/secrets/get.rs
+++ b/bitwarden_license/bitwarden-sm/src/secrets/get.rs
@@ -5,7 +5,7 @@ use uuid::Uuid;
 
 use crate::{error::SecretsManagerError, secrets::SecretResponse};
 
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 #[derive(Serialize, Deserialize, Debug, JsonSchema)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct SecretGetRequest {

--- a/bitwarden_license/bitwarden-sm/src/secrets/get_by_ids.rs
+++ b/bitwarden_license/bitwarden-sm/src/secrets/get_by_ids.rs
@@ -6,7 +6,7 @@ use uuid::Uuid;
 
 use crate::{error::SecretsManagerError, secrets::SecretsResponse};
 
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 #[derive(Serialize, Deserialize, Debug, JsonSchema)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct SecretsGetRequest {

--- a/bitwarden_license/bitwarden-sm/src/secrets/list.rs
+++ b/bitwarden_license/bitwarden-sm/src/secrets/list.rs
@@ -14,7 +14,7 @@ use uuid::Uuid;
 
 use crate::error::SecretsManagerError;
 
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 #[derive(Serialize, Deserialize, Debug, JsonSchema)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct SecretIdentifiersRequest {
@@ -38,7 +38,7 @@ pub(crate) async fn list_secrets(
     SecretIdentifiersResponse::process_response(res, &mut key_store.context())
 }
 
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 #[derive(Serialize, Deserialize, Debug, JsonSchema)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct SecretIdentifiersByProjectRequest {
@@ -62,7 +62,7 @@ pub(crate) async fn list_secrets_by_project(
     SecretIdentifiersResponse::process_response(res, &mut key_store.context())
 }
 
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 #[derive(Serialize, Deserialize, Debug, JsonSchema)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct SecretIdentifiersResponse {

--- a/bitwarden_license/bitwarden-sm/src/secrets/secret_response.rs
+++ b/bitwarden_license/bitwarden-sm/src/secrets/secret_response.rs
@@ -14,7 +14,7 @@ use uuid::Uuid;
 
 use crate::error::SecretsManagerError;
 
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 #[derive(Serialize, Deserialize, Debug, JsonSchema)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct SecretResponse {
@@ -86,7 +86,7 @@ impl SecretResponse {
     }
 }
 
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 #[derive(Serialize, Deserialize, Debug, JsonSchema)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct SecretsResponse {

--- a/bitwarden_license/bitwarden-sm/src/secrets/sync.rs
+++ b/bitwarden_license/bitwarden-sm/src/secrets/sync.rs
@@ -8,7 +8,7 @@ use uuid::Uuid;
 
 use crate::{error::SecretsManagerError, secrets::SecretResponse};
 
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 #[derive(Serialize, Deserialize, Debug, JsonSchema)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct SecretsSyncRequest {
@@ -36,7 +36,7 @@ pub(crate) async fn sync_secrets(
     SecretsSyncResponse::process_response(res, &mut key_store.context())
 }
 
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 #[derive(Serialize, Deserialize, Debug, JsonSchema)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct SecretsSyncResponse {

--- a/bitwarden_license/bitwarden-sm/src/secrets/update.rs
+++ b/bitwarden_license/bitwarden-sm/src/secrets/update.rs
@@ -11,7 +11,7 @@ use crate::{
     secrets::SecretResponse,
 };
 
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 #[derive(Serialize, Deserialize, Debug, JsonSchema, Validate)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct SecretPutRequest {

--- a/crates/bitwarden-api-api/src/apis/mod.rs
+++ b/crates/bitwarden-api-api/src/apis/mod.rs
@@ -93,7 +93,7 @@ pub fn parse_deep_object(prefix: &str, value: &serde_json::Value) -> Vec<(String
 
 /// Internal use only
 /// A content type supported by this client.
-#[allow(dead_code)]
+#[expect(dead_code)]
 enum ContentType {
     Json,
     Text,
@@ -183,7 +183,7 @@ pub mod configuration;
 
 use std::sync::Arc;
 
-#[allow(clippy::large_enum_variant, private_interfaces)]
+#[expect(clippy::large_enum_variant, private_interfaces)]
 pub enum ApiClient {
     Real(ApiClientReal),
     #[cfg(feature = "mockall")]

--- a/crates/bitwarden-api-identity/src/apis/mod.rs
+++ b/crates/bitwarden-api-identity/src/apis/mod.rs
@@ -93,7 +93,7 @@ pub fn parse_deep_object(prefix: &str, value: &serde_json::Value) -> Vec<(String
 
 /// Internal use only
 /// A content type supported by this client.
-#[allow(dead_code)]
+#[expect(dead_code)]
 enum ContentType {
     Json,
     Text,
@@ -120,7 +120,7 @@ pub mod configuration;
 
 use std::sync::Arc;
 
-#[allow(clippy::large_enum_variant, private_interfaces)]
+#[expect(clippy::large_enum_variant, private_interfaces)]
 pub enum ApiClient {
     Real(ApiClientReal),
     #[cfg(feature = "mockall")]

--- a/crates/bitwarden-auth/src/identity/client.rs
+++ b/crates/bitwarden-auth/src/identity/client.rs
@@ -6,7 +6,7 @@ use wasm_bindgen::prelude::*;
 #[derive(Clone)]
 #[cfg_attr(feature = "wasm", wasm_bindgen)]
 pub struct IdentityClient {
-    #[allow(dead_code)] // TODO: Remove when methods using client are implemented
+    #[expect(dead_code)] // TODO: Remove when methods using client are implemented
     pub(crate) client: Client,
 }
 

--- a/crates/bitwarden-auth/src/send_access/access_token_request.rs
+++ b/crates/bitwarden-auth/src/send_access/access_token_request.rs
@@ -39,11 +39,11 @@ pub struct SendEmailOtpCredentials {
 // {"password_hash_b64": "value"} instead of {"type": "password", "password_hash_b64": "value"}.
 #[serde(untagged)]
 pub enum SendAccessCredentials {
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     Password(SendPasswordCredentials),
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     Email(SendEmailCredentials),
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     EmailOtp(SendEmailOtpCredentials),
 }
 

--- a/crates/bitwarden-auth/src/send_access/api/token_api_error_response.rs
+++ b/crates/bitwarden-auth/src/send_access/api/token_api_error_response.rs
@@ -7,16 +7,16 @@ use tsify::Tsify;
 #[serde(rename_all = "snake_case")]
 /// Invalid request errors - typically due to missing parameters.
 pub enum SendAccessTokenInvalidRequestError {
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     SendIdRequired,
 
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     PasswordHashB64Required,
 
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     EmailRequired,
 
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     EmailAndOtpRequiredOtpSent,
 
     /// Fallback for unknown variants for forward compatibility
@@ -29,19 +29,19 @@ pub enum SendAccessTokenInvalidRequestError {
 #[serde(rename_all = "snake_case")]
 /// Invalid grant errors - typically due to invalid credentials.
 pub enum SendAccessTokenInvalidGrantError {
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     SendIdInvalid,
 
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     PasswordHashB64Invalid,
 
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     EmailInvalid,
 
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     OtpInvalid,
 
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     OtpGenerationFailed,
 
     /// Fallback for unknown variants for forward compatibility

--- a/crates/bitwarden-auth/src/send_access/api/token_request_payload.rs
+++ b/crates/bitwarden-auth/src/send_access/api/token_request_payload.rs
@@ -14,11 +14,11 @@ use crate::{
 pub(crate) enum SendAccessTokenPayloadCredentials {
     // Uses inline variant syntax for these as we don't need to reference them as independent
     // types elsewhere.
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     Password { password_hash_b64: String },
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     Email { email: String },
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     EmailOtp { email: String, otp: String },
     /// Represents an anonymous request, which does not require credentials.
     Anonymous,

--- a/crates/bitwarden-collections/src/collection.rs
+++ b/crates/bitwarden-collections/src/collection.rs
@@ -16,7 +16,7 @@ use crate::{error::CollectionsParseError, tree::TreeItem};
 
 uuid_newtype!(pub CollectionId);
 
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 #[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
@@ -33,7 +33,7 @@ pub struct Collection {
     pub r#type: CollectionType,
 }
 
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 #[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
@@ -66,7 +66,7 @@ pub enum CollectionType {
     DefaultUserCollection = 1,
 }
 
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 impl Decryptable<KeyIds, SymmetricKeyId, CollectionView> for Collection {
     fn decrypt(
         &self,
@@ -92,7 +92,7 @@ impl Decryptable<KeyIds, SymmetricKeyId, CollectionView> for Collection {
     }
 }
 
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 impl TryFrom<CollectionDetailsResponseModel> for Collection {
     type Error = CollectionsParseError;
 
@@ -111,14 +111,14 @@ impl TryFrom<CollectionDetailsResponseModel> for Collection {
     }
 }
 
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 impl IdentifyKey<SymmetricKeyId> for Collection {
     fn key_identifier(&self) -> SymmetricKeyId {
         SymmetricKeyId::Organization(self.organization_id)
     }
 }
 
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 impl TreeItem for CollectionView {
     fn id(&self) -> Uuid {
         self.id.map(|id| id.0).unwrap_or_default()
@@ -165,7 +165,7 @@ mod tests {
         let key = SymmetricCryptoKey::make_aes256_cbc_hmac_key();
         let org_id = ORGANIZATION_ID.parse().unwrap();
 
-        #[allow(deprecated)]
+        #[expect(deprecated)]
         store
             .context_mut()
             .set_symmetric_key(SymmetricKeyId::Organization(org_id), key)

--- a/crates/bitwarden-collections/src/error.rs
+++ b/crates/bitwarden-collections/src/error.rs
@@ -1,7 +1,7 @@
 use bitwarden_error::bitwarden_error;
 use thiserror::Error;
 
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 #[bitwarden_error(flat)]
 #[derive(Debug, Error)]
 pub enum CollectionDecryptError {
@@ -9,7 +9,7 @@ pub enum CollectionDecryptError {
     Crypto(#[from] bitwarden_crypto::CryptoError),
 }
 
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 #[derive(Debug, Error)]
 pub enum CollectionsParseError {
     #[error(transparent)]

--- a/crates/bitwarden-collections/src/tree.rs
+++ b/crates/bitwarden-collections/src/tree.rs
@@ -2,7 +2,7 @@ use std::{collections::HashMap, fmt::Debug};
 
 use uuid::Uuid;
 
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 pub trait TreeItem: Clone + Debug {
     fn id(&self) -> Uuid;
     /*
@@ -16,7 +16,7 @@ pub trait TreeItem: Clone + Debug {
     const DELIMITER: char;
 }
 
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 #[derive(Clone, Debug)]
 pub struct TreeIndex<T: TreeItem> {
     pub id: usize, // location in the tree
@@ -25,7 +25,7 @@ pub struct TreeIndex<T: TreeItem> {
 }
 
 impl<T: TreeItem> TreeIndex<T> {
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub fn new(id: usize, data: &T) -> Self {
         TreeIndex {
             id,
@@ -35,7 +35,7 @@ impl<T: TreeItem> TreeIndex<T> {
     }
 }
 
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 pub struct NodeItem<T: TreeItem> {
     pub item: T,
     pub parent: Option<T>,
@@ -43,7 +43,7 @@ pub struct NodeItem<T: TreeItem> {
     pub ancestors: HashMap<Uuid, String>,
 }
 
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 pub struct TreeNode {
     pub id: usize,
     pub item_id: Uuid,
@@ -53,7 +53,7 @@ pub struct TreeNode {
 }
 
 impl TreeNode {
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub fn new<T: TreeItem>(
         id: usize,
         parent_idx: Option<usize>,
@@ -70,7 +70,7 @@ impl TreeNode {
     }
 }
 
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 pub struct Tree<T: TreeItem> {
     pub nodes: Vec<TreeNode>,
     pub items: HashMap<Uuid, TreeIndex<T>>,

--- a/crates/bitwarden-core/src/auth/access_token.rs
+++ b/crates/bitwarden-core/src/auth/access_token.rs
@@ -6,7 +6,7 @@ use thiserror::Error;
 use uuid::Uuid;
 use zeroize::Zeroizing;
 
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 #[derive(Debug, Error)]
 pub enum AccessTokenInvalidError {
     #[error("Doesn't contain a decryption key")]

--- a/crates/bitwarden-core/src/auth/api/request/auth_request_token_request.rs
+++ b/crates/bitwarden-core/src/auth/api/request/auth_request_token_request.rs
@@ -27,7 +27,7 @@ pub(crate) struct AuthRequestTokenRequest {
     access_code: String,
 }
 
-#[allow(dead_code)]
+#[expect(dead_code)]
 impl AuthRequestTokenRequest {
     pub(crate) fn new(
         email: &str,

--- a/crates/bitwarden-core/src/auth/api/response/user_decryption_options_response.rs
+++ b/crates/bitwarden-core/src/auth/api/response/user_decryption_options_response.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 
 /// Provides user decryption options used to unlock user's vault.
 /// Currently, only master password unlock is supported.
-#[allow(dead_code)]
+#[expect(dead_code)]
 #[derive(Serialize, Deserialize, Debug, PartialEq)]
 pub(crate) struct UserDecryptionOptionsResponseModel {
     /// Contains information needed to unlock user's vault with master password.

--- a/crates/bitwarden-core/src/auth/auth_client.rs
+++ b/crates/bitwarden-core/src/auth/auth_client.rs
@@ -33,18 +33,18 @@ use crate::{
     client::encryption_settings::EncryptionSettingsError,
 };
 
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 pub struct AuthClient {
     pub(crate) client: crate::Client,
 }
 
 impl AuthClient {
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub async fn renew_token(&self) -> Result<(), LoginError> {
         renew_token(&self.client.internal).await
     }
 
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     #[cfg(feature = "secrets")]
     pub async fn login_access_token(
         &self,
@@ -56,7 +56,7 @@ impl AuthClient {
 
 #[cfg(feature = "internal")]
 impl AuthClient {
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub fn password_strength(
         &self,
         password: String,
@@ -66,7 +66,7 @@ impl AuthClient {
         password_strength(password, email, additional_inputs)
     }
 
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub fn satisfies_policy(
         &self,
         password: String,
@@ -76,7 +76,7 @@ impl AuthClient {
         satisfies_policy(password, strength, policy)
     }
 
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub fn make_register_keys(
         &self,
         email: String,
@@ -86,7 +86,7 @@ impl AuthClient {
         make_register_keys(email, password, kdf)
     }
 
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub fn make_register_tde_keys(
         &self,
         email: String,
@@ -96,20 +96,20 @@ impl AuthClient {
         make_register_tde_keys(&self.client, email, org_public_key, remember_device)
     }
 
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub fn make_key_connector_keys(&self) -> Result<KeyConnectorResponse, CryptoError> {
         let mut rng = rand::thread_rng();
         make_key_connector_keys(&mut rng)
     }
 
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub async fn prelogin(&self, email: String) -> Result<Kdf, PreloginError> {
         use crate::auth::login::prelogin;
 
         prelogin(&self.client, email).await
     }
 
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub async fn login_password(
         &self,
         input: &PasswordLoginRequest,
@@ -117,7 +117,7 @@ impl AuthClient {
         login_password(&self.client, input).await
     }
 
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub async fn login_api_key(
         &self,
         input: &ApiKeyLoginRequest,
@@ -125,7 +125,7 @@ impl AuthClient {
         login_api_key(&self.client, input).await
     }
 
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub async fn send_two_factor_email(
         &self,
         tf: &TwoFactorEmailRequest,
@@ -133,7 +133,7 @@ impl AuthClient {
         send_two_factor_email(&self.client, tf).await
     }
 
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub fn validate_password(
         &self,
         password: String,
@@ -142,7 +142,7 @@ impl AuthClient {
         validate_password(&self.client, password, password_hash)
     }
 
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub fn validate_password_user_key(
         &self,
         password: String,
@@ -151,7 +151,7 @@ impl AuthClient {
         validate_password_user_key(&self.client, password, encrypted_user_key)
     }
 
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub fn validate_pin(
         &self,
         pin: String,
@@ -160,12 +160,12 @@ impl AuthClient {
         validate_pin(&self.client, pin, pin_protected_user_key)
     }
 
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub fn new_auth_request(&self, email: &str) -> Result<AuthRequestResponse, CryptoError> {
         new_auth_request(email)
     }
 
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub fn approve_auth_request(
         &self,
         public_key: B64,
@@ -173,7 +173,7 @@ impl AuthClient {
         approve_auth_request(&self.client, public_key)
     }
 
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub fn trust_device(&self) -> Result<TrustDeviceResponse, TrustDeviceError> {
         trust_device(&self.client)
     }
@@ -181,7 +181,7 @@ impl AuthClient {
 
 #[cfg(feature = "internal")]
 impl AuthClient {
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub async fn login_device(
         &self,
         email: String,
@@ -192,7 +192,7 @@ impl AuthClient {
         send_new_auth_request(&self.client, email, device_identifier).await
     }
 
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub async fn login_device_complete(
         &self,
         auth_req: NewAuthRequestResponse,
@@ -203,7 +203,7 @@ impl AuthClient {
     }
 }
 
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 #[cfg(feature = "internal")]
 #[derive(Debug, thiserror::Error)]
 #[cfg_attr(feature = "uniffi", derive(uniffi::Error), uniffi(flat_error))]
@@ -219,14 +219,14 @@ fn trust_device(client: &Client) -> Result<TrustDeviceResponse, TrustDeviceError
     let key_store = client.internal.get_key_store();
     let ctx = key_store.context();
     // FIXME: [PM-18099] Once DeviceKey deals with KeyIds, this should be updated
-    #[allow(deprecated)]
+    #[expect(deprecated)]
     let user_key = ctx.dangerous_get_symmetric_key(SymmetricKeyId::User)?;
 
     Ok(DeviceKey::trust_device(user_key)?)
 }
 
 impl Client {
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub fn auth(&self) -> AuthClient {
         AuthClient {
             client: self.clone(),

--- a/crates/bitwarden-core/src/auth/auth_request.rs
+++ b/crates/bitwarden-core/src/auth/auth_request.rs
@@ -73,7 +73,7 @@ pub(crate) fn auth_request_decrypt_master_key(
     Ok(master_key.decrypt_user_key(user_key)?)
 }
 
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 #[derive(Debug, Error)]
 #[cfg_attr(feature = "uniffi", derive(uniffi::Error), uniffi(flat_error))]
 pub enum ApproveAuthRequestError {
@@ -94,7 +94,7 @@ pub(crate) fn approve_auth_request(
     let ctx = key_store.context();
 
     // FIXME: [PM-18110] This should be removed once the key store can handle public key encryption
-    #[allow(deprecated)]
+    #[expect(deprecated)]
     let key = ctx.dangerous_get_symmetric_key(SymmetricKeyId::User)?;
 
     Ok(UnsignedSharedKey::encapsulate_key_unsigned(
@@ -281,7 +281,7 @@ mod tests {
         let existing_key = {
             let key_store = existing_device.internal.get_key_store();
             let ctx = key_store.context();
-            #[allow(deprecated)]
+            #[expect(deprecated)]
             ctx.dangerous_get_symmetric_key(SymmetricKeyId::User)
                 .unwrap()
                 .to_base64()
@@ -290,7 +290,7 @@ mod tests {
         let new_key = {
             let key_store = new_device.internal.get_key_store();
             let ctx = key_store.context();
-            #[allow(deprecated)]
+            #[expect(deprecated)]
             ctx.dangerous_get_symmetric_key(SymmetricKeyId::User)
                 .unwrap()
                 .to_base64()

--- a/crates/bitwarden-core/src/auth/jwt_token.rs
+++ b/crates/bitwarden-core/src/auth/jwt_token.rs
@@ -25,7 +25,7 @@ pub struct JwtToken {
 }
 
 /// Error when parsing JWT tokens.
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 #[derive(Debug, Error)]
 pub enum JwtTokenParseError {
     #[error("JWT token parse error: {0}")]

--- a/crates/bitwarden-core/src/auth/key_connector.rs
+++ b/crates/bitwarden-core/src/auth/key_connector.rs
@@ -1,7 +1,7 @@
 use bitwarden_crypto::{CryptoError, MasterKey, RsaKeyPair};
 use bitwarden_encoding::B64;
 
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 #[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
 pub struct KeyConnectorResponse {
     pub master_key: B64,

--- a/crates/bitwarden-core/src/auth/login/access_token.rs
+++ b/crates/bitwarden-core/src/auth/login/access_token.rs
@@ -156,7 +156,7 @@ pub struct AccessTokenLoginRequest {
     pub state_file: Option<PathBuf>,
 }
 
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 #[derive(Serialize, Deserialize, Debug, JsonSchema)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct AccessTokenLoginResponse {

--- a/crates/bitwarden-core/src/auth/login/api_key.rs
+++ b/crates/bitwarden-core/src/auth/login/api_key.rs
@@ -89,7 +89,7 @@ pub struct ApiKeyLoginRequest {
     pub password: String,
 }
 
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 #[derive(Serialize, Deserialize, Debug, JsonSchema)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct ApiKeyLoginResponse {

--- a/crates/bitwarden-core/src/auth/login/auth_request.rs
+++ b/crates/bitwarden-core/src/auth/login/auth_request.rs
@@ -17,7 +17,7 @@ use crate::{
     require,
 };
 
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 pub struct NewAuthRequestResponse {
     pub fingerprint: String,
     email: String,

--- a/crates/bitwarden-core/src/auth/login/mod.rs
+++ b/crates/bitwarden-core/src/auth/login/mod.rs
@@ -1,4 +1,4 @@
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 pub mod response;
 
 #[cfg(feature = "internal")]
@@ -31,7 +31,7 @@ mod access_token;
 #[cfg(feature = "secrets")]
 pub use access_token::*;
 
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 #[derive(Debug, thiserror::Error)]
 pub enum LoginError {
     #[error(transparent)]

--- a/crates/bitwarden-core/src/auth/login/password.rs
+++ b/crates/bitwarden-core/src/auth/login/password.rs
@@ -115,7 +115,7 @@ pub struct PasswordLoginRequest {
     pub two_factor: Option<TwoFactorRequest>,
 }
 
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 #[derive(Serialize, Deserialize, Debug, JsonSchema)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct PasswordLoginResponse {

--- a/crates/bitwarden-core/src/auth/login/prelogin.rs
+++ b/crates/bitwarden-core/src/auth/login/prelogin.rs
@@ -4,7 +4,7 @@ use thiserror::Error;
 
 use crate::{ApiError, Client, MissingFieldError, require};
 
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 #[derive(Debug, Error)]
 pub enum PreloginError {
     #[error(transparent)]

--- a/crates/bitwarden-core/src/auth/login/response/mod.rs
+++ b/crates/bitwarden-core/src/auth/login/response/mod.rs
@@ -1,2 +1,2 @@
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 pub mod two_factor;

--- a/crates/bitwarden-core/src/auth/login/response/two_factor/authenticator.rs
+++ b/crates/bitwarden-core/src/auth/login/response/two_factor/authenticator.rs
@@ -1,7 +1,7 @@
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 #[derive(Serialize, Deserialize, Debug, JsonSchema)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct Authenticator {}

--- a/crates/bitwarden-core/src/auth/login/response/two_factor/duo.rs
+++ b/crates/bitwarden-core/src/auth/login/response/two_factor/duo.rs
@@ -1,7 +1,7 @@
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 #[derive(Serialize, Deserialize, Debug, JsonSchema)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct Duo {

--- a/crates/bitwarden-core/src/auth/login/response/two_factor/email.rs
+++ b/crates/bitwarden-core/src/auth/login/response/two_factor/email.rs
@@ -1,7 +1,7 @@
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 #[derive(Serialize, Deserialize, Debug, JsonSchema)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct Email {

--- a/crates/bitwarden-core/src/auth/login/response/two_factor/remember.rs
+++ b/crates/bitwarden-core/src/auth/login/response/two_factor/remember.rs
@@ -1,7 +1,7 @@
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 #[derive(Serialize, Deserialize, Debug, JsonSchema)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct Remember {}

--- a/crates/bitwarden-core/src/auth/login/response/two_factor/two_factor_providers.rs
+++ b/crates/bitwarden-core/src/auth/login/response/two_factor/two_factor_providers.rs
@@ -6,7 +6,7 @@ use crate::auth::login::response::two_factor::{
     yubi_key::YubiKey,
 };
 
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 #[derive(Serialize, Deserialize, Debug, JsonSchema)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct TwoFactorProviders {

--- a/crates/bitwarden-core/src/auth/login/response/two_factor/web_authn.rs
+++ b/crates/bitwarden-core/src/auth/login/response/two_factor/web_authn.rs
@@ -1,7 +1,7 @@
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 #[derive(Serialize, Deserialize, Debug, JsonSchema)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct WebAuthn {}

--- a/crates/bitwarden-core/src/auth/login/response/two_factor/yubi_key.rs
+++ b/crates/bitwarden-core/src/auth/login/response/two_factor/yubi_key.rs
@@ -1,7 +1,7 @@
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 #[derive(Serialize, Deserialize, Debug, JsonSchema)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct YubiKey {

--- a/crates/bitwarden-core/src/auth/login/two_factor.rs
+++ b/crates/bitwarden-core/src/auth/login/two_factor.rs
@@ -10,7 +10,7 @@ use crate::{
     auth::{login::PreloginError, password::determine_password_hash},
 };
 
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 #[derive(Serialize, Deserialize, Debug, JsonSchema)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct TwoFactorEmailRequest {
@@ -20,7 +20,7 @@ pub struct TwoFactorEmailRequest {
     pub email: String,
 }
 
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 #[derive(Debug, Error)]
 pub enum TwoFactorEmailError {
     #[error(transparent)]
@@ -64,7 +64,7 @@ pub(crate) async fn send_two_factor_email(
     Ok(())
 }
 
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 #[derive(Serialize_repr, Deserialize_repr, PartialEq, Debug, JsonSchema, Clone)]
 #[repr(u8)]
 pub enum TwoFactorProvider {
@@ -78,7 +78,7 @@ pub enum TwoFactorProvider {
     WebAuthn = 7,
 }
 
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 #[derive(Serialize, Deserialize, Debug, JsonSchema)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct TwoFactorRequest {

--- a/crates/bitwarden-core/src/auth/mod.rs
+++ b/crates/bitwarden-core/src/auth/mod.rs
@@ -11,18 +11,18 @@ mod access_token;
 mod api;
 #[cfg(feature = "internal")]
 pub(crate) use api::response::user_decryption_options_response::UserDecryptionOptionsResponseModel;
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 pub mod auth_client;
 mod jwt_token;
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 pub mod login;
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 #[cfg(feature = "internal")]
 pub mod password;
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 #[cfg(feature = "internal")]
 pub mod pin;
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 pub mod renew;
 pub use access_token::{AccessToken, AccessTokenInvalidError};
 pub use jwt_token::*;
@@ -49,7 +49,7 @@ mod key_connector;
 pub use key_connector::KeyConnectorResponse;
 
 /// Error for authentication related operations
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 #[derive(Debug, Error)]
 #[cfg_attr(feature = "uniffi", derive(uniffi::Error), uniffi(flat_error))]
 pub enum AuthValidateError {

--- a/crates/bitwarden-core/src/auth/password/policy.rs
+++ b/crates/bitwarden-core/src/auth/password/policy.rs
@@ -31,10 +31,10 @@ pub(crate) fn satisfies_policy(
     true
 }
 
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 #[derive(Debug)]
 #[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
-#[allow(dead_code)]
+#[expect(dead_code)]
 pub struct MasterPasswordPolicyOptions {
     min_complexity: u8,
     min_length: u8,

--- a/crates/bitwarden-core/src/auth/password/validate.rs
+++ b/crates/bitwarden-core/src/auth/password/validate.rs
@@ -18,7 +18,7 @@ pub(crate) fn validate_password(
         .get_login_method()
         .ok_or(NotAuthenticatedError)?;
 
-    #[allow(irrefutable_let_patterns)]
+    #[expect(irrefutable_let_patterns)]
     if let LoginMethod::User(login_method) = login_method.as_ref() {
         match login_method {
             UserLoginMethod::Username { email, kdf, .. }
@@ -50,7 +50,7 @@ pub(crate) fn validate_password_user_key(
         .get_login_method()
         .ok_or(NotAuthenticatedError)?;
 
-    #[allow(irrefutable_let_patterns)]
+    #[expect(irrefutable_let_patterns)]
     if let LoginMethod::User(login_method) = login_method.as_ref() {
         match login_method {
             UserLoginMethod::Username { email, kdf, .. }
@@ -63,7 +63,7 @@ pub(crate) fn validate_password_user_key(
                 let key_store = client.internal.get_key_store();
                 let ctx = key_store.context();
                 // FIXME: [PM-18099] Once MasterKey deals with KeyIds, this should be updated
-                #[allow(deprecated)]
+                #[expect(deprecated)]
                 let existing_key = ctx.dangerous_get_symmetric_key(SymmetricKeyId::User)?;
 
                 if user_key != *existing_key {

--- a/crates/bitwarden-core/src/auth/pin.rs
+++ b/crates/bitwarden-core/src/auth/pin.rs
@@ -17,7 +17,7 @@ pub(crate) fn validate_pin(
         .get_login_method()
         .ok_or(NotAuthenticatedError)?;
 
-    #[allow(irrefutable_let_patterns)]
+    #[expect(irrefutable_let_patterns)]
     let LoginMethod::User(login_method) = login_method.as_ref() else {
         return Err(NotAuthenticatedError)?;
     };
@@ -28,7 +28,7 @@ pub(crate) fn validate_pin(
             let key_store = client.internal.get_key_store();
             let ctx = key_store.context();
             // FIXME: [PM-18099] Once PinKey deals with KeyIds, this should be updated
-            #[allow(deprecated)]
+            #[expect(deprecated)]
             let user_key = ctx.dangerous_get_symmetric_key(SymmetricKeyId::User)?;
 
             let pin_key = PinKey::derive(pin.as_bytes(), email.as_bytes(), kdf)?;

--- a/crates/bitwarden-core/src/auth/register.rs
+++ b/crates/bitwarden-core/src/auth/register.rs
@@ -5,7 +5,7 @@ use thiserror::Error;
 
 use crate::ApiError;
 
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct RegisterRequest {
@@ -15,7 +15,7 @@ pub struct RegisterRequest {
     pub password_hint: Option<String>,
 }
 
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 #[derive(Debug, Error)]
 pub enum RegisterError {
     #[error(transparent)]
@@ -42,7 +42,7 @@ pub(super) fn make_register_keys(
     })
 }
 
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 #[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
 pub struct RegisterKeyResponse {
     pub master_password_hash: B64,

--- a/crates/bitwarden-core/src/auth/renew.rs
+++ b/crates/bitwarden-core/src/auth/renew.rs
@@ -105,7 +105,7 @@ async fn renew_token_sdk_managed(
                     {
                         let key_store = client.get_key_store();
                         let ctx = key_store.context();
-                        #[allow(deprecated)]
+                        #[expect(deprecated)]
                         if let Ok(enc_key) = ctx.dangerous_get_symmetric_key(SymmetricKeyId::User) {
                             let state =
                                 ClientState::new(r.access_token.clone(), enc_key.to_base64());

--- a/crates/bitwarden-core/src/auth/tde.rs
+++ b/crates/bitwarden-core/src/auth/tde.rs
@@ -62,7 +62,7 @@ pub(super) fn make_register_tde_keys(
     })
 }
 
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 #[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
 pub struct RegisterTdeKeyResponse {
     pub private_key: EncString,

--- a/crates/bitwarden-core/src/client/client.rs
+++ b/crates/bitwarden-core/src/client/client.rs
@@ -42,7 +42,7 @@ impl Client {
         let settings = settings_input.unwrap_or_default();
 
         fn new_client_builder() -> reqwest::ClientBuilder {
-            #[allow(unused_mut)]
+            #[expect(unused_mut)]
             let mut client_builder = reqwest::Client::builder();
 
             #[cfg(not(target_arch = "wasm32"))]

--- a/crates/bitwarden-core/src/client/client_settings.rs
+++ b/crates/bitwarden-core/src/client/client_settings.rs
@@ -52,7 +52,7 @@ impl Default for ClientSettings {
     }
 }
 
-#[allow(non_camel_case_types, missing_docs)]
+#[expect(non_camel_case_types, missing_docs)]
 #[derive(Serialize, Deserialize, Copy, Clone, Debug, JsonSchema)]
 #[cfg_attr(feature = "uniffi", derive(uniffi::Enum))]
 #[cfg_attr(

--- a/crates/bitwarden-core/src/client/encryption_settings.rs
+++ b/crates/bitwarden-core/src/client/encryption_settings.rs
@@ -21,7 +21,7 @@ use crate::key_management::{AsymmetricKeyId, SecurityState, SignedSecurityState,
 use crate::key_management::{KeyIds, SymmetricKeyId};
 use crate::{MissingPrivateKeyError, error::UserIdAlreadySetError};
 
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 #[bitwarden_error(flat)]
 #[derive(Debug, Error)]
 pub enum EncryptionSettingsError {
@@ -47,7 +47,7 @@ pub enum EncryptionSettingsError {
     WrongPin,
 }
 
-#[allow(clippy::large_enum_variant)]
+#[expect(clippy::large_enum_variant)]
 #[cfg(feature = "internal")]
 pub(crate) enum AccountEncryptionKeys {
     V1 {
@@ -62,7 +62,7 @@ pub(crate) enum AccountEncryptionKeys {
     },
 }
 
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 pub struct EncryptionSettings {}
 
 impl EncryptionSettings {
@@ -133,7 +133,7 @@ impl EncryptionSettings {
         };
 
         // FIXME: [PM-18098] When this is part of crypto we won't need to use deprecated methods
-        #[allow(deprecated)]
+        #[expect(deprecated)]
         {
             let mut ctx = store.context_mut();
             ctx.set_symmetric_key(SymmetricKeyId::User, user_key)?;
@@ -173,7 +173,7 @@ impl EncryptionSettings {
         store.set_security_state_version(security_state.version());
         *sdk_security_state.write().expect("RwLock not poisoned") = Some(security_state);
 
-        #[allow(deprecated)]
+        #[expect(deprecated)]
         {
             let mut ctx = store.context_mut();
             ctx.set_symmetric_key(SymmetricKeyId::User, user_key)?;
@@ -193,7 +193,7 @@ impl EncryptionSettings {
         store: &KeyStore<KeyIds>,
     ) {
         // FIXME: [PM-18098] When this is part of crypto we won't need to use deprecated methods
-        #[allow(deprecated)]
+        #[expect(deprecated)]
         store
             .context_mut()
             .set_symmetric_key(SymmetricKeyId::Organization(organization_id), key)

--- a/crates/bitwarden-core/src/client/internal.rs
+++ b/crates/bitwarden-core/src/client/internal.rs
@@ -51,7 +51,7 @@ impl From<&InitUserCryptoRequest> for UserKeyState {
     }
 }
 
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 pub struct ApiConfigurations {
     pub identity_client: bitwarden_api_identity::apis::ApiClient,
     pub api_client: bitwarden_api_api::apis::ApiClient,
@@ -118,7 +118,7 @@ pub trait ClientManagedTokens: std::fmt::Debug + Send + Sync {
 pub(crate) struct SdkManagedTokens {
     // These two fields are always written to, but they are not read
     // from the secrets manager SDK.
-    #[allow(dead_code)]
+    #[expect(dead_code)]
     access_token: Option<String>,
     pub(crate) expires_on: Option<i64>,
 
@@ -126,7 +126,7 @@ pub(crate) struct SdkManagedTokens {
     pub(crate) refresh_token: Option<String>,
 }
 
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 #[derive(Debug)]
 pub struct InternalClient {
     pub(crate) user_id: OnceLock<UserId>,
@@ -142,7 +142,7 @@ pub struct InternalClient {
     pub(crate) __api_configurations: RwLock<Arc<ApiConfigurations>>,
 
     /// Reqwest client useable for external integrations like email forwarders, HIBP.
-    #[allow(unused)]
+    #[expect(unused)]
     pub(crate) external_client: reqwest::Client,
 
     pub(super) key_store: KeyStore<KeyIds>,
@@ -175,7 +175,7 @@ impl InternalClient {
             .clone()
     }
 
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub fn get_access_token_organization(&self) -> Option<OrganizationId> {
         match self
             .login_method
@@ -218,7 +218,7 @@ impl InternalClient {
             .set_tokens(token);
     }
 
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     #[cfg(feature = "internal")]
     pub fn get_kdf(&self) -> Result<Kdf, NotAuthenticatedError> {
         match self
@@ -234,7 +234,7 @@ impl InternalClient {
         }
     }
 
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub async fn get_api_configurations(&self) -> Arc<ApiConfigurations> {
         // At the moment we ignore the error result from the token renewal, if it fails,
         // the token will end up expiring and the next operation is going to fail anyway.
@@ -245,13 +245,13 @@ impl InternalClient {
             .clone()
     }
 
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     #[cfg(feature = "internal")]
     pub fn get_http_client(&self) -> &reqwest::Client {
         &self.external_client
     }
 
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub fn get_key_store(&self) -> &KeyStore<KeyIds> {
         &self.key_store
     }
@@ -268,7 +268,7 @@ impl InternalClient {
             .map_or(1, |state| state.version())
     }
 
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub fn init_user_id(&self, user_id: UserId) -> Result<(), UserIdAlreadySetError> {
         let set_uuid = self.user_id.get_or_init(|| user_id);
 
@@ -282,7 +282,7 @@ impl InternalClient {
         }
     }
 
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub fn get_user_id(&self) -> Option<UserId> {
         self.user_id.get().copied()
     }
@@ -367,7 +367,7 @@ impl InternalClient {
 
             // Allowing deprecated here, until a refactor to pass the Local key ids to
             // `initialized_user_crypto_decrypted_key`
-            #[allow(deprecated)]
+            #[expect(deprecated)]
             ctx.dangerous_get_symmetric_key(decrypted_user_key_id)?
                 .clone()
         };
@@ -383,7 +383,7 @@ impl InternalClient {
         EncryptionSettings::new_single_org_key(organization_id, key, &self.key_store);
     }
 
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     #[cfg(feature = "internal")]
     pub fn initialize_org_crypto(
         &self,

--- a/crates/bitwarden-core/src/client/login_method.rs
+++ b/crates/bitwarden-core/src/client/login_method.rs
@@ -8,7 +8,7 @@ use crate::{OrganizationId, auth::AccessToken};
 
 #[derive(Debug)]
 pub(crate) enum LoginMethod {
-    #[allow(dead_code)]
+    #[expect(dead_code)]
     User(UserLoginMethod),
     // TODO: Organizations supports api key
     // Organization(OrganizationLoginMethod),
@@ -16,7 +16,7 @@ pub(crate) enum LoginMethod {
     ServiceAccount(ServiceAccountLoginMethod),
 }
 
-#[allow(dead_code)]
+#[expect(dead_code)]
 #[derive(Debug)]
 pub(crate) enum UserLoginMethod {
     Username {

--- a/crates/bitwarden-core/src/client/mod.rs
+++ b/crates/bitwarden-core/src/client/mod.rs
@@ -1,15 +1,15 @@
 //! Bitwarden SDK Client
 
-#[allow(clippy::module_inception)]
+#[expect(clippy::module_inception)]
 mod client;
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 pub mod client_settings;
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 pub mod encryption_settings;
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 pub mod internal;
 pub use internal::ApiConfigurations;
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 pub mod login_method;
 #[cfg(feature = "secrets")]
 pub(crate) use login_method::ServiceAccountLoginMethod;
@@ -20,6 +20,6 @@ mod flags;
 pub use client::Client;
 pub use client_settings::{ClientSettings, DeviceType};
 
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 #[cfg(feature = "internal")]
 pub mod test_accounts;

--- a/crates/bitwarden-core/src/error.rs
+++ b/crates/bitwarden-core/src/error.rs
@@ -28,7 +28,7 @@ macro_rules! impl_bitwarden_error {
 }
 
 /// Errors from performing network requests.
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 #[derive(Debug, Error)]
 #[cfg_attr(feature = "uniffi", derive(uniffi::Error), uniffi(flat_error))]
 pub enum ApiError {

--- a/crates/bitwarden-core/src/key_management/crypto.rs
+++ b/crates/bitwarden-core/src/key_management/crypto.rs
@@ -31,7 +31,7 @@ use crate::{
 };
 
 /// Catch all error for mobile crypto operations.
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 #[bitwarden_error(flat)]
 #[derive(Debug, thiserror::Error)]
 pub enum CryptoClientError {
@@ -72,7 +72,7 @@ pub struct InitUserCryptoRequest {
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 #[cfg_attr(feature = "uniffi", derive(uniffi::Enum))]
 #[cfg_attr(feature = "wasm", derive(Tsify), tsify(into_wasm_abi, from_wasm_abi))]
-#[allow(clippy::large_enum_variant)]
+#[expect(clippy::large_enum_variant)]
 pub enum InitUserCryptoMethod {
     /// Password
     Password {
@@ -296,7 +296,7 @@ pub(super) async fn get_user_encryption_key(client: &Client) -> Result<B64, Cryp
     let key_store = client.internal.get_key_store();
     let ctx = key_store.context();
     // This is needed because the mobile clients need access to the user encryption key
-    #[allow(deprecated)]
+    #[expect(deprecated)]
     let user_key = ctx.dangerous_get_symmetric_key(SymmetricKeyId::User)?;
 
     Ok(user_key.to_base64())
@@ -324,7 +324,7 @@ pub(super) fn make_update_kdf(
     let key_store = client.internal.get_key_store();
     let ctx = key_store.context();
     // FIXME: [PM-18099] Once MasterKey deals with KeyIds, this should be updated
-    #[allow(deprecated)]
+    #[expect(deprecated)]
     let user_key = ctx.dangerous_get_symmetric_key(SymmetricKeyId::User)?;
 
     let login_method = client
@@ -379,7 +379,7 @@ pub(super) fn make_update_password(
     let key_store = client.internal.get_key_store();
     let ctx = key_store.context();
     // FIXME: [PM-18099] Once MasterKey deals with KeyIds, this should be updated
-    #[allow(deprecated)]
+    #[expect(deprecated)]
     let user_key = ctx.dangerous_get_symmetric_key(SymmetricKeyId::User)?;
 
     let login_method = client
@@ -456,7 +456,7 @@ pub(super) fn derive_pin_key(
     let key_store = client.internal.get_key_store();
     let ctx = key_store.context();
     // FIXME: [PM-18099] Once PinKey deals with KeyIds, this should be updated
-    #[allow(deprecated)]
+    #[expect(deprecated)]
     let user_key = ctx.dangerous_get_symmetric_key(SymmetricKeyId::User)?;
 
     let login_method = client
@@ -479,7 +479,7 @@ pub(super) fn derive_pin_user_key(
     let key_store = client.internal.get_key_store();
     let ctx = key_store.context();
     // FIXME: [PM-18099] Once PinKey deals with KeyIds, this should be updated
-    #[allow(deprecated)]
+    #[expect(deprecated)]
     let user_key = ctx.dangerous_get_symmetric_key(SymmetricKeyId::User)?;
 
     let pin: String = encrypted_pin.decrypt_with_key(user_key)?;
@@ -510,7 +510,7 @@ fn derive_pin_protected_user_key(
     Ok(derived_key.encrypt_user_key(user_key)?)
 }
 
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 #[bitwarden_error(flat)]
 #[derive(Debug, thiserror::Error)]
 pub enum EnrollAdminPasswordResetError {
@@ -528,7 +528,7 @@ pub(super) fn enroll_admin_password_reset(
     let key_store = client.internal.get_key_store();
     let ctx = key_store.context();
     // FIXME: [PM-18110] This should be removed once the key store can handle public key encryption
-    #[allow(deprecated)]
+    #[expect(deprecated)]
     let key = ctx.dangerous_get_symmetric_key(SymmetricKeyId::User)?;
 
     Ok(UnsignedSharedKey::encapsulate_key_unsigned(
@@ -553,7 +553,7 @@ pub struct DeriveKeyConnectorRequest {
     pub email: String,
 }
 
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 #[bitwarden_error(flat)]
 #[derive(Debug, thiserror::Error)]
 pub enum DeriveKeyConnectorError {
@@ -739,7 +739,7 @@ pub(crate) fn make_v2_keys_for_v1_user(
         )));
     }
 
-    #[allow(deprecated)]
+    #[expect(deprecated)]
     let private_key = ctx.dangerous_get_asymmetric_key(private_key_id)?.clone();
 
     // New user key
@@ -837,12 +837,12 @@ mod tests {
     use crate::{Client, client::internal::UserKeyState};
     const TEST_VECTOR_USER_KEY_V2_B64: &str = "pQEEAlACHUUoybNAuJoZzqNMxz2bAzoAARFvBIQDBAUGIFggAvGl4ifaUAomQdCdUPpXLHtypiQxHjZwRHeI83caZM4B";
     const TEST_VECTOR_PRIVATE_KEY_V2: &str = "7.g1gdowE6AAERbwMZARwEUAIdRSjJs0C4mhnOo0zHPZuhBVgYthGLGqVLPeidY8mNMxpLJn3fyeSxyaWsWQTR6pxmRV2DyGZXly/0l9KK+Rsfetl9wvYIz0O4/RW3R6wf7eGxo5XmicV3WnFsoAmIQObxkKWShxFyjzg+ocKItQDzG7Gp6+MW4biTrAlfK51ML/ZS+PCjLmgI1QQr4eMHjiwA2TBKtKkxfjoTJkMXECpRVLEXOo8/mbIGYkuabbSA7oU+TJ0yXlfKDtD25gnyO7tjW/0JMFUaoEKRJOuKoXTN4n/ks4Hbxk0X5/DzfG05rxWad2UNBjNg7ehW99WrQ+33ckdQFKMQOri/rt8JzzrF1k11/jMJ+Y2TADKNHr91NalnUX+yqZAAe3sRt5Pv5ZhLIwRMKQi/1NrLcsQPRuUnogVSPOoMnE/eD6F70iU60Z6pvm1iBw2IvELZcrs/oxpO2SeCue08fIZW/jNZokbLnm90tQ7QeZTUpiPALhUgfGOa3J9VOJ7jQGCqDjd9CzV2DCVfhKCapeTbldm+RwEWBz5VvorH5vMx1AzbPRJxdIQuxcg3NqRrXrYC7fyZljWaPB9qP1tztiPtd1PpGEgxLByIfR6fqyZMCvOBsWbd0H6NhF8mNVdDw60+skFRdbRBTSCjCtKZeLVuVFb8ioH45PR5oXjtx4atIDzu6DKm6TTMCbR6DjZuZZ8GbwHxuUD2mDD3pAFhaof9kR3lQdjy7Zb4EzUUYskQxzcLPcqzp9ZgB3Rg91SStBCCMhdQ6AnhTy+VTGt/mY5AbBXNRSL6fI0r+P9K8CcEI4bNZCDkwwQr5v4O4ykSUzIvmVU0zKzDngy9bteIZuhkvGUoZlQ9UATNGPhoLfqq2eSvqEXkCbxTVZ5D+Ww9pHmWeVcvoBhcl5MvicfeQt++dY3tPjIfZq87nlugG4HiNbcv9nbVpgwe3v8cFetWXQgnO4uhx8JHSwGoSuxHFZtl2sdahjTHavRHnYjSABEFrViUKgb12UDD5ow1GAL62wVdSJKRf9HlLbJhN3PBxuh5L/E0wy1wGA9ecXtw/R1ktvXZ7RklGAt1TmNzZv6vI2J/CMXvndOX9rEpjKMbwbIDAjQ9PxiWdcnmc5SowT9f6yfIjbjXnRMWWidPAua7sgrtej4HP4Qjz1fpgLMLCRyF97tbMTmsAI5Cuj98Buh9PwcdyXj5SbVuHdJS1ehv9b5SWPsD4pwOm3+otVNK6FTazhoUl47AZoAoQzXfsXxrzqYzvF0yJkCnk9S1dcij1L569gQ43CJO6o6jIZFJvA4EmZDl95ELu+BC+x37Ip8dq4JLPsANDVSqvXO9tfDUIXEx25AaOYhW2KAUoDve/fbsU8d0UZR1o/w+ZrOQwawCIPeVPtbh7KFRVQi/rPI+Abl6XR6qMJbKPegliYGUuGF2oEMEc6QLTsMRCEPuw0S3kxbNfVPqml8nGhB2r8zUHBY1diJEmipVghnwH74gIKnyJ2C9nKjV8noUfKzqyV8vxUX2G5yXgodx8Jn0cWs3XhWuApFla9z4R28W/4jA1jK2WQMlx+b6xKUWgRk8+fYsc0HSt2fDrQ9pLpnjb8ME59RCxSPV++PThpnR2JtastZBZur2hBIJsGILCAmufUU4VC4gBKPhNfu/OK4Ktgz+uQlUa9fEC/FnkpTRQPxHuQjSQSNrIIyW1bIRBtnwjvvvNoui9FZJ";
-    #[allow(unused)]
+    #[expect(unused)]
     const TEST_VECTOR_PUBLIC_KEY_V2: &str = "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAz/+1jPJ1HqcaCdKrTPms8XJcvnmd9alI42U2XF/4GMNTM5KF1gI6snhR/23ZLatZRFMHoK8ZCMSpGNkjLadArz52ldceTvBOhQUiWylkZQ4NfNa3xIYJubXOmkeDyfNuyLxVZvcZOko9PdT+Qx2QxDrFi2XNo2I7aVFd19/COIEkex4mJ0eA3MHFpKCdxYbcTAsGID8+kVR9L84S1JptZoG8x+iB/D3/Q4y02UsQYpFTu0vbPY84YmW03ngJdxWzS8X4/UJI/jaEn5rO4xlU5QcL0l4IybP5LRpE9XEeUHATKVOG7eNfpe9zDfKV2qQoofQMH9VvkWO4psaWDjBSdwIDAQAB";
-    #[allow(unused)]
+    #[expect(unused)]
     const TEST_VECTOR_SIGNED_PUBLIC_KEY_V2: &str = "hFgepAEnAxg8BFAmkP0QgfdMVbIujX55W/yNOgABOH8BoFkBTqNpYWxnb3JpdGhtAG1jb250ZW50Rm9ybWF0AGlwdWJsaWNLZXlZASYwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDP/7WM8nUepxoJ0qtM+azxcly+eZ31qUjjZTZcX/gYw1MzkoXWAjqyeFH/bdktq1lEUwegrxkIxKkY2SMtp0CvPnaV1x5O8E6FBSJbKWRlDg181rfEhgm5tc6aR4PJ827IvFVm9xk6Sj091P5DHZDEOsWLZc2jYjtpUV3X38I4gSR7HiYnR4DcwcWkoJ3FhtxMCwYgPz6RVH0vzhLUmm1mgbzH6IH8Pf9DjLTZSxBikVO7S9s9jzhiZbTeeAl3FbNLxfj9Qkj+NoSfms7jGVTlBwvSXgjJs/ktGkT1cR5QcBMpU4bt41+l73MN8pXapCih9Awf1W+RY7imxpYOMFJ3AgMBAAFYQMq/hT4wod2w8xyoM7D86ctuLNX4ZRo+jRHf2sZfaO7QsvonG/ZYuNKF5fq8wpxMRjfoMvnY2TTShbgzLrW8BA4=";
     const TEST_VECTOR_SIGNING_KEY_V2: &str = "7.g1gcowE6AAERbwMYZQRQAh1FKMmzQLiaGc6jTMc9m6EFWBhYePc2qkCruHAPXgbzXsIP1WVk11ArbLNYUBpifToURlwHKs1je2BwZ1C/5thz4nyNbL0wDaYkRWI9ex1wvB7KhdzC7ltStEd5QttboTSCaXQROSZaGBPNO5+Bu3sTY8F5qK1pBUo6AHNN";
-    #[allow(unused)]
+    #[expect(unused)]
     const TEST_VECTOR_VERIFYING_KEY_V2: &str =
         "pgEBAlAmkP0QgfdMVbIujX55W/yNAycEgQIgBiFYIEM6JxBmjWQTruAm3s6BTaJy1q6BzQetMBacNeRJ0kxR";
     const TEST_VECTOR_SECURITY_STATE_V2: &str = "hFgepAEnAxg8BFAmkP0QgfdMVbIujX55W/yNOgABOH8CoFgkomhlbnRpdHlJZFBHOOw2BI9OQoNq+Vl1xZZKZ3ZlcnNpb24CWEAlchbJR0vmRfShG8On7Q2gknjkw4Dd6MYBLiH4u+/CmfQdmjNZdf6kozgW/6NXyKVNu8dAsKsin+xxXkDyVZoG";
@@ -928,7 +928,7 @@ mod tests {
         let client_key = {
             let key_store = client.internal.get_key_store();
             let ctx = key_store.context();
-            #[allow(deprecated)]
+            #[expect(deprecated)]
             ctx.dangerous_get_symmetric_key(SymmetricKeyId::User)
                 .unwrap()
                 .to_base64()
@@ -937,7 +937,7 @@ mod tests {
         let client2_key = {
             let key_store = client2.internal.get_key_store();
             let ctx = key_store.context();
-            #[allow(deprecated)]
+            #[expect(deprecated)]
             ctx.dangerous_get_symmetric_key(SymmetricKeyId::User)
                 .unwrap()
                 .to_base64()
@@ -1012,7 +1012,7 @@ mod tests {
         let client_key = {
             let key_store = client.internal.get_key_store();
             let ctx = key_store.context();
-            #[allow(deprecated)]
+            #[expect(deprecated)]
             ctx.dangerous_get_symmetric_key(SymmetricKeyId::User)
                 .unwrap()
                 .to_base64()
@@ -1021,7 +1021,7 @@ mod tests {
         let client2_key = {
             let key_store = client2.internal.get_key_store();
             let ctx = key_store.context();
-            #[allow(deprecated)]
+            #[expect(deprecated)]
             ctx.dangerous_get_symmetric_key(SymmetricKeyId::User)
                 .unwrap()
                 .to_base64()
@@ -1083,7 +1083,7 @@ mod tests {
         let client_key = {
             let key_store = client.internal.get_key_store();
             let ctx = key_store.context();
-            #[allow(deprecated)]
+            #[expect(deprecated)]
             ctx.dangerous_get_symmetric_key(SymmetricKeyId::User)
                 .unwrap()
                 .to_base64()
@@ -1092,7 +1092,7 @@ mod tests {
         let client2_key = {
             let key_store = client2.internal.get_key_store();
             let ctx = key_store.context();
-            #[allow(deprecated)]
+            #[expect(deprecated)]
             ctx.dangerous_get_symmetric_key(SymmetricKeyId::User)
                 .unwrap()
                 .to_base64()
@@ -1128,7 +1128,7 @@ mod tests {
         let client_key = {
             let key_store = client.internal.get_key_store();
             let ctx = key_store.context();
-            #[allow(deprecated)]
+            #[expect(deprecated)]
             ctx.dangerous_get_symmetric_key(SymmetricKeyId::User)
                 .unwrap()
                 .to_base64()
@@ -1137,7 +1137,7 @@ mod tests {
         let client3_key = {
             let key_store = client3.internal.get_key_store();
             let ctx = key_store.context();
-            #[allow(deprecated)]
+            #[expect(deprecated)]
             ctx.dangerous_get_symmetric_key(SymmetricKeyId::User)
                 .unwrap()
                 .to_base64()
@@ -1243,7 +1243,7 @@ mod tests {
 
         let key_store = client.internal.get_key_store();
         let ctx = key_store.context();
-        #[allow(deprecated)]
+        #[expect(deprecated)]
         let expected = ctx
             .dangerous_get_symmetric_key(SymmetricKeyId::User)
             .unwrap();
@@ -1428,7 +1428,7 @@ mod tests {
     #[tokio::test]
     async fn test_make_v2_keys_for_v1_user_with_v2_user_fails() {
         let client = Client::new(None);
-        #[allow(deprecated)]
+        #[expect(deprecated)]
         client
             .internal
             .get_key_store()
@@ -1470,7 +1470,7 @@ mod tests {
     #[test]
     fn test_get_v2_rotated_account_keys_non_v2_user() {
         let client = Client::new(None);
-        #[allow(deprecated)]
+        #[expect(deprecated)]
         client
             .internal
             .get_key_store()
@@ -1494,7 +1494,7 @@ mod tests {
     #[tokio::test]
     async fn test_get_v2_rotated_account_keys() {
         let client = Client::new(None);
-        #[allow(deprecated)]
+        #[expect(deprecated)]
         client
             .internal
             .get_key_store()

--- a/crates/bitwarden-core/src/key_management/crypto_client.rs
+++ b/crates/bitwarden-core/src/key_management/crypto_client.rs
@@ -132,7 +132,7 @@ impl CryptoClient {
     ) -> Result<Vec<u8>, CryptoClientError> {
         let mut ctx = self.client.internal.get_key_store().context_mut();
         let key_slot = envelope.unseal(pin.as_str(), &mut ctx)?;
-        #[allow(deprecated)]
+        #[expect(deprecated)]
         let key = ctx.dangerous_get_symmetric_key(key_slot)?;
         Ok(key.to_encoded().to_vec())
     }

--- a/crates/bitwarden-core/src/key_management/master_password.rs
+++ b/crates/bitwarden-core/src/key_management/master_password.rs
@@ -13,7 +13,7 @@ use wasm_bindgen::prelude::*;
 use crate::{MissingFieldError, require};
 
 /// Error for master password related operations.
-#[allow(dead_code)]
+#[expect(dead_code)]
 #[bitwarden_error(flat)]
 #[derive(Debug, thiserror::Error)]
 pub enum MasterPasswordError {
@@ -110,7 +110,7 @@ fn kdf_parse_nonzero_u32(value: impl TryInto<u32>) -> Result<NonZeroU32, MasterP
 }
 
 /// Represents the data required to authenticate with the master password.
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 #[cfg_attr(feature = "uniffi", derive(uniffi::Record))]

--- a/crates/bitwarden-core/src/key_management/mod.rs
+++ b/crates/bitwarden-core/src/key_management/mod.rs
@@ -71,7 +71,7 @@ key_ids! {
 pub fn create_test_crypto_with_user_key(key: SymmetricCryptoKey) -> KeyStore<KeyIds> {
     let store = KeyStore::default();
 
-    #[allow(deprecated)]
+    #[expect(deprecated)]
     store
         .context_mut()
         .set_symmetric_key(SymmetricKeyId::User, key.clone())
@@ -91,13 +91,13 @@ pub fn create_test_crypto_with_user_and_org_key(
 ) -> KeyStore<KeyIds> {
     let store = KeyStore::default();
 
-    #[allow(deprecated)]
+    #[expect(deprecated)]
     store
         .context_mut()
         .set_symmetric_key(SymmetricKeyId::User, key.clone())
         .expect("Mutable context");
 
-    #[allow(deprecated)]
+    #[expect(deprecated)]
     store
         .context_mut()
         .set_symmetric_key(SymmetricKeyId::Organization(org_id), org_key.clone())

--- a/crates/bitwarden-core/src/key_management/user_decryption.rs
+++ b/crates/bitwarden-core/src/key_management/user_decryption.rs
@@ -8,7 +8,7 @@ use crate::{
 
 /// Represents data required to decrypt user's vault.
 /// Currently, this is only used for master password unlock.
-#[allow(dead_code)]
+#[expect(dead_code)]
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct UserDecryptionData {

--- a/crates/bitwarden-core/src/platform/generate_fingerprint.rs
+++ b/crates/bitwarden-core/src/platform/generate_fingerprint.rs
@@ -31,7 +31,7 @@ pub struct FingerprintResponse {
 }
 
 /// Errors that can occur when computing a fingerprint.
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 #[derive(Debug, Error)]
 #[cfg_attr(feature = "uniffi", derive(uniffi::Error))]
 pub enum FingerprintError {
@@ -47,7 +47,7 @@ pub(crate) fn generate_fingerprint(input: &FingerprintRequest) -> Result<String,
 }
 
 /// Errors that can occur when computing a fingerprint.
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 #[derive(Debug, Error)]
 #[cfg_attr(feature = "uniffi", derive(uniffi::Error), uniffi(flat_error))]
 pub enum UserFingerprintError {
@@ -65,7 +65,7 @@ pub(crate) fn generate_user_fingerprint(
     let ctx = key_store.context();
     // FIXME: [PM-18110] This should be removed once the key store can handle public keys and
     // fingerprints
-    #[allow(deprecated)]
+    #[expect(deprecated)]
     let private_key = ctx.dangerous_get_asymmetric_key(AsymmetricKeyId::UserPrivateKey)?;
 
     let public_key = private_key.to_public_key().to_der()?;

--- a/crates/bitwarden-core/src/platform/get_user_api_key.rs
+++ b/crates/bitwarden-core/src/platform/get_user_api_key.rs
@@ -27,7 +27,7 @@ use crate::{
     require,
 };
 
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 #[derive(Debug, Error)]
 pub enum UserApiKeyError {
     #[error(transparent)]

--- a/crates/bitwarden-core/src/secrets_manager/state.rs
+++ b/crates/bitwarden-core/src/secrets_manager/state.rs
@@ -24,7 +24,7 @@ pub(crate) struct ClientState {
     pub(crate) encryption_key: B64,
 }
 
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 #[derive(Debug, thiserror::Error)]
 pub enum StateFileError {
     #[error(transparent)]

--- a/crates/bitwarden-core/src/uniffi_support.rs
+++ b/crates/bitwarden-core/src/uniffi_support.rs
@@ -22,7 +22,7 @@ uniffi::custom_type!(Uuid, String, {
 
 // Uniffi doesn't emit unused types, this is a dummy record to ensure that the custom type
 // converters are emitted
-#[allow(dead_code)]
+#[expect(dead_code)]
 #[derive(uniffi::Record)]
 struct UniffiConverterDummyRecord {
     uuid: Uuid,

--- a/crates/bitwarden-crypto/src/content_format.rs
+++ b/crates/bitwarden-crypto/src/content_format.rs
@@ -50,7 +50,7 @@ mod private {
 /// which can still be mis-used, but has to be misused explicitly.
 pub trait ConstContentFormat: private::Sealed {
     /// Returns the content format as a `ContentFormat` enum.
-    #[allow(private_interfaces)]
+    #[expect(private_interfaces)]
     fn content_format() -> ContentFormat;
 }
 
@@ -122,7 +122,7 @@ pub(crate) type Utf8Bytes = Bytes<Utf8ContentFormat>;
 pub struct OctetStreamContentFormat;
 impl private::Sealed for OctetStreamContentFormat {}
 impl ConstContentFormat for OctetStreamContentFormat {
-    #[allow(private_interfaces)]
+    #[expect(private_interfaces)]
     fn content_format() -> ContentFormat {
         ContentFormat::OctetStream
     }
@@ -136,7 +136,7 @@ pub type OctetStreamBytes = Bytes<OctetStreamContentFormat>;
 pub struct Pkcs8PrivateKeyDerContentFormat;
 impl private::Sealed for Pkcs8PrivateKeyDerContentFormat {}
 impl ConstContentFormat for Pkcs8PrivateKeyDerContentFormat {
-    #[allow(private_interfaces)]
+    #[expect(private_interfaces)]
     fn content_format() -> ContentFormat {
         ContentFormat::Pkcs8PrivateKey
     }
@@ -150,7 +150,7 @@ pub type Pkcs8PrivateKeyBytes = Bytes<Pkcs8PrivateKeyDerContentFormat>;
 pub struct SpkiPublicKeyDerContentFormat;
 impl private::Sealed for SpkiPublicKeyDerContentFormat {}
 impl ConstContentFormat for SpkiPublicKeyDerContentFormat {
-    #[allow(private_interfaces)]
+    #[expect(private_interfaces)]
     fn content_format() -> ContentFormat {
         ContentFormat::SPKIPublicKeyDer
     }
@@ -171,7 +171,7 @@ pub trait FromB64ContentFormat {}
 pub struct CoseKeyContentFormat;
 impl private::Sealed for CoseKeyContentFormat {}
 impl ConstContentFormat for CoseKeyContentFormat {
-    #[allow(private_interfaces)]
+    #[expect(private_interfaces)]
     fn content_format() -> ContentFormat {
         ContentFormat::CoseKey
     }
@@ -187,7 +187,7 @@ pub type CoseKeyBytes = Bytes<CoseKeyContentFormat>;
 pub struct BitwardenLegacyKeyContentFormat;
 impl private::Sealed for BitwardenLegacyKeyContentFormat {}
 impl ConstContentFormat for BitwardenLegacyKeyContentFormat {
-    #[allow(private_interfaces)]
+    #[expect(private_interfaces)]
     fn content_format() -> ContentFormat {
         ContentFormat::BitwardenLegacyKey
     }
@@ -203,7 +203,7 @@ pub type BitwardenLegacyKeyBytes = Bytes<BitwardenLegacyKeyContentFormat>;
 pub struct CoseSign1ContentFormat;
 impl private::Sealed for CoseSign1ContentFormat {}
 impl ConstContentFormat for CoseSign1ContentFormat {
-    #[allow(private_interfaces)]
+    #[expect(private_interfaces)]
     fn content_format() -> ContentFormat {
         ContentFormat::CoseSign1
     }
@@ -219,7 +219,7 @@ pub type CoseSign1Bytes = Bytes<CoseSign1ContentFormat>;
 pub struct CborContentFormat;
 impl private::Sealed for CborContentFormat {}
 impl ConstContentFormat for CborContentFormat {
-    #[allow(private_interfaces)]
+    #[expect(private_interfaces)]
     fn content_format() -> ContentFormat {
         ContentFormat::Cbor
     }
@@ -233,7 +233,7 @@ pub type CborBytes = Bytes<CborContentFormat>;
 pub struct CoseEncrypt0ContentFormat;
 impl private::Sealed for CoseEncrypt0ContentFormat {}
 impl ConstContentFormat for CoseEncrypt0ContentFormat {
-    #[allow(private_interfaces)]
+    #[expect(private_interfaces)]
     fn content_format() -> ContentFormat {
         ContentFormat::CoseEncrypt0
     }

--- a/crates/bitwarden-crypto/src/enc_string/asymmetric.rs
+++ b/crates/bitwarden-crypto/src/enc_string/asymmetric.rs
@@ -14,7 +14,7 @@ use crate::{
 };
 // This module is a workaround to avoid deprecated warnings that come from the ZeroizeOnDrop
 // macro expansion
-#[allow(deprecated)]
+#[expect(deprecated)]
 mod internal {
     #[cfg(feature = "wasm")]
     #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
@@ -52,9 +52,9 @@ mod internal {
     /// Where:
     /// - `[type]`: is a digit number representing the variant.
     /// - `[data]`: is the encrypted data.
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     #[derive(Clone, zeroize::ZeroizeOnDrop)]
-    #[allow(unused, non_camel_case_types)]
+    #[expect(unused, non_camel_case_types)]
     pub enum UnsignedSharedKey {
         /// 3
         Rsa2048_OaepSha256_B64 { data: Vec<u8> },
@@ -92,13 +92,13 @@ impl FromStr for UnsignedSharedKey {
                 let data = from_b64_vec(parts[0])?;
                 Ok(UnsignedSharedKey::Rsa2048_OaepSha1_B64 { data })
             }
-            #[allow(deprecated)]
+            #[expect(deprecated)]
             ("5", 2) => {
                 let data = from_b64_vec(parts[0])?;
                 let mac: Vec<u8> = from_b64_vec(parts[1])?;
                 Ok(UnsignedSharedKey::Rsa2048_OaepSha256_HmacSha256_B64 { data, mac })
             }
-            #[allow(deprecated)]
+            #[expect(deprecated)]
             ("6", 2) => {
                 let data = from_b64_vec(parts[0])?;
                 let mac: Vec<u8> = from_b64_vec(parts[1])?;
@@ -119,11 +119,11 @@ impl Display for UnsignedSharedKey {
         let parts: Vec<&[u8]> = match self {
             UnsignedSharedKey::Rsa2048_OaepSha256_B64 { data } => vec![data],
             UnsignedSharedKey::Rsa2048_OaepSha1_B64 { data } => vec![data],
-            #[allow(deprecated)]
+            #[expect(deprecated)]
             UnsignedSharedKey::Rsa2048_OaepSha256_HmacSha256_B64 { data, mac } => {
                 vec![data, mac]
             }
-            #[allow(deprecated)]
+            #[expect(deprecated)]
             UnsignedSharedKey::Rsa2048_OaepSha1_HmacSha256_B64 { data, mac } => {
                 vec![data, mac]
             }
@@ -183,9 +183,9 @@ impl UnsignedSharedKey {
         match self {
             UnsignedSharedKey::Rsa2048_OaepSha256_B64 { .. } => 3,
             UnsignedSharedKey::Rsa2048_OaepSha1_B64 { .. } => 4,
-            #[allow(deprecated)]
+            #[expect(deprecated)]
             UnsignedSharedKey::Rsa2048_OaepSha256_HmacSha256_B64 { .. } => 5,
-            #[allow(deprecated)]
+            #[expect(deprecated)]
             UnsignedSharedKey::Rsa2048_OaepSha1_HmacSha256_B64 { .. } => 6,
         }
     }
@@ -209,11 +209,11 @@ impl UnsignedSharedKey {
                     Rsa2048_OaepSha1_B64 { data } => {
                         rsa_private_key.decrypt(Oaep::new::<sha1::Sha1>(), data)
                     }
-                    #[allow(deprecated)]
+                    #[expect(deprecated)]
                     Rsa2048_OaepSha256_HmacSha256_B64 { data, .. } => {
                         rsa_private_key.decrypt(Oaep::new::<sha2::Sha256>(), data)
                     }
-                    #[allow(deprecated)]
+                    #[expect(deprecated)]
                     Rsa2048_OaepSha1_HmacSha256_B64 { data, .. } => {
                         rsa_private_key.decrypt(Oaep::new::<sha1::Sha1>(), data)
                     }

--- a/crates/bitwarden-crypto/src/enc_string/symmetric.rs
+++ b/crates/bitwarden-crypto/src/enc_string/symmetric.rs
@@ -53,9 +53,9 @@ export type EncString = Tagged<string, "EncString">;
 /// - `[data]`: is the encrypted data.
 /// - `[mac]`: (optional) is the MAC used to validate the integrity of the data.
 /// - `[cose_encrypt0_bytes]`: is the COSE Encrypt0 message, serialized to bytes
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 #[derive(Clone, zeroize::ZeroizeOnDrop, PartialEq)]
-#[allow(unused, non_camel_case_types)]
+#[expect(unused, non_camel_case_types)]
 pub enum EncString {
     /// 0
     Aes256Cbc_B64 {
@@ -115,7 +115,7 @@ impl EncString {
         s.map(|s| s.parse()).transpose()
     }
 
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub fn from_buffer(buf: &[u8]) -> Result<Self> {
         if buf.is_empty() {
             return Err(EncStringParseError::NoType.into());
@@ -149,7 +149,7 @@ impl EncString {
         }
     }
 
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub fn to_buffer(&self) -> Result<Vec<u8>> {
         let mut buf;
 
@@ -182,7 +182,7 @@ impl EncString {
 // from serializing to a string. For Aes256_Cbc, or Aes256_Cbc_Hmac, `ToString` and `Debug`
 // are the same. For `Cose_Encrypt0`, `Debug` will print the decoded COSE message, while
 // `ToString` will print the Cose_Encrypt0 bytes, encoded in base64.
-#[allow(clippy::to_string_trait_impl)]
+#[expect(clippy::to_string_trait_impl)]
 impl ToString for EncString {
     fn to_string(&self) -> String {
         fn fmt_parts(enc_type: u8, parts: &[&[u8]]) -> String {

--- a/crates/bitwarden-crypto/src/error.rs
+++ b/crates/bitwarden-crypto/src/error.rs
@@ -8,7 +8,7 @@ use uuid::Uuid;
 
 use crate::fingerprint::FingerprintError;
 
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 #[bitwarden_error(flat)]
 #[derive(Debug, Error)]
 pub enum CryptoError {

--- a/crates/bitwarden-crypto/src/keys/asymmetric_crypto_key.rs
+++ b/crates/bitwarden-crypto/src/keys/asymmetric_crypto_key.rs
@@ -102,7 +102,7 @@ impl AsymmetricCryptoKey {
         }
     }
 
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub fn from_pem(pem: &str) -> Result<Self> {
         use rsa::pkcs8::DecodePrivateKey;
         Ok(Self {
@@ -112,7 +112,7 @@ impl AsymmetricCryptoKey {
         })
     }
 
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub fn from_der(der: &Pkcs8PrivateKeyBytes) -> Result<Self> {
         use rsa::pkcs8::DecodePrivateKey;
         Ok(Self {
@@ -122,7 +122,7 @@ impl AsymmetricCryptoKey {
         })
     }
 
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub fn to_der(&self) -> Result<Pkcs8PrivateKeyBytes> {
         match &self.inner {
             RawPrivateKey::RsaOaepSha1(private_key) => {

--- a/crates/bitwarden-crypto/src/keys/device_key.rs
+++ b/crates/bitwarden-crypto/src/keys/device_key.rs
@@ -13,7 +13,7 @@ use crate::{
 #[derive(Debug)]
 pub struct DeviceKey(SymmetricCryptoKey);
 
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 #[derive(Debug)]
 #[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
 pub struct TrustDeviceResponse {

--- a/crates/bitwarden-crypto/src/keys/kdf.rs
+++ b/crates/bitwarden-crypto/src/keys/kdf.rs
@@ -118,7 +118,7 @@ pub fn dangerous_derive_kdf_material(
 ///
 /// In Bitwarden accounts can use multiple KDFs to derive their master key from their password. This
 /// Enum represents all the possible KDFs.
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 #[derive(Serialize, Deserialize, Debug, JsonSchema, Clone, PartialEq)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 #[cfg_attr(feature = "uniffi", derive(uniffi::Enum))]

--- a/crates/bitwarden-crypto/src/keys/key_encryptable.rs
+++ b/crates/bitwarden-crypto/src/keys/key_encryptable.rs
@@ -5,7 +5,7 @@ use uuid::Uuid;
 
 use crate::{ContentFormat, CryptoError, SymmetricCryptoKey, error::Result};
 
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 pub trait KeyContainer: Send + Sync {
     fn get_key(&self, org_id: &Option<Uuid>) -> Result<&SymmetricCryptoKey, CryptoError>;
 }
@@ -16,7 +16,7 @@ impl<T: KeyContainer> KeyContainer for Arc<T> {
     }
 }
 
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 pub trait CryptoKey {}
 
 /// An encryption operation that takes the input value and encrypts it into the output value
@@ -39,7 +39,7 @@ pub(crate) trait KeyEncryptableWithContentType<Key: CryptoKey, Output> {
     fn encrypt_with_key(self, key: &Key, content_format: ContentFormat) -> Result<Output>;
 }
 
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 pub trait KeyDecryptable<Key: CryptoKey, Output> {
     fn decrypt_with_key(&self, key: &Key) -> Result<Output>;
 }

--- a/crates/bitwarden-crypto/src/keys/master_key.rs
+++ b/crates/bitwarden-crypto/src/keys/master_key.rs
@@ -16,7 +16,7 @@ use crate::{
     util::{self},
 };
 
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 #[derive(Copy, Clone)]
 #[cfg_attr(feature = "uniffi", derive(uniffi::Enum))]
 pub enum HashPurpose {
@@ -28,7 +28,7 @@ pub enum HashPurpose {
 ///
 /// Derived from the users master password, used to protect the [UserKey].
 /// TODO: <https://bitwarden.atlassian.net/browse/PM-18366> split KeyConnectorKey into a separate file
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 pub enum MasterKey {
     KdfKey(KdfDerivedKeyMaterial),
     KeyConnectorKey(Pin<Box<GenericArray<u8, U32>>>),
@@ -83,7 +83,7 @@ impl MasterKey {
         decrypt_user_key(self.inner_bytes(), user_key)
     }
 
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub fn to_base64(&self) -> B64 {
         B64::from(self.inner_bytes().as_slice())
     }

--- a/crates/bitwarden-crypto/src/keys/mod.rs
+++ b/crates/bitwarden-crypto/src/keys/mod.rs
@@ -25,7 +25,7 @@ pub use device_key::{DeviceKey, TrustDeviceResponse};
 mod pin_key;
 pub use pin_key::PinKey;
 mod kdf;
-#[allow(deprecated)]
+#[expect(deprecated)]
 pub use kdf::dangerous_derive_kdf_material;
 mod key_id;
 pub use kdf::{

--- a/crates/bitwarden-crypto/src/keys/symmetric_crypto_key.rs
+++ b/crates/bitwarden-crypto/src/keys/symmetric_crypto_key.rs
@@ -121,9 +121,9 @@ impl PartialEq for XChaCha20Poly1305Key {
 /// A symmetric encryption key. Used to encrypt and decrypt [`EncString`](crate::EncString)
 #[derive(ZeroizeOnDrop, Clone)]
 pub enum SymmetricCryptoKey {
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     Aes256CbcKey(Aes256CbcKey),
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     Aes256CbcHmacKey(Aes256CbcHmacKey),
     /// Data encrypted by XChaCha20Poly1305Key keys has type
     /// [`Cose_Encrypt0_B64`](crate::EncString::Cose_Encrypt0_B64)
@@ -263,7 +263,7 @@ impl SymmetricCryptoKey {
         Ok(key)
     }
 
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub fn to_base64(&self) -> B64 {
         B64::from(self.to_encoded().as_ref())
     }
@@ -449,7 +449,7 @@ impl From<EncodedSymmetricKey> for Vec<u8> {
 }
 impl EncodedSymmetricKey {
     /// Returns the content format of the encoded symmetric key.
-    #[allow(private_interfaces)]
+    #[expect(private_interfaces)]
     pub fn content_format(&self) -> ContentFormat {
         match self {
             EncodedSymmetricKey::BitwardenLegacyKey(_) => ContentFormat::BitwardenLegacyKey,

--- a/crates/bitwarden-crypto/src/keys/user_key.rs
+++ b/crates/bitwarden-crypto/src/keys/user_key.rs
@@ -9,12 +9,12 @@ use crate::{
 pub struct UserKey(pub SymmetricCryptoKey);
 
 impl UserKey {
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub fn new(key: SymmetricCryptoKey) -> Self {
         Self(key)
     }
 
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub fn make_key_pair(&self) -> Result<RsaKeyPair> {
         make_key_pair(&self.0)
     }

--- a/crates/bitwarden-crypto/src/safe/data_envelope.rs
+++ b/crates/bitwarden-crypto/src/safe/data_envelope.rs
@@ -2,7 +2,7 @@ use std::str::FromStr;
 
 use bitwarden_encoding::{B64, FromStrVisitor, NotB64EncodedError};
 use ciborium::value::Integer;
-#[allow(unused_imports)]
+#[expect(unused_imports)]
 use coset::{CborSerializable, ProtectedHeader, RegisteredLabel, iana::CoapContentFormat};
 use serde::{Deserialize, Serialize, de::DeserializeOwned};
 use thiserror::Error;

--- a/crates/bitwarden-crypto/src/safe/password_protected_key_envelope.rs
+++ b/crates/bitwarden-crypto/src/safe/password_protected_key_envelope.rs
@@ -63,7 +63,7 @@ impl PasswordProtectedKeyEnvelope {
         password: &str,
         ctx: &KeyStoreContext<Ids>,
     ) -> Result<Self, PasswordProtectedKeyEnvelopeError> {
-        #[allow(deprecated)]
+        #[expect(deprecated)]
         let key_ref = ctx
             .dangerous_get_symmetric_key(key_to_seal)
             .map_err(|_| PasswordProtectedKeyEnvelopeError::KeyMissing)?;
@@ -519,7 +519,7 @@ mod tests {
         let key = envelope
             .unseal(TESTVECTOR_PASSWORD, &mut ctx)
             .expect("Unsealing should succeed");
-        #[allow(deprecated)]
+        #[expect(deprecated)]
         let unsealed_key = ctx
             .dangerous_get_symmetric_key(key)
             .expect("Key should exist in the key store");
@@ -539,7 +539,7 @@ mod tests {
         let key = envelope
             .unseal(TESTVECTOR_PASSWORD, &mut ctx)
             .expect("Unsealing should succeed");
-        #[allow(deprecated)]
+        #[expect(deprecated)]
         let unsealed_key = ctx
             .dangerous_get_symmetric_key(key)
             .expect("Key should exist in the key store");
@@ -567,12 +567,12 @@ mod tests {
         let key = deserialized.unseal(password, &mut ctx).unwrap();
 
         // Verify that the unsealed key matches the original key
-        #[allow(deprecated)]
+        #[expect(deprecated)]
         let unsealed_key = ctx
             .dangerous_get_symmetric_key(key)
             .expect("Key should exist in the key store");
 
-        #[allow(deprecated)]
+        #[expect(deprecated)]
         let key_before_sealing = ctx
             .dangerous_get_symmetric_key(test_key)
             .expect("Key should exist in the key store");
@@ -598,12 +598,12 @@ mod tests {
         let key = deserialized.unseal(password, &mut ctx).unwrap();
 
         // Verify that the unsealed key matches the original key
-        #[allow(deprecated)]
+        #[expect(deprecated)]
         let unsealed_key = ctx
             .dangerous_get_symmetric_key(key)
             .expect("Key should exist in the key store");
 
-        #[allow(deprecated)]
+        #[expect(deprecated)]
         let key_before_sealing = ctx
             .dangerous_get_symmetric_key(test_key)
             .expect("Key should exist in the key store");

--- a/crates/bitwarden-crypto/src/store/backend/mod.rs
+++ b/crates/bitwarden-crypto/src/store/backend/mod.rs
@@ -25,7 +25,7 @@ pub trait StoreBackend<Key: KeyId>: ZeroizeOnDrop + Send + Sync {
     /// Retrieves a key from the store.
     fn get(&self, key_id: Key) -> Option<&Key::KeyValue>;
 
-    #[allow(unused)]
+    #[expect(unused)]
     /// Removes a key from the store.
     fn remove(&mut self, key_id: Key);
 

--- a/crates/bitwarden-crypto/src/store/context.rs
+++ b/crates/bitwarden-crypto/src/store/context.rs
@@ -201,7 +201,7 @@ impl<Ids: KeyIds> KeyStoreContext<'_, Ids> {
 
         let new_key_id = Ids::Symmetric::new_local(LocalId::new());
 
-        #[allow(deprecated)]
+        #[expect(deprecated)]
         self.set_symmetric_key(new_key_id, key)?;
 
         // Returning the new key identifier for convenience
@@ -277,7 +277,7 @@ impl<Ids: KeyIds> KeyStoreContext<'_, Ids> {
         let decapsulated_key =
             encapsulated_shared_key.decapsulate_key_unsigned(decapsulation_key)?;
 
-        #[allow(deprecated)]
+        #[expect(deprecated)]
         self.set_symmetric_key(new_key_id, decapsulated_key)?;
 
         // Returning the new key identifier for convenience
@@ -330,7 +330,7 @@ impl<Ids: KeyIds> KeyStoreContext<'_, Ids> {
         key_id: Ids::Symmetric,
     ) -> Result<Ids::Symmetric> {
         let key = SymmetricCryptoKey::make_xchacha20_poly1305_key();
-        #[allow(deprecated)]
+        #[expect(deprecated)]
         self.set_symmetric_key(key_id, key)?;
         Ok(key_id)
     }
@@ -359,7 +359,7 @@ impl<Ids: KeyIds> KeyStoreContext<'_, Ids> {
         info: Option<&str>,
     ) -> Result<Ids::Symmetric> {
         let key_id = Ids::Symmetric::new_local(LocalId::new());
-        #[allow(deprecated)]
+        #[expect(deprecated)]
         self.set_symmetric_key(
             key_id,
             SymmetricCryptoKey::Aes256CbcHmacKey(derive_shareable_key(secret, name, info)),
@@ -368,7 +368,7 @@ impl<Ids: KeyIds> KeyStoreContext<'_, Ids> {
     }
 
     #[deprecated(note = "This function should ideally never be used outside this crate")]
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub fn dangerous_get_symmetric_key(
         &self,
         key_id: Ids::Symmetric,
@@ -377,7 +377,7 @@ impl<Ids: KeyIds> KeyStoreContext<'_, Ids> {
     }
 
     #[deprecated(note = "This function should ideally never be used outside this crate")]
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub fn dangerous_get_asymmetric_key(
         &self,
         key_id: Ids::Asymmetric,
@@ -431,7 +431,7 @@ impl<Ids: KeyIds> KeyStoreContext<'_, Ids> {
     }
 
     #[deprecated(note = "This function should ideally never be used outside this crate")]
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub fn set_symmetric_key(
         &mut self,
         key_id: Ids::Symmetric,
@@ -464,7 +464,7 @@ impl<Ids: KeyIds> KeyStoreContext<'_, Ids> {
     }
 
     #[deprecated(note = "This function should ideally never be used outside this crate")]
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub fn set_asymmetric_key(
         &mut self,
         key_id: Ids::Asymmetric,
@@ -574,7 +574,7 @@ impl<Ids: KeyIds> KeyStoreContext<'_, Ids> {
     /// Signs the given data using the specified signing key, for the given
     /// [crate::SigningNamespace] and returns the signature and the serialized message. See
     /// [crate::SigningKey::sign_detached]
-    #[allow(unused)]
+    #[expect(unused)]
     pub(crate) fn sign_detached<Message: Serialize>(
         &self,
         key: Ids::Signing,
@@ -599,7 +599,7 @@ impl<Ids: KeyIds> KeyStoreContext<'_, Ids> {
 }
 
 #[cfg(test)]
-#[allow(deprecated)]
+#[expect(deprecated)]
 mod tests {
     use serde::{Deserialize, Serialize};
 

--- a/crates/bitwarden-crypto/src/store/mod.rs
+++ b/crates/bitwarden-crypto/src/store/mod.rs
@@ -75,7 +75,7 @@ pub use key_rotation::*;
 /// // Initialize the store and insert a test key
 /// let store: KeyStore<Ids> = KeyStore::default();
 ///
-/// #[allow(deprecated)]
+/// #[expect(deprecated)]
 /// store.context_mut().set_symmetric_key(SymmKeyId::User, SymmetricCryptoKey::make_aes256_cbc_hmac_key());
 ///
 /// // Define some data that needs to be encrypted
@@ -426,7 +426,7 @@ pub(crate) mod tests {
 
         // Create a bunch of random keys
         for n in 0..15 {
-            #[allow(deprecated)]
+            #[expect(deprecated)]
             store
                 .context_mut()
                 .set_symmetric_key(

--- a/crates/bitwarden-crypto/src/traits/decryptable.rs
+++ b/crates/bitwarden-crypto/src/traits/decryptable.rs
@@ -4,7 +4,7 @@ use crate::{CryptoError, EncString, KeyId, KeyIds, store::KeyStoreContext};
 /// Implementations should generally consist of calling [Decryptable::decrypt] for all the fields of
 /// the type.
 pub trait Decryptable<Ids: KeyIds, Key: KeyId, Output> {
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     fn decrypt(&self, ctx: &mut KeyStoreContext<Ids>, key: Key) -> Result<Output, CryptoError>;
 }
 
@@ -64,7 +64,7 @@ mod tests {
 
         let key = SymmetricCryptoKey::try_from("sJnO8rVi0dTwND43n0T9x7665s8mVUYNAaJ4nm7gx1iia1I7947URL60nwfIHaf9QJePO4VkNN0oT9jh4iC6aA==".to_string()).unwrap();
 
-        #[allow(deprecated)]
+        #[expect(deprecated)]
         store
             .context_mut()
             .set_symmetric_key(TestSymmKey::A(0), key.clone())

--- a/crates/bitwarden-crypto/src/traits/encryptable.rs
+++ b/crates/bitwarden-crypto/src/traits/encryptable.rs
@@ -180,12 +180,12 @@ mod tests {
         let symm_key = SymmetricCryptoKey::make_aes256_cbc_hmac_key();
         let asymm_key = AsymmetricCryptoKey::make(PublicKeyEncryptionAlgorithm::RsaOaepSha1);
 
-        #[allow(deprecated)]
+        #[expect(deprecated)]
         store
             .context_mut()
             .set_symmetric_key(TestSymmKey::A(0), symm_key.clone())
             .unwrap();
-        #[allow(deprecated)]
+        #[expect(deprecated)]
         store
             .context_mut()
             .set_asymmetric_key(TestAsymmKey::A(0), asymm_key.clone())

--- a/crates/bitwarden-crypto/src/traits/key_id.rs
+++ b/crates/bitwarden-crypto/src/traits/key_id.rs
@@ -18,7 +18,7 @@ use crate::{AsymmetricCryptoKey, CryptoKey, SigningKey, SymmetricCryptoKey};
 pub trait KeyId:
     Debug + Clone + Copy + Hash + Eq + PartialEq + Ord + PartialOrd + Send + Sync + 'static
 {
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     type KeyValue: CryptoKey + Send + Sync + ZeroizeOnDrop;
 
     /// Returns whether the key is local to the current context or shared globally by the
@@ -32,9 +32,9 @@ pub trait KeyId:
 /// Represents a set of all the key identifiers that need to be defined to use a key store.
 /// At the moment it's just symmetric and asymmetric keys.
 pub trait KeyIds {
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     type Symmetric: KeyId<KeyValue = SymmetricCryptoKey>;
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     type Asymmetric: KeyId<KeyValue = AsymmetricCryptoKey>;
     /// Signing keys are used to create detached signatures and to sign objects.
     type Signing: KeyId<KeyValue = SigningKey>;
@@ -99,7 +99,7 @@ macro_rules! key_ids {
 
         $(
             #[derive(std::fmt::Debug, Clone, Copy, std::hash::Hash, Eq, PartialEq, Ord, PartialOrd)]
-            #[allow(missing_docs)]
+            #[expect(missing_docs)]
             $vis enum $name { $(
                 $variant  $( ($inner) )?,
             )* }
@@ -123,7 +123,7 @@ macro_rules! key_ids {
             }
         )+
 
-        #[allow(missing_docs)]
+        #[expect(missing_docs)]
         $ids_vis struct $ids_name;
         impl $crate::KeyIds for $ids_name {
             type Symmetric = $symm_name;

--- a/crates/bitwarden-crypto/src/traits/mod.rs
+++ b/crates/bitwarden-crypto/src/traits/mod.rs
@@ -10,7 +10,7 @@ pub use key_id::{KeyId, KeyIds, LocalId};
 /// Types implementing [IdentifyKey] are capable of knowing which cryptographic key is
 /// needed to encrypt/decrypt them.
 pub trait IdentifyKey<Key: KeyId> {
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     fn key_identifier(&self) -> Key;
 }
 

--- a/crates/bitwarden-error/src/flat_error.rs
+++ b/crates/bitwarden-error/src/flat_error.rs
@@ -1,4 +1,4 @@
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 pub trait FlatError {
     fn error_variant(&self) -> &'static str;
 }

--- a/crates/bitwarden-error/src/lib.rs
+++ b/crates/bitwarden-error/src/lib.rs
@@ -1,10 +1,10 @@
 #![doc = include_str!("../README.md")]
 
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 pub mod flat_error;
 
 #[cfg(feature = "wasm")]
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 pub mod wasm;
 
 /// Re-export the `js_sys` crate since the proc macro depends on it.

--- a/crates/bitwarden-error/src/wasm.rs
+++ b/crates/bitwarden-error/src/wasm.rs
@@ -1,6 +1,6 @@
 use wasm_bindgen::prelude::*;
 
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 #[cfg_attr(feature = "wasm", wasm_bindgen)]
 extern "C" {
     #[wasm_bindgen(js_name = Error)]

--- a/crates/bitwarden-error/tests/basic.rs
+++ b/crates/bitwarden-error/tests/basic.rs
@@ -5,7 +5,7 @@ use wasm_bindgen_test::*;
 
 #[wasm_bindgen_test]
 #[cfg(feature = "wasm")]
-#[allow(dead_code)] // Not actually dead, but rust-analyzer doesn't understand `wasm_bindgen_test`
+#[expect(dead_code)] // Not actually dead, but rust-analyzer doesn't understand `wasm_bindgen_test`
 fn converts_to_js_error_using_to_string() {
     use std::fmt::Display;
 
@@ -30,7 +30,7 @@ fn converts_to_js_error_using_to_string() {
 
 #[wasm_bindgen_test]
 #[cfg(feature = "wasm")]
-#[allow(dead_code)] // Not actually dead, but rust-analyzer doesn't understand `wasm_bindgen_test`
+#[expect(dead_code)] // Not actually dead, but rust-analyzer doesn't understand `wasm_bindgen_test`
 fn outputs_different_name_when_given_export_as() {
     use std::fmt::Display;
 

--- a/crates/bitwarden-error/tests/flat.rs
+++ b/crates/bitwarden-error/tests/flat.rs
@@ -32,7 +32,7 @@ fn variant_for_basic_enum() {
 
 #[test]
 fn variant_for_enum_with_fields() {
-    #[allow(dead_code)]
+    #[expect(dead_code)]
     #[bitwarden_error(flat)]
     enum ComplexError {
         Foo(String),
@@ -57,7 +57,7 @@ fn variant_for_enum_with_fields() {
 #[test]
 #[cfg(feature = "wasm")]
 fn variant_names_for_enum() {
-    #[allow(dead_code)]
+    #[expect(dead_code)]
     #[bitwarden_error(flat)]
     enum SimpleEnum {
         Foo,
@@ -82,7 +82,7 @@ fn variant_names_for_enum() {
 
 #[wasm_bindgen_test]
 #[cfg(feature = "wasm")]
-#[allow(dead_code)] // Not actually dead, but rust-analyzer doesn't understand `wasm_bindgen_test`
+#[expect(dead_code)] // Not actually dead, but rust-analyzer doesn't understand `wasm_bindgen_test`
 fn converts_to_js_error() {
     use bitwarden_error::wasm::SdkJsError;
     use wasm_bindgen::JsValue;
@@ -110,7 +110,7 @@ fn converts_to_js_error() {
 
 #[wasm_bindgen_test]
 #[cfg(feature = "wasm")]
-#[allow(dead_code)] // Not actually dead, but rust-analyzer doesn't understand `wasm_bindgen_test`
+#[expect(dead_code)] // Not actually dead, but rust-analyzer doesn't understand `wasm_bindgen_test`
 fn outputs_different_name_when_given_export_as() {
     use bitwarden_error::wasm::SdkJsError;
     use wasm_bindgen::JsValue;

--- a/crates/bitwarden-error/tests/full.rs
+++ b/crates/bitwarden-error/tests/full.rs
@@ -3,7 +3,7 @@
 #[cfg(feature = "wasm")]
 use wasm_bindgen_test::*;
 
-#[allow(dead_code)]
+#[expect(dead_code)]
 // Not actually dead, but rust-analyzer doesn't understand `wasm_bindgen_test`
 #[wasm_bindgen_test]
 #[cfg(feature = "wasm")]

--- a/crates/bitwarden-exporters/src/cxf/login.rs
+++ b/crates/bitwarden-exporters/src/cxf/login.rs
@@ -130,7 +130,7 @@ fn to_uris(scope: &CredentialScope) -> Vec<LoginUri> {
 /// Converts a `CredentialScope` to a vector of `Field` objects.
 ///
 /// This is used for non-login credentials.
-#[allow(unused)]
+#[expect(unused)]
 pub(super) fn to_fields(scope: &CredentialScope) -> Vec<Field> {
     let urls = scope.urls.iter().enumerate().map(|(i, u)| Field {
         name: Some(format!("Url {}", i + 1)),

--- a/crates/bitwarden-exporters/src/error.rs
+++ b/crates/bitwarden-exporters/src/error.rs
@@ -1,7 +1,7 @@
 use bitwarden_error::bitwarden_error;
 use thiserror::Error;
 
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 #[bitwarden_error(flat)]
 #[derive(Error, Debug)]
 pub enum ExportError {

--- a/crates/bitwarden-exporters/src/exporter_client.rs
+++ b/crates/bitwarden-exporters/src/exporter_client.rs
@@ -9,7 +9,7 @@ use crate::{
     export::{export_cxf, export_organization_vault, export_vault, import_cxf},
 };
 
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 #[cfg_attr(feature = "wasm", wasm_bindgen)]
 pub struct ExporterClient {
     client: Client,
@@ -21,7 +21,7 @@ impl ExporterClient {
         Self { client }
     }
 
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub fn export_vault(
         &self,
         folders: Vec<Folder>,
@@ -31,7 +31,7 @@ impl ExporterClient {
         export_vault(&self.client, folders, ciphers, format)
     }
 
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub fn export_organization_vault(
         &self,
         collections: Vec<Collection>,
@@ -66,7 +66,7 @@ impl ExporterClient {
     }
 }
 
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 pub trait ExporterClientExt {
     fn exporters(&self) -> ExporterClient;
 }

--- a/crates/bitwarden-exporters/src/lib.rs
+++ b/crates/bitwarden-exporters/src/lib.rs
@@ -26,7 +26,7 @@ mod error;
 mod export;
 pub use error::ExportError;
 
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 #[cfg_attr(feature = "uniffi", derive(uniffi::Enum))]
 #[cfg_attr(
     feature = "wasm",
@@ -43,7 +43,7 @@ pub enum ExportFormat {
 ///
 /// These are mostly duplicated from the `bitwarden` vault models to facilitate a stable export API
 /// that is not tied to the internal vault models. We may revisit this in the future.
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 pub struct Folder {
     pub id: Uuid,
     pub name: String,
@@ -53,7 +53,7 @@ pub struct Folder {
 ///
 /// These are mostly duplicated from the `bitwarden` vault models to facilitate a stable export API
 /// that is not tied to the internal vault models. We may revisit this in the future.
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 #[derive(Clone)]
 pub struct Cipher {
     pub id: Uuid,
@@ -78,7 +78,7 @@ pub struct Cipher {
 ///
 /// These are mostly duplicated from the `bitwarden` vault models to facilitate a stable export API
 /// that is not tied to the internal vault models. We may revisit this in the future.
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 #[derive(Clone)]
 #[cfg_attr(test, derive(Debug, PartialEq, Eq))]
 pub struct ImportingCipher {
@@ -278,7 +278,7 @@ impl From<LoginUri> for bitwarden_vault::LoginUriView {
     }
 }
 
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Field {
     pub name: Option<String>,
@@ -287,7 +287,7 @@ pub struct Field {
     pub linked_id: Option<u32>,
 }
 
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 #[derive(Clone)]
 #[cfg_attr(test, derive(Debug, PartialEq, Eq))]
 pub enum CipherType {
@@ -310,7 +310,7 @@ impl fmt::Display for CipherType {
     }
 }
 
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 #[derive(Clone)]
 #[cfg_attr(test, derive(Debug, PartialEq, Eq))]
 pub struct Login {
@@ -322,14 +322,14 @@ pub struct Login {
     pub fido2_credentials: Option<Vec<Fido2Credential>>,
 }
 
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct LoginUri {
     pub uri: Option<String>,
     pub r#match: Option<u8>,
 }
 
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 #[derive(Clone)]
 #[cfg_attr(test, derive(Debug, PartialEq, Eq))]
 pub struct Fido2Credential {
@@ -368,7 +368,7 @@ impl From<Fido2Credential> for Fido2CredentialFullView {
     }
 }
 
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 #[derive(Clone)]
 #[cfg_attr(test, derive(Debug, PartialEq, Eq))]
 pub struct Card {
@@ -380,21 +380,21 @@ pub struct Card {
     pub number: Option<String>,
 }
 
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 #[derive(Clone)]
 #[cfg_attr(test, derive(Debug, PartialEq, Eq))]
 pub struct SecureNote {
     pub r#type: SecureNoteType,
 }
 
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 #[derive(Clone)]
 #[cfg_attr(test, derive(Debug, PartialEq, Eq))]
 pub enum SecureNoteType {
     Generic = 0,
 }
 
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 #[derive(Clone, Default, Debug, PartialEq, Eq)]
 pub struct Identity {
     pub title: Option<String>,
@@ -417,7 +417,7 @@ pub struct Identity {
     pub license_number: Option<String>,
 }
 
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 #[derive(Clone)]
 #[cfg_attr(test, derive(Debug, PartialEq, Eq))]
 pub struct SshKey {

--- a/crates/bitwarden-fido/src/authenticator.rs
+++ b/crates/bitwarden-fido/src/authenticator.rs
@@ -34,7 +34,7 @@ pub enum GetSelectedCredentialError {
     Crypto(#[from] CryptoError),
 }
 
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 #[derive(Debug, Error)]
 #[cfg_attr(feature = "uniffi", derive(uniffi::Error), uniffi(flat_error))]
 pub enum MakeCredentialError {
@@ -50,7 +50,7 @@ pub enum MakeCredentialError {
     Other(String),
 }
 
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 #[derive(Debug, Error)]
 #[cfg_attr(feature = "uniffi", derive(uniffi::Error), uniffi(flat_error))]
 pub enum GetAssertionError {
@@ -68,7 +68,7 @@ pub enum GetAssertionError {
     Other(String),
 }
 
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 #[derive(Debug, Error)]
 #[cfg_attr(feature = "uniffi", derive(uniffi::Error), uniffi(flat_error))]
 pub enum SilentlyDiscoverCredentialsError {
@@ -82,7 +82,7 @@ pub enum SilentlyDiscoverCredentialsError {
     FromCipherView(#[from] Fido2CredentialAutofillViewError),
 }
 
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 #[derive(Debug, Error)]
 #[cfg_attr(feature = "uniffi", derive(uniffi::Error), uniffi(flat_error))]
 pub enum CredentialsForAutofillError {
@@ -96,7 +96,7 @@ pub enum CredentialsForAutofillError {
     FromCipherView(#[from] Fido2CredentialAutofillViewError),
 }
 
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 pub struct Fido2Authenticator<'a> {
     pub client: &'a Client,
     pub user_interface: &'a dyn Fido2UserInterface,
@@ -107,7 +107,7 @@ pub struct Fido2Authenticator<'a> {
 }
 
 impl<'a> Fido2Authenticator<'a> {
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub fn new(
         client: &'a Client,
         user_interface: &'a dyn Fido2UserInterface,
@@ -122,7 +122,7 @@ impl<'a> Fido2Authenticator<'a> {
         }
     }
 
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub async fn make_credential(
         &mut self,
         request: MakeCredentialRequest,
@@ -190,7 +190,7 @@ impl<'a> Fido2Authenticator<'a> {
         })
     }
 
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub async fn get_assertion(
         &mut self,
         request: GetAssertionRequest,
@@ -251,7 +251,7 @@ impl<'a> Fido2Authenticator<'a> {
         })
     }
 
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub async fn silently_discover_credentials(
         &mut self,
         rp_id: String,

--- a/crates/bitwarden-fido/src/client.rs
+++ b/crates/bitwarden-fido/src/client.rs
@@ -13,7 +13,7 @@ use super::{
 };
 use crate::types::InvalidOriginError;
 
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 #[derive(Debug, Error)]
 #[cfg_attr(feature = "uniffi", derive(uniffi::Error), uniffi(flat_error))]
 pub enum Fido2ClientError {
@@ -34,13 +34,13 @@ impl From<WebauthnError> for Fido2ClientError {
     }
 }
 
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 pub struct Fido2Client<'a> {
     pub authenticator: Fido2Authenticator<'a>,
 }
 
 impl Fido2Client<'_> {
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub async fn register(
         &mut self,
         origin: Origin,
@@ -95,7 +95,7 @@ impl Fido2Client<'_> {
         })
     }
 
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub async fn authenticate(
         &mut self,
         origin: Origin,

--- a/crates/bitwarden-fido/src/client_fido.rs
+++ b/crates/bitwarden-fido/src/client_fido.rs
@@ -7,13 +7,13 @@ use crate::{
     Fido2CredentialStore, Fido2UserInterface,
 };
 
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 #[derive(Clone)]
 pub struct ClientFido2 {
     pub(crate) client: Client,
 }
 
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 #[derive(Debug, Error)]
 #[cfg_attr(feature = "uniffi", derive(uniffi::Error), uniffi(flat_error))]
 pub enum DecryptFido2AutofillCredentialsError {
@@ -22,12 +22,12 @@ pub enum DecryptFido2AutofillCredentialsError {
 }
 
 impl ClientFido2 {
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub fn new(client: Client) -> Self {
         Self { client }
     }
 
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub fn create_authenticator<'a>(
         &'a self,
         user_interface: &'a dyn Fido2UserInterface,
@@ -36,7 +36,7 @@ impl ClientFido2 {
         Fido2Authenticator::new(&self.client, user_interface, credential_store)
     }
 
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub fn create_client<'a>(
         &'a self,
         user_interface: &'a dyn Fido2UserInterface,
@@ -47,7 +47,7 @@ impl ClientFido2 {
         }
     }
 
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub fn decrypt_fido2_autofill_credentials(
         &self,
         cipher_view: CipherView,
@@ -61,7 +61,7 @@ impl ClientFido2 {
     }
 }
 
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 pub trait ClientFido2Ext {
     fn fido2(&self) -> ClientFido2;
 }

--- a/crates/bitwarden-fido/src/lib.rs
+++ b/crates/bitwarden-fido/src/lib.rs
@@ -49,7 +49,7 @@ const AAGUID: Aaguid = Aaguid([
     0xd5, 0x48, 0x82, 0x6e, 0x79, 0xb4, 0xdb, 0x40, 0xa3, 0xd8, 0x11, 0x11, 0x6f, 0x7e, 0x83, 0x49,
 ]);
 
-#[allow(dead_code, missing_docs)]
+#[expect(dead_code, missing_docs)]
 #[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
 pub struct SelectedCredential {
     cipher: CipherView,
@@ -74,7 +74,7 @@ impl CipherViewContainer {
     }
 }
 
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 #[derive(Debug, Error)]
 pub enum Fido2Error {
     #[error(transparent)]
@@ -129,7 +129,7 @@ fn try_from_credential_full_view(value: Fido2CredentialFullView) -> Result<Passk
     })
 }
 
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 #[derive(Debug, Error)]
 pub enum FillCredentialError {
     #[error(transparent)]
@@ -138,7 +138,7 @@ pub enum FillCredentialError {
     CoseKeyToPkcs8(#[from] CoseKeyToPkcs8Error),
 }
 
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 pub fn fill_with_credential(
     view: &Fido2CredentialView,
     value: Passkey,
@@ -219,12 +219,12 @@ pub(crate) fn try_from_credential_full(
     })
 }
 
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 #[derive(Debug, Error)]
 #[error("Input should be a 16 byte array")]
 pub struct InvalidInputLengthError;
 
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 pub fn guid_bytes_to_string(source: &[u8]) -> Result<String, InvalidInputLengthError> {
     if source.len() != 16 {
         return Err(InvalidInputLengthError);
@@ -232,12 +232,12 @@ pub fn guid_bytes_to_string(source: &[u8]) -> Result<String, InvalidInputLengthE
     Ok(uuid::Uuid::from_bytes(source.try_into().expect("Invalid length")).to_string())
 }
 
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 #[derive(Debug, Error)]
 #[error("Invalid GUID")]
 pub struct InvalidGuidError;
 
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 pub fn string_to_guid_bytes(source: &str) -> Result<Vec<u8>, InvalidGuidError> {
     if source.starts_with("b64.") {
         let bytes =
@@ -251,7 +251,7 @@ pub fn string_to_guid_bytes(source: &str) -> Result<Vec<u8>, InvalidGuidError> {
     }
 }
 
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 #[derive(Debug, Error)]
 #[error("Unknown enum value")]
 pub struct UnknownEnumError;

--- a/crates/bitwarden-fido/src/traits.rs
+++ b/crates/bitwarden-fido/src/traits.rs
@@ -2,7 +2,7 @@ use bitwarden_vault::{CipherListView, CipherView, EncryptionContext, Fido2Creden
 use passkey::authenticator::UIHint;
 use thiserror::Error;
 
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 #[derive(Debug, Error)]
 pub enum Fido2CallbackError {
     #[error("The operation requires user interaction")]
@@ -15,7 +15,7 @@ pub enum Fido2CallbackError {
     Unknown(String),
 }
 
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 #[async_trait::async_trait]
 pub trait Fido2UserInterface: Send + Sync {
     async fn check_user<'a>(
@@ -35,7 +35,7 @@ pub trait Fido2UserInterface: Send + Sync {
     async fn is_verification_enabled(&self) -> bool;
 }
 
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 #[async_trait::async_trait]
 pub trait Fido2CredentialStore: Send + Sync {
     async fn find_credentials(
@@ -49,7 +49,7 @@ pub trait Fido2CredentialStore: Send + Sync {
     async fn save_credential(&self, cred: EncryptionContext) -> Result<(), Fido2CallbackError>;
 }
 
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 #[derive(Clone)]
 #[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
 pub struct CheckUserOptions {
@@ -57,7 +57,7 @@ pub struct CheckUserOptions {
     pub require_verification: Verification,
 }
 
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 #[derive(Clone)]
 #[cfg_attr(feature = "uniffi", derive(uniffi::Enum))]
 pub enum Verification {
@@ -66,7 +66,7 @@ pub enum Verification {
     Required,
 }
 
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 pub struct CheckUserResult {
     pub user_present: bool,
     pub user_verified: bool,

--- a/crates/bitwarden-fido/src/types.rs
+++ b/crates/bitwarden-fido/src/types.rs
@@ -14,7 +14,7 @@ use super::{
     get_enum_from_string_name, string_to_guid_bytes,
 };
 
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 #[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
@@ -50,7 +50,7 @@ impl NoneWhitespace for Option<String> {
     }
 }
 
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 #[derive(Debug, Error)]
 pub enum Fido2CredentialAutofillViewError {
     #[error("Autofill credentials can only be created from existing ciphers that have a cipher id")]
@@ -67,7 +67,7 @@ pub enum Fido2CredentialAutofillViewError {
 }
 
 impl Fido2CredentialAutofillView {
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub fn from_cipher_view(
         cipher: &CipherView,
         ctx: &mut KeyStoreContext<KeyIds>,
@@ -105,7 +105,7 @@ impl Fido2CredentialAutofillView {
             .collect()
     }
 
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub fn from_cipher_list_view(
         cipher: &CipherListView,
     ) -> Result<Vec<Fido2CredentialAutofillView>, Fido2CredentialAutofillViewError> {
@@ -150,14 +150,14 @@ impl Fido2CredentialAutofillView {
     }
 }
 
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 #[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
 pub struct PublicKeyCredentialRpEntity {
     pub id: String,
     pub name: Option<String>,
 }
 
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 #[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
 pub struct PublicKeyCredentialUserEntity {
     pub id: Vec<u8>,
@@ -225,7 +225,7 @@ impl TryFrom<PublicKeyCredentialDescriptor>
 
 pub type Extensions = Option<String>;
 
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 #[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
 pub struct MakeCredentialRequest {
     pub client_data_hash: Vec<u8>,
@@ -237,7 +237,7 @@ pub struct MakeCredentialRequest {
     pub extensions: Extensions,
 }
 
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 #[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
 pub struct MakeCredentialResult {
     pub authenticator_data: Vec<u8>,
@@ -245,7 +245,7 @@ pub struct MakeCredentialResult {
     pub credential_id: Vec<u8>,
 }
 
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 #[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
 pub struct GetAssertionRequest {
     pub rp_id: String,
@@ -255,7 +255,7 @@ pub struct GetAssertionRequest {
     pub extensions: Extensions,
 }
 
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 #[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
 pub struct Options {
     pub rk: bool,
@@ -318,7 +318,7 @@ impl From<UserVerificationRequirement> for UV {
     }
 }
 
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 #[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
 pub struct GetAssertionResult {
     pub credential_id: Vec<u8>,
@@ -329,7 +329,7 @@ pub struct GetAssertionResult {
     pub selected_credential: SelectedCredential,
 }
 
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 #[cfg_attr(feature = "uniffi", derive(uniffi::Enum))]
 pub enum ClientData {
     DefaultWithExtraData { android_package_name: String },
@@ -382,7 +382,7 @@ impl From<passkey::types::webauthn::CredentialPropertiesOutput> for CredPropsRes
     }
 }
 
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 #[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
 pub struct PublicKeyCredentialAuthenticatorAttestationResponse {
     pub id: String,
@@ -394,7 +394,7 @@ pub struct PublicKeyCredentialAuthenticatorAttestationResponse {
     pub selected_credential: SelectedCredential,
 }
 
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 #[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
 pub struct AuthenticatorAttestationResponse {
     pub client_data_json: Vec<u8>,
@@ -405,7 +405,7 @@ pub struct AuthenticatorAttestationResponse {
     pub transports: Option<Vec<String>>,
 }
 
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 #[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
 pub struct PublicKeyCredentialAuthenticatorAssertionResponse {
     pub id: String,
@@ -417,7 +417,7 @@ pub struct PublicKeyCredentialAuthenticatorAssertionResponse {
     pub selected_credential: SelectedCredential,
 }
 
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 #[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
 pub struct AuthenticatorAssertionResponse {
     pub client_data_json: Vec<u8>,

--- a/crates/bitwarden-generators/src/generator_client.rs
+++ b/crates/bitwarden-generators/src/generator_client.rs
@@ -8,7 +8,7 @@ use crate::{
     username::username,
 };
 
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 #[cfg_attr(feature = "wasm", wasm_bindgen)]
 pub struct GeneratorClient {
     client: Client,
@@ -102,7 +102,7 @@ impl GeneratorClient {
     }
 }
 
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 pub trait GeneratorClientsExt {
     fn generator(&self) -> GeneratorClient;
 }

--- a/crates/bitwarden-generators/src/passphrase.rs
+++ b/crates/bitwarden-generators/src/passphrase.rs
@@ -9,7 +9,7 @@ use tsify::Tsify;
 
 use crate::util::capitalize_first_letter;
 
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 #[bitwarden_error(full)]
 #[derive(Debug, Error)]
 pub enum PassphraseError {

--- a/crates/bitwarden-generators/src/password.rs
+++ b/crates/bitwarden-generators/src/password.rs
@@ -8,7 +8,7 @@ use thiserror::Error;
 #[cfg(feature = "wasm")]
 use tsify::Tsify;
 
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 #[bitwarden_error(flat)]
 #[derive(Debug, Error)]
 pub enum PasswordError {

--- a/crates/bitwarden-generators/src/username.rs
+++ b/crates/bitwarden-generators/src/username.rs
@@ -10,7 +10,7 @@ use tsify::Tsify;
 
 use crate::util::capitalize_first_letter;
 
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 #[bitwarden_error(flat)]
 #[derive(Debug, Error)]
 pub enum UsernameError {
@@ -48,7 +48,7 @@ pub enum AppendType {
 /// Configures the email forwarding service to use.
 /// For instructions on how to configure each service, see the documentation:
 /// <https://bitwarden.com/help/generator/#username-types>
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 pub enum ForwarderServiceType {
     /// Previously known as "AnonAddy"
     AddyIo {
@@ -75,7 +75,7 @@ pub enum ForwarderServiceType {
     },
 }
 
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 #[derive(Serialize, Deserialize, Debug, JsonSchema)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 #[cfg_attr(feature = "uniffi", derive(uniffi::Enum))]

--- a/crates/bitwarden-ipc/src/ipc_client.rs
+++ b/crates/bitwarden-ipc/src/ipc_client.rs
@@ -63,7 +63,7 @@ pub struct IpcClientTypedSubscription<Payload: DeserializeOwned + PayloadTypeNam
 
 #[derive(Debug, Error, Clone, PartialEq, Eq)]
 #[bitwarden_error(flat)]
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 pub enum SubscribeError {
     #[error("The IPC processing thread is not running")]
     NotStarted,
@@ -71,7 +71,7 @@ pub enum SubscribeError {
 
 #[derive(Debug, Error, PartialEq, Eq)]
 #[bitwarden_error(flat)]
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 pub enum ReceiveError {
     #[error("Failed to subscribe to the IPC channel: {0}")]
     Channel(#[from] tokio::sync::broadcast::error::RecvError),
@@ -85,7 +85,7 @@ pub enum ReceiveError {
 
 #[derive(Debug, Error, PartialEq, Eq)]
 #[bitwarden_error(flat)]
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 pub enum TypedReceiveError {
     #[error("Failed to subscribe to the IPC channel: {0}")]
     Channel(#[from] tokio::sync::broadcast::error::RecvError),
@@ -112,7 +112,7 @@ impl From<ReceiveError> for TypedReceiveError {
 
 #[derive(Debug, Error, PartialEq, Eq)]
 #[bitwarden_error(flat)]
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 pub enum RequestError {
     #[error(transparent)]
     Subscribe(#[from] SubscribeError),

--- a/crates/bitwarden-ipc/src/wasm/communication_backend.rs
+++ b/crates/bitwarden-ipc/src/wasm/communication_backend.rs
@@ -11,13 +11,13 @@ use crate::{
     traits::{CommunicationBackend, CommunicationBackendReceiver},
 };
 
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 #[derive(Debug, Error)]
 #[bitwarden_error(basic)]
 #[error("Failed to deserialize incoming message: {0}")]
 pub struct DeserializeError(String);
 
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 #[derive(Debug, Error)]
 #[bitwarden_error(basic)]
 #[error("Incoming message channel failed: {0}")]

--- a/crates/bitwarden-ipc/src/wasm/ipc_client.rs
+++ b/crates/bitwarden-ipc/src/wasm/ipc_client.rs
@@ -38,7 +38,7 @@ pub struct JsIpcClientSubscription {
 
 #[wasm_bindgen(js_class = IpcClientSubscription)]
 impl JsIpcClientSubscription {
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub async fn receive(
         &mut self,
         abort_signal: Option<AbortSignal>,
@@ -84,18 +84,18 @@ impl JsIpcClient {
         }
     }
 
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub async fn start(&self) {
         self.client.start().await
     }
 
     #[wasm_bindgen(js_name = isRunning)]
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub async fn is_running(&self) -> bool {
         self.client.is_running().await
     }
 
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub async fn send(&self, message: OutgoingMessage) -> Result<(), JsError> {
         self.client
             .send(message)
@@ -103,7 +103,7 @@ impl JsIpcClient {
             .map_err(|e| JsError::new(&e))
     }
 
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub async fn subscribe(&self) -> Result<JsIpcClientSubscription, SubscribeError> {
         let subscription = self.client.subscribe(None).await?;
         Ok(JsIpcClientSubscription { subscription })

--- a/crates/bitwarden-send/src/error.rs
+++ b/crates/bitwarden-send/src/error.rs
@@ -1,6 +1,6 @@
 use thiserror::Error;
 
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 #[derive(Debug, Error)]
 pub enum SendParseError {
     #[error(transparent)]

--- a/crates/bitwarden-send/src/send.rs
+++ b/crates/bitwarden-send/src/send.rs
@@ -64,7 +64,7 @@ pub enum SendType {
     File = 1,
 }
 
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 #[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
@@ -91,7 +91,7 @@ pub struct Send {
     pub expiration_date: Option<DateTime<Utc>>,
 }
 
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 #[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
@@ -125,7 +125,7 @@ pub struct SendView {
     pub expiration_date: Option<DateTime<Utc>>,
 }
 
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 #[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
@@ -144,7 +144,7 @@ pub struct SendListView {
 }
 
 impl Send {
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub fn get_key(
         ctx: &mut KeyStoreContext<KeyIds>,
         send_key: &EncString,
@@ -427,7 +427,7 @@ mod tests {
 
         // Get the send key
         let send_key = Send::get_key(&mut ctx, &send_key, SymmetricKeyId::User).unwrap();
-        #[allow(deprecated)]
+        #[expect(deprecated)]
         let send_key = ctx.dangerous_get_symmetric_key(send_key).unwrap();
         let send_key_b64 = send_key.to_base64();
         assert_eq!(

--- a/crates/bitwarden-send/src/send_client.rs
+++ b/crates/bitwarden-send/src/send_client.rs
@@ -9,7 +9,7 @@ use thiserror::Error;
 use crate::{Send, SendListView, SendView};
 
 /// Generic error type for send encryption errors.
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 #[derive(Debug, Error)]
 #[cfg_attr(feature = "uniffi", derive(uniffi::Error), uniffi(flat_error))]
 pub enum SendEncryptError {
@@ -18,7 +18,7 @@ pub enum SendEncryptError {
 }
 
 /// Generic error type for send decryption errors
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 #[derive(Debug, Error)]
 #[cfg_attr(feature = "uniffi", derive(uniffi::Error), uniffi(flat_error))]
 pub enum SendDecryptError {
@@ -27,7 +27,7 @@ pub enum SendDecryptError {
 }
 
 /// Generic error type for send encryption errors.
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 #[derive(Debug, Error)]
 #[cfg_attr(feature = "uniffi", derive(uniffi::Error), uniffi(flat_error))]
 pub enum SendEncryptFileError {
@@ -38,7 +38,7 @@ pub enum SendEncryptFileError {
 }
 
 /// Generic error type for send decryption errors
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 #[derive(Debug, Error)]
 #[cfg_attr(feature = "uniffi", derive(uniffi::Error), uniffi(flat_error))]
 pub enum SendDecryptFileError {
@@ -48,7 +48,7 @@ pub enum SendDecryptFileError {
     Io(#[from] std::io::Error),
 }
 
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 pub struct SendClient {
     client: Client,
 }
@@ -58,21 +58,21 @@ impl SendClient {
         Self { client }
     }
 
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub fn decrypt(&self, send: Send) -> Result<SendView, SendDecryptError> {
         let key_store = self.client.internal.get_key_store();
         let send_view = key_store.decrypt(&send)?;
         Ok(send_view)
     }
 
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub fn decrypt_list(&self, sends: Vec<Send>) -> Result<Vec<SendListView>, SendDecryptError> {
         let key_store = self.client.internal.get_key_store();
         let send_views = key_store.decrypt_list(&sends)?;
         Ok(send_views)
     }
 
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub fn decrypt_file(
         &self,
         send: Send,
@@ -85,7 +85,7 @@ impl SendClient {
         Ok(())
     }
 
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub fn decrypt_buffer(
         &self,
         send: Send,
@@ -100,7 +100,7 @@ impl SendClient {
         Ok(buf.decrypt(&mut ctx, key)?)
     }
 
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub fn encrypt(&self, send_view: SendView) -> Result<Send, SendEncryptError> {
         let key_store = self.client.internal.get_key_store();
 
@@ -109,7 +109,7 @@ impl SendClient {
         Ok(send)
     }
 
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub fn encrypt_file(
         &self,
         send: Send,
@@ -122,7 +122,7 @@ impl SendClient {
         Ok(())
     }
 
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub fn encrypt_buffer(&self, send: Send, buffer: &[u8]) -> Result<Vec<u8>, SendEncryptError> {
         let key_store = self.client.internal.get_key_store();
         let mut ctx = key_store.context();
@@ -134,7 +134,7 @@ impl SendClient {
     }
 }
 
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 pub trait SendClientExt {
     fn sends(&self) -> SendClient;
 }

--- a/crates/bitwarden-ssh/src/error.rs
+++ b/crates/bitwarden-ssh/src/error.rs
@@ -1,7 +1,7 @@
 use bitwarden_error::bitwarden_error;
 use thiserror::Error;
 
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 #[bitwarden_error(flat)]
 #[derive(Error, Debug)]
 pub enum KeyGenerationError {
@@ -11,7 +11,7 @@ pub enum KeyGenerationError {
     KeyConversion,
 }
 
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 #[bitwarden_error(flat)]
 #[derive(Error, Debug, PartialEq)]
 pub enum SshKeyImportError {
@@ -25,7 +25,7 @@ pub enum SshKeyImportError {
     UnsupportedKeyType,
 }
 
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 #[bitwarden_error(flat)]
 #[derive(Error, Debug, PartialEq)]
 pub enum SshKeyExportError {

--- a/crates/bitwarden-ssh/src/lib.rs
+++ b/crates/bitwarden-ssh/src/lib.rs
@@ -1,12 +1,12 @@
 #![doc = include_str!("../README.md")]
 
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 pub mod error;
 mod export;
 pub use export::export_pkcs8_der_key;
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 pub mod generator;
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 pub mod import;
 
 use bitwarden_vault::SshKeyView;

--- a/crates/bitwarden-state/src/registry.rs
+++ b/crates/bitwarden-state/src/registry.rs
@@ -28,7 +28,7 @@ impl std::fmt::Debug for StateRegistry {
     }
 }
 
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 #[bitwarden_error(flat)]
 #[derive(Debug, Error)]
 pub enum StateRegistryError {
@@ -48,7 +48,7 @@ pub struct RepositoryNotFoundError;
 
 impl StateRegistry {
     /// Creates a new empty `StateRegistry`.
-    #[allow(clippy::new_without_default)]
+    #[expect(clippy::new_without_default)]
     pub fn new() -> Self {
         StateRegistry {
             client_managed: RwLock::new(HashMap::new()),

--- a/crates/bitwarden-state/src/repository.rs
+++ b/crates/bitwarden-state/src/repository.rs
@@ -55,7 +55,7 @@ pub trait RepositoryItem: Internal + Send + Sync + 'static {
 }
 
 /// This struct holds metadata about a registered repository item type.
-#[allow(dead_code)]
+#[expect(dead_code)]
 #[derive(Debug, Clone, Copy)]
 pub struct RepositoryItemData {
     type_id: TypeId,
@@ -105,7 +105,7 @@ pub const fn validate_registry_name(name: &str) -> bool {
 pub struct RepositoryMigrations {
     pub(crate) steps: Vec<RepositoryMigrationStep>,
     // This is used only by indexedDB
-    #[allow(dead_code)]
+    #[expect(dead_code)]
     pub(crate) version: u32,
 }
 

--- a/crates/bitwarden-threading/src/lib.rs
+++ b/crates/bitwarden-threading/src/lib.rs
@@ -5,10 +5,10 @@ compile_error!(
     "The `wasm` feature must be enabled to use the `bitwarden-ipc` crate in a WebAssembly environment."
 );
 
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 pub mod cancellation_token;
 mod thread_bound_runner;
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 pub mod time;
 
 pub use thread_bound_runner::{CallError, ThreadBoundRunner};

--- a/crates/bitwarden-threading/src/thread_bound_runner.rs
+++ b/crates/bitwarden-threading/src/thread_bound_runner.rs
@@ -102,7 +102,7 @@ impl<ThreadState> ThreadBoundRunner<ThreadState>
 where
     ThreadState: 'static,
 {
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub fn new(state: ThreadState) -> Self {
         let (call_channel_tx, mut call_channel_rx) =
             tokio::sync::mpsc::channel::<CallRequest<ThreadState>>(1);
@@ -204,7 +204,7 @@ mod test {
             input.0 + input.1
         }
 
-        #[allow(clippy::unused_async)]
+        #[expect(clippy::unused_async)]
         pub async fn async_add(&self, input: (i32, i32)) -> i32 {
             input.0 + input.1
         }

--- a/crates/bitwarden-threading/src/time.rs
+++ b/crates/bitwarden-threading/src/time.rs
@@ -17,7 +17,7 @@ mod test {
     use wasm_bindgen_test::wasm_bindgen_test;
 
     #[wasm_bindgen_test]
-    #[allow(dead_code)] // Not actually dead, but rust-analyzer doesn't understand `wasm_bindgen_test`
+    #[expect(dead_code)] // Not actually dead, but rust-analyzer doesn't understand `wasm_bindgen_test`
     async fn should_sleep_wasm() {
         use js_sys::Date;
 

--- a/crates/bitwarden-threading/tests/cancellation_token/wasm.rs
+++ b/crates/bitwarden-threading/tests/cancellation_token/wasm.rs
@@ -11,7 +11,7 @@ mod to_cancellation_token {
     use super::*;
 
     #[wasm_bindgen_test]
-    #[allow(dead_code)] // Not actually dead, but rust-analyzer doesn't understand `wasm_bindgen_test`
+    #[expect(dead_code)] // Not actually dead, but rust-analyzer doesn't understand `wasm_bindgen_test`
     #[cfg(target_arch = "wasm32")]
     async fn rust_cancel_does_not_propagate_to_js() {
         console_error_panic_hook::set_once();
@@ -31,7 +31,7 @@ mod to_cancellation_token {
     }
 
     #[wasm_bindgen_test]
-    #[allow(dead_code)] // Not actually dead, but rust-analyzer doesn't understand `wasm_bindgen_test`
+    #[expect(dead_code)] // Not actually dead, but rust-analyzer doesn't understand `wasm_bindgen_test`
     #[cfg(target_arch = "wasm32")]
     async fn js_abort_propagate_to_rust() {
         console_error_panic_hook::set_once();

--- a/crates/bitwarden-threading/tests/thread_bound_runner/wasm.rs
+++ b/crates/bitwarden-threading/tests/thread_bound_runner/wasm.rs
@@ -45,7 +45,7 @@ extern "C" {
 }
 
 #[wasm_bindgen_test]
-#[allow(dead_code)] // Not actually dead, but rust-analyzer doesn't understand `wasm_bindgen_test`
+#[expect(dead_code)] // Not actually dead, but rust-analyzer doesn't understand `wasm_bindgen_test`
 pub async fn test_get_cipher() {
     console_error_panic_hook::set_once();
 

--- a/crates/bitwarden-uniffi-error/src/lib.rs
+++ b/crates/bitwarden-uniffi-error/src/lib.rs
@@ -2,7 +2,7 @@
 
 use std::sync::OnceLock;
 
-#[allow(clippy::type_complexity)]
+#[expect(clippy::type_complexity)]
 static ERROR_TO_UNIFFI_ERROR: OnceLock<
     Box<dyn Fn(Box<dyn std::error::Error + Send + Sync>) -> anyhow::Error + Send + Sync + 'static>,
 > = OnceLock::new();

--- a/crates/bitwarden-uniffi/src/android_support.rs
+++ b/crates/bitwarden-uniffi/src/android_support.rs
@@ -6,7 +6,7 @@ pub static JAVA_VM: OnceLock<jni::JavaVM> = OnceLock::new();
 
 // This function is called when the Android app calls `System.loadLibrary("bitwarden_uniffi")`
 // Important: This function must be named `JNI_OnLoad` or otherwise it won't be called
-#[allow(non_snake_case)]
+#[expect(non_snake_case)]
 #[unsafe(no_mangle)]
 pub extern "system" fn JNI_OnLoad(vm_ptr: jni::JavaVM, _reserved: *mut std::ffi::c_void) -> jint {
     log::info!("JNI_OnLoad initializing");

--- a/crates/bitwarden-uniffi/src/crypto.rs
+++ b/crates/bitwarden-uniffi/src/crypto.rs
@@ -7,7 +7,7 @@ use bitwarden_encoding::B64;
 
 use crate::error::Result;
 
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 #[derive(uniffi::Object)]
 pub struct CryptoClient(pub(crate) bitwarden_core::key_management::CryptoClient);
 

--- a/crates/bitwarden-uniffi/src/lib.rs
+++ b/crates/bitwarden-uniffi/src/lib.rs
@@ -7,17 +7,17 @@ use std::sync::Arc;
 use auth::AuthClient;
 use bitwarden_core::{ClientSettings, client::internal::ClientManagedTokens};
 
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 pub mod auth;
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 pub mod crypto;
 mod error;
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 pub mod platform;
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 pub mod tool;
 mod uniffi_support;
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 pub mod vault;
 
 #[cfg(target_os = "android")]
@@ -29,7 +29,7 @@ use platform::PlatformClient;
 use tool::{ExporterClient, GeneratorClients, SendClient, SshClient};
 use vault::VaultClient;
 
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 #[derive(uniffi::Object)]
 pub struct Client(pub(crate) bitwarden_pm::PasswordManagerClient);
 
@@ -63,7 +63,7 @@ impl Client {
         VaultClient(self.0.vault())
     }
 
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub fn platform(&self) -> PlatformClient {
         PlatformClient(self.0.0.clone())
     }

--- a/crates/bitwarden-uniffi/src/platform/fido2.rs
+++ b/crates/bitwarden-uniffi/src/platform/fido2.rs
@@ -160,7 +160,7 @@ impl ClientFido2Client {
 // Note that uniffi doesn't support external traits for now it seems, so we have to duplicate them
 // here.
 
-#[allow(dead_code)]
+#[expect(dead_code)]
 #[derive(uniffi::Record)]
 pub struct CheckUserResult {
     user_present: bool,
@@ -176,7 +176,7 @@ impl From<CheckUserResult> for bitwarden_fido::CheckUserResult {
     }
 }
 
-#[allow(dead_code)]
+#[expect(dead_code)]
 #[derive(uniffi::Record)]
 pub struct CheckUserAndPickCredentialForCreationResult {
     cipher: CipherViewWrapper,

--- a/crates/bitwarden-uniffi/src/vault/ciphers.rs
+++ b/crates/bitwarden-uniffi/src/vault/ciphers.rs
@@ -6,7 +6,7 @@ use bitwarden_vault::{
 
 use crate::Result;
 
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 #[derive(uniffi::Object)]
 pub struct CiphersClient(pub(crate) bitwarden_vault::CiphersClient);
 

--- a/crates/bitwarden-uniffi/src/vault/collections.rs
+++ b/crates/bitwarden-uniffi/src/vault/collections.rs
@@ -8,7 +8,7 @@ use bitwarden_vault::collection_client::AncestorMap;
 
 use crate::Result;
 
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 #[derive(uniffi::Object)]
 pub struct CollectionsClient(pub(crate) bitwarden_vault::collection_client::CollectionsClient);
 

--- a/crates/bitwarden-uniffi/src/vault/folders.rs
+++ b/crates/bitwarden-uniffi/src/vault/folders.rs
@@ -2,7 +2,7 @@ use bitwarden_vault::{Folder, FolderView};
 
 use crate::Result;
 
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 #[derive(uniffi::Object)]
 pub struct FoldersClient(pub(crate) bitwarden_vault::FoldersClient);
 

--- a/crates/bitwarden-uniffi/src/vault/mod.rs
+++ b/crates/bitwarden-uniffi/src/vault/mod.rs
@@ -3,18 +3,18 @@ use chrono::{DateTime, Utc};
 
 use crate::error::Result;
 
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 pub mod attachments;
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 pub mod ciphers;
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 pub mod collections;
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 pub mod folders;
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 pub mod password_history;
 
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 #[derive(uniffi::Object)]
 pub struct VaultClient(pub(crate) bitwarden_vault::VaultClient);
 

--- a/crates/bitwarden-uniffi/src/vault/password_history.rs
+++ b/crates/bitwarden-uniffi/src/vault/password_history.rs
@@ -2,7 +2,7 @@ use bitwarden_vault::{PasswordHistory, PasswordHistoryView};
 
 use crate::Result;
 
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 #[derive(uniffi::Object)]
 pub struct PasswordHistoryClient(pub(crate) bitwarden_vault::PasswordHistoryClient);
 

--- a/crates/bitwarden-uuid-macro/src/lib.rs
+++ b/crates/bitwarden-uuid-macro/src/lib.rs
@@ -8,7 +8,7 @@ use syn::{
     parse_macro_input,
 };
 
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 #[proc_macro]
 pub fn uuid_newtype(input: TokenStream) -> TokenStream {
     // Parse input as: vis ident
@@ -39,7 +39,7 @@ pub fn uuid_newtype(input: TokenStream) -> TokenStream {
         uniffi::custom_newtype!(#ident, uuid::Uuid);
 
         impl #ident {
-            #[allow(missing_docs)]
+            #[expect(missing_docs)]
             pub fn new(value: uuid::Uuid) -> Self {
                 Self(value)
             }

--- a/crates/bitwarden-uuid/tests/uuid.rs
+++ b/crates/bitwarden-uuid/tests/uuid.rs
@@ -44,7 +44,7 @@ fn test_deserialize() {
 }
 
 #[wasm_bindgen_test::wasm_bindgen_test]
-#[allow(dead_code)]
+#[expect(dead_code)]
 fn test_wasm_serialize() {
     let id: TestId = "d4a722ff-ce51-47f1-ba42-c2216f547851"
         .parse()

--- a/crates/bitwarden-vault/src/cipher/attachment.rs
+++ b/crates/bitwarden-vault/src/cipher/attachment.rs
@@ -11,7 +11,7 @@ use tsify::Tsify;
 use super::Cipher;
 use crate::VaultParseError;
 
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 #[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
@@ -35,7 +35,7 @@ impl From<Attachment> for CipherAttachmentModel {
     }
 }
 
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 #[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
@@ -88,7 +88,7 @@ impl AttachmentView {
     }
 }
 
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 #[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
@@ -97,7 +97,7 @@ pub struct AttachmentEncryptResult {
     pub contents: Vec<u8>,
 }
 
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 pub struct AttachmentFile {
     pub cipher: Cipher,
     pub attachment: AttachmentView,
@@ -109,7 +109,7 @@ pub struct AttachmentFile {
     pub contents: EncString,
 }
 
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 pub struct AttachmentFileView<'a> {
     pub cipher: Cipher,
     pub attachment: AttachmentView,
@@ -215,7 +215,7 @@ impl Decryptable<KeyIds, SymmetricKeyId, AttachmentView> for Attachment {
         let decrypted_key = if let Some(attachment_key) = &self.key {
             let content_key_id = ctx.unwrap_symmetric_key(key, attachment_key)?;
 
-            #[allow(deprecated)]
+            #[expect(deprecated)]
             let actual_key = ctx.dangerous_get_symmetric_key(content_key_id)?;
 
             Some(actual_key.to_base64())

--- a/crates/bitwarden-vault/src/cipher/attachment_client.rs
+++ b/crates/bitwarden-vault/src/cipher/attachment_client.rs
@@ -12,14 +12,14 @@ use crate::{
     Cipher, DecryptError, EncryptError,
 };
 
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 #[cfg_attr(feature = "wasm", wasm_bindgen)]
 pub struct AttachmentsClient {
     pub(crate) client: Client,
 }
 
 /// Generic error type for vault encryption errors.
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 #[bitwarden_error(flat)]
 #[derive(Debug, Error)]
 pub enum EncryptFileError {
@@ -30,7 +30,7 @@ pub enum EncryptFileError {
 }
 
 /// Generic error type for decryption errors
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 #[bitwarden_error(flat)]
 #[derive(Debug, Error)]
 pub enum DecryptFileError {
@@ -42,7 +42,7 @@ pub enum DecryptFileError {
 
 #[cfg_attr(feature = "wasm", wasm_bindgen)]
 impl AttachmentsClient {
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub fn decrypt_buffer(
         &self,
         cipher: Cipher,
@@ -60,7 +60,7 @@ impl AttachmentsClient {
 }
 
 impl AttachmentsClient {
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub fn encrypt_buffer(
         &self,
         cipher: Cipher,
@@ -76,7 +76,7 @@ impl AttachmentsClient {
         })?)
     }
 
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub fn encrypt_file(
         &self,
         cipher: Cipher,
@@ -93,7 +93,7 @@ impl AttachmentsClient {
         Ok(attachment)
     }
 
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub fn decrypt_file(
         &self,
         cipher: Cipher,

--- a/crates/bitwarden-vault/src/cipher/card.rs
+++ b/crates/bitwarden-vault/src/cipher/card.rs
@@ -24,7 +24,7 @@ pub struct Card {
     pub number: Option<EncString>,
 }
 
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 #[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
@@ -48,7 +48,7 @@ pub struct CardListView {
     pub brand: Option<String>,
 }
 
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 #[derive(Serialize, Deserialize)]
 pub enum CardBrand {
     Visa,

--- a/crates/bitwarden-vault/src/cipher/cipher.rs
+++ b/crates/bitwarden-vault/src/cipher/cipher.rs
@@ -44,7 +44,7 @@ use crate::{
 
 uuid_newtype!(pub CipherId);
 
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 #[bitwarden_error(flat)]
 #[derive(Debug, Error)]
 pub enum CipherError {
@@ -87,7 +87,7 @@ pub(super) trait CipherKind {
     fn get_copyable_fields(&self, cipher: Option<&Cipher>) -> Vec<CopyableCipherFields>;
 }
 
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 #[derive(Clone, Copy, Serialize_repr, Deserialize_repr, Debug, PartialEq)]
 #[repr(u8)]
 #[cfg_attr(feature = "uniffi", derive(uniffi::Enum))]
@@ -100,7 +100,7 @@ pub enum CipherType {
     SshKey = 5,
 }
 
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 #[derive(Clone, Copy, Default, Serialize_repr, Deserialize_repr, Debug, PartialEq)]
 #[repr(u8)]
 #[cfg_attr(feature = "uniffi", derive(uniffi::Enum))]
@@ -111,7 +111,7 @@ pub enum CipherRepromptType {
     Password = 1,
 }
 
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 #[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
@@ -265,7 +265,7 @@ impl From<EncryptionContext> for CipherRequestModel {
     }
 }
 
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 #[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
@@ -310,7 +310,7 @@ pub struct Cipher {
 
 bitwarden_state::register_repository_item!(Cipher, "Cipher");
 
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 #[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
@@ -352,7 +352,7 @@ pub struct CipherView {
     pub archived_date: Option<DateTime<Utc>>,
 }
 
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 #[derive(Serialize, Deserialize, Debug, PartialEq)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 #[cfg_attr(feature = "uniffi", derive(uniffi::Enum))]
@@ -383,7 +383,7 @@ pub enum CopyableCipherFields {
     SecureNotes,
 }
 
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 #[derive(Serialize, Deserialize, Debug, PartialEq)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 #[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
@@ -620,7 +620,7 @@ impl Cipher {
     /// This replaces the values provided by the API in the `login`, `secure_note`, `card`,
     /// `identity`, and `ssh_key` fields, relying instead on client-side parsing of the
     /// `data` field.
-    #[allow(unused)] // Will be used by future changes to support cipher versioning.
+    #[expect(unused)] // Will be used by future changes to support cipher versioning.
     pub(crate) fn populate_cipher_types(&mut self) -> Result<(), VaultParseError> {
         let data = self
             .data
@@ -638,7 +638,7 @@ impl Cipher {
     }
 }
 impl CipherView {
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub fn generate_cipher_key(
         &mut self,
         ctx: &mut KeyStoreContext<KeyIds>,
@@ -655,14 +655,14 @@ impl CipherView {
         Ok(())
     }
 
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub fn generate_checksums(&mut self) {
         if let Some(l) = self.login.as_mut() {
             l.generate_checksums();
         }
     }
 
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub fn remove_invalid_checksums(&mut self) {
         if let Some(uris) = self.login.as_mut().and_then(|l| l.uris.as_mut()) {
             uris.retain(|u| u.is_checksum_valid());
@@ -681,7 +681,7 @@ impl CipherView {
         Ok(())
     }
 
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub fn decrypt_fido2_credentials(
         &self,
         ctx: &mut KeyStoreContext<KeyIds>,
@@ -762,7 +762,7 @@ impl CipherView {
         Ok(())
     }
 
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub fn set_new_fido2_credentials(
         &mut self,
         ctx: &mut KeyStoreContext<KeyIds>,
@@ -778,7 +778,7 @@ impl CipherView {
         Ok(())
     }
 
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub fn get_fido2_credentials(
         &self,
         ctx: &mut KeyStoreContext<KeyIds>,
@@ -793,7 +793,7 @@ impl CipherView {
         Ok(res)
     }
 
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub fn decrypt_fido2_private_key(
         &self,
         ctx: &mut KeyStoreContext<KeyIds>,
@@ -1443,7 +1443,7 @@ mod tests {
             let attachment_key_enc = ctx
                 .wrap_symmetric_key(SymmetricKeyId::User, attachment_key)
                 .unwrap();
-            #[allow(deprecated)]
+            #[expect(deprecated)]
             let attachment_key_val = ctx
                 .dangerous_get_symmetric_key(attachment_key)
                 .unwrap()
@@ -1480,7 +1480,7 @@ mod tests {
         let new_attachment_key_id = ctx
             .unwrap_symmetric_key(org_key, &new_attachment_key)
             .unwrap();
-        #[allow(deprecated)]
+        #[expect(deprecated)]
         let new_attachment_key_dec = ctx
             .dangerous_get_symmetric_key(new_attachment_key_id)
             .unwrap();
@@ -1544,9 +1544,9 @@ mod tests {
         let new_cipher_key_dec = ctx
             .unwrap_symmetric_key(org_key, &wrapped_new_cipher_key)
             .unwrap();
-        #[allow(deprecated)]
+        #[expect(deprecated)]
         let new_cipher_key_dec = ctx.dangerous_get_symmetric_key(new_cipher_key_dec).unwrap();
-        #[allow(deprecated)]
+        #[expect(deprecated)]
         let cipher_key_val = ctx.dangerous_get_symmetric_key(cipher_key).unwrap();
 
         assert_eq!(new_cipher_key_dec, cipher_key_val);

--- a/crates/bitwarden-vault/src/cipher/cipher_client/create.rs
+++ b/crates/bitwarden-vault/src/cipher/cipher_client/create.rs
@@ -23,7 +23,7 @@ use crate::{
     cipher_view_type::CipherViewType,
 };
 
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 #[bitwarden_error(flat)]
 #[derive(Debug, Error)]
 pub enum CreateCipherError {
@@ -311,7 +311,7 @@ mod tests {
     #[tokio::test]
     async fn test_create_cipher() {
         let store: KeyStore<KeyIds> = KeyStore::default();
-        #[allow(deprecated)]
+        #[expect(deprecated)]
         let _ = store.context_mut().set_symmetric_key(
             SymmetricKeyId::User,
             SymmetricCryptoKey::make_aes256_cbc_hmac_key(),
@@ -411,7 +411,7 @@ mod tests {
     #[tokio::test]
     async fn test_create_cipher_http_error() {
         let store: KeyStore<KeyIds> = KeyStore::default();
-        #[allow(deprecated)]
+        #[expect(deprecated)]
         let _ = store.context_mut().set_symmetric_key(
             SymmetricKeyId::User,
             SymmetricCryptoKey::make_aes256_cbc_hmac_key(),

--- a/crates/bitwarden-vault/src/cipher/cipher_client/edit.rs
+++ b/crates/bitwarden-vault/src/cipher/cipher_client/edit.rs
@@ -25,7 +25,7 @@ use crate::{
     cipher_view_type::CipherViewType, password_history::MAX_PASSWORD_HISTORY_ENTRIES,
 };
 
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 #[bitwarden_error(flat)]
 #[derive(Debug, Error)]
 pub enum EditCipherError {
@@ -517,7 +517,7 @@ mod tests {
     #[tokio::test]
     async fn test_edit_cipher() {
         let store: KeyStore<KeyIds> = KeyStore::default();
-        #[allow(deprecated)]
+        #[expect(deprecated)]
         let _ = store.context_mut().set_symmetric_key(
             SymmetricKeyId::User,
             SymmetricCryptoKey::make_aes256_cbc_hmac_key(),
@@ -619,7 +619,7 @@ mod tests {
     #[tokio::test]
     async fn test_edit_cipher_http_error() {
         let store: KeyStore<KeyIds> = KeyStore::default();
-        #[allow(deprecated)]
+        #[expect(deprecated)]
         let _ = store.context_mut().set_symmetric_key(
             SymmetricKeyId::User,
             SymmetricCryptoKey::make_aes256_cbc_hmac_key(),

--- a/crates/bitwarden-vault/src/cipher/cipher_client/get.rs
+++ b/crates/bitwarden-vault/src/cipher/cipher_client/get.rs
@@ -7,7 +7,7 @@ use thiserror::Error;
 use super::CiphersClient;
 use crate::{Cipher, CipherView, ItemNotFoundError, cipher::cipher::DecryptCipherListResult};
 
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 #[bitwarden_error(flat)]
 #[derive(Debug, Error)]
 pub enum GetCipherError {

--- a/crates/bitwarden-vault/src/cipher/cipher_client/mod.rs
+++ b/crates/bitwarden-vault/src/cipher/cipher_client/mod.rs
@@ -23,7 +23,7 @@ mod edit;
 mod get;
 mod share_cipher;
 
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 #[cfg_attr(feature = "wasm", wasm_bindgen)]
 pub struct CiphersClient {
     pub(crate) client: Client,
@@ -31,7 +31,7 @@ pub struct CiphersClient {
 
 #[cfg_attr(feature = "wasm", wasm_bindgen)]
 impl CiphersClient {
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub fn encrypt(&self, mut cipher_view: CipherView) -> Result<EncryptionContext, EncryptError> {
         let user_id = self
             .client
@@ -109,14 +109,14 @@ impl CiphersClient {
         })
     }
 
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub fn decrypt(&self, cipher: Cipher) -> Result<CipherView, DecryptError> {
         let key_store = self.client.internal.get_key_store();
         let cipher_view = key_store.decrypt(&cipher)?;
         Ok(cipher_view)
     }
 
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub fn decrypt_list(&self, ciphers: Vec<Cipher>) -> Result<Vec<CipherListView>, DecryptError> {
         let key_store = self.client.internal.get_key_store();
         let cipher_views = key_store.decrypt_list(&ciphers)?;
@@ -135,7 +135,7 @@ impl CiphersClient {
         }
     }
 
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub fn decrypt_fido2_credentials(
         &self,
         cipher_view: CipherView,
@@ -163,7 +163,7 @@ impl CiphersClient {
         Ok(cipher_view)
     }
 
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub fn move_to_organization(
         &self,
         mut cipher_view: CipherView,
@@ -175,7 +175,7 @@ impl CiphersClient {
     }
 
     #[cfg(feature = "wasm")]
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub fn decrypt_fido2_private_key(
         &self,
         cipher_view: CipherView,

--- a/crates/bitwarden-vault/src/cipher/cipher_view_type.rs
+++ b/crates/bitwarden-vault/src/cipher/cipher_view_type.rs
@@ -9,7 +9,7 @@ use crate::{CardView, IdentityView, LoginView, SecureNoteView, SshKeyView};
 #[serde(rename_all = "camelCase")]
 #[cfg_attr(feature = "uniffi", derive(uniffi::Enum))]
 #[cfg_attr(feature = "wasm", derive(Tsify), tsify(into_wasm_abi, from_wasm_abi))]
-#[allow(missing_docs, clippy::large_enum_variant)]
+#[expect(missing_docs, clippy::large_enum_variant)]
 pub enum CipherViewType {
     Login(LoginView),
     Card(CardView),
@@ -31,7 +31,7 @@ impl CipherViewType {
     }
 }
 
-#[allow(unused)]
+#[expect(unused)]
 impl CipherViewType {
     pub(crate) fn as_login_view_mut(&mut self) -> Option<&mut LoginView> {
         match self {

--- a/crates/bitwarden-vault/src/cipher/field.rs
+++ b/crates/bitwarden-vault/src/cipher/field.rs
@@ -62,7 +62,7 @@ pub struct Field {
     linked_id: Option<LinkedIdType>,
 }
 
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 #[cfg_attr(feature = "uniffi", derive(uniffi::Record))]

--- a/crates/bitwarden-vault/src/cipher/identity.rs
+++ b/crates/bitwarden-vault/src/cipher/identity.rs
@@ -36,7 +36,7 @@ pub struct Identity {
     pub license_number: Option<EncString>,
 }
 
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 #[cfg_attr(feature = "uniffi", derive(uniffi::Record))]

--- a/crates/bitwarden-vault/src/cipher/login.rs
+++ b/crates/bitwarden-vault/src/cipher/login.rs
@@ -20,7 +20,7 @@ use wasm_bindgen::prelude::wasm_bindgen;
 use super::cipher::CipherKind;
 use crate::{Cipher, PasswordHistoryView, VaultParseError, cipher::cipher::CopyableCipherFields};
 
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 #[derive(Clone, Copy, Serialize_repr, Deserialize_repr, Debug, PartialEq)]
 #[repr(u8)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
@@ -45,7 +45,7 @@ pub struct LoginUri {
     pub uri_checksum: Option<EncString>,
 }
 
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 #[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
@@ -84,7 +84,7 @@ impl LoginUriView {
     }
 }
 
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 #[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
@@ -118,7 +118,7 @@ pub struct Fido2CredentialListView {
     pub counter: String,
 }
 
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 #[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
@@ -143,7 +143,7 @@ pub struct Fido2CredentialView {
 
 // This is mostly a copy of the Fido2CredentialView, but with the key exposed
 // Only meant to be used internally and not exposed to the outside world
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 #[cfg_attr(feature = "wasm", derive(Tsify), tsify(into_wasm_abi, from_wasm_abi))]
@@ -166,7 +166,7 @@ pub struct Fido2CredentialFullView {
 // This is mostly a copy of the Fido2CredentialView, meant to be exposed to the clients
 // to let them select where to store the new credential. Note that it doesn't contain
 // the encrypted key as that is only filled when the cipher is selected
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 #[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
@@ -279,7 +279,7 @@ impl Decryptable<KeyIds, SymmetricKeyId, Fido2CredentialFullView> for Fido2Crede
     }
 }
 
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
 #[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
@@ -296,7 +296,7 @@ pub struct Login {
     pub fido2_credentials: Option<Vec<Fido2Credential>>,
 }
 
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 #[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
@@ -368,7 +368,7 @@ impl LoginView {
     }
 }
 
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 #[cfg_attr(feature = "uniffi", derive(uniffi::Record))]

--- a/crates/bitwarden-vault/src/cipher/mod.rs
+++ b/crates/bitwarden-vault/src/cipher/mod.rs
@@ -1,7 +1,7 @@
 pub(crate) mod attachment;
 pub(crate) mod attachment_client;
 pub(crate) mod card;
-#[allow(clippy::module_inception)]
+#[expect(clippy::module_inception)]
 pub(crate) mod cipher;
 pub(crate) mod cipher_client;
 pub(crate) mod cipher_permissions;

--- a/crates/bitwarden-vault/src/cipher/secure_note.rs
+++ b/crates/bitwarden-vault/src/cipher/secure_note.rs
@@ -16,7 +16,7 @@ use crate::{
     cipher::cipher::{CipherKind, CopyableCipherFields},
 };
 
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 #[derive(Clone, Copy, Serialize_repr, Debug)]
 #[repr(u8)]
 #[cfg_attr(feature = "uniffi", derive(uniffi::Enum))]
@@ -51,7 +51,7 @@ impl<'de> Deserialize<'de> for SecureNoteType {
     }
 }
 
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 #[derive(Clone, Serialize, Deserialize, Debug)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 #[cfg_attr(feature = "uniffi", derive(uniffi::Record))]

--- a/crates/bitwarden-vault/src/cipher/ssh_key.rs
+++ b/crates/bitwarden-vault/src/cipher/ssh_key.rs
@@ -27,7 +27,7 @@ pub struct SshKey {
     pub fingerprint: EncString,
 }
 
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 #[cfg_attr(feature = "uniffi", derive(uniffi::Record))]

--- a/crates/bitwarden-vault/src/cipher_risk/cipher_risk_client.rs
+++ b/crates/bitwarden-vault/src/cipher_risk/cipher_risk_client.rs
@@ -17,7 +17,7 @@ use super::{
 };
 
 /// Error type for cipher risk evaluation operations
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 #[bitwarden_error(flat)]
 #[derive(Debug, Error)]
 pub enum CipherRiskError {

--- a/crates/bitwarden-vault/src/collection_client.rs
+++ b/crates/bitwarden-vault/src/collection_client.rs
@@ -14,7 +14,7 @@ use wasm_bindgen::prelude::wasm_bindgen;
 
 use crate::DecryptError;
 
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 #[cfg_attr(feature = "wasm", wasm_bindgen)]
 #[derive(Clone)]
 pub struct CollectionsClient {
@@ -23,14 +23,14 @@ pub struct CollectionsClient {
 
 #[cfg_attr(feature = "wasm", wasm_bindgen)]
 impl CollectionsClient {
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub fn decrypt(&self, collection: Collection) -> Result<CollectionView, DecryptError> {
         let key_store = self.client.internal.get_key_store();
         let view = key_store.decrypt(&collection)?;
         Ok(view)
     }
 
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub fn decrypt_list(
         &self,
         collections: Vec<Collection>,

--- a/crates/bitwarden-vault/src/domain.rs
+++ b/crates/bitwarden-vault/src/domain.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::VaultParseError;
 
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 #[derive(Serialize, Deserialize, Debug)]
 pub struct GlobalDomains {
     pub r#type: i32,

--- a/crates/bitwarden-vault/src/error.rs
+++ b/crates/bitwarden-vault/src/error.rs
@@ -4,7 +4,7 @@ use thiserror::Error;
 use crate::CipherError;
 
 /// Generic error type for vault encryption errors.
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 #[bitwarden_error(flat)]
 #[derive(Debug, Error)]
 pub enum EncryptError {
@@ -15,7 +15,7 @@ pub enum EncryptError {
 }
 
 /// Generic error type for decryption errors
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 #[bitwarden_error(flat)]
 #[derive(Debug, Error)]
 pub enum DecryptError {
@@ -23,7 +23,7 @@ pub enum DecryptError {
     Crypto(#[from] bitwarden_crypto::CryptoError),
 }
 
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 #[derive(Debug, Error)]
 pub enum VaultParseError {
     #[error(transparent)]

--- a/crates/bitwarden-vault/src/folder/create.rs
+++ b/crates/bitwarden-vault/src/folder/create.rs
@@ -46,7 +46,7 @@ impl IdentifyKey<SymmetricKeyId> for FolderAddEditRequest {
     }
 }
 
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 #[bitwarden_error(flat)]
 #[derive(Debug, Error)]
 pub enum CreateFolderError {
@@ -98,7 +98,7 @@ mod tests {
     #[tokio::test]
     async fn test_create_folder() {
         let store: KeyStore<KeyIds> = KeyStore::default();
-        #[allow(deprecated)]
+        #[expect(deprecated)]
         let _ = store.context_mut().set_symmetric_key(
             SymmetricKeyId::User,
             SymmetricCryptoKey::make_aes256_cbc_hmac_key(),
@@ -160,7 +160,7 @@ mod tests {
     #[tokio::test]
     async fn test_create_folder_http_error() {
         let store: KeyStore<KeyIds> = KeyStore::default();
-        #[allow(deprecated)]
+        #[expect(deprecated)]
         let _ = store.context_mut().set_symmetric_key(
             SymmetricKeyId::User,
             SymmetricCryptoKey::make_aes256_cbc_hmac_key(),

--- a/crates/bitwarden-vault/src/folder/edit.rs
+++ b/crates/bitwarden-vault/src/folder/edit.rs
@@ -10,7 +10,7 @@ use crate::{
     Folder, FolderAddEditRequest, FolderId, FolderView, ItemNotFoundError, VaultParseError,
 };
 
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 #[bitwarden_error(flat)]
 #[derive(Debug, Error)]
 pub enum EditFolderError {
@@ -89,7 +89,7 @@ mod tests {
     #[tokio::test]
     async fn test_edit_folder() {
         let store: KeyStore<KeyIds> = KeyStore::default();
-        #[allow(deprecated)]
+        #[expect(deprecated)]
         let _ = store.context_mut().set_symmetric_key(
             SymmetricKeyId::User,
             SymmetricCryptoKey::make_aes256_cbc_hmac_key(),
@@ -167,7 +167,7 @@ mod tests {
     #[tokio::test]
     async fn test_edit_folder_http_error() {
         let store: KeyStore<KeyIds> = KeyStore::default();
-        #[allow(deprecated)]
+        #[expect(deprecated)]
         let _ = store.context_mut().set_symmetric_key(
             SymmetricKeyId::User,
             SymmetricCryptoKey::make_aes256_cbc_hmac_key(),

--- a/crates/bitwarden-vault/src/folder/folder_models.rs
+++ b/crates/bitwarden-vault/src/folder/folder_models.rs
@@ -17,7 +17,7 @@ use crate::VaultParseError;
 
 uuid_newtype!(pub FolderId);
 
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
 #[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
@@ -30,7 +30,7 @@ pub struct Folder {
 
 bitwarden_state::register_repository_item!(Folder, "Folder");
 
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 #[cfg_attr(feature = "uniffi", derive(uniffi::Record))]

--- a/crates/bitwarden-vault/src/folder/get_list.rs
+++ b/crates/bitwarden-vault/src/folder/get_list.rs
@@ -6,7 +6,7 @@ use thiserror::Error;
 
 use crate::{Folder, FolderId, FolderView, ItemNotFoundError};
 
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 #[bitwarden_error(flat)]
 #[derive(Debug, Error)]
 pub enum GetFolderError {

--- a/crates/bitwarden-vault/src/lib.rs
+++ b/crates/bitwarden-vault/src/lib.rs
@@ -26,7 +26,7 @@ pub use error::{DecryptError, EncryptError, VaultParseError};
 mod vault_client;
 pub use vault_client::{VaultClient, VaultClientExt};
 
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 pub mod collection_client;
 mod totp_client;
 

--- a/crates/bitwarden-vault/src/password_history.rs
+++ b/crates/bitwarden-vault/src/password_history.rs
@@ -14,7 +14,7 @@ use crate::VaultParseError;
 /// Maximum number of password history entries to retain
 pub(crate) const MAX_PASSWORD_HISTORY_ENTRIES: usize = 5;
 
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 #[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
@@ -24,7 +24,7 @@ pub struct PasswordHistory {
     last_used_date: DateTime<Utc>,
 }
 
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 #[cfg_attr(feature = "uniffi", derive(uniffi::Record))]

--- a/crates/bitwarden-vault/src/password_history_client.rs
+++ b/crates/bitwarden-vault/src/password_history_client.rs
@@ -2,13 +2,13 @@ use bitwarden_core::Client;
 
 use crate::{DecryptError, EncryptError, PasswordHistory, PasswordHistoryView};
 
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 pub struct PasswordHistoryClient {
     pub(crate) client: Client,
 }
 
 impl PasswordHistoryClient {
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub fn encrypt(
         &self,
         history_view: PasswordHistoryView,
@@ -18,7 +18,7 @@ impl PasswordHistoryClient {
         Ok(history)
     }
 
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub fn decrypt_list(
         &self,
         history: Vec<PasswordHistory>,

--- a/crates/bitwarden-vault/src/totp.rs
+++ b/crates/bitwarden-vault/src/totp.rs
@@ -30,7 +30,7 @@ const DEFAULT_ALGORITHM: TotpAlgorithm = TotpAlgorithm::Sha1;
 const DEFAULT_DIGITS: u32 = 6;
 const DEFAULT_PERIOD: u32 = 30;
 
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 #[bitwarden_error(flat)]
 #[derive(Debug, Error)]
 pub enum TotpError {
@@ -43,7 +43,7 @@ pub enum TotpError {
     Crypto(#[from] CryptoError),
 }
 
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 #[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
@@ -95,7 +95,7 @@ pub fn generate_totp_cipher_view(
     generate_totp(key, time)
 }
 
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum TotpAlgorithm {
     Sha1,
@@ -149,7 +149,7 @@ impl fmt::Display for TotpAlgorithm {
 /// Should generally be considered internal to the bitwarden-vault crate. Consumers should use one
 /// of the generate functions if they want to generate a TOTP code. Credential Exchange requires
 /// access to the individual components.
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 #[derive(Debug)]
 pub struct Totp {
     pub account: Option<String>,

--- a/crates/bitwarden-vault/src/totp_client.rs
+++ b/crates/bitwarden-vault/src/totp_client.rs
@@ -5,7 +5,7 @@ use wasm_bindgen::prelude::*;
 
 use crate::{CipherListView, TotpError, TotpResponse, generate_totp, generate_totp_cipher_view};
 
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 #[cfg_attr(feature = "wasm", wasm_bindgen)]
 pub struct TotpClient {
     pub(crate) client: Client,

--- a/crates/bitwarden-vault/src/vault_client.rs
+++ b/crates/bitwarden-vault/src/vault_client.rs
@@ -7,7 +7,7 @@ use crate::{
     TotpClient, collection_client::CollectionsClient,
 };
 
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 #[derive(Clone)]
 #[cfg_attr(feature = "wasm", wasm_bindgen)]
 pub struct VaultClient {
@@ -72,7 +72,7 @@ impl VaultClient {
     }
 }
 
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 pub trait VaultClientExt {
     fn vault(&self) -> VaultClient;
 }

--- a/crates/bitwarden-wasm-internal/src/init.rs
+++ b/crates/bitwarden-wasm-internal/src/init.rs
@@ -26,7 +26,7 @@ pub fn set_log_level(level: LogLevel) {
     set_max_level(log_level.to_level_filter());
 }
 
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 #[wasm_bindgen]
 pub fn init_sdk(log_level: Option<LogLevel>) {
     console_error_panic_hook::set_once();

--- a/crates/bitwarden-wasm-internal/src/platform/mod.rs
+++ b/crates/bitwarden-wasm-internal/src/platform/mod.rs
@@ -59,14 +59,14 @@ pub struct IndexedDbConfiguration {
 
 #[wasm_bindgen]
 impl StateClient {
-    #[allow(deprecated)]
+    #[expect(deprecated)]
     #[deprecated(note = "Use `register_client_managed_repositories` instead")]
     pub fn register_cipher_repository(&self, cipher_repository: CipherRepository) {
         let cipher = cipher_repository.into_channel_impl();
         self.0.platform().state().register_client_managed(cipher);
     }
 
-    #[allow(deprecated)]
+    #[expect(deprecated)]
     #[deprecated(note = "Use `register_client_managed_repositories` instead")]
     pub fn register_folder_repository(&self, store: FolderRepository) {
         let store = store.into_channel_impl();

--- a/crates/bitwarden-wasm-internal/src/pure_crypto.rs
+++ b/crates/bitwarden-wasm-internal/src/pure_crypto.rs
@@ -1,7 +1,7 @@
 use std::str::FromStr;
 
 use bitwarden_core::key_management::KeyIds;
-#[allow(deprecated)]
+#[expect(deprecated)]
 use bitwarden_crypto::dangerous_derive_kdf_material;
 use bitwarden_crypto::{
     AsymmetricCryptoKey, AsymmetricPublicCryptoKey, BitwardenLegacyKeyBytes, CoseKeyBytes,
@@ -159,7 +159,7 @@ impl PureCrypto {
         // Note: The order of arguments is different here, and should probably be refactored
         let unwrapped = context
             .unwrap_symmetric_key(wrapping_key, &EncString::from_str(wrapped_key.as_str())?)?;
-        #[allow(deprecated)]
+        #[expect(deprecated)]
         let key = context.dangerous_get_symmetric_key(unwrapped)?;
         Ok(key.to_encoded().to_vec())
     }
@@ -301,7 +301,7 @@ impl PureCrypto {
         salt: &[u8],
         kdf: Kdf,
     ) -> Result<Vec<u8>, CryptoError> {
-        #[allow(deprecated)]
+        #[expect(deprecated)]
         dangerous_derive_kdf_material(password, salt, &kdf)
     }
 

--- a/crates/bw/src/auth/mod.rs
+++ b/crates/bw/src/auth/mod.rs
@@ -77,7 +77,7 @@ pub struct RegisterArgs {
 }
 
 impl RegisterArgs {
-    #[allow(unused_variables, clippy::unused_async)]
+    #[expect(unused_variables, clippy::unused_async)]
     pub async fn run(self) -> CommandResult {
         let settings = self.server.map(|server| ClientSettings {
             api_url: format!("{server}/api"),

--- a/crates/bw/src/platform/mod.rs
+++ b/crates/bw/src/platform/mod.rs
@@ -45,7 +45,7 @@ pub enum ConfigCommand {
 }
 
 impl ConfigCommand {
-    #[allow(clippy::unused_async)]
+    #[expect(clippy::unused_async)]
     pub async fn run(self) -> CommandResult {
         todo!()
     }

--- a/crates/bw/src/render.rs
+++ b/crates/bw/src/render.rs
@@ -4,7 +4,7 @@ use clap::ValueEnum;
 use crate::command::Cli;
 
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, ValueEnum, Debug)]
-#[allow(clippy::upper_case_acronyms)]
+#[expect(clippy::upper_case_acronyms)]
 pub(crate) enum Output {
     JSON,
     YAML,

--- a/crates/bw/src/vault/sync.rs
+++ b/crates/bw/src/vault/sync.rs
@@ -30,7 +30,7 @@ pub enum SyncError {
     NotAuthenticated(#[from] NotAuthenticatedError),
 }
 
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct SyncRequest {
@@ -98,7 +98,7 @@ pub struct DomainResponse {
     pub global_equivalent_domains: Vec<GlobalDomains>,
 }
 
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct SyncResponse {

--- a/support/openapi-template/reqwest-trait/api_mod.mustache
+++ b/support/openapi-template/reqwest-trait/api_mod.mustache
@@ -130,7 +130,7 @@ pub fn parse_deep_object(prefix: &str, value: &serde_json::Value) -> Vec<(String
 
 /// Internal use only
 /// A content type supported by this client.
-#[allow(dead_code)]
+#[expect(dead_code)]
 enum ContentType {
     Json,
     Text,
@@ -160,7 +160,7 @@ pub mod configuration;
 {{#topLevelApiClient}}
 use std::sync::Arc;
 
-#[allow(clippy::large_enum_variant, private_interfaces)]
+#[expect(clippy::large_enum_variant, private_interfaces)]
 pub enum ApiClient {
     Real(ApiClientReal),
     {{#mockall}}


### PR DESCRIPTION
## 📔 Objective

[Rust 1.81 stabilized the `#[expect]` attribute](https://github.com/rust-lang/rust/pull/120924/). This attribute acts very similarly to `#[allow]`, in that it allows for the suppression of various style lints. Unlike `#[allow]`, however, it tells the linter to _expect_ that you are overriding a linter warning. If the override is no longer applicable, then `#[expect]` will throw a warning stating that the lint suppression is no longer needed so that you can remove it.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation
  team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
