### PR TITLE
[PM-28790] [PM-18938] Isolate decryption support for type 0 keys

### DIFF
--- a/crates/bitwarden-crypto/src/error.rs
+++ b/crates/bitwarden-crypto/src/error.rs
@@ -79,6 +79,8 @@ pub enum CryptoError {
 pub enum UnsupportedOperationError {
     #[error("Encryption is not implemented for key")]
     EncryptionNotImplementedForKey,
+    #[error("Decryption is not implemented for key")]
+    DecryptionNotImplementedForKey,
 }
 
 #[derive(Debug, Error)]

--- a/crates/bitwarden-crypto/src/store/context.rs
+++ b/crates/bitwarden-crypto/src/store/context.rs
@@ -169,10 +169,10 @@ impl<Ids: KeyIds> KeyStoreContext<'_, Ids> {
         let wrapping_key = self.get_symmetric_key(wrapping_key)?;
 
         let key = match (wrapped_key, wrapping_key) {
-            (EncString::Aes256Cbc_B64 { iv, data }, SymmetricCryptoKey::Aes256CbcKey(key)) => {
-                SymmetricCryptoKey::try_from(&BitwardenLegacyKeyBytes::from(
-                    crate::aes::decrypt_aes256(iv, data.clone(), &key.enc_key)?,
-                ))?
+            (EncString::Aes256Cbc_B64 { .. }, SymmetricCryptoKey::Aes256CbcKey(_)) => {
+                return Err(CryptoError::OperationNotSupported(
+                    UnsupportedOperationError::DecryptionNotImplementedForKey,
+                ));
             }
             (
                 EncString::Aes256Cbc_HmacSha256_B64 { iv, mac, data },
@@ -517,8 +517,10 @@ impl<Ids: KeyIds> KeyStoreContext<'_, Ids> {
         let key = self.get_symmetric_key(key)?;
 
         match (data, key) {
-            (EncString::Aes256Cbc_B64 { iv, data }, SymmetricCryptoKey::Aes256CbcKey(key)) => {
-                crate::aes::decrypt_aes256(iv, data.clone(), &key.enc_key)
+            (EncString::Aes256Cbc_B64 { .. }, SymmetricCryptoKey::Aes256CbcKey(_)) => {
+                Err(CryptoError::OperationNotSupported(
+                    UnsupportedOperationError::DecryptionNotImplementedForKey,
+                ))
             }
             (
                 EncString::Aes256Cbc_HmacSha256_B64 { iv, mac, data },
@@ -605,8 +607,8 @@ mod tests {
 
     use crate::{
         AsymmetricCryptoKey, AsymmetricPublicCryptoKey, CompositeEncryptable, CoseKeyBytes,
-        CoseSerializable, CryptoError, Decryptable, KeyDecryptable, LocalId, Pkcs8PrivateKeyBytes,
-        SignatureAlgorithm, SigningKey, SigningNamespace, SymmetricCryptoKey,
+        CoseSerializable, CryptoError, Decryptable, EncString, KeyDecryptable, LocalId,
+        Pkcs8PrivateKeyBytes, SignatureAlgorithm, SigningKey, SigningNamespace, SymmetricCryptoKey,
         store::{
             KeyStore,
             tests::{Data, DataView},
@@ -892,6 +894,93 @@ mod tests {
                 Err(CryptoError::KeyOperationNotSupported(KeyOperation::Encrypt))
             ),
             "Expected encrypt to fail with KeyOperationNotSupported",
+        );
+    }
+
+    #[test]
+    fn test_encrypt_decrypt_data_fails_when_key_is_type_0() {
+        let store = KeyStore::<TestIds>::default();
+        let mut ctx = store.context_mut();
+
+        let key_id = TestSymmKey::A(0);
+        let key = SymmetricCryptoKey::Aes256CbcKey(crate::Aes256CbcKey {
+            enc_key: Box::pin([0u8; 32].into()),
+        });
+        ctx.set_symmetric_key_internal(key_id, key).unwrap();
+
+        let data_to_encrypt: Vec<u8> = vec![1, 2, 3, 4, 5];
+        let result = ctx.encrypt_data_with_symmetric_key(
+            key_id,
+            &data_to_encrypt,
+            crate::ContentFormat::OctetStream,
+        );
+        assert!(
+            matches!(
+                result,
+                Err(CryptoError::OperationNotSupported(
+                    crate::error::UnsupportedOperationError::EncryptionNotImplementedForKey
+                ))
+            ),
+            "Expected encrypt to fail when using deprecated type 0 keys",
+        );
+
+        let data_to_decrypt = EncString::Aes256Cbc_B64 {
+            iv: [0; 16],
+            data: data_to_encrypt,
+        }; // dummy value; shouldn't matter
+        let result = ctx.decrypt_data_with_symmetric_key(key_id, &data_to_decrypt);
+        assert!(
+            matches!(
+                result,
+                Err(CryptoError::OperationNotSupported(
+                    crate::error::UnsupportedOperationError::DecryptionNotImplementedForKey
+                ))
+            ),
+            "Expected decrypt to fail when using deprecated type 0 keys",
+        );
+    }
+
+    #[test]
+    fn test_wrap_unwrap_key_fails_when_key_is_type_0() {
+        let store = KeyStore::<TestIds>::default();
+        let mut ctx = store.context_mut();
+
+        let wrapping_key_id = TestSymmKey::A(0);
+        let wrapping_key = SymmetricCryptoKey::Aes256CbcKey(crate::Aes256CbcKey {
+            enc_key: Box::pin([0u8; 32].into()),
+        });
+        ctx.set_symmetric_key_internal(wrapping_key_id, wrapping_key)
+            .unwrap();
+
+        let key_to_wrap_id = TestSymmKey::A(1);
+        let key_to_wrap = SymmetricCryptoKey::make_aes256_cbc_hmac_key();
+        ctx.set_symmetric_key_internal(key_to_wrap_id, key_to_wrap)
+            .unwrap();
+
+        let result = ctx.wrap_symmetric_key(wrapping_key_id, key_to_wrap_id);
+        assert!(
+            matches!(
+                result,
+                Err(CryptoError::OperationNotSupported(
+                    crate::error::UnsupportedOperationError::EncryptionNotImplementedForKey
+                ))
+            ),
+            "Expected encrypt to fail when using deprecated type 0 keys",
+        );
+
+        let wrapped_key = &EncString::Aes256Cbc_B64 {
+            iv: [0; 16],
+            data: vec![0],
+        }; // dummy value; shouldn't matter
+        let result = ctx.unwrap_symmetric_key(wrapping_key_id, wrapped_key);
+        assert!(
+            matches!(
+                result,
+                Err(CryptoError::OperationNotSupported(
+                    crate::error::UnsupportedOperationError::DecryptionNotImplementedForKey
+                ))
+            ),
+            "Expected decrypt to fail when using deprecated type 0 keys",
         );
     }
 }


### PR DESCRIPTION
## 🎟️ Tracking

[https://bitwarden.atlassian.net/browse/PM-18938](https://bitwarden.atlassian.net/browse/PM-18938)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
Isolates Type 0 key decryption to the `master_key.rs:decrypt_user_key()` flow. All other uses now raise new `bitwarden-crypto` error `UnsupportedOperationError::DecryptionNotImplementedForKey`.

This is another small step in deprecating use of legacy Type 0 keys in the sdk, [see tech breakdown](https://bitwarden.atlassian.net/wiki/spaces/EN/pages/1932689422/Tech+Breakdown+-+Block+type+0+symmetric+keys+generally). Type 0 keys have been deprecated from active use for a long time, this continues the process of removing their functionality while still supporting master key decryption for old accounts.

Type 0-based encryption was already deprecated in a prior PR, this change isolates decryption. Prior work isolated clients to use only the `master_key.rs:decrypt_user_key` path (in TS clients, via `PureCrypto.decrypt_user_key_with_master_key` #465). Other uses of type 0 keys are expected to now throw an error.

## 🚨 Breaking Changes

<!-- Does this PR introduce any breaking changes? If so, please describe the impact and migration path for clients.

If you're unsure, the automated TypeScript compatibility check will run when you open/update this PR and provide feedback.

For breaking changes:
1. Describe what changed in the client interface
2. Explain why the change was necessary
3. Provide migration steps for client developers
4. Link to any paired client PRs if needed

Otherwise, you can remove this section. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation
  team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
