### PR TITLE
[PM-29846] Fix init when private key is corrupt

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -406,7 +406,7 @@ dependencies = [
  "globset",
  "home",
  "indexmap 2.9.0",
- "itertools",
+ "itertools 0.13.0",
  "nu-ansi-term",
  "once_cell",
  "path_abs",
@@ -516,6 +516,7 @@ dependencies = [
  "thiserror 1.0.69",
  "tokio",
  "tsify",
+ "uniffi",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "wiremock",
@@ -728,7 +729,7 @@ dependencies = [
  "bitwarden-vault",
  "chrono",
  "coset",
- "itertools",
+ "itertools 0.13.0",
  "p256",
  "passkey",
  "passkey-client",
@@ -1618,7 +1619,7 @@ dependencies = [
  "ciborium",
  "clap",
  "criterion-plot",
- "itertools",
+ "itertools 0.13.0",
  "num-traits",
  "oorandom",
  "plotters",
@@ -1637,7 +1638,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b1bcc0dc7dfae599d84ad0b1a55f80cde8af3725da8313b528da95ef783e338"
 dependencies = [
  "cast",
- "itertools",
+ "itertools 0.13.0",
 ]
 
 [[package]]
@@ -3100,6 +3101,15 @@ name = "itertools"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
 dependencies = [
  "either",
 ]
@@ -6942,7 +6952,7 @@ dependencies = [
  "chrono",
  "derive_builder",
  "fancy-regex 0.13.0",
- "itertools",
+ "itertools 0.13.0",
  "lazy_static",
  "regex",
  "time",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -406,7 +406,7 @@ dependencies = [
  "globset",
  "home",
  "indexmap 2.9.0",
- "itertools 0.13.0",
+ "itertools",
  "nu-ansi-term",
  "once_cell",
  "path_abs",
@@ -516,7 +516,6 @@ dependencies = [
  "thiserror 1.0.69",
  "tokio",
  "tsify",
- "uniffi",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "wiremock",
@@ -729,7 +728,7 @@ dependencies = [
  "bitwarden-vault",
  "chrono",
  "coset",
- "itertools 0.13.0",
+ "itertools",
  "p256",
  "passkey",
  "passkey-client",
@@ -1619,7 +1618,7 @@ dependencies = [
  "ciborium",
  "clap",
  "criterion-plot",
- "itertools 0.13.0",
+ "itertools",
  "num-traits",
  "oorandom",
  "plotters",
@@ -1638,7 +1637,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b1bcc0dc7dfae599d84ad0b1a55f80cde8af3725da8313b528da95ef783e338"
 dependencies = [
  "cast",
- "itertools 0.13.0",
+ "itertools",
 ]
 
 [[package]]
@@ -3101,15 +3100,6 @@ name = "itertools"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "itertools"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
 dependencies = [
  "either",
 ]
@@ -6952,7 +6942,7 @@ dependencies = [
  "chrono",
  "derive_builder",
  "fancy-regex 0.13.0",
- "itertools 0.13.0",
+ "itertools",
  "lazy_static",
  "regex",
  "time",

--- a/crates/bitwarden-core/src/key_management/account_cryptographic_state.rs
+++ b/crates/bitwarden-core/src/key_management/account_cryptographic_state.rs
@@ -20,7 +20,7 @@ use bitwarden_encoding::B64;
 use bitwarden_error::bitwarden_error;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
-use tracing::{info, trace};
+use tracing::info;
 #[cfg(feature = "wasm")]
 use tsify::Tsify;
 
@@ -229,7 +229,8 @@ impl WrappedAccountCryptographicState {
                     return Err(AccountCryptographyInitializationError::WrongUserKeyType);
                 }
 
-                // Some users have unreadable V1 private keys. In this case, we set no keys to state.
+                // Some users have unreadable V1 private keys. In this case, we set no keys to
+                // state.
                 if let Ok(private_key_id) = ctx.unwrap_private_key(user_key, private_key) {
                     ctx.persist_asymmetric_key(private_key_id, AsymmetricKeyId::UserPrivateKey)?;
                 } else {

--- a/crates/bitwarden-core/src/key_management/account_cryptographic_state.rs
+++ b/crates/bitwarden-core/src/key_management/account_cryptographic_state.rs
@@ -343,7 +343,7 @@ impl WrappedAccountCryptographicState {
 mod tests {
     use std::{str::FromStr, sync::RwLock};
 
-    use bitwarden_crypto::KeyStore;
+    use bitwarden_crypto::{KeyStore, PrimitiveEncryptable};
 
     use super::*;
     use crate::key_management::{AsymmetricKeyId, SigningKeyId, SymmetricKeyId};
@@ -516,5 +516,48 @@ mod tests {
             security_state.version(),
             model.security_state.unwrap().security_version as u64
         );
+    }
+
+    #[test]
+    fn test_set_to_context_v1_corrupt_private_key() {
+        // Test that a V1 account with a corrupt private key (valid EncString but invalid key data)
+        // can still initialize, but skips setting the private key
+        let temp_store: KeyStore<KeyIds> = KeyStore::default();
+        let mut temp_ctx = temp_store.context_mut();
+
+        let user_key = temp_ctx.make_symmetric_key(SymmetricKeyAlgorithm::Aes256CbcHmac);
+        let corrupt_private_key = "not a private key"
+            .encrypt(&mut temp_ctx, user_key)
+            .unwrap();
+
+        // Construct the V1 wrapped state with corrupt private key
+        let wrapped = WrappedAccountCryptographicState::V1 {
+            private_key: corrupt_private_key,
+        };
+
+        #[expect(deprecated)]
+        let user_key_material = temp_ctx
+            .dangerous_get_symmetric_key(user_key)
+            .unwrap()
+            .to_owned();
+        drop(temp_ctx);
+        drop(temp_store);
+
+        // Now attempt to set this wrapped state into a fresh store
+        let store: KeyStore<KeyIds> = KeyStore::default();
+        let mut ctx = store.context_mut();
+        let user_key = ctx.add_local_symmetric_key(user_key_material);
+        let security_state = RwLock::new(None);
+
+        wrapped
+            .set_to_context(&security_state, user_key, &store, ctx)
+            .unwrap();
+
+        let ctx = store.context();
+
+        // The user symmetric key should be set
+        assert!(ctx.has_symmetric_key(SymmetricKeyId::User));
+        // But the private key should NOT be set (due to corruption)
+        assert!(!ctx.has_asymmetric_key(AsymmetricKeyId::UserPrivateKey));
     }
 }


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-29846


## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
https://github.com/bitwarden/sdk-internal/pull/563 change the init process which now always requires a valid private key. This does not work for users that have a broken private key, and until those are fixed before unlock, these need to be supported in the SDK for V1.


## 🚨 Breaking Changes

<!-- Does this PR introduce any breaking changes? If so, please describe the impact and migration path for clients.

If you're unsure, the automated TypeScript compatibility check will run when you open/update this PR and provide feedback.

For breaking changes:
1. Describe what changed in the client interface
2. Explain why the change was necessary
3. Provide migration steps for client developers
4. Link to any paired client PRs if needed

Otherwise, you can remove this section. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation
  team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
