### PR TITLE
[PM-30563] Change mapped SendAccess token errors from Server 

### DIFF
--- a/crates/bitwarden-auth/src/send_access/api/token_api_error_response.rs
+++ b/crates/bitwarden-auth/src/send_access/api/token_api_error_response.rs
@@ -38,9 +38,6 @@ pub enum SendAccessTokenInvalidGrantError {
     PasswordHashB64Invalid,
 
     #[allow(missing_docs)]
-    EmailInvalid,
-
-    #[allow(missing_docs)]
     OtpInvalid,
 
     #[allow(missing_docs)]
@@ -325,10 +322,6 @@ mod tests {
                 (
                     SendAccessTokenInvalidGrantError::PasswordHashB64Invalid,
                     "\"password_hash_b64_invalid\"",
-                ),
-                (
-                    SendAccessTokenInvalidGrantError::EmailInvalid,
-                    "\"email_invalid\"",
                 ),
                 (
                     SendAccessTokenInvalidGrantError::OtpInvalid,

--- a/crates/bitwarden-auth/src/send_access/api/token_api_error_response.rs
+++ b/crates/bitwarden-auth/src/send_access/api/token_api_error_response.rs
@@ -18,7 +18,7 @@ pub enum SendAccessTokenInvalidRequestError {
     EmailRequired,
 
     #[allow(missing_docs)]
-    EmailAndOtpRequiredOtpSent,
+    EmailAndOtpRequired,
 
     /// Fallback for unknown variants for forward compatibility
     #[serde(other)]
@@ -157,8 +157,8 @@ mod tests {
                     "\"email_required\"",
                 ),
                 (
-                    SendAccessTokenInvalidRequestError::EmailAndOtpRequiredOtpSent,
-                    "\"email_and_otp_required_otp_sent\"",
+                    SendAccessTokenInvalidRequestError::EmailAndOtpRequired,
+                    "\"email_and_otp_required\"",
                 ),
             ];
 

--- a/crates/bitwarden-auth/src/send_access/client.rs
+++ b/crates/bitwarden-auth/src/send_access/client.rs
@@ -661,11 +661,11 @@ mod tests {
         #[tokio::test]
         async fn request_send_access_token_invalid_grant_invalid_email_error() {
             // Create a mock error response
-            let error_description = "email is invalid.".into();
+            let error_description = "email and otp are required.".into();
             let raw_error = serde_json::json!({
                 "error": "invalid_grant",
                 "error_description": error_description,
-                "send_access_error_type": "email_invalid"
+                "send_access_error_type": "email_and_otp_required"
             });
 
             // Register the mock for the request
@@ -698,9 +698,9 @@ mod tests {
                     // Now assert the inner enum:
                     assert_eq!(
                         api_err,
-                        SendAccessTokenApiErrorResponse::InvalidGrant {
+                        SendAccessTokenApiErrorResponse::InvalidRequest {
                             send_access_error_type: Some(
-                                SendAccessTokenInvalidGrantError::EmailInvalid
+                                SendAccessTokenInvalidRequestError::EmailAndOtpRequired
                             ),
                             error_description: Some(error_description),
                         }

--- a/crates/bitwarden-auth/src/send_access/client.rs
+++ b/crates/bitwarden-auth/src/send_access/client.rs
@@ -539,7 +539,7 @@ mod tests {
                         api_err,
                         SendAccessTokenApiErrorResponse::InvalidRequest {
                             send_access_error_type: Some(
-                                SendAccessTokenInvalidRequestError::EmailAndOtpRequiredOtpSent
+                                SendAccessTokenInvalidRequestError::EmailAndOtpRequired
                             ),
                             error_description: Some(error_description),
                         }

--- a/crates/bitwarden-auth/src/send_access/client.rs
+++ b/crates/bitwarden-auth/src/send_access/client.rs
@@ -504,7 +504,7 @@ mod tests {
             let raw_error = serde_json::json!({
                 "error": "invalid_request",
                 "error_description": error_description,
-                "send_access_error_type": "email_and_otp_required_otp_sent"
+                "send_access_error_type": "email_and_otp_required"
             });
 
             // Create the mock for the request
@@ -659,11 +659,11 @@ mod tests {
         }
 
         #[tokio::test]
-        async fn request_send_access_token_invalid_grant_invalid_email_error() {
+        async fn request_send_access_token_invalid_request_invalid_email_error() {
             // Create a mock error response
             let error_description = "email and otp are required.".into();
             let raw_error = serde_json::json!({
-                "error": "invalid_grant",
+                "error": "invalid_request",
                 "error_description": error_description,
                 "send_access_error_type": "email_and_otp_required"
             });


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[PM-30563](https://bitwarden.atlassian.net/browse/PM-30563)

Server PR: [#6911](https://github.com/bitwarden/server/pull/6911)
Client PR: [#18620](https://github.com/bitwarden/clients/pull/18620)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

We are no longer expecting `invalid_email` error type instead we are only expecting `email_and_otp_required`. We are doing this to better protect against Send enumeration attacks. 

[PM-30563]: https://bitwarden.atlassian.net/browse/PM-30563?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ