### PR TITLE
[PM-31668] Add search indexing fields to CipherListView 

### DIFF
--- a/crates/bitwarden-vault/src/cipher/cipher_client/mod.rs
+++ b/crates/bitwarden-vault/src/cipher/cipher_client/mod.rs
@@ -15,7 +15,8 @@ use super::EncryptionContext;
 use crate::Fido2CredentialFullView;
 use crate::{
     Cipher, CipherError, CipherListView, CipherView, DecryptError, EncryptError,
-    cipher::cipher::DecryptCipherListResult, cipher_client::admin::CipherAdminClient,
+    cipher::cipher::{DecryptCipherListResult, DecryptCipherResult},
+    cipher_client::admin::CipherAdminClient,
 };
 
 mod admin;
@@ -133,6 +134,19 @@ impl CiphersClient {
         let (successes, failures) = key_store.decrypt_list_with_failures(&ciphers);
 
         DecryptCipherListResult {
+            successes,
+            failures: failures.into_iter().cloned().collect(),
+        }
+    }
+
+    /// Decrypt full cipher list
+    /// Returns both successfully fully decrypted ciphers and any that failed to decrypt
+    #[cfg(feature = "wasm")]
+    pub fn decrypt_list_full_with_failures(&self, ciphers: Vec<Cipher>) -> DecryptCipherResult {
+        let key_store = self.client.internal.get_key_store();
+        let (successes, failures) = key_store.decrypt_list_with_failures(&ciphers);
+
+        DecryptCipherResult {
             successes,
             failures: failures.into_iter().cloned().collect(),
         }
@@ -544,6 +558,80 @@ mod tests {
             .unwrap();
 
         assert_eq!(content, b"Hello");
+    }
+
+    #[tokio::test]
+    #[cfg(feature = "wasm")]
+    async fn test_decrypt_list_full_with_failures_all_success() {
+        let client = Client::init_test_account(test_bitwarden_com_account()).await;
+
+        let valid_cipher = test_cipher();
+
+        let result = client
+            .vault()
+            .ciphers()
+            .decrypt_list_full_with_failures(vec![valid_cipher]);
+
+        assert_eq!(result.successes.len(), 1);
+        assert!(result.failures.is_empty());
+        assert_eq!(result.successes[0].name, "234234");
+    }
+
+    #[tokio::test]
+    #[cfg(feature = "wasm")]
+    async fn test_decrypt_list_full_with_failures_mixed_results() {
+        let client = Client::init_test_account(test_bitwarden_com_account()).await;
+        let valid_cipher = test_cipher();
+        let mut invalid_cipher = test_cipher();
+        // Set an invalid encrypted key to cause decryption failure
+        invalid_cipher.key = Some("2.Gg8yCM4IIgykCZyq0O4+cA==|GJLBtfvSJTDJh/F7X4cJPkzI6ccnzJm5DYl3yxOW2iUn7DgkkmzoOe61sUhC5dgVdV0kFqsZPcQ0yehlN1DDsFIFtrb4x7LwzJNIkMgxNyg=|1rGkGJ8zcM5o5D0aIIwAyLsjMLrPsP3EWm3CctBO3Fw=".parse().unwrap());
+
+        let ciphers = vec![valid_cipher, invalid_cipher.clone()];
+
+        let result = client
+            .vault()
+            .ciphers()
+            .decrypt_list_full_with_failures(ciphers);
+
+        assert_eq!(result.successes.len(), 1);
+        assert_eq!(result.failures.len(), 1);
+
+        assert_eq!(result.successes[0].name, "234234");
+    }
+
+    #[tokio::test]
+    #[cfg(feature = "wasm")]
+    async fn test_decrypt_list_full_with_failures_all_failures() {
+        let client = Client::init_test_account(test_bitwarden_com_account()).await;
+        let mut invalid_cipher1 = test_cipher();
+        let mut invalid_cipher2 = test_cipher();
+        // Set invalid encrypted keys to cause decryption failures
+        invalid_cipher1.key = Some("2.Gg8yCM4IIgykCZyq0O4+cA==|GJLBtfvSJTDJh/F7X4cJPkzI6ccnzJm5DYl3yxOW2iUn7DgkkmzoOe61sUhC5dgVdV0kFqsZPcQ0yehlN1DDsFIFtrb4x7LwzJNIkMgxNyg=|1rGkGJ8zcM5o5D0aIIwAyLsjMLrPsP3EWm3CctBO3Fw=".parse().unwrap());
+        invalid_cipher2.key = Some("2.Gg8yCM4IIgykCZyq0O4+cA==|GJLBtfvSJTDJh/F7X4cJPkzI6ccnzJm5DYl3yxOW2iUn7DgkkmzoOe61sUhC5dgVdV0kFqsZPcQ0yehlN1DDsFIFtrb4x7LwzJNIkMgxNyg=|1rGkGJ8zcM5o5D0aIIwAyLsjMLrPsP3EWm3CctBO3Fw=".parse().unwrap());
+
+        let ciphers = vec![invalid_cipher1, invalid_cipher2];
+
+        let result = client
+            .vault()
+            .ciphers()
+            .decrypt_list_full_with_failures(ciphers);
+
+        assert!(result.successes.is_empty());
+        assert_eq!(result.failures.len(), 2);
+    }
+
+    #[tokio::test]
+    #[cfg(feature = "wasm")]
+    async fn test_decrypt_list_full_with_failures_empty_list() {
+        let client = Client::init_test_account(test_bitwarden_com_account()).await;
+
+        let result = client
+            .vault()
+            .ciphers()
+            .decrypt_list_full_with_failures(vec![]);
+
+        assert!(result.successes.is_empty());
+        assert!(result.failures.is_empty());
     }
 
     #[tokio::test]

--- a/crates/bitwarden-vault/src/cipher/field.rs
+++ b/crates/bitwarden-vault/src/cipher/field.rs
@@ -75,6 +75,36 @@ pub struct FieldView {
     pub linked_id: Option<LinkedIdType>,
 }
 
+/// Minimal field view for list/search operations.
+/// Contains only the fields needed for search indexing.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+#[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
+#[cfg_attr(feature = "wasm", derive(Tsify), tsify(into_wasm_abi, from_wasm_abi))]
+pub struct FieldListView {
+    /// Only populated if the field has a name.
+    pub name: Option<String>,
+    /// Only populated for [FieldType::Text] fields.
+    pub value: Option<String>,
+    /// The field type.
+    pub r#type: FieldType,
+}
+
+#[cfg(feature = "wasm")]
+impl From<FieldView> for FieldListView {
+    fn from(field: FieldView) -> Self {
+        Self {
+            name: field.name,
+            value: if field.r#type == FieldType::Text {
+                field.value
+            } else {
+                None
+            },
+            r#type: field.r#type,
+        }
+    }
+}
+
 impl CompositeEncryptable<KeyIds, SymmetricKeyId, Field> for FieldView {
     fn encrypt_composite(
         &self,

--- a/crates/bitwarden-vault/src/cipher/mod.rs
+++ b/crates/bitwarden-vault/src/cipher/mod.rs
@@ -25,6 +25,8 @@ pub use cipher::{
 };
 pub use cipher_client::CiphersClient;
 pub use cipher_view_type::CipherViewType;
+#[cfg(feature = "wasm")]
+pub use field::FieldListView;
 pub use field::{FieldType, FieldView};
 pub use identity::IdentityView;
 pub use login::{

--- a/crates/bitwarden-vault/src/totp.rs
+++ b/crates/bitwarden-vault/src/totp.rs
@@ -756,6 +756,12 @@ mod tests {
             copyable_fields: vec![CopyableCipherFields::LoginTotp],
             local_data: None,
             archived_date: None,
+            #[cfg(feature = "wasm")]
+            notes: None,
+            #[cfg(feature = "wasm")]
+            fields: None,
+            #[cfg(feature = "wasm")]
+            attachment_names: None,
         };
 
         let key = SymmetricCryptoKey::try_from("w2LO+nwV4oxwswVYCxlOfRUseXfvU03VzvKQHrqeklPgiMZrspUe6sOBToCnDn9Ay0tuCBn8ykVVRb7PWhub2Q==".to_string()).unwrap();


### PR DESCRIPTION
## 🎟️ Tracking
https://bitwarden.atlassian.net/browse/PM-31668
<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective
  - Add `notes`, `fields`, and `attachment_names` fields to `CipherListView` to enable client-side search indexing without requiring full cipher decryption
  - Add `FieldListView` struct that exposes only field names and text field values (hidden field values are excluded for security) 
  - Add `decrypt_list_full_with_failures` method to decrypt list of ciphers and return full cipher views.
<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

## 🚨 Breaking Changes

<!-- Does this PR introduce any breaking changes? If so, please describe the impact and migration path for clients.

If you're unsure, the automated TypeScript compatibility check will run when you open/update this PR and provide feedback.

For breaking changes:
1. Describe what changed in the client interface
2. Explain why the change was necessary
3. Provide migration steps for client developers
4. Link to any paired client PRs if needed

Otherwise, you can remove this section. -->
