### PR TITLE
[PM-27277] Reset password key enrolment for SSO JIT MP encryption v2

### DIFF
--- a/crates/bitwarden-core/src/key_management/crypto_client.rs
+++ b/crates/bitwarden-core/src/key_management/crypto_client.rs
@@ -226,8 +226,15 @@ impl CryptoClient {
         user_id: UserId,
         master_password: String,
         salt: String,
+        org_public_key: B64,
     ) -> Result<MakeJitMasterPasswordRegistrationResponse, MakeKeysError> {
-        make_user_jit_master_password_registration(&self.client, user_id, master_password, salt)
+        make_user_jit_master_password_registration(
+            &self.client,
+            user_id,
+            master_password,
+            salt,
+            org_public_key,
+        )
     }
 }
 


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-27277

## 📔 Objective

Reset password key enrolment for SSO JIT MP encryption v2 account registration.

## 🚨 Breaking Changes

None, the `post_keys_for_jit_password_registration` is not used yet.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation
  team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
