### PR TITLE
[PM-33290] Add stop gap solution for rehydration auth/crypto state

### DIFF
--- a/crates/bw/src/main.rs
+++ b/crates/bw/src/main.rs
@@ -71,6 +71,11 @@ async fn process_commands(command: Commands, _session: Option<String>) -> Comman
     // to do two matches over the whole command tree
     let client = bitwarden_pm::PasswordManagerClient::new(None);
 
+    // Temporary until rehydration
+    if let (Ok(email), Ok(password)) = (std::env::var("BW_EMAIL"), std::env::var("BW_PASSWORD")) {
+        temp_login(&client.0, email, password).await?;
+    }
+
     match command {
         // Auth commands
         Commands::Login(args) => args.run().await,
@@ -135,4 +140,28 @@ async fn process_commands(command: Commands, _session: Option<String>) -> Comman
         // Server commands
         Commands::Serve(_args) => todo!(),
     }
+}
+
+// Stop-gap solution for login until we have a proper session management solution in place. This
+// allows us to test the commands that require authentication without having to implement
+// rehydration.
+async fn temp_login(
+    client: &bitwarden_core::Client,
+    email: String,
+    password: String,
+) -> color_eyre::eyre::Result<()> {
+    use bitwarden_core::auth::login::PasswordLoginRequest;
+
+    let result = client
+        .auth()
+        .login_password(&PasswordLoginRequest {
+            email,
+            password,
+            two_factor: None,
+        })
+        .await?;
+
+    tracing::info!("Login result: {:?}", result);
+
+    Ok(())
 }


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-33290
## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Instead of rehydrating auth/crypto state we can just always call login before the actual operation. This adds two environment variables which when set will log you in prior to calling the appropriate command.

This is a temporary solution until rehydration is in place.