### PR TITLE
PM-14922 - Move AC policy code to own crate to unblock auth login work

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -626,7 +626,7 @@ dependencies = [
  "rand 0.8.5",
  "rand_chacha 0.3.1",
  "rayon",
- "rsa 0.9.8",
+ "rsa 0.9.9",
  "schemars 1.0.0",
  "serde",
  "serde_bytes",
@@ -798,6 +798,18 @@ dependencies = [
  "uniffi",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+]
+
+[[package]]
+name = "bitwarden-policies"
+version = "1.0.0"
+dependencies = [
+ "bitwarden-api-api",
+ "bitwarden-core",
+ "serde",
+ "serde_json",
+ "serde_repr",
+ "uuid",
 ]
 
 [[package]]
@@ -1022,7 +1034,7 @@ dependencies = [
  "bitwarden-vault",
  "console_error_panic_hook",
  "rand 0.8.5",
- "rsa",
+ "rsa 0.9.9",
  "serde",
  "sha1",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -146,9 +146,6 @@ opt-level = "z"
 [profile.release.package.bitwarden-crypto]
 opt-level = 3
 
-
-
-
 # Stripping the binary reduces the size by ~30%, but the stacktraces won't be usable anymore.
 # This is fine as long as we don't have any unhandled panics, but let's keep it disabled for now
 # strip = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,6 @@ bitwarden-fido = { path = "crates/bitwarden-fido", version = "=1.0.0" }
 bitwarden-generators = { path = "crates/bitwarden-generators", version = "=1.0.0" }
 bitwarden-ipc = { path = "crates/bitwarden-ipc", version = "=1.0.0" }
 bitwarden-pm = { path = "crates/bitwarden-pm", version = "=1.0.0" }
-bitwarden-policies = { path = "crates/bitwarden-policies", version = "=1.0.0" }
 bitwarden-send = { path = "crates/bitwarden-send", version = "=1.0.0" }
 bitwarden-sm = { path = "bitwarden_license/bitwarden-sm", version = "=1.0.0" }
 bitwarden-ssh = { path = "crates/bitwarden-ssh", version = "=1.0.0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -147,6 +147,8 @@ opt-level = "z"
 opt-level = 3
 
 
+
+
 # Stripping the binary reduces the size by ~30%, but the stacktraces won't be usable anymore.
 # This is fine as long as we don't have any unhandled panics, but let's keep it disabled for now
 # strip = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ bitwarden-fido = { path = "crates/bitwarden-fido", version = "=1.0.0" }
 bitwarden-generators = { path = "crates/bitwarden-generators", version = "=1.0.0" }
 bitwarden-ipc = { path = "crates/bitwarden-ipc", version = "=1.0.0" }
 bitwarden-pm = { path = "crates/bitwarden-pm", version = "=1.0.0" }
+bitwarden-policies = { path = "crates/bitwarden-policies", version = "=1.0.0" }
 bitwarden-send = { path = "crates/bitwarden-send", version = "=1.0.0" }
 bitwarden-sm = { path = "bitwarden_license/bitwarden-sm", version = "=1.0.0" }
 bitwarden-ssh = { path = "crates/bitwarden-ssh", version = "=1.0.0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,9 @@ keywords = ["bitwarden"]
 
 # Define dependencies that are expected to be consistent across all crates
 [workspace.dependencies]
+
+# External crates that are expected to maintain a consistent version across all crates
+async-trait = ">=0.1.80, <0.2"
 bitwarden = { path = "crates/bitwarden", version = "=1.0.0" }
 bitwarden-api-api = { path = "crates/bitwarden-api-api", version = "=1.0.0" }
 bitwarden-api-identity = { path = "crates/bitwarden-api-identity", version = "=1.0.0" }
@@ -36,6 +39,7 @@ bitwarden-fido = { path = "crates/bitwarden-fido", version = "=1.0.0" }
 bitwarden-generators = { path = "crates/bitwarden-generators", version = "=1.0.0" }
 bitwarden-ipc = { path = "crates/bitwarden-ipc", version = "=1.0.0" }
 bitwarden-pm = { path = "crates/bitwarden-pm", version = "=1.0.0" }
+bitwarden-policies = { path = "crates/bitwarden-policies", version = "=1.0.0" }
 bitwarden-send = { path = "crates/bitwarden-send", version = "=1.0.0" }
 bitwarden-sm = { path = "bitwarden_license/bitwarden-sm", version = "=1.0.0" }
 bitwarden-ssh = { path = "crates/bitwarden-ssh", version = "=1.0.0" }
@@ -46,9 +50,6 @@ bitwarden-uniffi-error = { path = "crates/bitwarden-uniffi-error", version = "=1
 bitwarden-uuid = { path = "crates/bitwarden-uuid", version = "=1.0.0" }
 bitwarden-uuid-macro = { path = "crates/bitwarden-uuid-macro", version = "=1.0.0" }
 bitwarden-vault = { path = "crates/bitwarden-vault", version = "=1.0.0" }
-
-# External crates that are expected to maintain a consistent version across all crates
-async-trait = ">=0.1.80, <0.2"
 chrono = { version = ">=0.4.26, <0.5", features = [
     "clock",
     "serde",
@@ -69,11 +70,11 @@ reqwest = { version = ">=0.12.5, <0.13", features = [
 rsa = ">=0.9.2, <0.10"
 schemars = { version = ">=1.0.0, <2.0", features = ["uuid1", "chrono04"] }
 serde = { version = ">=1.0, <2.0", features = ["derive"] }
+serde-wasm-bindgen = ">=0.6.0, <0.7"
 serde_bytes = { version = ">=0.11.17, <0.12.0" }
 serde_json = ">=1.0.96, <2.0"
 serde_qs = ">=0.12.0, <0.16"
 serde_repr = ">=0.1.12, <0.2"
-serde-wasm-bindgen = ">=0.6.0, <0.7"
 sha1 = ">=0.10.5, <0.11"
 subtle = ">=2.5.0, <3.0"
 syn = ">=2.0.87, <3"
@@ -98,15 +99,6 @@ wasm-bindgen-test = "0.3.55"
 wiremock = ">=0.6.0, <0.7"
 zxcvbn = ">=3.0.1, <4.0"
 
-[patch.crates-io]
-
-uniffi = { git = "https://github.com/mozilla/uniffi-rs", rev = "6d46b3f756dde3213357c477d86771a0fc5da7b4" }
-uniffi_core = { git = "https://github.com/mozilla/uniffi-rs", rev = "6d46b3f756dde3213357c477d86771a0fc5da7b4" }
-uniffi_macros = { git = "https://github.com/mozilla/uniffi-rs", rev = "6d46b3f756dde3213357c477d86771a0fc5da7b4" }
-uniffi_internal_macros = { git = "https://github.com/mozilla/uniffi-rs", rev = "6d46b3f756dde3213357c477d86771a0fc5da7b4" }
-uniffi_bindgen = { git = "https://github.com/mozilla/uniffi-rs", rev = "6d46b3f756dde3213357c477d86771a0fc5da7b4" }
-uniffi_build = { git = "https://github.com/mozilla/uniffi-rs", rev = "6d46b3f756dde3213357c477d86771a0fc5da7b4" }
-
 [workspace.lints.clippy]
 disallowed-macros = "deny"
 unused_async = "deny"
@@ -122,16 +114,25 @@ unexpected_cfgs = { level = "warn", check-cfg = [
 [workspace.metadata.dylint]
 libraries = [{ path = "support/lints" }]
 
-# Compile all dependencies with some optimizations when building this crate on debug
-# This slows down clean builds by about 50%, but the resulting binaries can be orders of magnitude faster
-# As clean builds won't occur very often, this won't slow down the development process
-[profile.dev.package."*"]
-opt-level = 2
+[patch.crates-io]
+
+uniffi = { git = "https://github.com/mozilla/uniffi-rs", rev = "6d46b3f756dde3213357c477d86771a0fc5da7b4" }
+uniffi_core = { git = "https://github.com/mozilla/uniffi-rs", rev = "6d46b3f756dde3213357c477d86771a0fc5da7b4" }
+uniffi_macros = { git = "https://github.com/mozilla/uniffi-rs", rev = "6d46b3f756dde3213357c477d86771a0fc5da7b4" }
+uniffi_internal_macros = { git = "https://github.com/mozilla/uniffi-rs", rev = "6d46b3f756dde3213357c477d86771a0fc5da7b4" }
+uniffi_bindgen = { git = "https://github.com/mozilla/uniffi-rs", rev = "6d46b3f756dde3213357c477d86771a0fc5da7b4" }
+uniffi_build = { git = "https://github.com/mozilla/uniffi-rs", rev = "6d46b3f756dde3213357c477d86771a0fc5da7b4" }
 
 # Turn on a small amount of optimisation in development mode. This might interfere when trying to use a debugger
 # if the compiler decides to optimize some code away, if that's the case, it can be set to 0 or commented out
 [profile.dev]
 opt-level = 1
+
+# Compile all dependencies with some optimizations when building this crate on debug
+# This slows down clean builds by about 50%, but the resulting binaries can be orders of magnitude faster
+# As clean builds won't occur very often, this won't slow down the development process
+[profile.dev.package."*"]
+opt-level = 2
 
 # Turn on LTO on release mode
 [profile.release]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,9 +19,6 @@ keywords = ["bitwarden"]
 
 # Define dependencies that are expected to be consistent across all crates
 [workspace.dependencies]
-
-# External crates that are expected to maintain a consistent version across all crates
-async-trait = ">=0.1.80, <0.2"
 bitwarden = { path = "crates/bitwarden", version = "=1.0.0" }
 bitwarden-api-api = { path = "crates/bitwarden-api-api", version = "=1.0.0" }
 bitwarden-api-identity = { path = "crates/bitwarden-api-identity", version = "=1.0.0" }
@@ -50,6 +47,9 @@ bitwarden-uniffi-error = { path = "crates/bitwarden-uniffi-error", version = "=1
 bitwarden-uuid = { path = "crates/bitwarden-uuid", version = "=1.0.0" }
 bitwarden-uuid-macro = { path = "crates/bitwarden-uuid-macro", version = "=1.0.0" }
 bitwarden-vault = { path = "crates/bitwarden-vault", version = "=1.0.0" }
+
+# External crates that are expected to maintain a consistent version across all crates
+async-trait = ">=0.1.80, <0.2"
 chrono = { version = ">=0.4.26, <0.5", features = [
     "clock",
     "serde",
@@ -70,11 +70,11 @@ reqwest = { version = ">=0.12.5, <0.13", features = [
 rsa = ">=0.9.2, <0.10"
 schemars = { version = ">=1.0.0, <2.0", features = ["uuid1", "chrono04"] }
 serde = { version = ">=1.0, <2.0", features = ["derive"] }
-serde-wasm-bindgen = ">=0.6.0, <0.7"
 serde_bytes = { version = ">=0.11.17, <0.12.0" }
 serde_json = ">=1.0.96, <2.0"
 serde_qs = ">=0.12.0, <0.16"
 serde_repr = ">=0.1.12, <0.2"
+serde-wasm-bindgen = ">=0.6.0, <0.7"
 sha1 = ">=0.10.5, <0.11"
 subtle = ">=2.5.0, <3.0"
 syn = ">=2.0.87, <3"
@@ -99,6 +99,15 @@ wasm-bindgen-test = "0.3.55"
 wiremock = ">=0.6.0, <0.7"
 zxcvbn = ">=3.0.1, <4.0"
 
+[patch.crates-io]
+
+uniffi = { git = "https://github.com/mozilla/uniffi-rs", rev = "6d46b3f756dde3213357c477d86771a0fc5da7b4" }
+uniffi_core = { git = "https://github.com/mozilla/uniffi-rs", rev = "6d46b3f756dde3213357c477d86771a0fc5da7b4" }
+uniffi_macros = { git = "https://github.com/mozilla/uniffi-rs", rev = "6d46b3f756dde3213357c477d86771a0fc5da7b4" }
+uniffi_internal_macros = { git = "https://github.com/mozilla/uniffi-rs", rev = "6d46b3f756dde3213357c477d86771a0fc5da7b4" }
+uniffi_bindgen = { git = "https://github.com/mozilla/uniffi-rs", rev = "6d46b3f756dde3213357c477d86771a0fc5da7b4" }
+uniffi_build = { git = "https://github.com/mozilla/uniffi-rs", rev = "6d46b3f756dde3213357c477d86771a0fc5da7b4" }
+
 [workspace.lints.clippy]
 disallowed-macros = "deny"
 unused_async = "deny"
@@ -114,25 +123,16 @@ unexpected_cfgs = { level = "warn", check-cfg = [
 [workspace.metadata.dylint]
 libraries = [{ path = "support/lints" }]
 
-[patch.crates-io]
-
-uniffi = { git = "https://github.com/mozilla/uniffi-rs", rev = "6d46b3f756dde3213357c477d86771a0fc5da7b4" }
-uniffi_core = { git = "https://github.com/mozilla/uniffi-rs", rev = "6d46b3f756dde3213357c477d86771a0fc5da7b4" }
-uniffi_macros = { git = "https://github.com/mozilla/uniffi-rs", rev = "6d46b3f756dde3213357c477d86771a0fc5da7b4" }
-uniffi_internal_macros = { git = "https://github.com/mozilla/uniffi-rs", rev = "6d46b3f756dde3213357c477d86771a0fc5da7b4" }
-uniffi_bindgen = { git = "https://github.com/mozilla/uniffi-rs", rev = "6d46b3f756dde3213357c477d86771a0fc5da7b4" }
-uniffi_build = { git = "https://github.com/mozilla/uniffi-rs", rev = "6d46b3f756dde3213357c477d86771a0fc5da7b4" }
-
-# Turn on a small amount of optimisation in development mode. This might interfere when trying to use a debugger
-# if the compiler decides to optimize some code away, if that's the case, it can be set to 0 or commented out
-[profile.dev]
-opt-level = 1
-
 # Compile all dependencies with some optimizations when building this crate on debug
 # This slows down clean builds by about 50%, but the resulting binaries can be orders of magnitude faster
 # As clean builds won't occur very often, this won't slow down the development process
 [profile.dev.package."*"]
 opt-level = 2
+
+# Turn on a small amount of optimisation in development mode. This might interfere when trying to use a debugger
+# if the compiler decides to optimize some code away, if that's the case, it can be set to 0 or commented out
+[profile.dev]
+opt-level = 1
 
 # Turn on LTO on release mode
 [profile.release]
@@ -145,6 +145,7 @@ opt-level = "z"
 # other sensitive values being left behind without cleanup.
 [profile.release.package.bitwarden-crypto]
 opt-level = 3
+
 
 # Stripping the binary reduces the size by ~30%, but the stacktraces won't be usable anymore.
 # This is fine as long as we don't have any unhandled panics, but let's keep it disabled for now

--- a/crates/bitwarden-core/src/admin_console/mod.rs
+++ b/crates/bitwarden-core/src/admin_console/mod.rs
@@ -1,7 +1,0 @@
-//! Admin console module for Bitwarden Core.
-//!
-//! Contains policies.
-
-mod policy;
-
-pub use policy::Policy;

--- a/crates/bitwarden-core/src/lib.rs
+++ b/crates/bitwarden-core/src/lib.rs
@@ -5,8 +5,6 @@ uniffi::setup_scaffolding!();
 #[cfg(feature = "uniffi")]
 mod uniffi_support;
 
-#[cfg(feature = "internal")]
-pub mod admin_console;
 pub mod auth;
 pub mod client;
 mod error;

--- a/crates/bitwarden-policies/Cargo.toml
+++ b/crates/bitwarden-policies/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "bitwarden-policies"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+homepage.workspace = true
+repository.workspace = true
+license-file.workspace = true
+readme.workspace = true
+keywords.workspace = true
+
+[dependencies]
+bitwarden-api-api = { workspace = true }
+bitwarden-core = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+serde_repr = { workspace = true }
+uuid = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/bitwarden-policies/README.md
+++ b/crates/bitwarden-policies/README.md
@@ -1,0 +1,3 @@
+# Bitwarden Policies
+
+Contains Admin console owned policy code

--- a/crates/bitwarden-policies/src/lib.rs
+++ b/crates/bitwarden-policies/src/lib.rs
@@ -1,0 +1,5 @@
+#![doc = include_str!("../README.md")]
+
+mod policy;
+
+pub use policy::Policy;

--- a/crates/bitwarden-policies/src/policy.rs
+++ b/crates/bitwarden-policies/src/policy.rs
@@ -1,11 +1,10 @@
 use std::collections::HashMap;
 
 use bitwarden_api_api::models::PolicyResponseModel;
+use bitwarden_core::{MissingFieldError, require};
 use serde::{Deserialize, Serialize};
 use serde_repr::{Deserialize_repr, Serialize_repr};
 use uuid::Uuid;
-
-use crate::{MissingFieldError, require};
 
 /// Represents a policy that can be applied to an organization.
 #[derive(Serialize, Deserialize, Debug)]


### PR DESCRIPTION
## 🎟️ Tracking
<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-14922

## 📔 Objective
<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
To move the AC owned policy code out of the BW-Core crate into its own folder so I can place new domain models there which is required by the data we return for successful logins. 

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation
  team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
