### PR TITLE
Add model conversions for cipher and folder

### DIFF
--- a/crates/bitwarden-vault/src/cipher/cipher.rs
+++ b/crates/bitwarden-vault/src/cipher/cipher.rs
@@ -401,7 +401,7 @@ impl TryFrom<Cipher> for CipherWithIdRequestModel {
             identity: val.identity.map(|i| Box::new(i.into())),
             secure_note: val.secure_note.map(|s| Box::new(s.into())),
             ssh_key: val.ssh_key.map(|s| Box::new(s.into())),
-            data: None,
+            data: val.data,
             last_known_revision_date: Some(
                 val.revision_date
                     .to_rfc3339_opts(SecondsFormat::Millis, true),

--- a/crates/bitwarden-vault/src/cipher/cipher.rs
+++ b/crates/bitwarden-vault/src/cipher/cipher.rs
@@ -354,66 +354,6 @@ pub struct CipherView {
     pub archived_date: Option<DateTime<Utc>>,
 }
 
-pub struct ParseError;
-
-impl TryFrom<Cipher> for CipherWithIdRequestModel {
-    type Error = ParseError;
-
-    fn try_from(val: Cipher) -> Result<Self, ParseError> {
-        Ok(CipherWithIdRequestModel {
-            encrypted_for: None,
-            r#type: Some(val.r#type.into()),
-            organization_id: val.organization_id.map(|o| o.to_string()),
-            folder_id: val.folder_id.as_ref().map(ToString::to_string),
-            favorite: Some(val.favorite),
-            reprompt: Some(val.reprompt.into()),
-            key: val.key.map(|k| k.to_string()),
-            name: val.name.to_string(),
-            notes: val.notes.map(|n| n.to_string()),
-            fields: Some(val.fields.into_iter().flatten().map(Into::into).collect()),
-            password_history: Some(
-                val.password_history
-                    .into_iter()
-                    .flatten()
-                    .map(Into::into)
-                    .collect(),
-            ),
-            attachments: None,
-            attachments2: Some(
-                val.attachments
-                    .into_iter()
-                    .flatten()
-                    .filter_map(|a| {
-                        a.id.map(|id| {
-                            (
-                                id,
-                                bitwarden_api_api::models::CipherAttachmentModel {
-                                    file_name: a.file_name.map(|n| n.to_string()),
-                                    key: a.key.map(|k| k.to_string()),
-                                },
-                            )
-                        })
-                    })
-                    .collect(),
-            ),
-            login: val.login.map(|l| Box::new(l.into())),
-            card: val.card.map(|c| Box::new(c.into())),
-            identity: val.identity.map(|i| Box::new(i.into())),
-            secure_note: val.secure_note.map(|s| Box::new(s.into())),
-            ssh_key: val.ssh_key.map(|s| Box::new(s.into())),
-            data: val.data,
-            last_known_revision_date: Some(
-                val.revision_date
-                    .to_rfc3339_opts(SecondsFormat::Millis, true),
-            ),
-            archived_date: val
-                .archived_date
-                .map(|d| d.to_rfc3339_opts(SecondsFormat::Millis, true)),
-            id: val.id.ok_or(ParseError)?.into(),
-        })
-    }
-}
-
 #[allow(missing_docs)]
 #[derive(Serialize, Deserialize, Debug, PartialEq)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]

--- a/crates/bitwarden-vault/src/folder/folder_models.rs
+++ b/crates/bitwarden-vault/src/folder/folder_models.rs
@@ -28,15 +28,6 @@ pub struct Folder {
     pub revision_date: DateTime<Utc>,
 }
 
-impl From<&Folder> for FolderWithIdRequestModel {
-    fn from(val: &Folder) -> Self {
-        FolderWithIdRequestModel {
-            name: val.name.to_string(),
-            id: val.id.map(|id| id.0),
-        }
-    }
-}
-
 bitwarden_state::register_repository_item!(Folder, "Folder");
 
 #[allow(missing_docs)]
@@ -98,5 +89,14 @@ impl TryFrom<FolderResponseModel> for Folder {
             name: require!(EncString::try_from_optional(folder.name)?),
             revision_date: require!(folder.revision_date).parse()?,
         })
+    }
+}
+
+impl From<&Folder> for FolderWithIdRequestModel {
+    fn from(val: &Folder) -> Self {
+        FolderWithIdRequestModel {
+            name: val.name.to_string(),
+            id: val.id.map(|id| id.0),
+        }
     }
 }

--- a/crates/bitwarden-vault/src/folder/folder_models.rs
+++ b/crates/bitwarden-vault/src/folder/folder_models.rs
@@ -1,4 +1,4 @@
-use bitwarden_api_api::models::FolderResponseModel;
+use bitwarden_api_api::models::{FolderResponseModel, FolderWithIdRequestModel};
 use bitwarden_core::{
     key_management::{KeyIds, SymmetricKeyId},
     require,
@@ -26,6 +26,15 @@ pub struct Folder {
     pub id: Option<FolderId>,
     pub name: EncString,
     pub revision_date: DateTime<Utc>,
+}
+
+impl From<&Folder> for FolderWithIdRequestModel {
+    fn from(val: &Folder) -> Self {
+        FolderWithIdRequestModel {
+            name: val.name.to_string(),
+            id: val.id.map(|id| id.0),
+        }
+    }
 }
 
 bitwarden_state::register_repository_item!(Folder, "Folder");


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

Unblocks: https://github.com/bitwarden/sdk-internal/pull/650
https://bitwarden.atlassian.net/browse/PM-30144

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
To implement SDK key-rotation, we need a way to parse the response models into ciphers / folders. The PR is split out to make the review of #650  less complex.

## 🚨 Breaking Changes
None

<!-- Does this PR introduce any breaking changes? If so, please describe the impact and migration path for clients.

If you're unsure, the automated TypeScript compatibility check will run when you open/update this PR and provide feedback.

For breaking changes:
1. Describe what changed in the client interface
2. Explain why the change was necessary
3. Provide migration steps for client developers
4. Link to any paired client PRs if needed

Otherwise, you can remove this section. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation
  team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
