### PR TITLE
[PM-27233] Remove `master_key` field from SSO JIT MP account registration

### DIFF
--- a/crates/bitwarden-auth/src/registration.rs
+++ b/crates/bitwarden-auth/src/registration.rs
@@ -446,7 +446,6 @@ async fn internal_post_keys_for_jit_password_registration(
     // mature, the account cryptographic state and keys should be set directly here.
     Ok(JitMasterPasswordRegistrationResponse {
         account_cryptographic_state: registration_crypto_result.account_cryptographic_state,
-        master_key: registration_crypto_result.master_key.to_base64(),
         master_password_unlock: registration_crypto_result.master_password_unlock_data,
         user_key: registration_crypto_result
             .user_key
@@ -469,8 +468,6 @@ pub struct JitMasterPasswordRegistrationResponse {
     pub account_cryptographic_state: WrappedAccountCryptographicState,
     /// The master password unlock data
     pub master_password_unlock: MasterPasswordUnlockData,
-    /// The master key
-    pub master_key: B64,
     /// The decrypted user key.
     pub user_key: B64,
 }

--- a/crates/bitwarden-core/src/key_management/crypto.rs
+++ b/crates/bitwarden-core/src/key_management/crypto.rs
@@ -858,8 +858,6 @@ pub struct MakeJitMasterPasswordRegistrationResponse {
     pub account_cryptographic_state: WrappedAccountCryptographicState,
     /// The user's user key
     pub user_key: SymmetricCryptoKey,
-    /// The user's master key used to encrypt the user key
-    pub master_key: MasterKey,
     /// The master password unlock data
     pub master_password_authentication_data: MasterPasswordAuthenticationData,
     /// The master password unlock data
@@ -997,9 +995,6 @@ pub(crate) fn make_user_jit_master_password_registration(
         MasterPasswordAuthenticationData::derive(&master_password, &kdf, &salt)
             .map_err(MakeKeysError::MasterPasswordDerivation)?;
 
-    let master_key =
-        MasterKey::derive(&master_password, &salt, &kdf).map_err(MakeKeysError::Crypto)?;
-
     let cryptography_state_request_model = wrapped_state
         .to_request_model(&user_key_id, &mut ctx)
         .map_err(|_| MakeKeysError::RequestModelCreation)?;
@@ -1014,7 +1009,6 @@ pub(crate) fn make_user_jit_master_password_registration(
     Ok(MakeJitMasterPasswordRegistrationResponse {
         account_cryptographic_state: wrapped_state,
         user_key,
-        master_key,
         master_password_unlock_data,
         master_password_authentication_data,
         account_keys_request: cryptography_state_request_model,


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-27233

## 📔 Objective

The `master_key` field  from SSO JIT MP account registration, become redundant and is no longer necessary with https://github.com/bitwarden/clients/pull/18222

## 🚨 Breaking Changes

<!-- Does this PR introduce any breaking changes? If so, please describe the impact and migration path for clients.

If you're unsure, the automated TypeScript compatibility check will run when you open/update this PR and provide feedback.

For breaking changes:
1. Describe what changed in the client interface
2. Explain why the change was necessary
3. Provide migration steps for client developers
4. Link to any paired client PRs if needed

Otherwise, you can remove this section. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation
  team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
