### PR TITLE
[PM-30144] Filter out not-enrolled organizations

### DIFF
--- a/crates/bitwarden-user-crypto-management/src/key_rotation/mod.rs
+++ b/crates/bitwarden-user-crypto-management/src/key_rotation/mod.rs
@@ -82,7 +82,8 @@ impl UserCryptoManagementClient {
         .await
     }
 
-    /// Fetches the organization public keys for V1 organization memberships for the user.
+    /// Fetches the organization public keys for V1 organization memberships for the user for
+    /// organizations for which reset password is enrolled.
     /// These have to be trusted manually be the user before rotating.
     pub async fn get_untrusted_organization_public_keys(
         &self,

--- a/crates/bitwarden-user-crypto-management/src/key_rotation/sync.rs
+++ b/crates/bitwarden-user-crypto-management/src/key_rotation/sync.rs
@@ -77,7 +77,8 @@ async fn fetch_organization_public_key(
     .debug_map_err(SyncError::DataError)
 }
 
-// Download the public keys for the organizations, since these are not included in the sync
+// Download the public keys for the organizations for which reset password is enrolled, since these
+// are not included in the sync
 pub(crate) async fn sync_orgs(
     api_client: &ApiClient,
 ) -> Result<Vec<V1OrganizationMembership>, SyncError> {
@@ -91,6 +92,7 @@ pub(crate) async fn sync_orgs(
         .into_iter();
     let organizations = organizations
         .into_iter()
+        .filter(|org| org.reset_password_enrolled.unwrap_or(false))
         .map(async |org| {
             let id = org.id.ok_or(SyncError::DataError)?;
             let public_key = fetch_organization_public_key(api_client, id).await?;
@@ -614,6 +616,7 @@ mod tests {
             data: Some(vec![ProfileOrganizationResponseModel {
                 id: Some(org_id),
                 name: Some("Test Org".to_string()),
+                reset_password_enrolled: Some(true),
                 ..ProfileOrganizationResponseModel::new()
             }]),
             continuation_token: None,
@@ -899,16 +902,19 @@ mod tests {
                             ProfileOrganizationResponseModel {
                                 id: Some(org_id1),
                                 name: Some(org_name1.clone()),
+                                reset_password_enrolled: Some(true),
                                 ..ProfileOrganizationResponseModel::new()
                             },
                             ProfileOrganizationResponseModel {
                                 id: Some(org_id2),
                                 name: Some(org_name2.clone()),
+                                reset_password_enrolled: Some(true),
                                 ..ProfileOrganizationResponseModel::new()
                             },
                             ProfileOrganizationResponseModel {
                                 id: Some(org_id3),
                                 name: Some(org_name3.clone()),
+                                reset_password_enrolled: Some(true),
                                 ..ProfileOrganizationResponseModel::new()
                             },
                         ]),
@@ -994,6 +1000,7 @@ mod tests {
                         data: Some(vec![ProfileOrganizationResponseModel {
                             id: Some(org_id),
                             name: Some("Test Org".to_string()),
+                            reset_password_enrolled: Some(true),
                             ..ProfileOrganizationResponseModel::new()
                         }]),
                         continuation_token: None,
@@ -1407,6 +1414,117 @@ mod tests {
         if let ApiClient::Mock(mut mock) = api_client {
             mock.emergency_access_api.checkpoint();
             mock.users_api.checkpoint();
+        }
+    }
+
+    #[tokio::test]
+    async fn test_sync_orgs_filters_non_enrolled_orgs() {
+        let org_id_enrolled1 = uuid::Uuid::new_v4();
+        let org_id_not_enrolled = uuid::Uuid::new_v4();
+        let org_id_none_enrolled = uuid::Uuid::new_v4();
+        let org_id_enrolled2 = uuid::Uuid::new_v4();
+        let expected_public_key_b64 = test_public_key_b64();
+
+        let api_client = ApiClient::new_mocked(|mock| {
+            mock.organizations_api
+                .expect_get_user()
+                .once()
+                .returning(move || {
+                    Ok(ProfileOrganizationResponseModelListResponseModel {
+                        object: None,
+                        data: Some(vec![
+                            ProfileOrganizationResponseModel {
+                                id: Some(org_id_enrolled1),
+                                name: Some("Enrolled Org 1".to_string()),
+                                reset_password_enrolled: Some(true),
+                                ..ProfileOrganizationResponseModel::new()
+                            },
+                            ProfileOrganizationResponseModel {
+                                id: Some(org_id_not_enrolled),
+                                name: Some("Not Enrolled Org".to_string()),
+                                reset_password_enrolled: Some(false),
+                                ..ProfileOrganizationResponseModel::new()
+                            },
+                            ProfileOrganizationResponseModel {
+                                id: Some(org_id_none_enrolled),
+                                name: Some("None Enrolled Org".to_string()),
+                                reset_password_enrolled: None,
+                                ..ProfileOrganizationResponseModel::new()
+                            },
+                            ProfileOrganizationResponseModel {
+                                id: Some(org_id_enrolled2),
+                                name: Some("Enrolled Org 2".to_string()),
+                                reset_password_enrolled: Some(true),
+                                ..ProfileOrganizationResponseModel::new()
+                            },
+                        ]),
+                        continuation_token: None,
+                    })
+                });
+
+            let expected_public_key_b64 = expected_public_key_b64.clone();
+            mock.organizations_api
+                .expect_get_public_key()
+                .times(2)
+                .returning(move |_| {
+                    Ok(OrganizationPublicKeyResponseModel {
+                        object: None,
+                        public_key: Some(expected_public_key_b64.clone()),
+                    })
+                });
+        });
+
+        let result = sync_orgs(&api_client).await;
+        let memberships = result.unwrap();
+
+        assert_eq!(memberships.len(), 2);
+        assert_eq!(memberships[0].organization_id, org_id_enrolled1);
+        assert_eq!(memberships[0].name, "Enrolled Org 1");
+        assert_eq!(memberships[1].organization_id, org_id_enrolled2);
+        assert_eq!(memberships[1].name, "Enrolled Org 2");
+
+        if let ApiClient::Mock(mut mock) = api_client {
+            mock.organizations_api.checkpoint();
+        }
+    }
+
+    #[tokio::test]
+    async fn test_sync_orgs_all_not_enrolled_returns_empty() {
+        let api_client = ApiClient::new_mocked(|mock| {
+            mock.organizations_api
+                .expect_get_user()
+                .once()
+                .returning(move || {
+                    Ok(ProfileOrganizationResponseModelListResponseModel {
+                        object: None,
+                        data: Some(vec![
+                            ProfileOrganizationResponseModel {
+                                id: Some(uuid::Uuid::new_v4()),
+                                name: Some("Org A".to_string()),
+                                reset_password_enrolled: Some(false),
+                                ..ProfileOrganizationResponseModel::new()
+                            },
+                            ProfileOrganizationResponseModel {
+                                id: Some(uuid::Uuid::new_v4()),
+                                name: Some("Org B".to_string()),
+                                reset_password_enrolled: None,
+                                ..ProfileOrganizationResponseModel::new()
+                            },
+                        ]),
+                        continuation_token: None,
+                    })
+                });
+
+            mock.organizations_api.expect_get_public_key().never();
+        });
+
+        let result = sync_orgs(&api_client).await;
+        let memberships = result.unwrap();
+
+        assert_eq!(memberships.len(), 0);
+
+        if let ApiClient::Mock(mut mock) = api_client {
+            mock.organizations_api.checkpoint();
         }
     }
 }


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-30144

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
Filters out orgs that are not account recovery orgs from key rotation.

## 🚨 Breaking Changes

<!-- Does this PR introduce any breaking changes? If so, please describe the impact and migration path for clients.

If you're unsure, the automated TypeScript compatibility check will run when you open/update this PR and provide feedback.

For breaking changes:
1. Describe what changed in the client interface
2. Explain why the change was necessary
3. Provide migration steps for client developers
4. Link to any paired client PRs if needed

Otherwise, you can remove this section. -->
