### PR TITLE
[BEEEP] Clean up AES error handling

### DIFF
--- a/crates/bitwarden-crypto/src/enc_string/symmetric.rs
+++ b/crates/bitwarden-crypto/src/enc_string/symmetric.rs
@@ -335,11 +335,13 @@ impl KeyDecryptable<SymmetricCryptoKey, Vec<u8>> for EncString {
         match (self, key) {
             (EncString::Aes256Cbc_B64 { iv, data }, SymmetricCryptoKey::Aes256CbcKey(key)) => {
                 crate::aes::decrypt_aes256(iv, data.clone(), &key.enc_key)
+                    .map_err(|_| CryptoError::Decrypt)
             }
             (
                 EncString::Aes256Cbc_HmacSha256_B64 { iv, mac, data },
                 SymmetricCryptoKey::Aes256CbcHmacKey(key),
-            ) => crate::aes::decrypt_aes256_hmac(iv, mac, data.clone(), &key.mac_key, &key.enc_key),
+            ) => crate::aes::decrypt_aes256_hmac(iv, mac, data.clone(), &key.mac_key, &key.enc_key)
+                .map_err(|_| CryptoError::Decrypt),
             (
                 EncString::Cose_Encrypt0_B64 { data },
                 SymmetricCryptoKey::XChaCha20Poly1305Key(key),

--- a/crates/bitwarden-crypto/src/error.rs
+++ b/crates/bitwarden-crypto/src/error.rs
@@ -12,10 +12,10 @@ use crate::fingerprint::FingerprintError;
 #[bitwarden_error(flat)]
 #[derive(Debug, Error)]
 pub enum CryptoError {
+    #[error("The decryption operation failed")]
+    Decrypt,
     #[error("The provided key is not the expected type")]
     InvalidKey,
-    #[error("The cipher's MAC doesn't match the expected value")]
-    InvalidMac,
     #[error("The key provided expects mac protected encstrings, but the mac is missing")]
     MacNotProvided,
     #[error("Error while decrypting EncString")]

--- a/crates/bitwarden-crypto/src/keys/key_connector_key.rs
+++ b/crates/bitwarden-crypto/src/keys/key_connector_key.rs
@@ -45,7 +45,8 @@ impl KeyConnectorKey {
             // decrypting these old keys.
             EncString::Aes256Cbc_B64 { iv, ref data } => {
                 let legacy_key = Box::pin(GenericArray::clone_from_slice(&self.0));
-                crate::aes::decrypt_aes256(&iv, data.clone(), &legacy_key)?
+                crate::aes::decrypt_aes256(&iv, data.clone(), &legacy_key)
+                    .map_err(|_| CryptoError::Decrypt)?
             }
             EncString::Aes256Cbc_HmacSha256_B64 { .. } => {
                 let stretched_key = SymmetricCryptoKey::Aes256CbcHmacKey(stretch_key(&self.0)?);

--- a/crates/bitwarden-crypto/src/store/context.rs
+++ b/crates/bitwarden-crypto/src/store/context.rs
@@ -214,7 +214,7 @@ impl<Ids: KeyIds> KeyStoreContext<'_, Ids> {
             (EncString::Aes256Cbc_B64 { iv, data }, SymmetricCryptoKey::Aes256CbcKey(key)) => {
                 SymmetricCryptoKey::try_from(&BitwardenLegacyKeyBytes::from(
                     crate::aes::decrypt_aes256(iv, data.clone(), &key.enc_key)
-                        .map_err(|_| CryptoError::KeyDecrypt)?,
+                        .map_err(|_| CryptoError::Decrypt)?,
                 ))?
             }
             (
@@ -222,7 +222,7 @@ impl<Ids: KeyIds> KeyStoreContext<'_, Ids> {
                 SymmetricCryptoKey::Aes256CbcHmacKey(key),
             ) => SymmetricCryptoKey::try_from(&BitwardenLegacyKeyBytes::from(
                 crate::aes::decrypt_aes256_hmac(iv, mac, data.clone(), &key.mac_key, &key.enc_key)
-                    .map_err(|_| CryptoError::KeyDecrypt)?,
+                    .map_err(|_| CryptoError::Decrypt)?,
             ))?,
             (
                 EncString::Cose_Encrypt0_B64 { data },

--- a/crates/bitwarden-vault/src/cipher/cipher_client/mod.rs
+++ b/crates/bitwarden-vault/src/cipher/cipher_client/mod.rs
@@ -570,7 +570,7 @@ mod tests {
         // Decrypting the cipher "normally" will fail because it was encrypted with a new key
         assert!(matches!(
             client.vault().ciphers().decrypt(ctx.cipher).err(),
-            Some(DecryptError::Crypto(CryptoError::InvalidMac))
+            Some(DecryptError::Crypto(CryptoError::Decrypt))
         ));
     }
 }


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
Cleans up the lowest layer of encryption for AES and adds a custom error struct. This pushes up the error one layer. This does expand the crypto error temporarily until the upper layers are reworked too.

## 🚨 Breaking Changes

<!-- Does this PR introduce any breaking changes? If so, please describe the impact and migration path for clients.

If you're unsure, the automated TypeScript compatibility check will run when you open/update this PR and provide feedback.

For breaking changes:
1. Describe what changed in the client interface
2. Explain why the change was necessary
3. Provide migration steps for client developers
4. Link to any paired client PRs if needed

Otherwise, you can remove this section. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation
  team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
