### PR TITLE
[PM-28845] Add PureCrypto functions to replace webcrypto RSA entirely

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -988,7 +988,10 @@ dependencies = [
  "bitwarden-threading",
  "bitwarden-vault",
  "console_error_panic_hook",
+ "rand 0.8.5",
+ "rsa",
  "serde",
+ "sha1",
  "tracing",
  "tracing-subscriber",
  "tracing-web",
@@ -3823,7 +3826,7 @@ dependencies = [
  "bytes",
  "getrandom 0.3.3",
  "lru-slab",
- "rand 0.9.1",
+ "rand 0.9.2",
  "ring",
  "rustc-hash",
  "rustls",
@@ -3877,9 +3880,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.1"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fbfd9d094a40bf3ae768db9361049ace4c0e04a4fd6b359518bd7b73a73dd97"
+checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.3",
@@ -4104,9 +4107,9 @@ dependencies = [
 
 [[package]]
 name = "rsa"
-version = "0.9.8"
+version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78928ac1ed176a5ca1d17e578a1825f3d81ca54cf41053a592584b020cfd691b"
+checksum = "40a0376c50d0358279d9d643e4bf7b7be212f1f4ff1da9070a7b54d22ef75c88"
 dependencies = [
  "const-oid",
  "digest 0.10.7",
@@ -5291,9 +5294,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.30"
+version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81383ab64e72a7a8b8e13130c49e3dab29def6d0c7d76a03087b3cf71c5c6903"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5751,9 +5754,9 @@ dependencies = [
 
 [[package]]
 name = "walrus"
-version = "0.24.3"
+version = "0.24.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21b8fed39d0da6f4761a38de49e5f3e5d932b0aaa2245dc6da714586a72dd238"
+checksum = "ff282e73d21b86a9d397f42570d158eb9e5c521d0ead4d13cd049fd7cb45c467"
 dependencies = [
  "anyhow",
  "gimli 0.26.2",

--- a/crates/bitwarden-wasm-internal/Cargo.toml
+++ b/crates/bitwarden-wasm-internal/Cargo.toml
@@ -33,7 +33,10 @@ bitwarden-state = { workspace = true, features = ["wasm"] }
 bitwarden-threading = { workspace = true }
 bitwarden-vault = { workspace = true, features = ["wasm"] }
 console_error_panic_hook = "0.1.7"
+rand = ">=0.8.5, <0.9"
+rsa = ">=0.9.2, <0.10"
 serde = { workspace = true }
+sha1 = ">=0.10.5, <0.11"
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 tracing-web = { version = "0.1.3" }

--- a/crates/bitwarden-wasm-internal/src/pure_crypto.rs
+++ b/crates/bitwarden-wasm-internal/src/pure_crypto.rs
@@ -328,11 +328,11 @@ impl PureCrypto {
     /// returns the corresponding public RSA key in DER format.
     pub fn rsa_extract_public_key(private_key: Vec<u8>) -> Result<Vec<u8>, RsaError> {
         let private_key = AsymmetricCryptoKey::from_der(&Pkcs8PrivateKeyBytes::from(private_key))
-            .map_err(|_| RsaError::KeyParseFailed)?;
+            .map_err(|_| RsaError::KeyParse)?;
         let public_key = private_key.to_public_key();
         Ok(public_key
             .to_der()
-            .map_err(|_| RsaError::KeySerializeFailed)?
+            .map_err(|_| RsaError::KeySerialize)?
             .to_vec())
     }
 
@@ -341,7 +341,7 @@ impl PureCrypto {
         let private_key = AsymmetricCryptoKey::make(PublicKeyEncryptionAlgorithm::RsaOaepSha1);
         Ok(private_key
             .to_der()
-            .map_err(|_| RsaError::KeySerializeFailed)?
+            .map_err(|_| RsaError::KeySerialize)?
             .to_vec())
     }
 
@@ -351,32 +351,32 @@ impl PureCrypto {
         private_key: Vec<u8>,
     ) -> Result<Vec<u8>, RsaError> {
         let private_key = RsaPrivateKey::from_pkcs8_der(private_key.as_slice())
-            .map_err(|_| RsaError::KeyParseFailed)?;
+            .map_err(|_| RsaError::KeyParse)?;
         let padding = Oaep::new::<Sha1>();
         private_key
             .decrypt(padding, &encrypted_data)
-            .map_err(|_| RsaError::DecryptionFailed)
+            .map_err(|_| RsaError::Decryption)
     }
 
     /// Encrypts data using RSAES-OAEP with SHA-1
     pub fn rsa_encrypt_data(plain_data: Vec<u8>, public_key: Vec<u8>) -> Result<Vec<u8>, RsaError> {
         let public_key = RsaPublicKey::from_public_key_der(public_key.as_slice())
-            .map_err(|_| RsaError::KeyParseFailed)?;
+            .map_err(|_| RsaError::KeyParse)?;
         let padding = Oaep::new::<Sha1>();
         let mut rng = rand::thread_rng();
         public_key
             .encrypt(&mut rng, padding, &plain_data)
-            .map_err(|_| RsaError::EncryptionFailed)
+            .map_err(|_| RsaError::Encryption)
     }
 }
 
 #[wasm_bindgen]
 #[derive(Debug)]
 pub enum RsaError {
-    DecryptionFailed,
-    EncryptionFailed,
-    KeyParseFailed,
-    KeySerializeFailed,
+    Decryption,
+    Encryption,
+    KeyParse,
+    KeySerialize,
 }
 
 #[cfg(test)]

--- a/crates/bitwarden-wasm-internal/src/pure_crypto.rs
+++ b/crates/bitwarden-wasm-internal/src/pure_crypto.rs
@@ -371,6 +371,7 @@ impl PureCrypto {
 }
 
 #[wasm_bindgen]
+#[derive(Debug)]
 pub enum RsaError {
     DecryptionFailed,
     EncryptionFailed,
@@ -738,5 +739,15 @@ DnqOsltgPomWZ7xVfMkm9niL2OA=
         )
         .unwrap();
         assert_eq!(user_key.0.to_encoded().to_vec(), decrypted_user_key);
+    }
+
+    #[test]
+    fn test_rsa_round_trip() {
+        let private_key = PureCrypto::rsa_generate_keypair().unwrap();
+        let public_key = PureCrypto::rsa_extract_public_key(private_key.clone()).unwrap();
+        let plain_data = b"Test RSA encryption data".to_vec();
+        let encrypted_data = PureCrypto::rsa_encrypt_data(plain_data.clone(), public_key).unwrap();
+        let decrypted_data = PureCrypto::rsa_decrypt_data(encrypted_data, private_key).unwrap();
+        assert_eq!(plain_data, decrypted_data);
     }
 }

--- a/crates/bitwarden-wasm-internal/src/pure_crypto.rs
+++ b/crates/bitwarden-wasm-internal/src/pure_crypto.rs
@@ -4,12 +4,10 @@ use bitwarden_core::key_management::KeyIds;
 #[allow(deprecated)]
 use bitwarden_crypto::dangerous_derive_kdf_material;
 use bitwarden_crypto::{
-    AsymmetricCryptoKey, AsymmetricPublicCryptoKey, BitwardenLegacyKeyBytes, CoseKeyBytes,
-    CoseSerializable, CoseSign1Bytes, CryptoError, Decryptable, EncString, Kdf, KeyDecryptable,
-    KeyEncryptable, KeyStore, MasterKey, OctetStreamBytes, Pkcs8PrivateKeyBytes,
-    PrimitiveEncryptable, SignatureAlgorithm, SignedPublicKey, SigningKey, SpkiPublicKeyBytes,
-    SymmetricCryptoKey, UnsignedSharedKey, VerifyingKey,
+    AsymmetricCryptoKey, AsymmetricPublicCryptoKey, BitwardenLegacyKeyBytes, CoseKeyBytes, CoseSerializable, CoseSign1Bytes, CryptoError, Decryptable, EncString, Kdf, KeyDecryptable, KeyEncryptable, KeyStore, MasterKey, OctetStreamBytes, Pkcs8PrivateKeyBytes, PrimitiveEncryptable, PublicKeyEncryptionAlgorithm, SignatureAlgorithm, SignedPublicKey, SigningKey, SpkiPublicKeyBytes, SymmetricCryptoKey, UnsignedSharedKey, VerifyingKey
 };
+use rsa::{Oaep, RsaPrivateKey, RsaPublicKey, pkcs8::{DecodePrivateKey, DecodePublicKey}};
+use sha1::Sha1;
 use wasm_bindgen::prelude::*;
 
 /// This module represents a stopgap solution to provide access to primitive crypto functions for JS
@@ -319,21 +317,57 @@ impl PureCrypto {
         Ok(result.to_encoded().to_vec())
     }
 
-    /// Given an encrypted private RSA key and the symmetric key it is wrapped with, this returns
+    /// Given a decrypted private RSA key PKCS8 DER and the symmetric key it is wrapped with, this returns
     /// the corresponding public RSA key in DER format.
     pub fn rsa_extract_public_key(
-        encrypted_private_key: EncString,
-        wrapping_key: Vec<u8>,
-    ) -> Result<Vec<u8>, CryptoError> {
-        let wrapping_key =
-            SymmetricCryptoKey::try_from(&BitwardenLegacyKeyBytes::from(wrapping_key))?;
-        let decrypted_private_key: Vec<u8> =
-            encrypted_private_key.decrypt_with_key(&wrapping_key)?;
+        private_key: Vec<u8>,
+    ) -> Result<Vec<u8>, RsaError> {
         let private_key =
-            AsymmetricCryptoKey::from_der(&Pkcs8PrivateKeyBytes::from(decrypted_private_key))?;
+            AsymmetricCryptoKey::from_der(&Pkcs8PrivateKeyBytes::from(private_key))
+                .map_err(|_| RsaError::KeyParseFailed)?;
         let public_key = private_key.to_public_key();
-        Ok(public_key.to_der()?.to_vec())
+        Ok(public_key.to_der().map_err(|_| RsaError::KeySerializeFailed)?.to_vec())
     }
+
+    /// Generates a new RSA key pair and returns the private key
+    pub fn rsa_generate_keypair(
+    ) -> Result<Vec<u8>, RsaError> {
+        let private_key = AsymmetricCryptoKey::make(PublicKeyEncryptionAlgorithm::RsaOaepSha1);
+        Ok(private_key.to_der().map_err(|_| RsaError::KeySerializeFailed)?.to_vec())
+    }
+
+    /// Decrypts data using RSAES-OAEP with SHA-1
+    pub fn rsa_decrypt_data(
+        encrypted_data: Vec<u8>,
+        private_key: Vec<u8>,
+    ) -> Result<Vec<u8>, RsaError> {
+        let private_key = RsaPrivateKey::from_pkcs8_der(private_key.as_slice())
+            .map_err(|_| RsaError::KeyParseFailed)?;
+        let padding = Oaep::new::<Sha1>();
+        private_key.decrypt(padding, &encrypted_data)
+            .map_err(|_| RsaError::DecryptionFailed)
+    }
+
+    /// Encrypts data using RSAES-OAEP with SHA-1
+    pub fn rsa_encrypt_data(
+        plain_data: Vec<u8>,
+        public_key: Vec<u8>,
+    ) -> Result<Vec<u8>, RsaError> {
+        let public_key = RsaPublicKey::from_public_key_der(public_key.as_slice())
+            .map_err(|_| RsaError::KeyParseFailed)?;
+        let padding = Oaep::new::<Sha1>();
+        let mut rng = rand::thread_rng();
+        public_key.encrypt(&mut rng, padding, &plain_data)
+            .map_err(|_| RsaError::EncryptionFailed)
+    }
+}
+
+#[wasm_bindgen]
+pub enum RsaError {
+    DecryptionFailed,
+    EncryptionFailed,
+    KeyParseFailed,
+    KeySerializeFailed,
 }
 
 #[cfg(test)]

--- a/crates/bitwarden-wasm-internal/src/pure_crypto.rs
+++ b/crates/bitwarden-wasm-internal/src/pure_crypto.rs
@@ -4,9 +4,16 @@ use bitwarden_core::key_management::KeyIds;
 #[allow(deprecated)]
 use bitwarden_crypto::dangerous_derive_kdf_material;
 use bitwarden_crypto::{
-    AsymmetricCryptoKey, AsymmetricPublicCryptoKey, BitwardenLegacyKeyBytes, CoseKeyBytes, CoseSerializable, CoseSign1Bytes, CryptoError, Decryptable, EncString, Kdf, KeyDecryptable, KeyEncryptable, KeyStore, MasterKey, OctetStreamBytes, Pkcs8PrivateKeyBytes, PrimitiveEncryptable, PublicKeyEncryptionAlgorithm, SignatureAlgorithm, SignedPublicKey, SigningKey, SpkiPublicKeyBytes, SymmetricCryptoKey, UnsignedSharedKey, VerifyingKey
+    AsymmetricCryptoKey, AsymmetricPublicCryptoKey, BitwardenLegacyKeyBytes, CoseKeyBytes,
+    CoseSerializable, CoseSign1Bytes, CryptoError, Decryptable, EncString, Kdf, KeyDecryptable,
+    KeyEncryptable, KeyStore, MasterKey, OctetStreamBytes, Pkcs8PrivateKeyBytes,
+    PrimitiveEncryptable, PublicKeyEncryptionAlgorithm, SignatureAlgorithm, SignedPublicKey,
+    SigningKey, SpkiPublicKeyBytes, SymmetricCryptoKey, UnsignedSharedKey, VerifyingKey,
 };
-use rsa::{Oaep, RsaPrivateKey, RsaPublicKey, pkcs8::{DecodePrivateKey, DecodePublicKey}};
+use rsa::{
+    Oaep, RsaPrivateKey, RsaPublicKey,
+    pkcs8::{DecodePrivateKey, DecodePublicKey},
+};
 use sha1::Sha1;
 use wasm_bindgen::prelude::*;
 
@@ -317,23 +324,25 @@ impl PureCrypto {
         Ok(result.to_encoded().to_vec())
     }
 
-    /// Given a decrypted private RSA key PKCS8 DER and the symmetric key it is wrapped with, this returns
-    /// the corresponding public RSA key in DER format.
-    pub fn rsa_extract_public_key(
-        private_key: Vec<u8>,
-    ) -> Result<Vec<u8>, RsaError> {
-        let private_key =
-            AsymmetricCryptoKey::from_der(&Pkcs8PrivateKeyBytes::from(private_key))
-                .map_err(|_| RsaError::KeyParseFailed)?;
+    /// Given a decrypted private RSA key PKCS8 DER and the symmetric key it is wrapped with, this
+    /// returns the corresponding public RSA key in DER format.
+    pub fn rsa_extract_public_key(private_key: Vec<u8>) -> Result<Vec<u8>, RsaError> {
+        let private_key = AsymmetricCryptoKey::from_der(&Pkcs8PrivateKeyBytes::from(private_key))
+            .map_err(|_| RsaError::KeyParseFailed)?;
         let public_key = private_key.to_public_key();
-        Ok(public_key.to_der().map_err(|_| RsaError::KeySerializeFailed)?.to_vec())
+        Ok(public_key
+            .to_der()
+            .map_err(|_| RsaError::KeySerializeFailed)?
+            .to_vec())
     }
 
     /// Generates a new RSA key pair and returns the private key
-    pub fn rsa_generate_keypair(
-    ) -> Result<Vec<u8>, RsaError> {
+    pub fn rsa_generate_keypair() -> Result<Vec<u8>, RsaError> {
         let private_key = AsymmetricCryptoKey::make(PublicKeyEncryptionAlgorithm::RsaOaepSha1);
-        Ok(private_key.to_der().map_err(|_| RsaError::KeySerializeFailed)?.to_vec())
+        Ok(private_key
+            .to_der()
+            .map_err(|_| RsaError::KeySerializeFailed)?
+            .to_vec())
     }
 
     /// Decrypts data using RSAES-OAEP with SHA-1
@@ -344,20 +353,19 @@ impl PureCrypto {
         let private_key = RsaPrivateKey::from_pkcs8_der(private_key.as_slice())
             .map_err(|_| RsaError::KeyParseFailed)?;
         let padding = Oaep::new::<Sha1>();
-        private_key.decrypt(padding, &encrypted_data)
+        private_key
+            .decrypt(padding, &encrypted_data)
             .map_err(|_| RsaError::DecryptionFailed)
     }
 
     /// Encrypts data using RSAES-OAEP with SHA-1
-    pub fn rsa_encrypt_data(
-        plain_data: Vec<u8>,
-        public_key: Vec<u8>,
-    ) -> Result<Vec<u8>, RsaError> {
+    pub fn rsa_encrypt_data(plain_data: Vec<u8>, public_key: Vec<u8>) -> Result<Vec<u8>, RsaError> {
         let public_key = RsaPublicKey::from_public_key_der(public_key.as_slice())
             .map_err(|_| RsaError::KeyParseFailed)?;
         let padding = Oaep::new::<Sha1>();
         let mut rng = rand::thread_rng();
-        public_key.encrypt(&mut rng, padding, &plain_data)
+        public_key
+            .encrypt(&mut rng, padding, &plain_data)
             .map_err(|_| RsaError::EncryptionFailed)
     }
 }

--- a/crates/bitwarden-wasm-internal/src/pure_crypto.rs
+++ b/crates/bitwarden-wasm-internal/src/pure_crypto.rs
@@ -324,7 +324,7 @@ impl PureCrypto {
         Ok(result.to_encoded().to_vec())
     }
 
-    /// Given a decrypted private RSA key PKCS8 DER and the symmetric key it is wrapped with, this
+    /// Given a decrypted private RSA key PKCS8 DER this
     /// returns the corresponding public RSA key in DER format.
     pub fn rsa_extract_public_key(private_key: Vec<u8>) -> Result<Vec<u8>, RsaError> {
         let private_key = AsymmetricCryptoKey::from_der(&Pkcs8PrivateKeyBytes::from(private_key))


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://github.com/bitwarden/clients/pull/17742
https://bitwarden.atlassian.net/browse/PM-28845

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Preparing to nuke webcrypto's RSA implementation out of orbit. It is unreliable and we have reproduced around 50% of all private keys keys are generated by rustcrypto that are not parseable on webcrypto on Safari (but parseable on chrome / firefox). It is unclear why, most likely safari has some stricter condition for the keys (RSA ASN1 has many conditions that may apply here), or has a bug. We also suspect keys generated on old Xamarin PCLCrypto to be parseable by rust, or at least deliver good error messages on rust, but be unparseable on all of webcrypto. This changes the functions to be exactly the same as webcrypto so that they can be dropped in without refactoring anything else.

Note: Usually, implementing crypto directly in the wasm crate would not be a good idea, *however* is is justifiable here because we DO NOT WANT these to be public functions consumeable by any other crate, so they do not belong in the crypto crate. They are also only used by the wasm clients.

## 🚨 Breaking Changes

<!-- Does this PR introduce any breaking changes? If so, please describe the impact and migration path for clients.

If you're unsure, the automated TypeScript compatibility check will run when you open/update this PR and provide feedback.

For breaking changes:
1. Describe what changed in the client interface
2. Explain why the change was necessary
3. Provide migration steps for client developers
4. Link to any paired client PRs if needed

Otherwise, you can remove this section. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation
  team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
