### PR TITLE
[PM-27632] Expose CiphersClient delete, get, and restore operations to TS clients

### DIFF
--- a/crates/bitwarden-vault/src/cipher/cipher_client/admin/delete.rs
+++ b/crates/bitwarden-vault/src/cipher/cipher_client/admin/delete.rs
@@ -2,6 +2,7 @@ use bitwarden_api_api::models::CipherBulkDeleteRequestModel;
 use bitwarden_core::{ApiError, OrganizationId};
 use bitwarden_error::bitwarden_error;
 use thiserror::Error;
+#[cfg(feature = "wasm")]
 use wasm_bindgen::prelude::wasm_bindgen;
 
 use crate::{CipherId, cipher_client::admin::CipherAdminClient};

--- a/crates/bitwarden-vault/src/cipher/cipher_client/admin/delete.rs
+++ b/crates/bitwarden-vault/src/cipher/cipher_client/admin/delete.rs
@@ -1,7 +1,21 @@
 use bitwarden_api_api::models::CipherBulkDeleteRequestModel;
 use bitwarden_core::{ApiError, OrganizationId};
+use bitwarden_error::bitwarden_error;
+use thiserror::Error;
+use wasm_bindgen::prelude::wasm_bindgen;
 
 use crate::{CipherId, cipher_client::admin::CipherAdminClient};
+
+#[allow(missing_docs)]
+#[bitwarden_error(flat)]
+#[derive(Debug, Error)]
+/// Errors that can occur when deleting ciphers as an admin.
+pub enum DeleteCipherAdminError {
+    // ApiError is incompatible with wasm_bindgen, so we wrap it in this enum
+    // for wasm_bindgen compatibility.
+    #[error(transparent)]
+    Api(#[from] ApiError),
+}
 
 async fn delete_cipher(
     cipher_id: CipherId,
@@ -52,11 +66,12 @@ async fn soft_delete_many(
     Ok(())
 }
 
+#[cfg_attr(feature = "wasm", wasm_bindgen)]
 impl CipherAdminClient {
     /// Deletes the Cipher with the matching CipherId from the server, using the admin endpoint.
     /// Affects server data only, does not modify local state.
-    pub async fn delete(&self, cipher_id: CipherId) -> Result<(), ApiError> {
-        delete_cipher(
+    pub async fn delete(&self, cipher_id: CipherId) -> Result<(), DeleteCipherAdminError> {
+        Ok(delete_cipher(
             cipher_id,
             &self
                 .client
@@ -65,13 +80,13 @@ impl CipherAdminClient {
                 .await
                 .api_client,
         )
-        .await
+        .await?)
     }
 
     /// Soft-deletes the Cipher with the matching CipherId from the server, using the admin
     /// endpoint. Affects server data only, does not modify local state.
-    pub async fn soft_delete(&self, cipher_id: CipherId) -> Result<(), ApiError> {
-        soft_delete(
+    pub async fn soft_delete(&self, cipher_id: CipherId) -> Result<(), DeleteCipherAdminError> {
+        Ok(soft_delete(
             cipher_id,
             &self
                 .client
@@ -80,7 +95,7 @@ impl CipherAdminClient {
                 .await
                 .api_client,
         )
-        .await
+        .await?)
     }
 
     /// Deletes all Cipher objects with a matching CipherId from the server, using the admin
@@ -89,8 +104,8 @@ impl CipherAdminClient {
         &self,
         cipher_ids: Vec<CipherId>,
         organization_id: OrganizationId,
-    ) -> Result<(), ApiError> {
-        delete_ciphers_many(
+    ) -> Result<(), DeleteCipherAdminError> {
+        Ok(delete_ciphers_many(
             cipher_ids,
             organization_id,
             &self
@@ -100,7 +115,7 @@ impl CipherAdminClient {
                 .await
                 .api_client,
         )
-        .await
+        .await?)
     }
 
     /// Soft-deletes all Cipher objects for the given CipherIds from the server, using the admin
@@ -109,8 +124,8 @@ impl CipherAdminClient {
         &self,
         cipher_ids: Vec<CipherId>,
         organization_id: OrganizationId,
-    ) -> Result<(), ApiError> {
-        soft_delete_many(
+    ) -> Result<(), DeleteCipherAdminError> {
+        Ok(soft_delete_many(
             cipher_ids,
             organization_id,
             &self
@@ -120,7 +135,7 @@ impl CipherAdminClient {
                 .await
                 .api_client,
         )
-        .await
+        .await?)
     }
 }
 

--- a/crates/bitwarden-vault/src/cipher/cipher_client/admin/get.rs
+++ b/crates/bitwarden-vault/src/cipher/cipher_client/admin/get.rs
@@ -3,6 +3,7 @@ use bitwarden_core::{ApiError, OrganizationId, key_management::KeyIds};
 use bitwarden_crypto::{CryptoError, KeyStore};
 use bitwarden_error::bitwarden_error;
 use thiserror::Error;
+use wasm_bindgen::prelude::wasm_bindgen;
 
 use crate::{
     VaultParseError,
@@ -48,6 +49,7 @@ pub async fn list_org_ciphers(
     })
 }
 
+#[cfg_attr(feature = "wasm", wasm_bindgen)]
 impl CipherAdminClient {
     pub async fn list_org_ciphers(
         &self,

--- a/crates/bitwarden-vault/src/cipher/cipher_client/admin/get.rs
+++ b/crates/bitwarden-vault/src/cipher/cipher_client/admin/get.rs
@@ -3,6 +3,7 @@ use bitwarden_core::{ApiError, OrganizationId, key_management::KeyIds};
 use bitwarden_crypto::{CryptoError, KeyStore};
 use bitwarden_error::bitwarden_error;
 use thiserror::Error;
+#[cfg(feature = "wasm")]
 use wasm_bindgen::prelude::wasm_bindgen;
 
 use crate::{

--- a/crates/bitwarden-vault/src/cipher/cipher_client/admin/restore.rs
+++ b/crates/bitwarden-vault/src/cipher/cipher_client/admin/restore.rs
@@ -3,6 +3,7 @@ use bitwarden_core::{ApiError, OrganizationId, key_management::KeyIds};
 use bitwarden_crypto::{CryptoError, KeyStore};
 use bitwarden_error::bitwarden_error;
 use thiserror::Error;
+#[cfg(feature = "wasm")]
 use wasm_bindgen::prelude::wasm_bindgen;
 
 use crate::{

--- a/crates/bitwarden-vault/src/cipher/cipher_client/admin/restore.rs
+++ b/crates/bitwarden-vault/src/cipher/cipher_client/admin/restore.rs
@@ -3,6 +3,7 @@ use bitwarden_core::{ApiError, OrganizationId, key_management::KeyIds};
 use bitwarden_crypto::{CryptoError, KeyStore};
 use bitwarden_error::bitwarden_error;
 use thiserror::Error;
+use wasm_bindgen::prelude::wasm_bindgen;
 
 use crate::{
     Cipher, CipherId, CipherView, DecryptCipherListResult, VaultParseError,
@@ -71,9 +72,10 @@ pub async fn restore_many_as_admin(
     })
 }
 
+#[cfg_attr(feature = "wasm", wasm_bindgen)]
 impl CipherAdminClient {
     /// Restores a soft-deleted cipher on the server, using the admin endpoint.
-    pub async fn restore_as_admin(
+    pub async fn restore(
         &self,
         cipher_id: CipherId,
     ) -> Result<CipherView, RestoreCipherAdminError> {
@@ -88,7 +90,7 @@ impl CipherAdminClient {
         restore_as_admin(cipher_id, api_client, key_store).await
     }
     /// Restores multiple soft-deleted ciphers on the server.
-    pub async fn restore_many_as_admin(
+    pub async fn restore_many(
         &self,
         cipher_ids: Vec<CipherId>,
         org_id: OrganizationId,

--- a/crates/bitwarden-vault/src/cipher/cipher_client/delete.rs
+++ b/crates/bitwarden-vault/src/cipher/cipher_client/delete.rs
@@ -3,6 +3,7 @@ use bitwarden_core::{ApiError, OrganizationId};
 use bitwarden_error::bitwarden_error;
 use bitwarden_state::repository::{Repository, RepositoryError};
 use thiserror::Error;
+#[cfg(feature = "wasm")]
 use wasm_bindgen::prelude::wasm_bindgen;
 
 use crate::{Cipher, CipherId, CiphersClient};

--- a/crates/bitwarden-vault/src/cipher/cipher_client/delete.rs
+++ b/crates/bitwarden-vault/src/cipher/cipher_client/delete.rs
@@ -3,6 +3,7 @@ use bitwarden_core::{ApiError, OrganizationId};
 use bitwarden_error::bitwarden_error;
 use bitwarden_state::repository::{Repository, RepositoryError};
 use thiserror::Error;
+use wasm_bindgen::prelude::wasm_bindgen;
 
 use crate::{Cipher, CipherId, CiphersClient};
 
@@ -95,6 +96,7 @@ async fn process_soft_delete<R: Repository<Cipher> + ?Sized>(
     Ok(())
 }
 
+#[cfg_attr(feature = "wasm", wasm_bindgen)]
 impl CiphersClient {
     /// Deletes the [Cipher] with the matching [CipherId] from the server.
     pub async fn delete(&self, cipher_id: CipherId) -> Result<(), DeleteCipherError> {

--- a/crates/bitwarden-vault/src/cipher/cipher_client/get.rs
+++ b/crates/bitwarden-vault/src/cipher/cipher_client/get.rs
@@ -3,6 +3,7 @@ use bitwarden_crypto::{CryptoError, KeyStore};
 use bitwarden_error::bitwarden_error;
 use bitwarden_state::repository::{Repository, RepositoryError};
 use thiserror::Error;
+use wasm_bindgen::prelude::wasm_bindgen;
 
 use super::CiphersClient;
 use crate::{Cipher, CipherView, ItemNotFoundError, cipher::cipher::DecryptCipherListResult};
@@ -44,6 +45,7 @@ async fn list_ciphers(
     })
 }
 
+#[cfg_attr(feature = "wasm", wasm_bindgen)]
 impl CiphersClient {
     /// Get all ciphers from state and decrypt them, returning both successes and failures.
     /// This method will not fail when some ciphers fail to decrypt, allowing for graceful

--- a/crates/bitwarden-vault/src/cipher/cipher_client/get.rs
+++ b/crates/bitwarden-vault/src/cipher/cipher_client/get.rs
@@ -3,6 +3,7 @@ use bitwarden_crypto::{CryptoError, KeyStore};
 use bitwarden_error::bitwarden_error;
 use bitwarden_state::repository::{Repository, RepositoryError};
 use thiserror::Error;
+#[cfg(feature = "wasm")]
 use wasm_bindgen::prelude::wasm_bindgen;
 
 use super::CiphersClient;

--- a/crates/bitwarden-vault/src/cipher/cipher_client/restore.rs
+++ b/crates/bitwarden-vault/src/cipher/cipher_client/restore.rs
@@ -4,6 +4,7 @@ use bitwarden_crypto::{CryptoError, KeyStore};
 use bitwarden_error::bitwarden_error;
 use bitwarden_state::repository::{Repository, RepositoryError};
 use thiserror::Error;
+#[cfg(feature = "wasm")]
 use wasm_bindgen::prelude::wasm_bindgen;
 
 use crate::{

--- a/crates/bitwarden-vault/src/cipher/cipher_client/restore.rs
+++ b/crates/bitwarden-vault/src/cipher/cipher_client/restore.rs
@@ -4,6 +4,7 @@ use bitwarden_crypto::{CryptoError, KeyStore};
 use bitwarden_error::bitwarden_error;
 use bitwarden_state::repository::{Repository, RepositoryError};
 use thiserror::Error;
+use wasm_bindgen::prelude::wasm_bindgen;
 
 use crate::{
     Cipher, CipherId, CipherView, CiphersClient, DecryptCipherListResult, VaultParseError,
@@ -81,6 +82,7 @@ pub async fn restore_many<R: Repository<Cipher> + ?Sized>(
     })
 }
 
+#[cfg_attr(feature = "wasm", wasm_bindgen)]
 impl CiphersClient {
     /// Restores a soft-deleted cipher on the server.
     pub async fn restore(&self, cipher_id: CipherId) -> Result<CipherView, RestoreCipherError> {


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-27632

## 📔 Objective

When the delete/get/restore operations were added in CiphersClient, I missed the `#[wasm_bindgen]` annotations exposing them to the client - this adds those bindings, and makes minor changes for compatibility.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation
  team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
