### PR TITLE
Fix build for uniffi targets

### DIFF
--- a/crates/bitwarden-vault/src/cipher/cipher.rs
+++ b/crates/bitwarden-vault/src/cipher/cipher.rs
@@ -498,9 +498,9 @@ pub struct DecryptCipherListResult {
 /// This struct contains two vectors: `successes` and `failures`.
 /// `successes` contains the decrypted `CipherView` objects,
 /// while `failures` contains the original `Cipher` objects that failed to decrypt.
-#[cfg(feature = "wasm")]
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
+#[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
 #[cfg_attr(feature = "wasm", derive(Tsify), tsify(into_wasm_abi, from_wasm_abi))]
 pub struct DecryptCipherResult {
     /// The decrypted `CipherView` objects.


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-33427

## 📔 Objective

Fixes the uniffi builds by removing feature checks for the `DecryptCipherResult` type.
