### PR TITLE
[PM-30584] Add UserInitCryptoMethod::KeyConnectorUrl

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -667,6 +667,7 @@ version = "2.0.0"
 dependencies = [
  "aes 0.8.4",
  "argon2",
+ "bitwarden-api-key-connector",
  "bitwarden-encoding",
  "bitwarden-error",
  "bitwarden-uniffi-error",

--- a/crates/bitwarden-core/src/client/encryption_settings.rs
+++ b/crates/bitwarden-core/src/client/encryption_settings.rs
@@ -43,6 +43,9 @@ pub enum EncryptionSettingsError {
 
     #[error("Invalid upgrade token")]
     InvalidUpgradeToken,
+
+    #[error("Key connector retrieval failed")]
+    KeyConnectorRetrievalFailed,
 }
 
 #[allow(missing_docs)]

--- a/crates/bitwarden-core/src/client/encryption_settings.rs
+++ b/crates/bitwarden-core/src/client/encryption_settings.rs
@@ -47,7 +47,7 @@ pub enum EncryptionSettingsError {
     /// Retrieval of the key-connector-key from key-connector failed
     #[error("Key connector retrieval failed")]
     KeyConnectorRetrievalFailed,
-  
+
     /// The local user data key could not be initialized.
     #[error("Unable to initialize local user data key")]
     LocalUserDataKeyInitFailed,

--- a/crates/bitwarden-core/src/key_management/crypto.rs
+++ b/crates/bitwarden-core/src/key_management/crypto.rs
@@ -150,6 +150,13 @@ pub enum InitUserCryptoMethod {
         /// The user's encrypted symmetric crypto key
         user_key: EncString,
     },
+    /// In contrast to key-connector, this does all of the connection with key-connector in the sdk
+    KeyConnectorUrl {
+        /// The url to retrieve the key-connector-key from
+        url: String,
+        /// The encrypted user key, encrypted with the key connector key retrieved from the url
+        key_connector_key_wrapped_user_key: EncString,
+    },
 }
 
 /// Auth requests supports multiple initialization methods.
@@ -318,6 +325,23 @@ pub(super) async fn initialize_user_crypto(
                 account_crypto_state,
                 &req.upgrade_token,
             )?;
+        }
+        InitUserCryptoMethod::KeyConnectorUrl {
+            url,
+            key_connector_key_wrapped_user_key,
+        } => {
+            let api_client = client.internal.get_key_connector_client(url);
+            let key_connector_key = api_client
+                .user_keys_api()
+                .get_user_key()
+                .await
+                .map_err(|_| EncryptionSettingsError::CryptoInitialization)?;
+            let key_connector_key = KeyConnectorKey::try_from(key_connector_key.key)?;
+            let user_key =
+                key_connector_key.decrypt_user_key(key_connector_key_wrapped_user_key)?;
+            client
+                .internal
+                .initialize_user_crypto_decrypted_key(user_key, account_crypto_state)?;
         }
     }
 

--- a/crates/bitwarden-core/src/key_management/crypto.rs
+++ b/crates/bitwarden-core/src/key_management/crypto.rs
@@ -330,6 +330,7 @@ pub(super) async fn initialize_user_crypto(
             url,
             key_connector_key_wrapped_user_key,
         } => {
+            drop(_span_guard);
             let api_client = client.internal.get_key_connector_client(url);
             let key_connector_key = api_client
                 .user_keys_api()

--- a/crates/bitwarden-core/src/key_management/crypto.rs
+++ b/crates/bitwarden-core/src/key_management/crypto.rs
@@ -323,7 +323,6 @@ pub(super) async fn initialize_user_crypto(
             url,
             key_connector_key_wrapped_user_key,
         } => {
-            drop(_span_guard);
             let api_client = client.internal.get_key_connector_client(url);
             let key_connector_key_response = api_client
                 .user_keys_api()

--- a/crates/bitwarden-core/src/key_management/crypto.rs
+++ b/crates/bitwarden-core/src/key_management/crypto.rs
@@ -339,9 +339,11 @@ pub(super) async fn initialize_user_crypto(
             let key_connector_key = KeyConnectorKey::try_from(key_connector_key.key)?;
             let user_key =
                 key_connector_key.decrypt_user_key(key_connector_key_wrapped_user_key)?;
-            client
-                .internal
-                .initialize_user_crypto_decrypted_key(user_key, account_crypto_state)?;
+            client.internal.initialize_user_crypto_decrypted_key(
+                user_key,
+                account_crypto_state,
+                &req.upgrade_token,
+            )?;
         }
     }
 

--- a/crates/bitwarden-core/src/key_management/crypto.rs
+++ b/crates/bitwarden-core/src/key_management/crypto.rs
@@ -332,12 +332,12 @@ pub(super) async fn initialize_user_crypto(
         } => {
             drop(_span_guard);
             let api_client = client.internal.get_key_connector_client(url);
-            let key_connector_key = api_client
+            let key_connector_key_response = api_client
                 .user_keys_api()
                 .get_user_key()
                 .await
-                .map_err(|_| EncryptionSettingsError::CryptoInitialization)?;
-            let key_connector_key = KeyConnectorKey::try_from(key_connector_key.key)?;
+                .map_err(|_| EncryptionSettingsError::KeyConnectorRetrievalFailed)?;
+            let key_connector_key = KeyConnectorKey::try_from(key_connector_key_response)?;
             let user_key =
                 key_connector_key.decrypt_user_key(key_connector_key_wrapped_user_key)?;
             client.internal.initialize_user_crypto_decrypted_key(

--- a/crates/bitwarden-crypto/Cargo.toml
+++ b/crates/bitwarden-crypto/Cargo.toml
@@ -35,6 +35,7 @@ argon2 = { version = "=0.6.0-rc.2", features = [
     "std",
     "zeroize",
 ], default-features = false }
+bitwarden-api-key-connector = { workspace = true }
 bitwarden-encoding = { workspace = true }
 bitwarden-error = { workspace = true }
 bitwarden-uniffi-error = { workspace = true, optional = true }

--- a/crates/bitwarden-crypto/src/keys/key_connector_key.rs
+++ b/crates/bitwarden-crypto/src/keys/key_connector_key.rs
@@ -1,5 +1,6 @@
 use std::pin::Pin;
 
+use bitwarden_api_key_connector::models::user_key_response_model::UserKeyResponseModel;
 use bitwarden_encoding::B64;
 use generic_array::GenericArray;
 use rand::Rng;
@@ -83,11 +84,11 @@ impl From<KeyConnectorKey> for B64 {
     }
 }
 
-impl TryFrom<String> for KeyConnectorKey {
+impl TryFrom<UserKeyResponseModel> for KeyConnectorKey {
     type Error = CryptoError;
 
-    fn try_from(s: String) -> Result<Self, Self::Error> {
-        let bytes = B64::try_from(s).map_err(|_| CryptoError::InvalidKey)?;
+    fn try_from(s: UserKeyResponseModel) -> Result<Self, Self::Error> {
+        let bytes = B64::try_from(s.key).map_err(|_| CryptoError::InvalidKey)?;
 
         if bytes.as_bytes().len() != 32 {
             return Err(CryptoError::InvalidKeyLen);

--- a/crates/bitwarden-crypto/src/keys/key_connector_key.rs
+++ b/crates/bitwarden-crypto/src/keys/key_connector_key.rs
@@ -83,6 +83,22 @@ impl From<KeyConnectorKey> for B64 {
     }
 }
 
+impl TryFrom<String> for KeyConnectorKey {
+    type Error = CryptoError;
+
+    fn try_from(s: String) -> Result<Self, Self::Error> {
+        let bytes = B64::try_from(s).map_err(|_| CryptoError::InvalidKey)?;
+
+        if bytes.as_bytes().len() != 32 {
+            return Err(CryptoError::InvalidKeyLen);
+        }
+
+        Ok(KeyConnectorKey(Box::pin(GenericArray::clone_from_slice(
+            bytes.as_bytes(),
+        ))))
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use bitwarden_encoding::B64;


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-30584

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Adds the user init crypto method key-connector-url, which directly gets the key-connector-key within the SDK. This gets us closer to dropping the master-key support entirely in clients.

## 🚨 Breaking Changes

<!-- Does this PR introduce any breaking changes? If so, please describe the impact and migration path for clients.

If you're unsure, the automated TypeScript compatibility check will run when you open/update this PR and provide feedback.

For breaking changes:
1. Describe what changed in the client interface
2. Explain why the change was necessary
3. Provide migration steps for client developers
4. Link to any paired client PRs if needed

Otherwise, you can remove this section. -->
