### PR TITLE
[PM-33111] Leverage base64url annotations

### DIFF
--- a/support/openapi-template/model.mustache
+++ b/support/openapi-template/model.mustache
@@ -214,7 +214,7 @@ pub struct {{{classname}}} {
     /// {{{.}}}
     {{/description}}
     {{#isByteArray}}
-    {{#vendorExtensions.isMandatory}}#[serde_as(as = "serde_with::base64::Base64")]{{/vendorExtensions.isMandatory}}{{^vendorExtensions.isMandatory}}#[serde_as(as = "Option<serde_with::base64::Base64>")]{{/vendorExtensions.isMandatory}}
+   {{#vendorExtensions.isMandatory}}#[serde_as(as = "serde_with::base64::Base64{{#vendorExtensions.x-base64url}}<serde_with::base64::UrlSafe, serde_with::formats::Unpadded>{{/vendorExtensions.x-base64url}}")]{{/vendorExtensions.isMandatory}} {{^vendorExtensions.isMandatory}}#[serde_as(as = "Option<serde_with::base64::Base64{{#vendorExtensions.x-base64url}}<serde_with::base64::UrlSafe, serde_with::formats::Unpadded>{{/vendorExtensions.x-base64url}}>")]{{/vendorExtensions.isMandatory}}
     {{/isByteArray}}
     #[serde(rename = "{{{baseName}}}", alias = "{{{nameInPascalCase}}}"{{^required}}, skip_serializing_if = "Option::is_none"{{/required}})]
     pub {{{name}}}: {{!
@@ -269,7 +269,7 @@ pub struct {{{classname}}} {
     /// {{{.}}}
     {{/description}}
     {{#isByteArray}}
-    {{#vendorExtensions.isMandatory}}#[serde_as(as = "serde_with::base64::Base64")]{{/vendorExtensions.isMandatory}}{{^vendorExtensions.isMandatory}}#[serde_as(as = "Option<serde_with::base64::Base64>")]{{/vendorExtensions.isMandatory}}
+    {{#vendorExtensions.isMandatory}}#[serde_as(as = "serde_with::base64::Base64{{#vendorExtensions.x-base64url}}<serde_with::base64::UrlSafe, serde_with::formats::Unpadded>{{/vendorExtensions.x-base64url}}")]{{/vendorExtensions.isMandatory}}{{^vendorExtensions.isMandatory}}#[serde_as(as = "Option<serde_with::base64::Base64{{#vendorExtensions.x-base64url}}<serde_with::base64::UrlSafe, serde_with::formats::Unpadded>{{/vendorExtensions.x-base64url}}>")]{{/vendorExtensions.isMandatory}}
     {{/isByteArray}}
     #[serde(rename = "{{{baseName}}}", alias = "{{{nameInPascalCase}}}"{{^required}}, skip_serializing_if = "Option::is_none"{{/required}})]
     pub {{{name}}}: {{!


### PR DESCRIPTION
## 🎟️ Tracking

[PM-33111](https://bitwarden.atlassian.net/browse/PM-33111)

## 📔 Objective

We would like to register login+unlock passkeys on the Bitwarden server from mobile devices, so we're adding methods into the SDK to do this. The primary issue is deserialization. Our server (via Fido2Net) follows WebAuthn convention of encoding all byte array fields as unpadded base64url, but our Rust SDK bindings expect standard base64.

This PR reads the `x-base64url` extension flag introduced in https://github.com/bitwarden/server/pull/7128 and adds serde annotations to parse them properly.

An example diff of the output:

```diff
diff --git a/crates/bitwarden-api-api/src/models/public_key_credential_descriptor.rs b/crates/bitwarden-api-api/src/models/public_key_credential_descriptor.rs
index 0e3b3d43ea..036c59747d 100644
--- a/crates/bitwarden-api-api/src/models/public_key_credential_descriptor.rs
+++ b/crates/bitwarden-api-api/src/models/public_key_credential_descriptor.rs
@@ -22,7 +22,9 @@
         skip_serializing_if = "Option::is_none"
     )]
     pub r#type: Option<models::PublicKeyCredentialType>,
-    #[serde_as(as = "Option<serde_with::base64::Base64>")]
+    #[serde_as(
+        as = "Option<serde_with::base64::Base64<serde_with::base64::UrlSafe, serde_with::formats::Unpadded>>"
+    )]
     #[serde(rename = "id", alias = "Id", skip_serializing_if = "Option::is_none")]
     pub id: Option<Vec<u8>>,
     #[serde(
```

## 🚨 Breaking Changes

The models affected by the base64url deserialization were not being used in the SDK previously, so this should be an additive change. However, I'm not sure about the other models that were updated due to syncing the code from the server definitions.

[PM-33111]: https://bitwarden.atlassian.net/browse/PM-33111?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ