### PR TITLE
Add warning callout for SDK-managed state

### DIFF
--- a/crates/bitwarden-state/README.md
+++ b/crates/bitwarden-state/README.md
@@ -169,8 +169,9 @@ getClient(userId = userId).platform().store().registerCipherStore(CipherStoreImp
 > - Migrations between versions of state are not supported
 > - Secure storage is not supported as a state storage mechanism
 > - Reactivity is not supported
-> - Browser extension-speecific state syncrhonization mechanisms are not present For these SDK
->   clients, we recommend that they use client-managed state.
+> - Browser extension-speecific state syncrhonization mechanisms are not present
+>
+> For these SDK clients, we recommend that they use client-managed state.
 
 With `SDK-Managed State`, the SDK will be exclusively responsible for the data storage. This means
 that the clients don't need to make any changes themselves, as the implementation is internal to the

--- a/crates/bitwarden-state/README.md
+++ b/crates/bitwarden-state/README.md
@@ -161,8 +161,10 @@ getClient(userId = userId).platform().store().registerCipherStore(CipherStoreImp
 
 ## SDK-Managed State
 
-> [!WARNING] SDK-Managed State is currently **not supported for WASM or UniFFI clients** due to the
-> following limitations:
+> [!WARNING]
+>
+> SDK-Managed State is currently **not supported for WASM or UniFFI clients** due to the following
+> limitations:
 >
 > - Migrations between versions of state are not supported
 > - Secure storage is not supported as a state storage mechanism

--- a/crates/bitwarden-state/README.md
+++ b/crates/bitwarden-state/README.md
@@ -161,6 +161,15 @@ getClient(userId = userId).platform().store().registerCipherStore(CipherStoreImp
 
 ## SDK-Managed State
 
+> [!WARNING] SDK-Managed State is currently **not supported for WASM or UniFFI clients** due to the
+> following limitations:
+>
+> - Migrations between versions of state are not supported
+> - Secure storage is not supported as a state storage mechanism
+> - Reactivity is not supported
+> - Browser extension-speecific state syncrhonization mechanisms are not present For these SDK
+>   clients, we recommend that they use client-managed state.
+
 With `SDK-Managed State`, the SDK will be exclusively responsible for the data storage. This means
 that the clients don't need to make any changes themselves, as the implementation is internal to the
 SDK. To add support for an SDK managed `Repository`, a new migration step needs to be added to the

--- a/crates/bitwarden-state/README.md
+++ b/crates/bitwarden-state/README.md
@@ -169,7 +169,7 @@ getClient(userId = userId).platform().store().registerCipherStore(CipherStoreImp
 > - Migrations between versions of state are not supported
 > - Secure storage is not supported as a state storage mechanism
 > - Reactivity is not supported
-> - Browser extension-speecific state syncrhonization mechanisms are not present
+> - Browser extension-specific state synchronization mechanisms are not present
 >
 > For these SDK clients, we recommend that they use client-managed state.
 


### PR DESCRIPTION
## 📔 Objective

Adds a warning callout for SDK-managed state so that teams are aware of limitations in its current implementation.

## 🚨 Breaking Changes

<!-- Does this PR introduce any breaking changes? If so, please describe the impact and migration path for clients.

If you're unsure, the automated TypeScript compatibility check will run when you open/update this PR and provide feedback.

For breaking changes:
1. Describe what changed in the client interface
2. Explain why the change was necessary
3. Provide migration steps for client developers
4. Link to any paired client PRs if needed

Otherwise, you can remove this section. -->
