### PR TITLE
feat(sso): Add `acquireCookie` trait and function to ServerCommunicationConfigClient

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,6 @@ crates/bitwarden-uniffi/kotlin/sdk/src/main/java/com/bitwarden/**/*.kt
 
 # API Swagger files
 /artifacts
+
+# Claude
+.claude/settings.local.json

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -897,6 +897,7 @@ dependencies = [
 name = "bitwarden-server-communication-config"
 version = "2.0.0"
 dependencies = [
+ "async-trait",
  "bitwarden-error",
  "bitwarden-threading",
  "js-sys",
@@ -906,6 +907,7 @@ dependencies = [
  "thiserror 1.0.69",
  "tokio",
  "tsify",
+ "uniffi",
  "wasm-bindgen",
  "wasm-bindgen-futures",
 ]
@@ -1036,6 +1038,7 @@ dependencies = [
  "bitwarden-generators",
  "bitwarden-pm",
  "bitwarden-send",
+ "bitwarden-server-communication-config",
  "bitwarden-ssh",
  "bitwarden-state",
  "bitwarden-uniffi-error",

--- a/crates/bitwarden-server-communication-config/CLAUDE.md
+++ b/crates/bitwarden-server-communication-config/CLAUDE.md
@@ -10,12 +10,16 @@ for self-hosted environments requiring session affinity.
 - Provides data structures and repository pattern for storing per-hostname server communication
   settings
 - Manages SSO cookie configuration for load balancers that require session affinity
+- Coordinates platform-specific cookie acquisition through dependency injection
 - Exposes WASM bindings for TypeScript integration via State Provider
+- Exposes UniFFI bindings for mobile platforms (Swift/Kotlin)
 
 ### Key Concepts
 
 - **Repository Pattern**: Storage abstraction allowing TypeScript to implement via State Provider
   while Rust provides business logic
+- **Platform Integration Pattern**: Dependency injection for platform-specific operations (cookie
+  acquisition UI/WebView) that SDK cannot implement cross-platform
 - **Bootstrap Configuration**: Two modes - `Direct` (standard connection) or `SsoCookieVendor`
   (requires SSO cookie for load balancer)
 - **Hostname-Keyed Storage**: Configuration stored per vault hostname (e.g., "vault.acme.com"), not
@@ -30,24 +34,29 @@ for self-hosted environments requiring session affinity.
 ### System Architecture
 
 ```
-TypeScript Client (Desktop/Mobile)
-         ↓
-   WASM Bindings (JsServerCommunicationConfigClient)
-         ↓
-   ┌────────────────────────────────────────┐
-   │ ServerCommunicationConfigClient<R>     │
-   │  ├─ get_config(hostname) → Config      │
-   │  ├─ needs_bootstrap(hostname) → bool   │
-   │  └─ cookies(hostname) → Vec<(K,V)>     │
-   └────────────────────────────────────────┘
-         ↓
-   ┌────────────────────────────────────────┐
-   │ ServerCommunicationConfigRepository    │
-   │  ├─ get(hostname) → Option<Config>     │
-   │  └─ save(hostname, config)             │
-   └────────────────────────────────────────┘
-         ↓
-   TypeScript State Provider (implements repo)
+┌───────────────────────────────────────────────────────────────┐
+│                    Platform Clients                           │
+│  TypeScript (Web/Desktop)  │  Swift (iOS)  │  Kotlin (Android)│
+└───────────────────────────────────────────────────────────────┘
+         ↓                            ↓                ↓
+   WASM Bindings                          UniFFI Bindings
+   (JsClient)                           (UniffiClient wrapper)
+         ↓                            ↓                ↓
+   ┌───────────────────────────────────────────────────────────┐
+   │      ServerCommunicationConfigClient<R, P>                │
+   │       ├─ get_config(hostname) → Config                   │
+   │       ├─ needs_bootstrap(hostname) → bool                │
+   │       ├─ cookies(hostname) → Vec<(K,V)>                  │
+   │       └─ acquire_cookie(hostname) → Result<(), E>        │
+   └───────────────────────────────────────────────────────────┘
+         ↓                                    ↓
+   ┌─────────────────────────┐  ┌────────────────────────────────┐
+   │ Repository (storage)    │  │ PlatformApi (acquisition)      │
+   │  ├─ get(hostname)       │  │  └─ acquire_cookie(hostname)   │
+   │  └─ save(hostname, cfg) │  │       → Option<AcquiredCookie>│
+   └─────────────────────────┘  └────────────────────────────────┘
+         ↓                                    ↓
+   Platform Storage               Platform WebView/Browser API
 ```
 
 ### Code Organization
@@ -57,11 +66,22 @@ src/
 ├── lib.rs              # Public re-exports
 ├── config.rs           # Data structures (ServerCommunicationConfig, BootstrapConfig)
 ├── repository.rs       # Repository trait and error types
+├── platform_api.rs     # Platform API trait, AcquiredCookie, and acquisition errors
 ├── client.rs           # Client business logic
-└── wasm/               # WASM-only bindings (feature-gated)
+└── wasm/               # WASM-only bindings (feature = "wasm")
     ├── mod.rs          # WASM module re-exports
     ├── client.rs       # JsServerCommunicationConfigClient wrapper
-    └── js_repository.rs # ThreadBoundRunner-wrapped repository
+    ├── js_repository.rs    # ThreadBoundRunner-wrapped repository
+    └── js_platform_api.rs  # ThreadBoundRunner-wrapped platform API
+
+UniFFI bindings (feature = "uniffi"):
+├── uniffi.toml         # UniFFI configuration
+└── Integrated into bitwarden-uniffi crate:
+    └── src/platform/server_communication_config.rs
+        ├── UniffiServerCommunicationConfigClient wrapper
+        ├── ServerCommunicationConfigRepositoryTrait (foreign trait)
+        ├── UniffiRepositoryBridge adapter
+        └── UniffiPlatformApiBridge adapter
 ```
 
 ### Key Principles
@@ -98,13 +118,88 @@ pub trait ServerCommunicationConfigRepository: Send + Sync + 'static {
 **Usage**:
 
 ```rust
-// In tests: Use mock repository
-let repo = Arc::new(MockRepository::default());
-let client = ServerCommunicationConfigClient::new(repo);
+// In tests: Use mock repository and platform API
+let repo = MockRepository::default();
+let platform_api = MockPlatformApi::default();
+let client = ServerCommunicationConfigClient::new(repo, platform_api);
 
-// In WASM: TypeScript implements repository
+// In WASM: TypeScript implements both traits via JS bridges
 let js_repo = JsServerCommunicationConfigRepository::new(raw_js_repo);
-let client = ServerCommunicationConfigClient::new(Arc::new(js_repo));
+let js_platform_api = JsServerCommunicationConfigPlatformApi::new(raw_js_platform_api);
+let client = ServerCommunicationConfigClient::new(js_repo, js_platform_api);
+
+// In UniFFI: Swift/Kotlin implements traits, SDK provides wrapper
+let uniffi_client = UniffiServerCommunicationConfigClient::new(
+    Arc::new(platform_repository_impl),  // Implements ServerCommunicationConfigRepositoryTrait
+    Arc::new(platform_api_impl),          // Implements ServerCommunicationConfigPlatformApi
+);
+```
+
+#### Platform Integration Pattern
+
+**Purpose**: Dependency injection for platform-specific operations that SDK cannot implement
+cross-platform (WebView cookie flows, browser APIs, native UI)
+
+**Implementation**:
+
+```rust
+/// Cookie acquired from platform
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
+pub struct AcquiredCookie {
+    pub name: String,
+    pub value: String,
+}
+
+#[cfg_attr(feature = "uniffi", uniffi::export(with_foreign))]
+#[async_trait::async_trait]
+pub trait ServerCommunicationConfigPlatformApi: Send + Sync {
+    async fn acquire_cookie(&self, hostname: String) -> Option<AcquiredCookie>;
+}
+```
+
+**Note**: `AcquiredCookie` struct is used instead of tuple `(String, String)` because UniFFI does
+not support tuples in FFI signatures. The struct provides a consistent type across all platform
+bindings.
+
+**Platform-Specific Implementations**:
+
+- **Web (WASM)**: Opens browser window/iframe, uses `document.cookie` API
+- **Desktop/Mobile**: Opens WebView, intercepts cookie from navigation
+- **Tests**: Returns mock cookie tuples
+
+**Cookie Acquisition Flow**:
+
+1. SDK calls `client.acquire_cookie(hostname)`
+2. SDK retrieves expected cookie name from stored configuration
+3. SDK invokes `platform_api.acquire_cookie(hostname)` to trigger UI flow
+4. Platform opens IDP login URL in WebView/browser
+5. User authenticates with identity provider
+6. Platform extracts cookie from browser/WebView and returns `AcquiredCookie { name, value }`
+7. SDK validates cookie name matches expected name from configuration
+8. SDK saves cookie value to repository
+
+**Error Handling**:
+
+```rust
+#[derive(Debug, Error, Clone, PartialEq, Eq)]
+#[bitwarden_error(flat)]
+pub enum AcquireCookieError {
+    #[error("Cookie acquisition was cancelled")]
+    Cancelled,
+
+    #[error("Server configuration does not support SSO cookie acquisition (Direct bootstrap)")]
+    UnsupportedConfiguration,
+
+    #[error("Cookie name mismatch: expected {expected}, got {actual}")]
+    CookieNameMismatch { expected: String, actual: String },
+
+    #[error("Failed to get server configuration: {0}")]
+    RepositoryGetError(String),
+
+    #[error("Failed to save server configuration: {0}")]
+    RepositorySaveError(String),
+}
 ```
 
 #### Tagged Enum Serialization
@@ -210,6 +305,7 @@ pub struct SsoCookieVendorConfig {
 ### Error Types
 
 ```rust
+/// Repository operation errors
 #[derive(Debug, Error, Clone, PartialEq, Eq)]
 #[bitwarden_error(flat)]
 pub enum ServerCommunicationConfigRepositoryError {
@@ -219,7 +315,33 @@ pub enum ServerCommunicationConfigRepositoryError {
     #[error("Failed to save configuration: {0}")]
     SaveError(String),
 }
+
+/// Cookie acquisition errors
+#[derive(Debug, Error, Clone, PartialEq, Eq)]
+#[bitwarden_error(flat)]
+pub enum AcquireCookieError {
+    #[error("Cookie acquisition was cancelled")]
+    Cancelled,
+
+    #[error("Server configuration does not support SSO cookie acquisition (Direct bootstrap)")]
+    UnsupportedConfiguration,
+
+    #[error("Cookie name mismatch: expected {expected}, got {actual}")]
+    CookieNameMismatch { expected: String, actual: String },
+
+    #[error("Failed to get server configuration: {0}")]
+    RepositoryGetError(String),
+
+    #[error("Failed to save server configuration: {0}")]
+    RepositorySaveError(String),
+}
 ```
+
+**Note on `#[bitwarden_error(flat)]`**: This macro automatically generates:
+
+- WASM bindings (converts to string errors for JavaScript)
+- TypeScript interfaces for error handling
+- UniFFI error mappings for mobile bindings
 
 ---
 
@@ -249,7 +371,13 @@ This crate stores authentication configuration but does not perform authenticati
 
 - **Cookie Storage**: Stores SSO cookie configuration received from server
 - **Cookie Retrieval**: Provides cookies for HTTP client middleware to attach to requests
+- **Cookie Acquisition**: Coordinates platform-specific cookie acquisition through dependency
+  injection
 - **Bootstrap Detection**: Determines if cookie acquisition flow is needed
+
+**Cookie Validation**: When acquiring cookies, the SDK validates that the cookie name returned by
+the platform matches the expected name from the server configuration. This prevents accepting wrong
+cookies that could cause authentication failures.
 
 ---
 

--- a/crates/bitwarden-server-communication-config/Cargo.toml
+++ b/crates/bitwarden-server-communication-config/Cargo.toml
@@ -20,7 +20,10 @@ wasm = [
     "bitwarden-threading/wasm",
 ] # WASM support
 
+uniffi = ["dep:uniffi"] # UniFFI support for mobile bindings
+
 [dependencies]
+async-trait = { workspace = true }
 bitwarden-error = { workspace = true }
 bitwarden-threading = { workspace = true }
 js-sys = { workspace = true, optional = true }
@@ -29,6 +32,7 @@ serde-wasm-bindgen = { workspace = true, optional = true }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["sync"] }
 tsify = { workspace = true, optional = true }
+uniffi = { workspace = true, optional = true }
 wasm-bindgen = { workspace = true, optional = true }
 wasm-bindgen-futures = { workspace = true, optional = true }
 

--- a/crates/bitwarden-server-communication-config/README.md
+++ b/crates/bitwarden-server-communication-config/README.md
@@ -52,20 +52,47 @@ client application.
 
 ## Usage
 
-The SDK client is instantiated by TypeScript with a State Provider-backed repository:
+The SDK client is instantiated by TypeScript with State Provider-backed repository and platform API:
 
 ```typescript
 import { ServerCommunicationConfigClient } from "@bitwarden/sdk-internal";
 
 // State Provider provides the repository implementation
 const repository = stateProvider.getGlobal(ServerCommunicationConfig);
-const client = new ServerCommunicationConfigClient(repository);
 
-// Check if bootstrap is needed
-await client.needsBootstrap("vault.example.com");
+// Platform provides cookie acquisition implementation
+const platformApi = {
+  async acquireCookies(hostname: string): Promise<AcquiredCookie[] | undefined> {
+    // Platform-specific logic to:
+    // 1. Open browser/WebView to IdP login URL
+    // 2. Wait for authentication
+    // 3. Extract cookies from browser
+    // 4. Return as array of {name, value} objects
+    //
+    // For sharded cookies (AWS ALB), extract all shards:
+    // [
+    //   { name: "AWSELBAuthSessionCookie-0", value: "..." },
+    //   { name: "AWSELBAuthSessionCookie-1", value: "..." }
+    // ]
+    //
+    // For unsharded cookies, return single entry:
+    // [{ name: "SessionCookie", value: "..." }]
+  },
+};
 
-// Get cookies for HTTP requests
-await client.cookies("vault.example.com");
+const client = new ServerCommunicationConfigClient(repository, platformApi);
+
+// Check if bootstrap is needed (no cookie acquired yet)
+const needsBootstrap = await client.needsBootstrap("vault.example.com");
+
+if (needsBootstrap) {
+  // Trigger cookie acquisition flow
+  await client.acquireCookie("vault.example.com");
+}
+
+// Get cookies for HTTP requests (returns name-value pairs)
+const cookies = await client.cookies("vault.example.com");
+// cookies = [["CookieName-0", "value0"], ["CookieName-1", "value1"]]
 ```
 
 ## Features

--- a/crates/bitwarden-server-communication-config/README.md
+++ b/crates/bitwarden-server-communication-config/README.md
@@ -26,7 +26,9 @@ The crate follows the architecture pattern of other foundation layer SDK exports
 - **`ServerCommunicationConfig`**: Data structures for bootstrap configuration and SSO cookie
   settings
 - **`ServerCommunicationConfigRepository`**: Storage abstraction trait for WASM interop with
-  TypeScript
+  TypeScript (implemented by the platform)
+- **`ServerCommunicationConfigPlatformApi`**: Platform-specific operations trait for cookie
+  acquisition (implemented by the platform)
 - **`ServerCommunicationConfigClient`**: High-level client for retrieving configuration and cookies
   by hostname
 
@@ -36,6 +38,17 @@ Configuration is stored per-hostname and supports two bootstrap modes:
 
 1. **Direct**: Standard direct connection (no special cookies required)
 2. **SSO Cookie Vendor**: Load balancer requires SSO authentication cookies for session affinity
+
+### Integration Pattern
+
+SDK platforms inject logic for platform-specific operations:
+
+- **Repository**: The platform provides a storage implementation (e.g., State Provider)
+- **Platform API**: The platform provides cookie acquisition implementation (e.g., browser
+  redirects, WebView handling)
+
+This allows the SDK to remain platform-agnostic while delegating browser/WebView operations to the
+client application.
 
 ## Usage
 
@@ -58,6 +71,7 @@ await client.cookies("vault.example.com");
 ## Features
 
 - `wasm`: Enables WebAssembly bindings for TypeScript integration
+- `uniffi`: Enables UniFFI bindings for mobile platforms
 
 ## Non-Goals
 

--- a/crates/bitwarden-server-communication-config/src/client.rs
+++ b/crates/bitwarden-server-communication-config/src/client.rs
@@ -1,24 +1,36 @@
-use crate::{BootstrapConfig, ServerCommunicationConfig, ServerCommunicationConfigRepository};
+#[cfg(test)]
+use crate::AcquiredCookie;
+use crate::{
+    AcquireCookieError, BootstrapConfig, ServerCommunicationConfig,
+    ServerCommunicationConfigPlatformApi, ServerCommunicationConfigRepository,
+};
 
 /// Server communication configuration client
-pub struct ServerCommunicationConfigClient<R>
+pub struct ServerCommunicationConfigClient<R, P>
 where
     R: ServerCommunicationConfigRepository,
+    P: ServerCommunicationConfigPlatformApi,
 {
     repository: R,
+    platform_api: P,
 }
 
-impl<R> ServerCommunicationConfigClient<R>
+impl<R, P> ServerCommunicationConfigClient<R, P>
 where
     R: ServerCommunicationConfigRepository,
+    P: ServerCommunicationConfigPlatformApi,
 {
     /// Creates a new server communication configuration client
     ///
     /// # Arguments
     ///
-    /// * `repository` - Repository implementation for storing configuration
-    pub fn new(repository: R) -> Self {
-        Self { repository }
+    /// * `repository` - Cookie storage implementation (e.g a StateProvider hook)
+    /// * `platform_api` - Cookie acquistion implementation
+    pub fn new(repository: R, platform_api: P) -> Self {
+        Self {
+            repository,
+            platform_api,
+        }
     }
 
     /// Retrieves the server communication configuration for a hostname
@@ -56,6 +68,68 @@ where
         }
         Vec::new()
     }
+
+    /// Acquires a cookie from the platform and saves it to the repository
+    ///
+    /// This method calls the platform API to trigger cookie acquisition (e.g., browser
+    /// redirect to IdP), then validates and stores the acquired cookie in the repository.
+    ///
+    /// # Arguments
+    ///
+    /// * `hostname` - The server hostname (e.g., "vault.acme.com")
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if:
+    /// - Cookie acquisition was cancelled by the user ([`AcquireCookieError::Cancelled`])
+    /// - Server configuration doesn't support SSO cookies
+    ///   ([`AcquireCookieError::UnsupportedConfiguration`])
+    /// - Acquired cookie name doesn't match expected name
+    ///   ([`AcquireCookieError::CookieNameMismatch`])
+    /// - Repository operations fail ([`AcquireCookieError::RepositoryGetError`] or
+    ///   [`AcquireCookieError::RepositorySaveError`])
+    pub async fn acquire_cookie(&self, hostname: &str) -> Result<(), AcquireCookieError> {
+        // Get existing configuration - we need this to know what cookie to expect
+        let mut config = self
+            .repository
+            .get(hostname.to_string())
+            .await
+            .map_err(|e| AcquireCookieError::RepositoryGetError(format!("{:?}", e)))?
+            .ok_or(AcquireCookieError::UnsupportedConfiguration)?;
+
+        // Verify this is an SSO cookie vendor configuration and get mutable reference
+        let BootstrapConfig::SsoCookieVendor(ref mut vendor_config) = config.bootstrap else {
+            return Err(AcquireCookieError::UnsupportedConfiguration);
+        };
+
+        let expected_cookie_name = &vendor_config.cookie_name;
+
+        // Call platform API to acquire the cookie
+        let cookie = self
+            .platform_api
+            .acquire_cookie(hostname.to_string())
+            .await
+            .ok_or(AcquireCookieError::Cancelled)?;
+
+        // Validate the cookie name matches what we expect
+        if cookie.name != *expected_cookie_name {
+            return Err(AcquireCookieError::CookieNameMismatch {
+                expected: expected_cookie_name.clone(),
+                actual: cookie.name,
+            });
+        }
+
+        // Update the cookie value using the mutable reference we already have
+        vendor_config.cookie_value = Some(cookie.value);
+
+        // Save the updated config
+        self.repository
+            .save(hostname.to_string(), config)
+            .await
+            .map_err(|e| AcquireCookieError::RepositorySaveError(format!("{:?}", e)))?;
+
+        Ok(())
+    }
 }
 
 #[cfg(test)]
@@ -91,10 +165,36 @@ mod tests {
         }
     }
 
+    /// Mock platform API for testing
+    #[derive(Clone)]
+    struct MockPlatformApi {
+        cookie_to_return: std::sync::Arc<RwLock<Option<AcquiredCookie>>>,
+    }
+
+    impl MockPlatformApi {
+        fn new() -> Self {
+            Self {
+                cookie_to_return: std::sync::Arc::new(RwLock::new(None)),
+            }
+        }
+
+        async fn set_cookie(&self, cookie: Option<AcquiredCookie>) {
+            *self.cookie_to_return.write().await = cookie;
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl ServerCommunicationConfigPlatformApi for MockPlatformApi {
+        async fn acquire_cookie(&self, _hostname: String) -> Option<AcquiredCookie> {
+            self.cookie_to_return.read().await.clone()
+        }
+    }
+
     #[tokio::test]
     async fn get_config_returns_direct_when_not_found() {
         let repo = MockRepository::default();
-        let client = ServerCommunicationConfigClient::new(repo);
+        let platform_api = MockPlatformApi::new();
+        let client = ServerCommunicationConfigClient::new(repo, platform_api);
 
         let config = client
             .get_config("vault.example.com".to_string())
@@ -120,7 +220,8 @@ mod tests {
             .await
             .unwrap();
 
-        let client = ServerCommunicationConfigClient::new(repo.clone());
+        let platform_api = MockPlatformApi::new();
+        let client = ServerCommunicationConfigClient::new(repo.clone(), platform_api);
         let retrieved = client
             .get_config("vault.example.com".to_string())
             .await
@@ -148,7 +249,8 @@ mod tests {
             .await
             .unwrap();
 
-        let client = ServerCommunicationConfigClient::new(repo.clone());
+        let platform_api = MockPlatformApi::new();
+        let client = ServerCommunicationConfigClient::new(repo.clone(), platform_api);
         assert!(
             client
                 .needs_bootstrap("vault.example.com".to_string())
@@ -172,7 +274,8 @@ mod tests {
             .await
             .unwrap();
 
-        let client = ServerCommunicationConfigClient::new(repo.clone());
+        let platform_api = MockPlatformApi::new();
+        let client = ServerCommunicationConfigClient::new(repo.clone(), platform_api);
         assert!(
             !client
                 .needs_bootstrap("vault.example.com".to_string())
@@ -191,7 +294,8 @@ mod tests {
             .await
             .unwrap();
 
-        let client = ServerCommunicationConfigClient::new(repo.clone());
+        let platform_api = MockPlatformApi::new();
+        let client = ServerCommunicationConfigClient::new(repo.clone(), platform_api);
         assert!(
             !client
                 .needs_bootstrap("vault.example.com".to_string())
@@ -210,7 +314,8 @@ mod tests {
             .await
             .unwrap();
 
-        let client = ServerCommunicationConfigClient::new(repo.clone());
+        let platform_api = MockPlatformApi::new();
+        let client = ServerCommunicationConfigClient::new(repo.clone(), platform_api);
         let cookies = client.cookies("vault.example.com".to_string()).await;
 
         assert!(cookies.is_empty());
@@ -232,7 +337,8 @@ mod tests {
             .await
             .unwrap();
 
-        let client = ServerCommunicationConfigClient::new(repo.clone());
+        let platform_api = MockPlatformApi::new();
+        let client = ServerCommunicationConfigClient::new(repo.clone(), platform_api);
         let cookies = client.cookies("vault.example.com".to_string()).await;
 
         assert!(cookies.is_empty());
@@ -254,7 +360,8 @@ mod tests {
             .await
             .unwrap();
 
-        let client = ServerCommunicationConfigClient::new(repo.clone());
+        let platform_api = MockPlatformApi::new();
+        let client = ServerCommunicationConfigClient::new(repo.clone(), platform_api);
         let cookies = client.cookies("vault.example.com".to_string()).await;
 
         assert_eq!(cookies.len(), 1);
@@ -265,9 +372,176 @@ mod tests {
     #[tokio::test]
     async fn cookies_returns_empty_when_no_config() {
         let repo = MockRepository::default();
-        let client = ServerCommunicationConfigClient::new(repo);
+        let platform_api = MockPlatformApi::new();
+        let client = ServerCommunicationConfigClient::new(repo, platform_api);
         let cookies = client.cookies("vault.example.com".to_string()).await;
 
         assert!(cookies.is_empty());
+    }
+
+    #[tokio::test]
+    async fn acquire_cookie_saves_when_cookie_returned() {
+        let repo = MockRepository::default();
+        let platform_api = MockPlatformApi::new();
+
+        // Setup existing config with SsoCookieVendor
+        let config = ServerCommunicationConfig {
+            bootstrap: BootstrapConfig::SsoCookieVendor(SsoCookieVendorConfig {
+                idp_login_url: "https://example.com".to_string(),
+                cookie_name: "TestCookie".to_string(),
+                cookie_domain: "example.com".to_string(),
+                cookie_value: None,
+            }),
+        };
+        repo.save("vault.example.com".to_string(), config)
+            .await
+            .unwrap();
+
+        // Configure platform API to return a cookie with correct name
+        platform_api
+            .set_cookie(Some(AcquiredCookie {
+                name: "TestCookie".to_string(),
+                value: "acquired-cookie-value".to_string(),
+            }))
+            .await;
+
+        let client = ServerCommunicationConfigClient::new(repo.clone(), platform_api);
+
+        // Call acquire_cookie - should succeed
+        client.acquire_cookie("vault.example.com").await.unwrap();
+
+        // Verify cookie was saved
+        let saved_config = repo
+            .get("vault.example.com".to_string())
+            .await
+            .unwrap()
+            .unwrap();
+
+        if let BootstrapConfig::SsoCookieVendor(vendor_config) = saved_config.bootstrap {
+            assert_eq!(
+                vendor_config.cookie_value,
+                Some("acquired-cookie-value".to_string())
+            );
+        } else {
+            panic!("Expected SsoCookieVendor config");
+        }
+    }
+
+    #[tokio::test]
+    async fn acquire_cookie_returns_cancelled_when_none() {
+        let repo = MockRepository::default();
+        let platform_api = MockPlatformApi::new();
+
+        // Setup existing config
+        let config = ServerCommunicationConfig {
+            bootstrap: BootstrapConfig::SsoCookieVendor(SsoCookieVendorConfig {
+                idp_login_url: "https://example.com".to_string(),
+                cookie_name: "TestCookie".to_string(),
+                cookie_domain: "example.com".to_string(),
+                cookie_value: None,
+            }),
+        };
+        repo.save("vault.example.com".to_string(), config)
+            .await
+            .unwrap();
+
+        // Platform API returns None (user cancelled)
+        platform_api.set_cookie(None).await;
+
+        let client = ServerCommunicationConfigClient::new(repo, platform_api);
+
+        let result = client.acquire_cookie("vault.example.com").await;
+
+        assert!(matches!(result, Err(AcquireCookieError::Cancelled)));
+    }
+
+    #[tokio::test]
+    async fn acquire_cookie_returns_unsupported_for_direct_config() {
+        let repo = MockRepository::default();
+        let platform_api = MockPlatformApi::new();
+
+        // Setup Direct config
+        let config = ServerCommunicationConfig {
+            bootstrap: BootstrapConfig::Direct,
+        };
+        repo.save("vault.example.com".to_string(), config)
+            .await
+            .unwrap();
+
+        // Platform API returns a cookie
+        platform_api
+            .set_cookie(Some(AcquiredCookie {
+                name: "TestCookie".to_string(),
+                value: "cookie-value".to_string(),
+            }))
+            .await;
+
+        let client = ServerCommunicationConfigClient::new(repo, platform_api);
+
+        let result = client.acquire_cookie("vault.example.com").await;
+
+        // Should return UnsupportedConfiguration because config is Direct
+        assert!(matches!(
+            result,
+            Err(AcquireCookieError::UnsupportedConfiguration)
+        ));
+    }
+
+    #[tokio::test]
+    async fn acquire_cookie_validates_cookie_name() {
+        let repo = MockRepository::default();
+        let platform_api = MockPlatformApi::new();
+
+        // Setup config expecting "ExpectedCookie"
+        let config = ServerCommunicationConfig {
+            bootstrap: BootstrapConfig::SsoCookieVendor(SsoCookieVendorConfig {
+                idp_login_url: "https://example.com".to_string(),
+                cookie_name: "ExpectedCookie".to_string(),
+                cookie_domain: "example.com".to_string(),
+                cookie_value: None,
+            }),
+        };
+        repo.save("vault.example.com".to_string(), config)
+            .await
+            .unwrap();
+
+        // Platform API returns wrong cookie name
+        platform_api
+            .set_cookie(Some(AcquiredCookie {
+                name: "WrongCookie".to_string(),
+                value: "some-value".to_string(),
+            }))
+            .await;
+
+        let client = ServerCommunicationConfigClient::new(repo, platform_api);
+
+        let result = client.acquire_cookie("vault.example.com").await;
+
+        // Should return CookieNameMismatch
+        match result {
+            Err(AcquireCookieError::CookieNameMismatch { expected, actual }) => {
+                assert_eq!(expected, "ExpectedCookie");
+                assert_eq!(actual, "WrongCookie");
+            }
+            _ => panic!("Expected CookieNameMismatch error"),
+        }
+    }
+
+    #[tokio::test]
+    async fn acquire_cookie_returns_unsupported_when_no_config() {
+        let repo = MockRepository::default();
+        let platform_api = MockPlatformApi::new();
+
+        // No config saved for this hostname
+
+        let client = ServerCommunicationConfigClient::new(repo, platform_api);
+
+        let result = client.acquire_cookie("vault.example.com").await;
+
+        // Should return UnsupportedConfiguration because no config exists
+        assert!(matches!(
+            result,
+            Err(AcquireCookieError::UnsupportedConfiguration)
+        ));
     }
 }

--- a/crates/bitwarden-server-communication-config/src/config.rs
+++ b/crates/bitwarden-server-communication-config/src/config.rs
@@ -7,6 +7,7 @@ use serde::{Deserialize, Serialize};
     derive(tsify::Tsify),
     tsify(into_wasm_abi, from_wasm_abi)
 )]
+#[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
 pub struct ServerCommunicationConfig {
     /// Bootstrap configuration determining how to establish server communication
     pub bootstrap: BootstrapConfig,
@@ -19,6 +20,7 @@ pub struct ServerCommunicationConfig {
     derive(tsify::Tsify),
     tsify(into_wasm_abi, from_wasm_abi)
 )]
+#[cfg_attr(feature = "uniffi", derive(uniffi::Enum))]
 #[serde(tag = "type", rename_all = "camelCase")]
 pub enum BootstrapConfig {
     /// Direct connection with no special authentication requirements
@@ -36,6 +38,7 @@ pub enum BootstrapConfig {
     derive(tsify::Tsify),
     tsify(into_wasm_abi, from_wasm_abi)
 )]
+#[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
 pub struct SsoCookieVendorConfig {
     /// Identity provider login URL for browser redirect during bootstrap
     pub idp_login_url: String,

--- a/crates/bitwarden-server-communication-config/src/config.rs
+++ b/crates/bitwarden-server-communication-config/src/config.rs
@@ -48,8 +48,9 @@ pub struct SsoCookieVendorConfig {
     pub cookie_domain: String,
     /// Cookie value shards
     ///
-    /// IdP cookies can be sharded across multiple values. When present, all shards
-    /// should be concatenated when setting the cookie for HTTP requests.
+    /// IdP cookies can be sharded across multiple values to work around browser
+    /// 4KB cookie size limits. Each shard should be set as a separate cookie with
+    /// the same cookie name. The load balancer automatically reassembles them.
     pub cookie_value: Option<Vec<String>>,
 }
 

--- a/crates/bitwarden-server-communication-config/src/lib.rs
+++ b/crates/bitwarden-server-communication-config/src/lib.rs
@@ -6,12 +6,17 @@
 
 #![deny(missing_docs)]
 
+#[cfg(feature = "uniffi")]
+uniffi::setup_scaffolding!();
+
 mod client;
 mod config;
+mod platform_api;
 mod repository;
 
 pub use client::ServerCommunicationConfigClient;
 pub use config::{BootstrapConfig, ServerCommunicationConfig, SsoCookieVendorConfig};
+pub use platform_api::{AcquireCookieError, AcquiredCookie, ServerCommunicationConfigPlatformApi};
 pub use repository::{
     ServerCommunicationConfigRepository, ServerCommunicationConfigRepositoryError,
 };

--- a/crates/bitwarden-server-communication-config/src/platform_api.rs
+++ b/crates/bitwarden-server-communication-config/src/platform_api.rs
@@ -15,8 +15,9 @@ pub struct AcquiredCookie {
     pub name: String,
     /// Cookie value shards
     ///
-    /// IdP cookies can be sharded across multiple values. Each shard should be
-    /// preserved in order to properly reconstruct the cookie for HTTP requests.
+    /// IdP cookies can be sharded across multiple values to work around browser
+    /// 4KB cookie size limits. Each shard should be sent as a separate cookie with
+    /// the same cookie name. The load balancer automatically reassembles them.
     pub value: Vec<String>,
 }
 

--- a/crates/bitwarden-server-communication-config/src/platform_api.rs
+++ b/crates/bitwarden-server-communication-config/src/platform_api.rs
@@ -4,6 +4,11 @@ use thiserror::Error;
 
 /// A cookie acquired from the platform
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[cfg_attr(
+    feature = "wasm",
+    derive(tsify::Tsify),
+    tsify(into_wasm_abi, from_wasm_abi)
+)]
 #[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
 pub struct AcquiredCookie {
     /// Cookie name

--- a/crates/bitwarden-server-communication-config/src/platform_api.rs
+++ b/crates/bitwarden-server-communication-config/src/platform_api.rs
@@ -13,8 +13,11 @@ use thiserror::Error;
 pub struct AcquiredCookie {
     /// Cookie name
     pub name: String,
-    /// Cookie value
-    pub value: String,
+    /// Cookie value shards
+    ///
+    /// IdP cookies can be sharded across multiple values. Each shard should be
+    /// preserved in order to properly reconstruct the cookie for HTTP requests.
+    pub value: Vec<String>,
 }
 
 /// Errors that can occur during cookie acquisition

--- a/crates/bitwarden-server-communication-config/src/platform_api.rs
+++ b/crates/bitwarden-server-communication-config/src/platform_api.rs
@@ -1,0 +1,69 @@
+use bitwarden_error::bitwarden_error;
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+/// A cookie acquired from the platform
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
+pub struct AcquiredCookie {
+    /// Cookie name
+    pub name: String,
+    /// Cookie value
+    pub value: String,
+}
+
+/// Errors that can occur during cookie acquisition
+#[derive(Debug, Error, Clone, PartialEq, Eq)]
+#[bitwarden_error(flat)]
+pub enum AcquireCookieError {
+    /// Cookie acquisition was cancelled by the user
+    #[error("Cookie acquisition was cancelled")]
+    Cancelled,
+
+    /// The server configuration does not support cookie acquisition
+    #[error("Server configuration does not support SSO cookie acquisition (Direct bootstrap)")]
+    UnsupportedConfiguration,
+
+    /// The acquired cookie name does not match the expected cookie name
+    #[error("Cookie name mismatch: expected {expected}, got {actual}")]
+    CookieNameMismatch {
+        /// Expected cookie name from server configuration
+        expected: String,
+        /// Actual cookie name returned by platform
+        actual: String,
+    },
+
+    /// Failed to retrieve server configuration from repository
+    #[error("Failed to get server configuration: {0}")]
+    RepositoryGetError(String),
+
+    /// Failed to save updated configuration to repository
+    #[error("Failed to save server configuration: {0}")]
+    RepositorySaveError(String),
+}
+
+/// Platform API for acquiring cookies from the platform client
+///
+/// This trait abstracts the platform-specific logic for acquiring SSO cookies
+/// from load balancers. Platform clients (web, mobile, desktop) implement this
+/// trait to provide cookie acquisition through browser interactions or native
+/// HTTP client capabilities.
+#[cfg_attr(feature = "uniffi", uniffi::export(with_foreign))]
+#[async_trait::async_trait]
+pub trait ServerCommunicationConfigPlatformApi: Send + Sync {
+    /// Acquires a cookie for the given hostname
+    ///
+    /// The platform client should trigger any necessary user interaction
+    /// (e.g., browser redirect to IdP) to acquire the cookie from the
+    /// load balancer.
+    ///
+    /// # Arguments
+    ///
+    /// * `hostname` - The server hostname (e.g., "vault.acme.com")
+    ///
+    /// # Returns
+    ///
+    /// - `Some(cookie)` - Cookie was successfully acquired
+    /// - `None` - Cookie acquisition failed or was cancelled
+    async fn acquire_cookie(&self, hostname: String) -> Option<AcquiredCookie>;
+}

--- a/crates/bitwarden-server-communication-config/src/repository.rs
+++ b/crates/bitwarden-server-communication-config/src/repository.rs
@@ -104,13 +104,18 @@ mod tests {
 
     #[tokio::test]
     async fn repository_save_and_get() {
+        use crate::AcquiredCookie;
+
         let repo = InMemoryRepository::default();
         let config = ServerCommunicationConfig {
             bootstrap: BootstrapConfig::SsoCookieVendor(SsoCookieVendorConfig {
                 idp_login_url: "https://example.com/login".to_string(),
                 cookie_name: "TestCookie".to_string(),
                 cookie_domain: "example.com".to_string(),
-                cookie_value: Some(vec!["cookie-value-123".to_string()]),
+                cookie_value: Some(vec![AcquiredCookie {
+                    name: "TestCookie".to_string(),
+                    value: "cookie-value-123".to_string(),
+                }]),
             }),
         };
 
@@ -128,9 +133,10 @@ mod tests {
 
         if let BootstrapConfig::SsoCookieVendor(vendor_config) = retrieved.bootstrap {
             assert_eq!(vendor_config.cookie_name, "TestCookie");
+            assert_eq!(vendor_config.cookie_value.as_ref().unwrap().len(), 1);
             assert_eq!(
-                vendor_config.cookie_value,
-                Some(vec!["cookie-value-123".to_string()])
+                vendor_config.cookie_value.as_ref().unwrap()[0].value,
+                "cookie-value-123"
             );
         } else {
             panic!("Expected SsoCookieVendor");

--- a/crates/bitwarden-server-communication-config/src/repository.rs
+++ b/crates/bitwarden-server-communication-config/src/repository.rs
@@ -110,7 +110,7 @@ mod tests {
                 idp_login_url: "https://example.com/login".to_string(),
                 cookie_name: "TestCookie".to_string(),
                 cookie_domain: "example.com".to_string(),
-                cookie_value: Some("cookie-value-123".to_string()),
+                cookie_value: Some(vec!["cookie-value-123".to_string()]),
             }),
         };
 
@@ -130,7 +130,7 @@ mod tests {
             assert_eq!(vendor_config.cookie_name, "TestCookie");
             assert_eq!(
                 vendor_config.cookie_value,
-                Some("cookie-value-123".to_string())
+                Some(vec!["cookie-value-123".to_string()])
             );
         } else {
             panic!("Expected SsoCookieVendor");

--- a/crates/bitwarden-server-communication-config/src/repository.rs
+++ b/crates/bitwarden-server-communication-config/src/repository.rs
@@ -20,7 +20,7 @@ pub enum ServerCommunicationConfigRepositoryError {
 ///
 /// This trait abstracts storage to allow TypeScript implementations via State Provider
 /// in WASM contexts, while also supporting in-memory implementations for testing.
-pub trait ServerCommunicationConfigRepository: Send + Sync + 'static {
+pub trait ServerCommunicationConfigRepository: Send + Sync {
     /// Error type returned by `get()` operations
     type GetError: std::fmt::Debug + Send + Sync + 'static;
     /// Error type returned by `save()` operations

--- a/crates/bitwarden-server-communication-config/src/wasm/client.rs
+++ b/crates/bitwarden-server-communication-config/src/wasm/client.rs
@@ -2,7 +2,10 @@ use wasm_bindgen::prelude::*;
 
 use crate::{
     ServerCommunicationConfig, ServerCommunicationConfigClient,
-    wasm::{JsServerCommunicationConfigRepository, RawJsServerCommunicationConfigRepository},
+    wasm::{
+        JsServerCommunicationConfigPlatformApi, JsServerCommunicationConfigRepository,
+        RawJsServerCommunicationConfigPlatformApi, RawJsServerCommunicationConfigRepository,
+    },
 };
 
 /// JavaScript wrapper for ServerCommunicationConfigClient
@@ -11,12 +14,15 @@ use crate::{
 /// allowing clients to check bootstrap requirements and retrieve cookies for HTTP requests.
 #[wasm_bindgen(js_name = ServerCommunicationConfigClient)]
 pub struct JsServerCommunicationConfigClient {
-    client: ServerCommunicationConfigClient<JsServerCommunicationConfigRepository>,
+    client: ServerCommunicationConfigClient<
+        JsServerCommunicationConfigRepository,
+        JsServerCommunicationConfigPlatformApi,
+    >,
 }
 
 #[wasm_bindgen(js_class = ServerCommunicationConfigClient)]
 impl JsServerCommunicationConfigClient {
-    /// Creates a new ServerCommunicationConfigClient with a JavaScript repository
+    /// Creates a new ServerCommunicationConfigClient with a JavaScript repository and platform API
     ///
     /// The repository should be backed by StateProvider (or equivalent
     /// storage mechanism) for persistence.
@@ -24,11 +30,16 @@ impl JsServerCommunicationConfigClient {
     /// # Arguments
     ///
     /// * `repository` - JavaScript implementation of the repository interface
+    /// * `platform_api` - JavaScript implementation of the platform API interface
     #[wasm_bindgen(constructor)]
-    pub fn new(repository: RawJsServerCommunicationConfigRepository) -> Self {
+    pub fn new(
+        repository: RawJsServerCommunicationConfigRepository,
+        platform_api: RawJsServerCommunicationConfigPlatformApi,
+    ) -> Self {
         let js_repository = JsServerCommunicationConfigRepository::new(repository);
+        let js_platform_api = JsServerCommunicationConfigPlatformApi::new(platform_api);
         Self {
-            client: ServerCommunicationConfigClient::new(js_repository),
+            client: ServerCommunicationConfigClient::new(js_repository, js_platform_api),
         }
     }
 
@@ -69,5 +80,29 @@ impl JsServerCommunicationConfigClient {
     pub async fn cookies(&self, hostname: String) -> Result<JsValue, JsError> {
         let cookies = self.client.cookies(hostname).await;
         serde_wasm_bindgen::to_value(&cookies).map_err(|e| JsError::new(&e.to_string()))
+    }
+
+    /// Acquires a cookie from the platform and saves it to the repository
+    ///
+    /// This method calls the platform API to trigger cookie acquisition (e.g., browser
+    /// redirect to IdP), then validates and stores the acquired cookie in the repository.
+    ///
+    /// # Arguments
+    ///
+    /// * `hostname` - The server hostname (e.g., "vault.acme.com")
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if:
+    /// - Cookie acquisition was cancelled by the user
+    /// - Server configuration doesn't support SSO cookies (Direct bootstrap)
+    /// - Acquired cookie name doesn't match expected name
+    /// - Repository operations fail
+    #[wasm_bindgen(js_name = acquireCookie)]
+    pub async fn acquire_cookie(&self, hostname: String) -> Result<(), String> {
+        self.client
+            .acquire_cookie(&hostname)
+            .await
+            .map_err(|e| e.to_string())
     }
 }

--- a/crates/bitwarden-server-communication-config/src/wasm/js_platform_api.rs
+++ b/crates/bitwarden-server-communication-config/src/wasm/js_platform_api.rs
@@ -6,14 +6,6 @@ use crate::{AcquiredCookie, ServerCommunicationConfigPlatformApi};
 #[wasm_bindgen(typescript_custom_section)]
 const TS_CUSTOM_TYPES: &'static str = r#"
 /**
- * Acquired cookie structure
- */
-export interface AcquiredCookie {
-    name: string;
-    value: string;
-}
-
-/**
  * Platform API interface for acquiring SSO cookies.
  * 
  * Platform clients implement this interface to handle cookie acquisition

--- a/crates/bitwarden-server-communication-config/src/wasm/js_platform_api.rs
+++ b/crates/bitwarden-server-communication-config/src/wasm/js_platform_api.rs
@@ -1,0 +1,99 @@
+use bitwarden_threading::ThreadBoundRunner;
+use wasm_bindgen::prelude::*;
+
+use crate::{AcquiredCookie, ServerCommunicationConfigPlatformApi};
+
+#[wasm_bindgen(typescript_custom_section)]
+const TS_CUSTOM_TYPES: &'static str = r#"
+/**
+ * Acquired cookie structure
+ */
+export interface AcquiredCookie {
+    name: string;
+    value: string;
+}
+
+/**
+ * Platform API interface for acquiring SSO cookies.
+ * 
+ * Platform clients implement this interface to handle cookie acquisition
+ * through browser redirects or other platform-specific mechanisms.
+ */
+export interface ServerCommunicationConfigPlatformApi {
+    /**
+     * Acquires a cookie for the given hostname.
+     * 
+     * This typically involves redirecting to an IdP login page and extracting
+     * the cookie from the load balancer response.
+     * 
+     * @param hostname The server hostname (e.g., "vault.acme.com")
+     * @returns An AcquiredCookie object, or undefined if acquisition failed or was cancelled
+     */
+    acquireCookie(hostname: string): Promise<AcquiredCookie | undefined>;
+}
+"#;
+
+#[wasm_bindgen]
+extern "C" {
+    /// JavaScript interface for the ServerCommunicationConfigPlatformApi
+    #[wasm_bindgen(
+        js_name = ServerCommunicationConfigPlatformApi,
+        typescript_type = "ServerCommunicationConfigPlatformApi"
+    )]
+    pub type RawJsServerCommunicationConfigPlatformApi;
+
+    /// Acquires a cookie for a hostname
+    #[wasm_bindgen(catch, method, structural, js_name = acquireCookie)]
+    pub async fn acquire_cookie(
+        this: &RawJsServerCommunicationConfigPlatformApi,
+        hostname: String,
+    ) -> Result<JsValue, JsValue>;
+}
+
+/// Thread-safe JavaScript implementation of ServerCommunicationConfigPlatformApi
+///
+/// This wrapper ensures the JavaScript platform API can be safely used across
+/// threads in WASM environments by using ThreadBoundRunner to pin operations
+/// to the main thread.
+pub struct JsServerCommunicationConfigPlatformApi(
+    ThreadBoundRunner<RawJsServerCommunicationConfigPlatformApi>,
+);
+
+impl JsServerCommunicationConfigPlatformApi {
+    /// Creates a new JsServerCommunicationConfigPlatformApi wrapping the raw JavaScript platform
+    /// API
+    pub fn new(platform_api: RawJsServerCommunicationConfigPlatformApi) -> Self {
+        Self(ThreadBoundRunner::new(platform_api))
+    }
+}
+
+impl Clone for JsServerCommunicationConfigPlatformApi {
+    fn clone(&self) -> Self {
+        Self(self.0.clone())
+    }
+}
+
+#[async_trait::async_trait]
+impl ServerCommunicationConfigPlatformApi for JsServerCommunicationConfigPlatformApi {
+    async fn acquire_cookie(&self, hostname: String) -> Option<AcquiredCookie> {
+        self.0
+            .run_in_thread(move |platform_api| async move {
+                let js_value = platform_api
+                    .acquire_cookie(hostname)
+                    .await
+                    .map_err(|e| format!("{e:?}"))?;
+
+                if js_value.is_undefined() || js_value.is_null() {
+                    return Ok(None);
+                }
+
+                let cookie: AcquiredCookie =
+                    serde_wasm_bindgen::from_value(js_value).map_err(|e| e.to_string())?;
+                Ok(Some(cookie))
+            })
+            .await
+            .ok()
+            .and_then(|result: Result<Option<AcquiredCookie>, String>| result.ok())
+            .flatten()
+    }
+}

--- a/crates/bitwarden-server-communication-config/src/wasm/mod.rs
+++ b/crates/bitwarden-server-communication-config/src/wasm/mod.rs
@@ -1,6 +1,8 @@
 //! WASM bindings for server communication configuration
 
 mod client;
+mod js_platform_api;
 mod js_repository;
 pub use client::*;
+pub use js_platform_api::*;
 pub use js_repository::*;

--- a/crates/bitwarden-server-communication-config/uniffi.toml
+++ b/crates/bitwarden-server-communication-config/uniffi.toml
@@ -1,0 +1,9 @@
+[bindings.kotlin]
+package_name = "com.bitwarden.server_communication_config"
+generate_immutable_records = true
+android = true
+
+[bindings.swift]
+ffi_module_name = "BitwardenServerCommunicationConfigFFI"
+module_name = "BitwardenServerCommunicationConfig"
+generate_immutable_records = true

--- a/crates/bitwarden-server-communication-config/uniffi.toml
+++ b/crates/bitwarden-server-communication-config/uniffi.toml
@@ -1,5 +1,5 @@
 [bindings.kotlin]
-package_name = "com.bitwarden.server_communication_config"
+package_name = "com.bitwarden.servercommunicationconfig"
 generate_immutable_records = true
 android = true
 

--- a/crates/bitwarden-uniffi/Cargo.toml
+++ b/crates/bitwarden-uniffi/Cargo.toml
@@ -33,6 +33,7 @@ bitwarden-fido = { workspace = true, features = ["uniffi"] }
 bitwarden-generators = { workspace = true, features = ["uniffi"] }
 bitwarden-pm = { workspace = true, features = ["uniffi"] }
 bitwarden-send = { workspace = true, features = ["uniffi"] }
+bitwarden-server-communication-config = { workspace = true, features = ["uniffi"] }
 bitwarden-ssh = { workspace = true, features = ["uniffi"] }
 bitwarden-state = { workspace = true, features = ["uniffi"] }
 bitwarden-uniffi-error = { workspace = true }

--- a/crates/bitwarden-uniffi/kotlin/app/src/main/java/com/bitwarden/myapplication/MainActivity.kt
+++ b/crates/bitwarden-uniffi/kotlin/app/src/main/java/com/bitwarden/myapplication/MainActivity.kt
@@ -35,6 +35,7 @@ import com.bitwarden.crypto.HashPurpose
 import com.bitwarden.crypto.Kdf
 import com.bitwarden.myapplication.ui.theme.MyApplicationTheme
 import com.bitwarden.sdk.Client
+import com.bitwarden.servercommunicationconfig.AcquiredCookie
 import io.ktor.client.HttpClient
 import io.ktor.client.call.body
 import io.ktor.client.engine.cio.CIO
@@ -434,6 +435,25 @@ class MainActivity : FragmentActivity() {
         val decryptedFolders = client.vault().folders().decryptList(folders)
         outputText.value = decryptedFolders.toString()
         println(decryptedFolders)
+    }
+
+    private fun serverCommunicationConfigTest() {
+        // Test AcquiredCookie type - single name/value pair
+        val unshardedCookie = AcquiredCookie(
+            name = "TestCookie",
+            value = "cookie-value"
+        )
+        println("Unsharded cookie: ${unshardedCookie.name} = ${unshardedCookie.value}")
+
+        // Test sharded cookies - multiple AcquiredCookie objects with -N suffix
+        val shardedCookies = listOf(
+            AcquiredCookie(name = "TestCookie-0", value = "shard1"),
+            AcquiredCookie(name = "TestCookie-1", value = "shard2")
+        )
+        println("Sharded cookies:")
+        shardedCookies.forEach { cookie ->
+            println("  ${cookie.name} = ${cookie.value}")
+        }
     }
 }
 

--- a/crates/bitwarden-uniffi/src/error.rs
+++ b/crates/bitwarden-uniffi/src/error.rs
@@ -93,6 +93,10 @@ pub enum BitwardenError {
     SshGeneration(#[from] bitwarden_ssh::error::KeyGenerationError),
     #[error(transparent)]
     SshImport(#[from] bitwarden_ssh::error::SshKeyImportError),
+
+    #[error(transparent)]
+    AcquireCookie(#[from] bitwarden_server_communication_config::AcquireCookieError),
+
     #[error("Callback invocation failed")]
     CallbackError,
 

--- a/crates/bitwarden-uniffi/src/lib.rs
+++ b/crates/bitwarden-uniffi/src/lib.rs
@@ -29,6 +29,11 @@ use crypto::CryptoClient;
 use error::{Error, Result};
 pub use log_callback::LogCallback;
 use platform::PlatformClient;
+pub use platform::{
+    AcquiredCookie, BootstrapConfig, ServerCommunicationConfig,
+    ServerCommunicationConfigRepositoryTrait, SsoCookieVendorConfig,
+    UniffiServerCommunicationConfigClient,
+};
 use tool::{ExporterClient, GeneratorClients, SendClient, SshClient};
 use vault::VaultClient;
 

--- a/crates/bitwarden-uniffi/src/platform/mod.rs
+++ b/crates/bitwarden-uniffi/src/platform/mod.rs
@@ -13,6 +13,14 @@ mod fido2;
 mod repository;
 mod server_communication_config;
 
+// Re-export ServerCommunicationConfig types for UniFFI bindings
+pub use bitwarden_server_communication_config::{
+    AcquiredCookie, BootstrapConfig, ServerCommunicationConfig, SsoCookieVendorConfig,
+};
+pub use server_communication_config::{
+    ServerCommunicationConfigRepositoryTrait, UniffiServerCommunicationConfigClient,
+};
+
 #[derive(uniffi::Object)]
 pub struct PlatformClient(pub(crate) bitwarden_core::Client);
 

--- a/crates/bitwarden-uniffi/src/platform/mod.rs
+++ b/crates/bitwarden-uniffi/src/platform/mod.rs
@@ -11,6 +11,7 @@ use crate::error::Result;
 
 mod fido2;
 mod repository;
+mod server_communication_config;
 
 #[derive(uniffi::Object)]
 pub struct PlatformClient(pub(crate) bitwarden_core::Client);
@@ -40,6 +41,20 @@ impl PlatformClient {
 
     pub fn state(&self) -> StateClient {
         StateClient(self.0.clone())
+    }
+
+    /// Server communication configuration operations
+    pub fn server_communication_config(
+        &self,
+        repository: Arc<dyn server_communication_config::ServerCommunicationConfigRepositoryTrait>,
+        platform_api: Arc<
+            dyn bitwarden_server_communication_config::ServerCommunicationConfigPlatformApi,
+        >,
+    ) -> Arc<server_communication_config::UniffiServerCommunicationConfigClient> {
+        server_communication_config::UniffiServerCommunicationConfigClient::new(
+            repository,
+            platform_api,
+        )
     }
 }
 

--- a/crates/bitwarden-uniffi/src/platform/server_communication_config.rs
+++ b/crates/bitwarden-uniffi/src/platform/server_communication_config.rs
@@ -1,0 +1,128 @@
+use std::sync::Arc;
+
+use bitwarden_server_communication_config::{
+    AcquiredCookie, ServerCommunicationConfig, ServerCommunicationConfigClient,
+    ServerCommunicationConfigPlatformApi, ServerCommunicationConfigRepository,
+};
+
+use crate::error::Result;
+
+type UniffiRepository = UniffiRepositoryBridge<Arc<dyn ServerCommunicationConfigRepositoryTrait>>;
+type UniffiPlatformApi = UniffiPlatformApiBridge<Arc<dyn ServerCommunicationConfigPlatformApi>>;
+
+/// UniFFI wrapper for ServerCommunicationConfigClient
+#[derive(uniffi::Object)]
+pub struct UniffiServerCommunicationConfigClient {
+    client: ServerCommunicationConfigClient<UniffiRepository, UniffiPlatformApi>,
+}
+
+impl UniffiServerCommunicationConfigClient {
+    /// Creates a new server communication configuration client
+    pub fn new(
+        repository: Arc<dyn ServerCommunicationConfigRepositoryTrait>,
+        platform_api: Arc<dyn ServerCommunicationConfigPlatformApi>,
+    ) -> Arc<Self> {
+        Arc::new(Self {
+            client: ServerCommunicationConfigClient::new(
+                UniffiRepositoryBridge(repository),
+                UniffiPlatformApiBridge(platform_api),
+            ),
+        })
+    }
+}
+
+#[uniffi::export]
+impl UniffiServerCommunicationConfigClient {
+    /// Retrieves the server communication configuration for a hostname
+    pub async fn get_config(&self, hostname: String) -> Result<ServerCommunicationConfig> {
+        self.client.get_config(hostname).await
+    }
+
+    /// Determines if cookie bootstrapping is needed for this hostname
+    pub async fn needs_bootstrap(&self, hostname: String) -> bool {
+        self.client.needs_bootstrap(hostname).await
+    }
+
+    /// Returns all cookies that should be included in requests to this server
+    pub async fn cookies(&self, hostname: String) -> Vec<AcquiredCookie> {
+        self.client
+            .cookies(hostname)
+            .await
+            .into_iter()
+            .map(|(name, value)| AcquiredCookie { name, value })
+            .collect()
+    }
+
+    /// Acquires a cookie from the platform and saves it to the repository
+    pub async fn acquire_cookie(&self, hostname: String) -> Result<()> {
+        self.client.acquire_cookie(&hostname).await?;
+        Ok(())
+    }
+}
+
+/// UniFFI repository trait for server communication configuration
+#[uniffi::export(with_foreign)]
+#[async_trait::async_trait]
+pub trait ServerCommunicationConfigRepositoryTrait: Send + Sync {
+    /// Get configuration for a hostname
+    async fn get(&self, hostname: String) -> Result<Option<ServerCommunicationConfig>>;
+
+    /// Save configuration for a hostname
+    async fn save(&self, hostname: String, config: ServerCommunicationConfig) -> Result<()>;
+}
+
+/// Bridge from UniFFI trait to internal repository trait
+pub struct UniffiRepositoryBridge<T>(pub T);
+
+impl<T: ?Sized> UniffiRepositoryBridge<Arc<T>> {
+    #[allow(dead_code)]
+    pub fn new(repo: Arc<T>) -> Arc<Self> {
+        Arc::new(UniffiRepositoryBridge(repo))
+    }
+}
+
+impl<T: std::fmt::Debug> std::fmt::Debug for UniffiRepositoryBridge<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+impl<'a> ServerCommunicationConfigRepository
+    for UniffiRepositoryBridge<Arc<dyn ServerCommunicationConfigRepositoryTrait + 'a>>
+{
+    type GetError = crate::error::Error;
+    type SaveError = crate::error::Error;
+
+    async fn get(
+        &self,
+        hostname: String,
+    ) -> std::result::Result<Option<ServerCommunicationConfig>, Self::GetError> {
+        self.0.get(hostname).await
+    }
+
+    async fn save(
+        &self,
+        hostname: String,
+        config: ServerCommunicationConfig,
+    ) -> std::result::Result<(), Self::SaveError> {
+        self.0.save(hostname, config).await
+    }
+}
+
+/// Bridge for platform API trait
+pub struct UniffiPlatformApiBridge<T>(pub T);
+
+impl<T: std::fmt::Debug> std::fmt::Debug for UniffiPlatformApiBridge<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+#[async_trait::async_trait]
+impl<'a> ServerCommunicationConfigPlatformApi
+    for UniffiPlatformApiBridge<Arc<dyn ServerCommunicationConfigPlatformApi + 'a>>
+{
+    async fn acquire_cookie(&self, hostname: String) -> Option<AcquiredCookie> {
+        self.0.acquire_cookie(hostname).await
+    }
+}

--- a/crates/bitwarden-uniffi/src/platform/server_communication_config.rs
+++ b/crates/bitwarden-uniffi/src/platform/server_communication_config.rs
@@ -49,10 +49,7 @@ impl UniffiServerCommunicationConfigClient {
             .cookies(hostname)
             .await
             .into_iter()
-            .map(|(name, value)| AcquiredCookie {
-                name,
-                value: vec![value],
-            })
+            .map(|(name, value)| AcquiredCookie { name, value })
             .collect()
     }
 
@@ -125,7 +122,7 @@ impl<T: std::fmt::Debug> std::fmt::Debug for UniffiPlatformApiBridge<T> {
 impl<'a> ServerCommunicationConfigPlatformApi
     for UniffiPlatformApiBridge<Arc<dyn ServerCommunicationConfigPlatformApi + 'a>>
 {
-    async fn acquire_cookie(&self, hostname: String) -> Option<AcquiredCookie> {
-        self.0.acquire_cookie(hostname).await
+    async fn acquire_cookies(&self, hostname: String) -> Option<Vec<AcquiredCookie>> {
+        self.0.acquire_cookies(hostname).await
     }
 }

--- a/crates/bitwarden-uniffi/src/platform/server_communication_config.rs
+++ b/crates/bitwarden-uniffi/src/platform/server_communication_config.rs
@@ -49,7 +49,10 @@ impl UniffiServerCommunicationConfigClient {
             .cookies(hostname)
             .await
             .into_iter()
-            .map(|(name, value)| AcquiredCookie { name, value })
+            .map(|(name, value)| AcquiredCookie {
+                name,
+                value: vec![value],
+            })
             .collect()
     }
 

--- a/crates/bitwarden-uniffi/swift/iOS/App/ContentView.swift
+++ b/crates/bitwarden-uniffi/swift/iOS/App/ContentView.swift
@@ -389,12 +389,19 @@ struct ContentView: View {
         )
         print("SSO cookie config: \(ssoCookieConfig)")
 
-        // Test AcquiredCookie type
-        let cookie = AcquiredCookie(
+        // Test AcquiredCookie type - single name/value pair
+        let unshardedCookie = AcquiredCookie(
             name: "TestCookie",
-            value: ["shard1", "shard2"]
+            value: "cookie-value"
         )
-        print("Acquired cookie: \(cookie)")
+        print("Unsharded cookie: \(unshardedCookie)")
+
+        // Test sharded cookies - multiple AcquiredCookie objects with -N suffix
+        let shardedCookies = [
+            AcquiredCookie(name: "TestCookie-0", value: "shard1"),
+            AcquiredCookie(name: "TestCookie-1", value: "shard2")
+        ]
+        print("Sharded cookies: \(shardedCookies)")
     }
 
 }

--- a/crates/bitwarden-uniffi/swift/iOS/App/ContentView.swift
+++ b/crates/bitwarden-uniffi/swift/iOS/App/ContentView.swift
@@ -370,6 +370,33 @@ struct ContentView: View {
         let _ = try await authenticator.silentlyDiscoverCredentials(rpId: "", userHandle: nil)
     }
 
+    func serverCommunicationConfigTest() {
+        // Test ServerCommunicationConfig types compilation
+        let directConfig = ServerCommunicationConfig(
+            bootstrap: BootstrapConfig.direct
+        )
+        print("Direct config: \(directConfig)")
+
+        let ssoCookieConfig = ServerCommunicationConfig(
+            bootstrap: BootstrapConfig.ssoCookieVendor(
+                SsoCookieVendorConfig(
+                    idpLoginUrl: "https://example.com/login",
+                    cookieName: "TestCookie",
+                    cookieDomain: "example.com",
+                    cookieValue: nil
+                )
+            )
+        )
+        print("SSO cookie config: \(ssoCookieConfig)")
+
+        // Test AcquiredCookie type
+        let cookie = AcquiredCookie(
+            name: "TestCookie",
+            value: ["shard1", "shard2"]
+        )
+        print("Acquired cookie: \(cookie)")
+    }
+
 }
 
 struct ContentView_Previews: PreviewProvider {


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-30775

## 📔 Objective

Adds an `acquireCookie()` method to `ServerCommunicationConfigClient` to enable the cookie acquisition workflow. This method calls the platform API to trigger cookie acquisition, validates the returned cookie name matches the server configuration, and saves it to the repository.

As a side effect this also adds UniFFI bindings for the entire `bitwarden-server-communication-config` crate, which were missed in my previous PR https://github.com/bitwarden/sdk-internal/pull/704. This required replacing tuple return types with an `AcquiredCookie` struct (UniFFI doesn't support tuples), adding UniFFI annotations to all config types, and creating a `UniffiServerCommunicationConfigClient` wrapper.

## 🚨 Breaking Changes

None right now, because `ServerCommunicationConfigService` hasn't landed in clients. Part of PM-30775 is to implement a noop in `clients`, but I've skipped that for this reason.