### PR TITLE
SSO JIT Master Password encryption v2 new user registration Argon2Id KDF parallelism 4

### DIFF
--- a/crates/bitwarden-auth/src/registration.rs
+++ b/crates/bitwarden-auth/src/registration.rs
@@ -1006,7 +1006,7 @@ mod tests {
                                 kdf_type: KdfType::Argon2id,
                                 iterations: 6,
                                 memory: Some(32),
-                                parallelism: Some(3),
+                                parallelism: Some(4),
                             })
                         );
                         assert!(req.master_password_authentication.is_some());
@@ -1022,7 +1022,7 @@ mod tests {
                                 kdf_type: KdfType::Argon2id,
                                 iterations: 6,
                                 memory: Some(32),
-                                parallelism: Some(3),
+                                parallelism: Some(4),
                             })
                         );
                         true
@@ -1082,7 +1082,7 @@ mod tests {
             Kdf::Argon2id {
                 iterations: NonZeroU32::new(6).unwrap(),
                 memory: NonZeroU32::new(32).unwrap(),
-                parallelism: NonZeroU32::new(3).unwrap(),
+                parallelism: NonZeroU32::new(4).unwrap(),
             }
         );
 

--- a/crates/bitwarden-crypto/src/keys/kdf.rs
+++ b/crates/bitwarden-crypto/src/keys/kdf.rs
@@ -167,7 +167,7 @@ fn default_argon2_memory() -> NonZeroU32 {
 }
 /// Default Argon2 parallelism
 fn default_argon2_parallelism() -> NonZeroU32 {
-    NonZeroU32::new(3).expect("Non-zero number")
+    NonZeroU32::new(4).expect("Non-zero number")
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective

SSO JIT Master Password encryption v2 new user registration Argon2Id KDF parallelism should be at 4. 
It was incorrectly merged with parallelism 3 - typo in Jira ticket https://bitwarden.atlassian.net/browse/PM-27277, now corrected

## 🚨 Breaking Changes

<!-- Does this PR introduce any breaking changes? If so, please describe the impact and migration path for clients.

If you're unsure, the automated TypeScript compatibility check will run when you open/update this PR and provide feedback.

For breaking changes:
1. Describe what changed in the client interface
2. Explain why the change was necessary
3. Provide migration steps for client developers
4. Link to any paired client PRs if needed

Otherwise, you can remove this section. -->
