### PR TITLE
[PM-31241] Play framework & E2E test for cli api key login

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -945,7 +945,6 @@ dependencies = [
  "async-trait",
  "bitwarden-api-api",
  "bitwarden-state",
- "once_cell",
  "reqwest",
  "serde",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -945,6 +945,8 @@ dependencies = [
  "async-trait",
  "bitwarden-api-api",
  "bitwarden-state",
+ "bitwarden-test-macro",
+ "futures",
  "reqwest",
  "serde",
  "serde_json",
@@ -953,6 +955,15 @@ dependencies = [
  "tracing",
  "uuid",
  "wiremock",
+]
+
+[[package]]
+name = "bitwarden-test-macro"
+version = "2.0.0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -945,7 +945,14 @@ dependencies = [
  "async-trait",
  "bitwarden-api-api",
  "bitwarden-state",
+ "once_cell",
  "reqwest",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
+ "tokio",
+ "tracing",
+ "uuid",
  "wiremock",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,7 @@ bitwarden-sm = { path = "bitwarden_license/bitwarden-sm", version = "=2.0.0" }
 bitwarden-ssh = { path = "crates/bitwarden-ssh", version = "=2.0.0" }
 bitwarden-state = { path = "crates/bitwarden-state", version = "=2.0.0" }
 bitwarden-test = { path = "crates/bitwarden-test", version = "=2.0.0" }
+bitwarden-test-macro = { path = "crates/bitwarden-test-macro", version = "=2.0.0" }
 bitwarden-threading = { path = "crates/bitwarden-threading", version = "=2.0.0" }
 bitwarden-uniffi-error = { path = "crates/bitwarden-uniffi-error", version = "=2.0.0" }
 bitwarden-uuid = { path = "crates/bitwarden-uuid", version = "=2.0.0" }

--- a/crates/bitwarden-test-macro/Cargo.toml
+++ b/crates/bitwarden-test-macro/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "bitwarden-test-macro"
+description = """
+Internal crate for the bitwarden crate. Do not use.
+"""
+
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+readme.workspace = true
+homepage.workspace = true
+repository.workspace = true
+license-file.workspace = true
+keywords.workspace = true
+
+[lib]
+proc-macro = true
+
+[dependencies]
+proc-macro2 = { workspace = true }
+quote = { workspace = true }
+syn = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/bitwarden-test-macro/src/lib.rs
+++ b/crates/bitwarden-test-macro/src/lib.rs
@@ -1,0 +1,82 @@
+//! Proc macro for Play test framework
+//!
+//! Provides the `#[play_test]` attribute macro for writing E2E tests with automatic
+//! Play instance setup and cleanup.
+
+use proc_macro::TokenStream;
+use quote::quote;
+use syn::{ItemFn, parse_macro_input};
+
+/// Attribute macro for Play framework tests
+///
+/// Transforms an async test function that takes a `Play` parameter into a properly
+/// configured tokio test with automatic cleanup.
+///
+/// # Example
+///
+/// ```ignore
+/// use bitwarden_test::play::{play_test, Play, SingleUserArgs, SingleUserScene};
+///
+/// #[play_test]
+/// async fn test_user_login(play: Play) {
+///     let args = SingleUserArgs {
+///         email: "test@example.com".to_string(),
+///         ..Default::default()
+///     };
+///     let scene = play.scene::<SingleUserScene>(&args).await.unwrap();
+///     // Cleanup happens automatically when the test completes
+/// }
+/// ```
+///
+/// The macro transforms the above into:
+///
+/// ```ignore
+/// #[tokio::test]
+/// async fn test_user_login() {
+///     ::bitwarden_test::play::Play::builder()
+///         .run(|play: Play| async move {
+///             // original test body
+///         })
+///         .await;
+/// }
+/// ```
+#[proc_macro_attribute]
+pub fn play_test(_attr: TokenStream, item: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(item as ItemFn);
+
+    let fn_name = &input.sig.ident;
+    let fn_body = &input.block;
+    let fn_vis = &input.vis;
+    let fn_attrs = &input.attrs;
+
+    // Extract the play parameter name and type from the function signature
+    let (play_param, play_type) = input
+        .sig
+        .inputs
+        .first()
+        .and_then(|arg| {
+            if let syn::FnArg::Typed(pat_type) = arg {
+                if let syn::Pat::Ident(pat_ident) = &*pat_type.pat {
+                    return Some((pat_ident.ident.clone(), pat_type.ty.clone()));
+                }
+            }
+            None
+        })
+        .unwrap_or_else(|| {
+            let ident = syn::Ident::new("play", proc_macro2::Span::call_site());
+            let ty: syn::Type = syn::parse_quote!(::bitwarden_test::play::Play);
+            (ident, Box::new(ty))
+        });
+
+    let expanded = quote! {
+        #(#fn_attrs)*
+        #[::tokio::test]
+        #fn_vis async fn #fn_name() {
+            ::bitwarden_test::play::Play::builder()
+                .run(|#play_param: #play_type| async move #fn_body)
+                .await;
+        }
+    };
+
+    TokenStream::from(expanded)
+}

--- a/crates/bitwarden-test/Cargo.toml
+++ b/crates/bitwarden-test/Cargo.toml
@@ -21,5 +21,14 @@ bitwarden-state = { workspace = true }
 reqwest = { workspace = true }
 wiremock = { workspace = true }
 
+# Play framework dependencies
+once_cell = "1.19"
+serde = { workspace = true }
+serde_json = { workspace = true }
+thiserror = { workspace = true }
+tokio = { workspace = true, features = ["rt", "rt-multi-thread", "sync"] }
+tracing = { workspace = true }
+uuid = { workspace = true }
+
 [lints]
 workspace = true

--- a/crates/bitwarden-test/Cargo.toml
+++ b/crates/bitwarden-test/Cargo.toml
@@ -18,11 +18,13 @@ keywords.workspace = true
 async-trait = { workspace = true }
 bitwarden-api-api.workspace = true
 bitwarden-state = { workspace = true }
+bitwarden-test-macro = { workspace = true }
+futures = { workspace = true }
 reqwest = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
-tokio = { workspace = true, features = ["rt-multi-thread"] }
+tokio = { workspace = true }
 tracing = { workspace = true }
 uuid = { workspace = true }
 wiremock = { workspace = true }

--- a/crates/bitwarden-test/Cargo.toml
+++ b/crates/bitwarden-test/Cargo.toml
@@ -19,16 +19,13 @@ async-trait = { workspace = true }
 bitwarden-api-api.workspace = true
 bitwarden-state = { workspace = true }
 reqwest = { workspace = true }
-wiremock = { workspace = true }
-
-# Play framework dependencies
-once_cell = "1.19"
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
-tokio = { workspace = true, features = ["rt", "rt-multi-thread", "sync"] }
+tokio = { workspace = true, features = ["rt-multi-thread"] }
 tracing = { workspace = true }
 uuid = { workspace = true }
+wiremock = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/bitwarden-test/README.md
+++ b/crates/bitwarden-test/README.md
@@ -15,8 +15,9 @@ the server side `SeederApi` to generate data.
 
 1. Each `Play` instance generates a unique `play_id` (UUID)
 2. All HTTP requests include an `x-play-id` header for server-side test isolation
-3. The seeder API creates test data (users, etc.) associated with that `play_id`
-4. When the `Play` instance is dropped, all test data is automatically cleaned up
+3. Any db entry created through a request associated with an `x-play-id` (users, etc.) are saved as
+   associated with that `play_id`
+4. When the `Play` instance is dropped, associated data is automatically cleaned up
 
 ### Usage
 
@@ -37,7 +38,7 @@ async fn test_example() {
     let scene = play.scene::<SingleUserScene>(&args).await.unwrap();
 
     // Access the created user data (email is mangled server-side)
-    let client_id = scene.get_mangled("client_id").unwrap();
+    let client_id = scene.get_mangled("client_id");
 
     // Use credentials for testing...
 

--- a/crates/bitwarden-test/README.md
+++ b/crates/bitwarden-test/README.md
@@ -37,8 +37,7 @@ async fn test_example() {
     };
     let scene = play.scene::<SingleUserScene>(&args).await.unwrap();
 
-    // Access the created user data (email is mangled server-side)
-    let client_id = scene.get_mangled("client_id");
+    let email = scene.get_mangled("test@example.com");
 
     // Use credentials for testing...
 

--- a/crates/bitwarden-test/README.md
+++ b/crates/bitwarden-test/README.md
@@ -24,7 +24,7 @@ the server side `SeederApi` to generate data.
 ```rust
 use bitwarden_test::play::{Play, SingleUserArgs, SingleUserScene};
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_example() {
     // Create a Play instance - generates unique play_id
     let play = Play::new();

--- a/crates/bitwarden-test/README.md
+++ b/crates/bitwarden-test/README.md
@@ -5,3 +5,58 @@ This crate should only be used in tests and should not be included in production
 </div>
 
 Contains test utilities for Bitwarden.
+
+## Play Framework
+
+The Play framework provides scene-based E2E testing with automatic test isolation and cleanup. Using
+the server side `SeederApi` to generate data.
+
+### How It Works
+
+1. Each `Play` instance generates a unique `play_id` (UUID)
+2. All HTTP requests include an `x-play-id` header for server-side test isolation
+3. The seeder API creates test data (users, etc.) associated with that `play_id`
+4. When the `Play` instance is dropped, all test data is automatically cleaned up
+
+### Usage
+
+```rust
+use bitwarden_test::play::{Play, SingleUserArgs, SingleUserScene};
+
+#[tokio::test]
+async fn test_example() {
+    // Create a Play instance - generates unique play_id
+    let play = Play::new();
+
+    // Create a test user via the seeder API
+    let args = SingleUserArgs {
+        email: "test@example.com".to_string(),
+        verified: true,
+        ..Default::default()
+    };
+    let scene = play.scene::<SingleUserScene>(&args).await.unwrap();
+
+    // Access the created user data (email is mangled server-side)
+    let client_id = scene.get_mangled("client_id").unwrap();
+
+    // Use credentials for testing...
+
+    // Cleanup happens automatically when `play` is dropped
+}
+```
+
+### Environment Variables
+
+| Variable                 | Default                           | Description         |
+| ------------------------ | --------------------------------- | ------------------- |
+| `BITWARDEN_API_URL`      | `https://localhost:8080/api`      | Base API URL        |
+| `BITWARDEN_IDENTITY_URL` | `https://localhost:8080/identity` | Identity server URL |
+| `BITWARDEN_SEEDER_URL`   | `http://localhost:5047`           | Seeder API URL      |
+
+### Running E2E Tests
+
+E2E tests require a running Bitwarden server with the seeder API enabled:
+
+```bash
+cargo test -p bw --features integration
+```

--- a/crates/bitwarden-test/src/lib.rs
+++ b/crates/bitwarden-test/src/lib.rs
@@ -5,3 +5,5 @@ pub use api::*;
 
 mod repository;
 pub use repository::*;
+
+pub mod play;

--- a/crates/bitwarden-test/src/play/config.rs
+++ b/crates/bitwarden-test/src/play/config.rs
@@ -56,3 +56,21 @@ impl Default for PlayConfig {
         Self::from_env()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_new_creates_config_with_custom_urls() {
+        let config = PlayConfig::new(
+            String::from("https://api.example.com"),
+            "https://identity.example.com",
+            "http://seeder.example.com",
+        );
+
+        assert_eq!(config.api_url, "https://api.example.com");
+        assert_eq!(config.identity_url, "https://identity.example.com");
+        assert_eq!(config.seeder_url, "http://seeder.example.com");
+    }
+}

--- a/crates/bitwarden-test/src/play/config.rs
+++ b/crates/bitwarden-test/src/play/config.rs
@@ -27,6 +27,7 @@ impl PlayConfig {
         let identity_url = env::var("BITWARDEN_IDENTITY_URL")
             .unwrap_or_else(|_| "https://localhost:8080/identity".to_string());
 
+        // TODO: Should use the web proxy once available
         let seeder_url = env::var("BITWARDEN_SEEDER_URL")
             .unwrap_or_else(|_| "http://localhost:5047".to_string());
 

--- a/crates/bitwarden-test/src/play/config.rs
+++ b/crates/bitwarden-test/src/play/config.rs
@@ -1,0 +1,58 @@
+//! Configuration for the Play test framework
+//!
+//! Environment variables:
+//! - `BITWARDEN_API_URL`: Base API URL (default: `https://localhost:8080/api`)
+//! - `BITWARDEN_IDENTITY_URL`: Identity URL (default: `https://localhost:8080/identity`)
+//! - `BITWARDEN_SEEDER_URL`: Seeder API URL (defaults to `http://localhost:5047`)
+
+use std::env;
+
+/// Configuration for connecting to Bitwarden services during E2E tests
+#[derive(Debug, Clone)]
+pub struct PlayConfig {
+    /// Base API URL
+    pub api_url: String,
+    /// Identity URL for authentication
+    pub identity_url: String,
+    /// Seeder API URL for test data management
+    pub seeder_url: String,
+}
+
+impl PlayConfig {
+    /// Load configuration from environment variables
+    pub fn from_env() -> Self {
+        let api_url = env::var("BITWARDEN_API_URL")
+            .unwrap_or_else(|_| "https://localhost:8080/api".to_string());
+
+        let identity_url = env::var("BITWARDEN_IDENTITY_URL")
+            .unwrap_or_else(|_| "https://localhost:8080/identity".to_string());
+
+        let seeder_url = env::var("BITWARDEN_SEEDER_URL")
+            .unwrap_or_else(|_| "http://localhost:5047".to_string());
+
+        Self {
+            api_url,
+            identity_url,
+            seeder_url,
+        }
+    }
+
+    /// Create a new configuration with custom URLs
+    pub fn new(
+        api_url: impl Into<String>,
+        identity_url: impl Into<String>,
+        seeder_url: impl Into<String>,
+    ) -> Self {
+        Self {
+            api_url: api_url.into(),
+            identity_url: identity_url.into(),
+            seeder_url: seeder_url.into(),
+        }
+    }
+}
+
+impl Default for PlayConfig {
+    fn default() -> Self {
+        Self::from_env()
+    }
+}

--- a/crates/bitwarden-test/src/play/error.rs
+++ b/crates/bitwarden-test/src/play/error.rs
@@ -1,0 +1,27 @@
+//! Error types for the Play test framework
+
+use thiserror::Error;
+
+/// Errors that can occur during Play framework operations
+#[derive(Debug, Error)]
+pub enum PlayError {
+    /// HTTP request failed
+    #[error("HTTP request failed: {0}")]
+    Http(#[from] reqwest::Error),
+
+    /// JSON serialization/deserialization failed
+    #[error("JSON error: {0}")]
+    Json(#[from] serde_json::Error),
+
+    /// Server returned an error response
+    #[error("Server error [{status}]: {body}")]
+    ServerError {
+        /// HTTP status code
+        status: u16,
+        /// Response body
+        body: String,
+    },
+}
+
+/// Result type for Play framework operations
+pub type PlayResult<T> = Result<T, PlayError>;

--- a/crates/bitwarden-test/src/play/http_client.rs
+++ b/crates/bitwarden-test/src/play/http_client.rs
@@ -1,0 +1,116 @@
+//! HTTP client with automatic x-play-id header injection
+
+use reqwest::{Client, RequestBuilder, Response};
+use serde::{Serialize, de::DeserializeOwned};
+use tracing::debug;
+
+use super::{PlayConfig, PlayError, PlayResult};
+
+/// HTTP client wrapper that adds the x-play-id header to all requests
+#[derive(Debug, Clone)]
+pub struct PlayHttpClient {
+    client: Client,
+    play_id: String,
+    config: PlayConfig,
+}
+
+impl PlayHttpClient {
+    /// Create a new HTTP client with the given play_id
+    pub fn new(play_id: String, config: PlayConfig) -> Self {
+        let client = Client::builder()
+            .build()
+            .expect("Failed to build HTTP client");
+
+        Self {
+            client,
+            play_id,
+            config,
+        }
+    }
+
+    /// Get the play_id for this client
+    pub fn play_id(&self) -> &str {
+        &self.play_id
+    }
+
+    /// Get the configuration
+    pub fn config(&self) -> &PlayConfig {
+        &self.config
+    }
+
+    /// Add the x-play-id header to a request builder
+    fn with_play_id(&self, builder: RequestBuilder) -> RequestBuilder {
+        builder.header("x-play-id", &self.play_id)
+    }
+
+    /// POST JSON to the seeder API and parse JSON response
+    pub async fn post_seeder<T: Serialize, R: DeserializeOwned>(
+        &self,
+        path: &str,
+        body: &T,
+    ) -> PlayResult<R> {
+        let url = format!("{}{}", self.config.seeder_url, path);
+
+        debug!(
+            method = "POST",
+            url = %url,
+            play_id = %self.play_id,
+            body = ?serde_json::to_string(body).ok(),
+            "Play request"
+        );
+
+        let response = self
+            .with_play_id(self.client.post(&url))
+            .json(body)
+            .send()
+            .await?;
+
+        self.handle_json_response(response).await
+    }
+
+    /// DELETE to the seeder API
+    pub async fn delete_seeder(&self, path: &str) -> PlayResult<()> {
+        let url = format!("{}{}", self.config.seeder_url, path);
+
+        debug!(
+            method = "DELETE",
+            url = %url,
+            play_id = %self.play_id,
+            "Play request"
+        );
+
+        let response = self.with_play_id(self.client.delete(&url)).send().await?;
+
+        let status = response.status();
+        debug!(status = %status, "Play response");
+
+        if status.is_success() {
+            Ok(())
+        } else {
+            let body = response.text().await.unwrap_or_default();
+            debug!(body = %body, "Play error response body");
+            Err(PlayError::ServerError {
+                status: status.as_u16(),
+                body,
+            })
+        }
+    }
+
+    /// Handle a JSON response, returning an error for non-success status codes
+    async fn handle_json_response<R: DeserializeOwned>(&self, response: Response) -> PlayResult<R> {
+        let status = response.status();
+
+        if status.is_success() {
+            let body = response.text().await?;
+            debug!(status = %status, body = %body, "Play response");
+            Ok(serde_json::from_str(&body)?)
+        } else {
+            let body = response.text().await.unwrap_or_default();
+            debug!(status = %status, body = %body, "Play error response");
+            Err(PlayError::ServerError {
+                status: status.as_u16(),
+                body,
+            })
+        }
+    }
+}

--- a/crates/bitwarden-test/src/play/http_client.rs
+++ b/crates/bitwarden-test/src/play/http_client.rs
@@ -114,3 +114,134 @@ impl PlayHttpClient {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use wiremock::{
+        Mock, MockServer, ResponseTemplate,
+        matchers::{header, method, path},
+    };
+
+    use super::*;
+
+    fn create_test_config(seeder_url: &str) -> PlayConfig {
+        PlayConfig::new(
+            "https://api.example.com",
+            "https://identity.example.com",
+            seeder_url,
+        )
+    }
+
+    #[test]
+    fn test_new_stores_play_id_and_config() {
+        let config = create_test_config("http://localhost:5047");
+        let client = PlayHttpClient::new("test-play-id".to_string(), config);
+
+        assert_eq!(client.play_id(), "test-play-id");
+        assert_eq!(client.config().api_url, "https://api.example.com");
+        assert_eq!(client.config().identity_url, "https://identity.example.com");
+        assert_eq!(client.config().seeder_url, "http://localhost:5047");
+    }
+
+    #[tokio::test]
+    async fn test_post_seeder() {
+        let mock_server = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .and(path("/seed/"))
+            .and(header("x-play-id", "test-play-id"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "id": 42,
+                "name": "test-user"
+            })))
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+
+        let config = create_test_config(&mock_server.uri());
+        let client = PlayHttpClient::new("test-play-id".to_string(), config);
+
+        #[derive(serde::Deserialize, Debug, PartialEq)]
+        struct TestResponse {
+            id: i32,
+            name: String,
+        }
+
+        let result: TestResponse = client
+            .post_seeder("/seed/", &serde_json::json!({}))
+            .await
+            .unwrap();
+
+        assert_eq!(result.id, 42);
+        assert_eq!(result.name, "test-user");
+    }
+
+    #[tokio::test]
+    async fn test_post_seeder_handles_server_error() {
+        let mock_server = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .and(path("/seed/"))
+            .respond_with(ResponseTemplate::new(500).set_body_string("Internal Server Error"))
+            .mount(&mock_server)
+            .await;
+
+        let config = create_test_config(&mock_server.uri());
+        let client = PlayHttpClient::new("test-id".to_string(), config);
+
+        let result: PlayResult<serde_json::Value> =
+            client.post_seeder("/seed/", &serde_json::json!({})).await;
+
+        match result {
+            Err(PlayError::ServerError { status, body }) => {
+                assert_eq!(status, 500);
+                assert_eq!(body, "Internal Server Error");
+            }
+            _ => panic!("Expected ServerError"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_delete_seeder_sends_correct_request() {
+        let mock_server = MockServer::start().await;
+
+        Mock::given(method("DELETE"))
+            .and(path("/seed/test-play-id"))
+            .and(header("x-play-id", "test-play-id"))
+            .respond_with(ResponseTemplate::new(200))
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+
+        let config = create_test_config(&mock_server.uri());
+        let client = PlayHttpClient::new("test-play-id".to_string(), config);
+
+        let result = client.delete_seeder("/seed/test-play-id").await;
+
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_delete_seeder_handles_server_error() {
+        let mock_server = MockServer::start().await;
+
+        Mock::given(method("DELETE"))
+            .and(path("/seed/test-id"))
+            .respond_with(ResponseTemplate::new(404).set_body_string("Not found"))
+            .mount(&mock_server)
+            .await;
+
+        let config = create_test_config(&mock_server.uri());
+        let client = PlayHttpClient::new("test-id".to_string(), config);
+
+        let result = client.delete_seeder("/seed/test-id").await;
+
+        match result {
+            Err(PlayError::ServerError { status, body }) => {
+                assert_eq!(status, 404);
+                assert_eq!(body, "Not found");
+            }
+            _ => panic!("Expected ServerError"),
+        }
+    }
+}

--- a/crates/bitwarden-test/src/play/http_client.rs
+++ b/crates/bitwarden-test/src/play/http_client.rs
@@ -8,7 +8,7 @@ use super::{PlayConfig, PlayError, PlayResult};
 
 /// HTTP client wrapper that adds the x-play-id header to all requests
 #[derive(Debug, Clone)]
-pub struct PlayHttpClient {
+pub(crate) struct PlayHttpClient {
     client: Client,
     play_id: String,
     config: PlayConfig,
@@ -16,7 +16,7 @@ pub struct PlayHttpClient {
 
 impl PlayHttpClient {
     /// Create a new HTTP client with the given play_id
-    pub fn new(play_id: String, config: PlayConfig) -> Self {
+    pub(crate) fn new(play_id: String, config: PlayConfig) -> Self {
         let client = Client::builder()
             .build()
             .expect("Failed to build HTTP client");
@@ -29,12 +29,12 @@ impl PlayHttpClient {
     }
 
     /// Get the play_id for this client
-    pub fn play_id(&self) -> &str {
+    pub(crate) fn play_id(&self) -> &str {
         &self.play_id
     }
 
     /// Get the configuration
-    pub fn config(&self) -> &PlayConfig {
+    pub(crate) fn config(&self) -> &PlayConfig {
         &self.config
     }
 
@@ -44,7 +44,7 @@ impl PlayHttpClient {
     }
 
     /// POST JSON to the seeder API and parse JSON response
-    pub async fn post_seeder<T: Serialize, R: DeserializeOwned>(
+    pub(crate) async fn post_seeder<T: Serialize, R: DeserializeOwned>(
         &self,
         path: &str,
         body: &T,
@@ -69,7 +69,7 @@ impl PlayHttpClient {
     }
 
     /// DELETE to the seeder API
-    pub async fn delete_seeder(&self, path: &str) -> PlayResult<()> {
+    pub(crate) async fn delete_seeder(&self, path: &str) -> PlayResult<()> {
         let url = format!("{}{}", self.config.seeder_url, path);
 
         debug!(

--- a/crates/bitwarden-test/src/play/mod.rs
+++ b/crates/bitwarden-test/src/play/mod.rs
@@ -22,7 +22,7 @@ pub mod scenes;
 
 pub use config::PlayConfig;
 pub use error::{PlayError, PlayResult};
-pub use http_client::PlayHttpClient;
+pub(crate) use http_client::PlayHttpClient;
 pub use play::Play;
 pub use query::Query;
 pub(crate) use query::QueryRequest;

--- a/crates/bitwarden-test/src/play/mod.rs
+++ b/crates/bitwarden-test/src/play/mod.rs
@@ -7,7 +7,7 @@
 //! The Play framework enables E2E testing by:
 //! - Creating test data via a seeder API
 //! - Providing test isolation through unique play IDs
-//! - Automatic cleanup when scenes are dropped
+//! - Automatic cleanup when play instances are dropped
 
 mod config;
 mod error;

--- a/crates/bitwarden-test/src/play/mod.rs
+++ b/crates/bitwarden-test/src/play/mod.rs
@@ -1,0 +1,32 @@
+//! Play test framework for E2E testing
+//!
+//! This module provides a scene-based testing framework.
+//!
+//! # Overview
+//!
+//! The Play framework enables E2E testing by:
+//! - Creating test data via a seeder API
+//! - Providing test isolation through unique play IDs
+//! - Automatic cleanup when scenes are dropped
+
+mod config;
+mod error;
+mod http_client;
+#[allow(clippy::module_inception)]
+mod play;
+mod query;
+mod scene;
+mod scene_template;
+
+pub mod scenes;
+
+pub use config::PlayConfig;
+pub use error::{PlayError, PlayResult};
+pub use http_client::PlayHttpClient;
+pub use play::Play;
+pub use query::Query;
+pub(crate) use query::QueryRequest;
+pub use scene::Scene;
+pub use scene_template::SceneTemplate;
+pub(crate) use scene_template::{CreateSceneRequest, CreateSceneResponse};
+pub use scenes::{SingleUserArgs, SingleUserScene};

--- a/crates/bitwarden-test/src/play/mod.rs
+++ b/crates/bitwarden-test/src/play/mod.rs
@@ -1,13 +1,29 @@
 //! Play test framework for E2E testing
 //!
-//! This module provides a scene-based testing framework.
+//! This module provides a scene-based testing framework with automatic cleanup.
 //!
 //! # Overview
 //!
 //! The Play framework enables E2E testing by:
 //! - Creating test data via a seeder API
 //! - Providing test isolation through unique play IDs
-//! - Automatic cleanup when play instances are dropped
+//! - Automatic cleanup when the test closure completes
+//!
+//! # Example
+//!
+//! ```ignore
+//! use bitwarden_test::play::{play_test, Play, SingleUserArgs, SingleUserScene};
+//!
+//! #[play_test]
+//! async fn test_user_login(play: Play) {
+//!     let args = SingleUserArgs {
+//!         email: "test@example.com".to_string(),
+//!         ..Default::default()
+//!     };
+//!     let scene = play.scene::<SingleUserScene>(&args).await.unwrap();
+//!     // Cleanup happens automatically
+//! }
+//! ```
 
 mod config;
 mod error;
@@ -20,10 +36,11 @@ mod scene_template;
 
 pub mod scenes;
 
+pub use bitwarden_test_macro::play_test;
 pub use config::PlayConfig;
 pub use error::{PlayError, PlayResult};
 pub(crate) use http_client::PlayHttpClient;
-pub use play::Play;
+pub use play::{Play, PlayBuilder};
 pub use query::Query;
 pub(crate) use query::QueryRequest;
 pub use scene::Scene;

--- a/crates/bitwarden-test/src/play/play.rs
+++ b/crates/bitwarden-test/src/play/play.rs
@@ -24,7 +24,7 @@ fn generate_play_id() -> String {
 /// ```ignore
 /// use bitwarden_test::play::{Play, SingleUserArgs, SingleUserScene};
 ///
-/// #[tokio::test]
+/// #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 /// async fn test_user_login() {
 ///     let play = Play::new();
 ///
@@ -52,11 +52,7 @@ impl Play {
     /// Configuration is loaded from environment variables.
     /// All test data created through this instance will be cleaned up when dropped.
     pub fn new() -> Self {
-        let play_id = generate_play_id();
-        let config = PlayConfig::from_env();
-        let client = Arc::new(PlayHttpClient::new(play_id, config));
-
-        Play { client }
+        Self::new_with_config(PlayConfig::from_env())
     }
 
     /// Create a new Play instance with custom configuration
@@ -116,11 +112,6 @@ impl Play {
     /// Get the play_id for this instance
     pub fn play_id(&self) -> &str {
         self.client.play_id()
-    }
-
-    /// Get the HTTP client for advanced operations
-    pub fn http_client(&self) -> Arc<PlayHttpClient> {
-        self.client.clone()
     }
 
     /// Get the configuration
@@ -198,7 +189,6 @@ mod tests {
 
         // Accessors work correctly
         assert_eq!(play1.config().seeder_url, "http://localhost:5047");
-        assert_eq!(play1.http_client().play_id(), play1.play_id());
     }
 
     // Mock types for testing scene/query functionality

--- a/crates/bitwarden-test/src/play/play.rs
+++ b/crates/bitwarden-test/src/play/play.rs
@@ -179,7 +179,7 @@ mod tests {
         let config = PlayConfig::new(
             "https://api.example.com",
             "https://identity.example.com",
-            &server.uri(),
+            server.uri(),
         );
         (Play::new_with_config(config), server)
     }
@@ -337,7 +337,7 @@ mod tests {
         let config = PlayConfig::new(
             "https://api.example.com",
             "https://identity.example.com",
-            &server.uri(),
+            server.uri(),
         );
         let play = Play::new_with_config(config);
 

--- a/crates/bitwarden-test/src/play/play.rs
+++ b/crates/bitwarden-test/src/play/play.rs
@@ -287,7 +287,10 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(scene.inner().data, "test-data");
-        assert_eq!(scene.get_mangled("email@example.com"), "mangled@example.com");
+        assert_eq!(
+            scene.get_mangled("email@example.com"),
+            "mangled@example.com"
+        );
 
         // Test query execution
         Mock::given(method("POST"))

--- a/crates/bitwarden-test/src/play/play.rs
+++ b/crates/bitwarden-test/src/play/play.rs
@@ -285,7 +285,7 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(scene.inner().data, "test-data");
-        assert_eq!(scene.get_mangled("email"), Some("mangled@example.com"));
+        assert_eq!(scene.get_mangled("email"), "mangled@example.com");
 
         // Test query execution
         Mock::given(method("POST"))

--- a/crates/bitwarden-test/src/play/play.rs
+++ b/crates/bitwarden-test/src/play/play.rs
@@ -1,0 +1,148 @@
+//! Main Play struct with instance-based design and automatic cleanup
+
+use std::sync::Arc;
+
+use uuid::Uuid;
+
+use super::{
+    CreateSceneRequest, CreateSceneResponse, PlayConfig, PlayHttpClient, PlayResult, Query,
+    QueryRequest, Scene, SceneTemplate,
+};
+
+/// Generate a new unique play_id (first 8 chars of UUID)
+fn generate_play_id() -> String {
+    Uuid::new_v4().to_string()
+}
+
+/// The Play test framework for E2E testing
+///
+/// Provides methods for creating scenes, executing queries, and managing
+/// test data with automatic cleanup when dropped.
+///
+/// # Example
+///
+/// ```ignore
+/// use bitwarden_test::play::{Play, SingleUserScene, SingleUserBuilder};
+///
+/// #[tokio::test]
+/// async fn test_user_login() {
+///     let play = Play::new();
+///
+///     // Provide base email - the seeder mangles it server-side
+///     let args = SingleUserBuilder::new("test@example.com")
+///         .verified(true)
+///         .build();
+///     let scene = play.scene::<SingleUserScene>(&args).await.unwrap();
+///
+///     // Use scene.inner() to access mangled user data from server
+///     let user = scene.inner();
+///     let (client_id, client_secret) = user.api_key();
+///
+///     // All scenes are automatically cleaned up when `play` is dropped
+/// }
+/// ```
+pub struct Play {
+    client: Arc<PlayHttpClient>,
+}
+
+impl Play {
+    /// Create a new Play instance with a unique play_id
+    ///
+    /// Configuration is loaded from environment variables.
+    /// All test data created through this instance will be cleaned up when dropped.
+    pub fn new() -> Self {
+        let play_id = generate_play_id();
+        let config = PlayConfig::from_env();
+        let client = Arc::new(PlayHttpClient::new(play_id, config));
+
+        Play { client }
+    }
+
+    /// Create a new Play instance with custom configuration
+    ///
+    /// All test data created through this instance will be cleaned up when dropped.
+    pub fn new_with_config(config: PlayConfig) -> Self {
+        let play_id = generate_play_id();
+        let client = Arc::new(PlayHttpClient::new(play_id, config));
+
+        Play { client }
+    }
+
+    /// Create a new scene from template arguments
+    ///
+    /// The scene data will be cleaned up when this Play instance is dropped.
+    pub async fn scene<T>(&self, arguments: &T::Arguments) -> PlayResult<Scene<T>>
+    where
+        T: SceneTemplate,
+    {
+        let request = CreateSceneRequest {
+            template: T::template_name(),
+            arguments,
+        };
+
+        let response: CreateSceneResponse<T::Result> =
+            self.client.post_seeder("/seed/", &request).await?;
+
+        let template_instance = T::from_result(response.result);
+
+        Ok(Scene::new(template_instance, response.mangle_map))
+    }
+
+    /// Execute a query
+    pub async fn query<Q>(&self, arguments: &Q::Args) -> PlayResult<Q>
+    where
+        Q: Query,
+    {
+        let request = QueryRequest {
+            template: Q::template_name(),
+            arguments,
+        };
+
+        let result: Q::Result = self.client.post_seeder("/seed/query", &request).await?;
+
+        Ok(Q::from_result(result))
+    }
+
+    /// Manually clean all test data for this play_id
+    ///
+    /// This is called automatically when the Play instance is dropped.
+    pub async fn clean(&self) -> PlayResult<()> {
+        self.client
+            .delete_seeder(&format!("/seed/{}", self.client.play_id()))
+            .await
+    }
+
+    /// Get the play_id for this instance
+    pub fn play_id(&self) -> &str {
+        self.client.play_id()
+    }
+
+    /// Get the HTTP client for advanced operations
+    pub fn http_client(&self) -> Arc<PlayHttpClient> {
+        self.client.clone()
+    }
+
+    /// Get the configuration
+    pub fn config(&self) -> &PlayConfig {
+        self.client.config()
+    }
+}
+
+impl Default for Play {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Drop for Play {
+    fn drop(&mut self) {
+        let client = self.client.clone();
+        let play_id = client.play_id().to_string();
+
+        // Use the current runtime to run cleanup synchronously
+        let handle = tokio::runtime::Handle::current();
+        let _ = tokio::task::block_in_place(|| {
+            handle.block_on(async { client.delete_seeder(&format!("/seed/{}", play_id)).await })
+        });
+    }
+}

--- a/crates/bitwarden-test/src/play/play.rs
+++ b/crates/bitwarden-test/src/play/play.rs
@@ -287,7 +287,7 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(scene.inner().data, "test-data");
-        assert_eq!(scene.get_mangled("email"), "mangled@example.com");
+        assert_eq!(scene.get_mangled("email@example.com"), "mangled@example.com");
 
         // Test query execution
         Mock::given(method("POST"))

--- a/crates/bitwarden-test/src/play/play.rs
+++ b/crates/bitwarden-test/src/play/play.rs
@@ -265,7 +265,7 @@ mod tests {
             .and(path("/seed/"))
             .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
                 "result": { "data": "test-data" },
-                "mangleMap": { "email": "mangled@example.com" }
+                "mangleMap": { "email@example.com": "mangled@example.com" }
             })))
             .mount(&server)
             .await;

--- a/crates/bitwarden-test/src/play/query.rs
+++ b/crates/bitwarden-test/src/play/query.rs
@@ -1,0 +1,30 @@
+//! Query trait for parameterized database queries
+
+use serde::{Serialize, de::DeserializeOwned};
+
+/// Trait for defining parameterized queries
+///
+/// Queries allow executing specific operations against the test database.
+pub trait Query: Sized + Send + Sync {
+    /// The type of arguments passed to the query
+    type Args: Serialize + Clone + Send + Sync;
+
+    /// The type of result returned by the query
+    type Result: DeserializeOwned + Send + Sync;
+
+    /// The name of this query template
+    fn template_name() -> &'static str;
+
+    /// Get the arguments for this query
+    fn args(&self) -> &Self::Args;
+
+    /// Create an instance from the query result
+    fn from_result(result: Self::Result) -> Self;
+}
+
+/// Request body for executing a query
+#[derive(Serialize)]
+pub(crate) struct QueryRequest<'a, A: Serialize> {
+    pub template: &'a str,
+    pub arguments: &'a A,
+}

--- a/crates/bitwarden-test/src/play/scene.rs
+++ b/crates/bitwarden-test/src/play/scene.rs
@@ -29,8 +29,8 @@ impl<T: SceneTemplate> Scene<T> {
         &self.template
     }
 
-    /// Get the mangled value for a given key
-    pub fn get_mangled(&self, key: &str) -> Option<&str> {
-        self.mangle_map.get(key).map(|s| s.as_str())
+    /// Get the mangled value for a given key, or return the key if not found
+    pub fn get_mangled<'a>(&'a self, key: &'a str) -> &'a str {
+        self.mangle_map.get(key).map(|s| s.as_str()).unwrap_or(key)
     }
 }

--- a/crates/bitwarden-test/src/play/scene.rs
+++ b/crates/bitwarden-test/src/play/scene.rs
@@ -1,0 +1,36 @@
+//! Scene wrapper for test data
+
+use std::collections::HashMap;
+
+use super::SceneTemplate;
+
+/// A scene containing test data created by the seeder
+///
+/// The scene wraps a template instance with the server response data.
+/// Cleanup is handled by the owning `Play` instance when it is dropped.
+pub struct Scene<T: SceneTemplate> {
+    /// The template instance with populated data
+    template: T,
+    /// Map of original IDs to mangled IDs for test isolation
+    mangle_map: HashMap<String, String>,
+}
+
+impl<T: SceneTemplate> Scene<T> {
+    /// Create a new scene wrapper
+    pub(crate) fn new(template: T, mangle_map: HashMap<String, String>) -> Self {
+        Self {
+            template,
+            mangle_map,
+        }
+    }
+
+    /// Access the underlying template
+    pub fn inner(&self) -> &T {
+        &self.template
+    }
+
+    /// Get the mangled value for a given key
+    pub fn get_mangled(&self, key: &str) -> Option<&str> {
+        self.mangle_map.get(key).map(|s| s.as_str())
+    }
+}

--- a/crates/bitwarden-test/src/play/scene_template.rs
+++ b/crates/bitwarden-test/src/play/scene_template.rs
@@ -1,0 +1,38 @@
+//! SceneTemplate trait for defining test scenes
+
+use std::collections::HashMap;
+
+use serde::{Serialize, de::DeserializeOwned};
+
+/// Trait for defining scene templates
+///
+/// Scene templates define how to create and tear down test data.
+/// Each template has associated types for input arguments and output results.
+pub trait SceneTemplate: Sized + Send + Sync {
+    /// The type of arguments passed to create the scene
+    type Arguments: Serialize + Clone + Send + Sync;
+
+    /// The type of result returned when the scene is created
+    type Result: DeserializeOwned + Send + Sync;
+
+    /// The name of this template (used in API calls)
+    fn template_name() -> &'static str;
+
+    /// Create an instance of this template from the creation result
+    fn from_result(result: Self::Result) -> Self;
+}
+
+/// Request body for creating a scene
+#[derive(Serialize)]
+pub(crate) struct CreateSceneRequest<'a, A: Serialize> {
+    pub template: &'a str,
+    pub arguments: &'a A,
+}
+
+/// Response from creating a scene
+#[derive(serde::Deserialize)]
+pub(crate) struct CreateSceneResponse<R> {
+    pub result: R,
+    #[serde(rename = "mangleMap", default)]
+    pub mangle_map: HashMap<String, String>,
+}

--- a/crates/bitwarden-test/src/play/scenes/mod.rs
+++ b/crates/bitwarden-test/src/play/scenes/mod.rs
@@ -1,0 +1,5 @@
+//! Scene template implementations
+
+mod single_user;
+
+pub use single_user::{SingleUserArgs, SingleUserScene};

--- a/crates/bitwarden-test/src/play/scenes/single_user.rs
+++ b/crates/bitwarden-test/src/play/scenes/single_user.rs
@@ -1,0 +1,39 @@
+//! Single user scene template
+
+use serde::Serialize;
+use uuid::Uuid;
+
+use crate::play::SceneTemplate;
+
+/// Arguments for creating a single user scene
+#[derive(Default, Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SingleUserArgs {
+    /// User email address (should be mangled for test isolation)
+    pub email: String,
+    /// Whether the user's email is verified
+    pub verified: bool,
+    /// Whether the user has premium
+    pub premium: bool,
+    /// Optional user ID to set
+    pub id: Option<Uuid>,
+    /// Optional api key
+    pub api_key: Option<String>,
+}
+
+/// A single user scene for testing
+#[derive(Debug, Clone)]
+pub struct SingleUserScene;
+
+impl SceneTemplate for SingleUserScene {
+    type Arguments = SingleUserArgs;
+    type Result = ();
+
+    fn template_name() -> &'static str {
+        "SingleUserScene"
+    }
+
+    fn from_result(_result: Self::Result) -> Self {
+        Self
+    }
+}

--- a/crates/bw/Cargo.toml
+++ b/crates/bw/Cargo.toml
@@ -14,6 +14,9 @@ homepage.workspace = true
 repository.workspace = true
 license-file.workspace = true
 
+[features]
+integration = [] # Integration tests
+
 [dependencies]
 base64 = ">=0.22.1, <0.23"
 bat = { version = "0.26.0", features = [

--- a/crates/bw/Cargo.toml
+++ b/crates/bw/Cargo.toml
@@ -14,9 +14,6 @@ homepage.workspace = true
 repository.workspace = true
 license-file.workspace = true
 
-[features]
-integration = [] # Integration tests
-
 [dependencies]
 base64 = ">=0.22.1, <0.23"
 bat = { version = "0.26.0", features = [

--- a/crates/bw/src/auth/login.rs
+++ b/crates/bw/src/auth/login.rs
@@ -15,7 +15,10 @@ use crate::vault::{SyncRequest, sync};
 pub(crate) async fn login_password(client: Client, email: Option<String>) -> Result<()> {
     let email = text_prompt_when_none("Email", email)?;
 
-    let password = Password::new("Password").without_confirmation().prompt()?;
+    let password = match std::env::var("BW_PASSWORD") {
+        Ok(pw) => pw,
+        Err(_) => Password::new("Password").without_confirmation().prompt()?,
+    };
 
     let result = client
         .auth()
@@ -95,7 +98,10 @@ pub(crate) async fn login_api_key(
     let client_id = text_prompt_when_none("Client ID", client_id)?;
     let client_secret = text_prompt_when_none("Client Secret", client_secret)?;
 
-    let password = Password::new("Password").without_confirmation().prompt()?;
+    let password = match std::env::var("BW_PASSWORD") {
+        Ok(pw) => pw,
+        Err(_) => Password::new("Password").without_confirmation().prompt()?,
+    };
 
     let result = client
         .auth()

--- a/crates/bw/tests/api_key_login.rs
+++ b/crates/bw/tests/api_key_login.rs
@@ -36,11 +36,9 @@ async fn test_api_key_login() {
     // Build credentials from the mangled scene data
     let client_id = format!(
         "user.{}",
-        scene
-            .get_mangled("378538f1-2426-4788-87c5-df39a78618c1")
-            .unwrap()
+        scene.get_mangled("378538f1-2426-4788-87c5-df39a78618c1")
     );
-    let client_secret = scene.get_mangled("api_key").unwrap();
+    let client_secret = scene.get_mangled("api_key");
 
     let output = bw()
         .args(["login", "api-key", &client_id, client_secret])

--- a/crates/bw/tests/api_key_login.rs
+++ b/crates/bw/tests/api_key_login.rs
@@ -14,7 +14,7 @@ use common::bw;
 /// 4. Verifies authentication succeeds
 /// 5. Automatically cleans up the test user when play is dropped
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-#[cfg(feature = "integration")]
+#[ignore = "Integration test requires running Bitwarden server with seeder API"]
 async fn test_api_key_login() {
     let play = Play::new();
 
@@ -59,7 +59,7 @@ async fn test_api_key_login() {
 
 /// Test API key login with invalid credentials fails appropriately
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-#[cfg(feature = "integration")]
+#[ignore = "Integration test requires running Bitwarden server with seeder API"]
 async fn test_api_key_login_invalid_credentials() {
     let _play = Play::new();
 

--- a/crates/bw/tests/api_key_login.rs
+++ b/crates/bw/tests/api_key_login.rs
@@ -41,7 +41,7 @@ async fn test_api_key_login(play: Play) {
     let output = bw()
         .args(["login", "api-key", &client_id, client_secret])
         .args(["--server", &server])
-        .env("BW_PASSWORD", "asdfasdfasdf")
+        .env("BW_PASSWORD", scene.get_mangled("asdfasdfasdf"))
         .output()
         .expect("Failed to execute bw command");
 

--- a/crates/bw/tests/api_key_login.rs
+++ b/crates/bw/tests/api_key_login.rs
@@ -1,0 +1,79 @@
+//! E2E test for API key login using the Play test framework
+
+use bitwarden_test::play::{Play, SingleUserArgs, SingleUserScene};
+
+mod common;
+use common::bw;
+
+/// Test API key login flow using the Play framework
+///
+/// This test:
+/// 1. Creates a test user via the seeder API
+/// 2. Retrieves API key credentials
+/// 3. Performs API key login via the bw CLI
+/// 4. Verifies authentication succeeds
+/// 5. Automatically cleans up the test user when play is dropped
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+#[cfg(feature = "integration")]
+async fn test_api_key_login() {
+    let play = Play::new();
+
+    let args = SingleUserArgs {
+        email: "e2e-apikey@bitwarden.test".to_string(),
+        verified: true,
+        id: Some("378538f1-2426-4788-87c5-df39a78618c1".parse().unwrap()),
+        api_key: Some("api_key".to_string()),
+        ..Default::default()
+    };
+
+    let server = common::server_base();
+
+    let scene = play
+        .scene::<SingleUserScene>(&args)
+        .await
+        .expect("Failed to create SingleUserScene");
+
+    // Build credentials from the mangled scene data
+    let client_id = format!(
+        "user.{}",
+        scene
+            .get_mangled("378538f1-2426-4788-87c5-df39a78618c1")
+            .unwrap()
+    );
+    let client_secret = scene.get_mangled("api_key").unwrap();
+
+    let output = bw()
+        .args(["login", "api-key", &client_id, &client_secret])
+        .args(["--server", &server])
+        .env("BW_PASSWORD", "asdfasdfasdf")
+        .output()
+        .expect("Failed to execute bw command");
+
+    assert!(
+        output.status.success(),
+        "CLI login failed: stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+/// Test API key login with invalid credentials fails appropriately
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+#[cfg(feature = "integration")]
+async fn test_api_key_login_invalid_credentials() {
+    let _play = Play::new();
+
+    let server = common::server_base();
+
+    let output = bw()
+        .args(["login", "api-key", "invalid_client_id", "invalid_secret"])
+        .args(["--server", &server])
+        .env("BW_PASSWORD", "wrong_password")
+        .output()
+        .expect("Failed to execute bw command");
+
+    assert!(
+        !output.status.success(),
+        "Login with invalid credentials should fail"
+    );
+}

--- a/crates/bw/tests/api_key_login.rs
+++ b/crates/bw/tests/api_key_login.rs
@@ -43,7 +43,7 @@ async fn test_api_key_login() {
     let client_secret = scene.get_mangled("api_key").unwrap();
 
     let output = bw()
-        .args(["login", "api-key", &client_id, &client_secret])
+        .args(["login", "api-key", &client_id, client_secret])
         .args(["--server", &server])
         .env("BW_PASSWORD", "asdfasdfasdf")
         .output()

--- a/crates/bw/tests/api_key_login.rs
+++ b/crates/bw/tests/api_key_login.rs
@@ -1,6 +1,6 @@
 //! E2E test for API key login using the Play test framework
 
-use bitwarden_test::play::{Play, SingleUserArgs, SingleUserScene};
+use bitwarden_test::play::{Play, SingleUserArgs, SingleUserScene, play_test};
 
 mod common;
 use common::bw;
@@ -12,12 +12,10 @@ use common::bw;
 /// 2. Retrieves API key credentials
 /// 3. Performs API key login via the bw CLI
 /// 4. Verifies authentication succeeds
-/// 5. Automatically cleans up the test user when play is dropped
-#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+/// 5. Automatically cleans up the test user when the test completes
+#[play_test]
 #[ignore = "Integration test requires running Bitwarden server with seeder API"]
-async fn test_api_key_login() {
-    let play = Play::new();
-
+async fn test_api_key_login(play: Play) {
     let args = SingleUserArgs {
         email: "e2e-apikey@bitwarden.test".to_string(),
         verified: true,
@@ -56,11 +54,9 @@ async fn test_api_key_login() {
 }
 
 /// Test API key login with invalid credentials fails appropriately
-#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+#[play_test]
 #[ignore = "Integration test requires running Bitwarden server with seeder API"]
-async fn test_api_key_login_invalid_credentials() {
-    let _play = Play::new();
-
+async fn test_api_key_login_invalid_credentials(_play: Play) {
     let server = common::server_base();
 
     let output = bw()

--- a/crates/bw/tests/common/mod.rs
+++ b/crates/bw/tests/common/mod.rs
@@ -1,0 +1,14 @@
+use std::process::Command;
+
+/// Create a new bw CLI command
+pub fn bw() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_bw"))
+}
+
+/// Get the server base URL
+///
+/// Uses `BITWARDEN_SERVER_URL` environment variable if set,
+/// otherwise defaults to "https://localhost:8080"
+pub fn server_base() -> String {
+    std::env::var("BITWARDEN_SERVER_URL").unwrap_or_else(|_| "https://localhost:8080".to_string())
+}

--- a/crates/bw/tests/common/mod.rs
+++ b/crates/bw/tests/common/mod.rs
@@ -9,6 +9,7 @@ pub fn bw() -> Command {
 ///
 /// Uses `BITWARDEN_SERVER_URL` environment variable if set,
 /// otherwise defaults to "https://localhost:8080"
+#[allow(dead_code)]
 pub fn server_base() -> String {
     std::env::var("BITWARDEN_SERVER_URL").unwrap_or_else(|_| "https://localhost:8080".to_string())
 }

--- a/crates/bw/tests/help.rs
+++ b/crates/bw/tests/help.rs
@@ -1,12 +1,11 @@
 //! Tests for the bw CLI help functionality
 
-use std::process::Command;
+mod common;
+use common::bw;
 
 #[test]
 fn test_no_args_shows_help() {
-    let output = Command::new(env!("CARGO_BIN_EXE_bw"))
-        .output()
-        .expect("Failed to execute bw command");
+    let output = bw().output().expect("Failed to execute bw command");
 
     assert!(output.status.success(), "Command should exit successfully");
 

--- a/crates/bw/tests/version.rs
+++ b/crates/bw/tests/version.rs
@@ -1,10 +1,11 @@
 //! Tests for the bw CLI version flags
 
-use std::process::Command;
+mod common;
+use common::bw;
 
 /// Helper function to test version output
 fn assert_version_output(args: &[&str]) {
-    let output = Command::new(env!("CARGO_BIN_EXE_bw"))
+    let output = bw()
         .args(args)
         .output()
         .expect("Failed to execute bw command");


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-31241
## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Adds support for the play framework (SeederApi) which lets you create scenes which seed data. This framework automatically handles cleanup by calling the destroy endpoint on drop.

The framework is used to build a simple E2E test for api key login using the bw CLI.
