### PR TITLE
Skip updating clippy_utils, it's locked to dylint

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -133,5 +133,5 @@
       reviewers: ["team:team-platform-dev"],
     },
   ],
-  ignoreDeps: ["dotnet-sdk"],
+  ignoreDeps: ["clippy_utils", "dotnet-sdk"],
 }


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

We don't want renovate to update `clippy_utils` since we need to use the specific version `dylint` uses.
