### PR TITLE
Update publish workflow to include new api crates

### DIFF
--- a/.github/workflows/publish-rust-crates.yml
+++ b/.github/workflows/publish-rust-crates.yml
@@ -18,11 +18,15 @@ on:
         required: true
         type: string
         default: latest
+
+      # List of packages to publish
+      # Default includes all Bitwarden crates required to publish the SM `bitwarden` crate. To obtain this list, you can use the following command:
+      # cargo tree -p bitwarden-cli -p bitwarden-sm --prefix none | cut -d' ' -f1 | sort -u | grep bitwarden | tr '\n' ' '
       packages:
         description: "Space-separated list of packages to publish"
         required: false
         type: string
-        default: "bitwarden-api-api bitwarden-api-identity bitwarden-cli bitwarden-core bitwarden-crypto bitwarden-encoding bitwarden-error bitwarden-error-macro bitwarden-generators bitwarden-sm bitwarden-state bitwarden-threading bitwarden-uuid bitwarden-uuid-macro"
+        default: "bitwarden-api-api bitwarden-api-base bitwarden-api-identity bitwarden-api-key-connector bitwarden-cli bitwarden-core bitwarden-crypto bitwarden-encoding bitwarden-error bitwarden-error-macro bitwarden-generators bitwarden-sm bitwarden-state bitwarden-threading bitwarden-uuid bitwarden-uuid-macro"
 
 jobs:
   setup:


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective

The new `bitwarden-api-base` and `bitwarden-api-key-connector` crates will need to be published next time we publish the rust crates, so this PR adds them to the list. I've also documented the command I've used to get the list so it's easier to generate next time.

## 🚨 Breaking Changes

<!-- Does this PR introduce any breaking changes? If so, please describe the impact and migration path for clients.

If you're unsure, the automated TypeScript compatibility check will run when you open/update this PR and provide feedback.

For breaking changes:
1. Describe what changed in the client interface
2. Explain why the change was necessary
3. Provide migration steps for client developers
4. Link to any paired client PRs if needed

Otherwise, you can remove this section. -->
