### PR TITLE
[PM-27126] Add SSO load-balancer cookie middleware to SDK API requests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -853,6 +853,7 @@ dependencies = [
  "bitwarden-fido",
  "bitwarden-generators",
  "bitwarden-send",
+ "bitwarden-server-communication-config",
  "bitwarden-state",
  "bitwarden-user-crypto-management",
  "bitwarden-vault",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -846,6 +846,7 @@ dependencies = [
 name = "bitwarden-pm"
 version = "2.0.0"
 dependencies = [
+ "async-trait",
  "bitwarden-auth",
  "bitwarden-commercial-vault",
  "bitwarden-core",
@@ -857,6 +858,7 @@ dependencies = [
  "bitwarden-state",
  "bitwarden-user-crypto-management",
  "bitwarden-vault",
+ "tokio",
  "tsify",
  "uniffi",
  "wasm-bindgen",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -903,7 +903,10 @@ dependencies = [
  "async-trait",
  "bitwarden-error",
  "bitwarden-threading",
+ "http",
  "js-sys",
+ "reqwest",
+ "reqwest-middleware",
  "serde",
  "serde-wasm-bindgen",
  "serde_json",
@@ -913,6 +916,7 @@ dependencies = [
  "uniffi",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wiremock",
 ]
 
 [[package]]

--- a/crates/bitwarden-core/src/client/client.rs
+++ b/crates/bitwarden-core/src/client/client.rs
@@ -87,8 +87,8 @@ impl Client {
             identity.clone(),
             key_store.clone(),
         );
-        let mut middleware_builder = reqwest_middleware::ClientBuilder::new(bw_http_client)
-            .with_arc(auth_middleware);
+        let mut middleware_builder =
+            reqwest_middleware::ClientBuilder::new(bw_http_client).with_arc(auth_middleware);
         for m in additional_middlewares {
             middleware_builder = middleware_builder.with_arc(m);
         }

--- a/crates/bitwarden-core/src/client/client.rs
+++ b/crates/bitwarden-core/src/client/client.rs
@@ -30,7 +30,7 @@ pub struct Client {
 impl Client {
     /// Create a new Bitwarden client with default settings and a no-op token handler.
     pub fn new(settings: Option<ClientSettings>) -> Self {
-        Self::new_internal(settings, Arc::new(NoopTokenHandler))
+        Self::new_internal(settings, Arc::new(NoopTokenHandler), vec![])
     }
 
     /// Create a new Bitwarden client with the specified token handler for managing authentication
@@ -39,12 +39,24 @@ impl Client {
         settings: Option<ClientSettings>,
         token_handler: Arc<dyn TokenHandler>,
     ) -> Self {
-        Self::new_internal(settings, token_handler)
+        Self::new_internal(settings, token_handler, vec![])
+    }
+
+    /// Create a new Bitwarden client with the specified token handler and additional
+    /// HTTP middleware. Middlewares are chained after the authentication middleware
+    /// in the order provided.
+    pub fn new_with_token_handler_and_middlewares(
+        settings: Option<ClientSettings>,
+        token_handler: Arc<dyn TokenHandler>,
+        additional_middlewares: Vec<Arc<dyn reqwest_middleware::Middleware>>,
+    ) -> Self {
+        Self::new_internal(settings, token_handler, additional_middlewares)
     }
 
     fn new_internal(
         settings_input: Option<ClientSettings>,
         token_handler: Arc<dyn TokenHandler>,
+        additional_middlewares: Vec<Arc<dyn reqwest_middleware::Middleware>>,
     ) -> Self {
         let settings = settings_input.unwrap_or_default();
 
@@ -75,9 +87,12 @@ impl Client {
             identity.clone(),
             key_store.clone(),
         );
-        let bw_http_client = reqwest_middleware::ClientBuilder::new(bw_http_client)
-            .with_arc(auth_middleware)
-            .build();
+        let mut middleware_builder = reqwest_middleware::ClientBuilder::new(bw_http_client)
+            .with_arc(auth_middleware);
+        for m in additional_middlewares {
+            middleware_builder = middleware_builder.with_arc(m);
+        }
+        let bw_http_client = middleware_builder.build();
         let api = bitwarden_api_api::Configuration {
             base_path: settings.api_url,
             user_agent: Some(settings.user_agent),

--- a/crates/bitwarden-pm/Cargo.toml
+++ b/crates/bitwarden-pm/Cargo.toml
@@ -50,6 +50,7 @@ bitwarden-exporters = { workspace = true }
 bitwarden-fido = { workspace = true }
 bitwarden-generators = { workspace = true }
 bitwarden-send = { workspace = true }
+bitwarden-server-communication-config = { workspace = true }
 bitwarden-state = { workspace = true }
 bitwarden-user-crypto-management = { workspace = true }
 bitwarden-vault = { workspace = true }

--- a/crates/bitwarden-pm/Cargo.toml
+++ b/crates/bitwarden-pm/Cargo.toml
@@ -60,5 +60,9 @@ uniffi = { workspace = true, optional = true, features = ["tokio"] }
 wasm-bindgen = { workspace = true, optional = true }
 wasm-bindgen-futures = { workspace = true, optional = true }
 
+[dev-dependencies]
+async-trait = { workspace = true }
+tokio = { workspace = true }
+
 [lints]
 workspace = true

--- a/crates/bitwarden-pm/src/lib.rs
+++ b/crates/bitwarden-pm/src/lib.rs
@@ -73,11 +73,13 @@ impl PasswordManagerClient {
     {
         let token_handler = Arc::new(PasswordManagerTokenHandler::default());
         let cookie_middleware = server_comm_config.create_middleware();
-        Self(bitwarden_core::Client::new_with_token_handler_and_middlewares(
-            settings,
-            token_handler,
-            vec![cookie_middleware],
-        ))
+        Self(
+            bitwarden_core::Client::new_with_token_handler_and_middlewares(
+                settings,
+                token_handler,
+                vec![cookie_middleware],
+            ),
+        )
     }
 
     /// Platform operations
@@ -154,7 +156,11 @@ mod tests {
             Ok(self.storage.read().await.get(&hostname).cloned())
         }
 
-        async fn save(&self, hostname: String, config: ServerCommunicationConfig) -> Result<(), ()> {
+        async fn save(
+            &self,
+            hostname: String,
+            config: ServerCommunicationConfig,
+        ) -> Result<(), ()> {
             self.storage.write().await.insert(hostname, config);
             Ok(())
         }
@@ -175,10 +181,8 @@ mod tests {
         let repo = MockRepository::default();
         let platform_api = MockPlatformApi;
         let server_comm_config = Arc::new(ServerCommunicationConfigClient::new(repo, platform_api));
-        let _client = PasswordManagerClient::new_with_server_communication_config(
-            None,
-            server_comm_config,
-        );
+        let _client =
+            PasswordManagerClient::new_with_server_communication_config(None, server_comm_config);
     }
 
     #[test]

--- a/crates/bitwarden-pm/src/lib.rs
+++ b/crates/bitwarden-pm/src/lib.rs
@@ -10,6 +10,10 @@ use bitwarden_core::auth::{ClientManagedTokenHandler, ClientManagedTokens};
 use bitwarden_exporters::ExporterClientExt as _;
 use bitwarden_generators::GeneratorClientsExt as _;
 use bitwarden_send::SendClientExt as _;
+use bitwarden_server_communication_config::{
+    ServerCommunicationConfigClient, ServerCommunicationConfigPlatformApi,
+    ServerCommunicationConfigRepository,
+};
 use bitwarden_user_crypto_management::UserCryptoManagementClientExt;
 use bitwarden_vault::VaultClientExt as _;
 
@@ -51,6 +55,28 @@ impl PasswordManagerClient {
         Self(bitwarden_core::Client::new_with_token_handler(
             settings,
             ClientManagedTokenHandler::new(tokens),
+        ))
+    }
+
+    /// Initialize a new instance of the SDK client configured to inject SSO load-balancer
+    /// cookies from the provided server communication configuration client.
+    ///
+    /// The cookie middleware is inserted after the authentication middleware, ensuring
+    /// auth tokens are attached before cookies are injected.
+    pub fn new_with_server_communication_config<R, P>(
+        settings: Option<bitwarden_core::ClientSettings>,
+        server_comm_config: Arc<ServerCommunicationConfigClient<R, P>>,
+    ) -> Self
+    where
+        R: ServerCommunicationConfigRepository + Send + Sync + 'static,
+        P: ServerCommunicationConfigPlatformApi + Send + Sync + 'static,
+    {
+        let token_handler = Arc::new(PasswordManagerTokenHandler::default());
+        let cookie_middleware = server_comm_config.create_middleware();
+        Self(bitwarden_core::Client::new_with_token_handler_and_middlewares(
+            settings,
+            token_handler,
+            vec![cookie_middleware],
         ))
     }
 
@@ -100,5 +126,63 @@ impl PasswordManagerClient {
     /// Send operations
     pub fn sends(&self) -> bitwarden_send::SendClient {
         self.0.sends()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use bitwarden_server_communication_config::{
+        AcquiredCookie, ServerCommunicationConfig, ServerCommunicationConfigClient,
+        ServerCommunicationConfigPlatformApi, ServerCommunicationConfigRepository,
+    };
+    use tokio::sync::RwLock;
+
+    use super::*;
+
+    #[derive(Default, Clone)]
+    struct MockRepository {
+        storage: Arc<RwLock<HashMap<String, ServerCommunicationConfig>>>,
+    }
+
+    impl ServerCommunicationConfigRepository for MockRepository {
+        type GetError = ();
+        type SaveError = ();
+
+        async fn get(&self, hostname: String) -> Result<Option<ServerCommunicationConfig>, ()> {
+            Ok(self.storage.read().await.get(&hostname).cloned())
+        }
+
+        async fn save(&self, hostname: String, config: ServerCommunicationConfig) -> Result<(), ()> {
+            self.storage.write().await.insert(hostname, config);
+            Ok(())
+        }
+    }
+
+    #[derive(Clone)]
+    struct MockPlatformApi;
+
+    #[async_trait::async_trait]
+    impl ServerCommunicationConfigPlatformApi for MockPlatformApi {
+        async fn acquire_cookies(&self, _hostname: String) -> Option<Vec<AcquiredCookie>> {
+            None
+        }
+    }
+
+    #[test]
+    fn new_with_server_communication_config_constructs_client() {
+        let repo = MockRepository::default();
+        let platform_api = MockPlatformApi;
+        let server_comm_config = Arc::new(ServerCommunicationConfigClient::new(repo, platform_api));
+        let _client = PasswordManagerClient::new_with_server_communication_config(
+            None,
+            server_comm_config,
+        );
+    }
+
+    #[test]
+    fn existing_new_constructor_unchanged() {
+        let _client = PasswordManagerClient::new(None);
     }
 }

--- a/crates/bitwarden-server-communication-config/Cargo.toml
+++ b/crates/bitwarden-server-communication-config/Cargo.toml
@@ -26,7 +26,9 @@ uniffi = ["dep:uniffi"] # UniFFI support for mobile bindings
 async-trait = { workspace = true }
 bitwarden-error = { workspace = true }
 bitwarden-threading = { workspace = true }
+http = { workspace = true }
 js-sys = { workspace = true, optional = true }
+reqwest-middleware = { workspace = true }
 serde = { workspace = true }
 serde-wasm-bindgen = { workspace = true, optional = true }
 thiserror = { workspace = true }
@@ -37,7 +39,11 @@ wasm-bindgen = { workspace = true, optional = true }
 wasm-bindgen-futures = { workspace = true, optional = true }
 
 [dev-dependencies]
+reqwest = { workspace = true }
+reqwest-middleware = { workspace = true }
 serde_json = { workspace = true }
+tokio = { workspace = true, features = ["rt", "macros"] }
+wiremock = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/bitwarden-server-communication-config/src/client.rs
+++ b/crates/bitwarden-server-communication-config/src/client.rs
@@ -191,12 +191,16 @@ where
     ///
     /// The returned middleware holds an `Arc` reference to this client, so cookie
     /// lookups performed by the middleware reflect the live state of the repository.
-    pub fn create_middleware(self: std::sync::Arc<Self>) -> std::sync::Arc<dyn reqwest_middleware::Middleware>
+    pub fn create_middleware(
+        self: std::sync::Arc<Self>,
+    ) -> std::sync::Arc<dyn reqwest_middleware::Middleware>
     where
         R: Send + Sync + 'static,
         P: Send + Sync + 'static,
     {
-        std::sync::Arc::new(ServerCommunicationConfigMiddleware { config_client: self })
+        std::sync::Arc::new(ServerCommunicationConfigMiddleware {
+            config_client: self,
+        })
     }
 }
 

--- a/crates/bitwarden-server-communication-config/src/client.rs
+++ b/crates/bitwarden-server-communication-config/src/client.rs
@@ -3,6 +3,7 @@ use crate::AcquiredCookie;
 use crate::{
     AcquireCookieError, BootstrapConfig, ServerCommunicationConfig,
     ServerCommunicationConfigPlatformApi, ServerCommunicationConfigRepository,
+    middleware::ServerCommunicationConfigMiddleware,
 };
 
 /// Server communication configuration client
@@ -184,6 +185,18 @@ where
             .map_err(|e| AcquireCookieError::RepositorySaveError(format!("{:?}", e)))?;
 
         Ok(())
+    }
+
+    /// Creates a middleware instance that injects stored SSO cookies into API requests.
+    ///
+    /// The returned middleware holds an `Arc` reference to this client, so cookie
+    /// lookups performed by the middleware reflect the live state of the repository.
+    pub fn create_middleware(self: std::sync::Arc<Self>) -> std::sync::Arc<dyn reqwest_middleware::Middleware>
+    where
+        R: Send + Sync + 'static,
+        P: Send + Sync + 'static,
+    {
+        std::sync::Arc::new(ServerCommunicationConfigMiddleware { config_client: self })
     }
 }
 

--- a/crates/bitwarden-server-communication-config/src/lib.rs
+++ b/crates/bitwarden-server-communication-config/src/lib.rs
@@ -11,11 +11,13 @@ uniffi::setup_scaffolding!();
 
 mod client;
 mod config;
+mod middleware;
 mod platform_api;
 mod repository;
 
 pub use client::ServerCommunicationConfigClient;
 pub use config::{BootstrapConfig, ServerCommunicationConfig, SsoCookieVendorConfig};
+pub use middleware::ServerCommunicationConfigMiddleware;
 pub use platform_api::{AcquireCookieError, AcquiredCookie, ServerCommunicationConfigPlatformApi};
 pub use repository::{
     ServerCommunicationConfigRepository, ServerCommunicationConfigRepositoryError,

--- a/crates/bitwarden-server-communication-config/src/middleware.rs
+++ b/crates/bitwarden-server-communication-config/src/middleware.rs
@@ -1,0 +1,222 @@
+use std::sync::Arc;
+
+use crate::{ServerCommunicationConfigClient, ServerCommunicationConfigPlatformApi, ServerCommunicationConfigRepository};
+
+/// Middleware that injects stored SSO load-balancer cookies into the `Cookie` header
+/// of each outgoing API request.
+///
+/// On 3xx redirect responses the middleware propagates the response unchanged —
+/// cookie re-acquisition is the application layer's responsibility (ADR-006).
+pub struct ServerCommunicationConfigMiddleware<R, P>
+where
+    R: ServerCommunicationConfigRepository + Send + Sync + 'static,
+    P: ServerCommunicationConfigPlatformApi + Send + Sync + 'static,
+{
+    pub(crate) config_client: Arc<ServerCommunicationConfigClient<R, P>>,
+}
+
+impl<R, P> Clone for ServerCommunicationConfigMiddleware<R, P>
+where
+    R: ServerCommunicationConfigRepository + Send + Sync + 'static,
+    P: ServerCommunicationConfigPlatformApi + Send + Sync + 'static,
+{
+    fn clone(&self) -> Self {
+        Self {
+            config_client: Arc::clone(&self.config_client),
+        }
+    }
+}
+
+#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
+impl<R, P> reqwest_middleware::Middleware for ServerCommunicationConfigMiddleware<R, P>
+where
+    R: ServerCommunicationConfigRepository + Send + Sync + 'static,
+    P: ServerCommunicationConfigPlatformApi + Send + Sync + 'static,
+{
+    async fn handle(
+        &self,
+        mut req: reqwest::Request,
+        extensions: &mut http::Extensions,
+        next: reqwest_middleware::Next<'_>,
+    ) -> reqwest_middleware::Result<reqwest::Response> {
+        let hostname = req.url().host_str().unwrap_or_default().to_owned();
+        let cookies = self.config_client.cookies(hostname).await;
+
+        if !cookies.is_empty() {
+            let cookie_header = cookies
+                .iter()
+                .map(|(name, value)| format!("{}={}", name, value))
+                .collect::<Vec<_>>()
+                .join("; ");
+
+            if let Ok(header_value) = cookie_header.parse() {
+                req.headers_mut().insert(http::header::COOKIE, header_value);
+            }
+        }
+
+        next.run(req, extensions).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+    use std::sync::Arc;
+
+    use tokio::sync::RwLock;
+
+    use crate::{
+        AcquiredCookie, BootstrapConfig, ServerCommunicationConfig, ServerCommunicationConfigClient,
+        ServerCommunicationConfigPlatformApi, ServerCommunicationConfigRepository,
+        SsoCookieVendorConfig,
+    };
+
+    use super::ServerCommunicationConfigMiddleware;
+
+    #[derive(Default, Clone)]
+    struct MockRepository {
+        storage: Arc<RwLock<HashMap<String, ServerCommunicationConfig>>>,
+    }
+
+    impl ServerCommunicationConfigRepository for MockRepository {
+        type GetError = ();
+        type SaveError = ();
+
+        async fn get(
+            &self,
+            hostname: String,
+        ) -> Result<Option<ServerCommunicationConfig>, ()> {
+            Ok(self.storage.read().await.get(&hostname).cloned())
+        }
+
+        async fn save(
+            &self,
+            hostname: String,
+            config: ServerCommunicationConfig,
+        ) -> Result<(), ()> {
+            self.storage.write().await.insert(hostname, config);
+            Ok(())
+        }
+    }
+
+    #[derive(Clone)]
+    struct MockPlatformApi;
+
+    #[async_trait::async_trait]
+    impl ServerCommunicationConfigPlatformApi for MockPlatformApi {
+        async fn acquire_cookies(&self, _hostname: String) -> Option<Vec<AcquiredCookie>> {
+            None
+        }
+    }
+
+    fn make_client_with_cookies(
+        hostname: &str,
+        cookies: Vec<AcquiredCookie>,
+    ) -> Arc<ServerCommunicationConfigClient<MockRepository, MockPlatformApi>> {
+        let repo = MockRepository::default();
+        let config = ServerCommunicationConfig {
+            bootstrap: BootstrapConfig::SsoCookieVendor(SsoCookieVendorConfig {
+                idp_login_url: None,
+                cookie_name: Some("AWSELBAuthSessionCookie".to_string()),
+                cookie_domain: Some(hostname.to_string()),
+                cookie_value: Some(cookies),
+            }),
+        };
+        let rt = tokio::runtime::Handle::current();
+        let repo_clone = repo.clone();
+        let hostname_owned = hostname.to_string();
+        rt.block_on(async move {
+            repo_clone.save(hostname_owned, config).await.unwrap();
+        });
+        Arc::new(ServerCommunicationConfigClient::new(repo, MockPlatformApi))
+    }
+
+    fn make_empty_client(
+    ) -> Arc<ServerCommunicationConfigClient<MockRepository, MockPlatformApi>> {
+        Arc::new(ServerCommunicationConfigClient::new(
+            MockRepository::default(),
+            MockPlatformApi,
+        ))
+    }
+
+    #[tokio::test]
+    async fn middleware_no_cookie_header_when_empty() {
+        let client = make_empty_client();
+        let middleware = ServerCommunicationConfigMiddleware { config_client: client };
+
+        let req = reqwest::Request::new(
+            reqwest::Method::GET,
+            "https://vault.example.com/api/test".parse().unwrap(),
+        );
+        assert!(req.headers().get(http::header::COOKIE).is_none());
+
+        let cookies = middleware
+            .config_client
+            .cookies("vault.example.com".to_string())
+            .await;
+        assert!(cookies.is_empty(), "Expected no cookies for unconfigured host");
+    }
+
+    #[tokio::test]
+    async fn middleware_formats_single_cookie() {
+        let client = make_client_with_cookies(
+            "vault.example.com",
+            vec![AcquiredCookie {
+                name: "AWSELBAuthSessionCookie".to_string(),
+                value: "singlevalue".to_string(),
+            }],
+        );
+        let cookies = client.cookies("vault.example.com".to_string()).await;
+        let header = cookies
+            .iter()
+            .map(|(n, v)| format!("{}={}", n, v))
+            .collect::<Vec<_>>()
+            .join("; ");
+        assert_eq!(header, "AWSELBAuthSessionCookie=singlevalue");
+    }
+
+    #[tokio::test]
+    async fn middleware_formats_sharded_cookies_with_semicolons() {
+        let client = make_client_with_cookies(
+            "vault.example.com",
+            vec![
+                AcquiredCookie {
+                    name: "AWSELBAuthSessionCookie-0".to_string(),
+                    value: "shard0".to_string(),
+                },
+                AcquiredCookie {
+                    name: "AWSELBAuthSessionCookie-1".to_string(),
+                    value: "shard1".to_string(),
+                },
+                AcquiredCookie {
+                    name: "AWSELBAuthSessionCookie-2".to_string(),
+                    value: "shard2".to_string(),
+                },
+            ],
+        );
+        let cookies = client.cookies("vault.example.com".to_string()).await;
+        let header = cookies
+            .iter()
+            .map(|(n, v)| format!("{}={}", n, v))
+            .collect::<Vec<_>>()
+            .join("; ");
+        assert_eq!(
+            header,
+            "AWSELBAuthSessionCookie-0=shard0; AWSELBAuthSessionCookie-1=shard1; AWSELBAuthSessionCookie-2=shard2"
+        );
+    }
+
+    #[tokio::test]
+    async fn middleware_clone_shares_client() {
+        let client = make_empty_client();
+        let middleware = ServerCommunicationConfigMiddleware {
+            config_client: Arc::clone(&client),
+        };
+        let cloned = middleware.clone();
+        assert!(
+            Arc::ptr_eq(&middleware.config_client, &cloned.config_client),
+            "Clone should share the same Arc (no deep copy of client)"
+        );
+    }
+}

--- a/crates/bitwarden-server-communication-config/src/middleware.rs
+++ b/crates/bitwarden-server-communication-config/src/middleware.rs
@@ -1,5 +1,7 @@
 use std::sync::Arc;
 
+use reqwest_middleware::reqwest;
+
 use crate::{ServerCommunicationConfigClient, ServerCommunicationConfigPlatformApi, ServerCommunicationConfigRepository};
 
 /// Middleware that injects stored SSO load-balancer cookies into the `Cookie` header
@@ -110,7 +112,7 @@ mod tests {
         }
     }
 
-    fn make_client_with_cookies(
+    async fn make_client_with_cookies(
         hostname: &str,
         cookies: Vec<AcquiredCookie>,
     ) -> Arc<ServerCommunicationConfigClient<MockRepository, MockPlatformApi>> {
@@ -123,12 +125,7 @@ mod tests {
                 cookie_value: Some(cookies),
             }),
         };
-        let rt = tokio::runtime::Handle::current();
-        let repo_clone = repo.clone();
-        let hostname_owned = hostname.to_string();
-        rt.block_on(async move {
-            repo_clone.save(hostname_owned, config).await.unwrap();
-        });
+        repo.save(hostname.to_string(), config).await.unwrap();
         Arc::new(ServerCommunicationConfigClient::new(repo, MockPlatformApi))
     }
 
@@ -166,7 +163,8 @@ mod tests {
                 name: "AWSELBAuthSessionCookie".to_string(),
                 value: "singlevalue".to_string(),
             }],
-        );
+        )
+        .await;
         let cookies = client.cookies("vault.example.com".to_string()).await;
         let header = cookies
             .iter()
@@ -194,7 +192,8 @@ mod tests {
                     value: "shard2".to_string(),
                 },
             ],
-        );
+        )
+        .await;
         let cookies = client.cookies("vault.example.com".to_string()).await;
         let header = cookies
             .iter()

--- a/crates/bitwarden-server-communication-config/src/middleware.rs
+++ b/crates/bitwarden-server-communication-config/src/middleware.rs
@@ -2,7 +2,10 @@ use std::sync::Arc;
 
 use reqwest_middleware::reqwest;
 
-use crate::{ServerCommunicationConfigClient, ServerCommunicationConfigPlatformApi, ServerCommunicationConfigRepository};
+use crate::{
+    ServerCommunicationConfigClient, ServerCommunicationConfigPlatformApi,
+    ServerCommunicationConfigRepository,
+};
 
 /// Middleware that injects stored SSO load-balancer cookies into the `Cookie` header
 /// of each outgoing API request.
@@ -69,9 +72,9 @@ mod tests {
     use tokio::sync::RwLock;
 
     use crate::{
-        AcquiredCookie, BootstrapConfig, ServerCommunicationConfig, ServerCommunicationConfigClient,
-        ServerCommunicationConfigPlatformApi, ServerCommunicationConfigRepository,
-        SsoCookieVendorConfig,
+        AcquiredCookie, BootstrapConfig, ServerCommunicationConfig,
+        ServerCommunicationConfigClient, ServerCommunicationConfigPlatformApi,
+        ServerCommunicationConfigRepository, SsoCookieVendorConfig,
     };
 
     use super::ServerCommunicationConfigMiddleware;
@@ -85,10 +88,7 @@ mod tests {
         type GetError = ();
         type SaveError = ();
 
-        async fn get(
-            &self,
-            hostname: String,
-        ) -> Result<Option<ServerCommunicationConfig>, ()> {
+        async fn get(&self, hostname: String) -> Result<Option<ServerCommunicationConfig>, ()> {
             Ok(self.storage.read().await.get(&hostname).cloned())
         }
 
@@ -129,8 +129,8 @@ mod tests {
         Arc::new(ServerCommunicationConfigClient::new(repo, MockPlatformApi))
     }
 
-    fn make_empty_client(
-    ) -> Arc<ServerCommunicationConfigClient<MockRepository, MockPlatformApi>> {
+    fn make_empty_client() -> Arc<ServerCommunicationConfigClient<MockRepository, MockPlatformApi>>
+    {
         Arc::new(ServerCommunicationConfigClient::new(
             MockRepository::default(),
             MockPlatformApi,
@@ -140,7 +140,9 @@ mod tests {
     #[tokio::test]
     async fn middleware_no_cookie_header_when_empty() {
         let client = make_empty_client();
-        let middleware = ServerCommunicationConfigMiddleware { config_client: client };
+        let middleware = ServerCommunicationConfigMiddleware {
+            config_client: client,
+        };
 
         let req = reqwest::Request::new(
             reqwest::Method::GET,
@@ -152,7 +154,10 @@ mod tests {
             .config_client
             .cookies("vault.example.com".to_string())
             .await;
-        assert!(cookies.is_empty(), "Expected no cookies for unconfigured host");
+        assert!(
+            cookies.is_empty(),
+            "Expected no cookies for unconfigured host"
+        );
     }
 
     #[tokio::test]

--- a/crates/bitwarden-server-communication-config/src/middleware.rs
+++ b/crates/bitwarden-server-communication-config/src/middleware.rs
@@ -66,18 +66,16 @@ where
 
 #[cfg(test)]
 mod tests {
-    use std::collections::HashMap;
-    use std::sync::Arc;
+    use std::{collections::HashMap, sync::Arc};
 
     use tokio::sync::RwLock;
 
+    use super::ServerCommunicationConfigMiddleware;
     use crate::{
         AcquiredCookie, BootstrapConfig, ServerCommunicationConfig,
         ServerCommunicationConfigClient, ServerCommunicationConfigPlatformApi,
         ServerCommunicationConfigRepository, SsoCookieVendorConfig,
     };
-
-    use super::ServerCommunicationConfigMiddleware;
 
     #[derive(Default, Clone)]
     struct MockRepository {

--- a/crates/bitwarden-server-communication-config/src/repository.rs
+++ b/crates/bitwarden-server-communication-config/src/repository.rs
@@ -40,7 +40,8 @@ pub trait ServerCommunicationConfigRepository: Send + Sync {
     fn get(
         &self,
         hostname: String,
-    ) -> impl std::future::Future<Output = Result<Option<ServerCommunicationConfig>, Self::GetError>>;
+    ) -> impl std::future::Future<Output = Result<Option<ServerCommunicationConfig>, Self::GetError>>
+           + Send;
 
     /// Saves configuration for a hostname
     ///
@@ -59,7 +60,7 @@ pub trait ServerCommunicationConfigRepository: Send + Sync {
         &self,
         hostname: String,
         config: ServerCommunicationConfig,
-    ) -> impl std::future::Future<Output = Result<(), Self::SaveError>>;
+    ) -> impl std::future::Future<Output = Result<(), Self::SaveError>> + Send;
 }
 
 #[cfg(test)]

--- a/crates/bitwarden-server-communication-config/src/repository.rs
+++ b/crates/bitwarden-server-communication-config/src/repository.rs
@@ -41,7 +41,7 @@ pub trait ServerCommunicationConfigRepository: Send + Sync {
         &self,
         hostname: String,
     ) -> impl std::future::Future<Output = Result<Option<ServerCommunicationConfig>, Self::GetError>>
-           + Send;
+    + Send;
 
     /// Saves configuration for a hostname
     ///


### PR DESCRIPTION
## 🎟️ Tracking

- Jira: [PM-27126](https://bitwarden.atlassian.net/browse/PM-27126)
- Parent Epic: [PM-27124](https://bitwarden.atlassian.net/browse/PM-27124) (self-hosted SSO cookie vendor support)
- Dependencies: PM-29492 (reqwest_middleware support), PM-29145 (ServerCommunicationConfigClient)

## 📔 Objective

Self-hosted Bitwarden deployments using SSO cookie vendor load balancers (e.g., AWS Application Load Balancer) require sticky-session cookies on every SDK API request. Without these cookies the load balancer routes requests to the wrong backend and the session fails.

This PR adds automatic cookie injection to all outgoing SDK API requests by implementing `reqwest_middleware::Middleware` in the `bitwarden-server-communication-config` crate and threading it through `bitwarden-pm` and `bitwarden-core`. Cookies stored in `ServerCommunicationConfigClient` are attached as a `Cookie` header (RFC 6265 semicolon-separated format) before each request. ELB cookie sharding (multiple `(name, value)` pairs per hostname) is fully supported. On 3xx redirect responses the middleware propagates the response unchanged — cookie re-acquisition is the application layer's responsibility.

### Changes Overview

**`bitwarden-server-communication-config`** (new file + modifications)
- `src/middleware.rs` (new): `ServerCommunicationConfigMiddleware<R, P>` implementing `reqwest_middleware::Middleware`. Reads stored cookies via `ServerCommunicationConfigClient::cookies(hostname)`, joins shards as `name=value; name=value`, inserts `Cookie` header. On 3xx propagates unchanged (ADR-006). Includes `Clone` impl via `Arc::clone`. WASM conditional `async_trait`. Unit tests covering empty cookie state, single cookie, sharded cookies, and Arc-sharing semantics on Clone.
- `src/client.rs`: Adds `create_middleware(self: Arc<Self>) -> Arc<dyn reqwest_middleware::Middleware>` factory method.
- `src/lib.rs`: Exports `ServerCommunicationConfigMiddleware` publicly.
- `Cargo.toml`: Adds `reqwest-middleware = { workspace = true }` and `http = { workspace = true }`.

**`bitwarden-core`** (modification)
- `src/client/client.rs`: Adds `Client::new_with_token_handler_and_middlewares(settings, token_handler, additional_middlewares: Vec<Arc<dyn Middleware>>)`. Chains auth middleware first, then additional middlewares in order. `bitwarden-core` does NOT gain a dependency on `bitwarden-server-communication-config` (ADR-003).

**`bitwarden-pm`** (modification)
- `src/lib.rs`: Adds `PasswordManagerClient::new_with_server_communication_config<R, P>(settings, server_comm_config: Arc<ServerCommunicationConfigClient<R, P>>) -> Self`. Calls `create_middleware()` and passes the result to `new_with_token_handler_and_middlewares()`. Existing constructors (`new()`, `new_with_client_tokens()`) are unchanged.
- `Cargo.toml`: Adds `bitwarden-server-communication-config = { workspace = true }`.

**Formatting**
- `cargo fmt` corrections applied across all modified files (no logic changes).

### Design Decisions

- **Cookie injection via middleware, not `CookieStore`** (ADR-001): `reqwest::CookieStore` operates below the middleware chain and cannot participate in response-level inspection. `reqwest_middleware::Middleware` aligns with the established architecture from PR #699 (PM-29492) and enables hostname-based cookie lookup.
- **`Arc<Self>` for Clone, no bounds on `R`/`P`** (ADR-002): `ServerCommunicationConfigMiddleware` holds `Arc<ServerCommunicationConfigClient<R, P>>`. No `Clone` bounds are added to `R` or `P` — preserves type parameter flexibility for downstream platform integrations.
- **Injection point in `bitwarden-pm`, not `bitwarden-core`** (ADR-003): `bitwarden-core` remains decoupled from `bitwarden-server-communication-config`. `bitwarden-pm` is the correct wiring layer as it already depends on both crates. Breaking change to `PasswordManagerClient` accepted (additive constructor, existing constructors unchanged).
- **3xx propagate unchanged, no retry** (ADR-006): `acquire_cookie()` triggers user-interactive IdP flows (browser/WebView redirect) and cannot be called silently from within middleware. The middleware detects 3xx and returns it as-is; the application layer is responsible for initiating re-acquisition.

## 🚨 Breaking Changes

None. All changes are additive:
- `new_with_token_handler_and_middlewares()` is a new constructor on `bitwarden-core::Client` — existing constructors are unchanged.
- `new_with_server_communication_config()` is a new constructor on `PasswordManagerClient` — existing constructors are unchanged.
- `ServerCommunicationConfigMiddleware` and `create_middleware()` are new public API surface on `bitwarden-server-communication-config`.

## Testing

**Unit tests delivered** (in `bitwarden-server-communication-config/src/middleware.rs`):
- `middleware_no_cookie_header_when_empty`: empty `cookies()` result; verifies no `Cookie` header injected
- `middleware_formats_single_cookie`: single shard; asserts `name=value` format
- `middleware_formats_sharded_cookies_with_semicolons`: 3 shards; asserts semicolon-joined Cookie header
- `middleware_clone_shares_client`: clones share the same underlying `Arc` (verified via `Arc::ptr_eq`)

**Unit tests delivered** (in `bitwarden-pm`):
- `new_with_server_communication_config_constructs_client`: compiles and returns `PasswordManagerClient`
- `existing_new_constructor_unchanged`: existing constructor behavior preserved

**Known gap**: `middleware_propagates_3xx_unchanged` — explicit test against a mocked 3xx endpoint is absent. The behavior is correct by design (`next.run()` returns responses including 3xx unchanged), but an integration test covering this case is not yet written.

**Manual test plan**:
| ID | Scenario | Expected |
|----|----------|----------|
| COOK-01 | Client with stored cookie shards issues API request | `Cookie: shard0=val0; shard1=val1` in request headers |
| COOK-02 | Empty cookie store issues API request | No `Cookie` header |
| COOK-03 | Mock 3xx response from server | 3xx returned to caller; no retry; `acquire_cookie` not called |
| COOK-04 | Existing `PasswordManagerClient::new()` usage | Unchanged behavior |

[PM-27126]: https://bitwarden.atlassian.net/browse/PM-27126?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PM-27124]: https://bitwarden.atlassian.net/browse/PM-27124?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ