### PR TITLE
Add Commercial WASM2js blob to prettierignore

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -4,6 +4,7 @@ about.hbs
 
 # Language bindings
 crates/bitwarden-wasm-internal/npm/bitwarden_wasm_internal_bg.wasm.js
+crates/bitwarden-wasm-internal/bitwarden_license/npm/bitwarden_wasm_internal_bg.wasm.js
 crates/bitwarden-uniffi/kotlin/*
 crates/bitwarden-uniffi/swift/*
 


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective

This file was missing in prettierignore so prettier would try to format the 40MB transpiled JS file, taking ages to do it.

## 🚨 Breaking Changes

<!-- Does this PR introduce any breaking changes? If so, please describe the impact and migration path for clients.

If you're unsure, the automated TypeScript compatibility check will run when you open/update this PR and provide feedback.

For breaking changes:
1. Describe what changed in the client interface
2. Explain why the change was necessary
3. Provide migration steps for client developers
4. Link to any paired client PRs if needed

Otherwise, you can remove this section. -->
