### PR TITLE
feat(sso): add ServerCommunicationConfigClient for SSO cookie management

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -877,6 +877,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "bitwarden-server-communication-config"
+version = "2.0.0"
+dependencies = [
+ "bitwarden-error",
+ "bitwarden-threading",
+ "js-sys",
+ "serde",
+ "serde-wasm-bindgen",
+ "serde_json",
+ "thiserror 1.0.69",
+ "tokio",
+ "tsify",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+]
+
+[[package]]
 name = "bitwarden-sm"
 version = "2.0.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ bitwarden-ipc = { path = "crates/bitwarden-ipc", version = "=2.0.0" }
 bitwarden-pm = { path = "crates/bitwarden-pm", version = "=2.0.0" }
 bitwarden-policies = { path = "crates/bitwarden-policies", version = "=2.0.0" }
 bitwarden-send = { path = "crates/bitwarden-send", version = "=2.0.0" }
+bitwarden-server-communication-config = { path = "crates/bitwarden-server-communication-config", version = "=2.0.0" }
 bitwarden-sm = { path = "bitwarden_license/bitwarden-sm", version = "=2.0.0" }
 bitwarden-ssh = { path = "crates/bitwarden-ssh", version = "=2.0.0" }
 bitwarden-state = { path = "crates/bitwarden-state", version = "=2.0.0" }

--- a/crates/bitwarden-server-communication-config/CLAUDE.md
+++ b/crates/bitwarden-server-communication-config/CLAUDE.md
@@ -1,0 +1,267 @@
+# bitwarden-server-communication-config - Claude Code Configuration
+
+Storage abstraction for server communication configuration, specifically SSO load balancer cookies
+for self-hosted environments requiring session affinity.
+
+## Overview
+
+### What This Crate Does
+
+- Provides data structures and repository pattern for storing per-hostname server communication
+  settings
+- Manages SSO cookie configuration for load balancers that require session affinity
+- Exposes WASM bindings for TypeScript integration via State Provider
+
+### Key Concepts
+
+- **Repository Pattern**: Storage abstraction allowing TypeScript to implement via State Provider
+  while Rust provides business logic
+- **Bootstrap Configuration**: Two modes - `Direct` (standard connection) or `SsoCookieVendor`
+  (requires SSO cookie for load balancer)
+- **Hostname-Keyed Storage**: Configuration stored per vault hostname (e.g., "vault.acme.com"), not
+  full URLs
+- **Thread-Safe WASM**: `ThreadBoundRunner` pins JavaScript repository calls to main thread for
+  browser safety
+
+---
+
+## Architecture & Patterns
+
+### System Architecture
+
+```
+TypeScript Client (Desktop/Mobile)
+         ↓
+   WASM Bindings (JsServerCommunicationConfigClient)
+         ↓
+   ┌────────────────────────────────────────┐
+   │ ServerCommunicationConfigClient<R>     │
+   │  ├─ get_config(hostname) → Config      │
+   │  ├─ needs_bootstrap(hostname) → bool   │
+   │  └─ cookies(hostname) → Vec<(K,V)>     │
+   └────────────────────────────────────────┘
+         ↓
+   ┌────────────────────────────────────────┐
+   │ ServerCommunicationConfigRepository    │
+   │  ├─ get(hostname) → Option<Config>     │
+   │  └─ save(hostname, config)             │
+   └────────────────────────────────────────┘
+         ↓
+   TypeScript State Provider (implements repo)
+```
+
+### Code Organization
+
+```
+src/
+├── lib.rs              # Public re-exports
+├── config.rs           # Data structures (ServerCommunicationConfig, BootstrapConfig)
+├── repository.rs       # Repository trait and error types
+├── client.rs           # Client business logic
+└── wasm/               # WASM-only bindings (feature-gated)
+    ├── mod.rs          # WASM module re-exports
+    ├── client.rs       # JsServerCommunicationConfigClient wrapper
+    └── js_repository.rs # ThreadBoundRunner-wrapped repository
+```
+
+### Key Principles
+
+1. **Security First**: Cookie values are sensitive authentication tokens - never log, debug print,
+   or expose in errors
+2. **Graceful Degradation**: Methods return safe defaults (empty cookies, `Direct` mode) on errors
+   rather than panicking
+3. **Caller Validation**: This crate does NOT validate hostnames - caller responsibility to ensure
+   safe inputs
+
+### Core Patterns
+
+#### Repository Pattern
+
+**Purpose**: Abstracts storage to allow TypeScript implementation via State Provider while Rust
+provides business logic
+
+**Implementation**:
+
+```rust
+pub trait ServerCommunicationConfigRepository: Send + Sync + 'static {
+    type GetError: std::fmt::Debug + Send + Sync + 'static;
+    type SaveError: std::fmt::Debug + Send + Sync + 'static;
+
+    async fn get(&self, hostname: String)
+        -> Result<Option<ServerCommunicationConfig>, Self::GetError>;
+
+    async fn save(&self, hostname: String, config: ServerCommunicationConfig)
+        -> Result<(), Self::SaveError>;
+}
+```
+
+**Usage**:
+
+```rust
+// In tests: Use mock repository
+let repo = Arc::new(MockRepository::default());
+let client = ServerCommunicationConfigClient::new(repo);
+
+// In WASM: TypeScript implements repository
+let js_repo = JsServerCommunicationConfigRepository::new(raw_js_repo);
+let client = ServerCommunicationConfigClient::new(Arc::new(js_repo));
+```
+
+#### Tagged Enum Serialization
+
+**Purpose**: Type-safe configuration variants with language-neutral JSON representation
+
+**Implementation**:
+
+```rust
+#[derive(Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum BootstrapConfig {
+    Direct,                              // {"type": "direct"}
+    SsoCookieVendor(SsoCookieVendorConfig), // {"type": "sso_cookie_vendor", ...}
+}
+```
+
+**Usage**:
+
+```rust
+// Direct mode - no special handling
+let config = ServerCommunicationConfig {
+    bootstrap: BootstrapConfig::Direct,
+};
+
+// SSO cookie vendor mode
+let config = ServerCommunicationConfig {
+    bootstrap: BootstrapConfig::SsoCookieVendor(SsoCookieVendorConfig {
+        idp_login_url: "https://idp.example.com/login".to_string(),
+        cookie_name: "ALBAuthSessionCookie".to_string(),
+        cookie_domain: "vault.example.com".to_string(),
+        cookie_value: None, // Populated after bootstrap
+    }),
+};
+```
+
+#### ThreadBoundRunner for WASM Safety
+
+**Purpose**: Ensures JavaScript repository calls execute on main thread (required in browsers)
+
+**Implementation**:
+
+```rust
+pub struct JsServerCommunicationConfigRepository(
+    ThreadBoundRunner<RawJsServerCommunicationConfigRepository>,
+);
+
+impl ServerCommunicationConfigRepository for JsServerCommunicationConfigRepository {
+    async fn get(&self, hostname: String) -> Result<Option<ServerCommunicationConfig>, String> {
+        self.0.run_in_thread(move |repo| async move {
+            let js_value = repo.get(hostname).await.map_err(|e| format!("{e:?}"))?;
+
+            if js_value.is_undefined() || js_value.is_null() {
+                return Ok(None);
+            }
+
+            Ok(Some(serde_wasm_bindgen::from_value(js_value).map_err(|e| e.to_string())?))
+        }).await.map_err(|e| e.to_string())?
+    }
+
+    // save() follows same pattern
+}
+```
+
+---
+
+## Data Models
+
+### Core Types
+
+```rust
+/// Root configuration per hostname
+pub struct ServerCommunicationConfig {
+    pub bootstrap: BootstrapConfig,
+}
+
+/// Bootstrap configuration variants
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum BootstrapConfig {
+    /// Standard direct connection (no special handling)
+    Direct,
+
+    /// SSO cookie vendor configuration for load balancer authentication
+    SsoCookieVendor(SsoCookieVendorConfig),
+}
+
+/// SSO cookie configuration from server /api/config endpoint
+pub struct SsoCookieVendorConfig {
+    /// IDP login URL for browser redirect
+    pub idp_login_url: String,
+
+    /// Cookie name (e.g., "ALBAuthSessionCookie")
+    pub cookie_name: String,
+
+    /// Cookie domain for validation
+    pub cookie_domain: String,
+
+    /// Cookie value (populated after bootstrap flow)
+    pub cookie_value: Option<String>,
+}
+```
+
+### Error Types
+
+```rust
+#[derive(Debug, Error, Clone, PartialEq, Eq)]
+#[bitwarden_error(flat)]
+pub enum ServerCommunicationConfigRepositoryError {
+    #[error("Failed to get configuration: {0}")]
+    GetError(String),
+
+    #[error("Failed to save configuration: {0}")]
+    SaveError(String),
+}
+```
+
+---
+
+## Security & Configuration
+
+### Security Rules
+
+**MANDATORY - These rules have no exceptions:**
+
+1. **Never Log Cookie Values**: Cookie values in `SsoCookieVendorConfig.cookie_value` are sensitive
+   authentication tokens. They must NEVER appear in logs, error messages, debug output, traces, or
+   test failures. Use redacted strings in assertions.
+
+2. **Use Constant-Time Equality**: When comparing sensitive data (cookies, tokens), use
+   `bitwarden_crypto::constant_time_eq()` to prevent timing attacks. Never use `==` for sensitive
+   comparisons.
+
+3. **Generic Error Messages**: Repository implementations must not expose sensitive data, internal
+   paths, or implementation details in error messages. Return generic descriptions only.
+
+4. **No Hostname Validation**: This crate does NOT validate or sanitize hostnames. Callers are
+   responsible for ensuring hostnames are safe before passing them to the repository.
+
+### Authentication & Authorization
+
+This crate stores authentication configuration but does not perform authentication itself:
+
+- **Cookie Storage**: Stores SSO cookie configuration received from server
+- **Cookie Retrieval**: Provides cookies for HTTP client middleware to attach to requests
+- **Bootstrap Detection**: Determines if cookie acquisition flow is needed
+
+---
+
+## References
+
+### Official Documentation
+
+- [Bitwarden SDK Architecture](https://contributing.bitwarden.com/architecture/sdk/)
+
+### Internal Documentation
+
+- [Root CLAUDE.md](../../CLAUDE.md) - SDK-wide architectural patterns
+- [README.md](./README.md) - Crate architecture and usage
+- [bitwarden-ipc/CLAUDE.md](../bitwarden-ipc/CLAUDE.md) - Repository pattern origin
+- [bitwarden-threading/CLAUDE.md](../bitwarden-threading/CLAUDE.md) - ThreadBoundRunner details

--- a/crates/bitwarden-server-communication-config/Cargo.toml
+++ b/crates/bitwarden-server-communication-config/Cargo.toml
@@ -1,0 +1,39 @@
+[package]
+name = "bitwarden-server-communication-config"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+homepage.workspace = true
+repository.workspace = true
+license-file.workspace = true
+keywords.workspace = true
+
+[features]
+wasm = [
+    "dep:tsify",
+    "dep:wasm-bindgen",
+    "dep:wasm-bindgen-futures",
+    "dep:js-sys",
+    "dep:serde-wasm-bindgen",
+    "bitwarden-error/wasm",
+    "bitwarden-threading/wasm",
+] # WASM support
+
+[dependencies]
+bitwarden-error = { workspace = true }
+bitwarden-threading = { workspace = true }
+js-sys = { workspace = true, optional = true }
+serde = { workspace = true }
+serde-wasm-bindgen = { workspace = true, optional = true }
+thiserror = { workspace = true }
+tokio = { workspace = true, features = ["sync"] }
+tsify = { workspace = true, optional = true }
+wasm-bindgen = { workspace = true, optional = true }
+wasm-bindgen-futures = { workspace = true, optional = true }
+
+[dev-dependencies]
+serde_json = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/bitwarden-server-communication-config/README.md
+++ b/crates/bitwarden-server-communication-config/README.md
@@ -1,0 +1,65 @@
+# bitwarden-server-communication-config
+
+Server communication configuration management for the Bitwarden SDK.
+
+## Overview
+
+This crate provides storage and client abstractions for managing _external_ (not `bitwarden/server`)
+server communication settings, particularly for environments that require load balancer session
+affinity through SSO cookie authentication.
+
+In self-hosted deployments with load balancers that perform SSO authentication, Browser and Web
+clients naturally inherit cookies from the browser's cookie store. However, Desktop and Mobile
+clients require explicit cookie management to maintain session affinity across requests.
+
+## Relationship to Environment Configuration
+
+This crate manages **connection-level** configuration (per-hostname cookie requirements), which is
+distinct from `bitwarden-core`s **environment-level** configuration (what are my server urls). These
+names may be easily confused but serve separate purposes. Chances are if you're reading this you're
+looking for `client_settings.rs` or similar 🙂
+
+## Architecture
+
+The crate follows the architecture pattern of other foundation layer SDK exports:
+
+- **`ServerCommunicationConfig`**: Data structures for bootstrap configuration and SSO cookie
+  settings
+- **`ServerCommunicationConfigRepository`**: Storage abstraction trait for WASM interop with
+  TypeScript
+- **`ServerCommunicationConfigClient`**: High-level client for retrieving configuration and cookies
+  by hostname
+
+### Data Model
+
+Configuration is stored per-hostname and supports two bootstrap modes:
+
+1. **Direct**: Standard direct connection (no special cookies required)
+2. **SSO Cookie Vendor**: Load balancer requires SSO authentication cookies for session affinity
+
+## Usage
+
+The SDK client is instantiated by TypeScript with a State Provider-backed repository:
+
+```typescript
+import { ServerCommunicationConfigClient } from "@bitwarden/sdk-internal";
+
+// State Provider provides the repository implementation
+const repository = stateProvider.getGlobal(ServerCommunicationConfig);
+const client = new ServerCommunicationConfigClient(repository);
+
+// Check if bootstrap is needed
+await client.needsBootstrap("vault.example.com");
+
+// Get cookies for HTTP requests
+await client.cookies("vault.example.com");
+```
+
+## Features
+
+- `wasm`: Enables WebAssembly bindings for TypeScript integration
+
+## Non-Goals
+
+- General-purpose cookie jar implementation (only manages specific SSO cookies)
+- Environment management (handled by environment configuration)

--- a/crates/bitwarden-server-communication-config/src/client.rs
+++ b/crates/bitwarden-server-communication-config/src/client.rs
@@ -1,0 +1,275 @@
+use std::sync::Arc;
+
+use crate::{BootstrapConfig, ServerCommunicationConfig, ServerCommunicationConfigRepository};
+
+/// Server communication configuration client
+pub struct ServerCommunicationConfigClient<R>
+where
+    R: ServerCommunicationConfigRepository,
+{
+    repository: Arc<R>,
+}
+
+impl<R> ServerCommunicationConfigClient<R>
+where
+    R: ServerCommunicationConfigRepository,
+{
+    /// Creates a new server communication configuration client
+    ///
+    /// # Arguments
+    ///
+    /// * `repository` - Repository implementation for storing configuration
+    pub fn new(repository: Arc<R>) -> Self {
+        Self { repository }
+    }
+
+    /// Retrieves the server communication configuration for a hostname
+    pub async fn get_config(
+        &self,
+        hostname: String,
+    ) -> Result<ServerCommunicationConfig, R::GetError> {
+        Ok(self
+            .repository
+            .get(hostname)
+            .await?
+            .unwrap_or(ServerCommunicationConfig {
+                bootstrap: BootstrapConfig::Direct,
+            }))
+    }
+
+    /// Determines if cookie bootstrapping is needed for this hostname
+    pub async fn needs_bootstrap(&self, hostname: String) -> bool {
+        if let Ok(Some(config)) = self.repository.get(hostname).await {
+            if let BootstrapConfig::SsoCookieVendor(vendor_config) = config.bootstrap {
+                return vendor_config.cookie_value.is_none();
+            }
+        }
+        false
+    }
+
+    /// Returns cookies to include in HTTP requests
+    pub async fn cookies(&self, hostname: String) -> Vec<(String, String)> {
+        if let Ok(Some(config)) = self.repository.get(hostname).await {
+            if let BootstrapConfig::SsoCookieVendor(vendor_config) = config.bootstrap {
+                if let Some(cookie_value) = vendor_config.cookie_value {
+                    return vec![(vendor_config.cookie_name, cookie_value)];
+                }
+            }
+        }
+        Vec::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use tokio::sync::RwLock;
+
+    use super::*;
+    use crate::SsoCookieVendorConfig;
+
+    /// Mock in-memory repository for testing
+    #[derive(Default, Clone)]
+    struct MockRepository {
+        storage: Arc<RwLock<HashMap<String, ServerCommunicationConfig>>>,
+    }
+
+    impl ServerCommunicationConfigRepository for MockRepository {
+        type GetError = ();
+        type SaveError = ();
+
+        async fn get(&self, hostname: String) -> Result<Option<ServerCommunicationConfig>, ()> {
+            Ok(self.storage.read().await.get(&hostname).cloned())
+        }
+
+        async fn save(
+            &self,
+            hostname: String,
+            config: ServerCommunicationConfig,
+        ) -> Result<(), ()> {
+            self.storage.write().await.insert(hostname, config);
+            Ok(())
+        }
+    }
+
+    #[tokio::test]
+    async fn get_config_returns_direct_when_not_found() {
+        let repo = Arc::new(MockRepository::default());
+        let client = ServerCommunicationConfigClient::new(repo);
+
+        let config = client
+            .get_config("vault.example.com".to_string())
+            .await
+            .unwrap();
+
+        assert!(matches!(config.bootstrap, BootstrapConfig::Direct));
+    }
+
+    #[tokio::test]
+    async fn get_config_returns_saved_config() {
+        let repo = Arc::new(MockRepository::default());
+        let config = ServerCommunicationConfig {
+            bootstrap: BootstrapConfig::SsoCookieVendor(SsoCookieVendorConfig {
+                idp_login_url: "https://example.com".to_string(),
+                cookie_name: "TestCookie".to_string(),
+                cookie_domain: "example.com".to_string(),
+                cookie_value: Some("value123".to_string()),
+            }),
+        };
+
+        repo.save("vault.example.com".to_string(), config.clone())
+            .await
+            .unwrap();
+
+        let client = ServerCommunicationConfigClient::new(repo);
+        let retrieved = client
+            .get_config("vault.example.com".to_string())
+            .await
+            .unwrap();
+
+        assert!(matches!(
+            retrieved.bootstrap,
+            BootstrapConfig::SsoCookieVendor(_)
+        ));
+    }
+
+    #[tokio::test]
+    async fn needs_bootstrap_true_when_cookie_missing() {
+        let repo = Arc::new(MockRepository::default());
+        let config = ServerCommunicationConfig {
+            bootstrap: BootstrapConfig::SsoCookieVendor(SsoCookieVendorConfig {
+                idp_login_url: "https://example.com".to_string(),
+                cookie_name: "TestCookie".to_string(),
+                cookie_domain: "example.com".to_string(),
+                cookie_value: None,
+            }),
+        };
+
+        repo.save("vault.example.com".to_string(), config)
+            .await
+            .unwrap();
+
+        let client = ServerCommunicationConfigClient::new(repo);
+        assert!(
+            client
+                .needs_bootstrap("vault.example.com".to_string())
+                .await
+        );
+    }
+
+    #[tokio::test]
+    async fn needs_bootstrap_false_when_cookie_present() {
+        let repo = Arc::new(MockRepository::default());
+        let config = ServerCommunicationConfig {
+            bootstrap: BootstrapConfig::SsoCookieVendor(SsoCookieVendorConfig {
+                idp_login_url: "https://example.com".to_string(),
+                cookie_name: "TestCookie".to_string(),
+                cookie_domain: "example.com".to_string(),
+                cookie_value: Some("value123".to_string()),
+            }),
+        };
+
+        repo.save("vault.example.com".to_string(), config)
+            .await
+            .unwrap();
+
+        let client = ServerCommunicationConfigClient::new(repo);
+        assert!(
+            !client
+                .needs_bootstrap("vault.example.com".to_string())
+                .await
+        );
+    }
+
+    #[tokio::test]
+    async fn needs_bootstrap_false_for_direct() {
+        let repo = Arc::new(MockRepository::default());
+        let config = ServerCommunicationConfig {
+            bootstrap: BootstrapConfig::Direct,
+        };
+
+        repo.save("vault.example.com".to_string(), config)
+            .await
+            .unwrap();
+
+        let client = ServerCommunicationConfigClient::new(repo);
+        assert!(
+            !client
+                .needs_bootstrap("vault.example.com".to_string())
+                .await
+        );
+    }
+
+    #[tokio::test]
+    async fn cookies_returns_empty_for_direct() {
+        let repo = Arc::new(MockRepository::default());
+        let config = ServerCommunicationConfig {
+            bootstrap: BootstrapConfig::Direct,
+        };
+
+        repo.save("vault.example.com".to_string(), config)
+            .await
+            .unwrap();
+
+        let client = ServerCommunicationConfigClient::new(repo);
+        let cookies = client.cookies("vault.example.com".to_string()).await;
+
+        assert!(cookies.is_empty());
+    }
+
+    #[tokio::test]
+    async fn cookies_returns_empty_when_value_none() {
+        let repo = Arc::new(MockRepository::default());
+        let config = ServerCommunicationConfig {
+            bootstrap: BootstrapConfig::SsoCookieVendor(SsoCookieVendorConfig {
+                idp_login_url: "https://example.com".to_string(),
+                cookie_name: "TestCookie".to_string(),
+                cookie_domain: "example.com".to_string(),
+                cookie_value: None,
+            }),
+        };
+
+        repo.save("vault.example.com".to_string(), config)
+            .await
+            .unwrap();
+
+        let client = ServerCommunicationConfigClient::new(repo);
+        let cookies = client.cookies("vault.example.com".to_string()).await;
+
+        assert!(cookies.is_empty());
+    }
+
+    #[tokio::test]
+    async fn cookies_returns_cookie_when_present() {
+        let repo = Arc::new(MockRepository::default());
+        let config = ServerCommunicationConfig {
+            bootstrap: BootstrapConfig::SsoCookieVendor(SsoCookieVendorConfig {
+                idp_login_url: "https://example.com".to_string(),
+                cookie_name: "AELBAuthSessionCookie".to_string(),
+                cookie_domain: "example.com".to_string(),
+                cookie_value: Some("eyJhbGciOiJFUzI1NiIsImtpZCI6Im...".to_string()),
+            }),
+        };
+
+        repo.save("vault.example.com".to_string(), config)
+            .await
+            .unwrap();
+
+        let client = ServerCommunicationConfigClient::new(repo);
+        let cookies = client.cookies("vault.example.com".to_string()).await;
+
+        assert_eq!(cookies.len(), 1);
+        assert_eq!(cookies[0].0, "AELBAuthSessionCookie");
+        assert_eq!(cookies[0].1, "eyJhbGciOiJFUzI1NiIsImtpZCI6Im...");
+    }
+
+    #[tokio::test]
+    async fn cookies_returns_empty_when_no_config() {
+        let repo = Arc::new(MockRepository::default());
+        let client = ServerCommunicationConfigClient::new(repo);
+        let cookies = client.cookies("vault.example.com".to_string()).await;
+
+        assert!(cookies.is_empty());
+    }
+}

--- a/crates/bitwarden-server-communication-config/src/config.rs
+++ b/crates/bitwarden-server-communication-config/src/config.rs
@@ -2,8 +2,11 @@ use serde::{Deserialize, Serialize};
 
 /// Server communication configuration
 #[derive(Debug, Clone, Serialize, Deserialize)]
-#[cfg_attr(feature = "wasm", derive(tsify::Tsify))]
-#[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
+#[cfg_attr(
+    feature = "wasm",
+    derive(tsify::Tsify),
+    tsify(into_wasm_abi, from_wasm_abi)
+)]
 pub struct ServerCommunicationConfig {
     /// Bootstrap configuration determining how to establish server communication
     pub bootstrap: BootstrapConfig,
@@ -11,8 +14,11 @@ pub struct ServerCommunicationConfig {
 
 /// Bootstrap configuration for server communication
 #[derive(Debug, Clone, Serialize, Deserialize)]
-#[cfg_attr(feature = "wasm", derive(tsify::Tsify))]
-#[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
+#[cfg_attr(
+    feature = "wasm",
+    derive(tsify::Tsify),
+    tsify(into_wasm_abi, from_wasm_abi)
+)]
 #[serde(tag = "type", rename_all = "camelCase")]
 pub enum BootstrapConfig {
     /// Direct connection with no special authentication requirements
@@ -25,8 +31,11 @@ pub enum BootstrapConfig {
 ///
 /// This configuration is provided by the server.
 #[derive(Clone, Serialize, Deserialize)]
-#[cfg_attr(feature = "wasm", derive(tsify::Tsify))]
-#[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
+#[cfg_attr(
+    feature = "wasm",
+    derive(tsify::Tsify),
+    tsify(into_wasm_abi, from_wasm_abi)
+)]
 pub struct SsoCookieVendorConfig {
     /// Identity provider login URL for browser redirect during bootstrap
     pub idp_login_url: String,

--- a/crates/bitwarden-server-communication-config/src/config.rs
+++ b/crates/bitwarden-server-communication-config/src/config.rs
@@ -1,0 +1,167 @@
+use serde::{Deserialize, Serialize};
+
+/// Server communication configuration
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "wasm", derive(tsify::Tsify))]
+#[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
+pub struct ServerCommunicationConfig {
+    /// Bootstrap configuration determining how to establish server communication
+    pub bootstrap: BootstrapConfig,
+}
+
+/// Bootstrap configuration for server communication
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "wasm", derive(tsify::Tsify))]
+#[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
+#[serde(tag = "type", rename_all = "camelCase")]
+pub enum BootstrapConfig {
+    /// Direct connection with no special authentication requirements
+    Direct,
+    /// SSO cookie vendor configuration for load balancer authentication
+    SsoCookieVendor(SsoCookieVendorConfig),
+}
+
+/// SSO cookie vendor configuration
+///
+/// This configuration is provided by the server.
+#[derive(Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "wasm", derive(tsify::Tsify))]
+#[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
+pub struct SsoCookieVendorConfig {
+    /// Identity provider login URL for browser redirect during bootstrap
+    pub idp_login_url: String,
+    /// Cookie name
+    pub cookie_name: String,
+    /// Cookie domain for validation
+    pub cookie_domain: String,
+    /// Cookie value
+    pub cookie_value: Option<String>,
+}
+
+// We manually implement Debug to make sure we don't print sensitive cookie values
+impl std::fmt::Debug for SsoCookieVendorConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SsoCookieVendorConfig")
+            .field("idp_login_url", &self.idp_login_url)
+            .field("cookie_name", &self.cookie_name)
+            .field("cookie_domain", &self.cookie_domain)
+            .field("cookie_value", &"[REDACTED]")
+            .finish()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn direct_bootstrap_serialization() {
+        let config = ServerCommunicationConfig {
+            bootstrap: BootstrapConfig::Direct,
+        };
+
+        let json = serde_json::to_string(&config).unwrap();
+        assert!(json.contains("\"type\":\"direct\""));
+
+        let deserialized: ServerCommunicationConfig = serde_json::from_str(&json).unwrap();
+        assert!(matches!(deserialized.bootstrap, BootstrapConfig::Direct));
+    }
+
+    #[test]
+    fn sso_cookie_vendor_serialization() {
+        let config = ServerCommunicationConfig {
+            bootstrap: BootstrapConfig::SsoCookieVendor(SsoCookieVendorConfig {
+                idp_login_url: "https://timeloop-auth.acme.com/login".to_string(),
+                cookie_name: "ALBAuthSessionCookie".to_string(),
+                cookie_domain: "vault.example.com".to_string(),
+                cookie_value: None,
+            }),
+        };
+
+        let json = serde_json::to_string(&config).unwrap();
+        assert!(json.contains("\"type\":\"ssoCookieVendor\""));
+        assert!(json.contains("timeloop-auth.acme.com"));
+        assert!(json.contains("ALBAuthSessionCookie"));
+
+        let deserialized: ServerCommunicationConfig = serde_json::from_str(&json).unwrap();
+        if let BootstrapConfig::SsoCookieVendor(vendor_config) = deserialized.bootstrap {
+            assert_eq!(
+                vendor_config.idp_login_url,
+                "https://timeloop-auth.acme.com/login"
+            );
+            assert_eq!(vendor_config.cookie_name, "ALBAuthSessionCookie");
+            assert_eq!(vendor_config.cookie_domain, "vault.example.com");
+            assert!(vendor_config.cookie_value.is_none());
+        } else {
+            panic!("Expected SsoCookieVendor variant");
+        }
+    }
+
+    #[test]
+    fn cookie_value_some_and_none() {
+        // Test with None
+        let config_none = SsoCookieVendorConfig {
+            idp_login_url: "https://example.com".to_string(),
+            cookie_name: "TestCookie".to_string(),
+            cookie_domain: "example.com".to_string(),
+            cookie_value: None,
+        };
+
+        let json_none = serde_json::to_string(&config_none).unwrap();
+        let deserialized_none: SsoCookieVendorConfig = serde_json::from_str(&json_none).unwrap();
+        assert!(deserialized_none.cookie_value.is_none());
+
+        // Test with Some
+        let config_some = SsoCookieVendorConfig {
+            idp_login_url: "https://example.com".to_string(),
+            cookie_name: "TestCookie".to_string(),
+            cookie_domain: "example.com".to_string(),
+            cookie_value: Some("eyJhbGciOiJFUzI1NiIsImtpZCI6Im...".to_string()),
+        };
+
+        let json_some = serde_json::to_string(&config_some).unwrap();
+        let deserialized_some: SsoCookieVendorConfig = serde_json::from_str(&json_some).unwrap();
+        assert_eq!(
+            deserialized_some.cookie_value,
+            Some("eyJhbGciOiJFUzI1NiIsImtpZCI6Im...".to_string())
+        );
+    }
+
+    #[test]
+    fn enum_variants() {
+        let direct = BootstrapConfig::Direct;
+        assert!(matches!(direct, BootstrapConfig::Direct));
+
+        let vendor = BootstrapConfig::SsoCookieVendor(SsoCookieVendorConfig {
+            idp_login_url: "https://example.com".to_string(),
+            cookie_name: "Cookie".to_string(),
+            cookie_domain: "example.com".to_string(),
+            cookie_value: None,
+        });
+        assert!(matches!(vendor, BootstrapConfig::SsoCookieVendor(_)));
+    }
+
+    #[test]
+    fn debug_output_redacts_cookie_value() {
+        // Test that cookie values are not exposed in Debug output
+        let config_with_cookie = SsoCookieVendorConfig {
+            idp_login_url: "https://example.com/login".to_string(),
+            cookie_name: "SessionCookie".to_string(),
+            cookie_domain: "example.com".to_string(),
+            cookie_value: Some("super-secret-cookie-value-abc123".to_string()),
+        };
+
+        let debug_output = format!("{:?}", config_with_cookie);
+
+        // Should contain non-sensitive fields
+        assert!(debug_output.contains("SsoCookieVendorConfig"));
+        assert!(debug_output.contains("example.com/login"));
+        assert!(debug_output.contains("SessionCookie"));
+        assert!(debug_output.contains("example.com"));
+
+        // Should NOT contain the actual cookie value
+        assert!(!debug_output.contains("super-secret-cookie-value-abc123"));
+        // Should show redaction marker
+        assert!(debug_output.contains("[REDACTED]"));
+    }
+}

--- a/crates/bitwarden-server-communication-config/src/lib.rs
+++ b/crates/bitwarden-server-communication-config/src/lib.rs
@@ -1,0 +1,22 @@
+//! Server communication configuration management for SSO cookie handling
+//!
+//! This crate provides data structures and storage abstractions for managing
+//! server communication configuration, particularly for SSO load balancer cookies
+//! used in self-hosted environments.
+
+#![deny(missing_docs)]
+#![allow(clippy::disallowed_macros)] // For wasm_bindgen macro usage
+
+mod client;
+mod config;
+mod repository;
+
+pub use client::ServerCommunicationConfigClient;
+pub use config::{BootstrapConfig, ServerCommunicationConfig, SsoCookieVendorConfig};
+pub use repository::{
+    ServerCommunicationConfigRepository, ServerCommunicationConfigRepositoryError,
+};
+
+#[cfg(feature = "wasm")]
+/// WASM bindings for JavaScript interoperability
+pub mod wasm;

--- a/crates/bitwarden-server-communication-config/src/lib.rs
+++ b/crates/bitwarden-server-communication-config/src/lib.rs
@@ -5,7 +5,6 @@
 //! used in self-hosted environments.
 
 #![deny(missing_docs)]
-#![allow(clippy::disallowed_macros)] // For wasm_bindgen macro usage
 
 mod client;
 mod config;

--- a/crates/bitwarden-server-communication-config/src/repository.rs
+++ b/crates/bitwarden-server-communication-config/src/repository.rs
@@ -1,0 +1,219 @@
+use bitwarden_error::bitwarden_error;
+use thiserror::Error;
+
+use crate::ServerCommunicationConfig;
+
+/// Repository errors for configuration storage operations
+#[derive(Debug, Error, Clone, PartialEq, Eq)]
+#[bitwarden_error(flat)]
+pub enum ServerCommunicationConfigRepositoryError {
+    /// Error occurred while retrieving configuration
+    #[error("Failed to get configuration: {0}")]
+    GetError(String),
+
+    /// Error occurred while saving configuration
+    #[error("Failed to save configuration: {0}")]
+    SaveError(String),
+}
+
+/// Repository for storing server communication configuration
+///
+/// This trait abstracts storage to allow TypeScript implementations via State Provider
+/// in WASM contexts, while also supporting in-memory implementations for testing.
+pub trait ServerCommunicationConfigRepository: Send + Sync + 'static {
+    /// Error type returned by `get()` operations
+    type GetError: std::fmt::Debug + Send + Sync + 'static;
+    /// Error type returned by `save()` operations
+    type SaveError: std::fmt::Debug + Send + Sync + 'static;
+
+    /// Retrieves configuration for a hostname
+    ///
+    /// # Arguments
+    ///
+    /// * `hostname` - The server hostname (e.g., "vault.amazon.com")
+    ///
+    /// # Returns
+    ///
+    /// - `Ok(Some(config))` - Configuration exists for this hostname
+    /// - `Ok(None)` - No configuration exists (not an error)
+    /// - `Err(e)` - Storage operation failed
+    fn get(
+        &self,
+        hostname: String,
+    ) -> impl std::future::Future<Output = Result<Option<ServerCommunicationConfig>, Self::GetError>>;
+
+    /// Saves configuration for a hostname
+    ///
+    /// Overwrites any existing configuration for this hostname.
+    ///
+    /// # Arguments
+    ///
+    /// * `hostname` - The server hostname (e.g., "vault.amazon.com")
+    /// * `config` - The configuration to store
+    ///
+    /// # Returns
+    ///
+    /// - `Ok(())` - Configuration saved successfully
+    /// - `Err(e)` - Storage operation failed
+    fn save(
+        &self,
+        hostname: String,
+        config: ServerCommunicationConfig,
+    ) -> impl std::future::Future<Output = Result<(), Self::SaveError>>;
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{collections::HashMap, sync::Arc};
+
+    use tokio::sync::RwLock;
+
+    use super::*;
+    use crate::{BootstrapConfig, SsoCookieVendorConfig};
+
+    /// In-memory implementation of the repository for testing
+    #[derive(Default, Clone)]
+    struct InMemoryRepository {
+        storage: Arc<RwLock<HashMap<String, ServerCommunicationConfig>>>,
+    }
+
+    impl ServerCommunicationConfigRepository for InMemoryRepository {
+        type GetError = ();
+        type SaveError = ();
+
+        async fn get(&self, hostname: String) -> Result<Option<ServerCommunicationConfig>, ()> {
+            Ok(self.storage.read().await.get(&hostname).cloned())
+        }
+
+        async fn save(
+            &self,
+            hostname: String,
+            config: ServerCommunicationConfig,
+        ) -> Result<(), ()> {
+            self.storage.write().await.insert(hostname, config);
+            Ok(())
+        }
+    }
+
+    #[tokio::test]
+    async fn repository_get_none() {
+        let repo = InMemoryRepository::default();
+        let result = repo.get("vault.example.com".to_string()).await.unwrap();
+        assert!(result.is_none());
+    }
+
+    #[tokio::test]
+    async fn repository_save_and_get() {
+        let repo = InMemoryRepository::default();
+        let config = ServerCommunicationConfig {
+            bootstrap: BootstrapConfig::SsoCookieVendor(SsoCookieVendorConfig {
+                idp_login_url: "https://example.com/login".to_string(),
+                cookie_name: "TestCookie".to_string(),
+                cookie_domain: "example.com".to_string(),
+                cookie_value: Some("cookie-value-123".to_string()),
+            }),
+        };
+
+        // Save
+        repo.save("vault.example.com".to_string(), config.clone())
+            .await
+            .unwrap();
+
+        // Get
+        let retrieved = repo
+            .get("vault.example.com".to_string())
+            .await
+            .unwrap()
+            .unwrap();
+
+        if let BootstrapConfig::SsoCookieVendor(vendor_config) = retrieved.bootstrap {
+            assert_eq!(vendor_config.cookie_name, "TestCookie");
+            assert_eq!(
+                vendor_config.cookie_value,
+                Some("cookie-value-123".to_string())
+            );
+        } else {
+            panic!("Expected SsoCookieVendor");
+        }
+    }
+
+    #[tokio::test]
+    async fn repository_overwrite() {
+        let repo = InMemoryRepository::default();
+
+        // Save first config
+        let config1 = ServerCommunicationConfig {
+            bootstrap: BootstrapConfig::Direct,
+        };
+        repo.save("vault.example.com".to_string(), config1)
+            .await
+            .unwrap();
+
+        // Overwrite with second config
+        let config2 = ServerCommunicationConfig {
+            bootstrap: BootstrapConfig::SsoCookieVendor(SsoCookieVendorConfig {
+                idp_login_url: "https://example.com".to_string(),
+                cookie_name: "Cookie".to_string(),
+                cookie_domain: "example.com".to_string(),
+                cookie_value: None,
+            }),
+        };
+        repo.save("vault.example.com".to_string(), config2)
+            .await
+            .unwrap();
+
+        // Verify second config is retrieved
+        let retrieved = repo
+            .get("vault.example.com".to_string())
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(matches!(
+            retrieved.bootstrap,
+            BootstrapConfig::SsoCookieVendor(_)
+        ));
+    }
+
+    #[tokio::test]
+    async fn repository_multiple_hostnames() {
+        let repo = InMemoryRepository::default();
+
+        let config1 = ServerCommunicationConfig {
+            bootstrap: BootstrapConfig::Direct,
+        };
+        let config2 = ServerCommunicationConfig {
+            bootstrap: BootstrapConfig::SsoCookieVendor(SsoCookieVendorConfig {
+                idp_login_url: "https://example.com".to_string(),
+                cookie_name: "Cookie".to_string(),
+                cookie_domain: "example.com".to_string(),
+                cookie_value: None,
+            }),
+        };
+
+        // Save different configs for different hostnames
+        repo.save("vault1.example.com".to_string(), config1)
+            .await
+            .unwrap();
+        repo.save("vault2.example.com".to_string(), config2)
+            .await
+            .unwrap();
+
+        // Verify each hostname has its own config
+        let retrieved1 = repo
+            .get("vault1.example.com".to_string())
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(matches!(retrieved1.bootstrap, BootstrapConfig::Direct));
+
+        let retrieved2 = repo
+            .get("vault2.example.com".to_string())
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(matches!(
+            retrieved2.bootstrap,
+            BootstrapConfig::SsoCookieVendor(_)
+        ));
+    }
+}

--- a/crates/bitwarden-server-communication-config/src/wasm/client.rs
+++ b/crates/bitwarden-server-communication-config/src/wasm/client.rs
@@ -20,7 +20,8 @@ pub struct JsServerCommunicationConfigClient {
 impl JsServerCommunicationConfigClient {
     /// Creates a new ServerCommunicationConfigClient with a JavaScript repository
     ///
-    /// The repository should be backed by the State Provider for persistence.
+    /// The repository should be backed by StateProvider (or equivalent
+    /// storage mechanism) for persistence.
     ///
     /// # Arguments
     ///
@@ -50,9 +51,6 @@ impl JsServerCommunicationConfigClient {
     }
 
     /// Determines if cookie bootstrapping is needed for this hostname
-    ///
-    /// Always returns `false` in WASM environments since Browser/Web clients
-    /// share the browser's cookie store.
     ///
     /// # Arguments
     ///

--- a/crates/bitwarden-server-communication-config/src/wasm/client.rs
+++ b/crates/bitwarden-server-communication-config/src/wasm/client.rs
@@ -1,5 +1,3 @@
-use std::sync::Arc;
-
 use wasm_bindgen::prelude::*;
 
 use crate::{
@@ -30,7 +28,7 @@ impl JsServerCommunicationConfigClient {
     pub fn new(repository: RawJsServerCommunicationConfigRepository) -> Self {
         let js_repository = JsServerCommunicationConfigRepository::new(repository);
         Self {
-            client: ServerCommunicationConfigClient::new(Arc::new(js_repository)),
+            client: ServerCommunicationConfigClient::new(js_repository),
         }
     }
 

--- a/crates/bitwarden-server-communication-config/src/wasm/client.rs
+++ b/crates/bitwarden-server-communication-config/src/wasm/client.rs
@@ -1,0 +1,77 @@
+use std::sync::Arc;
+
+use wasm_bindgen::prelude::*;
+
+use crate::{
+    ServerCommunicationConfig, ServerCommunicationConfigClient,
+    wasm::{JsServerCommunicationConfigRepository, RawJsServerCommunicationConfigRepository},
+};
+
+/// JavaScript wrapper for ServerCommunicationConfigClient
+///
+/// This provides TypeScript access to the server communication configuration client,
+/// allowing clients to check bootstrap requirements and retrieve cookies for HTTP requests.
+#[wasm_bindgen(js_name = ServerCommunicationConfigClient)]
+pub struct JsServerCommunicationConfigClient {
+    client: ServerCommunicationConfigClient<JsServerCommunicationConfigRepository>,
+}
+
+#[wasm_bindgen(js_class = ServerCommunicationConfigClient)]
+impl JsServerCommunicationConfigClient {
+    /// Creates a new ServerCommunicationConfigClient with a JavaScript repository
+    ///
+    /// The repository should be backed by the State Provider for persistence.
+    ///
+    /// # Arguments
+    ///
+    /// * `repository` - JavaScript implementation of the repository interface
+    #[wasm_bindgen(constructor)]
+    pub fn new(repository: RawJsServerCommunicationConfigRepository) -> Self {
+        let js_repository = JsServerCommunicationConfigRepository::new(repository);
+        Self {
+            client: ServerCommunicationConfigClient::new(Arc::new(js_repository)),
+        }
+    }
+
+    /// Retrieves the server communication configuration for a hostname
+    ///
+    /// If no configuration exists, returns a default Direct bootstrap configuration.
+    ///
+    /// # Arguments
+    ///
+    /// * `hostname` - The server hostname (e.g., "vault.acme.com")
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the repository fails to retrieve the configuration.
+    #[wasm_bindgen(js_name = getConfig)]
+    pub async fn get_config(&self, hostname: String) -> Result<ServerCommunicationConfig, String> {
+        self.client.get_config(hostname).await
+    }
+
+    /// Determines if cookie bootstrapping is needed for this hostname
+    ///
+    /// Always returns `false` in WASM environments since Browser/Web clients
+    /// share the browser's cookie store.
+    ///
+    /// # Arguments
+    ///
+    /// * `hostname` - The server hostname (e.g., "vault.acme.com")
+    #[wasm_bindgen(js_name = needsBootstrap)]
+    pub async fn needs_bootstrap(&self, hostname: String) -> bool {
+        self.client.needs_bootstrap(hostname).await
+    }
+
+    /// Returns all cookies that should be included in requests to this server
+    ///
+    /// Returns an array of [cookie_name, cookie_value] pairs.
+    ///
+    /// # Arguments
+    ///
+    /// * `hostname` - The server hostname (e.g., "vault.acme.com")
+    #[wasm_bindgen(js_name = cookies)]
+    pub async fn cookies(&self, hostname: String) -> Result<JsValue, JsError> {
+        let cookies = self.client.cookies(hostname).await;
+        serde_wasm_bindgen::to_value(&cookies).map_err(|e| JsError::new(&e.to_string()))
+    }
+}

--- a/crates/bitwarden-server-communication-config/src/wasm/js_repository.rs
+++ b/crates/bitwarden-server-communication-config/src/wasm/js_repository.rs
@@ -1,0 +1,117 @@
+use bitwarden_threading::ThreadBoundRunner;
+use wasm_bindgen::prelude::*;
+
+use crate::{ServerCommunicationConfig, ServerCommunicationConfigRepository};
+
+#[wasm_bindgen(typescript_custom_section)]
+const TS_CUSTOM_TYPES: &'static str = r#"
+/**
+ * Repository interface for storing server communication configuration.
+ * 
+ * Implementations use StateProvider (or equivalent storage mechanism) to
+ * persist configuration across sessions. The hostname is typically the vault
+ * server's hostname (e.g., "vault.acme.com").
+ */
+export interface ServerCommunicationConfigRepository {
+    /**
+     * Retrieves the server communication configuration for a given hostname.
+     * 
+     * @param hostname The server hostname (e.g., "vault.acme.com")
+     * @returns The configuration if it exists, undefined otherwise
+     */
+    get(hostname: string): Promise<ServerCommunicationConfig | undefined>;
+    
+    /**
+     * Saves the server communication configuration for a given hostname.
+     * 
+     * @param hostname The server hostname (e.g., "vault.acme.com")
+     * @param config The configuration to store
+     */
+    save(hostname: string, config: ServerCommunicationConfig): Promise<void>;
+}
+"#;
+
+#[wasm_bindgen]
+extern "C" {
+    /// JavaScript interface for the ServerCommunicationConfigRepository
+    #[wasm_bindgen(
+        js_name = ServerCommunicationConfigRepository,
+        typescript_type = "ServerCommunicationConfigRepository"
+    )]
+    pub type RawJsServerCommunicationConfigRepository;
+
+    /// Retrieves configuration for a hostname
+    #[wasm_bindgen(catch, method, structural)]
+    pub async fn get(
+        this: &RawJsServerCommunicationConfigRepository,
+        hostname: String,
+    ) -> Result<JsValue, JsValue>;
+
+    /// Saves configuration for a hostname
+    #[wasm_bindgen(catch, method, structural)]
+    pub async fn save(
+        this: &RawJsServerCommunicationConfigRepository,
+        hostname: String,
+        config: JsValue,
+    ) -> Result<(), JsValue>;
+}
+
+/// Thread-safe JavaScript implementation of ServerCommunicationConfigRepository
+///
+/// This wrapper ensures the JavaScript repository can be safely used across
+/// threads in WASM environments by using ThreadBoundRunner to pin operations
+/// to the main thread.
+pub struct JsServerCommunicationConfigRepository(
+    ThreadBoundRunner<RawJsServerCommunicationConfigRepository>,
+);
+
+impl JsServerCommunicationConfigRepository {
+    /// Creates a new JsServerCommunicationConfigRepository wrapping the raw JavaScript repository
+    pub fn new(repository: RawJsServerCommunicationConfigRepository) -> Self {
+        Self(ThreadBoundRunner::new(repository))
+    }
+}
+
+impl Clone for JsServerCommunicationConfigRepository {
+    fn clone(&self) -> Self {
+        Self(self.0.clone())
+    }
+}
+
+impl ServerCommunicationConfigRepository for JsServerCommunicationConfigRepository {
+    type GetError = String;
+    type SaveError = String;
+
+    async fn get(&self, hostname: String) -> Result<Option<ServerCommunicationConfig>, String> {
+        self.0
+            .run_in_thread(move |repo| async move {
+                let js_value = repo.get(hostname).await.map_err(|e| format!("{e:?}"))?;
+
+                if js_value.is_undefined() || js_value.is_null() {
+                    return Ok(None);
+                }
+
+                Ok(Some(
+                    serde_wasm_bindgen::from_value(js_value).map_err(|e| e.to_string())?,
+                ))
+            })
+            .await
+            .map_err(|e| e.to_string())?
+    }
+
+    async fn save(
+        &self,
+        hostname: String,
+        config: ServerCommunicationConfig,
+    ) -> Result<(), String> {
+        self.0
+            .run_in_thread(move |repo| async move {
+                let js_value = serde_wasm_bindgen::to_value(&config).map_err(|e| e.to_string())?;
+                repo.save(hostname, js_value)
+                    .await
+                    .map_err(|e| format!("{e:?}"))
+            })
+            .await
+            .map_err(|e| e.to_string())?
+    }
+}

--- a/crates/bitwarden-server-communication-config/src/wasm/mod.rs
+++ b/crates/bitwarden-server-communication-config/src/wasm/mod.rs
@@ -1,0 +1,6 @@
+//! WASM bindings for server communication configuration
+
+mod client;
+mod js_repository;
+pub use client::*;
+pub use js_repository::*;


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-29145

## 📔 Objective

Implement `bitwarden-server-communication-config` crate to support SSO load balancer cookie authentication for self-hosted environments. 

The crate defines:

- `ServerCommunicationConfig` with `BootstrapConfig` variants (`Direct` and `SsoCookieVendor`) matching the server's `/api/config` endpoint schema from [PM-29144](https://bitwarden.atlassian.net/browse/PM-29144)
- a `ServerCommunicationConfigRepository` trait for platform-agnostic storage
- a `ServerCommunicationConfigClient` with methods to retrieve configurations, check if cookie bootstrap is needed, and extract cookies for HTTP requests. 

This crate provides the storage layer that bridges server-provided cookie requirements and client-side cookie acquisition flows. It enables downstream work to attach cookies to HTTP requests via request middleware, and allows TypeScript clients to implement `ServerCommunicationConfigService` with proper persistence. 

## 🚨 Breaking Changes

None. These are new concepts.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation
  team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-29144]: https://bitwarden.atlassian.net/browse/PM-29144?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ