### PR TITLE
ci(publish): add packages input for batched publishing

### DIFF
--- a/.github/workflows/publish-rust-crates.yml
+++ b/.github/workflows/publish-rust-crates.yml
@@ -18,6 +18,11 @@ on:
         required: true
         type: string
         default: latest
+      packages:
+        description: "Space-separated list of packages to publish"
+        required: false
+        type: string
+        default: "bitwarden-api-api bitwarden-api-identity bitwarden-cli bitwarden-core bitwarden-crypto bitwarden-encoding bitwarden-error bitwarden-error-macro bitwarden-generators bitwarden-sm bitwarden-state bitwarden-threading bitwarden-uuid bitwarden-uuid-macro"
 
 jobs:
   setup:
@@ -121,23 +126,10 @@ jobs:
         env:
           PUBLISH_GRACE_SLEEP: 10
           CARGO_REGISTRY_TOKEN: ${{ steps.retrieve-secrets.outputs.cratesio-api-token }}
+          PACKAGES_INPUT: ${{ inputs.packages }}
         run: |
-          PACKAGES=(
-            bitwarden-api-api
-            bitwarden-api-identity
-            bitwarden-cli
-            bitwarden-core
-            bitwarden-crypto
-            bitwarden-encoding
-            bitwarden-error
-            bitwarden-error-macro
-            bitwarden-generators
-            bitwarden-sm
-            bitwarden-state
-            bitwarden-threading
-            bitwarden-uuid
-            bitwarden-uuid-macro
-          )
+          # Convert space-separated string to array
+          IFS=' ' read -ra PACKAGES <<< "$PACKAGES_INPUT"
           PACKAGE_FLAGS=$(printf -- '-p %s ' "${PACKAGES[@]}")
           cargo-release release publish $PACKAGE_FLAGS --execute --no-confirm
 


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-28544

## 📔 Objective

I am trying to publish to crates.io for the first time in a year, and need to publish a few new crates. Unfortunately, I'm being rate limited. 

In this PR I'm moving the published crates list to an input variable so I can run a few batches.

<img width="657" height="128" alt="Screenshot 2025-12-11 at 3 04 07 PM" src="https://github.com/user-attachments/assets/81586fe1-1358-4938-b41c-60a7c596bad9" />

## 🚨 Breaking Changes

<!-- Does this PR introduce any breaking changes? If so, please describe the impact and migration path for clients.

If you're unsure, the automated TypeScript compatibility check will run when you open/update this PR and provide feedback.

For breaking changes:
1. Describe what changed in the client interface
2. Explain why the change was necessary
3. Provide migration steps for client developers
4. Link to any paired client PRs if needed

Otherwise, you can remove this section. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation
  team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
