### PR TITLE
[PM-33766] Fix key rotation when member of an organization with at least one vault item

### DIFF
--- a/crates/bitwarden-user-crypto-management/src/key_rotation/sync.rs
+++ b/crates/bitwarden-user-crypto-management/src/key_rotation/sync.rs
@@ -231,7 +231,7 @@ fn parse_ciphers(
     let ciphers = ciphers
         .ok_or(SyncError::DataError)?
         .into_iter()
-        .filter(|c| c.organization_id == None)
+        .filter(|c| c.organization_id.is_none())
         .map(|c| {
             let _span = debug_span!("deserializing_cipher", cipher_id = ?c.id).entered();
             Cipher::try_from(c).debug_map_err(SyncError::DataError)

--- a/crates/bitwarden-user-crypto-management/src/key_rotation/sync.rs
+++ b/crates/bitwarden-user-crypto-management/src/key_rotation/sync.rs
@@ -231,6 +231,7 @@ fn parse_ciphers(
     let ciphers = ciphers
         .ok_or(SyncError::DataError)?
         .into_iter()
+        .filter(|c| c.organization_id == None)
         .map(|c| {
             let _span = debug_span!("deserializing_cipher", cipher_id = ?c.id).entered();
             Cipher::try_from(c).debug_map_err(SyncError::DataError)
@@ -728,6 +729,21 @@ mod tests {
             mock.devices_api.checkpoint();
             mock.web_authn_api.checkpoint();
         }
+    }
+
+    #[test]
+    fn test_parse_ciphers_filters_organization_ciphers() {
+        let personal_cipher_id = uuid::Uuid::new_v4();
+        let organization_cipher_id = uuid::Uuid::new_v4();
+
+        let personal_cipher = create_test_cipher(personal_cipher_id);
+        let mut organization_cipher = create_test_cipher(organization_cipher_id);
+        organization_cipher.organization_id = Some(uuid::Uuid::new_v4());
+
+        let ciphers = parse_ciphers(Some(vec![personal_cipher, organization_cipher])).unwrap();
+
+        assert_eq!(ciphers.len(), 1);
+        assert_eq!(ciphers[0].id, Some(CipherId::new(personal_cipher_id)));
     }
 
     #[tokio::test]


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-33766

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
Ciphers that are part of an organization should be excluded from the sync during key-rotation.

## 🚨 Breaking Changes

<!-- Does this PR introduce any breaking changes? If so, please describe the impact and migration path for clients.

If you're unsure, the automated TypeScript compatibility check will run when you open/update this PR and provide feedback.

For breaking changes:
1. Describe what changed in the client interface
2. Explain why the change was necessary
3. Provide migration steps for client developers
4. Link to any paired client PRs if needed

Otherwise, you can remove this section. -->
