### PR TITLE
[PM-29470] Remove ownership of openapi-generator directory

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -18,9 +18,11 @@
 # Bindings for our API do not have an owner as the API is shared between teams.
 crates/bitwarden-api-api/src/**
 crates/bitwarden-api-api/README.md
+crates/bitwarden-api-api/.openapi-generator/**
 # Bindings for Identity are owned by Auth.
 crates/bitwarden-api-identity/src/** @bitwarden/team-auth-dev @bitwarden/team-platform-dev
 crates/bitwarden-api-identity/README.md @bitwarden/team-auth-dev @bitwarden/team-platform-dev
+crates/bitwarden-api-identity/.openapi-generator/** @bitwarden/team-auth-dev @bitwarden/team-platform-dev
 # Bindings for Key Connector are owned by Key Management.
 crates/bitwarden-api-key-connector/src/** @bitwarden/team-key-management-dev
 


### PR DESCRIPTION
## 🎟️ Tracking

[bitwarden.atlassian.net/browse/PM-29470](https://bitwarden.atlassian.net/browse/PM-29470)

## 📔 Objective

In https://github.com/bitwarden/sdk-internal/pull/655, we removed explicit Platform ownership of the files that OpenAPI would use to generate new bindings.  However, I missed the `/.openapi-generator` directory, which would also be updated - see https://github.com/bitwarden/sdk-internal/pull/720/changes#diff-116487989746088e859d98f682a724480f21bab6f5f644081ceb148d22a90ca7.

This PR removes ownership of this directory to ensure that teams can manage their API bindings and assigns Platform and Auth shared ownership of the bindings for Identity.

## 🚨 Breaking Changes

<!-- Does this PR introduce any breaking changes? If so, please describe the impact and migration path for clients.

If you're unsure, the automated TypeScript compatibility check will run when you open/update this PR and provide feedback.

For breaking changes:
1. Describe what changed in the client interface
2. Explain why the change was necessary
3. Provide migration steps for client developers
4. Link to any paired client PRs if needed

Otherwise, you can remove this section. -->
