### PR TITLE
refactor: make SsoCookieVendorConfig fields optional

### DIFF
--- a/crates/bitwarden-server-communication-config/CLAUDE.md
+++ b/crates/bitwarden-server-communication-config/CLAUDE.md
@@ -243,9 +243,9 @@ let config = ServerCommunicationConfig {
 // SSO cookie vendor mode
 let config = ServerCommunicationConfig {
     bootstrap: BootstrapConfig::SsoCookieVendor(SsoCookieVendorConfig {
-        idp_login_url: "https://idp.example.com/login".to_string(),
-        cookie_name: "ALBAuthSessionCookie".to_string(),
-        cookie_domain: "vault.example.com".to_string(),
+        idp_login_url: Some("https://idp.example.com/login".to_string()),
+        cookie_name: Some("ALBAuthSessionCookie".to_string()),
+        cookie_domain: Some("vault.example.com".to_string()),
         cookie_value: None, // Populated after bootstrap
     }),
 };
@@ -304,13 +304,13 @@ pub enum BootstrapConfig {
 /// SSO cookie configuration from server /api/config endpoint
 pub struct SsoCookieVendorConfig {
     /// IDP login URL for browser redirect
-    pub idp_login_url: String,
+    pub idp_login_url: Option<String>,
 
     /// Cookie name - base name without shard suffix (e.g., "AWSELBAuthSessionCookie")
-    pub cookie_name: String,
+    pub cookie_name: Option<String>,
 
     /// Cookie domain for validation
-    pub cookie_domain: String,
+    pub cookie_domain: Option<String>,
 
     /// Acquired cookies (populated after bootstrap flow)
     ///

--- a/crates/bitwarden-server-communication-config/src/client.rs
+++ b/crates/bitwarden-server-communication-config/src/client.rs
@@ -108,7 +108,10 @@ where
             return Err(AcquireCookieError::UnsupportedConfiguration);
         };
 
-        let expected_cookie_name = &vendor_config.cookie_name;
+        let expected_cookie_name = vendor_config
+            .cookie_name
+            .as_ref()
+            .ok_or(AcquireCookieError::UnsupportedConfiguration)?;
 
         // Call platform API to acquire cookies
         let cookies = self
@@ -241,9 +244,9 @@ mod tests {
         let repo = MockRepository::default();
         let config = ServerCommunicationConfig {
             bootstrap: BootstrapConfig::SsoCookieVendor(SsoCookieVendorConfig {
-                idp_login_url: "https://example.com".to_string(),
-                cookie_name: "TestCookie".to_string(),
-                cookie_domain: "example.com".to_string(),
+                idp_login_url: Some("https://example.com".to_string()),
+                cookie_name: Some("TestCookie".to_string()),
+                cookie_domain: Some("example.com".to_string()),
                 cookie_value: Some(vec![AcquiredCookie {
                     name: "TestCookie".to_string(),
                     value: "value123".to_string(),
@@ -273,9 +276,9 @@ mod tests {
         let repo = MockRepository::default();
         let config = ServerCommunicationConfig {
             bootstrap: BootstrapConfig::SsoCookieVendor(SsoCookieVendorConfig {
-                idp_login_url: "https://example.com".to_string(),
-                cookie_name: "TestCookie".to_string(),
-                cookie_domain: "example.com".to_string(),
+                idp_login_url: Some("https://example.com".to_string()),
+                cookie_name: Some("TestCookie".to_string()),
+                cookie_domain: Some("example.com".to_string()),
                 cookie_value: None,
             }),
         };
@@ -298,9 +301,9 @@ mod tests {
         let repo = MockRepository::default();
         let config = ServerCommunicationConfig {
             bootstrap: BootstrapConfig::SsoCookieVendor(SsoCookieVendorConfig {
-                idp_login_url: "https://example.com".to_string(),
-                cookie_name: "TestCookie".to_string(),
-                cookie_domain: "example.com".to_string(),
+                idp_login_url: Some("https://example.com".to_string()),
+                cookie_name: Some("TestCookie".to_string()),
+                cookie_domain: Some("example.com".to_string()),
                 cookie_value: Some(vec![AcquiredCookie {
                     name: "TestCookie".to_string(),
                     value: "value123".to_string(),
@@ -364,9 +367,9 @@ mod tests {
         let repo = MockRepository::default();
         let config = ServerCommunicationConfig {
             bootstrap: BootstrapConfig::SsoCookieVendor(SsoCookieVendorConfig {
-                idp_login_url: "https://example.com".to_string(),
-                cookie_name: "TestCookie".to_string(),
-                cookie_domain: "example.com".to_string(),
+                idp_login_url: Some("https://example.com".to_string()),
+                cookie_name: Some("TestCookie".to_string()),
+                cookie_domain: Some("example.com".to_string()),
                 cookie_value: None,
             }),
         };
@@ -387,9 +390,9 @@ mod tests {
         let repo = MockRepository::default();
         let config = ServerCommunicationConfig {
             bootstrap: BootstrapConfig::SsoCookieVendor(SsoCookieVendorConfig {
-                idp_login_url: "https://example.com".to_string(),
-                cookie_name: "AWSELBAuthSessionCookie".to_string(),
-                cookie_domain: "example.com".to_string(),
+                idp_login_url: Some("https://example.com".to_string()),
+                cookie_name: Some("AWSELBAuthSessionCookie".to_string()),
+                cookie_domain: Some("example.com".to_string()),
                 cookie_value: Some(vec![AcquiredCookie {
                     name: "AWSELBAuthSessionCookie".to_string(),
                     value: "eyJhbGciOiJFUzI1NiIsImtpZCI6Im...".to_string(),
@@ -426,9 +429,9 @@ mod tests {
         let repo = MockRepository::default();
         let config = ServerCommunicationConfig {
             bootstrap: BootstrapConfig::SsoCookieVendor(SsoCookieVendorConfig {
-                idp_login_url: "https://example.com".to_string(),
-                cookie_name: "AWSELBAuthSessionCookie".to_string(),
-                cookie_domain: "example.com".to_string(),
+                idp_login_url: Some("https://example.com".to_string()),
+                cookie_name: Some("AWSELBAuthSessionCookie".to_string()),
+                cookie_domain: Some("example.com".to_string()),
                 cookie_value: Some(vec![
                     AcquiredCookie {
                         name: "AWSELBAuthSessionCookie-0".to_string(),
@@ -487,9 +490,9 @@ mod tests {
         // Setup existing config with SsoCookieVendor
         let config = ServerCommunicationConfig {
             bootstrap: BootstrapConfig::SsoCookieVendor(SsoCookieVendorConfig {
-                idp_login_url: "https://example.com".to_string(),
-                cookie_name: "TestCookie".to_string(),
-                cookie_domain: "example.com".to_string(),
+                idp_login_url: Some("https://example.com".to_string()),
+                cookie_name: Some("TestCookie".to_string()),
+                cookie_domain: Some("example.com".to_string()),
                 cookie_value: None,
             }),
         };
@@ -540,9 +543,9 @@ mod tests {
         // Setup existing config
         let config = ServerCommunicationConfig {
             bootstrap: BootstrapConfig::SsoCookieVendor(SsoCookieVendorConfig {
-                idp_login_url: "https://example.com".to_string(),
-                cookie_name: "TestCookie".to_string(),
-                cookie_domain: "example.com".to_string(),
+                idp_login_url: Some("https://example.com".to_string()),
+                cookie_name: Some("TestCookie".to_string()),
+                cookie_domain: Some("example.com".to_string()),
                 cookie_value: None,
             }),
         };
@@ -600,9 +603,9 @@ mod tests {
         // Setup config expecting "ExpectedCookie"
         let config = ServerCommunicationConfig {
             bootstrap: BootstrapConfig::SsoCookieVendor(SsoCookieVendorConfig {
-                idp_login_url: "https://example.com".to_string(),
-                cookie_name: "ExpectedCookie".to_string(),
-                cookie_domain: "example.com".to_string(),
+                idp_login_url: Some("https://example.com".to_string()),
+                cookie_name: Some("ExpectedCookie".to_string()),
+                cookie_domain: Some("example.com".to_string()),
                 cookie_value: None,
             }),
         };
@@ -658,9 +661,9 @@ mod tests {
         // Setup config expecting "AWSELBAuthSessionCookie"
         let config = ServerCommunicationConfig {
             bootstrap: BootstrapConfig::SsoCookieVendor(SsoCookieVendorConfig {
-                idp_login_url: "https://example.com".to_string(),
-                cookie_name: "AWSELBAuthSessionCookie".to_string(),
-                cookie_domain: "example.com".to_string(),
+                idp_login_url: Some("https://example.com".to_string()),
+                cookie_name: Some("AWSELBAuthSessionCookie".to_string()),
+                cookie_domain: Some("example.com".to_string()),
                 cookie_value: None,
             }),
         };
@@ -725,9 +728,9 @@ mod tests {
         // Setup config
         let config = ServerCommunicationConfig {
             bootstrap: BootstrapConfig::SsoCookieVendor(SsoCookieVendorConfig {
-                idp_login_url: "https://example.com".to_string(),
-                cookie_name: "SessionCookie".to_string(),
-                cookie_domain: "example.com".to_string(),
+                idp_login_url: Some("https://example.com".to_string()),
+                cookie_name: Some("SessionCookie".to_string()),
+                cookie_domain: Some("example.com".to_string()),
                 cookie_value: None,
             }),
         };

--- a/crates/bitwarden-server-communication-config/src/config.rs
+++ b/crates/bitwarden-server-communication-config/src/config.rs
@@ -41,11 +41,11 @@ pub enum BootstrapConfig {
 #[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
 pub struct SsoCookieVendorConfig {
     /// Identity provider login URL for browser redirect during bootstrap
-    pub idp_login_url: String,
+    pub idp_login_url: Option<String>,
     /// Cookie name (base name, without shard suffix)
-    pub cookie_name: String,
+    pub cookie_name: Option<String>,
     /// Cookie domain for validation
-    pub cookie_domain: String,
+    pub cookie_domain: Option<String>,
     /// Acquired cookies
     ///
     /// For sharded cookies, this contains multiple entries with names like
@@ -61,7 +61,10 @@ impl std::fmt::Debug for SsoCookieVendorConfig {
             .field("idp_login_url", &self.idp_login_url)
             .field("cookie_name", &self.cookie_name)
             .field("cookie_domain", &self.cookie_domain)
-            .field("cookie_value", &"[REDACTED]")
+            .field(
+                "cookie_value",
+                &self.cookie_value.as_ref().map(|_| "[REDACTED]"),
+            )
             .finish()
     }
 }
@@ -87,9 +90,9 @@ mod tests {
     fn sso_cookie_vendor_serialization() {
         let config = ServerCommunicationConfig {
             bootstrap: BootstrapConfig::SsoCookieVendor(SsoCookieVendorConfig {
-                idp_login_url: "https://timeloop-auth.acme.com/login".to_string(),
-                cookie_name: "ALBAuthSessionCookie".to_string(),
-                cookie_domain: "vault.example.com".to_string(),
+                idp_login_url: Some("https://timeloop-auth.acme.com/login".to_string()),
+                cookie_name: Some("ALBAuthSessionCookie".to_string()),
+                cookie_domain: Some("vault.example.com".to_string()),
                 cookie_value: None,
             }),
         };
@@ -103,10 +106,16 @@ mod tests {
         if let BootstrapConfig::SsoCookieVendor(vendor_config) = deserialized.bootstrap {
             assert_eq!(
                 vendor_config.idp_login_url,
-                "https://timeloop-auth.acme.com/login"
+                Some("https://timeloop-auth.acme.com/login".to_string())
             );
-            assert_eq!(vendor_config.cookie_name, "ALBAuthSessionCookie");
-            assert_eq!(vendor_config.cookie_domain, "vault.example.com");
+            assert_eq!(
+                vendor_config.cookie_name,
+                Some("ALBAuthSessionCookie".to_string())
+            );
+            assert_eq!(
+                vendor_config.cookie_domain,
+                Some("vault.example.com".to_string())
+            );
             assert!(vendor_config.cookie_value.is_none());
         } else {
             panic!("Expected SsoCookieVendor variant");
@@ -119,9 +128,9 @@ mod tests {
 
         // Test with None
         let config_none = SsoCookieVendorConfig {
-            idp_login_url: "https://example.com".to_string(),
-            cookie_name: "TestCookie".to_string(),
-            cookie_domain: "example.com".to_string(),
+            idp_login_url: Some("https://example.com".to_string()),
+            cookie_name: Some("TestCookie".to_string()),
+            cookie_domain: Some("example.com".to_string()),
             cookie_value: None,
         };
 
@@ -131,9 +140,9 @@ mod tests {
 
         // Test with Some - single cookie
         let config_some = SsoCookieVendorConfig {
-            idp_login_url: "https://example.com".to_string(),
-            cookie_name: "TestCookie".to_string(),
-            cookie_domain: "example.com".to_string(),
+            idp_login_url: Some("https://example.com".to_string()),
+            cookie_name: Some("TestCookie".to_string()),
+            cookie_domain: Some("example.com".to_string()),
             cookie_value: Some(vec![AcquiredCookie {
                 name: "TestCookie".to_string(),
                 value: "eyJhbGciOiJFUzI1NiIsImtpZCI6Im...".to_string(),
@@ -150,9 +159,9 @@ mod tests {
 
         // Test with multiple shards
         let config_sharded = SsoCookieVendorConfig {
-            idp_login_url: "https://example.com".to_string(),
-            cookie_name: "TestCookie".to_string(),
-            cookie_domain: "example.com".to_string(),
+            idp_login_url: Some("https://example.com".to_string()),
+            cookie_name: Some("TestCookie".to_string()),
+            cookie_domain: Some("example.com".to_string()),
             cookie_value: Some(vec![
                 AcquiredCookie {
                     name: "TestCookie-0".to_string(),
@@ -185,9 +194,9 @@ mod tests {
         assert!(matches!(direct, BootstrapConfig::Direct));
 
         let vendor = BootstrapConfig::SsoCookieVendor(SsoCookieVendorConfig {
-            idp_login_url: "https://example.com".to_string(),
-            cookie_name: "Cookie".to_string(),
-            cookie_domain: "example.com".to_string(),
+            idp_login_url: Some("https://example.com".to_string()),
+            cookie_name: Some("Cookie".to_string()),
+            cookie_domain: Some("example.com".to_string()),
             cookie_value: None,
         });
         assert!(matches!(vendor, BootstrapConfig::SsoCookieVendor(_)));
@@ -199,9 +208,9 @@ mod tests {
 
         // Test that cookie values are not exposed in Debug output
         let config_with_cookie = SsoCookieVendorConfig {
-            idp_login_url: "https://example.com/login".to_string(),
-            cookie_name: "SessionCookie".to_string(),
-            cookie_domain: "example.com".to_string(),
+            idp_login_url: Some("https://example.com/login".to_string()),
+            cookie_name: Some("SessionCookie".to_string()),
+            cookie_domain: Some("example.com".to_string()),
             cookie_value: Some(vec![AcquiredCookie {
                 name: "SessionCookie".to_string(),
                 value: "super-secret-cookie-value-abc123".to_string(),

--- a/crates/bitwarden-server-communication-config/src/repository.rs
+++ b/crates/bitwarden-server-communication-config/src/repository.rs
@@ -109,9 +109,9 @@ mod tests {
         let repo = InMemoryRepository::default();
         let config = ServerCommunicationConfig {
             bootstrap: BootstrapConfig::SsoCookieVendor(SsoCookieVendorConfig {
-                idp_login_url: "https://example.com/login".to_string(),
-                cookie_name: "TestCookie".to_string(),
-                cookie_domain: "example.com".to_string(),
+                idp_login_url: Some("https://example.com/login".to_string()),
+                cookie_name: Some("TestCookie".to_string()),
+                cookie_domain: Some("example.com".to_string()),
                 cookie_value: Some(vec![AcquiredCookie {
                     name: "TestCookie".to_string(),
                     value: "cookie-value-123".to_string(),
@@ -132,7 +132,7 @@ mod tests {
             .unwrap();
 
         if let BootstrapConfig::SsoCookieVendor(vendor_config) = retrieved.bootstrap {
-            assert_eq!(vendor_config.cookie_name, "TestCookie");
+            assert_eq!(vendor_config.cookie_name, Some("TestCookie".to_string()));
             assert_eq!(vendor_config.cookie_value.as_ref().unwrap().len(), 1);
             assert_eq!(
                 vendor_config.cookie_value.as_ref().unwrap()[0].value,
@@ -158,9 +158,9 @@ mod tests {
         // Overwrite with second config
         let config2 = ServerCommunicationConfig {
             bootstrap: BootstrapConfig::SsoCookieVendor(SsoCookieVendorConfig {
-                idp_login_url: "https://example.com".to_string(),
-                cookie_name: "Cookie".to_string(),
-                cookie_domain: "example.com".to_string(),
+                idp_login_url: Some("https://example.com".to_string()),
+                cookie_name: Some("Cookie".to_string()),
+                cookie_domain: Some("example.com".to_string()),
                 cookie_value: None,
             }),
         };
@@ -189,9 +189,9 @@ mod tests {
         };
         let config2 = ServerCommunicationConfig {
             bootstrap: BootstrapConfig::SsoCookieVendor(SsoCookieVendorConfig {
-                idp_login_url: "https://example.com".to_string(),
-                cookie_name: "Cookie".to_string(),
-                cookie_domain: "example.com".to_string(),
+                idp_login_url: Some("https://example.com".to_string()),
+                cookie_name: Some("Cookie".to_string()),
+                cookie_domain: Some("example.com".to_string()),
                 cookie_value: None,
             }),
         };


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-29145

## 📔 Objective

The server returns nullable string fields for IdpLoginUrl, CookieName, and CookieDomain in the CommunicationBootstrapSettings. This commit updates the SDK's SsoCookieVendorConfig type to use Option<String> for these fields to properly match.

Changes:
- Changed idp_login_url, cookie_name, and cookie_domain from String to Option<String>
- Updated all test cases to use Some() wrappers for these fields
- Updated client.rs to properly handle the optional cookie_name field
- Updated CLAUDE.md documentation to reflect the new optional fields

## 🚨 Breaking Changes

<!-- Does this PR introduce any breaking changes? If so, please describe the impact and migration path for clients.

If you're unsure, the automated TypeScript compatibility check will run when you open/update this PR and provide feedback.

For breaking changes:
1. Describe what changed in the client interface
2. Explain why the change was necessary
3. Provide migration steps for client developers
4. Link to any paired client PRs if needed

Otherwise, you can remove this section. -->
