### PR TITLE
[PM-33554] Fix passkey key-rotation when encryption is not supported

### DIFF
--- a/crates/bitwarden-user-crypto-management/src/key_rotation/sync.rs
+++ b/crates/bitwarden-user-crypto-management/src/key_rotation/sync.rs
@@ -378,6 +378,7 @@ mod tests {
             ProfileResponseModel, PublicKeyEncryptionKeyPairResponseModel, SendResponseModel,
             SendType, SyncResponseModel, UserDecryptionResponseModel, UserKeyResponseModel,
             WebAuthnCredentialResponseModel, WebAuthnCredentialResponseModelListResponseModel,
+            WebAuthnPrfStatus,
         },
     };
     use bitwarden_encoding::B64;
@@ -595,6 +596,7 @@ mod tests {
             object: None,
             data: Some(vec![WebAuthnCredentialResponseModel {
                 id: Some(passkey_id.to_string()),
+                prf_status: Some(WebAuthnPrfStatus::Enabled),
                 encrypted_user_key: Some(TEST_UNSIGNED_SHARED_KEY.to_string()),
                 encrypted_public_key: Some(TEST_ENC_STRING.to_string()),
                 ..WebAuthnCredentialResponseModel::new()
@@ -954,18 +956,21 @@ mod tests {
                     data: Some(vec![
                         WebAuthnCredentialResponseModel {
                             id: Some(passkey_id1.to_string()),
+                            prf_status: Some(WebAuthnPrfStatus::Enabled),
                             encrypted_user_key: Some(TEST_UNSIGNED_SHARED_KEY.to_string()),
                             encrypted_public_key: Some(TEST_ENC_STRING.to_string()),
                             ..WebAuthnCredentialResponseModel::new()
                         },
                         WebAuthnCredentialResponseModel {
                             id: Some(passkey_id2.to_string()),
+                            prf_status: Some(WebAuthnPrfStatus::Enabled),
                             encrypted_user_key: Some(TEST_UNSIGNED_SHARED_KEY.to_string()),
                             encrypted_public_key: Some(TEST_ENC_STRING.to_string()),
                             ..WebAuthnCredentialResponseModel::new()
                         },
                         WebAuthnCredentialResponseModel {
                             id: Some(passkey_id3.to_string()),
+                            prf_status: Some(WebAuthnPrfStatus::Enabled),
                             encrypted_user_key: Some(TEST_UNSIGNED_SHARED_KEY.to_string()),
                             encrypted_public_key: Some(TEST_ENC_STRING.to_string()),
                             ..WebAuthnCredentialResponseModel::new()
@@ -995,6 +1000,73 @@ mod tests {
                 TEST_UNSIGNED_SHARED_KEY.to_string()
             );
         }
+
+        if let ApiClient::Mock(mut mock) = api_client {
+            mock.web_authn_api.checkpoint();
+        }
+    }
+
+    #[tokio::test]
+    async fn test_sync_passkeys_filters_passkeys_without_prf_encryption_enabled() {
+        let enabled_passkey_id = uuid::Uuid::new_v4();
+        let supported_passkey_id = uuid::Uuid::new_v4();
+        let unsupported_passkey_id = uuid::Uuid::new_v4();
+        let no_prf_status_passkey_id = uuid::Uuid::new_v4();
+
+        let api_client = ApiClient::new_mocked(|mock| {
+            mock.web_authn_api.expect_get().once().returning(move || {
+                Ok(WebAuthnCredentialResponseModelListResponseModel {
+                    object: None,
+                    data: Some(vec![
+                        WebAuthnCredentialResponseModel {
+                            id: Some(enabled_passkey_id.to_string()),
+                            prf_status: Some(WebAuthnPrfStatus::Enabled),
+                            encrypted_user_key: Some(TEST_UNSIGNED_SHARED_KEY.to_string()),
+                            encrypted_public_key: Some(TEST_ENC_STRING.to_string()),
+                            ..WebAuthnCredentialResponseModel::new()
+                        },
+                        WebAuthnCredentialResponseModel {
+                            id: Some(supported_passkey_id.to_string()),
+                            prf_status: Some(WebAuthnPrfStatus::Supported),
+                            // Non-enabled passkeys may not contain encryption material.
+                            encrypted_user_key: None,
+                            encrypted_public_key: None,
+                            ..WebAuthnCredentialResponseModel::new()
+                        },
+                        WebAuthnCredentialResponseModel {
+                            id: Some(unsupported_passkey_id.to_string()),
+                            prf_status: Some(WebAuthnPrfStatus::Unsupported),
+                            encrypted_user_key: None,
+                            encrypted_public_key: None,
+                            ..WebAuthnCredentialResponseModel::new()
+                        },
+                        WebAuthnCredentialResponseModel {
+                            id: Some(no_prf_status_passkey_id.to_string()),
+                            prf_status: None,
+                            encrypted_user_key: None,
+                            encrypted_public_key: None,
+                            ..WebAuthnCredentialResponseModel::new()
+                        },
+                    ]),
+                    continuation_token: None,
+                })
+            });
+        });
+
+        let result = sync_passkeys(&api_client).await;
+        let passkeys = result.unwrap();
+
+        // Only passkeys with PRF encryption enabled should be included.
+        assert_eq!(passkeys.len(), 1);
+        assert_eq!(passkeys[0].id, enabled_passkey_id);
+        assert_eq!(
+            passkeys[0].encrypted_public_key.to_string(),
+            TEST_ENC_STRING.to_string()
+        );
+        assert_eq!(
+            passkeys[0].encrypted_user_key.to_string(),
+            TEST_UNSIGNED_SHARED_KEY.to_string()
+        );
 
         if let ApiClient::Mock(mut mock) = api_client {
             mock.web_authn_api.checkpoint();

--- a/crates/bitwarden-user-crypto-management/src/key_rotation/sync.rs
+++ b/crates/bitwarden-user-crypto-management/src/key_rotation/sync.rs
@@ -1,7 +1,7 @@
 //! Functionality for syncing the latest account data from the server
 use std::str::FromStr;
 
-use bitwarden_api_api::apis::ApiClient;
+use bitwarden_api_api::{apis::ApiClient, models::WebAuthnPrfStatus};
 use bitwarden_core::key_management::account_cryptographic_state::WrappedAccountCryptographicState;
 use bitwarden_crypto::{EncString, Kdf, PublicKey, SpkiPublicKeyBytes, UnsignedSharedKey};
 use bitwarden_encoding::B64;
@@ -177,6 +177,7 @@ async fn sync_passkeys(api_client: &ApiClient) -> Result<Vec<PartialRotateableKe
         .data
         .ok_or(SyncError::DataError)?
         .into_iter()
+        .filter(|cred| cred.prf_status == Some(WebAuthnPrfStatus::Enabled))
         .map(|cred| {
             Ok(PartialRotateableKeyset {
                 id: Uuid::from_str(&cred.id.ok_or(SyncError::DataError)?)


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-33554

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
Passkey rotation only is supported for passkeys that have encryption enabled. Other passkeys don't have a rotateable key set which results in a dataerror being returned. This PR filters out the passkeys that don't support encryption.

This is verified with a unit test for all 4 cases which the passkey prf status value can have.

## 🚨 Breaking Changes

<!-- Does this PR introduce any breaking changes? If so, please describe the impact and migration path for clients.

If you're unsure, the automated TypeScript compatibility check will run when you open/update this PR and provide feedback.

For breaking changes:
1. Describe what changed in the client interface
2. Explain why the change was necessary
3. Provide migration steps for client developers
4. Link to any paired client PRs if needed

Otherwise, you can remove this section. -->
