### PR TITLE
refactor(server-communication-config): add vault_url to SsoCookieVendorConfig

### DIFF
--- a/crates/bitwarden-server-communication-config/src/client.rs
+++ b/crates/bitwarden-server-communication-config/src/client.rs
@@ -980,4 +980,80 @@ mod tests {
             BootstrapConfig::SsoCookieVendor(_)
         ));
     }
+
+    #[tokio::test]
+    async fn acquire_cookie_returns_unsupported_when_vault_url_none() {
+        let repo = MockRepository::default();
+        let platform_api = MockPlatformApi::new();
+
+        // Setup config with SsoCookieVendor but vault_url is None
+        let config = ServerCommunicationConfig {
+            bootstrap: BootstrapConfig::SsoCookieVendor(SsoCookieVendorConfig {
+                idp_login_url: Some("https://example.com".to_string()),
+                cookie_name: Some("TestCookie".to_string()),
+                cookie_domain: Some("example.com".to_string()),
+                vault_url: None, // Missing vault_url
+                cookie_value: None,
+            }),
+        };
+        repo.save("vault.example.com".to_string(), config)
+            .await
+            .unwrap();
+
+        // Platform API is ready to return cookies (but shouldn't be called)
+        platform_api
+            .set_cookies(Some(vec![AcquiredCookie {
+                name: "TestCookie".to_string(),
+                value: "value".to_string(),
+            }]))
+            .await;
+
+        let client = ServerCommunicationConfigClient::new(repo, platform_api);
+
+        let result = client.acquire_cookie("vault.example.com").await;
+
+        // Should return UnsupportedConfiguration because vault_url is None
+        assert!(matches!(
+            result,
+            Err(AcquireCookieError::UnsupportedConfiguration)
+        ));
+    }
+
+    #[tokio::test]
+    async fn acquire_cookie_returns_unsupported_when_vault_url_empty() {
+        let repo = MockRepository::default();
+        let platform_api = MockPlatformApi::new();
+
+        // Setup config with SsoCookieVendor but vault_url is empty string
+        let config = ServerCommunicationConfig {
+            bootstrap: BootstrapConfig::SsoCookieVendor(SsoCookieVendorConfig {
+                idp_login_url: Some("https://example.com".to_string()),
+                cookie_name: Some("TestCookie".to_string()),
+                cookie_domain: Some("example.com".to_string()),
+                vault_url: Some("".to_string()), // Empty vault_url
+                cookie_value: None,
+            }),
+        };
+        repo.save("vault.example.com".to_string(), config)
+            .await
+            .unwrap();
+
+        // Platform API is ready to return cookies (but shouldn't be called)
+        platform_api
+            .set_cookies(Some(vec![AcquiredCookie {
+                name: "TestCookie".to_string(),
+                value: "value".to_string(),
+            }]))
+            .await;
+
+        let client = ServerCommunicationConfigClient::new(repo, platform_api);
+
+        let result = client.acquire_cookie("vault.example.com").await;
+
+        // Should return UnsupportedConfiguration because vault_url is empty
+        assert!(matches!(
+            result,
+            Err(AcquireCookieError::UnsupportedConfiguration)
+        ));
+    }
 }

--- a/crates/bitwarden-server-communication-config/src/client.rs
+++ b/crates/bitwarden-server-communication-config/src/client.rs
@@ -134,12 +134,12 @@ where
             .ok_or(AcquireCookieError::UnsupportedConfiguration)?;
 
         // Extract vault_url from vendor_config
-        let vault_url = vendor_config.vault_url.clone();
-
-        // Validate vault_url is not empty
-        if vault_url.is_empty() {
-            return Err(AcquireCookieError::UnsupportedConfiguration);
-        }
+        let vault_url = vendor_config
+            .vault_url
+            .as_ref()
+            .filter(|s| !s.is_empty())
+            .ok_or(AcquireCookieError::UnsupportedConfiguration)?
+            .clone();
 
         // Call platform API to acquire cookies, passing vault_url
         let cookies = self
@@ -279,7 +279,7 @@ mod tests {
                 idp_login_url: Some("https://example.com".to_string()),
                 cookie_name: Some("TestCookie".to_string()),
                 cookie_domain: Some("example.com".to_string()),
-                vault_url: "https://vault.example.com".to_string(),
+                vault_url: Some("https://vault.example.com".to_string()),
                 cookie_value: Some(vec![AcquiredCookie {
                     name: "TestCookie".to_string(),
                     value: "value123".to_string(),
@@ -312,7 +312,7 @@ mod tests {
                 idp_login_url: Some("https://example.com".to_string()),
                 cookie_name: Some("TestCookie".to_string()),
                 cookie_domain: Some("example.com".to_string()),
-                vault_url: "https://vault.example.com".to_string(),
+                vault_url: Some("https://vault.example.com".to_string()),
                 cookie_value: None,
             }),
         };
@@ -338,7 +338,7 @@ mod tests {
                 idp_login_url: Some("https://example.com".to_string()),
                 cookie_name: Some("TestCookie".to_string()),
                 cookie_domain: Some("example.com".to_string()),
-                vault_url: "https://vault.example.com".to_string(),
+                vault_url: Some("https://vault.example.com".to_string()),
                 cookie_value: Some(vec![AcquiredCookie {
                     name: "TestCookie".to_string(),
                     value: "value123".to_string(),
@@ -405,7 +405,7 @@ mod tests {
                 idp_login_url: Some("https://example.com".to_string()),
                 cookie_name: Some("TestCookie".to_string()),
                 cookie_domain: Some("example.com".to_string()),
-                vault_url: "https://vault.example.com".to_string(),
+                vault_url: Some("https://vault.example.com".to_string()),
                 cookie_value: None,
             }),
         };
@@ -429,7 +429,7 @@ mod tests {
                 idp_login_url: Some("https://example.com".to_string()),
                 cookie_name: Some("AWSELBAuthSessionCookie".to_string()),
                 cookie_domain: Some("example.com".to_string()),
-                vault_url: "https://vault.example.com".to_string(),
+                vault_url: Some("https://vault.example.com".to_string()),
                 cookie_value: Some(vec![AcquiredCookie {
                     name: "AWSELBAuthSessionCookie".to_string(),
                     value: "eyJhbGciOiJFUzI1NiIsImtpZCI6Im...".to_string(),
@@ -469,7 +469,7 @@ mod tests {
                 idp_login_url: Some("https://example.com".to_string()),
                 cookie_name: Some("AWSELBAuthSessionCookie".to_string()),
                 cookie_domain: Some("example.com".to_string()),
-                vault_url: "https://vault.example.com".to_string(),
+                vault_url: Some("https://vault.example.com".to_string()),
                 cookie_value: Some(vec![
                     AcquiredCookie {
                         name: "AWSELBAuthSessionCookie-0".to_string(),
@@ -531,7 +531,7 @@ mod tests {
                 idp_login_url: Some("https://example.com".to_string()),
                 cookie_name: Some("TestCookie".to_string()),
                 cookie_domain: Some("example.com".to_string()),
-                vault_url: "https://vault.example.com".to_string(),
+                vault_url: Some("https://vault.example.com".to_string()),
                 cookie_value: None,
             }),
         };
@@ -585,7 +585,7 @@ mod tests {
                 idp_login_url: Some("https://example.com".to_string()),
                 cookie_name: Some("TestCookie".to_string()),
                 cookie_domain: Some("example.com".to_string()),
-                vault_url: "https://vault.example.com".to_string(),
+                vault_url: Some("https://vault.example.com".to_string()),
                 cookie_value: None,
             }),
         };
@@ -646,7 +646,7 @@ mod tests {
                 idp_login_url: Some("https://example.com".to_string()),
                 cookie_name: Some("ExpectedCookie".to_string()),
                 cookie_domain: Some("example.com".to_string()),
-                vault_url: "https://vault.example.com".to_string(),
+                vault_url: Some("https://vault.example.com".to_string()),
                 cookie_value: None,
             }),
         };
@@ -705,7 +705,7 @@ mod tests {
                 idp_login_url: Some("https://example.com".to_string()),
                 cookie_name: Some("AWSELBAuthSessionCookie".to_string()),
                 cookie_domain: Some("example.com".to_string()),
-                vault_url: "https://vault.example.com".to_string(),
+                vault_url: Some("https://vault.example.com".to_string()),
                 cookie_value: None,
             }),
         };
@@ -773,7 +773,7 @@ mod tests {
                 idp_login_url: Some("https://example.com".to_string()),
                 cookie_name: Some("SessionCookie".to_string()),
                 cookie_domain: Some("example.com".to_string()),
-                vault_url: "https://vault.example.com".to_string(),
+                vault_url: Some("https://vault.example.com".to_string()),
                 cookie_value: None,
             }),
         };
@@ -853,7 +853,7 @@ mod tests {
                 idp_login_url: Some("https://idp.example.com/login".to_string()),
                 cookie_name: Some("SessionCookie".to_string()),
                 cookie_domain: Some("vault.example.com".to_string()),
-                vault_url: "https://vault.example.com".to_string(),
+                vault_url: Some("https://vault.example.com".to_string()),
                 cookie_value: None,
             }),
         };
@@ -908,7 +908,7 @@ mod tests {
                 idp_login_url: Some("https://new-idp.example.com/login".to_string()),
                 cookie_name: Some("NewCookie".to_string()),
                 cookie_domain: Some("vault.example.com".to_string()),
-                vault_url: "https://vault.example.com".to_string(),
+                vault_url: Some("https://vault.example.com".to_string()),
                 cookie_value: None,
             }),
         };
@@ -957,7 +957,7 @@ mod tests {
                 idp_login_url: Some("https://idp.example.com/login".to_string()),
                 cookie_name: Some("TestCookie".to_string()),
                 cookie_domain: Some("vault2.example.com".to_string()),
-                vault_url: "https://vault2.example.com".to_string(),
+                vault_url: Some("https://vault2.example.com".to_string()),
                 cookie_value: None,
             }),
         };

--- a/crates/bitwarden-server-communication-config/src/client.rs
+++ b/crates/bitwarden-server-communication-config/src/client.rs
@@ -144,7 +144,7 @@ where
         // Call platform API to acquire cookies, passing vault_url
         let cookies = self
             .platform_api
-            .acquire_cookies(hostname.to_string(), vault_url)
+            .acquire_cookies(vault_url)
             .await
             .ok_or(AcquireCookieError::Cancelled)?;
 
@@ -248,11 +248,7 @@ mod tests {
 
     #[async_trait::async_trait]
     impl ServerCommunicationConfigPlatformApi for MockPlatformApi {
-        async fn acquire_cookies(
-            &self,
-            _hostname: String,
-            _vault_url: String,
-        ) -> Option<Vec<AcquiredCookie>> {
+        async fn acquire_cookies(&self, _vault_url: String) -> Option<Vec<AcquiredCookie>> {
             self.cookies_to_return.read().await.clone()
         }
     }

--- a/crates/bitwarden-server-communication-config/src/client.rs
+++ b/crates/bitwarden-server-communication-config/src/client.rs
@@ -133,10 +133,18 @@ where
             .as_ref()
             .ok_or(AcquireCookieError::UnsupportedConfiguration)?;
 
-        // Call platform API to acquire cookies
+        // Extract vault_url from vendor_config
+        let vault_url = vendor_config.vault_url.clone();
+
+        // Validate vault_url is not empty
+        if vault_url.is_empty() {
+            return Err(AcquireCookieError::UnsupportedConfiguration);
+        }
+
+        // Call platform API to acquire cookies, passing vault_url
         let cookies = self
             .platform_api
-            .acquire_cookies(hostname.to_string())
+            .acquire_cookies(hostname.to_string(), vault_url)
             .await
             .ok_or(AcquireCookieError::Cancelled)?;
 
@@ -240,7 +248,11 @@ mod tests {
 
     #[async_trait::async_trait]
     impl ServerCommunicationConfigPlatformApi for MockPlatformApi {
-        async fn acquire_cookies(&self, _hostname: String) -> Option<Vec<AcquiredCookie>> {
+        async fn acquire_cookies(
+            &self,
+            _hostname: String,
+            _vault_url: String,
+        ) -> Option<Vec<AcquiredCookie>> {
             self.cookies_to_return.read().await.clone()
         }
     }
@@ -267,6 +279,7 @@ mod tests {
                 idp_login_url: Some("https://example.com".to_string()),
                 cookie_name: Some("TestCookie".to_string()),
                 cookie_domain: Some("example.com".to_string()),
+                vault_url: "https://vault.example.com".to_string(),
                 cookie_value: Some(vec![AcquiredCookie {
                     name: "TestCookie".to_string(),
                     value: "value123".to_string(),
@@ -299,6 +312,7 @@ mod tests {
                 idp_login_url: Some("https://example.com".to_string()),
                 cookie_name: Some("TestCookie".to_string()),
                 cookie_domain: Some("example.com".to_string()),
+                vault_url: "https://vault.example.com".to_string(),
                 cookie_value: None,
             }),
         };
@@ -324,6 +338,7 @@ mod tests {
                 idp_login_url: Some("https://example.com".to_string()),
                 cookie_name: Some("TestCookie".to_string()),
                 cookie_domain: Some("example.com".to_string()),
+                vault_url: "https://vault.example.com".to_string(),
                 cookie_value: Some(vec![AcquiredCookie {
                     name: "TestCookie".to_string(),
                     value: "value123".to_string(),
@@ -390,6 +405,7 @@ mod tests {
                 idp_login_url: Some("https://example.com".to_string()),
                 cookie_name: Some("TestCookie".to_string()),
                 cookie_domain: Some("example.com".to_string()),
+                vault_url: "https://vault.example.com".to_string(),
                 cookie_value: None,
             }),
         };
@@ -413,6 +429,7 @@ mod tests {
                 idp_login_url: Some("https://example.com".to_string()),
                 cookie_name: Some("AWSELBAuthSessionCookie".to_string()),
                 cookie_domain: Some("example.com".to_string()),
+                vault_url: "https://vault.example.com".to_string(),
                 cookie_value: Some(vec![AcquiredCookie {
                     name: "AWSELBAuthSessionCookie".to_string(),
                     value: "eyJhbGciOiJFUzI1NiIsImtpZCI6Im...".to_string(),
@@ -452,6 +469,7 @@ mod tests {
                 idp_login_url: Some("https://example.com".to_string()),
                 cookie_name: Some("AWSELBAuthSessionCookie".to_string()),
                 cookie_domain: Some("example.com".to_string()),
+                vault_url: "https://vault.example.com".to_string(),
                 cookie_value: Some(vec![
                     AcquiredCookie {
                         name: "AWSELBAuthSessionCookie-0".to_string(),
@@ -513,6 +531,7 @@ mod tests {
                 idp_login_url: Some("https://example.com".to_string()),
                 cookie_name: Some("TestCookie".to_string()),
                 cookie_domain: Some("example.com".to_string()),
+                vault_url: "https://vault.example.com".to_string(),
                 cookie_value: None,
             }),
         };
@@ -566,6 +585,7 @@ mod tests {
                 idp_login_url: Some("https://example.com".to_string()),
                 cookie_name: Some("TestCookie".to_string()),
                 cookie_domain: Some("example.com".to_string()),
+                vault_url: "https://vault.example.com".to_string(),
                 cookie_value: None,
             }),
         };
@@ -626,6 +646,7 @@ mod tests {
                 idp_login_url: Some("https://example.com".to_string()),
                 cookie_name: Some("ExpectedCookie".to_string()),
                 cookie_domain: Some("example.com".to_string()),
+                vault_url: "https://vault.example.com".to_string(),
                 cookie_value: None,
             }),
         };
@@ -684,6 +705,7 @@ mod tests {
                 idp_login_url: Some("https://example.com".to_string()),
                 cookie_name: Some("AWSELBAuthSessionCookie".to_string()),
                 cookie_domain: Some("example.com".to_string()),
+                vault_url: "https://vault.example.com".to_string(),
                 cookie_value: None,
             }),
         };
@@ -751,6 +773,7 @@ mod tests {
                 idp_login_url: Some("https://example.com".to_string()),
                 cookie_name: Some("SessionCookie".to_string()),
                 cookie_domain: Some("example.com".to_string()),
+                vault_url: "https://vault.example.com".to_string(),
                 cookie_value: None,
             }),
         };
@@ -830,6 +853,7 @@ mod tests {
                 idp_login_url: Some("https://idp.example.com/login".to_string()),
                 cookie_name: Some("SessionCookie".to_string()),
                 cookie_domain: Some("vault.example.com".to_string()),
+                vault_url: "https://vault.example.com".to_string(),
                 cookie_value: None,
             }),
         };
@@ -884,6 +908,7 @@ mod tests {
                 idp_login_url: Some("https://new-idp.example.com/login".to_string()),
                 cookie_name: Some("NewCookie".to_string()),
                 cookie_domain: Some("vault.example.com".to_string()),
+                vault_url: "https://vault.example.com".to_string(),
                 cookie_value: None,
             }),
         };
@@ -932,6 +957,7 @@ mod tests {
                 idp_login_url: Some("https://idp.example.com/login".to_string()),
                 cookie_name: Some("TestCookie".to_string()),
                 cookie_domain: Some("vault2.example.com".to_string()),
+                vault_url: "https://vault2.example.com".to_string(),
                 cookie_value: None,
             }),
         };

--- a/crates/bitwarden-server-communication-config/src/config.rs
+++ b/crates/bitwarden-server-communication-config/src/config.rs
@@ -116,7 +116,7 @@ mod tests {
         assert!(json.contains("ALBAuthSessionCookie"));
 
         // Verify SDK can parse server JSON with camelCase fields
-        let server_json = r#"{"bootstrap":{"type":"ssoCookieVendor","idpLoginUrl":"https://idp.example.com/login","cookieName":"TestCookie","cookieDomain":"example.com"}}"#;
+        let server_json = r#"{"bootstrap":{"type":"ssoCookieVendor","idpLoginUrl":"https://idp.example.com/login","cookieName":"TestCookie","cookieDomain":"example.com","vaultUrl":"https://vault.example.com"}}"#;
         let parsed = serde_json::from_str::<ServerCommunicationConfig>(server_json).unwrap();
         if let BootstrapConfig::SsoCookieVendor(vendor) = parsed.bootstrap {
             assert_eq!(

--- a/crates/bitwarden-server-communication-config/src/config.rs
+++ b/crates/bitwarden-server-communication-config/src/config.rs
@@ -47,6 +47,16 @@ pub struct SsoCookieVendorConfig {
     pub cookie_name: Option<String>,
     /// Cookie domain for validation
     pub cookie_domain: Option<String>,
+    /// Vault URL for cookie acquisition redirect
+    ///
+    /// This is the full vault URL (scheme + host + port) where the browser
+    /// should be redirected for SSO cookie acquisition. Using an explicit
+    /// vault_url fixes two problems:
+    /// 1. Port preservation: localhost:8000 vs localhost (missing port)
+    /// 2. Multi-subdomain: api.bitwarden.com vs vault.bitwarden.com
+    ///
+    /// Extracted from /api/config response.environment.vault field.
+    pub vault_url: String,
     /// Acquired cookies
     ///
     /// For sharded cookies, this contains multiple entries with names like
@@ -62,6 +72,7 @@ impl std::fmt::Debug for SsoCookieVendorConfig {
             .field("idp_login_url", &self.idp_login_url)
             .field("cookie_name", &self.cookie_name)
             .field("cookie_domain", &self.cookie_domain)
+            .field("vault_url", &self.vault_url)
             .field(
                 "cookie_value",
                 &self.cookie_value.as_ref().map(|_| "[REDACTED]"),
@@ -94,6 +105,7 @@ mod tests {
                 idp_login_url: Some("https://timeloop-auth.acme.com/login".to_string()),
                 cookie_name: Some("ALBAuthSessionCookie".to_string()),
                 cookie_domain: Some("vault.example.com".to_string()),
+                vault_url: "https://vault.example.com".to_string(),
                 cookie_value: None,
             }),
         };
@@ -146,6 +158,7 @@ mod tests {
             idp_login_url: Some("https://example.com".to_string()),
             cookie_name: Some("TestCookie".to_string()),
             cookie_domain: Some("example.com".to_string()),
+            vault_url: "https://vault.example.com".to_string(),
             cookie_value: None,
         };
 
@@ -158,6 +171,7 @@ mod tests {
             idp_login_url: Some("https://example.com".to_string()),
             cookie_name: Some("TestCookie".to_string()),
             cookie_domain: Some("example.com".to_string()),
+            vault_url: "https://vault.example.com".to_string(),
             cookie_value: Some(vec![AcquiredCookie {
                 name: "TestCookie".to_string(),
                 value: "eyJhbGciOiJFUzI1NiIsImtpZCI6Im...".to_string(),
@@ -177,6 +191,7 @@ mod tests {
             idp_login_url: Some("https://example.com".to_string()),
             cookie_name: Some("TestCookie".to_string()),
             cookie_domain: Some("example.com".to_string()),
+            vault_url: "https://vault.example.com".to_string(),
             cookie_value: Some(vec![
                 AcquiredCookie {
                     name: "TestCookie-0".to_string(),
@@ -212,6 +227,7 @@ mod tests {
             idp_login_url: Some("https://example.com".to_string()),
             cookie_name: Some("Cookie".to_string()),
             cookie_domain: Some("example.com".to_string()),
+            vault_url: "https://vault.example.com".to_string(),
             cookie_value: None,
         });
         assert!(matches!(vendor, BootstrapConfig::SsoCookieVendor(_)));
@@ -226,6 +242,7 @@ mod tests {
             idp_login_url: Some("https://example.com/login".to_string()),
             cookie_name: Some("SessionCookie".to_string()),
             cookie_domain: Some("example.com".to_string()),
+            vault_url: "https://vault.example.com".to_string(),
             cookie_value: Some(vec![AcquiredCookie {
                 name: "SessionCookie".to_string(),
                 value: "super-secret-cookie-value-abc123".to_string(),

--- a/crates/bitwarden-server-communication-config/src/config.rs
+++ b/crates/bitwarden-server-communication-config/src/config.rs
@@ -50,12 +50,7 @@ pub struct SsoCookieVendorConfig {
     /// Vault URL for cookie acquisition redirect
     ///
     /// This is the full vault URL (scheme + host + port) where the browser
-    /// should be redirected for SSO cookie acquisition. Using an explicit
-    /// vault_url fixes two problems:
-    /// 1. Port preservation: localhost:8000 vs localhost (missing port)
-    /// 2. Multi-subdomain: api.bitwarden.com vs vault.bitwarden.com
-    ///
-    /// Extracted from /api/config response.environment.vault field.
+    /// should be redirected for SSO cookie acquisition.
     pub vault_url: Option<String>,
     /// Acquired cookies
     ///

--- a/crates/bitwarden-server-communication-config/src/config.rs
+++ b/crates/bitwarden-server-communication-config/src/config.rs
@@ -56,7 +56,7 @@ pub struct SsoCookieVendorConfig {
     /// 2. Multi-subdomain: api.bitwarden.com vs vault.bitwarden.com
     ///
     /// Extracted from /api/config response.environment.vault field.
-    pub vault_url: String,
+    pub vault_url: Option<String>,
     /// Acquired cookies
     ///
     /// For sharded cookies, this contains multiple entries with names like
@@ -105,7 +105,7 @@ mod tests {
                 idp_login_url: Some("https://timeloop-auth.acme.com/login".to_string()),
                 cookie_name: Some("ALBAuthSessionCookie".to_string()),
                 cookie_domain: Some("vault.example.com".to_string()),
-                vault_url: "https://vault.example.com".to_string(),
+                vault_url: Some("https://vault.example.com".to_string()),
                 cookie_value: None,
             }),
         };
@@ -158,7 +158,7 @@ mod tests {
             idp_login_url: Some("https://example.com".to_string()),
             cookie_name: Some("TestCookie".to_string()),
             cookie_domain: Some("example.com".to_string()),
-            vault_url: "https://vault.example.com".to_string(),
+            vault_url: Some("https://vault.example.com".to_string()),
             cookie_value: None,
         };
 
@@ -171,7 +171,7 @@ mod tests {
             idp_login_url: Some("https://example.com".to_string()),
             cookie_name: Some("TestCookie".to_string()),
             cookie_domain: Some("example.com".to_string()),
-            vault_url: "https://vault.example.com".to_string(),
+            vault_url: Some("https://vault.example.com".to_string()),
             cookie_value: Some(vec![AcquiredCookie {
                 name: "TestCookie".to_string(),
                 value: "eyJhbGciOiJFUzI1NiIsImtpZCI6Im...".to_string(),
@@ -191,7 +191,7 @@ mod tests {
             idp_login_url: Some("https://example.com".to_string()),
             cookie_name: Some("TestCookie".to_string()),
             cookie_domain: Some("example.com".to_string()),
-            vault_url: "https://vault.example.com".to_string(),
+            vault_url: Some("https://vault.example.com".to_string()),
             cookie_value: Some(vec![
                 AcquiredCookie {
                     name: "TestCookie-0".to_string(),
@@ -227,7 +227,7 @@ mod tests {
             idp_login_url: Some("https://example.com".to_string()),
             cookie_name: Some("Cookie".to_string()),
             cookie_domain: Some("example.com".to_string()),
-            vault_url: "https://vault.example.com".to_string(),
+            vault_url: Some("https://vault.example.com".to_string()),
             cookie_value: None,
         });
         assert!(matches!(vendor, BootstrapConfig::SsoCookieVendor(_)));
@@ -242,7 +242,7 @@ mod tests {
             idp_login_url: Some("https://example.com/login".to_string()),
             cookie_name: Some("SessionCookie".to_string()),
             cookie_domain: Some("example.com".to_string()),
-            vault_url: "https://vault.example.com".to_string(),
+            vault_url: Some("https://vault.example.com".to_string()),
             cookie_value: Some(vec![AcquiredCookie {
                 name: "SessionCookie".to_string(),
                 value: "super-secret-cookie-value-abc123".to_string(),

--- a/crates/bitwarden-server-communication-config/src/platform_api.rs
+++ b/crates/bitwarden-server-communication-config/src/platform_api.rs
@@ -71,8 +71,8 @@ pub trait ServerCommunicationConfigPlatformApi: Send + Sync {
     ///
     /// # Parameters
     /// - `hostname`: The API hostname (e.g., "api.bitwarden.com" or "localhost")
-    /// - `vault_url`: The full vault URL (scheme + host + port, e.g., "https://vault.bitwarden.com"
-    ///   or "https://localhost:8000")
+    /// - `vault_url`: The full vault URL (scheme + host + port, e.g., `"https://vault.bitwarden.com"`
+    ///   or `"https://localhost:8000"`)
     ///
     /// The `vault_url` parameter should be used for constructing the redirect URL
     /// instead of deriving it from `hostname`. This ensures port preservation

--- a/crates/bitwarden-server-communication-config/src/platform_api.rs
+++ b/crates/bitwarden-server-communication-config/src/platform_api.rs
@@ -69,16 +69,21 @@ pub trait ServerCommunicationConfigPlatformApi: Send + Sync {
     /// (e.g., browser redirect to IdP) to acquire cookies from the
     /// load balancer.
     ///
-    /// For sharded cookies, the platform should return multiple `AcquiredCookie`
-    /// entries, each with its full name including the `-{N}` suffix.
+    /// # Parameters
+    /// - `hostname`: The API hostname (e.g., "api.bitwarden.com" or "localhost")
+    /// - `vault_url`: The full vault URL (scheme + host + port, e.g., "https://vault.bitwarden.com" or "https://localhost:8000")
     ///
-    /// # Arguments
-    ///
-    /// * `hostname` - The server hostname (e.g., "vault.acme.com")
+    /// The `vault_url` parameter should be used for constructing the redirect URL
+    /// instead of deriving it from `hostname`. This ensures port preservation
+    /// (localhost:8000 vs localhost) and correct subdomain usage (vault.bitwarden.com
+    /// vs api.bitwarden.com).
     ///
     /// # Returns
-    ///
-    /// - `Some(cookies)` - Cookies were successfully acquired
-    /// - `None` - Cookie acquisition failed or was cancelled
-    async fn acquire_cookies(&self, hostname: String) -> Option<Vec<AcquiredCookie>>;
+    /// Returns `Some(Vec<AcquiredCookie>)` if cookies were successfully acquired,
+    /// or `None` if the operation was cancelled or failed.
+    async fn acquire_cookies(
+        &self,
+        hostname: String,
+        vault_url: String,
+    ) -> Option<Vec<AcquiredCookie>>;
 }

--- a/crates/bitwarden-server-communication-config/src/platform_api.rs
+++ b/crates/bitwarden-server-communication-config/src/platform_api.rs
@@ -75,9 +75,7 @@ pub trait ServerCommunicationConfigPlatformApi: Send + Sync {
     ///   or `"https://localhost:8000"`)
     ///
     /// The `vault_url` parameter should be used for constructing the redirect URL
-    /// instead of deriving it from `hostname`. This ensures port preservation
-    /// (localhost:8000 vs localhost) and correct subdomain usage (vault.bitwarden.com
-    /// vs api.bitwarden.com).
+    /// instead of deriving it from `hostname`.
     ///
     /// # Returns
     /// Returns `Some(Vec<AcquiredCookie>)` if cookies were successfully acquired,

--- a/crates/bitwarden-server-communication-config/src/platform_api.rs
+++ b/crates/bitwarden-server-communication-config/src/platform_api.rs
@@ -63,26 +63,18 @@ pub enum AcquireCookieError {
 #[cfg_attr(feature = "uniffi", uniffi::export(with_foreign))]
 #[async_trait::async_trait]
 pub trait ServerCommunicationConfigPlatformApi: Send + Sync {
-    /// Acquires cookies for the given hostname
+    /// Acquires cookies using the provided vault URL
     ///
     /// The platform client should trigger any necessary user interaction
     /// (e.g., browser redirect to IdP) to acquire cookies from the
     /// load balancer.
     ///
     /// # Parameters
-    /// - `hostname`: The API hostname (e.g., "api.bitwarden.com" or "localhost")
     /// - `vault_url`: The full vault URL (scheme + host + port, e.g., `"https://vault.bitwarden.com"`
-    ///   or `"https://localhost:8000"`)
-    ///
-    /// The `vault_url` parameter should be used for constructing the redirect URL
-    /// instead of deriving it from `hostname`.
+    ///   or `"https://localhost:8000"`). This URL is used for constructing the redirect URL.
     ///
     /// # Returns
     /// Returns `Some(Vec<AcquiredCookie>)` if cookies were successfully acquired,
     /// or `None` if the operation was cancelled or failed.
-    async fn acquire_cookies(
-        &self,
-        hostname: String,
-        vault_url: String,
-    ) -> Option<Vec<AcquiredCookie>>;
+    async fn acquire_cookies(&self, vault_url: String) -> Option<Vec<AcquiredCookie>>;
 }

--- a/crates/bitwarden-server-communication-config/src/platform_api.rs
+++ b/crates/bitwarden-server-communication-config/src/platform_api.rs
@@ -71,7 +71,8 @@ pub trait ServerCommunicationConfigPlatformApi: Send + Sync {
     ///
     /// # Parameters
     /// - `hostname`: The API hostname (e.g., "api.bitwarden.com" or "localhost")
-    /// - `vault_url`: The full vault URL (scheme + host + port, e.g., "https://vault.bitwarden.com" or "https://localhost:8000")
+    /// - `vault_url`: The full vault URL (scheme + host + port, e.g., "https://vault.bitwarden.com"
+    ///   or "https://localhost:8000")
     ///
     /// The `vault_url` parameter should be used for constructing the redirect URL
     /// instead of deriving it from `hostname`. This ensures port preservation

--- a/crates/bitwarden-server-communication-config/src/repository.rs
+++ b/crates/bitwarden-server-communication-config/src/repository.rs
@@ -112,6 +112,7 @@ mod tests {
                 idp_login_url: Some("https://example.com/login".to_string()),
                 cookie_name: Some("TestCookie".to_string()),
                 cookie_domain: Some("example.com".to_string()),
+                vault_url: "https://vault.example.com".to_string(),
                 cookie_value: Some(vec![AcquiredCookie {
                     name: "TestCookie".to_string(),
                     value: "cookie-value-123".to_string(),
@@ -161,6 +162,7 @@ mod tests {
                 idp_login_url: Some("https://example.com".to_string()),
                 cookie_name: Some("Cookie".to_string()),
                 cookie_domain: Some("example.com".to_string()),
+                vault_url: "https://vault.example.com".to_string(),
                 cookie_value: None,
             }),
         };
@@ -192,6 +194,7 @@ mod tests {
                 idp_login_url: Some("https://example.com".to_string()),
                 cookie_name: Some("Cookie".to_string()),
                 cookie_domain: Some("example.com".to_string()),
+                vault_url: "https://vault.example.com".to_string(),
                 cookie_value: None,
             }),
         };

--- a/crates/bitwarden-server-communication-config/src/repository.rs
+++ b/crates/bitwarden-server-communication-config/src/repository.rs
@@ -112,7 +112,7 @@ mod tests {
                 idp_login_url: Some("https://example.com/login".to_string()),
                 cookie_name: Some("TestCookie".to_string()),
                 cookie_domain: Some("example.com".to_string()),
-                vault_url: "https://vault.example.com".to_string(),
+                vault_url: Some("https://vault.example.com".to_string()),
                 cookie_value: Some(vec![AcquiredCookie {
                     name: "TestCookie".to_string(),
                     value: "cookie-value-123".to_string(),
@@ -162,7 +162,7 @@ mod tests {
                 idp_login_url: Some("https://example.com".to_string()),
                 cookie_name: Some("Cookie".to_string()),
                 cookie_domain: Some("example.com".to_string()),
-                vault_url: "https://vault.example.com".to_string(),
+                vault_url: Some("https://vault.example.com".to_string()),
                 cookie_value: None,
             }),
         };
@@ -194,7 +194,7 @@ mod tests {
                 idp_login_url: Some("https://example.com".to_string()),
                 cookie_name: Some("Cookie".to_string()),
                 cookie_domain: Some("example.com".to_string()),
-                vault_url: "https://vault.example.com".to_string(),
+                vault_url: Some("https://vault.example.com".to_string()),
                 cookie_value: None,
             }),
         };

--- a/crates/bitwarden-server-communication-config/src/wasm/js_platform_api.rs
+++ b/crates/bitwarden-server-communication-config/src/wasm/js_platform_api.rs
@@ -14,15 +14,16 @@ const TS_CUSTOM_TYPES: &'static str = r#"
 export interface ServerCommunicationConfigPlatformApi {
     /**
      * Acquires cookies for the given hostname.
-     * 
+     *
      * This typically involves redirecting to an IdP login page and extracting
      * cookies from the load balancer response. For sharded cookies, returns
      * multiple entries with names like "CookieName-0", "CookieName-1", etc.
-     * 
+     *
      * @param hostname The server hostname (e.g., "vault.acme.com")
+     * @param vaultUrl The full vault URL (e.g., "https://vault.bitwarden.com" or "https://localhost:8000")
      * @returns An array of AcquiredCookie objects, or undefined if acquisition failed or was cancelled
      */
-    acquireCookies(hostname: string): Promise<AcquiredCookie[] | undefined>;
+    acquireCookies(hostname: string, vaultUrl: string): Promise<AcquiredCookie[] | undefined>;
 }
 "#;
 
@@ -40,6 +41,7 @@ extern "C" {
     pub async fn acquire_cookies(
         this: &RawJsServerCommunicationConfigPlatformApi,
         hostname: String,
+        vault_url: String,
     ) -> Result<JsValue, JsValue>;
 }
 
@@ -68,11 +70,15 @@ impl Clone for JsServerCommunicationConfigPlatformApi {
 
 #[async_trait::async_trait]
 impl ServerCommunicationConfigPlatformApi for JsServerCommunicationConfigPlatformApi {
-    async fn acquire_cookies(&self, hostname: String) -> Option<Vec<AcquiredCookie>> {
+    async fn acquire_cookies(
+        &self,
+        hostname: String,
+        vault_url: String,
+    ) -> Option<Vec<AcquiredCookie>> {
         self.0
             .run_in_thread(move |platform_api| async move {
                 let js_value = platform_api
-                    .acquire_cookies(hostname)
+                    .acquire_cookies(hostname, vault_url)
                     .await
                     .map_err(|e| format!("{e:?}"))?;
 

--- a/crates/bitwarden-server-communication-config/src/wasm/js_platform_api.rs
+++ b/crates/bitwarden-server-communication-config/src/wasm/js_platform_api.rs
@@ -13,17 +13,16 @@ const TS_CUSTOM_TYPES: &'static str = r#"
  */
 export interface ServerCommunicationConfigPlatformApi {
     /**
-     * Acquires cookies for the given hostname.
+     * Acquires cookies using the provided vault URL.
      *
      * This typically involves redirecting to an IdP login page and extracting
      * cookies from the load balancer response. For sharded cookies, returns
      * multiple entries with names like "CookieName-0", "CookieName-1", etc.
      *
-     * @param hostname The server hostname (e.g., "vault.acme.com")
      * @param vaultUrl The full vault URL (e.g., "https://vault.bitwarden.com" or "https://localhost:8000")
      * @returns An array of AcquiredCookie objects, or undefined if acquisition failed or was cancelled
      */
-    acquireCookies(hostname: string, vaultUrl: string): Promise<AcquiredCookie[] | undefined>;
+    acquireCookies(vaultUrl: string): Promise<AcquiredCookie[] | undefined>;
 }
 "#;
 
@@ -40,7 +39,6 @@ extern "C" {
     #[wasm_bindgen(catch, method, structural, js_name = acquireCookies)]
     pub async fn acquire_cookies(
         this: &RawJsServerCommunicationConfigPlatformApi,
-        hostname: String,
         vault_url: String,
     ) -> Result<JsValue, JsValue>;
 }
@@ -70,15 +68,11 @@ impl Clone for JsServerCommunicationConfigPlatformApi {
 
 #[async_trait::async_trait]
 impl ServerCommunicationConfigPlatformApi for JsServerCommunicationConfigPlatformApi {
-    async fn acquire_cookies(
-        &self,
-        hostname: String,
-        vault_url: String,
-    ) -> Option<Vec<AcquiredCookie>> {
+    async fn acquire_cookies(&self, vault_url: String) -> Option<Vec<AcquiredCookie>> {
         self.0
             .run_in_thread(move |platform_api| async move {
                 let js_value = platform_api
-                    .acquire_cookies(hostname, vault_url)
+                    .acquire_cookies(vault_url)
                     .await
                     .map_err(|e| format!("{e:?}"))?;
 

--- a/crates/bitwarden-uniffi/src/platform/server_communication_config.rs
+++ b/crates/bitwarden-uniffi/src/platform/server_communication_config.rs
@@ -137,7 +137,11 @@ impl<T: std::fmt::Debug> std::fmt::Debug for UniffiPlatformApiBridge<T> {
 impl<'a> ServerCommunicationConfigPlatformApi
     for UniffiPlatformApiBridge<Arc<dyn ServerCommunicationConfigPlatformApi + 'a>>
 {
-    async fn acquire_cookies(&self, hostname: String) -> Option<Vec<AcquiredCookie>> {
-        self.0.acquire_cookies(hostname).await
+    async fn acquire_cookies(
+        &self,
+        hostname: String,
+        vault_url: String,
+    ) -> Option<Vec<AcquiredCookie>> {
+        self.0.acquire_cookies(hostname, vault_url).await
     }
 }

--- a/crates/bitwarden-uniffi/src/platform/server_communication_config.rs
+++ b/crates/bitwarden-uniffi/src/platform/server_communication_config.rs
@@ -137,11 +137,7 @@ impl<T: std::fmt::Debug> std::fmt::Debug for UniffiPlatformApiBridge<T> {
 impl<'a> ServerCommunicationConfigPlatformApi
     for UniffiPlatformApiBridge<Arc<dyn ServerCommunicationConfigPlatformApi + 'a>>
 {
-    async fn acquire_cookies(
-        &self,
-        hostname: String,
-        vault_url: String,
-    ) -> Option<Vec<AcquiredCookie>> {
-        self.0.acquire_cookies(hostname, vault_url).await
+    async fn acquire_cookies(&self, vault_url: String) -> Option<Vec<AcquiredCookie>> {
+        self.0.acquire_cookies(vault_url).await
     }
 }

--- a/crates/bitwarden-uniffi/swift/iOS/App/ContentView.swift
+++ b/crates/bitwarden-uniffi/swift/iOS/App/ContentView.swift
@@ -386,6 +386,7 @@ struct ContentView: View {
                     idpLoginUrl: "https://example.com/login",
                     cookieName: "TestCookie",
                     cookieDomain: "example.com",
+                    vaultUrl: "https://example.com",
                     cookieValue: nil
                 )
             )


### PR DESCRIPTION
## 🎟️ Tracking

- https://bitwarden.atlassian.net/browse/PM-33352
- https://github.com/bitwarden/clients/pull/19469

## 📔 Objective

Add an explicit `vault_url` field to `SsoCookieVendorConfig` to allow more flexibility in what servers are supported by this cookie flow.

The `vault_url` is extracted from the `/api/config` response's `environment.vault` field by clients and provides the explicit full URL (scheme + host + port) for the browser redirect. This replaces implicit URL construction that was failing to preserve ports, handle subdomain variations, etc.

## 🚨 Breaking Changes

- `SsoCookieVendorConfig` struct now requries a new `vault_url` field

- The parameter sent into `acquireCookies` is changed from `hostname` to `vaultUrl`. This should be used to construct the browser link: `${vaultUrl}/proxy-cookie-redirect-connector.html` instead of relying on `EnvironmentService` which is prone to edge-case bugs