### PR TITLE
[PM-30631] [Proposal] Consolidated interfaces for state

### DIFF
--- a/crates/bitwarden-core/src/platform/state_client.rs
+++ b/crates/bitwarden-core/src/platform/state_client.rs
@@ -46,11 +46,23 @@ impl StateClient {
     }
 
     /// Get a SDK managed state repository for a specific type, if it exists.
-    pub fn get_sdk_managed<
-        T: RepositoryItem + serde::ser::Serialize + serde::de::DeserializeOwned,
-    >(
+    pub fn get_sdk_managed<T: RepositoryItem>(
         &self,
-    ) -> Result<impl Repository<T>, StateRegistryError> {
+    ) -> Result<Arc<dyn Repository<T>>, StateRegistryError> {
         self.client.internal.repository_map.get_sdk_managed()
+    }
+
+    /// Get a repository with fallback: prefer client-managed, fall back to SDK-managed.
+    ///
+    /// This method first attempts to retrieve a client-managed repository. If not registered,
+    /// it falls back to an SDK-managed repository. Both are returned as `Arc<dyn Repository<T>>`.
+    ///
+    /// # Errors
+    /// Returns `StateRegistryError` when neither repository type is available.
+    pub fn get<T>(&self) -> Result<Arc<dyn Repository<T>>, StateRegistryError>
+    where
+        T: RepositoryItem + serde::ser::Serialize + serde::de::DeserializeOwned + 'static,
+    {
+        self.client.internal.repository_map.get()
     }
 }

--- a/crates/bitwarden-core/src/platform/state_client.rs
+++ b/crates/bitwarden-core/src/platform/state_client.rs
@@ -61,7 +61,7 @@ impl StateClient {
     /// Returns `StateRegistryError` when neither repository type is available.
     pub fn get<T>(&self) -> Result<Arc<dyn Repository<T>>, StateRegistryError>
     where
-        T: RepositoryItem + serde::ser::Serialize + serde::de::DeserializeOwned + 'static,
+        T: RepositoryItem,
     {
         self.client.internal.repository_map.get()
     }

--- a/crates/bitwarden-state/README.md
+++ b/crates/bitwarden-state/README.md
@@ -8,9 +8,12 @@ To make use of the `Repository` trait, the first thing to do is to ensure the da
 it is registered to do so:
 
 ```rust
+use serde::{Serialize, Deserialize};
+
+#[derive(Serialize, Deserialize)]
 struct Cipher {
     // Cipher fields
-};
+}
 
 // Register `Cipher` for use with a `Repository`.
 // This should be done in the crate where `Cipher` is defined.

--- a/crates/bitwarden-state/src/repository.rs
+++ b/crates/bitwarden-state/src/repository.rs
@@ -1,5 +1,7 @@
 use std::any::TypeId;
 
+use serde::{Serialize, de::DeserializeOwned};
+
 use crate::registry::RepositoryNotFoundError;
 
 /// An error resulting from operations on a repository.
@@ -39,7 +41,10 @@ pub trait Repository<V: RepositoryItem>: Send + Sync {
 /// This trait is used to mark types that can be stored in a repository.
 /// It should not be implemented manually; instead, users should
 /// use the [crate::register_repository_item] macro to register their item types.
-pub trait RepositoryItem: Internal + Send + Sync + 'static {
+///
+/// All repository items must implement `Serialize` and `DeserializeOwned` to support
+/// SDK-managed repositories that persist items to storage.
+pub trait RepositoryItem: Internal + Serialize + DeserializeOwned + Send + Sync + 'static {
     /// The name of the type implementing this trait.
     const NAME: &'static str;
 
@@ -64,7 +69,7 @@ pub struct RepositoryItemData {
 
 impl RepositoryItemData {
     /// Create a new `RepositoryItemData` from a type that implements `RepositoryItem`.
-    pub fn new<T: RepositoryItem + ?Sized>() -> Self {
+    pub fn new<T: RepositoryItem>() -> Self {
         Self {
             type_id: TypeId::of::<T>(),
             name: T::NAME,

--- a/crates/bitwarden-state/src/sdk_managed/mod.rs
+++ b/crates/bitwarden-state/src/sdk_managed/mod.rs
@@ -1,5 +1,6 @@
+use std::sync::Arc;
+
 use bitwarden_error::bitwarden_error;
-use serde::{de::DeserializeOwned, ser::Serialize};
 use thiserror::Error;
 
 use crate::repository::{Repository, RepositoryError, RepositoryItem, RepositoryMigrations};
@@ -48,25 +49,13 @@ pub trait Database {
     where
         Self: Sized;
 
-    async fn get<T: Serialize + DeserializeOwned + RepositoryItem>(
-        &self,
-        key: &str,
-    ) -> Result<Option<T>, DatabaseError>;
+    async fn get<T: RepositoryItem>(&self, key: &str) -> Result<Option<T>, DatabaseError>;
 
-    async fn list<T: Serialize + DeserializeOwned + RepositoryItem>(
-        &self,
-    ) -> Result<Vec<T>, DatabaseError>;
+    async fn list<T: RepositoryItem>(&self) -> Result<Vec<T>, DatabaseError>;
 
-    async fn set<T: Serialize + DeserializeOwned + RepositoryItem>(
-        &self,
-        key: &str,
-        value: T,
-    ) -> Result<(), DatabaseError>;
+    async fn set<T: RepositoryItem>(&self, key: &str, value: T) -> Result<(), DatabaseError>;
 
-    async fn remove<T: Serialize + DeserializeOwned + RepositoryItem>(
-        &self,
-        key: &str,
-    ) -> Result<(), DatabaseError>;
+    async fn remove<T: RepositoryItem>(&self, key: &str) -> Result<(), DatabaseError>;
 }
 
 struct DBRepository<T: RepositoryItem> {
@@ -75,7 +64,7 @@ struct DBRepository<T: RepositoryItem> {
 }
 
 #[async_trait::async_trait]
-impl<V: RepositoryItem + Serialize + DeserializeOwned> Repository<V> for DBRepository<V> {
+impl<V: RepositoryItem> Repository<V> for DBRepository<V> {
     async fn get(&self, key: String) -> Result<Option<V>, RepositoryError> {
         let value = self.database.get::<V>(&key).await?;
         Ok(value)
@@ -93,12 +82,12 @@ impl<V: RepositoryItem + Serialize + DeserializeOwned> Repository<V> for DBRepos
 }
 
 impl SystemDatabase {
-    pub(super) fn get_repository<V: RepositoryItem + Serialize + DeserializeOwned>(
+    pub(super) fn get_repository<V: RepositoryItem>(
         &self,
-    ) -> Result<impl Repository<V>, DatabaseError> {
-        Ok(DBRepository {
+    ) -> Result<Arc<dyn Repository<V>>, DatabaseError> {
+        Ok(Arc::new(DBRepository {
             database: self.clone(),
             _marker: std::marker::PhantomData,
-        })
+        }))
     }
 }

--- a/crates/bitwarden-wasm-internal/src/platform/repository.rs
+++ b/crates/bitwarden-wasm-internal/src/platform/repository.rs
@@ -37,7 +37,6 @@ use std::{future::Future, marker::PhantomData, rc::Rc};
 
 use bitwarden_state::repository::{Repository, RepositoryError, RepositoryItem};
 use bitwarden_threading::ThreadBoundRunner;
-use serde::{Serialize, de::DeserializeOwned};
 use wasm_bindgen::{JsValue, prelude::wasm_bindgen};
 
 /// This trait defines the methods that a [::wasm_bindgen] repository must implement.
@@ -65,7 +64,7 @@ impl<T, R: WasmRepository<T> + 'static> WasmRepositoryChannel<T, R> {
 }
 
 #[async_trait::async_trait]
-impl<T: RepositoryItem + Serialize + DeserializeOwned, R: WasmRepository<T> + 'static> Repository<T>
+impl<T: RepositoryItem, R: WasmRepository<T> + 'static> Repository<T>
     for WasmRepositoryChannel<T, R>
 {
     async fn get(&self, id: String) -> Result<Option<T>, RepositoryError> {


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-30631
## 📔 Objective

This PR introduces a new `get()` fallback method on `StateRegistry` that automatically tries client-managed repositories first, then falls back to SDK-managed repositories, simplifying repository access patterns throughout the SDK.

Additionally, this PR includes related refactorings to improve code maintainability:
- Changes `get_sdk_managed()` return type to `Arc<dyn Repository<T>>` for better testability
- Consolidates `Serialize + DeserializeOwned` trait bounds into `RepositoryItem` trait definition

### New Feature: StateRegistry.get() Fallback Method

Added `StateRegistry::get<T>()` that automatically handles repository fallback:
- Attempts to retrieve client-managed repository first
- Falls back to SDK-managed repository if not found  
- Returns `StateRegistryError::DatabaseNotInitialized` when neither is available

### Code Improvements

**Return Type Changes:**
- Changed `get_sdk_managed()` from `impl Repository<T>` to `Arc<dyn Repository<T>>`
- Enables easier dependency injection with mock repositories in tests
- Eliminates dereferencing issues when passing repositories to functions

**Trait Simplification:**
- Added `Serialize + DeserializeOwned` bounds directly to `RepositoryItem` trait
- Removed redundant bounds from 7+ method signatures across the codebase
- Single source of truth for serialization requirements

**What changed:** `get_sdk_managed()` now returns `Arc<dyn Repository<T>>` instead of `impl Repository<T>`
## ⏰ Reminders before review

- [x] Contributor guidelines followed
- [x] All formatters and local linters executed and passed
- [x] Written new unit and / or integration tests where applicable
- [x] Protected functional changes with optionality (feature flags) - N/A
- [x] Used internationalization (i18n) for all UI strings - N/A
- [x] CI builds passed - awaiting CI
- [x] Communicated to DevOps any deployment requirements - N/A
- [x] Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team - README.md updated

## 🦮 Reviewer guidelines

- 👍 for great changes
- 📝 for notes or general info
- ❓ for questions
- 🤔 for open inquiry / discussion
- 🎨 for suggestions / improvements
- ❌ or ⚠️ for significant concerns
- 🌱 for future improvements
- ⛏ for nitpicks