### PR TITLE
refactor: remove Uniffi prefix and Trait suffix from mobile bindings

### DIFF
--- a/crates/bitwarden-uniffi/src/lib.rs
+++ b/crates/bitwarden-uniffi/src/lib.rs
@@ -30,9 +30,8 @@ use error::{Error, Result};
 pub use log_callback::LogCallback;
 use platform::PlatformClient;
 pub use platform::{
-    AcquiredCookie, BootstrapConfig, ServerCommunicationConfig,
-    ServerCommunicationConfigRepositoryTrait, SsoCookieVendorConfig,
-    UniffiServerCommunicationConfigClient,
+    AcquiredCookie, BootstrapConfig, ServerCommunicationConfig, ServerCommunicationConfigClient,
+    ServerCommunicationConfigRepository, SsoCookieVendorConfig,
 };
 use tool::{ExporterClient, GeneratorClients, SendClient, SshClient};
 use vault::VaultClient;

--- a/crates/bitwarden-uniffi/src/platform/mod.rs
+++ b/crates/bitwarden-uniffi/src/platform/mod.rs
@@ -18,7 +18,7 @@ pub use bitwarden_server_communication_config::{
     AcquiredCookie, BootstrapConfig, ServerCommunicationConfig, SsoCookieVendorConfig,
 };
 pub use server_communication_config::{
-    ServerCommunicationConfigRepositoryTrait, UniffiServerCommunicationConfigClient,
+    ServerCommunicationConfigClient, ServerCommunicationConfigRepository,
 };
 
 #[derive(uniffi::Object)]
@@ -54,15 +54,12 @@ impl PlatformClient {
     /// Server communication configuration operations
     pub fn server_communication_config(
         &self,
-        repository: Arc<dyn server_communication_config::ServerCommunicationConfigRepositoryTrait>,
+        repository: Arc<dyn server_communication_config::ServerCommunicationConfigRepository>,
         platform_api: Arc<
             dyn bitwarden_server_communication_config::ServerCommunicationConfigPlatformApi,
         >,
-    ) -> Arc<server_communication_config::UniffiServerCommunicationConfigClient> {
-        server_communication_config::UniffiServerCommunicationConfigClient::new(
-            repository,
-            platform_api,
-        )
+    ) -> Arc<server_communication_config::ServerCommunicationConfigClient> {
+        server_communication_config::ServerCommunicationConfigClient::new(repository, platform_api)
     }
 }
 


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-30775

## 📔 Objective

Remove non-standard naming conventions from uniffi bindings to align with mobile team expectations:
- UniffiServerCommunicationConfigClient → ServerCommunicationConfigClient
- ServerCommunicationConfigRepositoryTrait → ServerCommunicationConfigRepository
