### PR TITLE
[PM-33374] Add CiphersClient::get_all(), which mimics list() but returns CipherView instead of CipherListView

### DIFF
--- a/crates/bitwarden-vault/src/cipher/cipher_client/get.rs
+++ b/crates/bitwarden-vault/src/cipher/cipher_client/get.rs
@@ -7,7 +7,10 @@ use thiserror::Error;
 use wasm_bindgen::prelude::wasm_bindgen;
 
 use super::CiphersClient;
-use crate::{Cipher, CipherView, ItemNotFoundError, cipher::cipher::DecryptCipherListResult};
+use crate::{
+    Cipher, CipherView, ItemNotFoundError,
+    cipher::cipher::{DecryptCipherListResult, DecryptCipherResult},
+};
 
 #[allow(missing_docs)]
 #[bitwarden_error(flat)]
@@ -44,16 +47,38 @@ async fn list_ciphers(
     })
 }
 
+async fn get_all_ciphers(
+    store: &KeyStore<KeyIds>,
+    repository: &dyn Repository<Cipher>,
+) -> Result<DecryptCipherResult, GetCipherError> {
+    let ciphers = repository.list().await?;
+    let (successes, failures) = store.decrypt_list_with_failures(&ciphers);
+    Ok(DecryptCipherResult {
+        successes,
+        failures: failures.into_iter().cloned().collect(),
+    })
+}
+
 #[cfg_attr(feature = "wasm", wasm_bindgen)]
 impl CiphersClient {
-    /// Get all ciphers from state and decrypt them, returning both successes and failures.
-    /// This method will not fail when some ciphers fail to decrypt, allowing for graceful
-    /// handling of corrupted or problematic cipher data.
+    /// Get all ciphers from state and decrypt them to [CipherListView], returning both successes
+    /// and failures. This method will not fail when some ciphers fail to decrypt, allowing
+    /// for graceful handling of corrupted or problematic cipher data.
     pub async fn list(&self) -> Result<DecryptCipherListResult, GetCipherError> {
         let key_store = self.client.internal.get_key_store();
         let repository = self.get_repository()?;
 
         list_ciphers(key_store, repository.as_ref()).await
+    }
+
+    /// Get all ciphers from state and decrypt them to full [CipherView], returning both
+    /// successes and failures. This method will not fail when some ciphers fail to decrypt,
+    /// allowing for graceful handling of corrupted or problematic cipher data.
+    pub async fn get_all(&self) -> Result<DecryptCipherResult, GetCipherError> {
+        let key_store = self.client.internal.get_key_store();
+        let repository = self.get_repository()?;
+
+        get_all_ciphers(key_store, repository.as_ref()).await
     }
 
     /// Get [Cipher] by ID from state and decrypt it to a [CipherView].

--- a/crates/bitwarden-vault/src/cipher/cipher_client/get.rs
+++ b/crates/bitwarden-vault/src/cipher/cipher_client/get.rs
@@ -61,9 +61,9 @@ async fn get_all_ciphers(
 
 #[cfg_attr(feature = "wasm", wasm_bindgen)]
 impl CiphersClient {
-    /// Get all ciphers from state and decrypt them to [CipherListView], returning both successes
-    /// and failures. This method will not fail when some ciphers fail to decrypt, allowing
-    /// for graceful handling of corrupted or problematic cipher data.
+    /// Get all ciphers from state and decrypt them to [crate::CipherListView], returning both
+    /// successes and failures. This method will not fail when some ciphers fail to decrypt,
+    /// allowing for graceful handling of corrupted or problematic cipher data.
     pub async fn list(&self) -> Result<DecryptCipherListResult, GetCipherError> {
         let key_store = self.client.internal.get_key_store();
         let repository = self.get_repository()?;

--- a/crates/bitwarden-vault/src/cipher/mod.rs
+++ b/crates/bitwarden-vault/src/cipher/mod.rs
@@ -21,7 +21,7 @@ pub use attachment_client::{AttachmentsClient, DecryptFileError, EncryptFileErro
 pub use card::{CardBrand, CardListView, CardView};
 pub use cipher::{
     Cipher, CipherError, CipherId, CipherListView, CipherListViewType, CipherRepromptType,
-    CipherType, CipherView, DecryptCipherListResult, EncryptionContext,
+    CipherType, CipherView, DecryptCipherListResult, DecryptCipherResult, EncryptionContext,
     ListOrganizationCiphersResult,
 };
 pub use cipher_client::CiphersClient;


### PR DESCRIPTION
## 🎟️ Tracking
 
https://bitwarden.atlassian.net/browse/PM-33374

## 📔 Objective

CiphersClient::list() returns a CipherListView[], when the web client expects a CipherView[]. Since CipherListView is needed for some clients for performance reasons, this adds a separate method get_all(), which deals with CipherViews. It's otherwise identical to the list() implementation.
