### PR TITLE
fix(ci): resolve git push permission errors in version-bump

### DIFF
--- a/.github/workflows/publish-rust-crates.yml
+++ b/.github/workflows/publish-rust-crates.yml
@@ -50,7 +50,7 @@ jobs:
           _VERSION: "${{ inputs.version }}"
         run: |
           if [[ "${_VERSION}" == "latest" || "${_VERSION}" == "" ]]; then
-            TAG_NAME=$(curl  "https://api.github.com/repos/bitwarden/sdk/releases" | jq -c '.[] | select(.tag_name | contains("rust")) | .tag_name' | head -1)
+            TAG_NAME=$(curl  "https://api.github.com/repos/bitwarden/sdk-internal/releases" | jq -c '.[] | select(.tag_name | contains("rust")) | .tag_name' | head -1)
             VERSION=$(echo $TAG_NAME | grep -ohE '20[0-9]{2}\.([1-9]|1[0-2])\.[0-9]+')
             echo "Latest Released Version: $VERSION"
             echo "version=$VERSION" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -23,7 +23,7 @@ jobs:
     name: "Bump ${{ inputs.project }} Version to v${{ inputs.version_number }}"
     runs-on: ubuntu-24.04
     permissions:
-      contents: read
+      contents: write
       id-token: write
     steps:
       - name: Install rust
@@ -48,44 +48,41 @@ jobs:
         id: retrieve-secrets
         uses: bitwarden/gh-actions/get-keyvault-secrets@main
         with:
-          keyvault: "bitwarden-ci"
-          secrets: "github-gpg-private-key,
-            github-gpg-private-key-passphrase,
-            github-pat-bitwarden-devops-bot-repo-scope"
+          keyvault: "gh-org-bitwarden"
+          secrets: "BW-GHAPP-ID,BW-GHAPP-KEY"
 
       - name: Log out from Azure
         uses: bitwarden/gh-actions/azure-logout@main
+
+      - name: Generate GH App token
+        uses: actions/create-github-app-token@67018539274d69449ef7c02e8e71183d1719ab42 # v2.1.4
+        id: app-token
+        with:
+          app-id: ${{ steps.retrieve-secrets.outputs.BW-GHAPP-ID }}
+          private-key: ${{ steps.retrieve-secrets.outputs.BW-GHAPP-KEY }}
+          repositories: sdk-internal
+          permissions: >-
+            contents: write
+            pull-requests: write
 
       - name: Checkout Branch
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           ref: main
-          repository: bitwarden/sdk
+          repository: bitwarden/sdk-internal
+          token: ${{ steps.app-token.outputs.token }}
           persist-credentials: true
-
-      - name: Import GPG key
-        uses: crazy-max/ghaction-import-gpg@cb9bde2e2525e640591a934b1fd28eef1dcaf5e5 # v6.2.0
-        with:
-          gpg_private_key: ${{ steps.retrieve-secrets.outputs.github-gpg-private-key }}
-          passphrase: ${{ steps.retrieve-secrets.outputs.github-gpg-private-key-passphrase }}
-          git_user_signingkey: true
-          git_commit_gpgsign: true
-
-      - name: Create Version Branch
-        id: branch
-        env:
-          VERSION: ${{ inputs.version_number }}
-          PROJECT: ${{ inputs.project }}
-        run: git switch -c sdk-${PROJECT}_version_bump_${VERSION}
 
       - name: Create Version Branch
         id: create-branch
         env:
-          REF_NAME: ${{ github.ref_name }}
           PROJECT: ${{ inputs.project }}
           VERSION_NUMBER: ${{ inputs.version_number }}
+          RUN_NUMBER: ${{ github.run_number }}
         run: |
-          NAME=version_bump_$REF_NAME_$PROJECT_$VERSION_NUMBER
+          NAME=version_bump_${PROJECT}_${VERSION_NUMBER}_${RUN_NUMBER}
+          # Delete remote branch if it exists
+          git push origin --delete $NAME 2>/dev/null || true
           git switch -c $NAME
           echo "name=$NAME" >> $GITHUB_OUTPUT
 
@@ -130,7 +127,7 @@ jobs:
         env:
           VERSION_NUMBER: ${{ inputs.version_number }}
           PROJECT: ${{ inputs.project }}
-        run: git commit -m "Bumped sdk-$PROJECT version to $VERSION_NUMBER" -a
+        run: git commit --no-verify -m "Bumped sdk-$PROJECT version to $VERSION_NUMBER" -a
 
       - name: Push changes
         if: ${{ steps.version-changed.outputs.changes_to_commit == 'TRUE' }}
@@ -142,7 +139,7 @@ jobs:
         if: ${{ steps.version-changed.outputs.changes_to_commit == 'TRUE' }}
         id: create-pr
         env:
-          GH_TOKEN: ${{ steps.retrieve-secrets.outputs.github-pat-bitwarden-devops-bot-repo-scope }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           PR_BRANCH: ${{ steps.create-branch.outputs.name }}
           TITLE: "Bump ${{ inputs.project }} version to ${{ inputs.version_number }}"
           PROJECT: ${{ inputs.project }}
@@ -153,27 +150,12 @@ jobs:
             --head "$PR_BRANCH" \
             --label "version update" \
             --label "automated pr" \
-            --body "
-              ## Type of change
-              - [ ] Bug fix
-              - [ ] New feature development
-              - [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
-              - [ ] Build/deploy pipeline (DevOps)
-              - [X] Other
-
-              ## Objective
-              Automated $PROJECT version bump to $VERSION_NUMBER.")
+            --body "Automated $PROJECT version bump to $VERSION_NUMBER.")
           echo "pr_number=${PR_URL##*/}" >> $GITHUB_OUTPUT
-
-      - name: Approve PR
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PR_NUMBER: ${{ steps.create-pr.outputs.pr_number }}
-        run: gh pr review $PR_NUMBER --approve
 
       - name: Merge PR
         env:
-          GH_TOKEN: ${{ steps.retrieve-secrets.outputs.github-pat-bitwarden-devops-bot-repo-scope }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           PR_NUMBER: ${{ steps.create-pr.outputs.pr_number }}
         run: gh pr merge $PR_NUMBER --squash --auto --delete-branch
 


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-28544

## 📔 Objective

I am trying to release bitwarden-core for the SM-SDK. A few workflow issues are making that not easy. Several workflows in the release process have not been run on `sdk-internal` and just need to be brought up to speed. I've updated these as best I can here, but am blocked from continuing debugging because I can't run the publish job at all (not even a dry run) without running it on main.

<img width="1286" height="314" alt="Screenshot 2025-12-10 at 3 12 35 PM" src="https://github.com/user-attachments/assets/3d580741-6e2c-4093-a178-78219052bd6c" />


## 🚨 Breaking Changes

<!-- Does this PR introduce any breaking changes? If so, please describe the impact and migration path for clients.

If you're unsure, the automated TypeScript compatibility check will run when you open/update this PR and provide feedback.

For breaking changes:
1. Describe what changed in the client interface
2. Explain why the change was necessary
3. Provide migration steps for client developers
4. Link to any paired client PRs if needed

Otherwise, you can remove this section. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation
  team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
