### PR TITLE
[PM-29825] Add prepare_ciphers_for_bulk_share method for mobile clients

### DIFF
--- a/crates/bitwarden-uniffi/src/vault/ciphers.rs
+++ b/crates/bitwarden-uniffi/src/vault/ciphers.rs
@@ -1,3 +1,4 @@
+use bitwarden_collections::collection::CollectionId;
 use bitwarden_core::OrganizationId;
 use bitwarden_vault::{
     Cipher, CipherListView, CipherView, DecryptCipherListResult, EncryptionContext,
@@ -52,5 +53,18 @@ impl CiphersClient {
         organization_id: OrganizationId,
     ) -> Result<CipherView> {
         Ok(self.0.move_to_organization(cipher, organization_id)?)
+    }
+
+    /// Prepare ciphers for bulk share to an organization
+    pub async fn prepare_ciphers_for_bulk_share(
+        &self,
+        ciphers: Vec<CipherView>,
+        organization_id: OrganizationId,
+        collection_ids: Vec<CollectionId>,
+    ) -> Result<Vec<EncryptionContext>> {
+        Ok(self
+            .0
+            .prepare_ciphers_for_bulk_share(ciphers, organization_id, collection_ids)
+            .await?)
     }
 }

--- a/crates/bitwarden-vault/src/cipher/cipher_client/share_cipher.rs
+++ b/crates/bitwarden-vault/src/cipher/cipher_client/share_cipher.rs
@@ -221,14 +221,12 @@ impl CiphersClient {
         Ok(())
     }
 
-    /// Moves a group of ciphers into an organization, adds them to collections, and calls the
-    /// share_ciphers API.
-    pub async fn share_ciphers_bulk(
+    async fn prepare_encrypted_ciphers_for_bulk_share(
         &self,
         cipher_views: Vec<CipherView>,
         organization_id: OrganizationId,
         collection_ids: Vec<CollectionId>,
-    ) -> Result<Vec<Cipher>, CipherError> {
+    ) -> Result<Vec<EncryptionContext>, CipherError> {
         let mut encrypted_ciphers: Vec<EncryptionContext> = Vec::new();
         for mut cv in cipher_views {
             cv = self.update_organization_and_collections(
@@ -239,6 +237,38 @@ impl CiphersClient {
             self.update_password_history(&mut cv, None).await?;
             encrypted_ciphers.push(self.encrypt(cv)?);
         }
+        Ok(encrypted_ciphers)
+    }
+
+    #[cfg(feature = "uniffi")]
+    /// Prepares ciphers for bulk sharing by assigning them to an organization, adding them to
+    /// collections, updating password history, and encrypting them. This method is exposed for
+    /// UniFFI bindings. Can be removed once Mobile supports authenticated API calls via the SDK.
+    pub async fn prepare_ciphers_for_bulk_share(
+        &self,
+        cipher_views: Vec<CipherView>,
+        organization_id: OrganizationId,
+        collection_ids: Vec<CollectionId>,
+    ) -> Result<Vec<EncryptionContext>, CipherError> {
+        self.prepare_encrypted_ciphers_for_bulk_share(cipher_views, organization_id, collection_ids)
+            .await
+    }
+
+    /// Moves a group of ciphers into an organization, adds them to collections, and calls the
+    /// share_ciphers API.
+    pub async fn share_ciphers_bulk(
+        &self,
+        cipher_views: Vec<CipherView>,
+        organization_id: OrganizationId,
+        collection_ids: Vec<CollectionId>,
+    ) -> Result<Vec<Cipher>, CipherError> {
+        let encrypted_ciphers = self
+            .prepare_encrypted_ciphers_for_bulk_share(
+                cipher_views,
+                organization_id,
+                collection_ids.clone(),
+            )
+            .await?;
 
         let api_client = &self
             .client


### PR DESCRIPTION
## 🎟️ Tracking

[PM-29825](https://bitwarden.atlassian.net/browse/PM-29825)

## 📔 Objective

Expose the logic of bulk transferring personal items to an organization **without** making an API call for Mobile clients that don't yet support authenticated API calls yet. 

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation
  team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-29825]: https://bitwarden.atlassian.net/browse/PM-29825?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ