### PR TITLE
[PM-30923] Update sdk-internal with the latest send models

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -870,6 +870,7 @@ dependencies = [
  "chrono",
  "serde",
  "serde_repr",
+ "sha2 0.10.9",
  "thiserror 2.0.12",
  "uniffi",
  "uuid",

--- a/crates/bitwarden-send/Cargo.toml
+++ b/crates/bitwarden-send/Cargo.toml
@@ -29,6 +29,7 @@ bitwarden-encoding = { workspace = true }
 chrono = { workspace = true }
 serde = { workspace = true }
 serde_repr = { workspace = true }
+sha2 = { version = ">=0.10.6, <0.11" }
 thiserror = { workspace = true }
 uniffi = { workspace = true, optional = true }
 uuid = { workspace = true }

--- a/crates/bitwarden-send/src/send.rs
+++ b/crates/bitwarden-send/src/send.rs
@@ -306,11 +306,9 @@ impl Decryptable<KeyIds, SymmetricKeyId, SendView> for Send {
             emails: self
                 .emails
                 .as_ref()
-                .and_then(|enc| {
-                    Decryptable::<KeyIds, SymmetricKeyId, String>::decrypt(enc, ctx, key).ok()
-                })
+                .and_then(|enc| -> Option<String> { enc.decrypt(ctx, key).ok() })
                 .as_deref()
-                .unwrap_or("")
+                .unwrap_or_default()
                 .split(',')
                 .map(|e| e.trim())
                 .filter(|e| !e.is_empty())
@@ -408,9 +406,9 @@ impl CompositeEncryptable<KeyIds, SymmetricKeyId, Send> for SendView {
                     .iter()
                     .map(|email| {
                         let hash = sha2::Sha256::new()
-                            .chain_update(email.to_lowercase().as_bytes())
+                            .chain_update(email.to_lowercase().trim().as_bytes())
                             .finalize();
-                        format!("{:X}", hash)
+                        format!("{hash:X}")
                     })
                     .collect::<Vec<_>>()
                     .join(",")

--- a/crates/bitwarden-send/src/send.rs
+++ b/crates/bitwarden-send/src/send.rs
@@ -11,6 +11,7 @@ use bitwarden_encoding::{B64, B64Url};
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use serde_repr::{Deserialize_repr, Serialize_repr};
+use sha2::Digest;
 use uuid::Uuid;
 use zeroize::Zeroizing;
 
@@ -108,7 +109,14 @@ pub struct Send {
     /// Email addresses for OTP authentication.
     /// **Note**: Mutually exclusive with `new_password`. If both are set,
     /// only password authentication will be used.
-    pub emails: Option<String>,
+    pub emails: Option<EncString>,
+
+    /// Email address hashes, a comma-separated list of SHA256 hex digests
+    /// for each email in `emails`:
+    ///  - plaintext email is lower-cased
+    ///  - lowercase plaintext email is hashed using SHA256
+    ///  - resulting digest is represented as upper-case hex
+    pub email_hashes: Option<String>,
     pub auth_type: AuthType,
 }
 
@@ -168,6 +176,8 @@ pub struct SendListView {
     pub revision_date: DateTime<Utc>,
     pub deletion_date: DateTime<Utc>,
     pub expiration_date: Option<DateTime<Utc>>,
+
+    pub auth_type: AuthType,
 }
 
 impl Send {
@@ -295,8 +305,12 @@ impl Decryptable<KeyIds, SymmetricKeyId, SendView> for Send {
 
             emails: self
                 .emails
+                .as_ref()
+                .and_then(|enc| {
+                    Decryptable::<KeyIds, SymmetricKeyId, String>::decrypt(enc, ctx, key).ok()
+                })
                 .as_deref()
-                .unwrap_or_default()
+                .unwrap_or("")
                 .split(',')
                 .map(|e| e.trim())
                 .filter(|e| !e.is_empty())
@@ -330,6 +344,8 @@ impl Decryptable<KeyIds, SymmetricKeyId, SendListView> for Send {
             revision_date: self.revision_date,
             deletion_date: self.deletion_date,
             expiration_date: self.expiration_date,
+
+            auth_type: self.auth_type,
         })
     }
 }
@@ -384,7 +400,21 @@ impl CompositeEncryptable<KeyIds, SymmetricKeyId, Send> for SendView {
             deletion_date: self.deletion_date,
             expiration_date: self.expiration_date,
 
-            emails: (!self.emails.is_empty()).then(|| self.emails.join(",")),
+            emails: (!self.emails.is_empty())
+                .then(|| self.emails.join(","))
+                .encrypt(ctx, send_key)?,
+            email_hashes: (!self.emails.is_empty()).then(|| {
+                self.emails
+                    .iter()
+                    .map(|email| {
+                        let hash = sha2::Sha256::new()
+                            .chain_update(email.to_lowercase().as_bytes())
+                            .finalize();
+                        format!("{:X}", hash)
+                    })
+                    .collect::<Vec<_>>()
+                    .join(",")
+            }),
             auth_type: self.auth_type,
         })
     }
@@ -423,7 +453,8 @@ impl TryFrom<SendResponseModel> for Send {
             revision_date: require!(send.revision_date).parse()?,
             deletion_date: require!(send.deletion_date).parse()?,
             expiration_date: send.expiration_date.map(|s| s.parse()).transpose()?,
-            emails: send.emails,
+            emails: send.emails.map(|s| s.parse()).transpose()?,
+            email_hashes: None,
             auth_type,
         })
     }
@@ -528,6 +559,7 @@ mod tests {
             deletion_date: "2024-01-14T23:56:48Z".parse().unwrap(),
             hide_email: false,
             emails: None,
+            email_hashes: None,
             auth_type: AuthType::None,
         };
 
@@ -715,22 +747,20 @@ mod tests {
             auth_type: AuthType::Email,
         };
 
-        let send: Send = crypto.encrypt(view).unwrap();
+        let send: Send = crypto.encrypt(view.clone()).unwrap();
 
+        // Verify email_hashes are computed correctly for sending to server as plaintext digests
         assert_eq!(
-            send.emails,
-            Some("test1@mail.com,test2@mail.com".to_string())
+            send.email_hashes,
+            Some("78310D2DD727B704FF9D9C4742D01941B1217B89F45AB71D1E9BF5A010144048,0B9E4A8314C2C737F3B466764FD4E5A50BFFCC8229B2D71931D940A8EE639D8D".to_string())
         );
-        assert_eq!(send.auth_type, AuthType::Email);
 
+        // Verify decrypted view matches original prior to encrypting
         let v: SendView = crypto.decrypt(&send).unwrap();
-        assert_eq!(
-            v.emails,
-            vec!(
-                String::from("test1@mail.com"),
-                String::from("test2@mail.com")
-            )
-        );
+
+        assert_eq!(v, view);
+
+        // Verify auth_type was preserved
         assert_eq!(v.auth_type, AuthType::Email);
     }
 }


### PR DESCRIPTION
## 🎟️ Tracking

](https://bitwarden.atlassian.net/browse/PM-30923

## 📔 Objective

This PR is intended to bring the SDK into parity with the `SendService` available in the `clients` repo. Specifically: 
- When a `Send` is configured to use Email OTP authentication the `emails` are encrypted using the send's key before leaving the client 
- A comma separated list of SHA256 hashes is sent to the server in plaintext, so that these hashes may be used to validate emails entered during the authentication flow 
