### PR TITLE
fix(ci): skip verification during cargo-release publish

### DIFF
--- a/.github/workflows/publish-rust-crates.yml
+++ b/.github/workflows/publish-rust-crates.yml
@@ -131,7 +131,12 @@ jobs:
           # Convert space-separated string to array
           IFS=' ' read -ra PACKAGES <<< "$PACKAGES_INPUT"
           PACKAGE_FLAGS=$(printf -- '-p %s ' "${PACKAGES[@]}")
-          cargo-release release publish $PACKAGE_FLAGS --execute --no-confirm
+
+          # no-verify avoids cargo-release complaining about Cargo.lock
+          # modifications that naturally happen during the pre-publishing
+          # validation for many of our crates that don't have commit lock
+          # files
+          cargo-release release publish $PACKAGE_FLAGS --execute --no-confirm --no-verify
 
       - name: Update deployment status to Success
         if: ${{ inputs.release_type != 'Dry Run' && success() }}


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-28544

## 📔 Objective

We are trying to publish to crates.io for the first time in a year, but the current jobs are very out of date and the prexisting publishing workflow has suffered from many unexpected issues. This time we are getting errors about git state being dirty during the pre-validation build step of `cargo-release`, since this generates lock files for each lib.

<img width="664" height="153" alt="Screenshot 2025-12-15 at 5 22 51 PM" src="https://github.com/user-attachments/assets/18684ef1-f7ec-4450-8485-01b4db893300" />

This PR fixes this failure in the `publish-rust-crates.yml` workflow by adding the `--no-verify` flag to the cargo-release command. 

The trade-off is that publishing now skips the verification build that would normally ensure each crate compiles successfully before uploading to crates.io. However, this verification is largely redundant in our workflow since all code already passes build validation during CI before reaching this step. The git tags we publish from represent already-validated, immutable snapshots of code that successfully built in CI. The additional validation is good, but redundant. I think adding this flag is a bit of a smell, but I'm unsure how else to address this right now. It seems like we are following best practices, and this is just necassary for how our pipelines are abstracted. Open to suggestion though.

## 🚨 Breaking Changes

<!-- Does this PR introduce any breaking changes? If so, please describe the impact and migration path for clients.

If you're unsure, the automated TypeScript compatibility check will run when you open/update this PR and provide feedback.

For breaking changes:
1. Describe what changed in the client interface
2. Explain why the change was necessary
3. Provide migration steps for client developers
4. Link to any paired client PRs if needed

Otherwise, you can remove this section. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation
  team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
