### PR TITLE
feat: automatically provide org ID for SM

### DIFF
--- a/bitwarden_license/bitwarden-sm/src/client.rs
+++ b/bitwarden_license/bitwarden-sm/src/client.rs
@@ -10,6 +10,7 @@ use bitwarden_generators::GeneratorClientsExt;
 use crate::{ProjectsClient, SecretsClient};
 
 /// The main struct for interacting with the Secrets Manager service through the SM SDK.
+#[derive(Clone)]
 pub struct SecretsManagerClient {
     client: bitwarden_core::Client,
     token_handler: Arc<SecretsManagerTokenHandler>,
@@ -27,12 +28,12 @@ impl SecretsManagerClient {
 
     /// Get access to the Projects API
     pub fn projects(&self) -> ProjectsClient {
-        ProjectsClient::new(self.client.clone())
+        ProjectsClient::new(self.clone())
     }
 
     /// Get access to the Secrets API
     pub fn secrets(&self) -> SecretsClient {
-        SecretsClient::new(self.client.clone())
+        SecretsClient::new(self.clone())
     }
 
     /// Get access to the Auth API
@@ -45,8 +46,12 @@ impl SecretsManagerClient {
         self.client.generator()
     }
 
-    #[doc(hidden)]
+    /// Get the Organization ID for the access token
     pub fn get_access_token_organization(&self) -> Option<OrganizationId> {
         self.token_handler.get_access_token_organization()
+    }
+
+    pub(crate) fn client(&self) -> &bitwarden_core::Client {
+        &self.client
     }
 }

--- a/bitwarden_license/bitwarden-sm/src/client_projects.rs
+++ b/bitwarden_license/bitwarden-sm/src/client_projects.rs
@@ -1,6 +1,5 @@
-use bitwarden_core::Client;
-
 use crate::{
+    SecretsManagerClient,
     error::SecretsManagerError,
     projects::{
         ProjectCreateRequest, ProjectGetRequest, ProjectPutRequest, ProjectResponse,
@@ -11,12 +10,12 @@ use crate::{
 
 #[allow(missing_docs)]
 pub struct ProjectsClient {
-    pub client: Client,
+    client: SecretsManagerClient,
 }
 
 impl ProjectsClient {
     #[allow(missing_docs)]
-    pub fn new(client: Client) -> Self {
+    pub fn new(client: SecretsManagerClient) -> Self {
         Self { client }
     }
 

--- a/bitwarden_license/bitwarden-sm/src/client_secrets.rs
+++ b/bitwarden_license/bitwarden-sm/src/client_secrets.rs
@@ -1,24 +1,21 @@
-use bitwarden_core::Client;
-
 use crate::{
-    error::SecretsManagerError,
-    secrets::{
+    SecretsManagerClient, error::SecretsManagerError, secrets::{
         SecretCreateRequest, SecretGetRequest, SecretIdentifiersByProjectRequest,
         SecretIdentifiersRequest, SecretIdentifiersResponse, SecretPutRequest, SecretResponse,
         SecretsDeleteRequest, SecretsDeleteResponse, SecretsGetRequest, SecretsResponse,
         SecretsSyncRequest, SecretsSyncResponse, create_secret, delete_secrets, get_secret,
         get_secrets_by_ids, list_secrets, list_secrets_by_project, sync_secrets, update_secret,
-    },
+    }
 };
 
 #[allow(missing_docs)]
 pub struct SecretsClient {
-    client: Client,
+    client: SecretsManagerClient,
 }
 
 impl SecretsClient {
     #[allow(missing_docs)]
-    pub fn new(client: Client) -> Self {
+    pub fn new(client: SecretsManagerClient) -> Self {
         Self { client }
     }
 

--- a/bitwarden_license/bitwarden-sm/src/client_secrets.rs
+++ b/bitwarden_license/bitwarden-sm/src/client_secrets.rs
@@ -1,11 +1,13 @@
 use crate::{
-    SecretsManagerClient, error::SecretsManagerError, secrets::{
+    SecretsManagerClient,
+    error::SecretsManagerError,
+    secrets::{
         SecretCreateRequest, SecretGetRequest, SecretIdentifiersByProjectRequest,
         SecretIdentifiersRequest, SecretIdentifiersResponse, SecretPutRequest, SecretResponse,
         SecretsDeleteRequest, SecretsDeleteResponse, SecretsGetRequest, SecretsResponse,
         SecretsSyncRequest, SecretsSyncResponse, create_secret, delete_secrets, get_secret,
         get_secrets_by_ids, list_secrets, list_secrets_by_project, sync_secrets, update_secret,
-    }
+    },
 };
 
 #[allow(missing_docs)]

--- a/bitwarden_license/bitwarden-sm/src/projects/create.rs
+++ b/bitwarden_license/bitwarden-sm/src/projects/create.rs
@@ -1,5 +1,5 @@
 use bitwarden_api_api::models::ProjectCreateRequestModel;
-use bitwarden_core::{Client, OrganizationId, key_management::SymmetricKeyId};
+use bitwarden_core::{OrganizationId, key_management::SymmetricKeyId};
 use bitwarden_crypto::PrimitiveEncryptable;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -7,6 +7,7 @@ use uuid::Uuid;
 use validator::Validate;
 
 use crate::{
+    SecretsManagerClient,
     error::{SecretsManagerError, validate_only_whitespaces},
     projects::ProjectResponse,
 };
@@ -22,9 +23,10 @@ pub struct ProjectCreateRequest {
 }
 
 pub(crate) async fn create_project(
-    client: &Client,
+    client: &SecretsManagerClient,
     input: &ProjectCreateRequest,
 ) -> Result<ProjectResponse, SecretsManagerError> {
+    let client = client.client();
     input.validate()?;
 
     let key_store = client.internal.get_key_store();
@@ -59,7 +61,7 @@ mod tests {
             name,
         };
 
-        super::create_project(&Client::new(None), &input).await
+        super::create_project(&SecretsManagerClient::new(None), &input).await
     }
 
     #[tokio::test]

--- a/bitwarden_license/bitwarden-sm/src/projects/delete.rs
+++ b/bitwarden_license/bitwarden-sm/src/projects/delete.rs
@@ -1,12 +1,12 @@
 use bitwarden_api_api::models::{
     BulkDeleteResponseModel, BulkDeleteResponseModelListResponseModel,
 };
-use bitwarden_core::{client::Client, require};
+use bitwarden_core::require;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
-use crate::error::SecretsManagerError;
+use crate::{SecretsManagerClient, error::SecretsManagerError};
 
 #[allow(missing_docs)]
 #[derive(Serialize, Deserialize, Debug, JsonSchema)]
@@ -17,9 +17,10 @@ pub struct ProjectsDeleteRequest {
 }
 
 pub(crate) async fn delete_projects(
-    client: &Client,
+    client: &SecretsManagerClient,
     input: ProjectsDeleteRequest,
 ) -> Result<ProjectsDeleteResponse, SecretsManagerError> {
+    let client = client.client();
     let config = client.internal.get_api_configurations();
     let res = config
         .api_client

--- a/bitwarden_license/bitwarden-sm/src/projects/get.rs
+++ b/bitwarden_license/bitwarden-sm/src/projects/get.rs
@@ -1,9 +1,8 @@
-use bitwarden_core::client::Client;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
-use crate::{error::SecretsManagerError, projects::ProjectResponse};
+use crate::{SecretsManagerClient, error::SecretsManagerError, projects::ProjectResponse};
 
 #[allow(missing_docs)]
 #[derive(Serialize, Deserialize, Debug, JsonSchema)]
@@ -14,9 +13,10 @@ pub struct ProjectGetRequest {
 }
 
 pub(crate) async fn get_project(
-    client: &Client,
+    client: &SecretsManagerClient,
     input: &ProjectGetRequest,
 ) -> Result<ProjectResponse, SecretsManagerError> {
+    let client = client.client();
     let config = client.internal.get_api_configurations();
 
     let res = config.api_client.projects_api().get(input.id).await?;

--- a/bitwarden_license/bitwarden-sm/src/projects/list.rs
+++ b/bitwarden_license/bitwarden-sm/src/projects/list.rs
@@ -1,11 +1,11 @@
 use bitwarden_api_api::models::ProjectResponseModelListResponseModel;
-use bitwarden_core::{client::Client, key_management::KeyIds};
+use bitwarden_core::key_management::KeyIds;
 use bitwarden_crypto::KeyStoreContext;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
-use crate::{error::SecretsManagerError, projects::ProjectResponse};
+use crate::{SecretsManagerClient, error::SecretsManagerError, projects::ProjectResponse};
 
 #[allow(missing_docs)]
 #[derive(Serialize, Deserialize, Debug, JsonSchema)]
@@ -16,9 +16,10 @@ pub struct ProjectsListRequest {
 }
 
 pub(crate) async fn list_projects(
-    client: &Client,
+    client: &SecretsManagerClient,
     input: &ProjectsListRequest,
 ) -> Result<ProjectsResponse, SecretsManagerError> {
+    let client = client.client();
     let config = client.internal.get_api_configurations();
     let res = config
         .api_client

--- a/bitwarden_license/bitwarden-sm/src/projects/update.rs
+++ b/bitwarden_license/bitwarden-sm/src/projects/update.rs
@@ -1,5 +1,5 @@
 use bitwarden_api_api::models::ProjectUpdateRequestModel;
-use bitwarden_core::{Client, OrganizationId, key_management::SymmetricKeyId};
+use bitwarden_core::{OrganizationId, key_management::SymmetricKeyId};
 use bitwarden_crypto::PrimitiveEncryptable;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -7,6 +7,7 @@ use uuid::Uuid;
 use validator::Validate;
 
 use crate::{
+    SecretsManagerClient,
     error::{SecretsManagerError, validate_only_whitespaces},
     projects::ProjectResponse,
 };
@@ -24,9 +25,10 @@ pub struct ProjectPutRequest {
 }
 
 pub(crate) async fn update_project(
-    client: &Client,
+    client: &SecretsManagerClient,
     input: &ProjectPutRequest,
 ) -> Result<ProjectResponse, SecretsManagerError> {
+    let client = client.client();
     input.validate()?;
 
     let key_store = client.internal.get_key_store();
@@ -62,7 +64,7 @@ mod tests {
             name,
         };
 
-        super::update_project(&Client::new(None), &input).await
+        super::update_project(&SecretsManagerClient::new(None), &input).await
     }
 
     #[tokio::test]

--- a/bitwarden_license/bitwarden-sm/src/secrets/create.rs
+++ b/bitwarden_license/bitwarden-sm/src/secrets/create.rs
@@ -1,5 +1,5 @@
 use bitwarden_api_api::models::SecretCreateRequestModel;
-use bitwarden_core::{Client, OrganizationId, key_management::SymmetricKeyId};
+use bitwarden_core::key_management::SymmetricKeyId;
 use bitwarden_crypto::PrimitiveEncryptable;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -7,6 +7,7 @@ use uuid::Uuid;
 use validator::Validate;
 
 use crate::{
+    SecretsManagerClient,
     error::{SecretsManagerError, validate_only_whitespaces},
     secrets::SecretResponse,
 };
@@ -30,13 +31,16 @@ pub struct SecretCreateRequest {
 }
 
 pub(crate) async fn create_secret(
-    client: &Client,
+    client: &SecretsManagerClient,
     input: &SecretCreateRequest,
 ) -> Result<SecretResponse, SecretsManagerError> {
+    let core_client = client.client();
     input.validate()?;
 
-    let key_store = client.internal.get_key_store();
-    let key = SymmetricKeyId::Organization(OrganizationId::new(input.organization_id));
+    let key_store = core_client.internal.get_key_store();
+    let organization_id = client.get_access_token_organization().expect("Access token isn't associated with an organization");
+
+    let key = SymmetricKeyId::Organization(organization_id);
 
     let secret = {
         let mut ctx = key_store.context();
@@ -54,11 +58,11 @@ pub(crate) async fn create_secret(
         })
     };
 
-    let config = client.internal.get_api_configurations();
+    let config = core_client.internal.get_api_configurations();
     let res = config
         .api_client
         .secrets_api()
-        .create(input.organization_id, secret)
+        .create(organization_id.into(), secret)
         .await?;
 
     SecretResponse::process_response(res, &mut key_store.context())
@@ -81,7 +85,7 @@ mod tests {
             project_ids: Some(vec![Uuid::new_v4()]),
         };
 
-        super::create_secret(&Client::new(None), &input).await
+        super::create_secret(&SecretsManagerClient::new(None), &input).await
     }
 
     #[tokio::test]

--- a/bitwarden_license/bitwarden-sm/src/secrets/create.rs
+++ b/bitwarden_license/bitwarden-sm/src/secrets/create.rs
@@ -38,7 +38,9 @@ pub(crate) async fn create_secret(
     input.validate()?;
 
     let key_store = core_client.internal.get_key_store();
-    let organization_id = client.get_access_token_organization().expect("Access token isn't associated with an organization");
+    let organization_id = client
+        .get_access_token_organization()
+        .expect("Access token isn't associated with an organization");
 
     let key = SymmetricKeyId::Organization(organization_id);
 

--- a/bitwarden_license/bitwarden-sm/src/secrets/delete.rs
+++ b/bitwarden_license/bitwarden-sm/src/secrets/delete.rs
@@ -1,12 +1,12 @@
 use bitwarden_api_api::models::{
     BulkDeleteResponseModel, BulkDeleteResponseModelListResponseModel,
 };
-use bitwarden_core::{client::Client, require};
+use bitwarden_core::require;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
-use crate::error::SecretsManagerError;
+use crate::{SecretsManagerClient, error::SecretsManagerError};
 
 #[allow(missing_docs)]
 #[derive(Serialize, Deserialize, Debug, JsonSchema)]
@@ -17,9 +17,10 @@ pub struct SecretsDeleteRequest {
 }
 
 pub(crate) async fn delete_secrets(
-    client: &Client,
+    client: &SecretsManagerClient,
     input: SecretsDeleteRequest,
 ) -> Result<SecretsDeleteResponse, SecretsManagerError> {
+    let client = client.client();
     let config = client.internal.get_api_configurations();
     let res = config
         .api_client

--- a/bitwarden_license/bitwarden-sm/src/secrets/get.rs
+++ b/bitwarden_license/bitwarden-sm/src/secrets/get.rs
@@ -1,9 +1,8 @@
-use bitwarden_core::Client;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
-use crate::{error::SecretsManagerError, secrets::SecretResponse};
+use crate::{SecretsManagerClient, error::SecretsManagerError, secrets::SecretResponse};
 
 #[allow(missing_docs)]
 #[derive(Serialize, Deserialize, Debug, JsonSchema)]
@@ -14,9 +13,10 @@ pub struct SecretGetRequest {
 }
 
 pub(crate) async fn get_secret(
-    client: &Client,
+    client: &SecretsManagerClient,
     input: &SecretGetRequest,
 ) -> Result<SecretResponse, SecretsManagerError> {
+    let client = client.client();
     let config = client.internal.get_api_configurations();
     let res = config.api_client.secrets_api().get(input.id).await?;
 

--- a/bitwarden_license/bitwarden-sm/src/secrets/get_by_ids.rs
+++ b/bitwarden_license/bitwarden-sm/src/secrets/get_by_ids.rs
@@ -1,10 +1,9 @@
 use bitwarden_api_api::models::GetSecretsRequestModel;
-use bitwarden_core::client::Client;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
-use crate::{error::SecretsManagerError, secrets::SecretsResponse};
+use crate::{SecretsManagerClient, error::SecretsManagerError, secrets::SecretsResponse};
 
 #[allow(missing_docs)]
 #[derive(Serialize, Deserialize, Debug, JsonSchema)]
@@ -15,9 +14,10 @@ pub struct SecretsGetRequest {
 }
 
 pub(crate) async fn get_secrets_by_ids(
-    client: &Client,
+    client: &SecretsManagerClient,
     input: SecretsGetRequest,
 ) -> Result<SecretsResponse, SecretsManagerError> {
+    let client = client.client();
     let request = Some(GetSecretsRequestModel { ids: input.ids });
 
     let config = client.internal.get_api_configurations();

--- a/bitwarden_license/bitwarden-sm/src/secrets/list.rs
+++ b/bitwarden_license/bitwarden-sm/src/secrets/list.rs
@@ -3,7 +3,6 @@ use bitwarden_api_api::models::{
 };
 use bitwarden_core::{
     OrganizationId,
-    client::Client,
     key_management::{KeyIds, SymmetricKeyId},
     require,
 };
@@ -12,7 +11,7 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
-use crate::error::SecretsManagerError;
+use crate::{SecretsManagerClient, error::SecretsManagerError};
 
 #[allow(missing_docs)]
 #[derive(Serialize, Deserialize, Debug, JsonSchema)]
@@ -23,9 +22,10 @@ pub struct SecretIdentifiersRequest {
 }
 
 pub(crate) async fn list_secrets(
-    client: &Client,
+    client: &SecretsManagerClient,
     input: &SecretIdentifiersRequest,
 ) -> Result<SecretIdentifiersResponse, SecretsManagerError> {
+    let client = client.client();
     let config = client.internal.get_api_configurations();
     let res = config
         .api_client
@@ -47,9 +47,10 @@ pub struct SecretIdentifiersByProjectRequest {
 }
 
 pub(crate) async fn list_secrets_by_project(
-    client: &Client,
+    client: &SecretsManagerClient,
     input: &SecretIdentifiersByProjectRequest,
 ) -> Result<SecretIdentifiersResponse, SecretsManagerError> {
+    let client = client.client();
     let config = client.internal.get_api_configurations();
     let res = config
         .api_client

--- a/bitwarden_license/bitwarden-sm/src/secrets/sync.rs
+++ b/bitwarden_license/bitwarden-sm/src/secrets/sync.rs
@@ -1,12 +1,12 @@
 use bitwarden_api_api::models::SecretsSyncResponseModel;
-use bitwarden_core::{Client, key_management::KeyIds, require};
+use bitwarden_core::{key_management::KeyIds, require};
 use bitwarden_crypto::KeyStoreContext;
 use chrono::{DateTime, Utc};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
-use crate::{error::SecretsManagerError, secrets::SecretResponse};
+use crate::{SecretsManagerClient, error::SecretsManagerError, secrets::SecretResponse};
 
 #[allow(missing_docs)]
 #[derive(Serialize, Deserialize, Debug, JsonSchema)]
@@ -19,9 +19,10 @@ pub struct SecretsSyncRequest {
 }
 
 pub(crate) async fn sync_secrets(
-    client: &Client,
+    client: &SecretsManagerClient,
     input: &SecretsSyncRequest,
 ) -> Result<SecretsSyncResponse, SecretsManagerError> {
+    let client = client.client();
     let config = client.internal.get_api_configurations();
     let last_synced_date = input.last_synced_date.map(|date| date.to_rfc3339());
 

--- a/bitwarden_license/bitwarden-sm/src/secrets/update.rs
+++ b/bitwarden_license/bitwarden-sm/src/secrets/update.rs
@@ -1,5 +1,5 @@
 use bitwarden_api_api::models::SecretUpdateRequestModel;
-use bitwarden_core::{Client, OrganizationId, key_management::SymmetricKeyId};
+use bitwarden_core::{OrganizationId, key_management::SymmetricKeyId};
 use bitwarden_crypto::PrimitiveEncryptable;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -7,6 +7,7 @@ use uuid::Uuid;
 use validator::Validate;
 
 use crate::{
+    SecretsManagerClient,
     error::{SecretsManagerError, validate_only_whitespaces},
     secrets::SecretResponse,
 };
@@ -29,9 +30,10 @@ pub struct SecretPutRequest {
 }
 
 pub(crate) async fn update_secret(
-    client: &Client,
+    client: &SecretsManagerClient,
     input: &SecretPutRequest,
 ) -> Result<SecretResponse, SecretsManagerError> {
+    let client = client.client();
     input.validate()?;
 
     let key_store = client.internal.get_key_store();
@@ -82,7 +84,7 @@ mod tests {
             project_ids: Some(vec![Uuid::new_v4()]),
         };
 
-        super::update_secret(&Client::new(None), &input).await
+        super::update_secret(&SecretsManagerClient::new(None), &input).await
     }
 
     #[tokio::test]


### PR DESCRIPTION
## 📔 Objective

Remove the requirement for SM SDK consumers to manually provide the Organization ID.

<!-- ## 🚨 Breaking Changes -->

<!-- Does this PR introduce any breaking changes? If so, please describe the impact and migration path for clients.

If you're unsure, the automated TypeScript compatibility check will run when you open/update this PR and provide feedback.

For breaking changes:
1. Describe what changed in the client interface
2. Explain why the change was necessary
3. Provide migration steps for client developers
4. Link to any paired client PRs if needed

Otherwise, you can remove this section. -->