### PR TITLE
Prevent crash when invalid dataenvelope is passed via uniffi

### DIFF
--- a/crates/bitwarden-crypto/src/uniffi_support.rs
+++ b/crates/bitwarden-crypto/src/uniffi_support.rs
@@ -37,8 +37,7 @@ uniffi::custom_type!(SignedPublicKey, String, {
 });
 
 uniffi::custom_type!(DataEnvelope, String, {
-    try_lift: |val| DataEnvelope::from_str(val.as_str())
-        .map_err(|e| e.into()),
+    try_lift: |val| convert_result(DataEnvelope::from_str(val.as_str())),
     lower: |obj| obj.to_string(),
 });
 


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://github.com/bitwarden/sdk-internal/pull/698#discussion_r2816635181

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

As per @dani-garcia 's comment, we should wrap the parsing into convert_result.

## 🚨 Breaking Changes

<!-- Does this PR introduce any breaking changes? If so, please describe the impact and migration path for clients.

If you're unsure, the automated TypeScript compatibility check will run when you open/update this PR and provide feedback.

For breaking changes:
1. Describe what changed in the client interface
2. Explain why the change was necessary
3. Provide migration steps for client developers
4. Link to any paired client PRs if needed

Otherwise, you can remove this section. -->
