### PR TITLE
[PM-30631] Make get_client_managed and get_sdk_managed internal

### DIFF
--- a/crates/bitwarden-core/src/platform/state_client.rs
+++ b/crates/bitwarden-core/src/platform/state_client.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use bitwarden_state::{
     DatabaseConfiguration,
-    registry::{RepositoryNotFoundError, StateRegistryError},
+    registry::StateRegistryError,
     repository::{Repository, RepositoryItem, RepositoryMigrations},
 };
 
@@ -25,13 +25,6 @@ impl StateClient {
             .register_client_managed(store)
     }
 
-    /// Get a client managed state repository for a specific type, if it exists.
-    pub fn get_client_managed<T: RepositoryItem>(
-        &self,
-    ) -> Result<Arc<dyn Repository<T>>, RepositoryNotFoundError> {
-        self.client.internal.repository_map.get_client_managed()
-    }
-
     /// Initialize the database for SDK managed repositories.
     pub async fn initialize_database(
         &self,
@@ -43,13 +36,6 @@ impl StateClient {
             .repository_map
             .initialize_database(configuration, migrations)
             .await
-    }
-
-    /// Get a SDK managed state repository for a specific type, if it exists.
-    pub fn get_sdk_managed<T: RepositoryItem>(
-        &self,
-    ) -> Result<Arc<dyn Repository<T>>, StateRegistryError> {
-        self.client.internal.repository_map.get_sdk_managed()
     }
 
     /// Get a repository with fallback: prefer client-managed, fall back to SDK-managed.

--- a/crates/bitwarden-state/src/repository.rs
+++ b/crates/bitwarden-state/src/repository.rs
@@ -2,7 +2,7 @@ use std::any::TypeId;
 
 use serde::{Serialize, de::DeserializeOwned};
 
-use crate::registry::RepositoryNotFoundError;
+use crate::registry::StateRegistryError;
 
 /// An error resulting from operations on a repository.
 #[derive(thiserror::Error, Debug)]
@@ -19,9 +19,9 @@ pub enum RepositoryError {
     #[error(transparent)]
     Database(#[from] crate::sdk_managed::DatabaseError),
 
-    /// Repository not found.
+    /// State registry error.
     #[error(transparent)]
-    RepositoryNotFound(#[from] RepositoryNotFoundError),
+    StateRegistry(#[from] StateRegistryError),
 }
 
 /// This trait represents a generic repository interface, capable of storing and retrieving

--- a/crates/bitwarden-vault/src/cipher/cipher_client/mod.rs
+++ b/crates/bitwarden-vault/src/cipher/cipher_client/mod.rs
@@ -199,11 +199,7 @@ impl CiphersClient {
 
 impl CiphersClient {
     fn get_repository(&self) -> Result<Arc<dyn Repository<Cipher>>, RepositoryError> {
-        Ok(self
-            .client
-            .platform()
-            .state()
-            .get_client_managed::<Cipher>()?)
+        Ok(self.client.platform().state().get::<Cipher>()?)
     }
 }
 

--- a/crates/bitwarden-vault/src/folder/folder_client.rs
+++ b/crates/bitwarden-vault/src/folder/folder_client.rs
@@ -93,10 +93,6 @@ impl FoldersClient {
 impl FoldersClient {
     /// Helper for getting the repository for folders.
     fn get_repository(&self) -> Result<Arc<dyn Repository<Folder>>, RepositoryError> {
-        Ok(self
-            .client
-            .platform()
-            .state()
-            .get_client_managed::<Folder>()?)
+        Ok(self.client.platform().state().get::<Folder>()?)
     }
 }


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-30631
## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Follow up to #669, removes the public `get_client_managed` and `get_sdk_managed`.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation
  team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
