### PR TITLE
Add PRF Parsing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -795,6 +795,7 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 2.0.18",
+ "tokio",
  "tracing",
  "uniffi",
  "uuid",

--- a/crates/bitwarden-fido/Cargo.toml
+++ b/crates/bitwarden-fido/Cargo.toml
@@ -39,5 +39,8 @@ tracing = { workspace = true }
 uniffi = { workspace = true, optional = true }
 uuid = { workspace = true }
 
+[dev-dependencies]
+tokio = { workspace = true }
+
 [lints]
 workspace = true

--- a/crates/bitwarden-fido/src/authenticator.rs
+++ b/crates/bitwarden-fido/src/authenticator.rs
@@ -42,8 +42,6 @@ pub enum MakeCredentialError {
     PublicKeyCredentialParameters(#[from] PublicKeyCredentialParametersError),
     #[error(transparent)]
     UnknownEnum(#[from] UnknownEnumError),
-    #[error(transparent)]
-    Serde(#[from] serde_json::Error),
     #[error("Missing attested_credential_data")]
     MissingAttestedCredentialData,
     #[error("make_credential error: {0}")]
@@ -56,8 +54,6 @@ pub enum MakeCredentialError {
 pub enum GetAssertionError {
     #[error(transparent)]
     UnknownEnum(#[from] UnknownEnumError),
-    #[error(transparent)]
-    Serde(#[from] serde_json::Error),
     #[error(transparent)]
     GetSelectedCredential(#[from] GetSelectedCredentialError),
     #[error(transparent)]
@@ -156,10 +152,12 @@ impl<'a> Fido2Authenticator<'a> {
                     .exclude_list
                     .map(|x| x.into_iter().map(TryInto::try_into).collect())
                     .transpose()?,
+                // TODO(PM-30510): Even though we forward the extensions to the
+                // authenticator, they will not be processed until they are
+                // enabled in the authenticator configuration.
                 extensions: request
                     .extensions
-                    .map(|e| serde_json::from_str(&e))
-                    .transpose()?,
+                    .map(passkey::types::ctap2::make_credential::ExtensionInputs::from),
                 options: passkey::types::ctap2::make_credential::Options {
                     rk: request.options.rk,
                     up: true,
@@ -182,11 +180,13 @@ impl<'a> Fido2Authenticator<'a> {
             .attested_credential_data
             .ok_or(MakeCredentialError::MissingAttestedCredentialData)?;
         let credential_id = attested_credential_data.credential_id().to_vec();
+        let extensions = response.unsigned_extension_outputs.into();
 
         Ok(MakeCredentialResult {
             authenticator_data,
             attestation_object,
             credential_id,
+            extensions,
         })
     }
 
@@ -215,10 +215,12 @@ impl<'a> Fido2Authenticator<'a> {
                             .collect::<Result<Vec<_>, _>>()
                     })
                     .transpose()?,
+                // TODO(PM-30510): Even though we forward the extensions to the
+                // authenticator, they will not be processed until they are
+                // enabled in the authenticator configuration.
                 extensions: request
                     .extensions
-                    .map(|e| serde_json::from_str(&e))
-                    .transpose()?,
+                    .map(passkey::types::ctap2::get_assertion::ExtensionInputs::from),
                 options: passkey::types::ctap2::make_credential::Options {
                     rk: request.options.rk,
                     up: true,
@@ -237,6 +239,7 @@ impl<'a> Fido2Authenticator<'a> {
         let selected_credential = self.get_selected_credential()?;
         let authenticator_data = response.auth_data.to_vec();
         let credential_id = string_to_guid_bytes(&selected_credential.credential.credential_id)?;
+        let extensions = response.unsigned_extension_outputs.into();
 
         Ok(GetAssertionResult {
             credential_id,
@@ -248,6 +251,7 @@ impl<'a> Fido2Authenticator<'a> {
                 .id
                 .into(),
             selected_credential,
+            extensions,
         })
     }
 

--- a/crates/bitwarden-fido/src/authenticator.rs
+++ b/crates/bitwarden-fido/src/authenticator.rs
@@ -683,3 +683,230 @@ fn map_ui_hint(hint: UiHint<'_, CipherViewContainer>) -> UiHint<'_, CipherView> 
         RequestExistingCredential(c) => RequestExistingCredential(&c.cipher),
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use async_trait::async_trait;
+    use bitwarden_core::{
+        Client,
+        key_management::{KeyIds, SymmetricKeyId},
+    };
+    use bitwarden_crypto::{KeyStoreContext, PrimitiveEncryptable, SymmetricCryptoKey};
+    use bitwarden_encoding::B64Url;
+    use bitwarden_vault::{
+        CipherListView, CipherRepromptType, CipherType, CipherView, EncryptionContext,
+        Fido2Credential, Fido2CredentialNewView, LoginView,
+    };
+    use passkey::authenticator::UiHint;
+
+    use super::Fido2Authenticator;
+    use crate::{
+        CheckUserOptions, CheckUserResult, Fido2CallbackError, Fido2CredentialStore,
+        Fido2UserInterface, GetAssertionExtensionsInput, GetAssertionPrfInput, PrfInputValues,
+        guid_bytes_to_string,
+        types::{GetAssertionRequest, Options, UV},
+    };
+
+    struct MockUserInterface;
+
+    #[async_trait]
+    impl Fido2UserInterface for MockUserInterface {
+        async fn check_user<'a>(
+            &self,
+            _options: CheckUserOptions,
+            _hint: UiHint<'a, CipherView>,
+        ) -> Result<CheckUserResult, Fido2CallbackError> {
+            Ok(CheckUserResult {
+                user_present: true,
+                user_verified: true,
+            })
+        }
+
+        async fn pick_credential_for_authentication(
+            &self,
+            available_credentials: Vec<CipherView>,
+        ) -> Result<CipherView, Fido2CallbackError> {
+            available_credentials
+                .into_iter()
+                .next()
+                .ok_or(Fido2CallbackError::Unknown("no credentials".to_string()))
+        }
+
+        async fn check_user_and_pick_credential_for_creation(
+            &self,
+            _options: CheckUserOptions,
+            _new_credential: Fido2CredentialNewView,
+        ) -> Result<(CipherView, CheckUserResult), Fido2CallbackError> {
+            unimplemented!("not needed for this test")
+        }
+
+        fn is_verification_enabled(&self) -> bool {
+            true
+        }
+    }
+
+    struct MockCredentialStore {
+        cipher: CipherView,
+    }
+
+    #[async_trait]
+    impl Fido2CredentialStore for MockCredentialStore {
+        async fn find_credentials(
+            &self,
+            _ids: Option<Vec<Vec<u8>>>,
+            _rp_id: String,
+            _user_handle: Option<Vec<u8>>,
+        ) -> Result<Vec<CipherView>, Fido2CallbackError> {
+            Ok(vec![self.cipher.clone()])
+        }
+
+        async fn all_credentials(&self) -> Result<Vec<CipherListView>, Fido2CallbackError> {
+            Ok(vec![])
+        }
+
+        async fn save_credential(
+            &self,
+            _cred: EncryptionContext,
+        ) -> Result<(), Fido2CallbackError> {
+            Ok(())
+        }
+    }
+
+    static TEST_FIDO_CREDENTIAL_ID: &str = "a36f3d35-5dae-4d07-8b24-f89e11082090";
+    static TEST_FIDO_RP_ID: &str = "example.com";
+    static TEST_FIDO_USER_HANDLE: &str = "YWJjZA";
+    // Hardcoded P-256 private key in PKCS8 DER format for testing
+    static TEST_FIDO_P256_KEY: &[u8] = &[
+        0x30, 0x81, 0x87, 0x02, 0x01, 0x00, 0x30, 0x13, 0x06, 0x07, 0x2a, 0x86, 0x48, 0xce, 0x3d,
+        0x02, 0x01, 0x06, 0x08, 0x2a, 0x86, 0x48, 0xce, 0x3d, 0x03, 0x01, 0x07, 0x04, 0x6d, 0x30,
+        0x6b, 0x02, 0x01, 0x01, 0x04, 0x20, 0x06, 0x76, 0x5e, 0x85, 0xe0, 0x7f, 0xef, 0x43, 0xaa,
+        0x17, 0xe0, 0x7a, 0xd7, 0x85, 0x63, 0x01, 0x80, 0x70, 0x8c, 0x6c, 0x61, 0x43, 0x7d, 0xc3,
+        0xb1, 0xe6, 0xf9, 0x09, 0x24, 0xeb, 0x1f, 0xf5, 0xa1, 0x44, 0x03, 0x42, 0x00, 0x04, 0x35,
+        0x9a, 0x52, 0xf3, 0x82, 0x44, 0x66, 0x5f, 0x3f, 0xe2, 0xc4, 0x0b, 0x1c, 0x16, 0x34, 0xc5,
+        0x60, 0x07, 0x3a, 0x25, 0xfe, 0x7e, 0x7f, 0x7f, 0xda, 0xd4, 0x1c, 0x36, 0x90, 0x00, 0xee,
+        0xb1, 0x8e, 0x92, 0xb3, 0xac, 0x91, 0x7f, 0xb1, 0x8c, 0xa4, 0x85, 0xe7, 0x03, 0x07, 0xd1,
+        0xf5, 0x5b, 0xd3, 0x7b, 0xc3, 0x56, 0x11, 0xdf, 0xbc, 0x7a, 0x97, 0x70, 0x32, 0x4b, 0x3c,
+        0x84, 0x05, 0x71,
+    ];
+
+    fn create_test_cipher(ctx: &mut KeyStoreContext<KeyIds>) -> CipherView {
+        let key = SymmetricKeyId::User;
+        let key_value = B64Url::from(TEST_FIDO_P256_KEY).to_string();
+
+        let fido2_credential = Fido2Credential {
+            credential_id: TEST_FIDO_CREDENTIAL_ID.encrypt(ctx, key).unwrap(),
+            key_type: "public-key".to_string().encrypt(ctx, key).unwrap(),
+            key_algorithm: "ECDSA".to_string().encrypt(ctx, key).unwrap(),
+            key_curve: "P-256".to_string().encrypt(ctx, key).unwrap(),
+            key_value: key_value.encrypt(ctx, key).unwrap(),
+            rp_id: TEST_FIDO_RP_ID.encrypt(ctx, key).unwrap(),
+            user_handle: Some(TEST_FIDO_USER_HANDLE.encrypt(ctx, key).unwrap()),
+            user_name: None,
+            counter: "0".to_string().encrypt(ctx, key).unwrap(),
+            rp_name: None,
+            user_display_name: None,
+            discoverable: "true".to_string().encrypt(ctx, key).unwrap(),
+            creation_date: "2024-06-07T14:12:36.150Z".parse().unwrap(),
+        };
+
+        CipherView {
+            id: Some("c2c7e624-dcfd-4f23-af41-b177014ffcb5".parse().unwrap()),
+            organization_id: None,
+            folder_id: None,
+            collection_ids: vec![],
+            key: None,
+            name: "Test Login".to_string(),
+            notes: None,
+            r#type: CipherType::Login,
+            login: Some(LoginView {
+                username: None,
+                password: None,
+                password_revision_date: None,
+                uris: None,
+                totp: None,
+                autofill_on_page_load: None,
+                fido2_credentials: Some(vec![fido2_credential]),
+            }),
+            identity: None,
+            card: None,
+            secure_note: None,
+            ssh_key: None,
+            favorite: false,
+            reprompt: CipherRepromptType::None,
+            organization_use_totp: false,
+            edit: true,
+            permissions: None,
+            view_password: true,
+            local_data: None,
+            attachments: None,
+            attachment_decryption_failures: None,
+            fields: None,
+            password_history: None,
+            creation_date: "2024-01-30T17:55:36.150Z".parse().unwrap(),
+            deleted_date: None,
+            revision_date: "2024-01-30T17:55:36.150Z".parse().unwrap(),
+            archived_date: None,
+        }
+    }
+
+    /// TODO(PM-30510): Even though we forward the extensions to the
+    /// authenticator, we have disabled the configuration.
+    /// When we implement PRF, this test should be updated to test that PRF _is_
+    /// evaluated when PRF extension input is received.
+    #[tokio::test]
+    async fn test_prf_is_not_evaluated() {
+        let client = Client::new(None);
+        let user_key: SymmetricCryptoKey =
+            "w2LO+nwV4oxwswVYCxlOfRUseXfvU03VzvKQHrqeklPgiMZrspUe6sOBToCnDn9Ay0tuCBn8ykVVRb7PWhub2Q=="
+                .to_string()
+                .try_into()
+                .unwrap();
+
+        #[allow(deprecated)]
+        client
+            .internal
+            .get_key_store()
+            .context_mut()
+            .set_symmetric_key(SymmetricKeyId::User, user_key)
+            .unwrap();
+
+        let cipher = {
+            let mut ctx = client.internal.get_key_store().context();
+            create_test_cipher(&mut ctx)
+        };
+
+        let user_interface = MockUserInterface;
+        let credential_store = MockCredentialStore { cipher };
+        let mut authenticator =
+            Fido2Authenticator::new(&client, &user_interface, &credential_store);
+
+        let request = GetAssertionRequest {
+            rp_id: "example.com".to_string(),
+            client_data_hash: vec![0u8; 32],
+            allow_list: None,
+            options: Options {
+                rk: false,
+                uv: UV::Preferred,
+            },
+            extensions: Some(GetAssertionExtensionsInput {
+                prf: Some(GetAssertionPrfInput {
+                    eval: Some(PrfInputValues {
+                        first: vec![1u8; 32],
+                        second: None,
+                    }),
+                    eval_by_credential: None,
+                }),
+            }),
+        };
+
+        let result = authenticator.get_assertion(request).await.unwrap();
+        assert_eq!(
+            TEST_FIDO_CREDENTIAL_ID,
+            guid_bytes_to_string(&result.credential_id).unwrap()
+        );
+        assert!(
+            result.extensions.prf.is_none(),
+            "PRF should not be evaluated"
+        );
+    }
+}

--- a/crates/bitwarden-fido/src/lib.rs
+++ b/crates/bitwarden-fido/src/lib.rs
@@ -34,8 +34,11 @@ pub use traits::{
 };
 pub use types::{
     AuthenticatorAssertionResponse, AuthenticatorAttestationResponse, ClientData,
-    Fido2CredentialAutofillView, Fido2CredentialAutofillViewError, GetAssertionRequest,
-    GetAssertionResult, MakeCredentialRequest, MakeCredentialResult, Options, Origin,
+    Fido2CredentialAutofillView, Fido2CredentialAutofillViewError, GetAssertionExtensionsInput,
+    GetAssertionExtensionsOutput, GetAssertionPrfInput, GetAssertionPrfOutput, GetAssertionRequest,
+    GetAssertionResult, MakeCredentialExtensionsInput, MakeCredentialExtensionsOutput,
+    MakeCredentialPrfInput, MakeCredentialPrfOutput, MakeCredentialRequest, MakeCredentialResult,
+    Options, Origin, PrfInputValues, PrfOutputValues,
     PublicKeyCredentialAuthenticatorAssertionResponse,
     PublicKeyCredentialAuthenticatorAttestationResponse, PublicKeyCredentialRpEntity,
     PublicKeyCredentialUserEntity, UnverifiedAssetLink,

--- a/crates/bitwarden-fido/src/types.rs
+++ b/crates/bitwarden-fido/src/types.rs
@@ -974,10 +974,4 @@ mod tests {
         let transformed = GetAssertionExtensionsOutput::from(output);
         assert_eq!(prf1, transformed.prf.unwrap().results.first);
     }
-
-    /// TODO(PM-30510): Even though we forward the extensions to the
-    /// authenticator, we have disabled the configuration.
-    /// When we implement PRF, this test should be updated to test that PRF _is_ evaluated.
-    #[test]
-    fn test_prf_is_not_evaluated() {}
 }

--- a/crates/bitwarden-fido/src/types.rs
+++ b/crates/bitwarden-fido/src/types.rs
@@ -1,4 +1,4 @@
-use std::borrow::Cow;
+use std::{borrow::Cow, collections::HashMap};
 
 use bitwarden_core::key_management::KeyIds;
 use bitwarden_crypto::{CryptoError, KeyStoreContext};
@@ -223,8 +223,6 @@ impl TryFrom<PublicKeyCredentialDescriptor>
     }
 }
 
-pub type Extensions = Option<String>;
-
 #[allow(missing_docs)]
 #[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
 pub struct MakeCredentialRequest {
@@ -234,25 +232,276 @@ pub struct MakeCredentialRequest {
     pub pub_key_cred_params: Vec<PublicKeyCredentialParameters>,
     pub exclude_list: Option<Vec<PublicKeyCredentialDescriptor>>,
     pub options: Options,
-    pub extensions: Extensions,
+
+    /// WebAuthn client extension inputs for credential creation requests.
+    ///
+    /// Cf. <https://www.w3.org/TR/webauthn-3/#dom-publickeycredentialcreationoptions-extensions>.
+    pub extensions: Option<MakeCredentialExtensionsInput>,
 }
 
-#[allow(missing_docs)]
+/// Fields corresponding to a WebAuthn [PublicKeyCredential][pub-key-cred]
+/// with an [AuthenticatorAttestationResponse][authenticator-attestation-response].
+///
+/// [pub-key-cred]: https://www.w3.org/TR/webauthn-3/#publickeycredential
+/// [authenticator-attestation-response]: https://www.w3.org/TR/webauthn-3/#authenticatorattestationresponse
 #[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
 pub struct MakeCredentialResult {
+    /// The authenticator data extracted from within the
+    /// [`attestation_object`][Self::attestation_object].
     pub authenticator_data: Vec<u8>,
+
+    /// [WebAuthn attestation object][webauthn-attestation-object] for the
+    /// authenticator response containing both the authenticator data and
+    /// attestation statement for the credential.
+    ///
+    /// [webauthn-attestation-object]: https://www.w3.org/TR/webauthn-3/#dom-authenticatorattestationresponse-attestationobject
     pub attestation_object: Vec<u8>,
+
+    /// ID for this credential, corresponding to [PublicKeyCredential.rawId][raw-id].
+    ///
+    /// [raw-id]: https://www.w3.org/TR/webauthn-3/#dom-publickeycredential-rawid
     pub credential_id: Vec<u8>,
+
+    /// Mix of CTAP [unsigned extension output][unsigned-extensions] and
+    /// [WebAuthn client extensions][webauthn-client-extensions] output returned
+    /// by the authenticator.
+    ///
+    /// [unsigned-extensions]: https://www.w3.org/TR/webauthn-3/#unsigned-extension-outputs
+    /// [webauthn-client-extensions]: https://www.w3.org/TR/webauthn-3/#dom-publickeycredential-clientextensionsresults-slot
+    pub extensions: MakeCredentialExtensionsOutput,
+}
+
+/// WebAuthn extension input for WebAuthn registration extensions.
+#[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
+#[derive(Debug, Default)]
+pub struct MakeCredentialExtensionsInput {
+    /// PRF input for WebAuthn registration request.
+    pub prf: Option<MakeCredentialPrfInput>,
+}
+
+impl From<MakeCredentialExtensionsInput>
+    for passkey::types::ctap2::make_credential::ExtensionInputs
+{
+    fn from(value: MakeCredentialExtensionsInput) -> Self {
+        Self {
+            hmac_secret: None,
+            hmac_secret_mc: None,
+            prf: value
+                .prf
+                .map(passkey::types::ctap2::extensions::AuthenticatorPrfInputs::from),
+        }
+    }
+}
+
+/// WebAuthn extension output for registration extensions.
+#[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
+#[derive(Debug)]
+pub struct MakeCredentialExtensionsOutput {
+    /// PRF output for registration extensions.
+    pub prf: Option<MakeCredentialPrfOutput>,
+}
+
+impl From<Option<passkey::types::ctap2::make_credential::UnsignedExtensionOutputs>>
+    for MakeCredentialExtensionsOutput
+{
+    fn from(
+        value: Option<passkey::types::ctap2::make_credential::UnsignedExtensionOutputs>,
+    ) -> Self {
+        if let Some(ext) = value {
+            MakeCredentialExtensionsOutput::from(ext)
+        } else {
+            MakeCredentialExtensionsOutput { prf: None }
+        }
+    }
+}
+
+impl From<passkey::types::ctap2::make_credential::UnsignedExtensionOutputs>
+    for MakeCredentialExtensionsOutput
+{
+    fn from(value: passkey::types::ctap2::make_credential::UnsignedExtensionOutputs) -> Self {
+        let prf = value.prf.map(|prf| MakeCredentialPrfOutput {
+            enabled: prf.enabled,
+            results: prf.results.map(|results| results.into()),
+        });
+        MakeCredentialExtensionsOutput { prf }
+    }
+}
+
+/// WebAuthn PRF extension input for use during registration.
+#[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
+#[derive(Debug)]
+pub struct MakeCredentialPrfInput {
+    /// PRF inputs.
+    pub eval: Option<PrfInputValues>,
+}
+
+impl From<MakeCredentialPrfInput> for passkey::types::ctap2::extensions::AuthenticatorPrfInputs {
+    fn from(value: MakeCredentialPrfInput) -> Self {
+        Self {
+            eval: value.eval.map(|v| v.into()),
+            eval_by_credential: None,
+        }
+    }
+}
+
+/// WebAuthn PRF extension output used during registration.
+#[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
+#[derive(Debug)]
+pub struct MakeCredentialPrfOutput {
+    /// Whether PRF is successfully processed for the newly created credential.
+    pub enabled: bool,
+
+    /// PRF outputs.
+    pub results: Option<PrfOutputValues>,
 }
 
 #[allow(missing_docs)]
+/// Type representing data from WebAuthn's
+/// [`PublicKeyCredentialRequestOptions`][pubkey-cred-request-options].
+///
+/// [pubkey-cred-request-options]: https://www.w3.org/TR/webauthn-3/#dictdef-publickeycredentialrequestoptions
 #[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
 pub struct GetAssertionRequest {
+    /// The RP ID for the request used to select credentials.
     pub rp_id: String,
+
+    /// Hash of the clientDataJSON for the request.
     pub client_data_hash: Vec<u8>,
+
+    /// Credential IDs known to the RP. If specified, it is a list of
+    /// credentials to filter by, ordered from most to least preferable. If
+    /// empty, only discoverable credentials will be returned.
     pub allow_list: Option<Vec<PublicKeyCredentialDescriptor>>,
+
     pub options: Options,
-    pub extensions: Extensions,
+
+    /// WebAuthn extension input for use during assertion.
+    pub extensions: Option<GetAssertionExtensionsInput>,
+}
+
+/// Fields corresponding to a WebAuthn [PublicKeyCredential][pub-key-cred]
+/// with an [AuthenticatorAssertionResponse][authenticator-assertion-response].
+///
+/// [pub-key-cred]: https://www.w3.org/TR/webauthn-3/#publickeycredential
+/// [authenticator-assertion-response]: https://www.w3.org/TR/webauthn-3/#authenticatorassertionresponse
+#[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
+pub struct GetAssertionResult {
+    /// ID for this credential, corresponding to [PublicKeyCredential.rawId][raw-id].
+    ///
+    /// [raw-id]: https://www.w3.org/TR/webauthn-3/#dom-publickeycredential-rawid
+    pub credential_id: Vec<u8>,
+
+    /// The authenticator data from the authenticator response.
+    pub authenticator_data: Vec<u8>,
+
+    /// Signature over the authenticator data.
+    pub signature: Vec<u8>,
+
+    /// The user handle returned from the authenticator.
+    pub user_handle: Vec<u8>,
+
+    /// A reference to the Bitwarden cipher for the selected credential.
+    pub selected_credential: SelectedCredential,
+
+    /// Mix of CTAP unsigned extension output and WebAuthn client extension output.
+    /// Signed extensions can be retrieved from authenticator data.
+    pub extensions: GetAssertionExtensionsOutput,
+}
+
+/// WebAuthn extension input for WebAuthn authentication extensions.
+#[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
+#[derive(Debug)]
+pub struct GetAssertionExtensionsInput {
+    /// PRF input for the authentication ceremony.
+    pub prf: Option<GetAssertionPrfInput>,
+}
+
+impl From<GetAssertionExtensionsInput> for passkey::types::ctap2::get_assertion::ExtensionInputs {
+    fn from(value: GetAssertionExtensionsInput) -> Self {
+        Self {
+            hmac_secret: None,
+            prf: value
+                .prf
+                .map(passkey::types::ctap2::extensions::AuthenticatorPrfInputs::from),
+        }
+    }
+}
+
+/// WebAuthn extension output of an authentication ceremony.
+#[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
+#[derive(Debug)]
+pub struct GetAssertionExtensionsOutput {
+    /// PRF output for an authentication ceremony.
+    pub prf: Option<GetAssertionPrfOutput>,
+}
+
+impl From<Option<passkey::types::ctap2::get_assertion::UnsignedExtensionOutputs>>
+    for GetAssertionExtensionsOutput
+{
+    fn from(value: Option<passkey::types::ctap2::get_assertion::UnsignedExtensionOutputs>) -> Self {
+        if let Some(value) = value {
+            value.into()
+        } else {
+            Self { prf: None }
+        }
+    }
+}
+
+impl From<passkey::types::ctap2::get_assertion::UnsignedExtensionOutputs>
+    for GetAssertionExtensionsOutput
+{
+    fn from(value: passkey::types::ctap2::get_assertion::UnsignedExtensionOutputs) -> Self {
+        let prf = value.prf.map(|prf| GetAssertionPrfOutput {
+            results: prf.results.into(),
+        });
+        GetAssertionExtensionsOutput { prf }
+    }
+}
+
+/// Input for WebAuthn PRF extension during authentication ceremonies.
+#[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
+#[derive(Debug)]
+pub struct GetAssertionPrfInput {
+    /// A PRF input to use for authentication. If a map of credential IDs to PRF
+    /// inputs is specified in [`Self::eval_by_credential`] along with this
+    /// value, the extension will fallback to this
+    /// value if the returned credential ID is not contained in the map.
+    pub eval: Option<PrfInputValues>,
+
+    /// A map of credential IDs to PRF input for a set of credentials specified in the
+    /// [`GetAssertionRequest::allow_list`] field of the request. If a key of
+    /// this map does not exist in the allow list, the extension will fail.
+    pub eval_by_credential: Option<HashMap<Vec<u8>, PrfInputValues>>,
+}
+
+impl From<GetAssertionPrfInput> for passkey::types::ctap2::extensions::AuthenticatorPrfInputs {
+    fn from(value: GetAssertionPrfInput) -> Self {
+        let eval_by_credential = if let Some(values) = value.eval_by_credential {
+            let map: HashMap<
+                passkey::types::Bytes,
+                passkey::types::ctap2::extensions::AuthenticatorPrfValues,
+            > = values
+                .into_iter()
+                .map(|(k, v)| (k.into(), v.into()))
+                .collect();
+            Some(map)
+        } else {
+            None
+        };
+        Self {
+            eval: value.eval.map(|v| v.into()),
+            eval_by_credential,
+        }
+    }
+}
+
+/// WebAuthn PRF extension output during an authentication ceremony.
+#[allow(missing_docs)]
+#[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
+#[derive(Debug)]
+pub struct GetAssertionPrfOutput {
+    /// The PRF output for the ceremony.
+    pub results: PrfOutputValues,
 }
 
 #[allow(missing_docs)]
@@ -319,17 +568,6 @@ impl From<UserVerificationRequirement> for UV {
 }
 
 #[allow(missing_docs)]
-#[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
-pub struct GetAssertionResult {
-    pub credential_id: Vec<u8>,
-    pub authenticator_data: Vec<u8>,
-    pub signature: Vec<u8>,
-    pub user_handle: Vec<u8>,
-
-    pub selected_credential: SelectedCredential,
-}
-
-#[allow(missing_docs)]
 #[cfg_attr(feature = "uniffi", derive(uniffi::Enum))]
 pub enum ClientData {
     DefaultWithExtraData { android_package_name: String },
@@ -362,6 +600,75 @@ impl passkey::client::ClientData<Option<AndroidClientData>> for ClientData {
     }
 }
 
+/// Salt inputs for WebAuthn PRF extension.
+#[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
+pub struct PrfInputValues {
+    /// An input on which to evaluate PRF. Required.
+    pub first: Vec<u8>,
+
+    /// An optional secondary input on which to evaluate PRF.
+    pub second: Option<Vec<u8>>,
+}
+
+impl PrfInputValues {
+    const WEBAUTHN_PRF_CONTEXT_STRING: &[u8] = b"WebAuthn PRF\0";
+
+    fn hash_webauthn_prf_input(input: &[u8]) -> [u8; 32] {
+        passkey::types::crypto::sha256(&[Self::WEBAUTHN_PRF_CONTEXT_STRING, input].concat())
+    }
+}
+
+impl std::fmt::Debug for PrfInputValues {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("PrfInputValues")
+            .field("first", &"********")
+            .field("second", &self.second.as_ref().map(|_| "********"))
+            .finish()
+    }
+}
+
+impl From<PrfInputValues> for passkey::types::ctap2::extensions::AuthenticatorPrfValues {
+    /// This converts PRF input received from a client into the format that
+    /// passkey-rs expects. This is not valid for converting output received from passkey-rs.
+    fn from(value: PrfInputValues) -> Self {
+        // passkey-rs expects the salt input to be hashed already according to
+        // WebAuthn PRF extension client processing rules.
+        let first = PrfInputValues::hash_webauthn_prf_input(value.first.as_ref());
+        let second = value
+            .second
+            .as_deref()
+            .map(PrfInputValues::hash_webauthn_prf_input);
+        Self { first, second }
+    }
+}
+
+/// WebAuthn PRF output values.
+#[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
+pub struct PrfOutputValues {
+    /// The output of the PRF evaluation of the first PRF input.
+    pub first: Vec<u8>,
+
+    /// The output of the PRF evaluation of the second PRF input, if it was specified.
+    pub second: Option<Vec<u8>>,
+}
+
+impl std::fmt::Debug for PrfOutputValues {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("PrfOutputValues")
+            .field("first", &"********")
+            .field("second", &self.second.as_ref().map(|_| "********"))
+            .finish()
+    }
+}
+
+impl From<passkey::types::ctap2::extensions::AuthenticatorPrfValues> for PrfOutputValues {
+    fn from(value: passkey::types::ctap2::extensions::AuthenticatorPrfValues) -> Self {
+        Self {
+            first: value.first.to_vec(),
+            second: value.second.map(|s| s.to_vec()),
+        }
+    }
+}
 #[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
 pub struct ClientExtensionResults {
     pub cred_props: Option<CredPropsResult>,
@@ -489,9 +796,44 @@ impl TryFrom<UnverifiedAssetLink> for passkey::client::UnverifiedAssetLink<'_> {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashMap;
+
+    use passkey::types::ctap2::{
+        extensions::{
+            AuthenticatorPrfGetOutputs, AuthenticatorPrfMakeOutputs, AuthenticatorPrfValues,
+        },
+        get_assertion, make_credential,
+    };
     use serde::{Deserialize, Serialize};
 
-    use super::AndroidClientData;
+    use super::{
+        AndroidClientData, GetAssertionExtensionsInput, GetAssertionExtensionsOutput,
+        GetAssertionPrfInput, MakeCredentialExtensionsInput, MakeCredentialExtensionsOutput,
+        MakeCredentialPrfInput, PrfInputValues,
+    };
+
+    /// Raw PRF input for testing.
+    static TEST_SALT1_RAW_INPUT: &[u8] = b"salt1";
+
+    /// PRF input of after applying WebAuthn PRF domain separation to [TEST_SALT1_RAW_INPUT].
+    // SHA-256(UTF-8("WebAuthn PRF") || 0x00 || TEST_SALT1_RAW_INPUT)
+    static TEST_SALT1_WEBAUTHN_INPUT: [u8; 32] = [
+        0x2A, 0x19, 0x90, 0xF9, 0xC9, 0xBB, 0xFE, 0x1B, 0xBF, 0x56, 0xAB, 0xEE, 0x2B, 0x5A, 0x0F,
+        0x59, 0xBE, 0x5F, 0x63, 0x3A, 0x35, 0xC2, 0xA5, 0xF0, 0x7D, 0x85, 0x53, 0x3E, 0xEE, 0xCB,
+        0xDD, 0x3C,
+    ];
+
+    /// Raw PRF input for testing.
+    static TEST_SALT2_RAW_INPUT: &[u8] = b"salt2";
+
+    /// PRF input after applying WebAuthn PRF domain separation to [TEST_SALT2_RAW_INPUT].
+    ///
+    /// SHA-256(UTF-8("WebAuthn PRF") || 0x00 || TEST_SALT2_RAW_INPUT)
+    static TEST_SALT2_WEBAUTHN_INPUT: [u8; 32] = [
+        0xA6, 0x42, 0xFA, 0x8B, 0x6E, 0xAC, 0x68, 0xD3, 0x73, 0xCF, 0x08, 0xEA, 0xC8, 0x5E, 0x1D,
+        0x62, 0x9B, 0x50, 0x10, 0x6D, 0x60, 0xEB, 0x92, 0x48, 0xEC, 0xB6, 0x54, 0xE2, 0x94, 0x9A,
+        0xDD, 0x65,
+    ];
 
     // This is a stripped down of the passkey-rs implementation, to test the
     // serialization of the `ClientData` enum, and to make sure that () and None
@@ -545,4 +887,97 @@ mod tests {
             r#"{"origin":"https://example.com","androidPackageName":"com.example.app"}"#
         );
     }
+
+    #[test]
+    fn test_transform_make_credential_extension_input() {
+        let input = MakeCredentialExtensionsInput {
+            prf: Some(MakeCredentialPrfInput {
+                eval: Some(PrfInputValues {
+                    first: TEST_SALT1_RAW_INPUT.to_vec(),
+                    second: Some(TEST_SALT2_RAW_INPUT.to_vec()),
+                }),
+            }),
+        };
+        let transformed = make_credential::ExtensionInputs::from(input);
+        let eval = transformed.prf.unwrap().eval.unwrap();
+        assert_eq!(TEST_SALT1_WEBAUTHN_INPUT, eval.first);
+        assert_eq!(TEST_SALT2_WEBAUTHN_INPUT, eval.second.unwrap());
+    }
+
+    #[test]
+    fn test_transform_make_credential_extension_output() {
+        let prf1: Vec<u8> = (0..32).collect();
+        let output = make_credential::UnsignedExtensionOutputs {
+            prf: Some(AuthenticatorPrfMakeOutputs {
+                enabled: true,
+                results: Some(AuthenticatorPrfValues {
+                    first: prf1.clone().try_into().unwrap(),
+                    second: None,
+                }),
+            }),
+        };
+        let transformed = MakeCredentialExtensionsOutput::from(output);
+        assert!(transformed.prf.as_ref().unwrap().enabled);
+        assert_eq!(prf1, transformed.prf.unwrap().results.unwrap().first);
+    }
+
+    #[test]
+    fn test_transform_get_assertion_extension_input() {
+        let input = GetAssertionExtensionsInput {
+            prf: Some(GetAssertionPrfInput {
+                eval: Some(PrfInputValues {
+                    first: TEST_SALT1_RAW_INPUT.to_vec(),
+                    second: Some(TEST_SALT2_RAW_INPUT.to_vec()),
+                }),
+                eval_by_credential: None,
+            }),
+        };
+        let transformed = get_assertion::ExtensionInputs::from(input);
+        let eval = transformed.prf.unwrap().eval.unwrap();
+        assert_eq!(TEST_SALT1_WEBAUTHN_INPUT, eval.first);
+        assert_eq!(TEST_SALT2_WEBAUTHN_INPUT, eval.second.unwrap());
+    }
+
+    #[test]
+    fn test_transform_get_assertion_extension_input_with_eval_by_credential() {
+        let cred_id = b"credential_id1".to_vec();
+        let input = GetAssertionExtensionsInput {
+            prf: Some(GetAssertionPrfInput {
+                eval: None,
+                eval_by_credential: Some(HashMap::from([(
+                    cred_id.clone(),
+                    PrfInputValues {
+                        first: TEST_SALT1_RAW_INPUT.to_vec(),
+                        second: Some(TEST_SALT2_RAW_INPUT.to_vec()),
+                    },
+                )])),
+            }),
+        };
+        let transformed = get_assertion::ExtensionInputs::from(input);
+        let output = transformed.prf.unwrap().eval_by_credential.unwrap();
+        let results = output.get(&cred_id.into()).unwrap();
+        assert_eq!(TEST_SALT1_WEBAUTHN_INPUT, results.first);
+        assert_eq!(TEST_SALT2_WEBAUTHN_INPUT, results.second.unwrap());
+    }
+
+    #[test]
+    fn test_transform_get_assertion_extension_output() {
+        let prf1: Vec<u8> = (0..32).collect();
+        let output = get_assertion::UnsignedExtensionOutputs {
+            prf: Some(AuthenticatorPrfGetOutputs {
+                results: AuthenticatorPrfValues {
+                    first: prf1.clone().try_into().unwrap(),
+                    second: None,
+                },
+            }),
+        };
+        let transformed = GetAssertionExtensionsOutput::from(output);
+        assert_eq!(prf1, transformed.prf.unwrap().results.first);
+    }
+
+    /// TODO(PM-30510): Even though we forward the extensions to the
+    /// authenticator, we have disabled the configuration.
+    /// When we implement PRF, this test should be updated to test that PRF _is_ evaluated.
+    #[test]
+    fn test_prf_is_not_evaluated() {}
 }


### PR DESCRIPTION
## 🎟️ Tracking

[PM-33111](https://bitwarden.atlassian.net/browse/PM-33111)

## 📔 Objective

As part of the device auth key initiative, we need to be able to parse PRF input from the incoming make credential and get assertion requests. This adds types to parse the data from the extensions without having to parse the JSON manually.

Note that this enables parsing PRF input, but the authenticator is not evaluating PRF input on vault items. A follow-up PR will use the passkey-rs library to evaluate PRF input for the device auth key only.

(This PR also opens the door for supporting other extensions, like `largeBlob`.)

## 🚨 Breaking Changes

This changes the type of `extensions` fields on the `MakeCredentialRequest` and `GetAssertionRequest` structs to `Option<MakeCredentialExtensionInputs>` and `Option<GetAssertionExtensionInputs>`. (It also adds an `extensions` field to both `MakeCredentialResult` and `GetAssertionResult`, but that should be non-breaking as it should only be read from clients.)

However, these were previously `Option<String>`, and we do not support any extensions, so this is set to `nil` in the iOS client (the only consumer, currently). So no client code changes should be required.

[PM-33111]: https://bitwarden.atlassian.net/browse/PM-33111?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ