### PR TITLE
[PM-30144] Add tests for account cryptographic state rotation

### DIFF
--- a/crates/bitwarden-core/src/key_management/account_cryptographic_state.rs
+++ b/crates/bitwarden-core/src/key_management/account_cryptographic_state.rs
@@ -671,7 +671,7 @@ mod tests {
         // 1. The new state is valid and can be set to context
         match rotated_state {
             WrappedAccountCryptographicState::V2 { .. } => {}
-            _ => panic!("Expected V2 after rotation from V2"),
+            _ => panic!("Expected V2 after rotation from V1"),
         }
         let store_2 = KeyStore::<KeyIds>::default();
         let mut ctx_2 = store_2.context_mut();

--- a/crates/bitwarden-core/src/key_management/account_cryptographic_state.rs
+++ b/crates/bitwarden-core/src/key_management/account_cryptographic_state.rs
@@ -654,7 +654,8 @@ mod tests {
             .set_to_context(&RwLock::new(None), old_user_key_id, &store, ctx)
             .unwrap();
 
-        // The previous context got consumed, so we are creating a new one here. Setting the state to context persisted the user-key and other keys
+        // The previous context got consumed, so we are creating a new one here. Setting the state
+        // to context persisted the user-key and other keys
         let mut ctx = store.context_mut();
         let new_user_key_id = ctx.add_local_symmetric_key(new_user_key_owned.clone());
 
@@ -715,7 +716,8 @@ mod tests {
             .set_to_context(&RwLock::new(None), old_user_key_id, &store, ctx)
             .unwrap();
 
-        // The previous context got consumed, so we are creating a new one here. Setting the state to context persisted the user-key and other keys
+        // The previous context got consumed, so we are creating a new one here. Setting the state
+        // to context persisted the user-key and other keys
         let mut ctx = store.context_mut();
         let new_user_key_id = ctx.add_local_symmetric_key(new_user_key_owned.clone());
 


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-30144

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

## 🚨 Breaking Changes

<!-- Does this PR introduce any breaking changes? If so, please describe the impact and migration path for clients.

If you're unsure, the automated TypeScript compatibility check will run when you open/update this PR and provide feedback.

For breaking changes:
1. Describe what changed in the client interface
2. Explain why the change was necessary
3. Provide migration steps for client developers
4. Link to any paired client PRs if needed

Otherwise, you can remove this section. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation
  team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
