### PR TITLE
bw-auth - Add uniffi support

### DIFF
--- a/crates/bitwarden-auth/Cargo.toml
+++ b/crates/bitwarden-auth/Cargo.toml
@@ -21,6 +21,10 @@ wasm = [
     "dep:wasm-bindgen",
     "dep:wasm-bindgen-futures"
 ] # WASM support
+uniffi = [
+    "bitwarden-core/uniffi",
+    "dep:uniffi"
+] # Uniffi bindings
 
 # Note: dependencies must be alphabetized to pass the cargo sort check in the CI pipeline.
 [dependencies]

--- a/crates/bitwarden-auth/Cargo.toml
+++ b/crates/bitwarden-auth/Cargo.toml
@@ -21,10 +21,7 @@ wasm = [
     "dep:wasm-bindgen",
     "dep:wasm-bindgen-futures"
 ] # WASM support
-uniffi = [
-    "bitwarden-core/uniffi",
-    "dep:uniffi"
-] # Uniffi bindings
+uniffi = ["bitwarden-core/uniffi", "dep:uniffi"] # Uniffi bindings
 
 # Note: dependencies must be alphabetized to pass the cargo sort check in the CI pipeline.
 [dependencies]
@@ -35,6 +32,7 @@ reqwest = { workspace = true }
 serde = { workspace = true }
 thiserror = { workspace = true }
 tsify = { workspace = true, optional = true }
+uniffi = { workspace = true, optional = true }
 wasm-bindgen = { workspace = true, optional = true }
 wasm-bindgen-futures = { workspace = true, optional = true }
 

--- a/crates/bitwarden-auth/src/lib.rs
+++ b/crates/bitwarden-auth/src/lib.rs
@@ -1,5 +1,9 @@
 #![doc = include_str!("../README.md")]
 
+// Enable uniffi scaffolding when the "uniffi" feature is enabled.
+#[cfg(feature = "uniffi")]
+uniffi::setup_scaffolding!();
+
 mod auth_client;
 
 pub mod identity;

--- a/crates/bitwarden-auth/src/send_access/access_token_response.rs
+++ b/crates/bitwarden-auth/src/send_access/access_token_response.rs
@@ -10,6 +10,7 @@ use crate::send_access::api::{SendAccessTokenApiErrorResponse, SendAccessTokenAp
     derive(tsify::Tsify),
     tsify(into_wasm_abi, from_wasm_abi)
 )]
+#[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
 #[derive(Debug)]
 pub struct SendAccessTokenResponse {
     /// The actual token string.
@@ -73,3 +74,7 @@ impl From<reqwest::Error> for SendAccessTokenError {
     tsify(into_wasm_abi, from_wasm_abi)
 )]
 pub struct UnexpectedIdentityError(pub String);
+
+// Newtype wrapper for unexpected identity errors for uniffi compatibility.
+#[cfg(feature = "uniffi")] // only compile this when uniffi feature is enabled
+uniffi::custom_newtype!(UnexpectedIdentityError, String);

--- a/crates/bitwarden-auth/src/send_access/api/token_api_error_response.rs
+++ b/crates/bitwarden-auth/src/send_access/api/token_api_error_response.rs
@@ -4,6 +4,7 @@ use tsify::Tsify;
 
 #[derive(Serialize, Deserialize, PartialEq, Eq, Debug)]
 #[cfg_attr(feature = "wasm", derive(Tsify), tsify(into_wasm_abi, from_wasm_abi))]
+#[cfg_attr(feature = "uniffi", derive(uniffi::Error))]
 #[serde(rename_all = "snake_case")]
 /// Invalid request errors - typically due to missing parameters.
 pub enum SendAccessTokenInvalidRequestError {
@@ -26,6 +27,7 @@ pub enum SendAccessTokenInvalidRequestError {
 
 #[derive(Serialize, Deserialize, PartialEq, Eq, Debug)]
 #[cfg_attr(feature = "wasm", derive(Tsify), tsify(into_wasm_abi, from_wasm_abi))]
+#[cfg_attr(feature = "uniffi", derive(uniffi::Error))]
 #[serde(rename_all = "snake_case")]
 /// Invalid grant errors - typically due to invalid credentials.
 pub enum SendAccessTokenInvalidGrantError {
@@ -51,6 +53,7 @@ pub enum SendAccessTokenInvalidGrantError {
 
 #[derive(Serialize, Deserialize, PartialEq, Eq, Debug)]
 #[cfg_attr(feature = "wasm", derive(Tsify), tsify(into_wasm_abi, from_wasm_abi))]
+#[cfg_attr(feature = "uniffi", derive(uniffi::Error))]
 #[serde(rename_all = "snake_case")]
 #[serde(tag = "error")]
 // ^ "error" becomes the variant discriminator which matches against the rename annotations;

--- a/crates/bitwarden-auth/uniffi.toml
+++ b/crates/bitwarden-auth/uniffi.toml
@@ -1,0 +1,9 @@
+[bindings.kotlin]
+package_name = "com.bitwarden.auth"
+generate_immutable_records = true
+android = true
+
+[bindings.swift]
+ffi_module_name = "BitwardenAuthFFI"
+module_name = "BitwardenAuth"
+generate_immutable_records = true


### PR DESCRIPTION
## 🎟️ Tracking
<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
n/a but blocks https://github.com/bitwarden/sdk-internal/pull/549 and https://github.com/bitwarden/sdk-internal/pull/596

## 📔 Objective
<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
To add UNIFFI support to the bw-auth crate 

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation
  team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
