### PR TITLE
[PM-30802] - fix archived_date for cipher mini response

### DIFF
--- a/crates/bitwarden-api-api/src/models/cipher_mini_details_response_model.rs
+++ b/crates/bitwarden-api-api/src/models/cipher_mini_details_response_model.rs
@@ -133,12 +133,6 @@ pub struct CipherMiniDetailsResponseModel {
     #[serde(rename = "key", alias = "Key", skip_serializing_if = "Option::is_none")]
     pub key: Option<String>,
     #[serde(
-        rename = "archivedDate",
-        alias = "ArchivedDate",
-        skip_serializing_if = "Option::is_none"
-    )]
-    pub archived_date: Option<String>,
-    #[serde(
         rename = "collectionIds",
         alias = "CollectionIds",
         skip_serializing_if = "Option::is_none"
@@ -170,7 +164,6 @@ impl CipherMiniDetailsResponseModel {
             deleted_date: None,
             reprompt: None,
             key: None,
-            archived_date: None,
             collection_ids: None,
         }
     }

--- a/crates/bitwarden-api-api/src/models/cipher_mini_response_model.rs
+++ b/crates/bitwarden-api-api/src/models/cipher_mini_response_model.rs
@@ -132,12 +132,6 @@ pub struct CipherMiniResponseModel {
     pub reprompt: Option<models::CipherRepromptType>,
     #[serde(rename = "key", alias = "Key", skip_serializing_if = "Option::is_none")]
     pub key: Option<String>,
-    #[serde(
-        rename = "archivedDate",
-        alias = "ArchivedDate",
-        skip_serializing_if = "Option::is_none"
-    )]
-    pub archived_date: Option<String>,
 }
 
 impl CipherMiniResponseModel {
@@ -164,7 +158,6 @@ impl CipherMiniResponseModel {
             deleted_date: None,
             reprompt: None,
             key: None,
-            archived_date: None,
         }
     }
 }

--- a/crates/bitwarden-vault/src/cipher/cipher.rs
+++ b/crates/bitwarden-vault/src/cipher/cipher.rs
@@ -1129,11 +1129,7 @@ impl PartialCipher for CipherMiniResponseModel {
             revision_date: require!(self.revision_date)
                 .parse()
                 .map_err(Into::<VaultParseError>::into)?,
-            archived_date: self
-                .archived_date
-                .map(|d| d.parse())
-                .transpose()
-                .map_err(Into::<VaultParseError>::into)?,
+            archived_date: cipher.map_or(Default::default(), |c| c.archived_date),
             folder_id: cipher.map_or(Default::default(), |c| c.folder_id),
             favorite: cipher.map_or(Default::default(), |c| c.favorite),
             edit: cipher.map_or(Default::default(), |c| c.edit),
@@ -1189,17 +1185,13 @@ impl PartialCipher for CipherMiniDetailsResponseModel {
             revision_date: require!(self.revision_date)
                 .parse()
                 .map_err(Into::<VaultParseError>::into)?,
-            archived_date: self
-                .archived_date
-                .map(|d| d.parse())
-                .transpose()
-                .map_err(Into::<VaultParseError>::into)?,
             collection_ids: self
                 .collection_ids
                 .into_iter()
                 .flatten()
                 .map(CollectionId::new)
                 .collect(),
+            archived_date: cipher.map_or(Default::default(), |c| c.archived_date),
             folder_id: cipher.map_or(Default::default(), |c| c.folder_id),
             favorite: cipher.map_or(Default::default(), |c| c.favorite),
             edit: cipher.map_or(Default::default(), |c| c.edit),

--- a/crates/bitwarden-vault/src/cipher/cipher_client/admin/edit.rs
+++ b/crates/bitwarden-vault/src/cipher/cipher_client/admin/edit.rs
@@ -249,7 +249,6 @@ mod tests {
                         password_history: body.password_history,
                         attachments: None,
                         data: None,
-                        archived_date: None,
                     })
                 })
                 .once();

--- a/crates/bitwarden-vault/src/cipher/cipher_client/share_cipher.rs
+++ b/crates/bitwarden-vault/src/cipher/cipher_client/share_cipher.rs
@@ -118,11 +118,10 @@ async fn share_ciphers_bulk(
             revision_date: require!(cipher_mini.revision_date)
                 .parse()
                 .map_err(Into::<VaultParseError>::into)?,
-            archived_date: cipher_mini
-                .archived_date
-                .map(|d| d.parse())
-                .transpose()
-                .map_err(Into::<VaultParseError>::into)?,
+            archived_date: orig_cipher
+                .as_ref()
+                .map(|c| c.archived_date)
+               .unwrap_or_default(),
             edit: orig_cipher.as_ref().map(|c| c.edit).unwrap_or_default(),
             favorite: orig_cipher.as_ref().map(|c| c.favorite).unwrap_or_default(),
             folder_id: orig_cipher

--- a/crates/bitwarden-vault/src/cipher/cipher_client/share_cipher.rs
+++ b/crates/bitwarden-vault/src/cipher/cipher_client/share_cipher.rs
@@ -121,7 +121,7 @@ async fn share_ciphers_bulk(
             archived_date: orig_cipher
                 .as_ref()
                 .map(|c| c.archived_date)
-               .unwrap_or_default(),
+                .unwrap_or_default(),
             edit: orig_cipher.as_ref().map(|c| c.edit).unwrap_or_default(),
             favorite: orig_cipher.as_ref().map(|c| c.favorite).unwrap_or_default(),
             folder_id: orig_cipher


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-30802

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

## 🚨 Breaking Changes

<!-- Does this PR introduce any breaking changes? If so, please describe the impact and migration path for clients.

If you're unsure, the automated TypeScript compatibility check will run when you open/update this PR and provide feedback.

For breaking changes:
1. Describe what changed in the client interface
2. Explain why the change was necessary
3. Provide migration steps for client developers
4. Link to any paired client PRs if needed

Otherwise, you can remove this section. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation
  team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
