### PR TITLE
[PM-33274] Add reset to origin/main to binding update job to ensure latest templates are used

### DIFF
--- a/.github/workflows/update-api-bindings.yml
+++ b/.github/workflows/update-api-bindings.yml
@@ -171,6 +171,7 @@ jobs:
           git fetch origin
           if git switch $BRANCH_NAME 2>/dev/null; then
             echo "✅ Switched to existing branch: $BRANCH_NAME"
+            git rebase origin/main
             echo "updating_existing_branch=true" >> $GITHUB_OUTPUT
           else
             echo "📝 Creating new branch: $BRANCH_NAME from $BASE_SHA"
@@ -224,7 +225,7 @@ jobs:
           echo "👀 Committing API bindings update..."
           git add crates/bitwarden-api-api
           git commit -m "Update API bindings to $_HASH" --no-verify || echo "No changes to commit for API"
-          git push origin $_BRANCH_NAME
+          git push --force-with-lease origin $_BRANCH_NAME
 
       - name: Create or Update API Pull Request
         if: ${{ inputs.binding_type == 'api' || inputs.binding_type == 'both' || !inputs.binding_type }}
@@ -277,6 +278,7 @@ jobs:
           git fetch origin
           if git switch $BRANCH_NAME 2>/dev/null; then
             echo "✅ Switched to existing branch: $BRANCH_NAME"
+            git rebase origin/main
             echo "updating_existing_branch=true" >> $GITHUB_OUTPUT
           else
             echo "📝 Creating new branch: $BRANCH_NAME from $BASE_SHA"
@@ -330,7 +332,7 @@ jobs:
           echo "👀 Committing Identity bindings update..."
           git add crates/bitwarden-api-identity
           git commit -m "Update Identity bindings to $_HASH" --no-verify || echo "No changes to commit for Identity"
-          git push origin $_BRANCH_NAME
+          git push --force-with-lease origin $_BRANCH_NAME
 
       - name: Create or Update Identity Pull Request
         if: ${{ inputs.binding_type == 'identity' || inputs.binding_type == 'both' || !inputs.binding_type }}

--- a/.github/workflows/update-api-bindings.yml
+++ b/.github/workflows/update-api-bindings.yml
@@ -171,7 +171,6 @@ jobs:
           git fetch origin
           if git switch $BRANCH_NAME 2>/dev/null; then
             echo "✅ Switched to existing branch: $BRANCH_NAME"
-            git rebase origin/main
             echo "updating_existing_branch=true" >> $GITHUB_OUTPUT
           else
             echo "📝 Creating new branch: $BRANCH_NAME from $BASE_SHA"
@@ -205,6 +204,10 @@ jobs:
           fi
 
           echo "✅ Branch tip commit was made by the bot. Safe to proceed."
+
+      - name: Reset API branch to main
+        if: ${{ (inputs.binding_type == 'api' || inputs.binding_type == 'both' || !inputs.binding_type) && steps.switch-api-branch.outputs.updating_existing_branch == 'true' }}
+        run: git reset --hard origin/main
 
       - name: Generate API bindings
         if: ${{ inputs.binding_type == 'api' || inputs.binding_type == 'both' || !inputs.binding_type }}
@@ -278,7 +281,6 @@ jobs:
           git fetch origin
           if git switch $BRANCH_NAME 2>/dev/null; then
             echo "✅ Switched to existing branch: $BRANCH_NAME"
-            git rebase origin/main
             echo "updating_existing_branch=true" >> $GITHUB_OUTPUT
           else
             echo "📝 Creating new branch: $BRANCH_NAME from $BASE_SHA"
@@ -312,6 +314,10 @@ jobs:
           fi
 
           echo "✅ Branch tip commit was made by the bot. Safe to proceed."
+
+      - name: Reset Identity branch to main
+        if: ${{ (inputs.binding_type == 'identity' || inputs.binding_type == 'both' || !inputs.binding_type) && steps.switch-identity-branch.outputs.updating_existing_branch == 'true' }}
+        run: git reset --hard origin/main
 
       - name: Generate Identity bindings
         if: ${{ inputs.binding_type == 'identity' || inputs.binding_type == 'both' || !inputs.binding_type }}


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-33274

## 📔 Objective

The `update-api-bindings` workflow switches to the existing `api-bindings-update` branch before running the bindings generator. This means the generator uses templates from that branch, not from `main`. Normally this is fine because the PR gets merged quickly and the branch is recreated fresh from `main` on the next run. It only breaks when a template change lands on `main` while the bindings PR is still open, and the changes aren't reflected in the output.

In this case, #807 (base64url annotations) updated `support/openapi-template/` on `main` after the PR was already open, so the generator kept producing bindings without those annotations.

## 🚨 Breaking Changes

<!-- Does this PR introduce any breaking changes? If so, please describe the impact and migration path for clients.

If you're unsure, the automated TypeScript compatibility check will run when you open/update this PR and provide feedback.

For breaking changes:
1. Describe what changed in the client interface
2. Explain why the change was necessary
3. Provide migration steps for client developers
4. Link to any paired client PRs if needed

Otherwise, you can remove this section. -->
