### PR TITLE
Remove async from get_api_configurations

### DIFF
--- a/bitwarden_license/bitwarden-sm/src/projects/create.rs
+++ b/bitwarden_license/bitwarden-sm/src/projects/create.rs
@@ -39,7 +39,7 @@ pub(crate) async fn create_project(
             .to_string(),
     });
 
-    let config = client.internal.get_api_configurations().await;
+    let config = client.internal.get_api_configurations();
     let res = config
         .api_client
         .projects_api()

--- a/bitwarden_license/bitwarden-sm/src/projects/delete.rs
+++ b/bitwarden_license/bitwarden-sm/src/projects/delete.rs
@@ -20,7 +20,7 @@ pub(crate) async fn delete_projects(
     client: &Client,
     input: ProjectsDeleteRequest,
 ) -> Result<ProjectsDeleteResponse, SecretsManagerError> {
-    let config = client.internal.get_api_configurations().await;
+    let config = client.internal.get_api_configurations();
     let res = config
         .api_client
         .projects_api()

--- a/bitwarden_license/bitwarden-sm/src/projects/get.rs
+++ b/bitwarden_license/bitwarden-sm/src/projects/get.rs
@@ -17,7 +17,7 @@ pub(crate) async fn get_project(
     client: &Client,
     input: &ProjectGetRequest,
 ) -> Result<ProjectResponse, SecretsManagerError> {
-    let config = client.internal.get_api_configurations().await;
+    let config = client.internal.get_api_configurations();
 
     let res = config.api_client.projects_api().get(input.id).await?;
 

--- a/bitwarden_license/bitwarden-sm/src/projects/list.rs
+++ b/bitwarden_license/bitwarden-sm/src/projects/list.rs
@@ -19,7 +19,7 @@ pub(crate) async fn list_projects(
     client: &Client,
     input: &ProjectsListRequest,
 ) -> Result<ProjectsResponse, SecretsManagerError> {
-    let config = client.internal.get_api_configurations().await;
+    let config = client.internal.get_api_configurations();
     let res = config
         .api_client
         .projects_api()

--- a/bitwarden_license/bitwarden-sm/src/projects/update.rs
+++ b/bitwarden_license/bitwarden-sm/src/projects/update.rs
@@ -41,7 +41,7 @@ pub(crate) async fn update_project(
             .to_string(),
     });
 
-    let config = client.internal.get_api_configurations().await;
+    let config = client.internal.get_api_configurations();
     let res = config
         .api_client
         .projects_api()

--- a/bitwarden_license/bitwarden-sm/src/secrets/create.rs
+++ b/bitwarden_license/bitwarden-sm/src/secrets/create.rs
@@ -54,7 +54,7 @@ pub(crate) async fn create_secret(
         })
     };
 
-    let config = client.internal.get_api_configurations().await;
+    let config = client.internal.get_api_configurations();
     let res = config
         .api_client
         .secrets_api()

--- a/bitwarden_license/bitwarden-sm/src/secrets/delete.rs
+++ b/bitwarden_license/bitwarden-sm/src/secrets/delete.rs
@@ -20,7 +20,7 @@ pub(crate) async fn delete_secrets(
     client: &Client,
     input: SecretsDeleteRequest,
 ) -> Result<SecretsDeleteResponse, SecretsManagerError> {
-    let config = client.internal.get_api_configurations().await;
+    let config = client.internal.get_api_configurations();
     let res = config
         .api_client
         .secrets_api()

--- a/bitwarden_license/bitwarden-sm/src/secrets/get.rs
+++ b/bitwarden_license/bitwarden-sm/src/secrets/get.rs
@@ -17,7 +17,7 @@ pub(crate) async fn get_secret(
     client: &Client,
     input: &SecretGetRequest,
 ) -> Result<SecretResponse, SecretsManagerError> {
-    let config = client.internal.get_api_configurations().await;
+    let config = client.internal.get_api_configurations();
     let res = config.api_client.secrets_api().get(input.id).await?;
 
     let key_store = client.internal.get_key_store();

--- a/bitwarden_license/bitwarden-sm/src/secrets/get_by_ids.rs
+++ b/bitwarden_license/bitwarden-sm/src/secrets/get_by_ids.rs
@@ -20,7 +20,7 @@ pub(crate) async fn get_secrets_by_ids(
 ) -> Result<SecretsResponse, SecretsManagerError> {
     let request = Some(GetSecretsRequestModel { ids: input.ids });
 
-    let config = client.internal.get_api_configurations().await;
+    let config = client.internal.get_api_configurations();
 
     let res = config
         .api_client

--- a/bitwarden_license/bitwarden-sm/src/secrets/list.rs
+++ b/bitwarden_license/bitwarden-sm/src/secrets/list.rs
@@ -26,7 +26,7 @@ pub(crate) async fn list_secrets(
     client: &Client,
     input: &SecretIdentifiersRequest,
 ) -> Result<SecretIdentifiersResponse, SecretsManagerError> {
-    let config = client.internal.get_api_configurations().await;
+    let config = client.internal.get_api_configurations();
     let res = config
         .api_client
         .secrets_api()
@@ -50,7 +50,7 @@ pub(crate) async fn list_secrets_by_project(
     client: &Client,
     input: &SecretIdentifiersByProjectRequest,
 ) -> Result<SecretIdentifiersResponse, SecretsManagerError> {
-    let config = client.internal.get_api_configurations().await;
+    let config = client.internal.get_api_configurations();
     let res = config
         .api_client
         .secrets_api()

--- a/bitwarden_license/bitwarden-sm/src/secrets/sync.rs
+++ b/bitwarden_license/bitwarden-sm/src/secrets/sync.rs
@@ -22,7 +22,7 @@ pub(crate) async fn sync_secrets(
     client: &Client,
     input: &SecretsSyncRequest,
 ) -> Result<SecretsSyncResponse, SecretsManagerError> {
-    let config = client.internal.get_api_configurations().await;
+    let config = client.internal.get_api_configurations();
     let last_synced_date = input.last_synced_date.map(|date| date.to_rfc3339());
 
     let res = config

--- a/bitwarden_license/bitwarden-sm/src/secrets/update.rs
+++ b/bitwarden_license/bitwarden-sm/src/secrets/update.rs
@@ -54,7 +54,7 @@ pub(crate) async fn update_secret(
         })
     };
 
-    let config = client.internal.get_api_configurations().await;
+    let config = client.internal.get_api_configurations();
     let res = config
         .api_client
         .secrets_api()

--- a/crates/bitwarden-auth/src/login/login_via_password/login_via_password_impl.rs
+++ b/crates/bitwarden-auth/src/login/login_via_password/login_via_password_impl.rs
@@ -29,7 +29,7 @@ impl LoginClient {
         let api_request: LoginApiRequest<PasswordLoginApiRequest> =
             (request, master_password_authentication).into();
 
-        let api_configs = self.client.internal.get_api_configurations().await;
+        let api_configs = self.client.internal.get_api_configurations();
 
         let response = send_login_request(&api_configs.identity_config, &api_request).await;
 

--- a/crates/bitwarden-auth/src/login/login_via_password/password_prelogin.rs
+++ b/crates/bitwarden-auth/src/login/login_via_password/password_prelogin.rs
@@ -41,7 +41,7 @@ impl LoginClient {
         email: String,
     ) -> Result<PasswordPreloginResponse, PasswordPreloginError> {
         let request_model = PasswordPreloginRequestModel::new(email);
-        let api_configs = self.client.internal.get_api_configurations().await;
+        let api_configs = self.client.internal.get_api_configurations();
         let response = api_configs
             .identity_client
             .accounts_api()

--- a/crates/bitwarden-auth/src/registration.rs
+++ b/crates/bitwarden-auth/src/registration.rs
@@ -98,7 +98,7 @@ impl RegistrationClient {
         request: TdeRegistrationRequest,
     ) -> Result<TdeRegistrationResponse, RegistrationError> {
         let client = &self.client.internal;
-        let api_client = &client.get_api_configurations().await.api_client;
+        let api_client = &client.get_api_configurations().api_client;
         internal_post_keys_for_tde_registration(self, api_client, request).await
     }
 
@@ -110,7 +110,7 @@ impl RegistrationClient {
         sso_org_identifier: String,
     ) -> Result<KeyConnectorRegistrationResult, RegistrationError> {
         let client = &self.client.internal;
-        let configuration = &client.get_api_configurations().await;
+        let configuration = &client.get_api_configurations();
         let key_connector_client = client.get_key_connector_client(key_connector_url);
 
         internal_post_keys_for_key_connector_registration(
@@ -129,7 +129,7 @@ impl RegistrationClient {
         request: JitMasterPasswordRegistrationRequest,
     ) -> Result<JitMasterPasswordRegistrationResponse, RegistrationError> {
         let client = &self.client.internal;
-        let api_client = &client.get_api_configurations().await.api_client;
+        let api_client = &client.get_api_configurations().api_client;
         internal_post_keys_for_jit_password_registration(self, api_client, request).await
     }
 }

--- a/crates/bitwarden-auth/src/send_access/client.rs
+++ b/crates/bitwarden-auth/src/send_access/client.rs
@@ -40,7 +40,7 @@ impl SendAccessClient {
         // this request, so we are not including it here. If needed, we can revisit this and
         // add it back in.
 
-        let configurations = self.client.internal.get_api_configurations().await;
+        let configurations = self.client.internal.get_api_configurations();
 
         // save off url in variable for re-use
         let url = format!(

--- a/crates/bitwarden-core/README.md
+++ b/crates/bitwarden-core/README.md
@@ -101,7 +101,7 @@ authentication token if required.
 # use bitwarden_core::Client;
 # async fn example(client: &Client) -> Result<(), Box<dyn std::error::Error>> {
 // Example API call
-let api_config = client.internal.get_api_configurations().await;
+let api_config = client.internal.get_api_configurations();
 let response = api_config.api_client.ciphers_api().get_all().await?;
 # Ok(())
 # }

--- a/crates/bitwarden-core/src/auth/login/access_token.rs
+++ b/crates/bitwarden-core/src/auth/login/access_token.rs
@@ -108,7 +108,7 @@ async fn request_access_token(
     client: &Client,
     input: &AccessToken,
 ) -> Result<IdentityTokenResponse, LoginError> {
-    let config = client.internal.get_api_configurations().await;
+    let config = client.internal.get_api_configurations();
     AccessTokenRequest::new(input.access_token_id, &input.client_secret)
         .send(&config.identity_config)
         .await

--- a/crates/bitwarden-core/src/auth/login/api_key.rs
+++ b/crates/bitwarden-core/src/auth/login/api_key.rs
@@ -68,7 +68,7 @@ async fn request_api_identity_tokens(
     client: &Client,
     input: &ApiKeyLoginRequest,
 ) -> Result<IdentityTokenResponse, LoginError> {
-    let config = client.internal.get_api_configurations().await;
+    let config = client.internal.get_api_configurations();
     ApiTokenRequest::new(&input.client_id, &input.client_secret)
         .send(&config.identity_config)
         .await

--- a/crates/bitwarden-core/src/auth/login/auth_request.rs
+++ b/crates/bitwarden-core/src/auth/login/auth_request.rs
@@ -33,7 +33,7 @@ pub(crate) async fn send_new_auth_request(
     email: String,
     device_identifier: String,
 ) -> Result<NewAuthRequestResponse, LoginError> {
-    let config = client.internal.get_api_configurations().await;
+    let config = client.internal.get_api_configurations();
 
     let auth = new_auth_request(&email)?;
 
@@ -66,7 +66,7 @@ pub(crate) async fn complete_auth_request(
     client: &Client,
     auth_req: NewAuthRequestResponse,
 ) -> Result<(), LoginError> {
-    let config = client.internal.get_api_configurations().await;
+    let config = client.internal.get_api_configurations();
     let res = config
         .api_client
         .auth_requests_api()

--- a/crates/bitwarden-core/src/auth/login/password.rs
+++ b/crates/bitwarden-core/src/auth/login/password.rs
@@ -85,7 +85,7 @@ async fn request_identity_tokens(
 ) -> Result<IdentityTokenResponse, LoginError> {
     use crate::DeviceType;
 
-    let config = client.internal.get_api_configurations().await;
+    let config = client.internal.get_api_configurations();
     PasswordTokenRequest::new(
         &input.email,
         password_hash,

--- a/crates/bitwarden-core/src/auth/login/prelogin.rs
+++ b/crates/bitwarden-core/src/auth/login/prelogin.rs
@@ -15,7 +15,7 @@ pub enum PreloginError {
 
 pub(crate) async fn prelogin(client: &Client, email: String) -> Result<Kdf, PreloginError> {
     let request_model = PasswordPreloginRequestModel::new(email);
-    let config = client.internal.get_api_configurations().await;
+    let config = client.internal.get_api_configurations();
     let result = config
         .identity_client
         .accounts_api()

--- a/crates/bitwarden-core/src/auth/login/two_factor.rs
+++ b/crates/bitwarden-core/src/auth/login/two_factor.rs
@@ -45,7 +45,7 @@ pub(crate) async fn send_two_factor_email(
         HashPurpose::ServerAuthorization,
     )?;
 
-    let config = client.internal.get_api_configurations().await;
+    let config = client.internal.get_api_configurations();
     config
         .api_client
         .two_factor_api()

--- a/crates/bitwarden-core/src/client/internal.rs
+++ b/crates/bitwarden-core/src/client/internal.rs
@@ -174,8 +174,9 @@ impl InternalClient {
             .get_key_connector_client(key_connector_url)
     }
 
-    #[allow(missing_docs, clippy::unused_async)]
-    pub async fn get_api_configurations(&self) -> Arc<ApiConfigurations> {
+    /// Get the `ApiConfigurations` containing API clients and configurations for making requests to
+    /// the Bitwarden services.
+    pub fn get_api_configurations(&self) -> Arc<ApiConfigurations> {
         self.api_configurations.clone()
     }
 

--- a/crates/bitwarden-core/src/platform/get_user_api_key.rs
+++ b/crates/bitwarden-core/src/platform/get_user_api_key.rs
@@ -51,7 +51,7 @@ pub(crate) async fn get_user_api_key(
     debug!(?input);
 
     let auth_settings = get_login_method(client)?;
-    let config = client.internal.get_api_configurations().await;
+    let config = client.internal.get_api_configurations();
 
     let request = build_secret_verification_request(&auth_settings, input)?;
     let response = config

--- a/crates/bitwarden-user-crypto-management/src/key_rotation/mod.rs
+++ b/crates/bitwarden-user-crypto-management/src/key_rotation/mod.rs
@@ -62,12 +62,7 @@ impl UserCryptoManagementClient {
         &self,
         request: RotateUserKeysRequest,
     ) -> Result<(), RotateUserKeysError> {
-        let api_client = &self
-            .client
-            .internal
-            .get_api_configurations()
-            .await
-            .api_client;
+        let api_client = &self.client.internal.get_api_configurations().api_client;
 
         post_rotate_user_keys(
             self,
@@ -85,12 +80,7 @@ impl UserCryptoManagementClient {
     pub async fn get_untrusted_organization_public_keys(
         &self,
     ) -> Result<Vec<V1OrganizationMembership>, RotateUserKeysError> {
-        let api_client = &self
-            .client
-            .internal
-            .get_api_configurations()
-            .await
-            .api_client;
+        let api_client = &self.client.internal.get_api_configurations().api_client;
         let organizations = sync::sync_orgs(api_client)
             .await
             .map_err(|_| RotateUserKeysError::ApiError)?;
@@ -102,12 +92,7 @@ impl UserCryptoManagementClient {
     pub async fn get_untrusted_emergency_access_public_keys(
         &self,
     ) -> Result<Vec<V1EmergencyAccessMembership>, RotateUserKeysError> {
-        let api_client = &self
-            .client
-            .internal
-            .get_api_configurations()
-            .await
-            .api_client;
+        let api_client = &self.client.internal.get_api_configurations().api_client;
         let emergency_access = sync::sync_emergency_access(api_client)
             .await
             .map_err(|_| RotateUserKeysError::ApiError)?;
@@ -314,7 +299,6 @@ async fn post_rotate_user_keys(
         .client
         .internal
         .get_api_configurations()
-        .await
         .api_client
         .accounts_key_management_api()
         .rotate_user_account_keys(Some(request))

--- a/crates/bitwarden-vault/src/cipher/cipher_client/admin/create.rs
+++ b/crates/bitwarden-vault/src/cipher/cipher_client/admin/create.rs
@@ -71,7 +71,7 @@ impl CipherAdminClient {
         request: CipherCreateRequest,
     ) -> Result<CipherView, CreateCipherAdminError> {
         let key_store = self.client.internal.get_key_store();
-        let config = self.client.internal.get_api_configurations().await;
+        let config = self.client.internal.get_api_configurations();
         let mut internal_request: CipherCreateRequestInternal = request.into();
 
         let user_id = self

--- a/crates/bitwarden-vault/src/cipher/cipher_client/admin/delete.rs
+++ b/crates/bitwarden-vault/src/cipher/cipher_client/admin/delete.rs
@@ -74,12 +74,7 @@ impl CipherAdminClient {
     pub async fn delete(&self, cipher_id: CipherId) -> Result<(), DeleteCipherAdminError> {
         Ok(delete_cipher(
             cipher_id,
-            &self
-                .client
-                .internal
-                .get_api_configurations()
-                .await
-                .api_client,
+            &self.client.internal.get_api_configurations().api_client,
         )
         .await?)
     }
@@ -89,12 +84,7 @@ impl CipherAdminClient {
     pub async fn soft_delete(&self, cipher_id: CipherId) -> Result<(), DeleteCipherAdminError> {
         Ok(soft_delete(
             cipher_id,
-            &self
-                .client
-                .internal
-                .get_api_configurations()
-                .await
-                .api_client,
+            &self.client.internal.get_api_configurations().api_client,
         )
         .await?)
     }
@@ -109,12 +99,7 @@ impl CipherAdminClient {
         Ok(delete_ciphers_many(
             cipher_ids,
             organization_id,
-            &self
-                .client
-                .internal
-                .get_api_configurations()
-                .await
-                .api_client,
+            &self.client.internal.get_api_configurations().api_client,
         )
         .await?)
     }
@@ -129,12 +114,7 @@ impl CipherAdminClient {
         Ok(soft_delete_many(
             cipher_ids,
             organization_id,
-            &self
-                .client
-                .internal
-                .get_api_configurations()
-                .await
-                .api_client,
+            &self.client.internal.get_api_configurations().api_client,
         )
         .await?)
     }

--- a/crates/bitwarden-vault/src/cipher/cipher_client/admin/delete_attachment.rs
+++ b/crates/bitwarden-vault/src/cipher/cipher_client/admin/delete_attachment.rs
@@ -37,12 +37,7 @@ impl CipherAdminClient {
         Ok(delete_attachment(
             cipher_id,
             &attachment_id,
-            &self
-                .client
-                .internal
-                .get_api_configurations()
-                .await
-                .api_client,
+            &self.client.internal.get_api_configurations().api_client,
         )
         .await?)
     }

--- a/crates/bitwarden-vault/src/cipher/cipher_client/admin/edit.rs
+++ b/crates/bitwarden-vault/src/cipher/cipher_client/admin/edit.rs
@@ -104,7 +104,7 @@ impl CipherAdminClient {
         original_cipher_view: CipherView,
     ) -> Result<CipherView, EditCipherAdminError> {
         let key_store = self.client.internal.get_key_store();
-        let config = self.client.internal.get_api_configurations().await;
+        let config = self.client.internal.get_api_configurations();
 
         let user_id = self
             .client
@@ -144,12 +144,7 @@ impl CipherAdminClient {
         add_to_collections(
             cipher_id,
             collection_ids,
-            &self
-                .client
-                .internal
-                .get_api_configurations()
-                .await
-                .api_client,
+            &self.client.internal.get_api_configurations().api_client,
             self.client.internal.get_key_store(),
         )
         .await

--- a/crates/bitwarden-vault/src/cipher/cipher_client/admin/get.rs
+++ b/crates/bitwarden-vault/src/cipher/cipher_client/admin/get.rs
@@ -60,12 +60,7 @@ impl CipherAdminClient {
         list_org_ciphers(
             org_id,
             include_member_items,
-            &self
-                .client
-                .internal
-                .get_api_configurations()
-                .await
-                .api_client,
+            &self.client.internal.get_api_configurations().api_client,
             self.client.internal.get_key_store(),
         )
         .await

--- a/crates/bitwarden-vault/src/cipher/cipher_client/admin/restore.rs
+++ b/crates/bitwarden-vault/src/cipher/cipher_client/admin/restore.rs
@@ -80,12 +80,7 @@ impl CipherAdminClient {
         &self,
         cipher_id: CipherId,
     ) -> Result<CipherView, RestoreCipherAdminError> {
-        let api_client = &self
-            .client
-            .internal
-            .get_api_configurations()
-            .await
-            .api_client;
+        let api_client = &self.client.internal.get_api_configurations().api_client;
         let key_store = self.client.internal.get_key_store();
 
         restore_as_admin(cipher_id, api_client, key_store).await
@@ -96,12 +91,7 @@ impl CipherAdminClient {
         cipher_ids: Vec<CipherId>,
         org_id: OrganizationId,
     ) -> Result<DecryptCipherListResult, RestoreCipherAdminError> {
-        let api_client = &self
-            .client
-            .internal
-            .get_api_configurations()
-            .await
-            .api_client;
+        let api_client = &self.client.internal.get_api_configurations().api_client;
         let key_store = self.client.internal.get_key_store();
 
         restore_many_as_admin(cipher_ids, org_id, api_client, key_store).await

--- a/crates/bitwarden-vault/src/cipher/cipher_client/create.rs
+++ b/crates/bitwarden-vault/src/cipher/cipher_client/create.rs
@@ -263,7 +263,7 @@ impl CiphersClient {
         request: CipherCreateRequest,
     ) -> Result<CipherView, CreateCipherError> {
         let key_store = self.client.internal.get_key_store();
-        let config = self.client.internal.get_api_configurations().await;
+        let config = self.client.internal.get_api_configurations();
         let repository = self.get_repository()?;
         let mut internal_request: CipherCreateRequestInternal = request.into();
 

--- a/crates/bitwarden-vault/src/cipher/cipher_client/delete.rs
+++ b/crates/bitwarden-vault/src/cipher/cipher_client/delete.rs
@@ -101,7 +101,7 @@ async fn process_soft_delete<R: Repository<Cipher> + ?Sized>(
 impl CiphersClient {
     /// Deletes the [Cipher] with the matching [CipherId] from the server.
     pub async fn delete(&self, cipher_id: CipherId) -> Result<(), DeleteCipherError> {
-        let configs = self.client.internal.get_api_configurations().await;
+        let configs = self.client.internal.get_api_configurations();
         delete_cipher(cipher_id, &configs.api_client, &*self.get_repository()?).await
     }
 
@@ -111,7 +111,7 @@ impl CiphersClient {
         cipher_ids: Vec<CipherId>,
         organization_id: Option<OrganizationId>,
     ) -> Result<(), DeleteCipherError> {
-        let configs = self.client.internal.get_api_configurations().await;
+        let configs = self.client.internal.get_api_configurations();
         delete_ciphers(
             cipher_ids,
             organization_id,
@@ -123,7 +123,7 @@ impl CiphersClient {
 
     /// Soft-deletes the [Cipher] with the matching [CipherId] from the server.
     pub async fn soft_delete(&self, cipher_id: CipherId) -> Result<(), DeleteCipherError> {
-        let configs = self.client.internal.get_api_configurations().await;
+        let configs = self.client.internal.get_api_configurations();
         soft_delete(cipher_id, &configs.api_client, &*self.get_repository()?).await
     }
 
@@ -136,12 +136,7 @@ impl CiphersClient {
         soft_delete_many(
             cipher_ids,
             organization_id,
-            &self
-                .client
-                .internal
-                .get_api_configurations()
-                .await
-                .api_client,
+            &self.client.internal.get_api_configurations().api_client,
             &*self.get_repository()?,
         )
         .await

--- a/crates/bitwarden-vault/src/cipher/cipher_client/delete_attachment.rs
+++ b/crates/bitwarden-vault/src/cipher/cipher_client/delete_attachment.rs
@@ -62,7 +62,7 @@ impl CiphersClient {
         cipher_id: CipherId,
         attachment_id: String,
     ) -> Result<Cipher, CipherDeleteAttachmentError> {
-        let configs = self.client.internal.get_api_configurations().await;
+        let configs = self.client.internal.get_api_configurations();
         delete_attachment(
             cipher_id,
             &attachment_id,

--- a/crates/bitwarden-vault/src/cipher/cipher_client/edit.rs
+++ b/crates/bitwarden-vault/src/cipher/cipher_client/edit.rs
@@ -362,7 +362,7 @@ impl CiphersClient {
         mut request: CipherEditRequest,
     ) -> Result<CipherView, EditCipherError> {
         let key_store = self.client.internal.get_key_store();
-        let config = self.client.internal.get_api_configurations().await;
+        let config = self.client.internal.get_api_configurations();
         let repository = self.get_repository()?;
 
         let user_id = self
@@ -409,7 +409,7 @@ impl CiphersClient {
         };
         let repository = self.get_repository()?;
 
-        let api_config = self.client.internal.get_api_configurations().await;
+        let api_config = self.client.internal.get_api_configurations();
         let api = api_config.api_client.ciphers_api();
         let orig_cipher = repository.get(cipher_id).await?;
         let cipher = if is_admin {

--- a/crates/bitwarden-vault/src/cipher/cipher_client/restore.rs
+++ b/crates/bitwarden-vault/src/cipher/cipher_client/restore.rs
@@ -85,12 +85,7 @@ pub async fn restore_many<R: Repository<Cipher> + ?Sized>(
 impl CiphersClient {
     /// Restores a soft-deleted cipher on the server.
     pub async fn restore(&self, cipher_id: CipherId) -> Result<CipherView, RestoreCipherError> {
-        let api_client = &self
-            .client
-            .internal
-            .get_api_configurations()
-            .await
-            .api_client;
+        let api_client = &self.client.internal.get_api_configurations().api_client;
         let key_store = self.client.internal.get_key_store();
 
         restore(cipher_id, api_client, &*self.get_repository()?, key_store).await
@@ -101,12 +96,7 @@ impl CiphersClient {
         &self,
         cipher_ids: Vec<CipherId>,
     ) -> Result<DecryptCipherListResult, RestoreCipherError> {
-        let api_client = &self
-            .client
-            .internal
-            .get_api_configurations()
-            .await
-            .api_client;
+        let api_client = &self.client.internal.get_api_configurations().api_client;
         let key_store = self.client.internal.get_key_store();
         let repository = &*self.get_repository()?;
 

--- a/crates/bitwarden-vault/src/cipher/cipher_client/share_cipher.rs
+++ b/crates/bitwarden-vault/src/cipher/cipher_client/share_cipher.rs
@@ -187,12 +187,7 @@ impl CiphersClient {
 
         let encrypted_cipher = self.encrypt(cipher_view)?;
 
-        let api_client = &self
-            .client
-            .internal
-            .get_api_configurations()
-            .await
-            .api_client;
+        let api_client = &self.client.internal.get_api_configurations().api_client;
 
         share_cipher(
             api_client.ciphers_api(),
@@ -269,12 +264,7 @@ impl CiphersClient {
             )
             .await?;
 
-        let api_client = &self
-            .client
-            .internal
-            .get_api_configurations()
-            .await
-            .api_client;
+        let api_client = &self.client.internal.get_api_configurations().api_client;
 
         share_ciphers_bulk(
             api_client.ciphers_api(),

--- a/crates/bitwarden-vault/src/folder/folder_client.rs
+++ b/crates/bitwarden-vault/src/folder/folder_client.rs
@@ -63,7 +63,7 @@ impl FoldersClient {
         request: FolderAddEditRequest,
     ) -> Result<FolderView, CreateFolderError> {
         let key_store = self.client.internal.get_key_store();
-        let config = self.client.internal.get_api_configurations().await;
+        let config = self.client.internal.get_api_configurations();
         let repository = self.get_repository()?;
 
         create_folder(key_store, &config.api_client, repository.as_ref(), request).await
@@ -76,7 +76,7 @@ impl FoldersClient {
         request: FolderAddEditRequest,
     ) -> Result<FolderView, EditFolderError> {
         let key_store = self.client.internal.get_key_store();
-        let config = self.client.internal.get_api_configurations().await;
+        let config = self.client.internal.get_api_configurations();
         let repository = self.get_repository()?;
 
         edit_folder(

--- a/crates/bw/src/vault/sync.rs
+++ b/crates/bw/src/vault/sync.rs
@@ -39,7 +39,7 @@ pub struct SyncRequest {
 }
 
 pub(crate) async fn sync(client: &Client, input: &SyncRequest) -> Result<SyncResponse, SyncError> {
-    let config = client.internal.get_api_configurations().await;
+    let config = client.internal.get_api_configurations();
     let sync = config
         .api_client
         .sync_api()


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Removes `async` from `get_api_configurations` since it's no longer necessary after #740  

