### PR TITLE
Update passkey-rs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2953,16 +2953,6 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "idna"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "634d9b1461af396cad843f47fdba5597a4f9e6ddd4bfb6ff5d85028c25cb12f6"
-dependencies = [
- "unicode-bidi",
- "unicode-normalization",
-]
-
-[[package]]
-name = "idna"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "686f825264d630750a544639377bae737628043f20d38bbc029e8f29ea968a7e"
@@ -3616,8 +3606,8 @@ dependencies = [
 
 [[package]]
 name = "passkey"
-version = "0.2.0"
-source = "git+https://github.com/bitwarden/passkey-rs?rev=3b764633ebc6576c07bdd12ee14d8e5c87b494ed#3b764633ebc6576c07bdd12ee14d8e5c87b494ed"
+version = "0.5.0"
+source = "git+https://github.com/bitwarden/passkey-rs?rev=357cc9672340f6ff1f22a0b210a74de64799fa73#357cc9672340f6ff1f22a0b210a74de64799fa73"
 dependencies = [
  "passkey-authenticator",
  "passkey-client",
@@ -3627,8 +3617,8 @@ dependencies = [
 
 [[package]]
 name = "passkey-authenticator"
-version = "0.2.0"
-source = "git+https://github.com/bitwarden/passkey-rs?rev=3b764633ebc6576c07bdd12ee14d8e5c87b494ed#3b764633ebc6576c07bdd12ee14d8e5c87b494ed"
+version = "0.5.0"
+source = "git+https://github.com/bitwarden/passkey-rs?rev=357cc9672340f6ff1f22a0b210a74de64799fa73#357cc9672340f6ff1f22a0b210a74de64799fa73"
 dependencies = [
  "async-trait",
  "coset",
@@ -3640,12 +3630,13 @@ dependencies = [
 
 [[package]]
 name = "passkey-client"
-version = "0.2.0"
-source = "git+https://github.com/bitwarden/passkey-rs?rev=3b764633ebc6576c07bdd12ee14d8e5c87b494ed#3b764633ebc6576c07bdd12ee14d8e5c87b494ed"
+version = "0.5.0"
+source = "git+https://github.com/bitwarden/passkey-rs?rev=357cc9672340f6ff1f22a0b210a74de64799fa73#357cc9672340f6ff1f22a0b210a74de64799fa73"
 dependencies = [
  "ciborium",
  "coset",
- "idna 0.5.0",
+ "idna",
+ "itertools 0.14.0",
  "nom",
  "passkey-authenticator",
  "passkey-types",
@@ -3658,24 +3649,27 @@ dependencies = [
 [[package]]
 name = "passkey-transports"
 version = "0.1.0"
-source = "git+https://github.com/bitwarden/passkey-rs?rev=3b764633ebc6576c07bdd12ee14d8e5c87b494ed#3b764633ebc6576c07bdd12ee14d8e5c87b494ed"
+source = "git+https://github.com/bitwarden/passkey-rs?rev=357cc9672340f6ff1f22a0b210a74de64799fa73#357cc9672340f6ff1f22a0b210a74de64799fa73"
 
 [[package]]
 name = "passkey-types"
-version = "0.2.1"
-source = "git+https://github.com/bitwarden/passkey-rs?rev=3b764633ebc6576c07bdd12ee14d8e5c87b494ed#3b764633ebc6576c07bdd12ee14d8e5c87b494ed"
+version = "0.5.0"
+source = "git+https://github.com/bitwarden/passkey-rs?rev=357cc9672340f6ff1f22a0b210a74de64799fa73#357cc9672340f6ff1f22a0b210a74de64799fa73"
 dependencies = [
  "bitflags 2.9.1",
  "ciborium",
  "coset",
  "data-encoding",
  "getrandom 0.2.16",
+ "hmac 0.12.1",
  "indexmap 2.9.0",
  "rand 0.8.5",
  "serde",
  "serde_json",
  "sha2 0.10.9",
  "strum",
+ "url",
+ "zeroize",
 ]
 
 [[package]]
@@ -4006,8 +4000,8 @@ dependencies = [
 
 [[package]]
 name = "public-suffix"
-version = "0.1.1"
-source = "git+https://github.com/bitwarden/passkey-rs?rev=3b764633ebc6576c07bdd12ee14d8e5c87b494ed#3b764633ebc6576c07bdd12ee14d8e5c87b494ed"
+version = "0.1.3"
+source = "git+https://github.com/bitwarden/passkey-rs?rev=357cc9672340f6ff1f22a0b210a74de64799fa73#357cc9672340f6ff1f22a0b210a74de64799fa73"
 
 [[package]]
 name = "quick-error"
@@ -5748,25 +5742,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75b844d17643ee918803943289730bec8aac480150456169e647ed0b576ba539"
 
 [[package]]
-name = "unicode-bidi"
-version = "0.3.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
-
-[[package]]
 name = "unicode-ident"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
-
-[[package]]
-name = "unicode-normalization"
-version = "0.1.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5033c97c4262335cded6d6fc3e5c18ab755e1a3dc96376350f3d8e9f009ad956"
-dependencies = [
- "tinyvec",
-]
 
 [[package]]
 name = "unicode-segmentation"
@@ -5974,8 +5953,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32f8b686cadd1473f4bd0117a5d28d36b1ade384ea9b5069a1c40aefed7fda60"
 dependencies = [
  "form_urlencoded",
- "idna 1.0.3",
+ "idna",
  "percent-encoding",
+ "serde",
 ]
 
 [[package]]
@@ -6008,7 +5988,7 @@ version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43fb22e1a008ece370ce08a3e9e4447a910e92621bb49b85d6e48a45397e7cfa"
 dependencies = [
- "idna 1.0.3",
+ "idna",
  "once_cell",
  "regex",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ version = "1.0.0"
 authors = ["Bitwarden Inc"]
 edition = "2024"
 # Important: Changing rust-version should be considered a breaking change
-rust-version = "1.85"
+rust-version = "1.85.1"
 homepage = "https://bitwarden.com"
 repository = "https://github.com/bitwarden/sdk-internal"
 license-file = "LICENSE"

--- a/crates/bitwarden-fido/Cargo.toml
+++ b/crates/bitwarden-fido/Cargo.toml
@@ -27,8 +27,8 @@ chrono = { workspace = true }
 coset = ">=0.3.7, <0.4"
 itertools = ">=0.13.0, <0.15"
 p256 = ">=0.13.2, <0.14"
-passkey = { git = "https://github.com/bitwarden/passkey-rs", rev = "3b764633ebc6576c07bdd12ee14d8e5c87b494ed" }
-passkey-client = { git = "https://github.com/bitwarden/passkey-rs", rev = "3b764633ebc6576c07bdd12ee14d8e5c87b494ed", features = [
+passkey = { git = "https://github.com/bitwarden/passkey-rs", rev = "357cc9672340f6ff1f22a0b210a74de64799fa73" }
+passkey-client = { git = "https://github.com/bitwarden/passkey-rs", rev = "357cc9672340f6ff1f22a0b210a74de64799fa73", features = [
     "android-asset-validation",
 ] }
 reqwest = { workspace = true }

--- a/crates/bitwarden-fido/src/authenticator.rs
+++ b/crates/bitwarden-fido/src/authenticator.rs
@@ -163,7 +163,7 @@ impl<'a> Fido2Authenticator<'a> {
                 options: passkey::types::ctap2::make_credential::Options {
                     rk: request.options.rk,
                     up: true,
-                    uv: self.convert_requested_uv(request.options.uv).await,
+                    uv: self.convert_requested_uv(request.options.uv),
                 },
                 pin_auth: None,
                 pin_protocol: None,
@@ -222,7 +222,7 @@ impl<'a> Fido2Authenticator<'a> {
                 options: passkey::types::ctap2::make_credential::Options {
                     rk: request.options.rk,
                     up: true,
-                    uv: self.convert_requested_uv(request.options.uv).await,
+                    uv: self.convert_requested_uv(request.options.uv),
                 },
                 pin_auth: None,
                 pin_protocol: None,
@@ -305,8 +305,8 @@ impl<'a> Fido2Authenticator<'a> {
         )
     }
 
-    async fn convert_requested_uv(&self, uv: UV) -> bool {
-        let verification_enabled = self.user_interface.is_verification_enabled().await;
+    fn convert_requested_uv(&self, uv: UV) -> bool {
+        let verification_enabled = self.user_interface.is_verification_enabled();
         match (uv, verification_enabled) {
             (UV::Preferred, true) => true,
             (UV::Preferred, false) => false,
@@ -656,17 +656,12 @@ impl passkey::authenticator::UserValidationMethod for UserValidationMethodImpl<'
         })
     }
 
-    async fn is_presence_enabled(&self) -> bool {
+    fn is_presence_enabled(&self) -> bool {
         true
     }
 
-    async fn is_verification_enabled(&self) -> Option<bool> {
-        Some(
-            self.authenticator
-                .user_interface
-                .is_verification_enabled()
-                .await,
-        )
+    fn is_verification_enabled(&self) -> Option<bool> {
+        Some(self.authenticator.user_interface.is_verification_enabled())
     }
 }
 

--- a/crates/bitwarden-fido/src/client.rs
+++ b/crates/bitwarden-fido/src/client.rs
@@ -130,10 +130,7 @@ impl Fido2Client<'_> {
                 cred_props: result
                     .client_extension_results
                     .cred_props
-                    .map(|c| CredPropsResult {
-                        rk: c.discoverable,
-                        authenticator_display_name: c.authenticator_display_name,
-                    }),
+                    .map(|c| CredPropsResult { rk: c.discoverable }),
             },
             response: AuthenticatorAssertionResponse {
                 client_data_json: result.response.client_data_json.into(),

--- a/crates/bitwarden-fido/src/lib.rs
+++ b/crates/bitwarden-fido/src/lib.rs
@@ -7,7 +7,7 @@ use bitwarden_vault::{
     CipherError, CipherView, Fido2CredentialFullView, Fido2CredentialNewView, Fido2CredentialView,
 };
 use crypto::{CoseKeyToPkcs8Error, PrivateKeyFromSecretKeyError};
-use passkey::types::{Passkey, ctap2::Aaguid};
+use passkey::types::{CredentialExtensions, Passkey, ctap2::Aaguid};
 
 #[cfg(feature = "uniffi")]
 uniffi::setup_scaffolding!();
@@ -26,7 +26,7 @@ pub use authenticator::{
 };
 pub use client::{Fido2Client, Fido2ClientError};
 pub use client_fido::{ClientFido2, ClientFido2Ext, DecryptFido2AutofillCredentialsError};
-pub use passkey::authenticator::UIHint;
+pub use passkey::authenticator::UiHint;
 use thiserror::Error;
 pub use traits::{
     CheckUserOptions, CheckUserResult, Fido2CallbackError, Fido2CredentialStore,
@@ -126,6 +126,7 @@ fn try_from_credential_full_view(value: Fido2CredentialFullView) -> Result<Passk
         rp_id: value.rp_id.clone(),
         user_handle: user_handle.map(|u| u.into_bytes().into()),
         counter,
+        extensions: CredentialExtensions { hmac_secret: None },
     })
 }
 

--- a/crates/bitwarden-fido/src/traits.rs
+++ b/crates/bitwarden-fido/src/traits.rs
@@ -1,5 +1,5 @@
 use bitwarden_vault::{CipherListView, CipherView, EncryptionContext, Fido2CredentialNewView};
-use passkey::authenticator::UIHint;
+use passkey::authenticator::UiHint;
 use thiserror::Error;
 
 #[allow(missing_docs)]
@@ -21,7 +21,7 @@ pub trait Fido2UserInterface: Send + Sync {
     async fn check_user<'a>(
         &self,
         options: CheckUserOptions,
-        hint: UIHint<'a, CipherView>,
+        hint: UiHint<'a, CipherView>,
     ) -> Result<CheckUserResult, Fido2CallbackError>;
     async fn pick_credential_for_authentication(
         &self,
@@ -42,6 +42,7 @@ pub trait Fido2CredentialStore: Send + Sync {
         &self,
         ids: Option<Vec<Vec<u8>>>,
         rip_id: String,
+        // TODO: Add user_handle
     ) -> Result<Vec<CipherView>, Fido2CallbackError>;
 
     async fn all_credentials(&self) -> Result<Vec<CipherListView>, Fido2CallbackError>;

--- a/crates/bitwarden-fido/src/traits.rs
+++ b/crates/bitwarden-fido/src/traits.rs
@@ -42,7 +42,7 @@ pub trait Fido2CredentialStore: Send + Sync {
         &self,
         ids: Option<Vec<Vec<u8>>>,
         rip_id: String,
-        // TODO: Add user_handle
+        user_handle: Option<Vec<u8>>,
     ) -> Result<Vec<CipherView>, Fido2CallbackError>;
 
     async fn all_credentials(&self) -> Result<Vec<CipherListView>, Fido2CallbackError>;

--- a/crates/bitwarden-fido/src/traits.rs
+++ b/crates/bitwarden-fido/src/traits.rs
@@ -32,7 +32,7 @@ pub trait Fido2UserInterface: Send + Sync {
         options: CheckUserOptions,
         new_credential: Fido2CredentialNewView,
     ) -> Result<(CipherView, CheckUserResult), Fido2CallbackError>;
-    async fn is_verification_enabled(&self) -> bool;
+    fn is_verification_enabled(&self) -> bool;
 }
 
 #[allow(missing_docs)]

--- a/crates/bitwarden-uniffi/src/platform/fido2.rs
+++ b/crates/bitwarden-uniffi/src/platform/fido2.rs
@@ -92,13 +92,14 @@ impl ClientFido2Authenticator {
     pub async fn silently_discover_credentials(
         &self,
         rp_id: String,
+        user_handle: Option<Vec<u8>>,
     ) -> Result<Vec<Fido2CredentialAutofillView>> {
         let ui = UniffiTraitBridge(self.1.as_ref());
         let cs = UniffiTraitBridge(self.2.as_ref());
         let mut auth = self.0.create_authenticator(&ui, &cs);
 
         let result = auth
-            .silently_discover_credentials(rp_id)
+            .silently_discover_credentials(rp_id, user_handle)
             .await
             .map_err(Error::SilentlyDiscoverCredentials)?;
         Ok(result)
@@ -241,6 +242,7 @@ pub trait Fido2CredentialStore: Send + Sync {
         &self,
         ids: Option<Vec<Vec<u8>>>,
         rip_id: String,
+        user_handle: Option<Vec<u8>>,
     ) -> Result<Vec<CipherView>, Fido2CallbackError>;
 
     async fn all_credentials(&self) -> Result<Vec<CipherListView>, Fido2CallbackError>;
@@ -260,9 +262,10 @@ impl bitwarden_fido::Fido2CredentialStore for UniffiTraitBridge<&dyn Fido2Creden
         &self,
         ids: Option<Vec<Vec<u8>>>,
         rip_id: String,
+        user_handle: Option<Vec<u8>>,
     ) -> Result<Vec<CipherView>, BitFido2CallbackError> {
         self.0
-            .find_credentials(ids, rip_id)
+            .find_credentials(ids, rip_id, user_handle)
             .await
             .map_err(Into::into)
     }

--- a/crates/bitwarden-uniffi/src/platform/fido2.rs
+++ b/crates/bitwarden-uniffi/src/platform/fido2.rs
@@ -293,9 +293,9 @@ pub enum UIHint {
     RequestExistingCredential(CipherView),
 }
 
-impl From<bitwarden_fido::UIHint<'_, CipherView>> for UIHint {
-    fn from(hint: bitwarden_fido::UIHint<'_, CipherView>) -> Self {
-        use bitwarden_fido::UIHint as BWUIHint;
+impl From<bitwarden_fido::UiHint<'_, CipherView>> for UIHint {
+    fn from(hint: bitwarden_fido::UiHint<'_, CipherView>) -> Self {
+        use bitwarden_fido::UiHint as BWUIHint;
         match hint {
             BWUIHint::InformExcludedCredentialFound(cipher) => {
                 UIHint::InformExcludedCredentialFound(cipher.clone())
@@ -324,7 +324,7 @@ impl bitwarden_fido::Fido2UserInterface for UniffiTraitBridge<&dyn Fido2UserInte
     async fn check_user<'a>(
         &self,
         options: CheckUserOptions,
-        hint: bitwarden_fido::UIHint<'a, CipherView>,
+        hint: bitwarden_fido::UiHint<'a, CipherView>,
     ) -> Result<bitwarden_fido::CheckUserResult, BitFido2CallbackError> {
         self.0
             .check_user(options.clone(), hint.into())

--- a/crates/bitwarden-uniffi/src/platform/fido2.rs
+++ b/crates/bitwarden-uniffi/src/platform/fido2.rs
@@ -231,7 +231,7 @@ pub trait Fido2UserInterface: Send + Sync {
         options: CheckUserOptions,
         new_credential: Fido2CredentialNewView,
     ) -> Result<CheckUserAndPickCredentialForCreationResult, Fido2CallbackError>;
-    async fn is_verification_enabled(&self) -> bool;
+    fn is_verification_enabled(&self) -> bool;
 }
 
 #[uniffi::export(with_foreign)]
@@ -353,7 +353,7 @@ impl bitwarden_fido::Fido2UserInterface for UniffiTraitBridge<&dyn Fido2UserInte
             .map(|v| (v.cipher.cipher, v.check_user_result.into()))
             .map_err(Into::into)
     }
-    async fn is_verification_enabled(&self) -> bool {
-        self.0.is_verification_enabled().await
+    fn is_verification_enabled(&self) -> bool {
+        self.0.is_verification_enabled()
     }
 }

--- a/crates/bitwarden-uniffi/swift/iOS/App/ContentView.swift
+++ b/crates/bitwarden-uniffi/swift/iOS/App/ContentView.swift
@@ -408,7 +408,7 @@ class Fido2UserInterfaceImpl: Fido2UserInterface {
         return CheckUserResult(userPresent: true, userVerified: true)
     }
 
-    func isVerificationEnabled() async  -> Bool {
+    func isVerificationEnabled() -> Bool {
         true
     }
 }

--- a/crates/bitwarden-uniffi/swift/iOS/App/ContentView.swift
+++ b/crates/bitwarden-uniffi/swift/iOS/App/ContentView.swift
@@ -363,7 +363,7 @@ struct ContentView: View {
             extensions: nil
         ))
 
-        let _ = try await authenticator.silentlyDiscoverCredentials(rpId: "")
+        let _ = try await authenticator.silentlyDiscoverCredentials(rpId: "", userHandle: nil)
     }
 
 }
@@ -418,7 +418,7 @@ class Fido2CredentialStoreImpl: Fido2CredentialStore {
         abort()
     }
 
-    func findCredentials(ids: [Data]?, ripId: String) async throws -> [BitwardenSdk.CipherView] {
+    func findCredentials(ids: [Data]?, ripId: String, userHandle: Data?) async throws -> [BitwardenSdk.CipherView] {
         abort()
     }
 


### PR DESCRIPTION
## 🎟️ Tracking

[PM-17241](https://bitwarden.atlassian.net/browse/PM-17241)

## 📔 Objective

This updates the SDK to point to a new version of our passkey-rs fork that has been synced with upstream. (The remaining differences between upstream and our fork are documented in the README of our fork.)

If approved, we should update `passkey-rs`'s `main` branch to point to the version referenced in this PR (https://github.com/bitwarden/passkey-rs/commit/2e5c0ba1fb60a3a6dec9c7dba175d3e07dc89862).

## 🚨 Breaking Changes

- `is_user_verification_enabled()` is no longer asynchronous. Clients should implement any dynamic checks for UV availability in the `check_user()` implementation.
- `user_handle has been added to the `find_credential()` method as an optional parameter. If the incoming request contains the user handle, then clients should pass it on. Otherwise, pass a `null` value, and the previous behavior.

iOS PR: https://github.com/bitwarden/ios/pull/2190

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation
  team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-17241]: https://bitwarden.atlassian.net/browse/PM-17241?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ