### PR TITLE
[PM-32525] Unwrap using key_identifier when generating cipher view key

### DIFF
--- a/crates/bitwarden-vault/src/cipher/cipher.rs
+++ b/crates/bitwarden-vault/src/cipher/cipher.rs
@@ -738,16 +738,17 @@ impl CipherView {
     pub fn generate_cipher_key(
         &mut self,
         ctx: &mut KeyStoreContext<KeyIds>,
-        key: SymmetricKeyId,
+        wrapping_key: SymmetricKeyId,
     ) -> Result<(), CryptoError> {
-        let old_ciphers_key = Cipher::decrypt_cipher_key(ctx, key, &self.key)?;
+        let old_unwrapping_key = self.key_identifier();
+        let old_ciphers_key = Cipher::decrypt_cipher_key(ctx, old_unwrapping_key, &self.key)?;
 
         let new_key = ctx.generate_symmetric_key();
 
         self.reencrypt_attachment_keys(ctx, old_ciphers_key, new_key)?;
         self.reencrypt_fido2_credentials(ctx, old_ciphers_key, new_key)?;
 
-        self.key = Some(ctx.wrap_symmetric_key(key, new_key)?);
+        self.key = Some(ctx.wrap_symmetric_key(wrapping_key, new_key)?);
         Ok(())
     }
 


### PR DESCRIPTION
## 🎟️ Tracking

[https://bitwarden.atlassian.net/browse/PM-32525](https://bitwarden.atlassian.net/browse/PM-32525)

## 📔 Objective

The `generate_cipher_key` function assumes that the `SymmetricKeyId` parameter should be used for both unwrapping existing ciphers and for rewrapping the newly generated cipher key. However, when rotating cipher keys via `encrypt_cipher_for_rotation`, the `new_key` is only meant to wrap the newly generated key. The old key, which can be found in `cipher_view.key_identifier()`, needs to be used for unwrapping the cipher along with fido2 credentials and attachment keys. The existing `cipher_view.reencrypt_cipher_keys()` follows this same pattern of passing in the new wrapping key and calling `self.key_identifier()` to get the old key.

All other places which call `generate_cipher_key` already pass in `cipher_view.key_identifier()` as the wrapping key. 
