### PR TITLE
[PM-29048] Validate pin protected user key envelope

### DIFF
--- a/crates/bitwarden-core/src/auth/auth_client.rs
+++ b/crates/bitwarden-core/src/auth/auth_client.rs
@@ -1,6 +1,7 @@
 #[cfg(feature = "internal")]
 use bitwarden_crypto::{
     CryptoError, DeviceKey, EncString, Kdf, TrustDeviceResponse, UnsignedSharedKey,
+    safe::PasswordProtectedKeyEnvelope,
 };
 #[cfg(feature = "internal")]
 use bitwarden_encoding::B64;
@@ -26,7 +27,7 @@ use crate::{
             MasterPasswordPolicyOptions, password_strength, satisfies_policy, validate_password,
             validate_password_user_key,
         },
-        pin::validate_pin,
+        pin::{validate_pin, validate_pin_protected_user_key_envelope},
         register::make_register_keys,
         tde::{RegisterTdeKeyResponse, make_register_tde_keys},
     },
@@ -158,6 +159,18 @@ impl AuthClient {
         pin_protected_user_key: EncString,
     ) -> Result<bool, AuthValidateError> {
         validate_pin(&self.client, pin, pin_protected_user_key)
+    }
+
+    /// Validates a PIN against a PIN-protected user key envelope.
+    /// Returns `false` if the PIN fails to decrypt the envelope.
+    /// Requires the user key to be present in the client, otherwise returns
+    /// [`AuthValidateError::NotAuthenticated`].
+    pub fn validate_pin_protected_user_key_envelope(
+        &self,
+        pin: String,
+        pin_protected_user_key_envelope: PasswordProtectedKeyEnvelope,
+    ) -> Result<bool, AuthValidateError> {
+        validate_pin_protected_user_key_envelope(&self.client, pin, pin_protected_user_key_envelope)
     }
 
     #[allow(missing_docs)]

--- a/crates/bitwarden-core/src/auth/auth_client.rs
+++ b/crates/bitwarden-core/src/auth/auth_client.rs
@@ -162,14 +162,15 @@ impl AuthClient {
     }
 
     /// Validates a PIN against a PIN-protected user key envelope.
-    /// Returns `false` if the PIN fails to decrypt the envelope.
-    /// Requires the user key to be present in the client, otherwise returns
-    /// [`AuthValidateError::NotAuthenticated`].
+    ///
+    /// Returns `false` if validation fails for any reason:
+    /// - The PIN is incorrect
+    /// - The envelope is corrupted or malformed
     pub fn validate_pin_protected_user_key_envelope(
         &self,
         pin: String,
         pin_protected_user_key_envelope: PasswordProtectedKeyEnvelope,
-    ) -> Result<bool, AuthValidateError> {
+    ) -> bool {
         validate_pin_protected_user_key_envelope(&self.client, pin, pin_protected_user_key_envelope)
     }
 

--- a/crates/bitwarden-uniffi/src/auth/mod.rs
+++ b/crates/bitwarden-uniffi/src/auth/mod.rs
@@ -2,8 +2,10 @@ use bitwarden_core::auth::{
     AuthRequestResponse, KeyConnectorResponse, RegisterKeyResponse, RegisterTdeKeyResponse,
     password::MasterPasswordPolicyOptions,
 };
-use bitwarden_crypto::safe::PasswordProtectedKeyEnvelope;
-use bitwarden_crypto::{EncString, HashPurpose, Kdf, TrustDeviceResponse, UnsignedSharedKey};
+use bitwarden_crypto::{
+    EncString, HashPurpose, Kdf, TrustDeviceResponse, UnsignedSharedKey,
+    safe::PasswordProtectedKeyEnvelope,
+};
 use bitwarden_encoding::B64;
 
 use crate::error::Result;

--- a/crates/bitwarden-uniffi/src/auth/mod.rs
+++ b/crates/bitwarden-uniffi/src/auth/mod.rs
@@ -2,6 +2,7 @@ use bitwarden_core::auth::{
     AuthRequestResponse, KeyConnectorResponse, RegisterKeyResponse, RegisterTdeKeyResponse,
     password::MasterPasswordPolicyOptions,
 };
+use bitwarden_crypto::safe::PasswordProtectedKeyEnvelope;
 use bitwarden_crypto::{EncString, HashPurpose, Kdf, TrustDeviceResponse, UnsignedSharedKey};
 use bitwarden_encoding::B64;
 
@@ -112,6 +113,24 @@ impl AuthClient {
     /// be unlocked.
     pub fn validate_pin(&self, pin: String, pin_protected_user_key: EncString) -> Result<bool> {
         Ok(self.0.auth().validate_pin(pin, pin_protected_user_key)?)
+    }
+
+    /// Validate the user PIN
+    ///
+    /// To validate the user PIN, you need to have the user's `pin_protected_user_key_envelope`.
+    /// This key is obtained when enabling PIN unlock on the account with the `enroll_pin` method.
+    ///
+    /// This works by comparing the decrypted user key with the current user key, so the client must
+    /// be unlocked.
+    pub fn validate_pin_protected_user_key_envelope(
+        &self,
+        pin: String,
+        pin_protected_user_key_envelope: PasswordProtectedKeyEnvelope,
+    ) -> Result<bool> {
+        Ok(self
+            .0
+            .auth()
+            .validate_pin_protected_user_key_envelope(pin, pin_protected_user_key_envelope)?)
     }
 
     /// Initialize a new auth request

--- a/crates/bitwarden-uniffi/src/auth/mod.rs
+++ b/crates/bitwarden-uniffi/src/auth/mod.rs
@@ -117,22 +117,22 @@ impl AuthClient {
         Ok(self.0.auth().validate_pin(pin, pin_protected_user_key)?)
     }
 
-    /// Validate the user PIN
+    /// Validates a PIN against a PIN-protected user key envelope.
     ///
-    /// To validate the user PIN, you need to have the user's `pin_protected_user_key_envelope`.
-    /// This key is obtained when enabling PIN unlock on the account with the `enroll_pin` method.
+    /// The `pin_protected_user_key_envelope` key is obtained when enabling PIN unlock on the
+    /// account with the [bitwarden_core::key_management::CryptoClient::enroll_pin] method.
     ///
-    /// This works by comparing the decrypted user key with the current user key, so the client must
-    /// be unlocked.
+    /// Returns `false` if validation fails for any reason:
+    /// - The PIN is incorrect
+    /// - The envelope is corrupted or malformed
     pub fn validate_pin_protected_user_key_envelope(
         &self,
         pin: String,
         pin_protected_user_key_envelope: PasswordProtectedKeyEnvelope,
-    ) -> Result<bool> {
-        Ok(self
-            .0
+    ) -> bool {
+        self.0
             .auth()
-            .validate_pin_protected_user_key_envelope(pin, pin_protected_user_key_envelope)?)
+            .validate_pin_protected_user_key_envelope(pin, pin_protected_user_key_envelope)
     }
 
     /// Initialize a new auth request

--- a/crates/bitwarden-uniffi/src/uniffi_support.rs
+++ b/crates/bitwarden-uniffi/src/uniffi_support.rs
@@ -1,3 +1,4 @@
+use bitwarden_crypto::safe;
 use uuid::Uuid;
 
 // Forward the type definitions to the main bitwarden crate
@@ -5,3 +6,5 @@ type DateTime = chrono::DateTime<chrono::Utc>;
 uniffi::use_remote_type!(bitwarden_core::DateTime);
 
 uniffi::use_remote_type!(bitwarden_core::Uuid);
+
+uniffi::use_remote_type!(bitwarden_crypto::safe::PasswordProtectedKeyEnvelope);


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-29048

## 📔 Objective

Enables validation for a PIN for a pin protected key envelope, so that mobile can move off of `validatePin` which only works with pin key protected userkeys.

The original `validate_pin` implementation compared the decrypted user key from envelope with the client key stored user key. This implementation is much simpler, we simply validate if the envelope can be successfully unsealed with provided PIN.

Tested against android.

## 🚨 Breaking Changes

None

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation
  team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
