### PR TITLE
[PM-33310] Client managed local user data key state

### DIFF
--- a/crates/bitwarden-core/src/key_management/crypto.rs
+++ b/crates/bitwarden-core/src/key_management/crypto.rs
@@ -34,8 +34,8 @@ use crate::{
     client::{LoginMethod, UserLoginMethod, encryption_settings::EncryptionSettingsError},
     error::StatefulCryptoError,
     key_management::{
-        LocalUserDataKeyState, MasterPasswordError, PrivateKeyId, SecurityState,
-        SignedSecurityState, SigningKeyId, SymmetricKeyId, V2UpgradeToken,
+        MasterPasswordError, PrivateKeyId, SecurityState, SignedSecurityState, SigningKeyId,
+        SymmetricKeyId, V2UpgradeToken,
         account_cryptographic_state::{
             AccountCryptographyInitializationError, WrappedAccountCryptographicState,
         },
@@ -1039,19 +1039,6 @@ pub(crate) fn make_user_key_connector_registration(
 /// Subsequent calls are idempotent: if the key already exists in state it is loaded as-is,
 /// preserving any data that was previously encrypted with it (e.g. after a key rotation).
 async fn initialize_user_local_data_key(client: &Client) -> Result<(), EncryptionSettingsError> {
-    // If the repository isn't registered (e.g. database not initialized), skip silently.
-    if client
-        .platform()
-        .state()
-        .get::<LocalUserDataKeyState>()
-        .is_err()
-    {
-        info!(
-            "LocalUserDataKeyState repository not available, skipping local user data key initialization"
-        );
-        return Ok(());
-    }
-
     let user_id = client
         .internal
         .get_user_id()

--- a/crates/bitwarden-pm/src/migrations.rs
+++ b/crates/bitwarden-pm/src/migrations.rs
@@ -1,6 +1,6 @@
 //! Manages repository migrations for the Bitwarden SDK.
 
-use bitwarden_core::key_management::{LocalUserDataKeyState, UserKeyState};
+use bitwarden_core::key_management::UserKeyState;
 use bitwarden_state::{
     SettingItem,
     repository::{RepositoryItem, RepositoryMigrationStep, RepositoryMigrations},
@@ -17,7 +17,6 @@ pub fn get_sdk_managed_migrations() -> RepositoryMigrations {
         Add(Folder::data()),
         Add(UserKeyState::data()),
         Add(SettingItem::data()),
-        Add(LocalUserDataKeyState::data()),
     ])
 }
 
@@ -35,6 +34,7 @@ macro_rules! create_client_managed_repositories {
             ::bitwarden_vault::Cipher, Cipher, cipher, CipherRepository;
             ::bitwarden_vault::Folder, Folder, folder, FolderRepository;
             ::bitwarden_core::key_management::UserKeyState, UserKeyState, user_key_state, UserKeyStateRepository;
+            ::bitwarden_core::key_management::LocalUserDataKeyState, LocalUserDataKeyState, local_user_data_key_state, LocalUserDataKeyStateRepository;
         }
     };
 }


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-33310

## 📔 Objective

Change LocalUserDataKey state to be client-managed, since sdk-managed is not allowed.

## 🚨 Breaking Changes

<!-- Does this PR introduce any breaking changes? If so, please describe the impact and migration path for clients.

If you're unsure, the automated TypeScript compatibility check will run when you open/update this PR and provide feedback.

For breaking changes:
1. Describe what changed in the client interface
2. Explain why the change was necessary
3. Provide migration steps for client developers
4. Link to any paired client PRs if needed

Otherwise, you can remove this section. -->
