### PR TITLE
Adjust Cargo and package dependency files to only be unowned at root

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -66,9 +66,9 @@ crates/bw/src/vault/** @bitwarden/team-vault-dev @bitwarden/team-sdk-sme
 **/entrypoint.sh @bitwarden/team-appsec @bitwarden/dept-bre
 **/docker-compose.yml @bitwarden/team-appsec @bitwarden/dept-bre
 
-## No ownership for dependency management files to allow Renovate to manage updates
-Cargo.lock
-Cargo.toml
-package-lock.json
-package.json
+## No ownership for root dependency management files to allow Renovate to manage updates
+/Cargo.lock
+/Cargo.toml
+/package-lock.json
+/package.json
 


### PR DESCRIPTION
## 🎟️ Tracking

[bitwarden.atlassian.net/browse/PM-30256](https://bitwarden.atlassian.net/browse/PM-30256)

## 📔 Objective

In https://github.com/bitwarden/sdk-internal/pull/639, we removed code ownership from `Cargo.toml` and `package.json` files to allow Renovate to own dependencies.

However, this was intended only to affect the _root_ dependency files, not all those in crates.  If a team were to add dependencies to their crates (non-workspace-owned), then we do want them to have ownership over maintaining updates to that dependency.

### Desired behavior
#### Dependency is workspace-managed
  - Dependency version is defined in root `Cargo.toml`
  - Ownership is defined in `renovate.json5` and enforced with a pre-commit hook to ensure that any added dependency is owned.
  - When a dependency update is made, the team will have a PR assigned to them by Renovate assigning the reviewer.
#### Dependency is managed by the crate
 - Dependency version is defined in crate-level `Cargo.toml`
 - Ownership is defined by `CODEOWNERS` on that crate.
 - When a dependency update is made, the team will have a PR assigned to them by `CODEOWNERS`, since the `Cargo.toml` file will be updated by the dependency version bump.

## 🚨 Breaking Changes

<!-- Does this PR introduce any breaking changes? If so, please describe the impact and migration path for clients.

If you're unsure, the automated TypeScript compatibility check will run when you open/update this PR and provide feedback.

For breaking changes:
1. Describe what changed in the client interface
5. Explain why the change was necessary
6. Provide migration steps for client developers
7. Link to any paired client PRs if needed

Otherwise, you can remove this section. -->
