### PR TITLE
[BEEEP|PM-30620] Add crypto debug and tracing

### DIFF
--- a/bitwarden_license/bitwarden-commercial-vault/Cargo.toml
+++ b/bitwarden_license/bitwarden-commercial-vault/Cargo.toml
@@ -24,7 +24,7 @@ wasm = [
 # WARNING: This feature is for debugging purposes only and should never be enabled in production.
 # It disables compile-time debug prevention for cryptographic keys, exposing sensitive key material
 # in debug output, and adds tracing debug logs to encrypt/decrypt operations.
-dangerous-crypto-debug = ["bitwarden-crypto/dangerous-crypto-debug"]
+dangerous-crypto-debug = ["bitwarden-core/dangerous-crypto-debug"]
 
 [dependencies]
 bitwarden-core = { workspace = true, features = ["internal"] }

--- a/bitwarden_license/bitwarden-commercial-vault/Cargo.toml
+++ b/bitwarden_license/bitwarden-commercial-vault/Cargo.toml
@@ -21,6 +21,10 @@ wasm = [
     "dep:wasm-bindgen",
     "dep:wasm-bindgen-futures",
 ] # WASM support
+# WARNING: This feature is for debugging purposes only and should never be enabled in production.
+# It disables compile-time debug prevention for cryptographic keys, exposing sensitive key material
+# in debug output, and adds tracing debug logs to encrypt/decrypt operations.
+dangerous-crypto-debug = ["bitwarden-crypto/dangerous-crypto-debug"]
 
 [dependencies]
 bitwarden-core = { workspace = true, features = ["internal"] }

--- a/bitwarden_license/bitwarden-sm/Cargo.toml
+++ b/bitwarden_license/bitwarden-sm/Cargo.toml
@@ -13,6 +13,12 @@ repository.workspace = true
 license-file = "../../LICENSE_SDK.txt"
 keywords.workspace = true
 
+[features]
+# WARNING: This feature is for debugging purposes only and should never be enabled in production.
+# It disables compile-time debug prevention for cryptographic keys, exposing sensitive key material
+# in debug output, and adds tracing debug logs to encrypt/decrypt operations.
+dangerous-crypto-debug = ["bitwarden-crypto/dangerous-crypto-debug"]
+
 [dependencies]
 bitwarden-api-api = { workspace = true }
 bitwarden-core = { workspace = true, features = ["secrets"] }

--- a/bitwarden_license/bitwarden-sm/Cargo.toml
+++ b/bitwarden_license/bitwarden-sm/Cargo.toml
@@ -13,12 +13,6 @@ repository.workspace = true
 license-file = "../../LICENSE_SDK.txt"
 keywords.workspace = true
 
-[features]
-# WARNING: This feature is for debugging purposes only and should never be enabled in production.
-# It disables compile-time debug prevention for cryptographic keys, exposing sensitive key material
-# in debug output, and adds tracing debug logs to encrypt/decrypt operations.
-dangerous-crypto-debug = ["bitwarden-crypto/dangerous-crypto-debug"]
-
 [dependencies]
 bitwarden-api-api = { workspace = true }
 bitwarden-core = { workspace = true, features = ["secrets"] }

--- a/crates/bitwarden-core/Cargo.toml
+++ b/crates/bitwarden-core/Cargo.toml
@@ -39,14 +39,14 @@ wasm = [
 # WARNING: This feature is for debugging purposes only and should never be enabled in production.
 # It disables compile-time debug prevention for cryptographic keys, exposing sensitive key material
 # in debug output, and adds tracing debug logs to encrypt/decrypt operations.
-dangerous-crypto-debug = []
+dangerous-crypto-debug = ["bitwarden-crypto/dangerous-crypto-debug"]
 
 [dependencies]
 async-trait = { workspace = true }
 bitwarden-api-api = { workspace = true }
 bitwarden-api-identity = { workspace = true }
 bitwarden-api-key-connector = { workspace = true }
-bitwarden-crypto = { workspace = true, features = ["dangerous-crypto-debug"] }
+bitwarden-crypto = { workspace = true, features = [] }
 bitwarden-encoding = { workspace = true }
 bitwarden-error = { workspace = true }
 bitwarden-state = { workspace = true }

--- a/crates/bitwarden-core/Cargo.toml
+++ b/crates/bitwarden-core/Cargo.toml
@@ -46,7 +46,7 @@ async-trait = { workspace = true }
 bitwarden-api-api = { workspace = true }
 bitwarden-api-identity = { workspace = true }
 bitwarden-api-key-connector = { workspace = true }
-bitwarden-crypto = { workspace = true, features = [] }
+bitwarden-crypto = { workspace = true }
 bitwarden-encoding = { workspace = true }
 bitwarden-error = { workspace = true }
 bitwarden-state = { workspace = true }

--- a/crates/bitwarden-core/Cargo.toml
+++ b/crates/bitwarden-core/Cargo.toml
@@ -36,13 +36,17 @@ wasm = [
     "dep:wasm-bindgen-futures",
     "dep:tsify",
 ] # WASM support
+# WARNING: This feature is for debugging purposes only and should never be enabled in production.
+# It disables compile-time debug prevention for cryptographic keys, exposing sensitive key material
+# in debug output, and adds tracing debug logs to encrypt/decrypt operations.
+dangerous-crypto-debug = []
 
 [dependencies]
 async-trait = { workspace = true }
 bitwarden-api-api = { workspace = true }
 bitwarden-api-identity = { workspace = true }
 bitwarden-api-key-connector = { workspace = true }
-bitwarden-crypto = { workspace = true }
+bitwarden-crypto = { workspace = true, features = ["dangerous-crypto-debug"] }
 bitwarden-encoding = { workspace = true }
 bitwarden-error = { workspace = true }
 bitwarden-state = { workspace = true }

--- a/crates/bitwarden-core/src/client/internal.rs
+++ b/crates/bitwarden-core/src/client/internal.rs
@@ -10,9 +10,8 @@ use bitwarden_crypto::{
 #[cfg(feature = "internal")]
 use bitwarden_state::registry::StateRegistry;
 use chrono::Utc;
-use tracing::info;
 #[cfg(feature = "internal")]
-use tracing::instrument;
+use tracing::{info, instrument};
 
 #[cfg(any(feature = "internal", feature = "secrets"))]
 use crate::client::encryption_settings::EncryptionSettings;

--- a/crates/bitwarden-core/src/client/internal.rs
+++ b/crates/bitwarden-core/src/client/internal.rs
@@ -10,6 +10,7 @@ use bitwarden_crypto::{
 #[cfg(feature = "internal")]
 use bitwarden_state::registry::StateRegistry;
 use chrono::Utc;
+use tracing::info;
 #[cfg(feature = "internal")]
 use tracing::instrument;
 
@@ -315,7 +316,14 @@ impl InternalClient {
         account_crypto_state: WrappedAccountCryptographicState,
     ) -> Result<(), EncryptionSettingsError> {
         let mut ctx = self.key_store.context_mut();
+
+        // Note: The actual key does not get logged unless the crypto crate has the
+        // dangerous-crypto-debug feature enabled, so this is safe
+        info!("Setting user key {:?}", user_key);
         let user_key = ctx.add_local_symmetric_key(user_key);
+        // The user key gets set to the local context frame here; It then gets persisted to the
+        // context when the cryptographic state was unwrapped correctly, so that there is no
+        // risk of a partial / incorrect setup.
         account_crypto_state
             .set_to_context(&self.security_state, user_key, &self.key_store, ctx)
             .map_err(|_| EncryptionSettingsError::CryptoInitialization)

--- a/crates/bitwarden-crypto/Cargo.toml
+++ b/crates/bitwarden-crypto/Cargo.toml
@@ -24,6 +24,10 @@ uniffi = [
     "dep:uniffi",
 ] # Uniffi bindings
 wasm = ["dep:tsify", "dep:wasm-bindgen"] # WASM support
+# WARNING: This feature is for debugging purposes only and should never be enabled in production.
+# It disables compile-time debug prevention for cryptographic keys, exposing sensitive key material
+# in debug output, and adds tracing debug logs to encrypt/decrypt operations.
+dangerous-crypto-debug = []
 
 [dependencies]
 aes = { version = ">=0.8.2, <0.9", features = ["zeroize"] }

--- a/crates/bitwarden-crypto/src/keys/asymmetric_crypto_key.rs
+++ b/crates/bitwarden-crypto/src/keys/asymmetric_crypto_key.rs
@@ -106,8 +106,8 @@ impl AsymmetricCryptoKey {
     }
 
     #[allow(missing_docs)]
-    #[cfg_attr(feature = "dangerous-crypto-debug", instrument(skip_all, err))]
-    #[cfg_attr(not(feature = "dangerous-crypto-debug"), instrument(err))]
+    #[cfg_attr(feature = "dangerous-crypto-debug", instrument(err))]
+    #[cfg_attr(not(feature = "dangerous-crypto-debug"), instrument(skip_all, err))]
     pub fn from_pem(pem: &str) -> Result<Self> {
         use rsa::pkcs8::DecodePrivateKey;
         Ok(Self {
@@ -118,8 +118,8 @@ impl AsymmetricCryptoKey {
     }
 
     #[allow(missing_docs)]
-    #[cfg_attr(feature = "dangerous-crypto-debug", instrument(skip_all, err))]
-    #[cfg_attr(not(feature = "dangerous-crypto-debug"), instrument(err))]
+    #[cfg_attr(feature = "dangerous-crypto-debug", instrument(err))]
+    #[cfg_attr(not(feature = "dangerous-crypto-debug"), instrument(skip_all, err))]
     pub fn from_der(der: &Pkcs8PrivateKeyBytes) -> Result<Self> {
         use rsa::pkcs8::DecodePrivateKey;
         Ok(Self {
@@ -130,8 +130,8 @@ impl AsymmetricCryptoKey {
     }
 
     #[allow(missing_docs)]
-    #[cfg_attr(feature = "dangerous-crypto-debug", instrument(skip_all, err))]
-    #[cfg_attr(not(feature = "dangerous-crypto-debug"), instrument(err))]
+    #[cfg_attr(feature = "dangerous-crypto-debug", instrument(err))]
+    #[cfg_attr(not(feature = "dangerous-crypto-debug"), instrument(skip_all, err))]
     pub fn to_der(&self) -> Result<Pkcs8PrivateKeyBytes> {
         match &self.inner {
             RawPrivateKey::RsaOaepSha1(private_key) => {

--- a/crates/bitwarden-crypto/src/keys/kdf.rs
+++ b/crates/bitwarden-crypto/src/keys/kdf.rs
@@ -25,6 +25,7 @@ const ARGON2ID_MIN_PARALLELISM: u32 = 1;
 /// further using HKDF (HMAC-based Key Derivation Function).
 ///
 /// Uses a pinned heap data structure, as noted in [Pinned heap data][crate#pinned-heap-data]
+#[cfg_attr(feature = "dangerous-crypto-debug", derive(Debug))]
 pub struct KdfDerivedKeyMaterial(pub(super) Pin<Box<GenericArray<u8, U32>>>);
 
 impl KdfDerivedKeyMaterial {

--- a/crates/bitwarden-crypto/src/keys/key_connector_key.rs
+++ b/crates/bitwarden-crypto/src/keys/key_connector_key.rs
@@ -26,11 +26,8 @@ impl KeyConnectorKey {
     }
 
     /// Wraps the user key with this key connector key.
-    #[cfg_attr(feature = "dangerous-crypto-debug", instrument(skip(self), err))]
-    #[cfg_attr(
-        not(feature = "dangerous-crypto-debug"),
-        instrument(skip(self, user_key), err)
-    )]
+    #[cfg_attr(feature = "dangerous-crypto-debug", instrument(err))]
+    #[cfg_attr(not(feature = "dangerous-crypto-debug"), instrument(skip_all, err))]
     pub fn encrypt_user_key(
         &self,
         user_key: &SymmetricCryptoKey,
@@ -41,11 +38,8 @@ impl KeyConnectorKey {
     }
 
     /// Unwraps the user key with this key connector key.
-    #[cfg_attr(feature = "dangerous-crypto-debug", instrument(skip(self), err))]
-    #[cfg_attr(
-        not(feature = "dangerous-crypto-debug"),
-        instrument(skip(self, user_key), err)
-    )]
+    #[cfg_attr(feature = "dangerous-crypto-debug", instrument(err))]
+    #[cfg_attr(not(feature = "dangerous-crypto-debug"), instrument(skip_all, err))]
     pub fn decrypt_user_key(
         &self,
         user_key: EncString,

--- a/crates/bitwarden-crypto/src/keys/key_connector_key.rs
+++ b/crates/bitwarden-crypto/src/keys/key_connector_key.rs
@@ -3,6 +3,7 @@ use std::pin::Pin;
 use bitwarden_encoding::B64;
 use generic_array::GenericArray;
 use rand::Rng;
+use tracing::instrument;
 use typenum::U32;
 
 use crate::{
@@ -25,6 +26,11 @@ impl KeyConnectorKey {
     }
 
     /// Wraps the user key with this key connector key.
+    #[cfg_attr(feature = "dangerous-crypto-debug", instrument(skip(self), err))]
+    #[cfg_attr(
+        not(feature = "dangerous-crypto-debug"),
+        instrument(skip(self, user_key), err)
+    )]
     pub fn encrypt_user_key(
         &self,
         user_key: &SymmetricCryptoKey,
@@ -35,6 +41,11 @@ impl KeyConnectorKey {
     }
 
     /// Unwraps the user key with this key connector key.
+    #[cfg_attr(feature = "dangerous-crypto-debug", instrument(skip(self), err))]
+    #[cfg_attr(
+        not(feature = "dangerous-crypto-debug"),
+        instrument(skip(self, user_key), err)
+    )]
     pub fn decrypt_user_key(
         &self,
         user_key: EncString,
@@ -64,7 +75,10 @@ impl KeyConnectorKey {
 
 impl std::fmt::Debug for KeyConnectorKey {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("KeyConnectorKey").finish()
+        let mut debug_struct = f.debug_struct("KeyConnectorKey");
+        #[cfg(feature = "dangerous-crypto-debug")]
+        debug_struct.field("key", &self.0.as_slice());
+        debug_struct.finish()
     }
 }
 

--- a/crates/bitwarden-crypto/src/keys/master_key.rs
+++ b/crates/bitwarden-crypto/src/keys/master_key.rs
@@ -79,21 +79,15 @@ impl MasterKey {
     }
 
     /// Encrypt the users user key
-    #[cfg_attr(feature = "dangerous-crypto-debug", instrument(skip(self), err))]
-    #[cfg_attr(
-        not(feature = "dangerous-crypto-debug"),
-        instrument(skip(self, user_key), err)
-    )]
+    #[cfg_attr(feature = "dangerous-crypto-debug", instrument(err))]
+    #[cfg_attr(not(feature = "dangerous-crypto-debug"), instrument(skip_all, err))]
     pub fn encrypt_user_key(&self, user_key: &SymmetricCryptoKey) -> Result<EncString> {
         encrypt_user_key(self.inner_bytes(), user_key)
     }
 
     /// Decrypt the users user key
-    #[cfg_attr(feature = "dangerous-crypto-debug", instrument(skip(self), err))]
-    #[cfg_attr(
-        not(feature = "dangerous-crypto-debug"),
-        instrument(skip(self, user_key), err)
-    )]
+    #[cfg_attr(feature = "dangerous-crypto-debug", instrument(err))]
+    #[cfg_attr(not(feature = "dangerous-crypto-debug"), instrument(skip_all, err))]
     pub fn decrypt_user_key(&self, user_key: EncString) -> Result<SymmetricCryptoKey> {
         decrypt_user_key(self.inner_bytes(), user_key)
     }

--- a/crates/bitwarden-crypto/src/keys/master_key.rs
+++ b/crates/bitwarden-crypto/src/keys/master_key.rs
@@ -3,6 +3,7 @@ use std::pin::Pin;
 use bitwarden_encoding::B64;
 use generic_array::GenericArray;
 use rand::Rng;
+use tracing::instrument;
 use typenum::U32;
 use zeroize::Zeroize;
 
@@ -19,6 +20,7 @@ use crate::{
 #[allow(missing_docs)]
 #[derive(Copy, Clone)]
 #[cfg_attr(feature = "uniffi", derive(uniffi::Enum))]
+#[cfg_attr(feature = "dangerous-crypto-debug", derive(Debug))]
 pub enum HashPurpose {
     ServerAuthorization = 1,
     LocalAuthorization = 2,
@@ -29,6 +31,7 @@ pub enum HashPurpose {
 /// Derived from the users master password, used to protect the [UserKey].
 /// TODO: <https://bitwarden.atlassian.net/browse/PM-18366> split KeyConnectorKey into a separate file
 #[allow(missing_docs)]
+#[cfg_attr(feature = "dangerous-crypto-debug", derive(Debug))]
 pub enum MasterKey {
     KdfKey(KdfDerivedKeyMaterial),
     KeyConnectorKey(Pin<Box<GenericArray<u8, U32>>>),
@@ -57,11 +60,13 @@ impl MasterKey {
     /// Derives a users master key from their password, email and KDF.
     ///
     /// Note: the email is trimmed and converted to lowercase before being used.
+    #[cfg_attr(feature = "dangerous-crypto-debug", instrument)]
     pub fn derive(password: &str, email: &str, kdf: &Kdf) -> Result<Self, CryptoError> {
         Ok(KdfDerivedKeyMaterial::derive(password, email, kdf)?.into())
     }
 
     /// Derive the master key hash, used for local and remote password validation.
+    #[cfg_attr(feature = "dangerous-crypto-debug", instrument)]
     pub fn derive_master_key_hash(&self, password: &[u8], purpose: HashPurpose) -> B64 {
         let hash = util::pbkdf2(self.inner_bytes().as_slice(), password, purpose as u32);
 
@@ -74,11 +79,21 @@ impl MasterKey {
     }
 
     /// Encrypt the users user key
+    #[cfg_attr(feature = "dangerous-crypto-debug", instrument(skip(self), err))]
+    #[cfg_attr(
+        not(feature = "dangerous-crypto-debug"),
+        instrument(skip(self, user_key), err)
+    )]
     pub fn encrypt_user_key(&self, user_key: &SymmetricCryptoKey) -> Result<EncString> {
         encrypt_user_key(self.inner_bytes(), user_key)
     }
 
     /// Decrypt the users user key
+    #[cfg_attr(feature = "dangerous-crypto-debug", instrument(skip(self), err))]
+    #[cfg_attr(
+        not(feature = "dangerous-crypto-debug"),
+        instrument(skip(self, user_key), err)
+    )]
     pub fn decrypt_user_key(&self, user_key: EncString) -> Result<SymmetricCryptoKey> {
         decrypt_user_key(self.inner_bytes(), user_key)
     }

--- a/crates/bitwarden-crypto/src/keys/symmetric_crypto_key.rs
+++ b/crates/bitwarden-crypto/src/keys/symmetric_crypto_key.rs
@@ -402,21 +402,31 @@ impl std::fmt::Debug for SymmetricCryptoKey {
 
 impl std::fmt::Debug for Aes256CbcKey {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("Aes256CbcKey").finish()
+        let mut debug_struct = f.debug_struct("Aes256CbcKey");
+        #[cfg(feature = "dangerous-crypto-debug")]
+        debug_struct.field("enc_key", &self.enc_key.as_slice());
+        debug_struct.finish()
     }
 }
 
 impl std::fmt::Debug for Aes256CbcHmacKey {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("Aes256CbcHmacKey").finish()
+        let mut debug_struct = f.debug_struct("Aes256CbcHmacKey");
+        #[cfg(feature = "dangerous-crypto-debug")]
+        debug_struct
+            .field("enc_key", &self.enc_key.as_slice())
+            .field("mac_key", &self.mac_key.as_slice());
+        debug_struct.finish()
     }
 }
 
 impl std::fmt::Debug for XChaCha20Poly1305Key {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("XChaCha20Poly1305Key")
-            .field("key_id", &self.key_id)
-            .finish()
+        let mut debug_struct = f.debug_struct("XChaCha20Poly1305Key");
+        debug_struct.field("key_id", &self.key_id);
+        #[cfg(feature = "dangerous-crypto-debug")]
+        debug_struct.field("enc_key", &self.enc_key.as_slice());
+        debug_struct.finish()
     }
 }
 

--- a/crates/bitwarden-crypto/src/store/context.rs
+++ b/crates/bitwarden-crypto/src/store/context.rs
@@ -5,6 +5,7 @@ use std::{
 
 use coset::iana::KeyOperation;
 use serde::Serialize;
+use tracing::instrument;
 use zeroize::Zeroizing;
 
 use super::KeyStoreInner;
@@ -203,6 +204,7 @@ impl<Ids: KeyIds> KeyStoreContext<'_, Ids> {
     /// * `new_key_id` - The key id where the decrypted key will be stored. If it already exists, it
     ///   will be overwritten
     /// * `wrapped_key` - The key to decrypt
+    #[instrument(skip(self, wrapped_key), err)]
     pub fn unwrap_symmetric_key(
         &mut self,
         wrapping_key: Ids::Symmetric,
@@ -238,7 +240,10 @@ impl<Ids: KeyIds> KeyStoreContext<'_, Ids> {
                     _ => return Err(CryptoError::InvalidKey),
                 }
             }
-            _ => return Err(CryptoError::InvalidKey),
+            _ => {
+                tracing::warn!("Unsupported unwrap operation for the given key and data");
+                return Err(CryptoError::InvalidKey);
+            }
         };
 
         let new_key_id = Ids::Symmetric::new_local(LocalId::new());
@@ -354,6 +359,7 @@ impl<Ids: KeyIds> KeyStoreContext<'_, Ids> {
     ///
     /// # Errors
     /// Returns an error if decryption or parsing fails.
+    #[instrument(skip(self, wrapped_key), err)]
     pub fn unwrap_private_key(
         &mut self,
         wrapping_key: Ids::Symmetric,
@@ -760,6 +766,7 @@ impl<Ids: KeyIds> KeyStoreContext<'_, Ids> {
         Ok(key_id)
     }
 
+    #[instrument(skip(self, data), err)]
     pub(crate) fn decrypt_data_with_symmetric_key(
         &self,
         key: Ids::Symmetric,
@@ -785,7 +792,10 @@ impl<Ids: KeyIds> KeyStoreContext<'_, Ids> {
                 )?;
                 Ok(data)
             }
-            _ => Err(CryptoError::InvalidKey),
+            _ => {
+                tracing::warn!("Unsupported decryption operation for the given key and data");
+                Err(CryptoError::InvalidKey)
+            }
         }
     }
 

--- a/crates/bitwarden-uniffi/Cargo.toml
+++ b/crates/bitwarden-uniffi/Cargo.toml
@@ -17,6 +17,10 @@ crate-type = ["lib", "staticlib", "cdylib"]
 bench = false
 
 [features]
+# WARNING: This feature is for debugging purposes only and should never be enabled in production.
+# It disables compile-time debug prevention for cryptographic keys, exposing sensitive key material
+# in debug output, and adds tracing debug logs to encrypt/decrypt operations.
+dangerous-crypto-debug = ["bitwarden-crypto/dangerous-crypto-debug"]
 
 [dependencies]
 async-trait = { workspace = true }

--- a/crates/bitwarden-uniffi/Cargo.toml
+++ b/crates/bitwarden-uniffi/Cargo.toml
@@ -20,7 +20,7 @@ bench = false
 # WARNING: This feature is for debugging purposes only and should never be enabled in production.
 # It disables compile-time debug prevention for cryptographic keys, exposing sensitive key material
 # in debug output, and adds tracing debug logs to encrypt/decrypt operations.
-dangerous-crypto-debug = ["bitwarden-crypto/dangerous-crypto-debug"]
+dangerous-crypto-debug = ["bitwarden-core/dangerous-crypto-debug"]
 
 [dependencies]
 async-trait = { workspace = true }

--- a/crates/bitwarden-uniffi/src/lib.rs
+++ b/crates/bitwarden-uniffi/src/lib.rs
@@ -169,6 +169,10 @@ fn init_logger() {
                 .with(filter)
                 .init();
         }
+        #[cfg(feature = "dangerous-crypto-debug")]
+        tracing::warn!(
+            "Dangerous crypto debug features are enabled. THIS MUST NOT BE USED IN PRODUCTION BUILDS!!"
+        );
     });
 }
 

--- a/crates/bitwarden-wasm-internal/Cargo.toml
+++ b/crates/bitwarden-wasm-internal/Cargo.toml
@@ -20,7 +20,7 @@ bitwarden-license = ["bitwarden-pm/bitwarden-license", "dep:bitwarden-commercial
 # WARNING: This feature is for debugging purposes only and should never be enabled in production.
 # It disables compile-time debug prevention for cryptographic keys, exposing sensitive key material
 # in debug output, and adds tracing debug logs to encrypt/decrypt operations.
-dangerous-crypto-debug = []
+dangerous-crypto-debug = ["bitwarden-crypto/dangerous-crypto-debug"]
 
 [dependencies]
 async-trait = { workspace = true }
@@ -28,7 +28,7 @@ bitwarden-commercial-vault = { workspace = true, optional = true, features = [
   "wasm",
 ] }
 bitwarden-core = { workspace = true, features = ["wasm", "internal"] }
-bitwarden-crypto = { workspace = true, features = ["wasm", "dangerous-crypto-debug"] }
+bitwarden-crypto = { workspace = true, features = ["wasm"] }
 bitwarden-error = { workspace = true }
 bitwarden-ipc = { workspace = true, features = ["wasm"] }
 bitwarden-pm = { workspace = true, features = ["wasm"] }

--- a/crates/bitwarden-wasm-internal/Cargo.toml
+++ b/crates/bitwarden-wasm-internal/Cargo.toml
@@ -17,6 +17,10 @@ crate-type = ["cdylib"]
 
 [features]
 bitwarden-license = ["bitwarden-pm/bitwarden-license", "dep:bitwarden-commercial-vault"]
+# WARNING: This feature is for debugging purposes only and should never be enabled in production.
+# It disables compile-time debug prevention for cryptographic keys, exposing sensitive key material
+# in debug output, and adds tracing debug logs to encrypt/decrypt operations.
+dangerous-crypto-debug = []
 
 [dependencies]
 async-trait = { workspace = true }
@@ -24,7 +28,7 @@ bitwarden-commercial-vault = { workspace = true, optional = true, features = [
   "wasm",
 ] }
 bitwarden-core = { workspace = true, features = ["wasm", "internal"] }
-bitwarden-crypto = { workspace = true, features = ["wasm"] }
+bitwarden-crypto = { workspace = true, features = ["wasm", "dangerous-crypto-debug"] }
 bitwarden-error = { workspace = true }
 bitwarden-ipc = { workspace = true, features = ["wasm"] }
 bitwarden-pm = { workspace = true, features = ["wasm"] }

--- a/crates/bitwarden-wasm-internal/Cargo.toml
+++ b/crates/bitwarden-wasm-internal/Cargo.toml
@@ -20,7 +20,7 @@ bitwarden-license = ["bitwarden-pm/bitwarden-license", "dep:bitwarden-commercial
 # WARNING: This feature is for debugging purposes only and should never be enabled in production.
 # It disables compile-time debug prevention for cryptographic keys, exposing sensitive key material
 # in debug output, and adds tracing debug logs to encrypt/decrypt operations.
-dangerous-crypto-debug = ["bitwarden-crypto/dangerous-crypto-debug"]
+dangerous-crypto-debug = ["bitwarden-core/dangerous-crypto-debug"]
 
 [dependencies]
 async-trait = { workspace = true }

--- a/crates/bitwarden-wasm-internal/src/init.rs
+++ b/crates/bitwarden-wasm-internal/src/init.rs
@@ -50,6 +50,6 @@ pub fn init_sdk(log_level: Option<LogLevel>) {
 
     #[cfg(feature = "dangerous-crypto-debug")]
     tracing::warn!(
-        "Dangerous crypto debug features are enabled. THIS MUST NOT BE USED IN PRODUCTION BULIDS!!"
+        "Dangerous crypto debug features are enabled. THIS MUST NOT BE USED IN PRODUCTION BUILDS!!"
     );
 }

--- a/crates/bitwarden-wasm-internal/src/init.rs
+++ b/crates/bitwarden-wasm-internal/src/init.rs
@@ -47,4 +47,9 @@ pub fn init_sdk(log_level: Option<LogLevel>) {
         .with(filter)
         .with(fmt)
         .init();
+
+    #[cfg(feature = "dangerous-crypto-debug")]
+    tracing::warn!(
+        "Dangerous crypto debug features are enabled. THIS MUST NOT BE USED IN PRODUCTION BULIDS!!"
+    );
 }

--- a/crates/bitwarden-wasm-internal/src/pure_crypto.rs
+++ b/crates/bitwarden-wasm-internal/src/pure_crypto.rs
@@ -37,6 +37,7 @@ impl PureCrypto {
         enc_string: String,
         key: Vec<u8>,
     ) -> Result<String, CryptoError> {
+        let _span = tracing::info_span!("PureCrypto::symmetric_decrypt_string").entered();
         let key = &BitwardenLegacyKeyBytes::from(key);
         EncString::from_str(&enc_string)?.decrypt_with_key(&SymmetricCryptoKey::try_from(key)?)
     }
@@ -45,6 +46,7 @@ impl PureCrypto {
         enc_string: String,
         key: Vec<u8>,
     ) -> Result<Vec<u8>, CryptoError> {
+        let _span = tracing::info_span!("PureCrypto::symmetric_decrypt_bytes").entered();
         let key = &BitwardenLegacyKeyBytes::from(key);
         EncString::from_str(&enc_string)?.decrypt_with_key(&SymmetricCryptoKey::try_from(key)?)
     }
@@ -62,11 +64,13 @@ impl PureCrypto {
         enc_bytes: Vec<u8>,
         key: Vec<u8>,
     ) -> Result<Vec<u8>, CryptoError> {
+        let _span = tracing::info_span!("PureCrypto::symmetric_decrypt_filedata").entered();
         let key = &BitwardenLegacyKeyBytes::from(key);
         EncString::from_buffer(&enc_bytes)?.decrypt_with_key(&SymmetricCryptoKey::try_from(key)?)
     }
 
     pub fn symmetric_encrypt_string(plain: String, key: Vec<u8>) -> Result<String, CryptoError> {
+        let _span = tracing::info_span!("PureCrypto::symmetric_encrypt_string").entered();
         let key = &BitwardenLegacyKeyBytes::from(key);
         plain
             .encrypt_with_key(&SymmetricCryptoKey::try_from(key)?)
@@ -75,6 +79,7 @@ impl PureCrypto {
 
     /// DEPRECATED: Only used by send keys
     pub fn symmetric_encrypt_bytes(plain: Vec<u8>, key: Vec<u8>) -> Result<String, CryptoError> {
+        let _span = tracing::info_span!("PureCrypto::symmetric_encrypt_bytes").entered();
         let key = &BitwardenLegacyKeyBytes::from(key);
         OctetStreamBytes::from(plain)
             .encrypt_with_key(&SymmetricCryptoKey::try_from(key)?)
@@ -85,6 +90,7 @@ impl PureCrypto {
         plain: Vec<u8>,
         key: Vec<u8>,
     ) -> Result<Vec<u8>, CryptoError> {
+        let _span = tracing::info_span!("PureCrypto::symmetric_encrypt_filedata").entered();
         let key = &BitwardenLegacyKeyBytes::from(key);
         OctetStreamBytes::from(plain)
             .encrypt_with_key(&SymmetricCryptoKey::try_from(key)?)?
@@ -97,6 +103,13 @@ impl PureCrypto {
         email: String,
         kdf: Kdf,
     ) -> Result<Vec<u8>, CryptoError> {
+        let _span = tracing::info_span!(
+            "PureCrypto::decrypt_user_key_with_master_password",
+            email = %email,
+            kdf = ?kdf
+        )
+        .entered();
+
         let master_key = MasterKey::derive(master_password.as_str(), email.as_str(), &kdf)?;
         let encrypted_user_key = EncString::from_str(&encrypted_user_key)?;
         let result = master_key
@@ -111,6 +124,12 @@ impl PureCrypto {
         email: String,
         kdf: Kdf,
     ) -> Result<String, CryptoError> {
+        let _span = tracing::info_span!(
+            "PureCrypto::encrypt_user_key_with_master_password",
+            email = %email,
+            kdf = ?kdf
+        )
+        .entered();
         let master_key = MasterKey::derive(master_password.as_str(), email.as_str(), &kdf)?;
         let user_key = &BitwardenLegacyKeyBytes::from(user_key);
         let user_key = SymmetricCryptoKey::try_from(user_key)?;
@@ -136,6 +155,7 @@ impl PureCrypto {
         key_to_be_wrapped: Vec<u8>,
         wrapping_key: Vec<u8>,
     ) -> Result<String, CryptoError> {
+        let _span = tracing::info_span!("PureCrypto::wrap_symmetric_key").entered();
         let tmp_store: KeyStore<KeyIds> = KeyStore::default();
         let mut context = tmp_store.context();
         let wrapping_key =
@@ -156,6 +176,7 @@ impl PureCrypto {
         wrapped_key: String,
         wrapping_key: Vec<u8>,
     ) -> Result<Vec<u8>, CryptoError> {
+        let _span = tracing::info_span!("PureCrypto::unwrap_symmetric_key").entered();
         let tmp_store: KeyStore<KeyIds> = KeyStore::default();
         let mut context = tmp_store.context();
         let wrapping_key =
@@ -178,6 +199,7 @@ impl PureCrypto {
         encapsulation_key: Vec<u8>,
         wrapping_key: Vec<u8>,
     ) -> Result<String, CryptoError> {
+        let _span = tracing::info_span!("PureCrypto::wrap_encapsulation_key").entered();
         let tmp_store: KeyStore<KeyIds> = KeyStore::default();
         let mut context = tmp_store.context();
         let wrapping_key = context.add_local_symmetric_key(SymmetricCryptoKey::try_from(
@@ -194,6 +216,7 @@ impl PureCrypto {
         wrapped_key: String,
         wrapping_key: Vec<u8>,
     ) -> Result<Vec<u8>, CryptoError> {
+        let _span = tracing::info_span!("PureCrypto::unwrap_encapsulation_key").entered();
         let tmp_store: KeyStore<KeyIds> = KeyStore::default();
         let mut context = tmp_store.context();
         let wrapping_key = context.add_local_symmetric_key(SymmetricCryptoKey::try_from(
@@ -208,6 +231,7 @@ impl PureCrypto {
         decapsulation_key: Vec<u8>,
         wrapping_key: Vec<u8>,
     ) -> Result<String, CryptoError> {
+        let _span = tracing::info_span!("PureCrypto::wrap_decapsulation_key").entered();
         let tmp_store: KeyStore<KeyIds> = KeyStore::default();
         let mut context = tmp_store.context();
         let wrapping_key = context.add_local_symmetric_key(SymmetricCryptoKey::try_from(
@@ -224,6 +248,7 @@ impl PureCrypto {
         wrapped_key: String,
         wrapping_key: Vec<u8>,
     ) -> Result<Vec<u8>, CryptoError> {
+        let _span = tracing::info_span!("PureCrypto::unwrap_decapsulation_key").entered();
         let tmp_store: KeyStore<KeyIds> = KeyStore::default();
         let mut context = tmp_store.context();
         let wrapping_key = context.add_local_symmetric_key(SymmetricCryptoKey::try_from(
@@ -239,6 +264,7 @@ impl PureCrypto {
         shared_key: Vec<u8>,
         encapsulation_key: Vec<u8>,
     ) -> Result<String, CryptoError> {
+        let _span = tracing::info_span!("PureCrypto::encapsulate_key_unsigned").entered();
         let encapsulation_key =
             AsymmetricPublicCryptoKey::from_der(&SpkiPublicKeyBytes::from(encapsulation_key))?;
         Ok(UnsignedSharedKey::encapsulate_key_unsigned(
@@ -255,6 +281,7 @@ impl PureCrypto {
         encapsulated_key: String,
         decapsulation_key: Vec<u8>,
     ) -> Result<Vec<u8>, CryptoError> {
+        let _span = tracing::info_span!("PureCrypto::decapsulate_key_unsigned").entered();
         Ok(UnsignedSharedKey::from_str(encapsulated_key.as_str())?
             .decapsulate_key_unsigned(&AsymmetricCryptoKey::from_der(
                 &Pkcs8PrivateKeyBytes::from(decapsulation_key),
@@ -269,6 +296,7 @@ impl PureCrypto {
         signing_key: String,
         wrapping_key: Vec<u8>,
     ) -> Result<Vec<u8>, CryptoError> {
+        let _span = tracing::info_span!("PureCrypto::verifying_key_for_signing_key").entered();
         let bytes = Self::symmetric_decrypt_bytes(signing_key, wrapping_key)?;
         let signing_key = SigningKey::from_cose(&CoseKeyBytes::from(bytes))?;
         let verifying_key = signing_key.to_verifying_key();
@@ -279,6 +307,7 @@ impl PureCrypto {
     pub fn key_algorithm_for_verifying_key(
         verifying_key: Vec<u8>,
     ) -> Result<SignatureAlgorithm, CryptoError> {
+        let _span = tracing::info_span!("PureCrypto::key_algorithm_for_verifying_key").entered();
         let verifying_key = VerifyingKey::from_cose(&CoseKeyBytes::from(verifying_key))?;
         let algorithm = verifying_key.algorithm();
         Ok(algorithm)
@@ -292,6 +321,8 @@ impl PureCrypto {
         signed_public_key: Vec<u8>,
         verifying_key: Vec<u8>,
     ) -> Result<Vec<u8>, CryptoError> {
+        let _span =
+            tracing::info_span!("PureCrypto::verify_and_unwrap_signed_public_key").entered();
         let signed_public_key = SignedPublicKey::try_from(CoseSign1Bytes::from(signed_public_key))?;
         let verifying_key = VerifyingKey::from_cose(&CoseKeyBytes::from(verifying_key))?;
         signed_public_key
@@ -306,6 +337,7 @@ impl PureCrypto {
         salt: &[u8],
         kdf: Kdf,
     ) -> Result<Vec<u8>, CryptoError> {
+        let _span = tracing::info_span!("PureCrypto::derive_kdf_material", kdf = ?kdf).entered();
         #[allow(deprecated)]
         dangerous_derive_kdf_material(password, salt, &kdf)
     }
@@ -314,6 +346,7 @@ impl PureCrypto {
         encrypted_user_key: String,
         master_key: Vec<u8>,
     ) -> Result<Vec<u8>, CryptoError> {
+        let _span = tracing::info_span!("PureCrypto::decrypt_user_key_with_master_key").entered();
         let master_key = &BitwardenLegacyKeyBytes::from(master_key);
         let master_key = &SymmetricCryptoKey::try_from(master_key)?;
         let master_key = MasterKey::try_from(master_key)?;
@@ -328,6 +361,7 @@ impl PureCrypto {
     /// returns the corresponding public RSA key in DER format.
     /// HAZMAT WARNING: Do not use outside of implementing cryptofunctionservice
     pub fn rsa_extract_public_key(private_key: Vec<u8>) -> Result<Vec<u8>, RsaError> {
+        let _span = tracing::info_span!("PureCrypto::rsa_extract_public_key").entered();
         let private_key = AsymmetricCryptoKey::from_der(&Pkcs8PrivateKeyBytes::from(private_key))
             .map_err(|_| RsaError::KeyParse)?;
         let public_key = private_key.to_public_key();
@@ -340,6 +374,7 @@ impl PureCrypto {
     /// Generates a new RSA key pair and returns the private key
     /// HAZMAT WARNING: Do not use outside of implementing cryptofunctionservice
     pub fn rsa_generate_keypair() -> Result<Vec<u8>, RsaError> {
+        let _span = tracing::info_span!("PureCrypto::rsa_generate_keypair").entered();
         let private_key = AsymmetricCryptoKey::make(PublicKeyEncryptionAlgorithm::RsaOaepSha1);
         Ok(private_key
             .to_der()
@@ -353,6 +388,7 @@ impl PureCrypto {
         encrypted_data: Vec<u8>,
         private_key: Vec<u8>,
     ) -> Result<Vec<u8>, RsaError> {
+        let _span = tracing::info_span!("PureCrypto::rsa_decrypt_data").entered();
         let private_key = RsaPrivateKey::from_pkcs8_der(private_key.as_slice())
             .map_err(|_| RsaError::KeyParse)?;
         let padding = Oaep::new::<Sha1>();
@@ -364,6 +400,7 @@ impl PureCrypto {
     /// Encrypts data using RSAES-OAEP with SHA-1
     /// HAZMAT WARNING: Do not use outside of implementing cryptofunctionservice
     pub fn rsa_encrypt_data(plain_data: Vec<u8>, public_key: Vec<u8>) -> Result<Vec<u8>, RsaError> {
+        let _span = tracing::info_span!("PureCrypto::rsa_encrypt_data").entered();
         let public_key = RsaPublicKey::from_public_key_der(public_key.as_slice())
             .map_err(|_| RsaError::KeyParse)?;
         let padding = Oaep::new::<Sha1>();


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-30620

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
Some crypto errors are very hard to pin-point down with exiting tooling. There are three reasons for this: Errors are being mapped to very generic errors (especially InvalidKey). The solution here eventually is splitting up `CryptoError` into small, per-function or per-module errors instead of having this mega error. The second part to this is our prevention of logging of key material, which could be used to confirm exact key values (to find out if a wrong key was used). The third is being able to pin-point down error location due to missing stack traces.

We fix all three of these in this PR. For the second issue, we add tracing statements in a few locations. For the first and last issue, we add a `dangerous-crypto-debug` crate feature that is compile-time toggled. This disables the prevention of key-material logging and gives us extra data.

Considerations for security: We never want devs to accidentally enable this. So it both has a name, indicating that it is dangerous, but it also logs a line into the console on init, warning anyone who looks at the console logs that this must not be enabled in production. This should reasonably prevent this feature from making it to prod.

## 🚨 Breaking Changes

<!-- Does this PR introduce any breaking changes? If so, please describe the impact and migration path for clients.

If you're unsure, the automated TypeScript compatibility check will run when you open/update this PR and provide feedback.

For breaking changes:
1. Describe what changed in the client interface
2. Explain why the change was necessary
3. Provide migration steps for client developers
4. Link to any paired client PRs if needed

Otherwise, you can remove this section. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation
  team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
