### PR TITLE
[PM-33764] Annotate KeyIds with #[must_use]

### DIFF
--- a/crates/bitwarden-crypto/examples/protect_key_with_password.rs
+++ b/crates/bitwarden-crypto/examples/protect_key_with_password.rs
@@ -47,7 +47,7 @@ fn main() {
             .expect("Loading from disk should work"),
     )
     .expect("Deserializing envelope should work");
-    deserialized
+    let _unsealed_vault_key = deserialized
         .unseal(
             pin,
             PasswordProtectedKeyEnvelopeNamespace::PinUnlock,

--- a/crates/bitwarden-crypto/src/traits/key_id.rs
+++ b/crates/bitwarden-crypto/src/traits/key_id.rs
@@ -97,6 +97,7 @@ macro_rules! key_ids {
         use $crate::LocalId;
 
         $(
+            #[must_use]
             #[derive(std::fmt::Debug, Clone, Copy, std::hash::Hash, Eq, PartialEq, Ord, PartialOrd)]
             #[allow(missing_docs)]
             $vis enum $name { $(

--- a/crates/bitwarden-vault/src/cipher/cipher.rs
+++ b/crates/bitwarden-vault/src/cipher/cipher.rs
@@ -1557,7 +1557,8 @@ mod tests {
         // Make sure that the cipher key is decryptable
         let wrapped_key = original_cipher.key.unwrap();
         let mut ctx = key_store.context();
-        ctx.unwrap_symmetric_key(SymmetricKeyId::User, &wrapped_key)
+        let _ = ctx
+            .unwrap_symmetric_key(SymmetricKeyId::User, &wrapped_key)
             .unwrap();
     }
 


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-33764

## 📔 Objective

While testing an unrelated change, I noticed that functions in `KeyStoreContext` returning `KeyId`s weren't annotated with `#[must_use]`.

Since these `KeyId`s are often local and intended to be consumed by the caller, silently discarding the return value is a programming error in a lot of cases. Adding `#[must_use]` surfaces these cases as warnings at compile time:

```
warning: unused `ExampleSymmetricKey` that must be used
  --> crates/bitwarden-crypto/examples/protect_key_with_password.rs:50:5
   |
50 | /     deserialized
51 | |         .unseal(
52 | |             pin,
53 | |             PasswordProtectedKeyEnvelopeNamespace::PinUnlock,
...  |
56 | |         .expect("Unsealing should work");
   | |________________________________________^
   |
   = note: `#[warn(unused_must_use)]` (part of `#[warn(unused)]`) on by default
help: use `let _ = ...` to ignore the resulting value
   |
50 |     let _ = deserialized
   |     +++++++
```

## 🚨 Breaking Changes

<!-- Does this PR introduce any breaking changes? If so, please describe the impact and migration path for clients.

If you're unsure, the automated TypeScript compatibility check will run when you open/update this PR and provide feedback.

For breaking changes:
1. Describe what changed in the client interface
2. Explain why the change was necessary
3. Provide migration steps for client developers
4. Link to any paired client PRs if needed

Otherwise, you can remove this section. -->
