### PR TITLE
[PM-32613] Handle uninitialized UserKeyState repository

### DIFF
--- a/crates/bitwarden-core/src/key_management/wasm_unlock_state.rs
+++ b/crates/bitwarden-core/src/key_management/wasm_unlock_state.rs
@@ -36,30 +36,34 @@ pub(crate) async fn copy_user_key_to_client_managed_state(
             .clone()
     };
 
-    // Get the current key
-    let existing_key = client
+    if let Ok(user_key_repository) = client
         .platform()
         .state()
         .get::<key_management::UserKeyState>()
-        .map_err(|_| UnableToSetError)?
-        .get(USER_KEY_REPOSITORY_KEY.to_string())
-        .await
-        .map_err(|_| UnableToSetError)?;
-
-    // We do not want to set the user-key if it is already set as that may trigger an observable
-    // loop in the client side which subscribes to the state
-    if let Some(existing_key) = existing_key {
-        if SymmetricCryptoKey::try_from(existing_key.decrypted_user_key)
-            .map_err(|_| UnableToSetError)?
-            == user_key
+    {
+        // We do not want to set the user-key if it is already set as that may trigger an observable
+        // loop in the client side which subscribes to the state
+        if let Ok(Some(existing_key)) = user_key_repository
+            .get(USER_KEY_REPOSITORY_KEY.to_string())
+            .await
         {
-            info!("User-key in client managed state is already up to date, skipping set");
-            return Ok(());
+            if SymmetricCryptoKey::try_from(existing_key.decrypted_user_key)
+                .map_err(|_| UnableToSetError)?
+                == user_key
+            {
+                info!("User-key in client managed state is already up to date, skipping set");
+                return Ok(());
+            } else {
+                info!("User-key in client managed state is outdated, updating it");
+            }
         } else {
-            info!("User-key in client managed state is outdated, updating it");
+            info!("No user-key in client managed state, setting it");
         }
     } else {
-        info!("No user-key in client managed state, setting it");
+        // UserKeyState repository does not exist, older clients should
+        // just return gracefully.
+        info!("No UserKeyState repository exists in client managed state, exiting gracefully");
+        return Ok(());
     }
 
     info!("Setting the user-key to client managed-state from SDK");


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-32613

## 📔 Objective

When initialized a user's cryptographic state, if the client managed state doesn't contain the `UserKeyState` we want to gracefully exit instead of returning an error. This will allow older clients to use a newer `sdk-internal` version.

## 🚨 Breaking Changes
