### PR TITLE
[PM-30144] Add key rotation impl for account cryptographic state

### DIFF
--- a/crates/bitwarden-core/src/key_management/account_cryptographic_state.rs
+++ b/crates/bitwarden-core/src/key_management/account_cryptographic_state.rs
@@ -278,7 +278,8 @@ impl WrappedAccountCryptographicState {
                 signing_key,
                 security_state,
             } => {
-                // To rotate a V2 state, the private and signing keys are re-encrypted with the new user key.
+                // To rotate a V2 state, the private and signing keys are re-encrypted with the new
+                // user key.
                 // 1. Re-encrypt private key
                 let private_key_id = ctx
                     .unwrap_private_key(*current_user_key, private_key)

--- a/crates/bitwarden-core/src/key_management/account_cryptographic_state.rs
+++ b/crates/bitwarden-core/src/key_management/account_cryptographic_state.rs
@@ -224,7 +224,7 @@ impl WrappedAccountCryptographicState {
         ctx: &mut KeyStoreContext<KeyIds>,
     ) -> Result<(SymmetricKeyId, Self), AccountCryptographyInitializationError> {
         let user_key = ctx.make_symmetric_key(SymmetricKeyAlgorithm::Aes256CbcHmac);
-        let private_key = ctx.make_private_key(PublicKeyEncryptionAlgorithm::RsaOaepSha1)?;
+        let private_key = ctx.make_private_key(PublicKeyEncryptionAlgorithm::RsaOaepSha1);
 
         Ok((
             user_key,
@@ -261,10 +261,7 @@ impl WrappedAccountCryptographicState {
                     .map_err(|_| RotateCryptographyStateError::KeyMissing)?;
 
                 // 2. The signing key is generated
-                let signing_key_id = ctx
-                    .make_signing_key(SignatureAlgorithm::Ed25519)
-                    // Result is removed in https://github.com/bitwarden/sdk-internal/pull/679
-                    .expect("Making signing key cannot fail");
+                let signing_key_id = ctx.make_signing_key(SignatureAlgorithm::Ed25519);
                 let new_signing_key = ctx
                     .wrap_signing_key(*new_user_key, signing_key_id)
                     .map_err(|_| RotateCryptographyStateError::KeyMissing)?;

--- a/crates/bitwarden-core/src/key_management/account_cryptographic_state.rs
+++ b/crates/bitwarden-core/src/key_management/account_cryptographic_state.rs
@@ -19,7 +19,7 @@ use bitwarden_encoding::B64;
 use bitwarden_error::bitwarden_error;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
-use tracing::info;
+use tracing::{info, instrument};
 #[cfg(feature = "wasm")]
 use tsify::Tsify;
 
@@ -63,9 +63,21 @@ impl From<CryptoError> for AccountCryptographyInitializationError {
     }
 }
 
+/// Errors that can occur during rotation of the account cryptographic state.
+#[derive(Debug, Error)]
+#[bitwarden_error(flat)]
+pub enum RotateCryptographyStateError {
+    /// The key is missing from the key store
+    #[error("The provided key is missing from the key store")]
+    KeyMissing,
+    /// The provided data was invalid
+    #[error("The provided data was invalid")]
+    InvalidData,
+}
+
 /// Any keys / cryptographic protection "downstream" from the account symmetric key (user key).
 /// Private keys are protected by the user key.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "uniffi", derive(uniffi::Enum))]
 #[cfg_attr(feature = "wasm", derive(Tsify), tsify(into_wasm_abi, from_wasm_abi))]
 #[allow(clippy::large_enum_variant)]
@@ -91,6 +103,19 @@ pub enum WrappedAccountCryptographicState {
         /// The user's signed security state.
         security_state: SignedSecurityState,
     },
+}
+
+impl std::fmt::Debug for WrappedAccountCryptographicState {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            WrappedAccountCryptographicState::V1 { .. } => f
+                .debug_struct("WrappedAccountCryptographicState::V1")
+                .finish(),
+            WrappedAccountCryptographicState::V2 { .. } => f
+                .debug_struct("WrappedAccountCryptographicState::V2")
+                .finish(),
+        }
+    }
 }
 
 impl WrappedAccountCryptographicState {
@@ -192,6 +217,92 @@ impl WrappedAccountCryptographicState {
                 security_state: signed_security_state,
             },
         ))
+    }
+
+    /// Re-wraps the account cryptographic state with a new user key. If the cryptographic state is
+    /// a V1 state, it gets upgraded to a V2 state
+    #[instrument(skip(self, ctx), err)]
+    pub fn rotate(
+        &self,
+        current_user_key: &SymmetricKeyId,
+        new_user_key: &SymmetricKeyId,
+        user_id: UserId,
+        ctx: &mut KeyStoreContext<KeyIds>,
+    ) -> Result<Self, RotateCryptographyStateError> {
+        match self {
+            WrappedAccountCryptographicState::V1 { private_key } => {
+                // To upgrade a V1 state to a V2 state,
+                // 1. The private key is re-encrypted
+                // 2. The signing key is generated
+                // 3. The public key is signed and
+                // 4. The security state is initialized and signed.
+
+                // 1. Re-encrypt private key
+                let private_key_id = ctx
+                    .unwrap_private_key(*current_user_key, private_key)
+                    .map_err(|_| RotateCryptographyStateError::InvalidData)?;
+                let new_private_key = ctx
+                    .wrap_private_key(*new_user_key, private_key_id)
+                    .map_err(|_| RotateCryptographyStateError::KeyMissing)?;
+
+                // 2. The signing key is generated
+                let signing_key_id = ctx
+                    .make_signing_key(SignatureAlgorithm::Ed25519)
+                    // Result is removed in https://github.com/bitwarden/sdk-internal/pull/679
+                    .expect("Making signing key cannot fail");
+                let new_signing_key = ctx
+                    .wrap_signing_key(*new_user_key, signing_key_id)
+                    .map_err(|_| RotateCryptographyStateError::KeyMissing)?;
+
+                // 3. The public key is signed and
+                let signed_public_key = ctx
+                    .make_signed_public_key(private_key_id, signing_key_id)
+                    .map_err(|_| RotateCryptographyStateError::KeyMissing)?;
+
+                // 4. The security state is initialized and signed.
+                let security_state = SecurityState::initialize_for_user(user_id);
+                let signed_security_state = security_state
+                    .sign(signing_key_id, ctx)
+                    .map_err(|_| RotateCryptographyStateError::KeyMissing)?;
+
+                Ok(WrappedAccountCryptographicState::V2 {
+                    private_key: new_private_key,
+                    signed_public_key: Some(signed_public_key),
+                    signing_key: new_signing_key,
+                    security_state: signed_security_state,
+                })
+            }
+            WrappedAccountCryptographicState::V2 {
+                private_key,
+                signed_public_key,
+                signing_key,
+                security_state,
+            } => {
+                // To rotate a V2 state, the private and signing keys are re-encrypted with the new user key.
+                // 1. Re-encrypt private key
+                let private_key_id = ctx
+                    .unwrap_private_key(*current_user_key, private_key)
+                    .map_err(|_| RotateCryptographyStateError::KeyMissing)?;
+                let new_private_key = ctx
+                    .wrap_private_key(*new_user_key, private_key_id)
+                    .map_err(|_| RotateCryptographyStateError::KeyMissing)?;
+
+                // 2. Re-encrypt signing key
+                let signing_key_id = ctx
+                    .unwrap_signing_key(*current_user_key, signing_key)
+                    .map_err(|_| RotateCryptographyStateError::KeyMissing)?;
+                let new_signing_key = ctx
+                    .wrap_signing_key(*new_user_key, signing_key_id)
+                    .map_err(|_| RotateCryptographyStateError::KeyMissing)?;
+
+                Ok(WrappedAccountCryptographicState::V2 {
+                    private_key: new_private_key,
+                    signed_public_key: signed_public_key.clone(),
+                    signing_key: new_signing_key,
+                    security_state: security_state.clone(),
+                })
+            }
+        }
     }
 
     /// Set the decrypted account cryptographic state to the context's non-local storage.
@@ -514,5 +625,86 @@ mod tests {
         assert!(ctx.has_symmetric_key(SymmetricKeyId::User));
         // But the private key should NOT be set (due to corruption)
         assert!(!ctx.has_asymmetric_key(AsymmetricKeyId::UserPrivateKey));
+    }
+
+    #[test]
+    fn test_rotate_v1_to_v2() {
+        use bitwarden_crypto::SymmetricKeyAlgorithm;
+        // Create a key store and context
+        let store: KeyStore<KeyIds> = KeyStore::default();
+        let mut ctx = store.context_mut();
+
+        // Create a V1-style user key and add to context
+        let user_key = ctx.make_symmetric_key(SymmetricKeyAlgorithm::Aes256CbcHmac);
+        let new_user_key = ctx.make_symmetric_key(SymmetricKeyAlgorithm::Aes256CbcHmac);
+
+        // Make a private key and wrap it with the user key
+        let private_key_id = ctx
+            .make_private_key(PublicKeyEncryptionAlgorithm::RsaOaepSha1)
+            .unwrap();
+        let wrapped_private = ctx.wrap_private_key(user_key, private_key_id).unwrap();
+
+        // Construct the V1 wrapped state
+        let wrapped = WrappedAccountCryptographicState::V1 {
+            private_key: wrapped_private,
+        };
+
+        // Rotate the state
+        let user_id = UserId::new_v4();
+        let rotated = wrapped
+            .rotate(&user_key, &new_user_key, user_id, &mut ctx)
+            .unwrap();
+
+        // Should now be V2
+        match rotated {
+            WrappedAccountCryptographicState::V2 { .. } => {}
+            _ => panic!("Expected V2 after rotation from V1"),
+        }
+    }
+
+    #[test]
+    fn test_rotate_v2() {
+        use bitwarden_crypto::SymmetricKeyAlgorithm;
+        // Create a key store and context
+        let store: KeyStore<KeyIds> = KeyStore::default();
+        let mut ctx = store.context_mut();
+
+        // Create a V2-style user key and add to context
+        let user_key = ctx.make_symmetric_key(SymmetricKeyAlgorithm::XChaCha20Poly1305);
+        let new_user_key = ctx.make_symmetric_key(SymmetricKeyAlgorithm::XChaCha20Poly1305);
+
+        // Make keys
+        let private_key_id = ctx
+            .make_private_key(PublicKeyEncryptionAlgorithm::RsaOaepSha1)
+            .unwrap();
+        let signing_key_id = ctx.make_signing_key(SignatureAlgorithm::Ed25519).unwrap();
+        let signed_public_key = ctx
+            .make_signed_public_key(private_key_id, signing_key_id)
+            .unwrap();
+        let user_id = UserId::new_v4();
+        let security_state = SecurityState::initialize_for_user(user_id);
+        let signed_security_state = security_state.sign(signing_key_id, &mut ctx).unwrap();
+
+        // Wrap the private and signing keys with the user key
+        let wrapped_private = ctx.wrap_private_key(user_key, private_key_id).unwrap();
+        let wrapped_signing = ctx.wrap_signing_key(user_key, signing_key_id).unwrap();
+
+        let wrapped = WrappedAccountCryptographicState::V2 {
+            private_key: wrapped_private,
+            signed_public_key: Some(signed_public_key),
+            signing_key: wrapped_signing,
+            security_state: signed_security_state,
+        };
+
+        // Rotate the state
+        let rotated = wrapped
+            .rotate(&user_key, &new_user_key, user_id, &mut ctx)
+            .unwrap();
+
+        // Should still be V2
+        match rotated {
+            WrappedAccountCryptographicState::V2 { .. } => {}
+            _ => panic!("Expected V2 after rotation from V2"),
+        }
     }
 }

--- a/crates/bitwarden-core/src/key_management/crypto.rs
+++ b/crates/bitwarden-core/src/key_management/crypto.rs
@@ -1726,7 +1726,8 @@ mod tests {
         .unwrap();
 
         #[expect(deprecated)]
-        assert!(get_v2_rotated_account_keys(&client).is_ok());
+        let result = get_v2_rotated_account_keys(&client);
+        assert!(result.is_ok());
     }
 
     #[tokio::test]

--- a/crates/bitwarden-core/src/key_management/crypto.rs
+++ b/crates/bitwarden-core/src/key_management/crypto.rs
@@ -7,6 +7,7 @@
 use std::collections::HashMap;
 
 use bitwarden_api_api::models::AccountKeysRequestModel;
+#[expect(deprecated)]
 use bitwarden_crypto::{
     AsymmetricCryptoKey, AsymmetricPublicCryptoKey, CoseSerializable, CryptoError, DeviceKey,
     EncString, Kdf, KeyConnectorKey, KeyDecryptable, KeyEncryptable, MasterKey,
@@ -724,6 +725,7 @@ pub struct UserCryptoV2KeysResponse {
 /// Creates the user's cryptographic state for v2 users. This includes ensuring signature key pair
 /// is present, a signed public key is present, a security state is present and signed, and the user
 /// key is a Cose key.
+#[deprecated(note = "Use AccountCryptographicState::rotate instead")]
 pub(crate) fn make_v2_keys_for_v1_user(
     client: &Client,
 ) -> Result<UserCryptoV2KeysResponse, StatefulCryptoError> {
@@ -792,6 +794,7 @@ pub(crate) fn make_v2_keys_for_v1_user(
 ///
 /// In the current implementation, it just re-encrypts any existing keys. This function expects a
 /// user to be a v2 user; that is, they have a signing key, a cose user-key, and a private key
+#[deprecated(note = "Use AccountCryptographicState::rotate instead")]
 pub(crate) fn get_v2_rotated_account_keys(
     client: &Client,
 ) -> Result<UserCryptoV2KeysResponse, StatefulCryptoError> {
@@ -817,6 +820,7 @@ pub(crate) fn get_v2_rotated_account_keys(
         // security state is present.
         .ok_or(StatefulCryptoError::MissingSecurityState)?;
 
+    #[expect(deprecated)]
     let rotated_keys = dangerous_get_v2_rotated_account_keys(
         AsymmetricKeyId::UserPrivateKey,
         SigningKeyId::UserSigningKey,

--- a/crates/bitwarden-core/src/key_management/crypto.rs
+++ b/crates/bitwarden-core/src/key_management/crypto.rs
@@ -1605,6 +1605,7 @@ mod tests {
             },
         )
         .unwrap();
+        #[expect(deprecated)]
         let enrollment_response = make_v2_keys_for_v1_user(&client).unwrap();
         let encrypted_userkey_v2 = master_key
             .encrypt_user_key(
@@ -1668,6 +1669,7 @@ mod tests {
         .await
         .unwrap();
 
+        #[expect(deprecated)]
         let result = make_v2_keys_for_v1_user(&client);
         assert!(matches!(
             result,
@@ -1687,6 +1689,7 @@ mod tests {
             .unwrap();
         drop(ctx);
 
+        #[expect(deprecated)]
         let result = get_v2_rotated_account_keys(&client);
         assert!(matches!(
             result,
@@ -1722,6 +1725,7 @@ mod tests {
         .await
         .unwrap();
 
+        #[expect(deprecated)]
         assert!(get_v2_rotated_account_keys(&client).is_ok());
     }
 

--- a/crates/bitwarden-core/src/key_management/crypto_client.rs
+++ b/crates/bitwarden-core/src/key_management/crypto_client.rs
@@ -23,6 +23,7 @@ use crate::key_management::{
         initialize_org_crypto, initialize_user_crypto, make_prf_user_key_set,
     },
 };
+#[expect(deprecated)]
 use crate::{
     Client, UserId,
     client::encryption_settings::EncryptionSettingsError,
@@ -81,6 +82,7 @@ impl CryptoClient {
     pub fn make_keys_for_user_crypto_v2(
         &self,
     ) -> Result<UserCryptoV2KeysResponse, StatefulCryptoError> {
+        #[expect(deprecated)]
         make_v2_keys_for_v1_user(&self.client)
     }
 
@@ -88,6 +90,7 @@ impl CryptoClient {
     pub fn get_v2_rotated_account_keys(
         &self,
     ) -> Result<UserCryptoV2KeysResponse, StatefulCryptoError> {
+        #[expect(deprecated)]
         get_v2_rotated_account_keys(&self.client)
     }
 

--- a/crates/bitwarden-crypto/src/lib.rs
+++ b/crates/bitwarden-crypto/src/lib.rs
@@ -31,6 +31,7 @@ pub use util::{generate_random_alphanumeric, generate_random_bytes, pbkdf2};
 mod wordlist;
 pub use wordlist::EFF_LONG_WORD_LIST;
 mod store;
+#[expect(deprecated)]
 pub use store::{
     KeyStore, KeyStoreContext, RotatedUserKeys, dangerous_get_v2_rotated_account_keys,
 };

--- a/crates/bitwarden-crypto/src/store/context.rs
+++ b/crates/bitwarden-crypto/src/store/context.rs
@@ -855,6 +855,7 @@ impl<Ids: KeyIds> KeyStoreContext<'_, Ids> {
         current_user_private_key_id: Ids::Asymmetric,
         current_user_signing_key_id: Ids::Signing,
     ) -> Result<RotatedUserKeys> {
+        #[expect(deprecated)]
         crate::dangerous_get_v2_rotated_account_keys(
             current_user_private_key_id,
             current_user_signing_key_id,

--- a/crates/bitwarden-crypto/src/store/key_rotation.rs
+++ b/crates/bitwarden-crypto/src/store/key_rotation.rs
@@ -21,6 +21,7 @@ pub struct RotatedUserKeys {
 }
 
 /// Generates a new user key and re-encrypts the current private and signing keys with it.
+#[deprecated(note = "Use AccountCryptographicState::rotate instead")]
 pub fn dangerous_get_v2_rotated_account_keys<Ids: KeyIds>(
     current_user_private_key_id: Ids::Asymmetric,
     current_user_signing_key_id: Ids::Signing,

--- a/crates/bitwarden-crypto/src/store/key_rotation.rs
+++ b/crates/bitwarden-crypto/src/store/key_rotation.rs
@@ -65,6 +65,7 @@ mod tests {
         let current_user_private_key_id = ctx.make_asymmetric_key().unwrap();
 
         // Get the rotated account keys
+        #[expect(deprecated)]
         let rotated_keys = dangerous_get_v2_rotated_account_keys(
             current_user_private_key_id,
             current_user_signing_key_id,


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-30144

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
Adds a key-rotation impl for the account cryptography state. Deprecates the old functions, which will be removed after the SDK key rotation has been rolled out and TS key rotation can be removed.

## 🚨 Breaking Changes

<!-- Does this PR introduce any breaking changes? If so, please describe the impact and migration path for clients.

If you're unsure, the automated TypeScript compatibility check will run when you open/update this PR and provide feedback.

For breaking changes:
1. Describe what changed in the client interface
2. Explain why the change was necessary
3. Provide migration steps for client developers
4. Link to any paired client PRs if needed

Otherwise, you can remove this section. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation
  team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
