### PR TITLE
[PM-33870] Fix Cipher Corruption for some cipher key scenarios

### DIFF
--- a/crates/bitwarden-vault/src/cipher/cipher_client/mod.rs
+++ b/crates/bitwarden-vault/src/cipher/cipher_client/mod.rs
@@ -52,6 +52,7 @@ impl CiphersClient {
                 .internal
                 .get_flags()
                 .enable_cipher_key_encryption
+            && cipher_view.view_password
         {
             let key = cipher_view.key_identifier();
             cipher_view.generate_cipher_key(&mut key_store.context(), key)?;
@@ -99,6 +100,7 @@ impl CiphersClient {
                 .internal
                 .get_flags()
                 .enable_cipher_key_encryption
+            && cipher_view.view_password
         {
             cipher_view.generate_cipher_key(&mut ctx, new_key_id)?;
         } else {
@@ -139,7 +141,7 @@ impl CiphersClient {
         let prepared_views: Vec<CipherView> = cipher_views
             .into_iter()
             .map(|mut cv| {
-                if cv.key.is_none() && enable_cipher_key {
+                if cv.key.is_none() && enable_cipher_key && cv.view_password {
                     let key = cv.key_identifier();
                     cv.generate_cipher_key(&mut ctx, key)?;
                 }


### PR DESCRIPTION
 ## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-33870

## 📔 Objective

When a cipher is saved by a user meeting the following conditions, then the cipher gets corrupted. This fixes the scenario by preventing migration to a cipher key when the user does not have permissions to view cipher passwords.

The issue occurs when a user edits a cipher meeting the following conditions:
1. The user has "Edit items, hidden passwords" permission for the cipher's Collection.
2. The cipher does not currently have a cipher key
3. cipher-key-encryption is enabled
