### PR TITLE
feat: Add set_communication_type method to ServerCommunicationConfigClient

### DIFF
--- a/crates/bitwarden-server-communication-config/src/wasm/client.rs
+++ b/crates/bitwarden-server-communication-config/src/wasm/client.rs
@@ -82,6 +82,28 @@ impl JsServerCommunicationConfigClient {
         serde_wasm_bindgen::to_value(&cookies).map_err(|e| JsError::new(&e.to_string()))
     }
 
+    /// Sets the server communication configuration for a hostname
+    ///
+    /// This method saves the provided communication configuration to the repository.
+    /// Typically called when receiving the `/api/config` response from the server.
+    ///
+    /// # Arguments
+    ///
+    /// * `hostname` - The server hostname (e.g., "vault.acme.com")
+    /// * `config` - The server communication configuration to store
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the repository save operation fails
+    #[wasm_bindgen(js_name = setCommunicationType)]
+    pub async fn set_communication_type(
+        &self,
+        hostname: String,
+        config: ServerCommunicationConfig,
+    ) -> Result<(), String> {
+        self.client.set_communication_type(hostname, config).await
+    }
+
     /// Acquires a cookie from the platform and saves it to the repository
     ///
     /// This method calls the platform API to trigger cookie acquisition (e.g., browser

--- a/crates/bitwarden-uniffi/src/platform/server_communication_config.rs
+++ b/crates/bitwarden-uniffi/src/platform/server_communication_config.rs
@@ -55,6 +55,19 @@ impl ServerCommunicationConfigClient {
             .collect()
     }
 
+    /// Sets the server communication configuration for a hostname
+    ///
+    /// This method saves the provided communication configuration to the repository.
+    /// Typically called when receiving the `/api/config` response from the server.
+    pub async fn set_communication_type(
+        &self,
+        hostname: String,
+        config: ServerCommunicationConfig,
+    ) -> Result<()> {
+        self.client.set_communication_type(hostname, config).await?;
+        Ok(())
+    }
+
     /// Acquires a cookie from the platform and saves it to the repository
     pub async fn acquire_cookie(&self, hostname: String) -> Result<()> {
         self.client.acquire_cookie(&hostname).await?;


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-31244

## 📔 Objective

Add set_communication_type() method to allow clients to store server communication configuration received from /api/config endpoint. This is a wrapper around save, meant to be used for receiving a config from the server instead of acquiring and saving a cookie value.