### PR TITLE
[PM-33554] Fix emergency access key-rotation

### DIFF
--- a/crates/bitwarden-user-crypto-management/src/key_rotation/unlock.rs
+++ b/crates/bitwarden-user-crypto-management/src/key_rotation/unlock.rs
@@ -190,8 +190,10 @@ fn reencrypt_emergency_access_keys(
             // and the passed in public-key must be verified/trusted.
             match UnsignedSharedKey::encapsulate(new_user_key_id, &ea.public_key, ctx) {
                 Ok(reencrypted_key) => Ok(EmergencyAccessWithIdRequestModel {
+                    // Default value that is ignored on the server
                     r#type: models::EmergencyAccessType::Takeover,
-                    wait_time_days: 0,
+                    // Default value that is ignored on the server
+                    wait_time_days: 1,
                     id: ea.id,
                     key_encrypted: reencrypted_key.to_string().into(),
                 }),


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-33554

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
Fixes key-rotation for emergency access. Emergency access on the server validates the wait time on the server model. However, the value is completely unused for key-rotation, and we just set default values here. We should replace the model with a key-rotation specific model which drops these fields in the future.

## 🚨 Breaking Changes

<!-- Does this PR introduce any breaking changes? If so, please describe the impact and migration path for clients.

If you're unsure, the automated TypeScript compatibility check will run when you open/update this PR and provide feedback.

For breaking changes:
1. Describe what changed in the client interface
2. Explain why the change was necessary
3. Provide migration steps for client developers
4. Link to any paired client PRs if needed

Otherwise, you can remove this section. -->
