### PR TITLE
Only allow one auth method on the server bindings

### DIFF
--- a/support/openapi-template/reqwest-trait/api.mustache
+++ b/support/openapi-template/reqwest-trait/api.mustache
@@ -353,6 +353,7 @@ impl {{classname}} for {{classname}}Client {
         {{/hasHeaderParams}}
         {{#hasAuthMethods}}
         {{#authMethods}}
+        {{#-first}}
         {{#supportTokenSource}}
         // Obtain a token from source provider.
         // Tokens can be Id or access tokens depending on the provider type and configuration.
@@ -391,6 +392,7 @@ impl {{classname}} for {{classname}}Client {
         };
         {{/isOAuth}}
         {{/supportTokenSource}}
+        {{/-first}}
         {{/authMethods}}
         {{/hasAuthMethods}}
         {{#isMultipart}}


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective

The server bindings template iterates over all auth methods of all the servers and generates code for each of them. This means that if the schema has two servers defined (like the US and EU servers) it will generate code like this:
```rust
        if let Some(ref token) = config.oauth_access_token {
            request = request.bearer_auth(token.to_owned());
        };
        // This one is just duplicate
        if let Some(ref token) = config.oauth_access_token {
            request = request.bearer_auth(token.to_owned());
        };
```

This won't break anything and is safe to do, but it's kind of wasteful. Instead, we can just use the first auth method only. 

The change doesn't have any effect on the bindings for the moment as we're only ever defining one server and one auth method, but https://github.com/bitwarden/server/pull/6653 will add the US and EU servers to the server API schema, which will result in the above shown duplication.

## 🚨 Breaking Changes

<!-- Does this PR introduce any breaking changes? If so, please describe the impact and migration path for clients.

If you're unsure, the automated TypeScript compatibility check will run when you open/update this PR and provide feedback.

For breaking changes:
1. Describe what changed in the client interface
2. Explain why the change was necessary
3. Provide migration steps for client developers
4. Link to any paired client PRs if needed

Otherwise, you can remove this section. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation
  team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
