### PR TITLE
[PM-27126] Add cookie to fetch requests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -846,6 +846,7 @@ dependencies = [
 name = "bitwarden-pm"
 version = "2.0.0"
 dependencies = [
+ "async-trait",
  "bitwarden-auth",
  "bitwarden-commercial-vault",
  "bitwarden-core",
@@ -853,9 +854,11 @@ dependencies = [
  "bitwarden-fido",
  "bitwarden-generators",
  "bitwarden-send",
+ "bitwarden-server-communication-config",
  "bitwarden-state",
  "bitwarden-user-crypto-management",
  "bitwarden-vault",
+ "tokio",
  "tsify",
  "uniffi",
  "wasm-bindgen",
@@ -903,16 +906,21 @@ dependencies = [
  "async-trait",
  "bitwarden-error",
  "bitwarden-threading",
+ "http",
  "js-sys",
+ "reqwest",
+ "reqwest-middleware",
  "serde",
  "serde-wasm-bindgen",
  "serde_json",
  "thiserror 2.0.18",
  "tokio",
+ "tracing",
  "tsify",
  "uniffi",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wiremock",
 ]
 
 [[package]]

--- a/crates/bitwarden-core/src/client/client.rs
+++ b/crates/bitwarden-core/src/client/client.rs
@@ -30,7 +30,7 @@ pub struct Client {
 impl Client {
     /// Create a new Bitwarden client with default settings and a no-op token handler.
     pub fn new(settings: Option<ClientSettings>) -> Self {
-        Self::new_internal(settings, Arc::new(NoopTokenHandler))
+        Self::new_internal(settings, Arc::new(NoopTokenHandler), None)
     }
 
     /// Create a new Bitwarden client with the specified token handler for managing authentication
@@ -39,12 +39,26 @@ impl Client {
         settings: Option<ClientSettings>,
         token_handler: Arc<dyn TokenHandler>,
     ) -> Self {
-        Self::new_internal(settings, token_handler)
+        Self::new_internal(settings, token_handler, None)
+    }
+
+    /// Create a new Bitwarden client with the specified token handler and cookie middleware.
+    ///
+    /// Use this constructor when the deployment requires session-affinity cookies
+    /// (e.g., self-hosted behind AWS ALB). The provided cookie middleware will inject
+    /// stored SSO cookies on each API request.
+    pub fn new_with_token_handler_and_cookie_middleware(
+        settings: Option<ClientSettings>,
+        token_handler: Arc<dyn TokenHandler>,
+        cookie_middleware: Arc<dyn reqwest_middleware::Middleware>,
+    ) -> Self {
+        Self::new_internal(settings, token_handler, Some(cookie_middleware))
     }
 
     fn new_internal(
         settings_input: Option<ClientSettings>,
         token_handler: Arc<dyn TokenHandler>,
+        cookie_middleware: Option<Arc<dyn reqwest_middleware::Middleware>>,
     ) -> Self {
         let settings = settings_input.unwrap_or_default();
 
@@ -75,9 +89,12 @@ impl Client {
             identity.clone(),
             key_store.clone(),
         );
-        let bw_http_client = reqwest_middleware::ClientBuilder::new(bw_http_client)
-            .with_arc(auth_middleware)
-            .build();
+        let mut builder =
+            reqwest_middleware::ClientBuilder::new(bw_http_client).with_arc(auth_middleware);
+        if let Some(cm) = cookie_middleware {
+            builder = builder.with_arc(cm);
+        }
+        let bw_http_client = builder.build();
         let api = bitwarden_api_api::Configuration {
             base_path: settings.api_url,
             user_agent: Some(settings.user_agent),

--- a/crates/bitwarden-pm/Cargo.toml
+++ b/crates/bitwarden-pm/Cargo.toml
@@ -36,6 +36,7 @@ wasm = [
     "bitwarden-generators/wasm",
     "bitwarden-state/wasm",
     "bitwarden-vault/wasm",
+    "bitwarden-server-communication-config/wasm",
     "dep:wasm-bindgen",
     "dep:wasm-bindgen-futures",
     "dep:tsify",
@@ -46,6 +47,7 @@ bitwarden-license = ["dep:bitwarden-commercial-vault"]
 bitwarden-auth = { workspace = true }
 bitwarden-commercial-vault = { workspace = true, optional = true }
 bitwarden-core = { workspace = true, features = ["internal"] }
+bitwarden-server-communication-config = { workspace = true }
 bitwarden-exporters = { workspace = true }
 bitwarden-fido = { workspace = true }
 bitwarden-generators = { workspace = true }
@@ -58,6 +60,10 @@ tsify = { workspace = true, optional = true }
 uniffi = { workspace = true, optional = true, features = ["tokio"] }
 wasm-bindgen = { workspace = true, optional = true }
 wasm-bindgen-futures = { workspace = true, optional = true }
+
+[dev-dependencies]
+async-trait = { workspace = true }
+tokio = { workspace = true, features = ["rt"] }
 
 [lints]
 workspace = true

--- a/crates/bitwarden-pm/Cargo.toml
+++ b/crates/bitwarden-pm/Cargo.toml
@@ -15,9 +15,7 @@ license-file.workspace = true
 keywords.workspace = true
 
 [features]
-no-memory-hardening = [
-    "bitwarden-core/no-memory-hardening",
-] # Disable memory hardening features
+no-memory-hardening = ["bitwarden-core/no-memory-hardening"]
 uniffi = [
     "bitwarden-core/uniffi",
     "bitwarden-exporters/uniffi",
@@ -27,7 +25,7 @@ uniffi = [
     "bitwarden-state/uniffi",
     "bitwarden-vault/uniffi",
     "dep:uniffi",
-] # Uniffi bindings
+]
 wasm = [
     "bitwarden-auth/wasm",
     "bitwarden-commercial-vault/wasm",
@@ -40,18 +38,18 @@ wasm = [
     "dep:wasm-bindgen",
     "dep:wasm-bindgen-futures",
     "dep:tsify",
-] # WASM support
+]
 bitwarden-license = ["dep:bitwarden-commercial-vault"]
 
 [dependencies]
 bitwarden-auth = { workspace = true }
 bitwarden-commercial-vault = { workspace = true, optional = true }
 bitwarden-core = { workspace = true, features = ["internal"] }
-bitwarden-server-communication-config = { workspace = true }
 bitwarden-exporters = { workspace = true }
 bitwarden-fido = { workspace = true }
 bitwarden-generators = { workspace = true }
 bitwarden-send = { workspace = true }
+bitwarden-server-communication-config = { workspace = true }
 bitwarden-state = { workspace = true }
 bitwarden-user-crypto-management = { workspace = true }
 bitwarden-vault = { workspace = true }

--- a/crates/bitwarden-pm/src/lib.rs
+++ b/crates/bitwarden-pm/src/lib.rs
@@ -135,12 +135,12 @@ impl PasswordManagerClient {
 mod tests {
     use std::collections::HashMap;
 
-    use tokio::sync::RwLock;
-
-    use super::*;
     use bitwarden_server_communication_config::{
         AcquiredCookie, ServerCommunicationConfig, ServerCommunicationConfigRepository,
     };
+    use tokio::sync::RwLock;
+
+    use super::*;
 
     #[derive(Default, Clone)]
     struct MockRepository {

--- a/crates/bitwarden-pm/src/lib.rs
+++ b/crates/bitwarden-pm/src/lib.rs
@@ -10,6 +10,10 @@ use bitwarden_core::auth::{ClientManagedTokenHandler, ClientManagedTokens};
 use bitwarden_exporters::ExporterClientExt as _;
 use bitwarden_generators::GeneratorClientsExt as _;
 use bitwarden_send::SendClientExt as _;
+use bitwarden_server_communication_config::{
+    ServerCommunicationConfigClient, ServerCommunicationConfigPlatformApi,
+    ServerCommunicationConfigRepository,
+};
 use bitwarden_user_crypto_management::UserCryptoManagementClientExt;
 use bitwarden_vault::VaultClientExt as _;
 
@@ -52,6 +56,30 @@ impl PasswordManagerClient {
             settings,
             ClientManagedTokenHandler::new(tokens),
         ))
+    }
+
+    /// Initialize a new instance of the SDK client with SSO cookie middleware.
+    ///
+    /// Use this constructor when the deployment requires session-affinity cookies
+    /// (e.g., self-hosted behind AWS ALB). The provided
+    /// `communication_config_client` will supply cookies on each API request.
+    pub fn new_with_communication_config<R, P>(
+        settings: Option<bitwarden_core::ClientSettings>,
+        communication_config_client: ServerCommunicationConfigClient<R, P>,
+    ) -> Self
+    where
+        R: ServerCommunicationConfigRepository + Send + Sync + 'static,
+        P: ServerCommunicationConfigPlatformApi + Send + Sync + 'static,
+    {
+        let token_handler = Arc::new(PasswordManagerTokenHandler::default());
+        let cookie_middleware = communication_config_client.create_middleware_arc();
+        Self(
+            bitwarden_core::Client::new_with_token_handler_and_cookie_middleware(
+                settings,
+                token_handler,
+                cookie_middleware,
+            ),
+        )
     }
 
     /// Platform operations
@@ -100,5 +128,65 @@ impl PasswordManagerClient {
     /// Send operations
     pub fn sends(&self) -> bitwarden_send::SendClient {
         self.0.sends()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use tokio::sync::RwLock;
+
+    use super::*;
+    use bitwarden_server_communication_config::{
+        AcquiredCookie, ServerCommunicationConfig, ServerCommunicationConfigRepository,
+    };
+
+    #[derive(Default, Clone)]
+    struct MockRepository {
+        storage: std::sync::Arc<RwLock<HashMap<String, ServerCommunicationConfig>>>,
+    }
+
+    impl ServerCommunicationConfigRepository for MockRepository {
+        type GetError = ();
+        type SaveError = ();
+
+        async fn get(&self, hostname: String) -> Result<Option<ServerCommunicationConfig>, ()> {
+            Ok(self.storage.read().await.get(&hostname).cloned())
+        }
+
+        async fn save(
+            &self,
+            hostname: String,
+            config: ServerCommunicationConfig,
+        ) -> Result<(), ()> {
+            self.storage.write().await.insert(hostname, config);
+            Ok(())
+        }
+    }
+
+    #[derive(Clone)]
+    struct MockPlatformApi;
+
+    #[async_trait::async_trait]
+    impl bitwarden_server_communication_config::ServerCommunicationConfigPlatformApi
+        for MockPlatformApi
+    {
+        async fn acquire_cookies(&self, _hostname: String) -> Option<Vec<AcquiredCookie>> {
+            None
+        }
+    }
+
+    #[tokio::test]
+    async fn new_with_communication_config_constructs_successfully() {
+        let repo = MockRepository::default();
+        let platform_api = MockPlatformApi;
+        let communication_config_client = ServerCommunicationConfigClient::new(repo, platform_api);
+
+        let client =
+            PasswordManagerClient::new_with_communication_config(None, communication_config_client);
+
+        // Verify the client is constructed (has internal state accessible)
+        let _ = client.crypto();
     }
 }

--- a/crates/bitwarden-server-communication-config/Cargo.toml
+++ b/crates/bitwarden-server-communication-config/Cargo.toml
@@ -26,11 +26,15 @@ uniffi = ["dep:uniffi"] # UniFFI support for mobile bindings
 async-trait = { workspace = true }
 bitwarden-error = { workspace = true }
 bitwarden-threading = { workspace = true }
+http = { workspace = true }
 js-sys = { workspace = true, optional = true }
+reqwest = { workspace = true }
+reqwest-middleware = { workspace = true }
 serde = { workspace = true }
 serde-wasm-bindgen = { workspace = true, optional = true }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["sync"] }
+tracing = { workspace = true }
 tsify = { workspace = true, optional = true }
 uniffi = { workspace = true, optional = true }
 wasm-bindgen = { workspace = true, optional = true }
@@ -38,6 +42,8 @@ wasm-bindgen-futures = { workspace = true, optional = true }
 
 [dev-dependencies]
 serde_json = { workspace = true }
+tokio = { workspace = true, features = ["rt"] }
+wiremock = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/bitwarden-server-communication-config/Cargo.toml
+++ b/crates/bitwarden-server-communication-config/Cargo.toml
@@ -18,9 +18,9 @@ wasm = [
     "dep:serde-wasm-bindgen",
     "bitwarden-error/wasm",
     "bitwarden-threading/wasm",
-] # WASM support
+]
 
-uniffi = ["dep:uniffi"] # UniFFI support for mobile bindings
+uniffi = ["dep:uniffi"]
 
 [dependencies]
 async-trait = { workspace = true }

--- a/crates/bitwarden-server-communication-config/src/client.rs
+++ b/crates/bitwarden-server-communication-config/src/client.rs
@@ -1,9 +1,23 @@
+use std::sync::Arc;
+
 #[cfg(test)]
 use crate::AcquiredCookie;
 use crate::{
     AcquireCookieError, BootstrapConfig, ServerCommunicationConfig,
     ServerCommunicationConfigPlatformApi, ServerCommunicationConfigRepository,
+    middleware::ServerCommunicationConfigMiddleware,
 };
+
+/// Private inner state for ServerCommunicationConfigClient, wrapped in Arc for Clone support.
+/// See ADR-078.
+struct InnerClient<R, P>
+where
+    R: ServerCommunicationConfigRepository,
+    P: ServerCommunicationConfigPlatformApi,
+{
+    repository: R,
+    platform_api: P,
+}
 
 /// Server communication configuration client
 pub struct ServerCommunicationConfigClient<R, P>
@@ -11,8 +25,19 @@ where
     R: ServerCommunicationConfigRepository,
     P: ServerCommunicationConfigPlatformApi,
 {
-    repository: R,
-    platform_api: P,
+    inner: Arc<InnerClient<R, P>>,
+}
+
+impl<R, P> Clone for ServerCommunicationConfigClient<R, P>
+where
+    R: ServerCommunicationConfigRepository,
+    P: ServerCommunicationConfigPlatformApi,
+{
+    fn clone(&self) -> Self {
+        Self {
+            inner: Arc::clone(&self.inner),
+        }
+    }
 }
 
 impl<R, P> ServerCommunicationConfigClient<R, P>
@@ -28,9 +53,32 @@ where
     /// * `platform_api` - Cookie acquistion implementation
     pub fn new(repository: R, platform_api: P) -> Self {
         Self {
-            repository,
-            platform_api,
+            inner: Arc::new(InnerClient {
+                repository,
+                platform_api,
+            }),
         }
+    }
+
+    /// Creates a middleware that injects cookies from this client into HTTP requests.
+    pub fn create_middleware(&self) -> ServerCommunicationConfigMiddleware<R, P>
+    where
+        R: Send + Sync + 'static,
+        P: Send + Sync + 'static,
+    {
+        ServerCommunicationConfigMiddleware::new(self.clone())
+    }
+
+    /// Creates a type-erased middleware that injects cookies from this client into HTTP requests.
+    ///
+    /// Returns `Arc<dyn reqwest_middleware::Middleware>` for callers that do not directly depend
+    /// on `reqwest-middleware`.
+    pub fn create_middleware_arc(&self) -> Arc<dyn reqwest_middleware::Middleware>
+    where
+        R: Send + Sync + 'static,
+        P: Send + Sync + 'static,
+    {
+        Arc::new(self.create_middleware())
     }
 
     /// Retrieves the server communication configuration for a hostname
@@ -39,6 +87,7 @@ where
         hostname: String,
     ) -> Result<ServerCommunicationConfig, R::GetError> {
         Ok(self
+            .inner
             .repository
             .get(hostname)
             .await?
@@ -49,7 +98,7 @@ where
 
     /// Determines if cookie bootstrapping is needed for this hostname
     pub async fn needs_bootstrap(&self, hostname: String) -> bool {
-        if let Ok(Some(config)) = self.repository.get(hostname).await
+        if let Ok(Some(config)) = self.inner.repository.get(hostname).await
             && let BootstrapConfig::SsoCookieVendor(vendor_config) = config.bootstrap
         {
             return vendor_config.cookie_value.is_none();
@@ -62,7 +111,7 @@ where
     /// Returns the stored cookies as-is. For sharded cookies, each entry includes
     /// the full cookie name with its `-{N}` suffix (e.g., `AWSELBAuthSessionCookie-0`).
     pub async fn cookies(&self, hostname: String) -> Vec<(String, String)> {
-        if let Ok(Some(config)) = self.repository.get(hostname).await
+        if let Ok(Some(config)) = self.inner.repository.get(hostname).await
             && let BootstrapConfig::SsoCookieVendor(vendor_config) = config.bootstrap
             && let Some(acquired_cookies) = vendor_config.cookie_value
         {
@@ -92,7 +141,7 @@ where
         hostname: String,
         config: ServerCommunicationConfig,
     ) -> Result<(), R::SaveError> {
-        self.repository.save(hostname, config).await
+        self.inner.repository.save(hostname, config).await
     }
 
     /// Acquires a cookie from the platform and saves it to the repository
@@ -117,6 +166,7 @@ where
     pub async fn acquire_cookie(&self, hostname: &str) -> Result<(), AcquireCookieError> {
         // Get existing configuration - we need this to know what cookie to expect
         let mut config = self
+            .inner
             .repository
             .get(hostname.to_string())
             .await
@@ -135,6 +185,7 @@ where
 
         // Call platform API to acquire cookies
         let cookies = self
+            .inner
             .platform_api
             .acquire_cookies(hostname.to_string())
             .await
@@ -178,7 +229,8 @@ where
         vendor_config.cookie_value = Some(cookies);
 
         // Save the updated config
-        self.repository
+        self.inner
+            .repository
             .save(hostname.to_string(), config)
             .await
             .map_err(|e| AcquireCookieError::RepositorySaveError(format!("{:?}", e)))?;

--- a/crates/bitwarden-server-communication-config/src/lib.rs
+++ b/crates/bitwarden-server-communication-config/src/lib.rs
@@ -11,11 +11,13 @@ uniffi::setup_scaffolding!();
 
 mod client;
 mod config;
+mod middleware;
 mod platform_api;
 mod repository;
 
 pub use client::ServerCommunicationConfigClient;
 pub use config::{BootstrapConfig, ServerCommunicationConfig, SsoCookieVendorConfig};
+pub use middleware::ServerCommunicationConfigMiddleware;
 pub use platform_api::{AcquireCookieError, AcquiredCookie, ServerCommunicationConfigPlatformApi};
 pub use repository::{
     ServerCommunicationConfigRepository, ServerCommunicationConfigRepositoryError,

--- a/crates/bitwarden-server-communication-config/src/middleware.rs
+++ b/crates/bitwarden-server-communication-config/src/middleware.rs
@@ -1,0 +1,260 @@
+use crate::{
+    ServerCommunicationConfigClient, ServerCommunicationConfigPlatformApi,
+    ServerCommunicationConfigRepository,
+};
+
+/// Middleware that injects SSO load-balancer cookies into HTTP requests.
+///
+/// Extracts the request hostname, checks for stored cookies, bootstraps if needed,
+/// and inserts a Cookie header. See ADR-077.
+pub struct ServerCommunicationConfigMiddleware<R, P>
+where
+    R: ServerCommunicationConfigRepository,
+    P: ServerCommunicationConfigPlatformApi,
+{
+    client: ServerCommunicationConfigClient<R, P>,
+}
+
+impl<R, P> ServerCommunicationConfigMiddleware<R, P>
+where
+    R: ServerCommunicationConfigRepository,
+    P: ServerCommunicationConfigPlatformApi,
+{
+    pub(crate) fn new(client: ServerCommunicationConfigClient<R, P>) -> Self {
+        Self { client }
+    }
+}
+
+#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
+impl<R, P> reqwest_middleware::Middleware for ServerCommunicationConfigMiddleware<R, P>
+where
+    R: ServerCommunicationConfigRepository + Send + Sync + 'static,
+    P: ServerCommunicationConfigPlatformApi + Send + Sync + 'static,
+{
+    async fn handle(
+        &self,
+        mut req: reqwest::Request,
+        ext: &mut http::Extensions,
+        next: reqwest_middleware::Next<'_>,
+    ) -> Result<reqwest::Response, reqwest_middleware::Error> {
+        let hostname = req.url().host_str().unwrap_or("").to_string();
+
+        if !hostname.is_empty() {
+            #[allow(clippy::collapsible_if)]
+            if self.client.needs_bootstrap(hostname.clone()).await {
+                if let Err(e) = self.client.acquire_cookie(&hostname).await {
+                    tracing::warn!(
+                        "Cookie bootstrap failed for {}: {:?}. Continuing without cookie.",
+                        hostname,
+                        e
+                    );
+                }
+            }
+
+            let cookies = self.client.cookies(hostname).await;
+            if !cookies.is_empty() {
+                let header_value = cookies
+                    .iter()
+                    .map(|(name, value)| format!("{}={}", name, value))
+                    .collect::<Vec<_>>()
+                    .join("; ");
+
+                if let Ok(value) = reqwest::header::HeaderValue::from_str(&header_value) {
+                    req.headers_mut().insert(reqwest::header::COOKIE, value);
+                }
+            }
+        }
+
+        next.run(req, ext).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use tokio::sync::RwLock;
+
+    use super::*;
+    use crate::{
+        AcquiredCookie, BootstrapConfig, ServerCommunicationConfig, SsoCookieVendorConfig,
+    };
+
+    #[derive(Default, Clone)]
+    struct MockRepository {
+        storage: std::sync::Arc<RwLock<HashMap<String, ServerCommunicationConfig>>>,
+    }
+
+    impl ServerCommunicationConfigRepository for MockRepository {
+        type GetError = ();
+        type SaveError = ();
+
+        async fn get(&self, hostname: String) -> Result<Option<ServerCommunicationConfig>, ()> {
+            Ok(self.storage.read().await.get(&hostname).cloned())
+        }
+
+        async fn save(
+            &self,
+            hostname: String,
+            config: ServerCommunicationConfig,
+        ) -> Result<(), ()> {
+            self.storage.write().await.insert(hostname, config);
+            Ok(())
+        }
+    }
+
+    #[derive(Clone)]
+    struct MockPlatformApi;
+
+    #[async_trait::async_trait]
+    impl ServerCommunicationConfigPlatformApi for MockPlatformApi {
+        async fn acquire_cookies(&self, _hostname: String) -> Option<Vec<AcquiredCookie>> {
+            None
+        }
+    }
+
+    fn make_client(
+        repo: MockRepository,
+    ) -> ServerCommunicationConfigClient<MockRepository, MockPlatformApi> {
+        ServerCommunicationConfigClient::new(repo, MockPlatformApi)
+    }
+
+    #[tokio::test]
+    async fn middleware_skips_cookie_injection_when_no_cookies() {
+        let repo = MockRepository::default();
+        // No config stored — Direct mode, no cookies
+        let client = make_client(repo.clone());
+        let middleware = client.create_middleware();
+
+        let mock_server = wiremock::MockServer::start().await;
+        wiremock::Mock::given(wiremock::matchers::any())
+            .respond_with(wiremock::ResponseTemplate::new(200))
+            .mount(&mock_server)
+            .await;
+
+        let reqwest_client = reqwest::Client::new();
+        let client_with_mw = reqwest_middleware::ClientBuilder::new(reqwest_client)
+            .with(middleware)
+            .build();
+
+        client_with_mw
+            .get(mock_server.uri())
+            .send()
+            .await
+            .expect("Request should succeed");
+
+        let requests = mock_server.received_requests().await.unwrap();
+        assert_eq!(requests.len(), 1);
+        assert!(
+            !requests[0].headers.contains_key("cookie"),
+            "No Cookie header should be injected when no cookies are stored"
+        );
+    }
+
+    #[tokio::test]
+    async fn middleware_injects_single_cookie_header() {
+        let repo = MockRepository::default();
+        let config = ServerCommunicationConfig {
+            bootstrap: BootstrapConfig::SsoCookieVendor(SsoCookieVendorConfig {
+                idp_login_url: None,
+                cookie_name: Some("SessionCookie".to_string()),
+                cookie_domain: None,
+                cookie_value: Some(vec![AcquiredCookie {
+                    name: "SessionCookie".to_string(),
+                    value: "abc123".to_string(),
+                }]),
+            }),
+        };
+
+        let mock_server = wiremock::MockServer::start().await;
+        let hostname = mock_server.address().ip().to_string();
+
+        repo.save(hostname.clone(), config).await.unwrap();
+
+        let client = make_client(repo);
+        let middleware = client.create_middleware();
+
+        wiremock::Mock::given(wiremock::matchers::any())
+            .respond_with(wiremock::ResponseTemplate::new(200))
+            .mount(&mock_server)
+            .await;
+
+        let reqwest_client = reqwest::Client::new();
+        let client_with_mw = reqwest_middleware::ClientBuilder::new(reqwest_client)
+            .with(middleware)
+            .build();
+
+        client_with_mw
+            .get(mock_server.uri())
+            .send()
+            .await
+            .expect("Request should succeed");
+
+        let requests = mock_server.received_requests().await.unwrap();
+        assert_eq!(requests.len(), 1);
+        let cookie_header = requests[0]
+            .headers
+            .get("cookie")
+            .expect("Cookie header should be present");
+        assert_eq!(cookie_header.as_bytes(), b"SessionCookie=abc123");
+    }
+
+    #[tokio::test]
+    async fn middleware_injects_multiple_sharded_cookies_semicolon_separated() {
+        let repo = MockRepository::default();
+
+        let mock_server = wiremock::MockServer::start().await;
+        let hostname = mock_server.address().ip().to_string();
+
+        let config = ServerCommunicationConfig {
+            bootstrap: BootstrapConfig::SsoCookieVendor(SsoCookieVendorConfig {
+                idp_login_url: None,
+                cookie_name: Some("AWSELBAuthSessionCookie".to_string()),
+                cookie_domain: None,
+                cookie_value: Some(vec![
+                    AcquiredCookie {
+                        name: "AWSELBAuthSessionCookie-0".to_string(),
+                        value: "shard0".to_string(),
+                    },
+                    AcquiredCookie {
+                        name: "AWSELBAuthSessionCookie-1".to_string(),
+                        value: "shard1".to_string(),
+                    },
+                ]),
+            }),
+        };
+
+        repo.save(hostname.clone(), config).await.unwrap();
+
+        let client = make_client(repo);
+        let middleware = client.create_middleware();
+
+        wiremock::Mock::given(wiremock::matchers::any())
+            .respond_with(wiremock::ResponseTemplate::new(200))
+            .mount(&mock_server)
+            .await;
+
+        let reqwest_client = reqwest::Client::new();
+        let client_with_mw = reqwest_middleware::ClientBuilder::new(reqwest_client)
+            .with(middleware)
+            .build();
+
+        client_with_mw
+            .get(mock_server.uri())
+            .send()
+            .await
+            .expect("Request should succeed");
+
+        let requests = mock_server.received_requests().await.unwrap();
+        assert_eq!(requests.len(), 1);
+        let cookie_header = requests[0]
+            .headers
+            .get("cookie")
+            .expect("Cookie header should be present");
+        assert_eq!(
+            cookie_header.as_bytes(),
+            b"AWSELBAuthSessionCookie-0=shard0; AWSELBAuthSessionCookie-1=shard1"
+        );
+    }
+}

--- a/crates/bitwarden-server-communication-config/src/repository.rs
+++ b/crates/bitwarden-server-communication-config/src/repository.rs
@@ -40,7 +40,8 @@ pub trait ServerCommunicationConfigRepository: Send + Sync {
     fn get(
         &self,
         hostname: String,
-    ) -> impl std::future::Future<Output = Result<Option<ServerCommunicationConfig>, Self::GetError>>;
+    ) -> impl std::future::Future<Output = Result<Option<ServerCommunicationConfig>, Self::GetError>>
+    + Send;
 
     /// Saves configuration for a hostname
     ///
@@ -59,7 +60,7 @@ pub trait ServerCommunicationConfigRepository: Send + Sync {
         &self,
         hostname: String,
         config: ServerCommunicationConfig,
-    ) -> impl std::future::Future<Output = Result<(), Self::SaveError>>;
+    ) -> impl std::future::Future<Output = Result<(), Self::SaveError>> + Send;
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## 🎟️ Tracking

[PM-27126](https://bitwarden.atlassian.net/browse/PM-27126) — Add Cookie to Fetch Requests (SDK)
Parent epic: [PM-27124](https://bitwarden.atlassian.net/browse/PM-27124) — Support load balancer cookies on API requests

## 📔 Objective

Adds SSO session-affinity cookie support to the Bitwarden SDK for self-hosted deployments running behind load balancers (e.g., AWS ELB) that require sticky-session cookies. Without this change, SDK API requests on such deployments fail after the initial SSO redirect because subsequent requests land on different backend nodes with no session context.

The implementation introduces `ServerCommunicationConfigMiddleware`, a `reqwest_middleware::Middleware` that handles the full cookie lifecycle — bootstrapping SSO cookies when needed and injecting stored cookies as a `Cookie` header on every outgoing request (RFC 6265). Cookie sharding is supported: AWS ELB produces sharded cookies (`AWSELBAuthSessionCookie-0`, `-1`, `-2`, …) and all parts are included as separate `name=value` pairs.

**Key design decisions:**

- **Middleware injection over CookieStore (ADR-077):** `reqwest` evaluates `CookieStore` before the `reqwest_middleware` stack executes, creating a circular dependency between cookie acquisition (which is async) and cookie attachment (which would be sync). Concentrating both concerns in a single middleware eliminates this timing ambiguity.

- **`Arc<InnerClient>` for Clone (ADR-078):** `reqwest_middleware` requires middleware types to implement `Clone`. Adding `Clone` bounds to the generic parameters `R` and `P` of `ServerCommunicationConfigClient<R, P>` would propagate constraints to all platform integrations. The `Arc<InnerClient>` pattern — already used by `bitwarden_core::Client` — provides O(1) cheap clone without bounding the generics.

**Changes across three commits:**

1. `bitwarden-server-communication-config` (ed0975f3): Wraps client internals in `Arc<InnerClient<R,P>>`, adds `+ Send` bounds to repository trait futures, adds `create_middleware_arc()` factory, implements `ServerCommunicationConfigMiddleware` with `reqwest_middleware::Middleware`.

2. `bitwarden-core` (92dc6be0): Adds `Client::new_with_token_handler_and_cookie_middleware()` constructor. Existing constructors (`new()`, `new_with_token_handler()`) pass `None` and are unaffected. Cookie middleware is chained after auth middleware so auth headers are present when cookie logic runs.

3. `bitwarden-pm` (7798fc7b): Adds `PasswordManagerClient::new_with_communication_config()` which accepts a `ServerCommunicationConfigClient`, creates a cookie middleware via `create_middleware_arc()`, and passes it to the core `Client` constructor alongside the standard `PasswordManagerTokenHandler`.

## 🚨 Breaking Changes

None. All new constructors are additive. Existing `Client::new()`, `Client::new_with_token_handler()`, and `PasswordManagerClient::new()` are unchanged and pass `None` for the middleware parameter.

[PM-27126]: https://bitwarden.atlassian.net/browse/PM-27126?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PM-27124]: https://bitwarden.atlassian.net/browse/PM-27124?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ