### PR TITLE
Document data model conventions in CLAUDE.md

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -121,6 +121,11 @@ picture.
 requires an `id`, `revision_date`, or fields that are immutable after creation), use **separate**
 `*CreateRequest` and `*EditRequest` structs.
 
+**Variant data**: When a model has a type discriminant with per-variant associated data (e.g. a send
+is either a file or text, never both), use an enum with associated data rather than a bare
+discriminant field alongside multiple `Option` fields. The mapping from server wire format (numeric
+discriminant + optional fields) belongs at the API→domain boundary.
+
 ## Development Workflow
 
 **Build & Test:**

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -117,8 +117,9 @@ picture.
 | `Request`  | Public input DTO from client into SDK                   | `CipherCreateRequest`    |
 | `Response` | Public output DTO from SDK to client                    | `LoginResponse`          |
 
-**Create vs. Edit requests**: When a resource supports both create and edit operations, define
-**separate** `*CreateRequest` and `*EditRequest` structs rather than a single combined struct.
+**Create vs. Edit requests**: When the fields for creating and editing an item differ (e.g. edit
+requires an `id`, `revision_date`, or fields that are immutable after creation), use **separate**
+`*CreateRequest` and `*EditRequest` structs.
 
 **Variant data**: When a model has a type discriminant with per-variant associated data (e.g. a send
 is either a file or text, never both), use an enum with associated data rather than a bare

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -119,8 +119,7 @@ picture.
 
 **Create vs. Edit requests**: When the fields for creating and editing an item differ (e.g. edit
 requires an `id`, `revision_date`, or fields that are immutable after creation), use **separate**
-`*CreateRequest` and `*EditRequest` structs. Combined `*AddEditRequest` structs exist in some older
-code (e.g. `FolderAddEditRequest`) but should not be used for new code.
+`*CreateRequest` and `*EditRequest` structs.
 
 ## Development Workflow
 

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -117,9 +117,8 @@ picture.
 | `Request`  | Public input DTO from client into SDK                   | `CipherCreateRequest`    |
 | `Response` | Public output DTO from SDK to client                    | `LoginResponse`          |
 
-**Create vs. Edit requests**: When the fields for creating and editing an item differ (e.g. edit
-requires an `id`, `revision_date`, or fields that are immutable after creation), use **separate**
-`*CreateRequest` and `*EditRequest` structs.
+**Create vs. Edit requests**: When a resource supports both create and edit operations, define
+**separate** `*CreateRequest` and `*EditRequest` structs rather than a single combined struct.
 
 **Variant data**: When a model has a type discriminant with per-variant associated data (e.g. a send
 is either a file or text, never both), use an enum with associated data rather than a bare

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -104,6 +104,24 @@ Monorepo crates organized in **four architectural layers**:
 - TypeScript compilation tested against `clients` repo on PR
 - Document migration path for clients
 
+### Data Model Conventions
+
+The SDK uses distinct model layers; use the correct type for the context. See the
+[data models docs](https://contributing.bitwarden.com/architecture/sdk/data-models) for the full
+picture.
+
+| Suffix     | Role                                                    | Example                  |
+| ---------- | ------------------------------------------------------- | ------------------------ |
+| _(none)_   | Encrypted domain model — internal, not exposed publicly | `Cipher`, `Send`         |
+| `View`     | Decrypted DTO returned to clients                       | `CipherView`, `SendView` |
+| `Request`  | Public input DTO from client into SDK                   | `CipherCreateRequest`    |
+| `Response` | Public output DTO from SDK to client                    | `LoginResponse`          |
+
+**Create vs. Edit requests**: When the fields for creating and editing an item differ (e.g. edit
+requires an `id`, `revision_date`, or fields that are immutable after creation), use **separate**
+`*CreateRequest` and `*EditRequest` structs. Combined `*AddEditRequest` structs exist in some older
+code (e.g. `FolderAddEditRequest`) but should not be used for new code.
+
 ## Development Workflow
 
 **Build & Test:**

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -110,12 +110,12 @@ The SDK uses distinct model layers; use the correct type for the context. See th
 [data models docs](https://contributing.bitwarden.com/architecture/sdk/data-models) for the full
 picture.
 
-| Suffix     | Role                                                    | Example                  |
-| ---------- | ------------------------------------------------------- | ------------------------ |
-| _(none)_   | Encrypted domain model — internal, not exposed publicly | `Cipher`, `Send`         |
-| `View`     | Decrypted DTO returned to clients                       | `CipherView`, `SendView` |
-| `Request`  | Public input DTO from client into SDK                   | `CipherCreateRequest`    |
-| `Response` | Public output DTO from SDK to client                    | `LoginResponse`          |
+| Suffix     | Role                                                                              | Example                  |
+| ---------- | --------------------------------------------------------------------------------- | ------------------------ |
+| _(none)_   | Server/storage-layer model — prefer `View`/`Request`/`Response` at API boundaries | `Cipher`, `Send`         |
+| `View`     | Decrypted DTO returned to clients                                                 | `CipherView`, `SendView` |
+| `Request`  | Public input DTO from client into SDK                                             | `CipherCreateRequest`    |
+| `Response` | Public output DTO from SDK to client                                              | `LoginResponse`          |
 
 **Create vs. Edit requests**: When the fields for creating and editing an item differ (e.g. edit
 requires an `id`, `revision_date`, or fields that are immutable after creation), use **separate**


### PR DESCRIPTION
## Summary

- Adds a "Data Model Conventions" section to the root `CLAUDE.md` summarising the four model layers (domain, `View`, `Request`, `Response`) with a reference to the contributing docs
- Codifies the rule that resources with both create and edit operations should use separate `*CreateRequest` and `*EditRequest` structs
- Codifies the rule that models with a type discriminant and per-variant data should use enums with associated data rather than a bare discriminant field alongside multiple `Option` fields