### PR TITLE
[BEEEP] Clean up PRF/HKDF error handling

### DIFF
--- a/crates/bitwarden-core/src/key_management/crypto.rs
+++ b/crates/bitwarden-core/src/key_management/crypto.rs
@@ -51,6 +51,8 @@ pub enum CryptoClientError {
     InvalidKdfSettings,
     #[error(transparent)]
     PasswordProtectedKeyEnvelope(#[from] PasswordProtectedKeyEnvelopeError),
+    #[error("Invalid PRF input")]
+    InvalidPrfInput,
 }
 
 /// State used for initializing the user cryptographic state.
@@ -515,7 +517,8 @@ pub(super) fn make_prf_user_key_set(
     client: &Client,
     prf: B64,
 ) -> Result<RotateableKeySet, CryptoClientError> {
-    let prf_key = derive_symmetric_key_from_prf(prf.as_bytes())?;
+    let prf_key = derive_symmetric_key_from_prf(prf.as_bytes())
+        .map_err(|_| CryptoClientError::InvalidPrfInput)?;
     let ctx = client.internal.get_key_store().context();
     let key_set = RotateableKeySet::new(&ctx, &prf_key, SymmetricKeyId::User)?;
     Ok(key_set)

--- a/crates/bitwarden-crypto/src/keys/key_connector_key.rs
+++ b/crates/bitwarden-crypto/src/keys/key_connector_key.rs
@@ -29,7 +29,7 @@ impl KeyConnectorKey {
         &self,
         user_key: &SymmetricCryptoKey,
     ) -> crate::error::Result<EncString> {
-        let stretched_key = stretch_key(&self.0)?;
+        let stretched_key = stretch_key(&self.0);
         let user_key_bytes = user_key.to_encoded();
         EncString::encrypt_aes256_hmac(user_key_bytes.as_ref(), &stretched_key)
     }
@@ -48,7 +48,7 @@ impl KeyConnectorKey {
                 crate::aes::decrypt_aes256(&iv, data.clone(), &legacy_key)?
             }
             EncString::Aes256Cbc_HmacSha256_B64 { .. } => {
-                let stretched_key = SymmetricCryptoKey::Aes256CbcHmacKey(stretch_key(&self.0)?);
+                let stretched_key = SymmetricCryptoKey::Aes256CbcHmacKey(stretch_key(&self.0));
                 user_key.decrypt_with_key(&stretched_key)?
             }
             _ => {

--- a/crates/bitwarden-crypto/src/keys/master_key.rs
+++ b/crates/bitwarden-crypto/src/keys/master_key.rs
@@ -129,7 +129,7 @@ pub(super) fn encrypt_user_key(
     master_key: &Pin<Box<GenericArray<u8, U32>>>,
     user_key: &SymmetricCryptoKey,
 ) -> Result<EncString> {
-    let stretched_master_key = stretch_key(master_key)?;
+    let stretched_master_key = stretch_key(master_key);
     let user_key_bytes = user_key.to_encoded();
     EncString::encrypt_aes256_hmac(user_key_bytes.as_ref(), &stretched_master_key)
 }
@@ -150,7 +150,7 @@ pub(super) fn decrypt_user_key(
             user_key.decrypt_with_key(&legacy_key)?
         }
         EncString::Aes256Cbc_HmacSha256_B64 { .. } => {
-            let stretched_key = SymmetricCryptoKey::Aes256CbcHmacKey(stretch_key(key)?);
+            let stretched_key = SymmetricCryptoKey::Aes256CbcHmacKey(stretch_key(key));
             user_key.decrypt_with_key(&stretched_key)?
         }
         EncString::Cose_Encrypt0_B64 { .. } => {

--- a/crates/bitwarden-crypto/src/keys/pin_key.rs
+++ b/crates/bitwarden-crypto/src/keys/pin_key.rs
@@ -34,7 +34,7 @@ impl CryptoKey for PinKey {}
 
 impl KeyEncryptable<PinKey, EncString> for &SymmetricCryptoKey {
     fn encrypt_with_key(self, key: &PinKey) -> Result<EncString> {
-        let stretched_key = SymmetricCryptoKey::Aes256CbcHmacKey(stretch_key(&key.0.0)?);
+        let stretched_key = SymmetricCryptoKey::Aes256CbcHmacKey(stretch_key(&key.0.0));
         // The (stretched) pin key is currently always an AES-256-CBC-HMAC key, and wraps a
         // bitwarden legacy encoded symmetric key
         self.to_encoded().encrypt_with_key(&stretched_key)
@@ -43,15 +43,13 @@ impl KeyEncryptable<PinKey, EncString> for &SymmetricCryptoKey {
 
 impl KeyEncryptable<PinKey, EncString> for String {
     fn encrypt_with_key(self, key: &PinKey) -> Result<EncString> {
-        self.encrypt_with_key(&SymmetricCryptoKey::Aes256CbcHmacKey(stretch_key(
-            &key.0.0,
-        )?))
+        self.encrypt_with_key(&SymmetricCryptoKey::Aes256CbcHmacKey(stretch_key(&key.0.0)))
     }
 }
 
 impl KeyDecryptable<PinKey, String> for EncString {
     fn decrypt_with_key(&self, key: &PinKey) -> Result<String> {
-        let stretched_key = SymmetricCryptoKey::Aes256CbcHmacKey(stretch_key(&key.0.0)?);
+        let stretched_key = SymmetricCryptoKey::Aes256CbcHmacKey(stretch_key(&key.0.0));
         self.decrypt_with_key(&stretched_key)
     }
 }

--- a/crates/bitwarden-crypto/src/keys/utils.rs
+++ b/crates/bitwarden-crypto/src/keys/utils.rs
@@ -9,11 +9,12 @@ use crate::{CryptoError, Result, util::hkdf_expand};
 /// Stretch the given key using HKDF.
 /// This can be either a kdf-derived key (PIN/Master password) or
 /// a random key from key connector
-pub(super) fn stretch_key(key: &Pin<Box<GenericArray<u8, U32>>>) -> Result<Aes256CbcHmacKey> {
-    Ok(Aes256CbcHmacKey {
-        enc_key: hkdf_expand(key, Some("enc"))?,
-        mac_key: hkdf_expand(key, Some("mac"))?,
-    })
+pub(super) fn stretch_key(key: &Pin<Box<GenericArray<u8, U32>>>) -> Aes256CbcHmacKey {
+    Aes256CbcHmacKey {
+        // this is safe because the key length is always 32 bytes
+        enc_key: hkdf_expand(key, Some("enc")).expect("HKDF expand to succeed"),
+        mac_key: hkdf_expand(key, Some("mac")).expect("HKDF expand to succeed"),
+    }
 }
 
 /// Pads bytes to a minimum length using PKCS7-like padding.
@@ -58,7 +59,7 @@ mod tests {
             ]
             .into(),
         );
-        let stretched = stretch_key(&key).unwrap();
+        let stretched = stretch_key(&key);
 
         assert_eq!(
             [


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
Cleans up the error handling for HKDF. CryptoError should not be used here. It adds a custom error, and adds expects where we know from the inputs that an error can't happen to simplify the public interface.

## 🚨 Breaking Changes

<!-- Does this PR introduce any breaking changes? If so, please describe the impact and migration path for clients.

If you're unsure, the automated TypeScript compatibility check will run when you open/update this PR and provide feedback.

For breaking changes:
1. Describe what changed in the client interface
2. Explain why the change was necessary
3. Provide migration steps for client developers
4. Link to any paired client PRs if needed

Otherwise, you can remove this section. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation
  team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
