### PR TITLE
[PM-25283] Wrap SM code in a client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -900,6 +900,7 @@ dependencies = [
  "bitwarden-api-api",
  "bitwarden-core",
  "bitwarden-crypto",
+ "bitwarden-generators",
  "chrono",
  "schemars 1.0.0",
  "serde",

--- a/bitwarden_license/bitwarden-sm/Cargo.toml
+++ b/bitwarden_license/bitwarden-sm/Cargo.toml
@@ -17,6 +17,7 @@ keywords.workspace = true
 bitwarden-api-api = { workspace = true }
 bitwarden-core = { workspace = true, features = ["secrets"] }
 bitwarden-crypto = { workspace = true }
+bitwarden-generators = { workspace = true }
 chrono = { workspace = true }
 schemars = { workspace = true }
 serde = { workspace = true }

--- a/bitwarden_license/bitwarden-sm/src/client.rs
+++ b/bitwarden_license/bitwarden-sm/src/client.rs
@@ -1,0 +1,46 @@
+//! Client for the Bitwarden Secrets Manager API
+
+pub use bitwarden_core::ClientSettings;
+use bitwarden_core::{OrganizationId, auth::auth_client::AuthClient};
+use bitwarden_generators::GeneratorClientsExt;
+
+use crate::{ProjectsClient, SecretsClient};
+
+/// The main struct for interacting with the Secrets Manager service through the SM SDK.
+pub struct SecretsManagerClient {
+    client: bitwarden_core::Client,
+}
+
+impl SecretsManagerClient {
+    /// Create a new SecretsManagerClient
+    pub fn new(settings: Option<ClientSettings>) -> Self {
+        Self {
+            client: bitwarden_core::Client::new(settings),
+        }
+    }
+
+    /// Get access to the Projects API
+    pub fn projects(&self) -> ProjectsClient {
+        ProjectsClient::new(self.client.clone())
+    }
+
+    /// Get access to the Secrets API
+    pub fn secrets(&self) -> SecretsClient {
+        SecretsClient::new(self.client.clone())
+    }
+
+    /// Get access to the Auth API
+    pub fn auth(&self) -> AuthClient {
+        self.client.auth()
+    }
+
+    /// Get access to the Generators API
+    pub fn generator(&self) -> bitwarden_generators::GeneratorClient {
+        self.client.generator()
+    }
+
+    #[doc(hidden)]
+    pub fn get_access_token_organization(&self) -> Option<OrganizationId> {
+        self.client.internal.get_access_token_organization()
+    }
+}

--- a/bitwarden_license/bitwarden-sm/src/client_projects.rs
+++ b/bitwarden_license/bitwarden-sm/src/client_projects.rs
@@ -9,9 +9,6 @@ use crate::{
     },
 };
 
-/// Aliases to maintain backward compatibility
-pub type ClientProjects = ProjectsClient;
-
 #[allow(missing_docs)]
 pub struct ProjectsClient {
     pub client: Client,
@@ -61,29 +58,5 @@ impl ProjectsClient {
         input: ProjectsDeleteRequest,
     ) -> Result<ProjectsDeleteResponse, SecretsManagerError> {
         delete_projects(&self.client, input).await
-    }
-}
-
-/// This trait is for backward compatibility
-pub trait ClientProjectsExt {
-    #[allow(missing_docs)]
-    fn projects(&self) -> ClientProjects;
-}
-
-impl ClientProjectsExt for Client {
-    fn projects(&self) -> ClientProjects {
-        ProjectsClient::new(self.clone())
-    }
-}
-
-#[allow(missing_docs)]
-pub trait ProjectsClientExt {
-    #[allow(missing_docs)]
-    fn projects(&self) -> ProjectsClient;
-}
-
-impl ProjectsClientExt for Client {
-    fn projects(&self) -> ProjectsClient {
-        ProjectsClient::new(self.clone())
     }
 }

--- a/bitwarden_license/bitwarden-sm/src/client_secrets.rs
+++ b/bitwarden_license/bitwarden-sm/src/client_secrets.rs
@@ -11,9 +11,6 @@ use crate::{
     },
 };
 
-/// Aliases to maintain backward compatibility
-pub type ClientSecrets = SecretsClient;
-
 #[allow(missing_docs)]
 pub struct SecretsClient {
     client: Client,
@@ -90,42 +87,18 @@ impl SecretsClient {
     }
 }
 
-/// This trait is for backward compatibility
-pub trait ClientSecretsExt {
-    #[allow(missing_docs)]
-    fn secrets(&self) -> ClientSecrets;
-}
-
-impl ClientSecretsExt for Client {
-    fn secrets(&self) -> ClientSecrets {
-        SecretsClient::new(self.clone())
-    }
-}
-
-#[allow(missing_docs)]
-pub trait SecretsClientExt {
-    #[allow(missing_docs)]
-    fn secrets(&self) -> SecretsClient;
-}
-
-impl SecretsClientExt for Client {
-    fn secrets(&self) -> SecretsClient {
-        SecretsClient::new(self.clone())
-    }
-}
-
 #[cfg(test)]
 mod tests {
-    use bitwarden_core::{
-        Client, ClientSettings, DeviceType, auth::login::AccessTokenLoginRequest,
-    };
+    use bitwarden_core::{ClientSettings, DeviceType, auth::login::AccessTokenLoginRequest};
 
     use crate::{
-        ClientSecretsExt,
+        SecretsManagerClient,
         secrets::{SecretGetRequest, SecretIdentifiersRequest},
     };
 
-    async fn start_mock(mocks: Vec<wiremock::Mock>) -> (wiremock::MockServer, Client) {
+    async fn start_mock(
+        mocks: Vec<wiremock::Mock>,
+    ) -> (wiremock::MockServer, SecretsManagerClient) {
         let server = wiremock::MockServer::start().await;
 
         for mock in mocks {
@@ -142,7 +115,7 @@ mod tests {
             bitwarden_package_type: None,
         };
 
-        (server, Client::new(Some(settings)))
+        (server, SecretsManagerClient::new(Some(settings)))
     }
 
     #[tokio::test]

--- a/bitwarden_license/bitwarden-sm/src/lib.rs
+++ b/bitwarden_license/bitwarden-sm/src/lib.rs
@@ -9,9 +9,12 @@ pub mod projects;
 #[allow(missing_docs)]
 pub mod secrets;
 
-pub use bitwarden_core::auth::{
-    AccessToken,
-    login::{AccessTokenLoginRequest, AccessTokenLoginResponse},
+pub use bitwarden_core::{
+    DeviceType,
+    auth::{
+        AccessToken,
+        login::{AccessTokenLoginRequest, AccessTokenLoginResponse},
+    },
 };
 pub use client::{ClientSettings, SecretsManagerClient};
 pub use client_projects::ProjectsClient;

--- a/bitwarden_license/bitwarden-sm/src/lib.rs
+++ b/bitwarden_license/bitwarden-sm/src/lib.rs
@@ -1,5 +1,6 @@
 #![doc = include_str!("../README.md")]
 
+pub mod client;
 mod client_projects;
 mod client_secrets;
 mod error;
@@ -8,5 +9,10 @@ pub mod projects;
 #[allow(missing_docs)]
 pub mod secrets;
 
-pub use client_projects::{ClientProjects, ClientProjectsExt, ProjectsClient, ProjectsClientExt};
-pub use client_secrets::{ClientSecrets, ClientSecretsExt, SecretsClient, SecretsClientExt};
+pub use bitwarden_core::auth::{
+    AccessToken,
+    login::{AccessTokenLoginRequest, AccessTokenLoginResponse},
+};
+pub use client::{ClientSettings, SecretsManagerClient};
+pub use client_projects::ProjectsClient;
+pub use client_secrets::SecretsClient;


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-25283

## 📔 Objective

The secrets manager crates in sdk-sm are exposing `core::Client` directly. This makes it pretty hard to make changes to initialization code for password manager, as it would break the SM API.

This PR is introducing a new `SecretsManagerClient`. This is a small indirection layer, same as `PasswordManagerClient` in `bitwarden-pm`, which allows us a bit more control in how the SM client gets initialized without requiring a breaking change in the SM API. It also allows us to  remove the `Ext` traits from the API, which I think also helps with discovery.

I have a draft PR on the sdk-sm repo showing what the changes would look like: https://github.com/bitwarden/sdk-sm/pull/1425

## 🚨 Breaking Changes

<!-- Does this PR introduce any breaking changes? If so, please describe the impact and migration path for clients.

If you're unsure, the automated TypeScript compatibility check will run when you open/update this PR and provide feedback.

For breaking changes:
1. Describe what changed in the client interface
2. Explain why the change was necessary
3. Provide migration steps for client developers
4. Link to any paired client PRs if needed

Otherwise, you can remove this section. -->
