### PR TITLE
Derive Clone for Keystore manually

### DIFF
--- a/crates/bitwarden-crypto/src/store/mod.rs
+++ b/crates/bitwarden-crypto/src/store/mod.rs
@@ -95,11 +95,19 @@ pub use key_rotation::*;
 /// let decrypted = Data("Hello, World!".to_string());
 /// let encrypted = store.encrypt(decrypted).unwrap();
 /// ```
-#[derive(Clone)]
 pub struct KeyStore<Ids: KeyIds> {
     // We use an Arc<> to make it easier to pass this store around, as we can
     // clone it instead of passing references
     inner: Arc<RwLock<KeyStoreInner<Ids>>>,
+}
+
+// Manually implement Clone to avoid requiring Ids: Clone
+impl<Ids: KeyIds> Clone for KeyStore<Ids> {
+    fn clone(&self) -> Self {
+        KeyStore {
+            inner: Arc::clone(&self.inner),
+        }
+    }
 }
 
 /// [KeyStore] contains sensitive data, provide a dummy [Debug] implementation.


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective

The Clone derive macro adds a `Ids: Clone` bound on the `KeyStore` Clone impl, which is not needed as the type is only used inside an `Arc` which is always clonable.

## 🚨 Breaking Changes

<!-- Does this PR introduce any breaking changes? If so, please describe the impact and migration path for clients.

If you're unsure, the automated TypeScript compatibility check will run when you open/update this PR and provide feedback.

For breaking changes:
1. Describe what changed in the client interface
2. Explain why the change was necessary
3. Provide migration steps for client developers
4. Link to any paired client PRs if needed

Otherwise, you can remove this section. -->
