### PR TITLE
Remove Platform as codeowners for binding updates on Identity

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -20,9 +20,9 @@ crates/bitwarden-api-api/src/**
 crates/bitwarden-api-api/README.md
 crates/bitwarden-api-api/.openapi-generator/**
 # Bindings for Identity are owned by Auth.
-crates/bitwarden-api-identity/src/** @bitwarden/team-auth-dev @bitwarden/team-platform-dev
-crates/bitwarden-api-identity/README.md @bitwarden/team-auth-dev @bitwarden/team-platform-dev
-crates/bitwarden-api-identity/.openapi-generator/** @bitwarden/team-auth-dev @bitwarden/team-platform-dev
+crates/bitwarden-api-identity/src/** @bitwarden/team-auth-dev
+crates/bitwarden-api-identity/README.md @bitwarden/team-auth-dev
+crates/bitwarden-api-identity/.openapi-generator/** @bitwarden/team-auth-dev
 # Bindings for Key Connector are owned by Key Management.
 crates/bitwarden-api-key-connector/src/** @bitwarden/team-key-management-dev
 


### PR DESCRIPTION
## 📔 Objective

For Identity binding update PRs, we want to avoid having both Platform and Auth have to review them.  For example: https://github.com/bitwarden/sdk-internal/pull/775.

Auth has agreed that it makes sense for them to own these PRs.

## 🚨 Breaking Changes

<!-- Does this PR introduce any breaking changes? If so, please describe the impact and migration path for clients.

If you're unsure, the automated TypeScript compatibility check will run when you open/update this PR and provide feedback.

For breaking changes:
1. Describe what changed in the client interface
2. Explain why the change was necessary
3. Provide migration steps for client developers
4. Link to any paired client PRs if needed

Otherwise, you can remove this section. -->
