### PR TITLE
[no ticket] Fix clippy warning when compiled without performance tracing flag

### DIFF
--- a/crates/bitwarden-wasm-internal/src/init.rs
+++ b/crates/bitwarden-wasm-internal/src/init.rs
@@ -1,8 +1,6 @@
 use tracing::Level;
-use tracing_subscriber::{
-    EnvFilter, fmt::format::Pretty, layer::SubscriberExt as _, util::SubscriberInitExt as _,
-};
-use tracing_web::{MakeWebConsoleWriter, performance_layer};
+use tracing_subscriber::{EnvFilter, layer::SubscriberExt as _, util::SubscriberInitExt as _};
+use tracing_web::MakeWebConsoleWriter;
 use wasm_bindgen::prelude::*;
 
 #[wasm_bindgen]
@@ -43,7 +41,8 @@ pub fn init_sdk(log_level: Option<LogLevel>) {
     let tracing_subscriber = tracing_subscriber::registry().with(filter).with(fmt);
     #[cfg(feature = "performance-tracing")]
     let tracing_subscriber = {
-        let perf_layer = performance_layer().with_details_from_fields(Pretty::default());
+        let perf_layer = tracing_web::performance_layer()
+            .with_details_from_fields(tracing_subscriber::fmt::format::Pretty::default());
         tracing_subscriber.with(perf_layer)
     };
     tracing_subscriber.init();


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
Fixes a warn introduced when not compiling with all features enabled, since the imports are specific to the performance layer integration.

## 🚨 Breaking Changes

<!-- Does this PR introduce any breaking changes? If so, please describe the impact and migration path for clients.

If you're unsure, the automated TypeScript compatibility check will run when you open/update this PR and provide feedback.

For breaking changes:
1. Describe what changed in the client interface
2. Explain why the change was necessary
3. Provide migration steps for client developers
4. Link to any paired client PRs if needed

Otherwise, you can remove this section. -->
