### PR TITLE
[PM-32716] Remove user id from security state

### DIFF
--- a/crates/bitwarden-auth/src/registration.rs
+++ b/crates/bitwarden-auth/src/registration.rs
@@ -108,7 +108,6 @@ impl RegistrationClient {
         &self,
         key_connector_url: String,
         sso_org_identifier: String,
-        user_id: UserId,
     ) -> Result<KeyConnectorRegistrationResult, RegistrationError> {
         let client = &self.client.internal;
         let configuration = &client.get_api_configurations().await;
@@ -119,7 +118,6 @@ impl RegistrationClient {
             &configuration.api_client,
             &key_connector_client,
             sso_org_identifier,
-            user_id,
         )
         .await
     }
@@ -146,7 +144,7 @@ async fn internal_post_keys_for_tde_registration(
     let tde_registration_crypto_result = registration_client
         .client
         .crypto()
-        .make_user_tde_registration(request.user_id, request.org_public_key.clone())
+        .make_user_tde_registration(request.org_public_key.clone())
         .map_err(|_| RegistrationError::Crypto)?;
 
     // Post the generated keys to the API here. The user now has keys and is "registered", but
@@ -265,14 +263,13 @@ async fn internal_post_keys_for_key_connector_registration(
     api_client: &bitwarden_api_api::apis::ApiClient,
     key_connector_api_client: &bitwarden_api_key_connector::apis::ApiClient,
     sso_org_identifier: String,
-    user_id: UserId,
 ) -> Result<KeyConnectorRegistrationResult, RegistrationError> {
     // First call crypto API to get all keys
     info!("Initializing account cryptography");
     let registration_crypto_result = registration_client
         .client
         .crypto()
-        .make_user_key_connector_registration(user_id)
+        .make_user_key_connector_registration()
         .map_err(|_| RegistrationError::Crypto)?;
 
     info!("Posting key connector key to key connector server");
@@ -374,7 +371,6 @@ async fn internal_post_keys_for_jit_password_registration(
         .client
         .crypto()
         .make_user_jit_master_password_registration(
-            request.user_id,
             request.master_password,
             request.salt,
             request.org_public_key,
@@ -819,7 +815,6 @@ mod tests {
             &api_client,
             &key_connector_api_client,
             TEST_SSO_ORG_IDENTIFIER.to_string(),
-            UserId::new(uuid::uuid!(TEST_USER_ID)),
         )
         .await;
         assert!(result.is_ok());
@@ -875,7 +870,6 @@ mod tests {
             &api_client,
             &key_connector_api_client,
             TEST_SSO_ORG_IDENTIFIER.to_string(),
-            UserId::new(uuid::uuid!(TEST_USER_ID)),
         )
         .await;
 
@@ -936,7 +930,6 @@ mod tests {
             &api_client,
             &key_connector_api_client,
             TEST_SSO_ORG_IDENTIFIER.to_string(),
-            UserId::new(uuid::uuid!(TEST_USER_ID)),
         )
         .await;
 

--- a/crates/bitwarden-core/src/key_management/crypto_client.rs
+++ b/crates/bitwarden-core/src/key_management/crypto_client.rs
@@ -205,10 +205,9 @@ impl CryptoClient {
     /// and security state) wrapped with a new user key.
     pub fn make_user_tde_registration(
         &self,
-        user_id: UserId,
         org_public_key: B64,
     ) -> Result<MakeTdeRegistrationResponse, MakeKeysError> {
-        make_user_tde_registration(&self.client, user_id, org_public_key)
+        make_user_tde_registration(&self.client, org_public_key)
     }
 
     /// Creates a new V2 account cryptographic state for Key Connector registration.
@@ -216,9 +215,8 @@ impl CryptoClient {
     /// and security state) wrapped with a new user key.
     pub fn make_user_key_connector_registration(
         &self,
-        user_id: UserId,
     ) -> Result<MakeKeyConnectorRegistrationResponse, MakeKeysError> {
-        make_user_key_connector_registration(&self.client, user_id)
+        make_user_key_connector_registration(&self.client)
     }
 
     /// Creates a new V2 account cryptographic state for SSO JIT master password registration.
@@ -226,14 +224,12 @@ impl CryptoClient {
     /// and security state) wrapped with a new user key.
     pub fn make_user_jit_master_password_registration(
         &self,
-        user_id: UserId,
         master_password: String,
         salt: String,
         org_public_key: B64,
     ) -> Result<MakeJitMasterPasswordRegistrationResponse, MakeKeysError> {
         make_user_jit_master_password_registration(
             &self.client,
-            user_id,
             master_password,
             salt,
             org_public_key,

--- a/crates/bitwarden-core/src/key_management/crypto_client.rs
+++ b/crates/bitwarden-core/src/key_management/crypto_client.rs
@@ -25,7 +25,7 @@ use crate::key_management::{
 };
 #[expect(deprecated)]
 use crate::{
-    Client, UserId,
+    Client,
     client::encryption_settings::EncryptionSettingsError,
     error::StatefulCryptoError,
     key_management::crypto::{

--- a/crates/bitwarden-core/src/key_management/security_state.rs
+++ b/crates/bitwarden-core/src/key_management/security_state.rs
@@ -48,9 +48,6 @@ export type SignedSecurityState = string;
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct SecurityState {
-    /// The entity ID is a permanent, unchangeable, unique identifier for the object this security
-    /// state applies to. For users, this is the user ID, which never changes.
-    entity_id: UserId,
     /// The version of the security state gates feature availability. It can only ever be
     /// incremented. Components can use it to gate format support of specific formats (like
     /// item url hashes).
@@ -60,11 +57,8 @@ pub struct SecurityState {
 impl SecurityState {
     /// Initialize a new `SecurityState` for the given user ID, to the lowest version possible.
     /// The user needs to be a v2 encryption user.
-    pub fn initialize_for_user(user_id: UserId) -> Self {
-        SecurityState {
-            entity_id: user_id,
-            version: 2,
-        }
+    pub fn new() -> Self {
+        SecurityState { version: 2 }
     }
 
     /// Returns the version of the security state
@@ -190,8 +184,7 @@ mod tests {
         let store: KeyStore<KeyIds> = KeyStore::default();
         let mut ctx = store.context_mut();
 
-        let user_id = UserId::new_v4();
-        let security_state = SecurityState::initialize_for_user(user_id);
+        let security_state = SecurityState::new();
         let signing_key = SigningKey::make(SignatureAlgorithm::Ed25519);
         let key = ctx.add_local_signing_key(signing_key.clone());
         let signed_security_state = security_state.sign(key, &mut ctx).unwrap();
@@ -205,8 +198,7 @@ mod tests {
         let store: KeyStore<KeyIds> = KeyStore::default();
         let mut ctx = store.context_mut();
 
-        let user_id = UserId::new_v4();
-        let security_state = SecurityState::initialize_for_user(user_id);
+        let security_state = SecurityState::new();
         let signing_key = SigningKey::make(SignatureAlgorithm::Ed25519);
         let key = ctx.add_local_signing_key(signing_key.clone());
         let signed_security_state = security_state.sign(key, &mut ctx).unwrap();
@@ -227,8 +219,7 @@ mod tests {
         let store: KeyStore<KeyIds> = KeyStore::default();
         let mut ctx = store.context_mut();
 
-        let user_id = UserId::new_v4();
-        let security_state = SecurityState::initialize_for_user(user_id);
+        let security_state = SecurityState::new();
         let signing_key = SigningKey::make(SignatureAlgorithm::Ed25519);
         let key = ctx.add_local_signing_key(signing_key.clone());
         let signed_security_state = security_state.sign(key, &mut ctx).unwrap();
@@ -238,7 +229,6 @@ mod tests {
             .verify_and_unwrap(&verifying_key)
             .unwrap();
 
-        assert_eq!(verified_security_state.entity_id, user_id);
         assert_eq!(verified_security_state.version(), 2);
     }
 

--- a/crates/bitwarden-core/src/key_management/security_state.rs
+++ b/crates/bitwarden-core/src/key_management/security_state.rs
@@ -52,6 +52,12 @@ pub struct SecurityState {
     version: u64,
 }
 
+impl Default for SecurityState {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl SecurityState {
     /// Initialize a new `SecurityState` for the given user ID, to the lowest version possible.
     /// The user needs to be a v2 encryption user.
@@ -208,7 +214,7 @@ mod tests {
         );
         println!(
             "const TEST_VERIFYING_KEY: &str = \"{}\";",
-            B64::from(verifying_key.to_cose()).to_string()
+            B64::from(verifying_key.to_cose())
         );
     }
 

--- a/crates/bitwarden-core/src/key_management/security_state.rs
+++ b/crates/bitwarden-core/src/key_management/security_state.rs
@@ -29,8 +29,6 @@ use bitwarden_crypto::{
 use bitwarden_encoding::{B64, FromStrVisitor};
 use serde::{Deserialize, Serialize};
 
-use crate::UserId;
-
 /// Icon URI hashes are enforced starting with this security state version.
 pub const MINIMUM_ENFORCE_ICON_URI_HASH_VERSION: u64 = 2;
 

--- a/crates/bitwarden-user-crypto-management/src/key_rotation/crypto.rs
+++ b/crates/bitwarden-user-crypto-management/src/key_rotation/crypto.rs
@@ -1,9 +1,6 @@
 //! Functionality for re-encrypting account cryptographic state during user key rotation.
-use bitwarden_core::{
-    UserId,
-    key_management::{
-        KeyIds, SymmetricKeyId, account_cryptographic_state::WrappedAccountCryptographicState,
-    },
+use bitwarden_core::key_management::{
+    KeyIds, SymmetricKeyId, account_cryptographic_state::WrappedAccountCryptographicState,
 };
 use tracing::debug;
 
@@ -14,11 +11,11 @@ pub(super) fn rotate_account_cryptographic_state(
     wrapped_account_cryptographic_state: &WrappedAccountCryptographicState,
     current_user_key_id: &SymmetricKeyId,
     new_user_key_id: &SymmetricKeyId,
-    user_id: UserId,
     ctx: &mut bitwarden_crypto::KeyStoreContext<KeyIds>,
 ) -> Result<bitwarden_api_api::models::AccountKeysRequestModel, ()> {
     debug!(
-        %user_id, ?current_user_key_id, ?new_user_key_id,
+        ?current_user_key_id,
+        ?new_user_key_id,
         "Rotating account cryptographic state",
     );
 
@@ -28,15 +25,11 @@ pub(super) fn rotate_account_cryptographic_state(
         wrapped_account_cryptographic_state,
         current_user_key_id,
         new_user_key_id,
-        user_id,
         ctx,
     )
     .map_err(|_| ())?;
 
-    debug!(
-        %user_id,
-        "Converting rotated account cryptographic state to request model",
-    );
+    debug!("Converting rotated account cryptographic state to request model",);
 
     // Rotate the account keys for the user
     let account_keys_model = rotated_account_cryptographic_state
@@ -80,7 +73,6 @@ mod tests {
         let mut ctx = store.context_mut();
 
         // Create a V1-style wrapped state
-        let user_id = UserId::new_v4();
         let (old_user_key_id, public_key, wrapped_state) = make_v1_wrapped_state(&mut ctx);
 
         // Create a new user key for rotation
@@ -90,7 +82,6 @@ mod tests {
             &wrapped_state,
             &old_user_key_id,
             &new_user_key_id,
-            user_id,
             &mut ctx,
         )
         .expect("rotate_account_cryptographic_state should succeed");
@@ -157,9 +148,8 @@ mod tests {
         let mut ctx = store.context_mut();
 
         // Create a V2-style wrapped state
-        let user_id = UserId::new_v4();
         let (old_user_key_id, wrapped_state) =
-            WrappedAccountCryptographicState::make(&mut ctx, user_id).unwrap();
+            WrappedAccountCryptographicState::make(&mut ctx).unwrap();
 
         // Get the public key before rotation
         let private_key_id = match &wrapped_state {
@@ -186,7 +176,6 @@ mod tests {
             &wrapped_state,
             &old_user_key_id,
             &new_user_key_id,
-            user_id,
             &mut ctx,
         )
         .expect("rotate_account_cryptographic_state should succeed");

--- a/crates/bitwarden-user-crypto-management/src/key_rotation/mod.rs
+++ b/crates/bitwarden-user-crypto-management/src/key_rotation/mod.rs
@@ -222,7 +222,6 @@ async fn post_rotate_user_keys(
             &sync.wrapped_account_cryptographic_state,
             &current_user_key_id,
             &new_user_key_id,
-            UserId::new(sync.user_id),
             &mut ctx,
         )
         .map_err(|_| RotateUserKeysError::CryptoError)?;

--- a/crates/bitwarden-user-crypto-management/src/key_rotation/mod.rs
+++ b/crates/bitwarden-user-crypto-management/src/key_rotation/mod.rs
@@ -6,10 +6,7 @@ mod sync;
 mod unlock;
 
 use bitwarden_api_api::models::RotateUserAccountKeysAndDataRequestModel;
-use bitwarden_core::{
-    UserId,
-    key_management::{MasterPasswordAuthenticationData, SymmetricKeyId},
-};
+use bitwarden_core::key_management::{MasterPasswordAuthenticationData, SymmetricKeyId};
 use bitwarden_crypto::PublicKey;
 use bitwarden_error::bitwarden_error;
 use serde::{Deserialize, Serialize};

--- a/crates/bitwarden-user-crypto-management/src/key_rotation/sync.rs
+++ b/crates/bitwarden-user-crypto-management/src/key_rotation/sync.rs
@@ -41,7 +41,6 @@ pub(super) struct SyncedAccountData {
     pub(super) trusted_devices: Vec<PartialRotateableKeyset>,
     pub(super) passkeys: Vec<PartialRotateableKeyset>,
     pub(super) kdf_and_salt: Option<(Kdf, String)>,
-    pub(super) user_id: uuid::Uuid,
 }
 
 #[derive(Debug, Error)]
@@ -340,11 +339,6 @@ pub(super) async fn sync_current_account_data(
     let wrapped_account_cryptographic_state =
         WrappedAccountCryptographicState::try_from(account_cryptographic_state.as_ref())
             .debug_map_err(SyncError::DataError)?;
-    let user_id = sync
-        .profile
-        .as_ref()
-        .and_then(|p| p.id)
-        .ok_or(SyncError::DataError)?;
 
     // Concurrently sync organization memberships, emergency access memberships, trusted devices,
     // and passkeys
@@ -366,7 +360,6 @@ pub(super) async fn sync_current_account_data(
         trusted_devices,
         passkeys,
         kdf_and_salt,
-        user_id,
     })
 }
 
@@ -660,8 +653,6 @@ mod tests {
 
         let result = sync_current_account_data(&api_client).await;
         let data = result.unwrap();
-
-        assert_eq!(data.user_id, user_id);
 
         // Verify folders
         assert_eq!(data.folders.len(), 1);


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.slack.com/archives/C07HY17HUHE/p1771865163146259
https://bitwarden.atlassian.net/browse/PM-32716

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
Due to a creation order problem, we cannot add the user id to the security state, since the server decides the user-id, but the client needs to submit the signed security state to the server at registration time.

We do not actually need it, so we are removing the user-id entirely.

## 🚨 Breaking Changes

<!-- Does this PR introduce any breaking changes? If so, please describe the impact and migration path for clients.

If you're unsure, the automated TypeScript compatibility check will run when you open/update this PR and provide feedback.

For breaking changes:
1. Describe what changed in the client interface
2. Explain why the change was necessary
3. Provide migration steps for client developers
4. Link to any paired client PRs if needed

Otherwise, you can remove this section. -->
