### PR TITLE
feat(uniffi): add logging callback for mobile observability 

### DIFF
--- a/crates/bitwarden-uniffi/docs/logging-callback.md
+++ b/crates/bitwarden-uniffi/docs/logging-callback.md
@@ -99,6 +99,24 @@ pub trait LogCallback: Send + Sync {
 }
 ```
 
+## Quick Start
+
+Call `initLogger()` once before creating clients:
+
+```kotlin
+// Kotlin
+initLogger(FlightRecorderCallback())
+val client = Client(tokenProvider, settings)
+```
+
+```swift
+// Swift
+initLogger(callback: FlightRecorderCallback())
+let client = try Client(tokenProvider: tokenProvider, settings: settings)
+```
+
+Skip `initLogger()` to use only platform loggers (oslog/logcat).
+
 ### Thread Safety Requirements
 
 The `Send + Sync` bounds are mandatory. The SDK invokes callbacks from arbitrary background threads,

--- a/crates/bitwarden-uniffi/docs/logging-callback.md
+++ b/crates/bitwarden-uniffi/docs/logging-callback.md
@@ -1,0 +1,164 @@
+# SDK Logging Callback Guide
+
+## Overview
+
+The Bitwarden SDK provides an optional logging callback interface that enables mobile applications
+to receive trace logs from the SDK and forward them to observability systems like Flight Recorder.
+This document explains the design, integration patterns, and best practices for using the logging
+callback feature.
+
+## Purpose and Use Case
+
+The logging callback addresses mobile teams' requirements for:
+
+- **Observability**: Collecting SDK trace events in centralized monitoring systems
+- **Debugging**: Capturing SDK behavior for troubleshooting production issues
+- **Flight Recorder Integration**: Feeding SDK logs into mobile observability platforms
+
+The callback is entirely optional. Platform-specific loggers (oslog on iOS, android_logger on
+Android) continue functioning independently whether or not a callback is registered.
+
+## Architecture
+
+### Design Principles
+
+1. **Non-intrusive**: The SDK operates identically with or without a callback registered
+2. **Thread-safe**: Multiple SDK threads may invoke the callback concurrently
+3. **Error-resilient**: Mobile callback failures do not crash the SDK
+4. **Simple contract**: Mobile teams receive level, target, and message - all other decisions are
+   theirs
+
+### Data Flow
+
+```mermaid
+graph TB
+    A[SDK Code] -->|tracing::info!| B[Tracing Subscriber]
+    B --> C[tracing-subscriber Registry]
+    C --> D[CallbackLayer]
+    C --> E[Platform Loggers]
+
+    D --> F{Callback<br/>Registered?}
+    F -->|Yes| G[UNIFFI Callback]
+    F -->|No| H[No-op]
+
+    G -->|FFI Boundary| I[Mobile Implementation]
+    I --> J[Flight Recorder]
+
+    E --> K[oslog iOS]
+    E --> L[android_logger]
+    E --> M[env_logger Other]
+
+    style D fill:#e1f5ff
+    style G fill:#ffe1e1
+    style I fill:#fff4e1
+    style J fill:#e1ffe1
+```
+
+Platform loggers (oslog/android_logger) operate in parallel, receiving the same events
+independently.
+
+### Callback Invocation Flow
+
+```mermaid
+sequenceDiagram
+    participant SDK as SDK Code
+    participant Tracing as Tracing Layer
+    participant Callback as CallbackLayer
+    participant UNIFFI as UNIFFI Bridge
+    participant Mobile as Mobile Client
+    participant FR as Flight Recorder
+
+    SDK->>Tracing: tracing::info!("message")
+    Tracing->>Callback: on_event()
+    Callback->>Callback: Extract level, target, message
+    Callback->>UNIFFI: callback.on_log(...)
+    UNIFFI->>Mobile: onLog(...) [FFI]
+    Mobile-->>FR: Queue & Process
+    UNIFFI-->>Callback: Result<(), Error>
+
+    Note over Callback: If error: log to platform logger
+    Note over Mobile: Mobile controls batching, filtering
+```
+
+## LogCallback Interface
+
+### Trait Definition
+
+```rust
+pub trait LogCallback: Send + Sync {
+    /// Called when SDK emits a log entry
+    ///
+    /// # Parameters
+    /// - level: Log level string ("TRACE", "DEBUG", "INFO", "WARN", "ERROR")
+    /// - target: Module that emitted log (e.g., "bitwarden_core::auth")
+    /// - message: The formatted log message
+    ///
+    /// # Returns
+    /// Result<()> - Return errors rather than panicking
+    fn on_log(&self, level: String, target: String, message: String) -> Result<()>;
+}
+```
+
+### Thread Safety Requirements
+
+The `Send + Sync` bounds are mandatory. The SDK invokes callbacks from arbitrary background threads,
+potentially concurrently. Mobile implementations **must** use thread-safe patterns:
+
+- **Kotlin**: `ConcurrentLinkedQueue`, synchronized blocks, or coroutine channels
+- **Swift**: `DispatchQueue`, `OSAllocatedUnfairLock`, or actor isolation
+
+**Critical**: Callbacks are invoked on SDK background threads, NOT the main/UI thread. Performing UI
+updates directly in the callback will cause crashes.
+
+## Performance Considerations
+
+### Callback Execution Requirements
+
+Callbacks should return quickly (ideally < 1ms). Blocking operations in the callback delay SDK
+operations. Follow these patterns:
+
+✅ **Do:**
+
+- Queue logs to thread-safe data structure immediately
+- Process queued logs asynchronously in background
+- Batch multiple logs per Flight Recorder API call
+- Use timeouts for Flight Recorder network calls
+- Handle errors gracefully (catch exceptions, return errors)
+
+❌ **Don't:**
+
+- Make synchronous network calls in callback
+- Perform expensive computation in callback
+- Access shared state without synchronization
+- Update UI directly (wrong thread!)
+- Throw exceptions without catching
+
+### Filtering Strategy
+
+The SDK sends all INFO+ logs to the callback. Mobile teams filter based on requirements:
+
+```kotlin
+override fun onLog(level: String, target: String, message: String) {
+    // Example: Only forward WARN and ERROR to Flight Recorder
+    if (level == "WARN" || level == "ERROR") {
+        logQueue.offer(LogEntry(level, target, message))
+    }
+    // INFO logs are ignored
+}
+```
+
+## Known Limitations
+
+The current implementation has these characteristics:
+
+1. **Span Support**: Only individual log events are forwarded, not span lifecycle events
+   (enter/exit/close). Mobile teams receive logs without hierarchical operation context.
+
+2. **Structured Fields**: Log metadata (user IDs, request IDs, etc.) is flattened to strings. Mobile
+   teams cannot access structured key-value data without parsing message strings.
+
+3. **Dynamic Filtering**: Mobile teams cannot adjust the SDK's filter level at runtime. The callback
+   receives all INFO+ logs regardless of mobile interest.
+
+4. **Observability**: The callback mechanism itself does not emit metrics (success rate, invocation
+   latency, error frequency). Mobile teams implement monitoring in their callback implementations.

--- a/crates/bitwarden-uniffi/examples/callback_demo.rs
+++ b/crates/bitwarden-uniffi/examples/callback_demo.rs
@@ -54,9 +54,19 @@ fn main() {
     println!("Emitting SDK logs at different levels...\n");
 
     // Emit logs that will be captured by callback
-    tracing::info!("User authentication started");
-    tracing::warn!("API rate limit approaching");
-    tracing::error!("Network request failed");
+    // These examples demonstrate both simple messages and structured fields
+    tracing::info!("Hello world");
+
+    let user_id = 123;
+    tracing::info!(user_id, "User authentication started");
+
+    let remaining_requests = 50;
+    let limit = 1000;
+    tracing::warn!(remaining_requests, limit, "API rate limit approaching");
+
+    let error_code = "TIMEOUT";
+    let retry_count = 3;
+    tracing::error!(error_code, retry_count, "Network request failed");
 
     println!("\n📊 Summary:");
     let captured = logs.lock().expect("Failed to lock logs mutex");

--- a/crates/bitwarden-uniffi/examples/callback_demo.rs
+++ b/crates/bitwarden-uniffi/examples/callback_demo.rs
@@ -1,0 +1,73 @@
+//! Demonstration of SDK logging callback mechanism
+//!
+//! This example shows how mobile clients can register a callback to receive
+//! SDK logs and forward them to Flight Recorder or other observability systems.
+
+use std::sync::{Arc, Mutex};
+
+use bitwarden_core::client::internal::ClientManagedTokens;
+use bitwarden_uniffi::{Client, LogCallback};
+
+/// Mock token provider for demo
+#[derive(Debug)]
+struct DemoTokenProvider;
+
+#[async_trait::async_trait]
+impl ClientManagedTokens for DemoTokenProvider {
+    async fn get_access_token(&self) -> Option<String> {
+        Some("demo_token".to_string())
+    }
+}
+
+/// Demo callback that prints logs to stdout
+struct DemoLogCallback {
+    logs: Arc<Mutex<Vec<(String, String, String)>>>,
+}
+
+impl LogCallback for DemoLogCallback {
+    fn on_log(
+        &self,
+        level: String,
+        target: String,
+        message: String,
+    ) -> Result<(), bitwarden_uniffi::error::BitwardenError> {
+        println!("📋 Callback received: [{}] {} - {}", level, target, message);
+        self.logs
+            .lock()
+            .expect("Failed to lock logs mutex")
+            .push((level, target, message));
+        Ok(())
+    }
+}
+
+fn main() {
+    println!("🚀 SDK Logging Callback Demonstration\n");
+    println!("Creating SDK client with logging callback...\n");
+
+    let logs = Arc::new(Mutex::new(Vec::new()));
+    let callback = Arc::new(DemoLogCallback { logs: logs.clone() });
+
+    // Create client with callback
+    let _client = Client::new(Arc::new(DemoTokenProvider), None, Some(callback));
+
+    println!("✅ Client initialized with callback\n");
+    println!("Emitting SDK logs at different levels...\n");
+
+    // Emit logs that will be captured by callback
+    tracing::info!("User authentication started");
+    tracing::warn!("API rate limit approaching");
+    tracing::error!("Network request failed");
+
+    println!("\n📊 Summary:");
+    let captured = logs.lock().expect("Failed to lock logs mutex");
+    println!("   Captured {} log events", captured.len());
+    println!(
+        "   Levels: {}",
+        captured
+            .iter()
+            .map(|(l, _, _)| l.as_str())
+            .collect::<Vec<_>>()
+            .join(", ")
+    );
+    println!("\n✨ Callback successfully forwarded all SDK logs!");
+}

--- a/crates/bitwarden-uniffi/examples/callback_demo.rs
+++ b/crates/bitwarden-uniffi/examples/callback_demo.rs
@@ -42,14 +42,14 @@ impl LogCallback for DemoLogCallback {
 
 fn main() {
     println!("🚀 SDK Logging Callback Demonstration\n");
-    
+
     let logs = Arc::new(Mutex::new(Vec::new()));
     let callback = Arc::new(DemoLogCallback { logs: logs.clone() });
 
     // Initialize logger with callback BEFORE creating any clients
     println!("Step 1: Initialize SDK logger with callback...\n");
     bitwarden_uniffi::init_logger(Some(callback));
-    
+
     println!("Step 2: Create SDK client...\n");
     let _client = Client::new(Arc::new(DemoTokenProvider), None);
 

--- a/crates/bitwarden-uniffi/examples/callback_demo.rs
+++ b/crates/bitwarden-uniffi/examples/callback_demo.rs
@@ -42,15 +42,18 @@ impl LogCallback for DemoLogCallback {
 
 fn main() {
     println!("🚀 SDK Logging Callback Demonstration\n");
-    println!("Creating SDK client with logging callback...\n");
-
+    
     let logs = Arc::new(Mutex::new(Vec::new()));
     let callback = Arc::new(DemoLogCallback { logs: logs.clone() });
 
-    // Create client with callback
-    let _client = Client::new(Arc::new(DemoTokenProvider), None, Some(callback));
+    // Initialize logger with callback BEFORE creating any clients
+    println!("Step 1: Initialize SDK logger with callback...\n");
+    bitwarden_uniffi::init_logger(Some(callback));
+    
+    println!("Step 2: Create SDK client...\n");
+    let _client = Client::new(Arc::new(DemoTokenProvider), None);
 
-    println!("✅ Client initialized with callback\n");
+    println!("✅ Client created - callback is receiving logs\n");
     println!("Emitting SDK logs at different levels...\n");
 
     // Emit logs that will be captured by callback

--- a/crates/bitwarden-uniffi/src/error.rs
+++ b/crates/bitwarden-uniffi/src/error.rs
@@ -93,7 +93,16 @@ pub enum BitwardenError {
     SshGeneration(#[from] bitwarden_ssh::error::KeyGenerationError),
     #[error(transparent)]
     SshImport(#[from] bitwarden_ssh::error::SshKeyImportError),
+    #[error("Callback invocation failed")]
+    CallbackError,
 
     #[error("A conversion error occurred: {0}")]
     Conversion(String),
+}
+/// Required From implementation for UNIFFI callback error handling
+/// Converts unexpected mobile exceptions into BitwardenError
+impl From<uniffi::UnexpectedUniFFICallbackError> for BitwardenError {
+    fn from(_: uniffi::UnexpectedUniFFICallbackError) -> Self {
+        Self::CallbackError
+    }
 }

--- a/crates/bitwarden-uniffi/src/lib.rs
+++ b/crates/bitwarden-uniffi/src/lib.rs
@@ -242,7 +242,7 @@ mod tests {
 
         // Initialize logger with callback before creating client
         init_logger(Some(callback));
-        
+
         // Create client
         let _client = Client::new(Arc::new(MockTokenProvider), None);
 
@@ -252,13 +252,13 @@ mod tests {
         // Verify callback received it
         let captured = logs.lock().expect("Failed to lock logs mutex");
         assert!(!captured.is_empty(), "Callback should receive logs");
-        
+
         // Find our specific test log (there may be other SDK logs during init)
         let test_log = captured
             .iter()
             .find(|(_, _, msg)| msg.contains("test message"))
             .expect("Should find our test log message");
-        
+
         assert_eq!(test_log.0, "INFO");
         assert!(test_log.2.contains("test message"));
     }

--- a/crates/bitwarden-uniffi/src/lib.rs
+++ b/crates/bitwarden-uniffi/src/lib.rs
@@ -228,7 +228,14 @@ mod tests {
         // Verify callback received it
         let captured = logs.lock().expect("Failed to lock logs mutex");
         assert!(!captured.is_empty(), "Callback should receive logs");
-        assert_eq!(captured[0].0, "INFO");
-        assert!(captured[0].2.contains("test message"));
+        
+        // Find our specific test log (there may be other SDK logs during init)
+        let test_log = captured
+            .iter()
+            .find(|(_, _, msg)| msg.contains("test message"))
+            .expect("Should find our test log message");
+        
+        assert_eq!(test_log.0, "INFO");
+        assert!(test_log.2.contains("test message"));
     }
 }

--- a/crates/bitwarden-uniffi/src/lib.rs
+++ b/crates/bitwarden-uniffi/src/lib.rs
@@ -123,8 +123,8 @@ static INIT: Once = Once::new();
 /// registers a callback to receive log events.
 ///
 /// # Parameters
-/// - `callback`: Optional callback to receive SDK log events. Pass `None` to use
-///   only platform loggers (oslog on iOS, logcat on Android).
+/// - `callback`: Optional callback to receive SDK log events. Pass `None` to use only platform
+///   loggers (oslog on iOS, logcat on Android).
 ///
 /// # Example
 /// ```kotlin

--- a/crates/bitwarden-uniffi/src/log_callback.rs
+++ b/crates/bitwarden-uniffi/src/log_callback.rs
@@ -1,0 +1,107 @@
+use std::sync::Arc;
+
+use tracing_subscriber::{Layer, layer::Context};
+/// Callback interface for receiving SDK log events
+/// Mobile implementations forward these to Flight Recorder
+#[uniffi::export(with_foreign)]
+pub trait LogCallback: Send + Sync {
+    /// Called when SDK emits a log entry
+    ///
+    /// # Parameters
+    /// - level: Log level ("TRACE", "DEBUG", "INFO", "WARN", "ERROR")
+    /// - target: Module that emitted log (e.g., "bitwarden_core::auth")
+    /// - message: The log message text
+    ///
+    /// # Returns
+    /// Result<(), BitwardenError> - mobile implementations should catch exceptions
+    /// and return errors rather than panicking
+    fn on_log(&self, level: String, target: String, message: String) -> crate::Result<()>;
+}
+
+/// Custom tracing Layer that forwards events to UNIFFI callback
+pub(crate) struct CallbackLayer {
+    callback: Arc<dyn LogCallback>,
+}
+impl CallbackLayer {
+    pub(crate) fn new(callback: Arc<dyn LogCallback>) -> Self {
+        Self { callback }
+    }
+}
+impl<S> Layer<S> for CallbackLayer
+where
+    S: tracing::Subscriber,
+{
+    fn on_event(&self, event: &tracing::Event<'_>, _ctx: Context<'_, S>) {
+        let metadata = event.metadata();
+        // Filter out our own error messages to prevent infinite callback loop
+        if metadata.target() == "bitwarden_uniffi::log_callback" {
+            return; // Platform loggers still receive this for debugging
+        }
+        let level = metadata.level().to_string();
+        let target = metadata.target().to_string();
+        // Format event message
+        let mut visitor = MessageVisitor::default();
+        event.record(&mut visitor);
+        let message = visitor.message;
+        // Forward to UNIFFI callback with error handling
+        if let Err(e) = self.callback.on_log(level, target, message) {
+            tracing::error!(target: "bitwarden_uniffi::log_callback", "Logging callback failed: {:?}", e);
+        }
+    }
+}
+/// Visitor to extract message from tracing event
+///
+/// **Why only record_debug is implemented:**
+///
+/// The tracing::field::Visit trait provides default implementations for all record
+/// methods (record_str, record_i64, record_bool, etc.) that forward to record_debug.
+/// This means implementing only record_debug captures all field types. The SDK's
+/// logging patterns (including % and ? format specifiers) all route through this
+/// single method via tracing's default implementations.
+#[derive(Default)]
+struct MessageVisitor {
+    message: String,
+}
+impl tracing::field::Visit for MessageVisitor {
+    fn record_debug(&mut self, field: &tracing::field::Field, value: &dyn std::fmt::Debug) {
+        if field.name() == "message" {
+            self.message = format!("{:?}", value);
+        }
+    }
+}
+#[cfg(test)]
+mod tests {
+    use std::sync::{Arc, Mutex};
+
+    use super::*;
+
+    struct TestLogCallback {
+        logs: Arc<Mutex<Vec<(String, String, String)>>>,
+    }
+
+    impl LogCallback for TestLogCallback {
+        fn on_log(&self, level: String, target: String, message: String) -> crate::Result<()> {
+            self.logs.lock().unwrap().push((level, target, message));
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn test_trait_can_be_implemented() {
+        let _callback: Arc<dyn LogCallback> = Arc::new(TestLogCallback {
+            logs: Arc::new(Mutex::new(Vec::new())),
+        });
+    }
+
+    #[test]
+    fn test_callback_layer_forwards_events() {
+        // Verify CallbackLayer correctly extracts and forwards log data
+        let logs = Arc::new(Mutex::new(Vec::new()));
+        let callback = Arc::new(TestLogCallback { logs: logs.clone() });
+        let _layer = CallbackLayer::new(callback);
+
+        // Test that layer compiles and can be created
+        // Full integration test will happen after Client::new() modification
+        assert!(logs.lock().unwrap().is_empty());
+    }
+}

--- a/crates/bitwarden-uniffi/tests/callback_error_handling.rs
+++ b/crates/bitwarden-uniffi/tests/callback_error_handling.rs
@@ -40,10 +40,7 @@ fn test_callback_error_does_not_crash_sdk() {
     init_logger(Some(Arc::new(FailingCallback)));
 
     // Create client
-    let client = Client::new(
-        Arc::new(MockTokenProvider),
-        None,
-    );
+    let client = Client::new(Arc::new(MockTokenProvider), None);
 
     // SDK should work before triggering callback
     assert_eq!(client.echo("test".into()), "test");

--- a/crates/bitwarden-uniffi/tests/callback_error_handling.rs
+++ b/crates/bitwarden-uniffi/tests/callback_error_handling.rs
@@ -1,0 +1,62 @@
+//! Integration test validating SDK resilience to callback errors.
+//!
+//! Verifies that the SDK continues operating normally when the registered callback
+//! returns errors, preventing mobile callback failures from crashing the SDK.
+
+use std::sync::Arc;
+
+use bitwarden_uniffi::*;
+
+// Type alias to match trait definition
+type Result<T> = std::result::Result<T, bitwarden_uniffi::error::BitwardenError>;
+
+/// Mock token provider for testing
+#[derive(Debug)]
+struct MockTokenProvider;
+
+#[async_trait::async_trait]
+impl bitwarden_core::client::internal::ClientManagedTokens for MockTokenProvider {
+    async fn get_access_token(&self) -> Option<String> {
+        Some("mock_token".to_string())
+    }
+}
+
+/// Failing callback that always returns errors
+struct FailingCallback;
+
+impl LogCallback for FailingCallback {
+    fn on_log(&self, _level: String, _target: String, _message: String) -> Result<()> {
+        // Simulate mobile callback exception
+        // Use a simple error that will be converted at FFI boundary
+        Err(bitwarden_uniffi::error::BitwardenError::Conversion(
+            "Simulated mobile callback failure".to_string(),
+        ))
+    }
+}
+
+#[test]
+fn test_callback_error_does_not_crash_sdk() {
+    // Create client with failing callback
+    let client = Client::new(
+        Arc::new(MockTokenProvider),
+        None,
+        Some(Arc::new(FailingCallback)),
+    );
+
+    // SDK should work before triggering callback
+    assert_eq!(client.echo("test".into()), "test");
+
+    // Trigger logs that invoke failing callback
+    tracing::info!("This log triggers failing callback");
+    tracing::warn!("Another log that fails");
+    tracing::error!("Yet another failing log");
+
+    // Verify SDK still operational after multiple callback errors
+    assert_eq!(client.echo("still works".into()), "still works");
+
+    // SDK operations continue normally despite callback failures
+    assert_eq!(
+        client.echo("definitely still working".into()),
+        "definitely still working"
+    );
+}

--- a/crates/bitwarden-uniffi/tests/callback_error_handling.rs
+++ b/crates/bitwarden-uniffi/tests/callback_error_handling.rs
@@ -36,11 +36,13 @@ impl LogCallback for FailingCallback {
 
 #[test]
 fn test_callback_error_does_not_crash_sdk() {
-    // Create client with failing callback
+    // Initialize logger with failing callback
+    init_logger(Some(Arc::new(FailingCallback)));
+
+    // Create client
     let client = Client::new(
         Arc::new(MockTokenProvider),
         None,
-        Some(Arc::new(FailingCallback)),
     );
 
     // SDK should work before triggering callback

--- a/crates/bitwarden-uniffi/tests/callback_field_coverage.rs
+++ b/crates/bitwarden-uniffi/tests/callback_field_coverage.rs
@@ -58,19 +58,22 @@ fn test_message_visitor_captures_message_field() {
     let captured = logs.lock().expect("Failed to lock logs mutex");
 
     // Verify all messages captured (tests run in parallel so may have logs from other tests)
-    assert!(captured.len() >= 3, "Should capture at least our 3 log entries");
+    assert!(
+        captured.len() >= 3,
+        "Should capture at least our 3 log entries"
+    );
 
     // Find our specific log messages
     let info_log = captured
         .iter()
         .find(|(lvl, _, msg)| lvl == "INFO" && msg.contains("info message"))
         .expect("INFO message should be captured");
-    
+
     let warn_log = captured
         .iter()
         .find(|(lvl, _, msg)| lvl == "WARN" && msg.contains("warn message"))
         .expect("WARN message should be captured");
-    
+
     let error_log = captured
         .iter()
         .find(|(lvl, _, msg)| lvl == "ERROR" && msg.contains("error message"))

--- a/crates/bitwarden-uniffi/tests/callback_field_coverage.rs
+++ b/crates/bitwarden-uniffi/tests/callback_field_coverage.rs
@@ -45,7 +45,10 @@ fn test_message_visitor_captures_message_field() {
     let logs = Arc::new(Mutex::new(Vec::new()));
     let callback = Arc::new(TestCallback { logs: logs.clone() });
 
-    let _client = Client::new(Arc::new(MockTokenProvider), None, Some(callback));
+    // Initialize logger with callback
+    init_logger(Some(callback));
+
+    let _client = Client::new(Arc::new(MockTokenProvider), None);
 
     // Emit logs at different levels with message text
     tracing::info!("info message");

--- a/crates/bitwarden-uniffi/tests/callback_field_coverage.rs
+++ b/crates/bitwarden-uniffi/tests/callback_field_coverage.rs
@@ -1,0 +1,81 @@
+//! Integration test validating MessageVisitor field extraction.
+//!
+//! Verifies that the MessageVisitor correctly extracts the message field from
+//! tracing events and forwards it through the callback interface.
+
+use std::sync::{Arc, Mutex};
+
+use bitwarden_uniffi::*;
+
+// Type alias to match trait definition
+type Result<T> = std::result::Result<T, bitwarden_uniffi::error::BitwardenError>;
+
+/// Mock token provider for testing
+#[derive(Debug)]
+struct MockTokenProvider;
+
+#[async_trait::async_trait]
+impl bitwarden_core::client::internal::ClientManagedTokens for MockTokenProvider {
+    async fn get_access_token(&self) -> Option<String> {
+        Some("mock_token".to_string())
+    }
+}
+
+/// Test callback that captures logs
+struct TestCallback {
+    logs: Arc<Mutex<Vec<(String, String, String)>>>,
+}
+
+impl LogCallback for TestCallback {
+    fn on_log(&self, level: String, target: String, message: String) -> Result<()> {
+        self.logs
+            .lock()
+            .expect("Failed to lock logs mutex")
+            .push((level, target, message));
+        Ok(())
+    }
+}
+
+#[test]
+fn test_message_visitor_captures_message_field() {
+    // Validate MessageVisitor captures the message field from trace events
+    // Note: Structured fields (user_id, valid, etc.) are NOT captured
+    // currently. The visitor only extracts the "message" field, not
+    // additional structured metadata.
+    let logs = Arc::new(Mutex::new(Vec::new()));
+    let callback = Arc::new(TestCallback { logs: logs.clone() });
+
+    let _client = Client::new(Arc::new(MockTokenProvider), None, Some(callback));
+
+    // Emit logs at different levels with message text
+    tracing::info!("info message");
+    tracing::warn!("warn message");
+    tracing::error!("error message");
+
+    let captured = logs.lock().expect("Failed to lock logs mutex");
+
+    // Verify all messages captured
+    assert_eq!(captured.len(), 3, "All log entries should be captured");
+
+    // Validate message field extraction
+    assert!(
+        captured[0].2.contains("info message"),
+        "INFO message should be captured, got: {}",
+        captured[0].2
+    );
+    assert!(
+        captured[1].2.contains("warn message"),
+        "WARN message should be captured, got: {}",
+        captured[1].2
+    );
+    assert!(
+        captured[2].2.contains("error message"),
+        "ERROR message should be captured, got: {}",
+        captured[2].2
+    );
+
+    // Validate levels
+    assert_eq!(captured[0].0, "INFO");
+    assert_eq!(captured[1].0, "WARN");
+    assert_eq!(captured[2].0, "ERROR");
+}

--- a/crates/bitwarden-uniffi/tests/callback_field_coverage.rs
+++ b/crates/bitwarden-uniffi/tests/callback_field_coverage.rs
@@ -57,28 +57,44 @@ fn test_message_visitor_captures_message_field() {
 
     let captured = logs.lock().expect("Failed to lock logs mutex");
 
-    // Verify all messages captured
-    assert_eq!(captured.len(), 3, "All log entries should be captured");
+    // Verify all messages captured (tests run in parallel so may have logs from other tests)
+    assert!(captured.len() >= 3, "Should capture at least our 3 log entries");
+
+    // Find our specific log messages
+    let info_log = captured
+        .iter()
+        .find(|(lvl, _, msg)| lvl == "INFO" && msg.contains("info message"))
+        .expect("INFO message should be captured");
+    
+    let warn_log = captured
+        .iter()
+        .find(|(lvl, _, msg)| lvl == "WARN" && msg.contains("warn message"))
+        .expect("WARN message should be captured");
+    
+    let error_log = captured
+        .iter()
+        .find(|(lvl, _, msg)| lvl == "ERROR" && msg.contains("error message"))
+        .expect("ERROR message should be captured");
 
     // Validate message field extraction
     assert!(
-        captured[0].2.contains("info message"),
+        info_log.2.contains("info message"),
         "INFO message should be captured, got: {}",
-        captured[0].2
+        info_log.2
     );
     assert!(
-        captured[1].2.contains("warn message"),
+        warn_log.2.contains("warn message"),
         "WARN message should be captured, got: {}",
-        captured[1].2
+        warn_log.2
     );
     assert!(
-        captured[2].2.contains("error message"),
+        error_log.2.contains("error message"),
         "ERROR message should be captured, got: {}",
-        captured[2].2
+        error_log.2
     );
 
     // Validate levels
-    assert_eq!(captured[0].0, "INFO");
-    assert_eq!(captured[1].0, "WARN");
-    assert_eq!(captured[2].0, "ERROR");
+    assert_eq!(info_log.0, "INFO");
+    assert_eq!(warn_log.0, "WARN");
+    assert_eq!(error_log.0, "ERROR");
 }

--- a/crates/bitwarden-uniffi/tests/callback_happy_path.rs
+++ b/crates/bitwarden-uniffi/tests/callback_happy_path.rs
@@ -55,8 +55,14 @@ fn test_callback_happy_path() {
     let captured = logs.lock().expect("Failed to lock logs mutex");
     assert!(!captured.is_empty(), "Callback should receive logs");
 
+    // Find our specific log message (tests run in parallel so may have logs from other tests)
+    let our_log = captured
+        .iter()
+        .find(|(_, _, msg)| msg.contains("integration test message"))
+        .expect("Should find our integration test message");
+
     // Validate log data structure
-    let (level, target, message) = &captured[0];
+    let (level, target, message) = our_log;
     assert_eq!(level, "INFO", "Log level should be INFO");
     assert!(!target.is_empty(), "Target should not be empty");
     assert!(

--- a/crates/bitwarden-uniffi/tests/callback_happy_path.rs
+++ b/crates/bitwarden-uniffi/tests/callback_happy_path.rs
@@ -1,0 +1,63 @@
+//! Integration test validating basic callback functionality.
+//!
+//! Verifies that registered callbacks receive log events with correct data structure
+//! including level, target, and message fields.
+
+use std::sync::{Arc, Mutex};
+
+use bitwarden_uniffi::*;
+
+// Type alias to match trait definition
+type Result<T> = std::result::Result<T, bitwarden_uniffi::error::BitwardenError>;
+
+/// Mock token provider for testing
+#[derive(Debug)]
+struct MockTokenProvider;
+
+#[async_trait::async_trait]
+impl bitwarden_core::client::internal::ClientManagedTokens for MockTokenProvider {
+    async fn get_access_token(&self) -> Option<String> {
+        Some("mock_token".to_string())
+    }
+}
+
+/// Test callback implementation that captures logs
+struct TestCallback {
+    logs: Arc<Mutex<Vec<(String, String, String)>>>,
+}
+
+impl LogCallback for TestCallback {
+    fn on_log(&self, level: String, target: String, message: String) -> Result<()> {
+        self.logs
+            .lock()
+            .expect("Failed to lock logs mutex")
+            .push((level, target, message));
+        Ok(())
+    }
+}
+
+#[test]
+fn test_callback_happy_path() {
+    // Verify callback receives logs with correct data
+    let logs = Arc::new(Mutex::new(Vec::new()));
+    let callback = Arc::new(TestCallback { logs: logs.clone() });
+
+    // Create client with callback
+    let _client = Client::new(Arc::new(MockTokenProvider), None, Some(callback));
+
+    // Trigger SDK logging
+    tracing::info!("integration test message");
+
+    // Verify callback received the log
+    let captured = logs.lock().expect("Failed to lock logs mutex");
+    assert!(!captured.is_empty(), "Callback should receive logs");
+
+    // Validate log data structure
+    let (level, target, message) = &captured[0];
+    assert_eq!(level, "INFO", "Log level should be INFO");
+    assert!(!target.is_empty(), "Target should not be empty");
+    assert!(
+        message.contains("integration test message"),
+        "Message should contain logged text"
+    );
+}

--- a/crates/bitwarden-uniffi/tests/callback_happy_path.rs
+++ b/crates/bitwarden-uniffi/tests/callback_happy_path.rs
@@ -42,8 +42,11 @@ fn test_callback_happy_path() {
     let logs = Arc::new(Mutex::new(Vec::new()));
     let callback = Arc::new(TestCallback { logs: logs.clone() });
 
-    // Create client with callback
-    let _client = Client::new(Arc::new(MockTokenProvider), None, Some(callback));
+    // Initialize logger with callback
+    init_logger(Some(callback));
+
+    // Create client
+    let _client = Client::new(Arc::new(MockTokenProvider), None);
 
     // Trigger SDK logging
     tracing::info!("integration test message");

--- a/crates/bitwarden-uniffi/tests/callback_multiple_levels.rs
+++ b/crates/bitwarden-uniffi/tests/callback_multiple_levels.rs
@@ -42,7 +42,10 @@ fn test_callback_receives_multiple_log_levels() {
     let logs = Arc::new(Mutex::new(Vec::new()));
     let callback = Arc::new(TestCallback { logs: logs.clone() });
 
-    let _client = Client::new(Arc::new(MockTokenProvider), None, Some(callback));
+    // Initialize logger with callback
+    init_logger(Some(callback));
+
+    let _client = Client::new(Arc::new(MockTokenProvider), None);
 
     // Emit logs at multiple levels
     tracing::info!("info message");

--- a/crates/bitwarden-uniffi/tests/callback_multiple_levels.rs
+++ b/crates/bitwarden-uniffi/tests/callback_multiple_levels.rs
@@ -52,17 +52,33 @@ fn test_callback_receives_multiple_log_levels() {
     tracing::warn!("warn message");
     tracing::error!("error message");
 
-    // Verify all levels captured
+    // Verify all levels captured (tests run in parallel so may have logs from other tests)
     let captured = logs.lock().expect("Failed to lock logs mutex");
-    assert_eq!(captured.len(), 3, "Should capture all 3 log levels");
+    assert!(captured.len() >= 3, "Should capture at least our 3 log levels");
+
+    // Find our specific log messages
+    let info_log = captured
+        .iter()
+        .find(|(lvl, _, msg)| lvl == "INFO" && msg.contains("info message"))
+        .expect("Should find INFO log");
+    
+    let warn_log = captured
+        .iter()
+        .find(|(lvl, _, msg)| lvl == "WARN" && msg.contains("warn message"))
+        .expect("Should find WARN log");
+    
+    let error_log = captured
+        .iter()
+        .find(|(lvl, _, msg)| lvl == "ERROR" && msg.contains("error message"))
+        .expect("Should find ERROR log");
 
     // Validate each level
-    assert_eq!(captured[0].0, "INFO");
-    assert!(captured[0].2.contains("info message"));
+    assert_eq!(info_log.0, "INFO");
+    assert!(info_log.2.contains("info message"));
 
-    assert_eq!(captured[1].0, "WARN");
-    assert!(captured[1].2.contains("warn message"));
+    assert_eq!(warn_log.0, "WARN");
+    assert!(warn_log.2.contains("warn message"));
 
-    assert_eq!(captured[2].0, "ERROR");
-    assert!(captured[2].2.contains("error message"));
+    assert_eq!(error_log.0, "ERROR");
+    assert!(error_log.2.contains("error message"));
 }

--- a/crates/bitwarden-uniffi/tests/callback_multiple_levels.rs
+++ b/crates/bitwarden-uniffi/tests/callback_multiple_levels.rs
@@ -54,19 +54,22 @@ fn test_callback_receives_multiple_log_levels() {
 
     // Verify all levels captured (tests run in parallel so may have logs from other tests)
     let captured = logs.lock().expect("Failed to lock logs mutex");
-    assert!(captured.len() >= 3, "Should capture at least our 3 log levels");
+    assert!(
+        captured.len() >= 3,
+        "Should capture at least our 3 log levels"
+    );
 
     // Find our specific log messages
     let info_log = captured
         .iter()
         .find(|(lvl, _, msg)| lvl == "INFO" && msg.contains("info message"))
         .expect("Should find INFO log");
-    
+
     let warn_log = captured
         .iter()
         .find(|(lvl, _, msg)| lvl == "WARN" && msg.contains("warn message"))
         .expect("Should find WARN log");
-    
+
     let error_log = captured
         .iter()
         .find(|(lvl, _, msg)| lvl == "ERROR" && msg.contains("error message"))

--- a/crates/bitwarden-uniffi/tests/callback_multiple_levels.rs
+++ b/crates/bitwarden-uniffi/tests/callback_multiple_levels.rs
@@ -1,0 +1,65 @@
+//! Integration test validating callback receives multiple log levels.
+//!
+//! Verifies that the callback mechanism correctly forwards log events at different
+//! severity levels (INFO, WARN, ERROR) to the registered callback implementation.
+
+use std::sync::{Arc, Mutex};
+
+use bitwarden_uniffi::*;
+
+// Type alias to match trait definition
+type Result<T> = std::result::Result<T, bitwarden_uniffi::error::BitwardenError>;
+
+/// Mock token provider for testing
+#[derive(Debug)]
+struct MockTokenProvider;
+
+#[async_trait::async_trait]
+impl bitwarden_core::client::internal::ClientManagedTokens for MockTokenProvider {
+    async fn get_access_token(&self) -> Option<String> {
+        Some("mock_token".to_string())
+    }
+}
+
+/// Test callback that captures logs
+struct TestCallback {
+    logs: Arc<Mutex<Vec<(String, String, String)>>>,
+}
+
+impl LogCallback for TestCallback {
+    fn on_log(&self, level: String, target: String, message: String) -> Result<()> {
+        self.logs
+            .lock()
+            .expect("Failed to lock logs mutex")
+            .push((level, target, message));
+        Ok(())
+    }
+}
+
+#[test]
+fn test_callback_receives_multiple_log_levels() {
+    // Verify callback receives events at different log levels
+    let logs = Arc::new(Mutex::new(Vec::new()));
+    let callback = Arc::new(TestCallback { logs: logs.clone() });
+
+    let _client = Client::new(Arc::new(MockTokenProvider), None, Some(callback));
+
+    // Emit logs at multiple levels
+    tracing::info!("info message");
+    tracing::warn!("warn message");
+    tracing::error!("error message");
+
+    // Verify all levels captured
+    let captured = logs.lock().expect("Failed to lock logs mutex");
+    assert_eq!(captured.len(), 3, "Should capture all 3 log levels");
+
+    // Validate each level
+    assert_eq!(captured[0].0, "INFO");
+    assert!(captured[0].2.contains("info message"));
+
+    assert_eq!(captured[1].0, "WARN");
+    assert!(captured[1].2.contains("warn message"));
+
+    assert_eq!(captured[2].0, "ERROR");
+    assert!(captured[2].2.contains("error message"));
+}

--- a/crates/bitwarden-uniffi/tests/callback_thread_safety.rs
+++ b/crates/bitwarden-uniffi/tests/callback_thread_safety.rs
@@ -45,7 +45,10 @@ fn test_callback_thread_safety() {
     let logs = Arc::new(Mutex::new(Vec::new()));
     let callback = Arc::new(TestCallback { logs: logs.clone() });
 
-    let _client = Client::new(Arc::new(MockTokenProvider), None, Some(callback));
+    // Initialize logger with callback
+    init_logger(Some(callback));
+
+    let _client = Client::new(Arc::new(MockTokenProvider), None);
 
     // Spawn multiple threads logging simultaneously
     let handles: Vec<_> = (0..10)

--- a/crates/bitwarden-uniffi/tests/callback_thread_safety.rs
+++ b/crates/bitwarden-uniffi/tests/callback_thread_safety.rs
@@ -64,16 +64,21 @@ fn test_callback_thread_safety() {
         handle.join().expect("Thread should not panic");
     }
 
-    // Verify all logs captured without data races (tests run in parallel so may have logs from other tests)
+    // Verify all logs captured without data races (tests run in parallel so may have logs from
+    // other tests)
     let captured = logs.lock().expect("Failed to lock logs mutex");
-    
+
     // Find our specific thread messages
     let our_logs: Vec<_> = captured
         .iter()
         .filter(|(lvl, _, msg)| lvl == "INFO" && msg.contains("thread") && msg.contains("message"))
         .collect();
-    
-    assert_eq!(our_logs.len(), 10, "All 10 threaded logs should be captured");
+
+    assert_eq!(
+        our_logs.len(),
+        10,
+        "All 10 threaded logs should be captured"
+    );
 
     // Verify no corrupted entries (all should be INFO level with thread messages)
     for (level, _target, message) in our_logs.iter() {

--- a/crates/bitwarden-uniffi/tests/callback_thread_safety.rs
+++ b/crates/bitwarden-uniffi/tests/callback_thread_safety.rs
@@ -1,0 +1,74 @@
+//! Integration test validating callback thread safety.
+//!
+//! Verifies that the callback mechanism safely handles concurrent log emissions
+//! from multiple SDK threads without data races or corruption.
+
+use std::{
+    sync::{Arc, Mutex},
+    thread,
+};
+
+use bitwarden_uniffi::*;
+
+// Type alias to match trait definition
+type Result<T> = std::result::Result<T, bitwarden_uniffi::error::BitwardenError>;
+
+/// Mock token provider for testing
+#[derive(Debug)]
+struct MockTokenProvider;
+
+#[async_trait::async_trait]
+impl bitwarden_core::client::internal::ClientManagedTokens for MockTokenProvider {
+    async fn get_access_token(&self) -> Option<String> {
+        Some("mock_token".to_string())
+    }
+}
+
+/// Thread-safe test callback
+struct TestCallback {
+    logs: Arc<Mutex<Vec<(String, String, String)>>>,
+}
+
+impl LogCallback for TestCallback {
+    fn on_log(&self, level: String, target: String, message: String) -> Result<()> {
+        self.logs
+            .lock()
+            .expect("Failed to lock logs mutex")
+            .push((level, target, message));
+        Ok(())
+    }
+}
+
+#[test]
+fn test_callback_thread_safety() {
+    // Verify callback handles concurrent invocations safely
+    let logs = Arc::new(Mutex::new(Vec::new()));
+    let callback = Arc::new(TestCallback { logs: logs.clone() });
+
+    let _client = Client::new(Arc::new(MockTokenProvider), None, Some(callback));
+
+    // Spawn multiple threads logging simultaneously
+    let handles: Vec<_> = (0..10)
+        .map(|i| {
+            thread::spawn(move || {
+                tracing::info!("thread {} message", i);
+            })
+        })
+        .collect();
+
+    // Wait for all threads to complete
+    for handle in handles {
+        handle.join().expect("Thread should not panic");
+    }
+
+    // Verify all logs captured without data races
+    let captured = logs.lock().expect("Failed to lock logs mutex");
+    assert_eq!(captured.len(), 10, "All threaded logs should be captured");
+
+    // Verify no corrupted entries (all should be INFO level)
+    for (level, _target, message) in captured.iter() {
+        assert_eq!(level, "INFO");
+        assert!(message.contains("thread"));
+        assert!(message.contains("message"));
+    }
+}


### PR DESCRIPTION
## 🎟️ Tracking

- https://bitwarden.atlassian.net/browse/PM-27800
- [Tech breakdown](https://bitwarden.atlassian.net/wiki/spaces/EN/pages/2333212675/Add+SDK+Logging+Callback+for+Mobile+Observability)

## 📔 Objective

This PR introduces an optional UNIFFI logging callback that enables mobile clients to receive SDK trace events and forward them to Flight Recorder observability systems.

The changes add a new `LogCallback` trait that allows mobile teams to register a callback during `Client::new()` initialization. When registered, the SDK forwards all INFO+ log events through this callback alongside existing platform loggers (oslog, android_logger). The callback is completely optional - existing SDK clients continue functioning without code changes.

### Documentation

Please review `crates/bitwarden-uniffi/docs/logging-callback.md` for comprehensive details including:
- Complete architecture and integration patterns
- Thread safety requirements and implementation guidance
- Known limitations and design decisions

The documentation is the authoritative reference for this feature. You can also find a tech breakdown linked in the Tracking section.

### Demo

Also included is an example showing how to use the callback. It, alongside the tests, are the assertions that the whole thing works. Here is a screenshot showing the output of the example:

<img width="1728" height="1117" alt="Screenshot 2025-12-23 at 4 34 19 PM" src="https://github.com/user-attachments/assets/8f0530a3-900b-48fe-b643-55b1caed8b5c" />

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation
  team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
