### PR TITLE
feat: block WASM and UNIFFI clients from using sdk-managed state

### DIFF
--- a/crates/bitwarden-uniffi/src/platform/mod.rs
+++ b/crates/bitwarden-uniffi/src/platform/mod.rs
@@ -87,7 +87,10 @@ impl StateClient {
     }
 
     /// Initialize the database for SDK managed repositories.
+    #[allow(unused)]
     pub async fn initialize_state(&self, configuration: SqliteConfiguration) -> Result<()> {
+        panic!("SDK-Managed State is currently **not supported for UNIFFI clients**");
+
         let migrations = bitwarden_pm::migrations::get_sdk_managed_migrations();
 
         self.0

--- a/crates/bitwarden-wasm-internal/src/platform/mod.rs
+++ b/crates/bitwarden-wasm-internal/src/platform/mod.rs
@@ -78,10 +78,13 @@ impl StateClient {
     }
 
     /// Initialize the database for SDK managed repositories.
+    #[allow(unused)]
     pub async fn initialize_state(
         &self,
         configuration: IndexedDbConfiguration,
     ) -> Result<(), bitwarden_state::registry::StateRegistryError> {
+        panic!("SDK-Managed State is currently **not supported for WASM clients**");
+
         let sdk_managed_repositories = bitwarden_pm::migrations::get_sdk_managed_migrations();
 
         self.0


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective

Throws a panic if you try to use sdk-managed storage

## 🚨 Breaking Changes

<!-- Does this PR introduce any breaking changes? If so, please describe the impact and migration path for clients.

If you're unsure, the automated TypeScript compatibility check will run when you open/update this PR and provide feedback.

For breaking changes:
1. Describe what changed in the client interface
2. Explain why the change was necessary
3. Provide migration steps for client developers
4. Link to any paired client PRs if needed

Otherwise, you can remove this section. -->
