### PR TITLE
[bre-1450] coverage step failing due to runner disk full

### DIFF
--- a/.github/workflows/rust-test.yml
+++ b/.github/workflows/rust-test.yml
@@ -39,6 +39,18 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Free runner disk space (Linux only)
+        if: runner.os == 'Linux'
+        run: |
+          echo "Disk space before cleanup:"
+          df -h
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /usr/local/lib/android
+          sudo rm -rf /usr/share/swift
+          sudo rm -rf /usr/local/.ghcup
+          echo "Disk space after cleanup:"
+          df -h
+
       - name: Install rust
         uses: dtolnay/rust-toolchain@0b1efabc08b657293548b77fb76cc02d26091c7e # stable
         with:

--- a/.github/workflows/rust-test.yml
+++ b/.github/workflows/rust-test.yml
@@ -39,17 +39,8 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Free runner disk space (Linux only)
-        if: runner.os == 'Linux'
-        run: |
-          echo "Disk space before cleanup:"
-          df -h
-          sudo rm -rf /usr/share/dotnet
-          sudo rm -rf /usr/local/lib/android
-          sudo rm -rf /usr/share/swift
-          sudo rm -rf /usr/local/.ghcup
-          echo "Disk space after cleanup:"
-          df -h
+      - name: Free disk space
+        uses: bitwarden/gh-actions/free-disk-space@main
 
       - name: Install rust
         uses: dtolnay/rust-toolchain@0b1efabc08b657293548b77fb76cc02d26091c7e # stable
@@ -102,16 +93,8 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Free runner disk space
-        run: |
-          echo "Disk space before cleanup:"
-          df -h
-          sudo rm -rf /usr/share/dotnet
-          sudo rm -rf /usr/local/lib/android
-          sudo rm -rf /usr/share/swift
-          sudo rm -rf /usr/local/.ghcup
-          echo "Disk space after cleanup:"
-          df -h
+      - name: Free disk space
+        uses: bitwarden/gh-actions/free-disk-space@main
 
       - name: Install rust
         uses: dtolnay/rust-toolchain@0b1efabc08b657293548b77fb76cc02d26091c7e # stable

--- a/.github/workflows/rust-test.yml
+++ b/.github/workflows/rust-test.yml
@@ -90,6 +90,17 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Free runner disk space
+        run: |
+          echo "Disk space before cleanup:"
+          df -h
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /usr/local/lib/android
+          sudo rm -rf /usr/share/swift
+          sudo rm -rf /usr/local/.ghcup
+          echo "Disk space after cleanup:"
+          df -h
+
       - name: Install rust
         uses: dtolnay/rust-toolchain@0b1efabc08b657293548b77fb76cc02d26091c7e # stable
         with:
@@ -100,7 +111,7 @@ jobs:
         uses: Swatinem/rust-cache@f0deed1e0edfc6a9be95417288c0e1099b1eeec3 # v2.7.7
 
       - name: Install cargo-llvm-cov
-        run: cargo install cargo-llvm-cov --version 0.5.38 --locked
+        run: cargo install --version 0.5.38 --locked
 
       - name: Generate coverage
         run: cargo llvm-cov --all-features --lcov --output-path lcov.info --ignore-filename-regex "crates/bitwarden-api-"

--- a/.github/workflows/rust-test.yml
+++ b/.github/workflows/rust-test.yml
@@ -111,7 +111,7 @@ jobs:
         uses: Swatinem/rust-cache@f0deed1e0edfc6a9be95417288c0e1099b1eeec3 # v2.7.7
 
       - name: Install cargo-llvm-cov
-        run: cargo install --version 0.5.38 --locked
+        run: cargo install cargo-llvm-cov --version 0.5.38 --locked
 
       - name: Generate coverage
         run: cargo llvm-cov --all-features --lcov --output-path lcov.info --ignore-filename-regex "crates/bitwarden-api-"


### PR DESCRIPTION
## 🎟️ Tracking

[bre-1450](https://bitwarden.atlassian.net/browse/bre-1450)

## 📔 Objective

free up disk space on the runner by removing unused libraries. this uses a github action we maintain here https://github.com/bitwarden/gh-actions/tree/main/free-disk-space
in practice this resolves out of space issues and other flakiness and failures these two jobs were experiencing and raised by multiple engineers
