### PR TITLE
fix(server-communication-config): prevent set_communication_type from clearing acquired cookies

### DIFF
--- a/crates/bitwarden-server-communication-config/src/client.rs
+++ b/crates/bitwarden-server-communication-config/src/client.rs
@@ -1,8 +1,9 @@
 #[cfg(test)]
 use crate::AcquiredCookie;
 use crate::{
-    AcquireCookieError, BootstrapConfig, ServerCommunicationConfig,
+    AcquireCookieError, BootstrapConfig, BootstrapConfigRequest, ServerCommunicationConfig,
     ServerCommunicationConfigPlatformApi, ServerCommunicationConfigRepository,
+    SetCommunicationTypeRequest, SsoCookieVendorConfig,
 };
 
 /// Server communication configuration client
@@ -82,10 +83,14 @@ where
     /// This method saves the provided communication configuration to the repository.
     /// Typically called when receiving the `/api/config` response from the server.
     ///
+    /// The request type intentionally excludes `cookie_value`, since cookies are
+    /// managed separately via [`Self::acquire_cookie`]. Any previously acquired
+    /// cookies stored in the repository are preserved across calls to this method.
+    ///
     /// # Arguments
     ///
     /// * `hostname` - The server hostname (e.g., "vault.acme.com")
-    /// * `config` - The server communication configuration to store
+    /// * `request` - The server communication configuration to store
     ///
     /// # Errors
     ///
@@ -93,8 +98,37 @@ where
     pub async fn set_communication_type(
         &self,
         hostname: String,
-        config: ServerCommunicationConfig,
+        request: SetCommunicationTypeRequest,
     ) -> Result<(), R::SaveError> {
+        let existing_cookie_value = match &request.bootstrap {
+            BootstrapConfigRequest::SsoCookieVendor(_) => self
+                .repository
+                .get(hostname.clone())
+                .await
+                .ok()
+                .flatten()
+                .and_then(|existing| match existing.bootstrap {
+                    BootstrapConfig::SsoCookieVendor(v) => v.cookie_value,
+                    _ => None,
+                }),
+            BootstrapConfigRequest::Direct => None,
+        };
+
+        let config = ServerCommunicationConfig {
+            bootstrap: match request.bootstrap {
+                BootstrapConfigRequest::Direct => BootstrapConfig::Direct,
+                BootstrapConfigRequest::SsoCookieVendor(v) => {
+                    BootstrapConfig::SsoCookieVendor(SsoCookieVendorConfig {
+                        idp_login_url: v.idp_login_url,
+                        cookie_name: v.cookie_name,
+                        cookie_domain: v.cookie_domain,
+                        vault_url: v.vault_url,
+                        cookie_value: existing_cookie_value,
+                    })
+                }
+            },
+        };
+
         self.repository.save(hostname, config).await
     }
 
@@ -205,7 +239,7 @@ mod tests {
     use tokio::sync::RwLock;
 
     use super::*;
-    use crate::SsoCookieVendorConfig;
+    use crate::{SsoCookieVendorConfig, SsoCookieVendorConfigRequest};
 
     /// Mock in-memory repository for testing
     #[derive(Default, Clone)]
@@ -821,17 +855,15 @@ mod tests {
         let platform_api = MockPlatformApi::new();
         let client = ServerCommunicationConfigClient::new(repo.clone(), platform_api);
 
-        let config = ServerCommunicationConfig {
-            bootstrap: BootstrapConfig::Direct,
+        let request = SetCommunicationTypeRequest {
+            bootstrap: BootstrapConfigRequest::Direct,
         };
 
-        // Call set_communication_type
         client
-            .set_communication_type("vault.example.com".to_string(), config.clone())
+            .set_communication_type("vault.example.com".to_string(), request)
             .await
             .unwrap();
 
-        // Verify config was saved
         let saved_config = repo
             .get("vault.example.com".to_string())
             .await
@@ -847,23 +879,20 @@ mod tests {
         let platform_api = MockPlatformApi::new();
         let client = ServerCommunicationConfigClient::new(repo.clone(), platform_api);
 
-        let config = ServerCommunicationConfig {
-            bootstrap: BootstrapConfig::SsoCookieVendor(SsoCookieVendorConfig {
+        let request = SetCommunicationTypeRequest {
+            bootstrap: BootstrapConfigRequest::SsoCookieVendor(SsoCookieVendorConfigRequest {
                 idp_login_url: Some("https://idp.example.com/login".to_string()),
                 cookie_name: Some("SessionCookie".to_string()),
                 cookie_domain: Some("vault.example.com".to_string()),
                 vault_url: Some("https://vault.example.com".to_string()),
-                cookie_value: None,
             }),
         };
 
-        // Call set_communication_type
         client
-            .set_communication_type("vault.example.com".to_string(), config.clone())
+            .set_communication_type("vault.example.com".to_string(), request)
             .await
             .unwrap();
 
-        // Verify config was saved
         let saved_config = repo
             .get("vault.example.com".to_string())
             .await
@@ -902,22 +931,20 @@ mod tests {
         let client = ServerCommunicationConfigClient::new(repo.clone(), platform_api);
 
         // Overwrite with SsoCookieVendor config
-        let new_config = ServerCommunicationConfig {
-            bootstrap: BootstrapConfig::SsoCookieVendor(SsoCookieVendorConfig {
+        let request = SetCommunicationTypeRequest {
+            bootstrap: BootstrapConfigRequest::SsoCookieVendor(SsoCookieVendorConfigRequest {
                 idp_login_url: Some("https://new-idp.example.com/login".to_string()),
                 cookie_name: Some("NewCookie".to_string()),
                 cookie_domain: Some("vault.example.com".to_string()),
                 vault_url: Some("https://vault.example.com".to_string()),
-                cookie_value: None,
             }),
         };
 
         client
-            .set_communication_type("vault.example.com".to_string(), new_config)
+            .set_communication_type("vault.example.com".to_string(), request)
             .await
             .unwrap();
 
-        // Verify new config replaced old config
         let saved_config = repo
             .get("vault.example.com".to_string())
             .await
@@ -941,31 +968,27 @@ mod tests {
         let platform_api = MockPlatformApi::new();
         let client = ServerCommunicationConfigClient::new(repo.clone(), platform_api);
 
-        // Save config for first hostname
-        let config1 = ServerCommunicationConfig {
-            bootstrap: BootstrapConfig::Direct,
+        let request1 = SetCommunicationTypeRequest {
+            bootstrap: BootstrapConfigRequest::Direct,
         };
         client
-            .set_communication_type("vault1.example.com".to_string(), config1)
+            .set_communication_type("vault1.example.com".to_string(), request1)
             .await
             .unwrap();
 
-        // Save different config for second hostname
-        let config2 = ServerCommunicationConfig {
-            bootstrap: BootstrapConfig::SsoCookieVendor(SsoCookieVendorConfig {
+        let request2 = SetCommunicationTypeRequest {
+            bootstrap: BootstrapConfigRequest::SsoCookieVendor(SsoCookieVendorConfigRequest {
                 idp_login_url: Some("https://idp.example.com/login".to_string()),
                 cookie_name: Some("TestCookie".to_string()),
                 cookie_domain: Some("vault2.example.com".to_string()),
                 vault_url: Some("https://vault2.example.com".to_string()),
-                cookie_value: None,
             }),
         };
         client
-            .set_communication_type("vault2.example.com".to_string(), config2)
+            .set_communication_type("vault2.example.com".to_string(), request2)
             .await
             .unwrap();
 
-        // Verify both configs are stored independently
         let saved_config1 = repo
             .get("vault1.example.com".to_string())
             .await
@@ -982,6 +1005,64 @@ mod tests {
             saved_config2.bootstrap,
             BootstrapConfig::SsoCookieVendor(_)
         ));
+    }
+
+    #[tokio::test]
+    async fn set_communication_type_preserves_existing_cookies() {
+        let repo = MockRepository::default();
+        let platform_api = MockPlatformApi::new();
+
+        // Setup existing config with acquired cookies
+        let existing_config = ServerCommunicationConfig {
+            bootstrap: BootstrapConfig::SsoCookieVendor(SsoCookieVendorConfig {
+                idp_login_url: Some("https://idp.example.com/login".to_string()),
+                cookie_name: Some("SessionCookie".to_string()),
+                cookie_domain: Some("example.com".to_string()),
+                vault_url: Some("https://vault.example.com".to_string()),
+                cookie_value: Some(vec![AcquiredCookie {
+                    name: "SessionCookie".to_string(),
+                    value: "previously-acquired-value".to_string(),
+                }]),
+            }),
+        };
+        repo.save("vault.example.com".to_string(), existing_config)
+            .await
+            .unwrap();
+
+        let client = ServerCommunicationConfigClient::new(repo.clone(), platform_api);
+
+        // Re-emit the same config (as happens during auth state transitions)
+        let request = SetCommunicationTypeRequest {
+            bootstrap: BootstrapConfigRequest::SsoCookieVendor(SsoCookieVendorConfigRequest {
+                idp_login_url: Some("https://idp.example.com/login".to_string()),
+                cookie_name: Some("SessionCookie".to_string()),
+                cookie_domain: Some("example.com".to_string()),
+                vault_url: Some("https://vault.example.com".to_string()),
+            }),
+        };
+
+        client
+            .set_communication_type("vault.example.com".to_string(), request)
+            .await
+            .unwrap();
+
+        // Verify cookies were preserved
+        let saved_config = repo
+            .get("vault.example.com".to_string())
+            .await
+            .unwrap()
+            .unwrap();
+
+        if let BootstrapConfig::SsoCookieVendor(vendor_config) = saved_config.bootstrap {
+            let cookies = vendor_config
+                .cookie_value
+                .expect("cookies should be preserved");
+            assert_eq!(cookies.len(), 1);
+            assert_eq!(cookies[0].name, "SessionCookie");
+            assert_eq!(cookies[0].value, "previously-acquired-value");
+        } else {
+            panic!("Expected SsoCookieVendor config");
+        }
     }
 
     #[tokio::test]

--- a/crates/bitwarden-server-communication-config/src/config.rs
+++ b/crates/bitwarden-server-communication-config/src/config.rs
@@ -60,6 +60,65 @@ pub struct SsoCookieVendorConfig {
     pub cookie_value: Option<Vec<crate::AcquiredCookie>>,
 }
 
+/// Request to set server communication configuration for a hostname
+///
+/// This is the input type for [`ServerCommunicationConfigClient::set_communication_type`].
+/// Unlike [`ServerCommunicationConfig`], this type does not include acquired cookies,
+/// since cookies are managed separately via
+/// [`ServerCommunicationConfigClient::acquire_cookie`].
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(
+    feature = "wasm",
+    derive(tsify::Tsify),
+    tsify(into_wasm_abi, from_wasm_abi)
+)]
+#[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
+pub struct SetCommunicationTypeRequest {
+    /// Bootstrap configuration determining how to establish server communication
+    pub bootstrap: BootstrapConfigRequest,
+}
+
+/// Bootstrap configuration variant for [`SetCommunicationTypeRequest`]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(
+    feature = "wasm",
+    derive(tsify::Tsify),
+    tsify(into_wasm_abi, from_wasm_abi)
+)]
+#[cfg_attr(feature = "uniffi", derive(uniffi::Enum))]
+#[serde(tag = "type", rename_all = "camelCase")]
+pub enum BootstrapConfigRequest {
+    /// Direct connection with no special authentication requirements
+    Direct,
+    /// SSO cookie vendor configuration for load balancer authentication
+    SsoCookieVendor(SsoCookieVendorConfigRequest),
+}
+
+/// SSO cookie vendor configuration for [`SetCommunicationTypeRequest`]
+///
+/// Contains the server-provided configuration fields without acquired cookies.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[cfg_attr(
+    feature = "wasm",
+    derive(tsify::Tsify),
+    tsify(into_wasm_abi, from_wasm_abi)
+)]
+#[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
+pub struct SsoCookieVendorConfigRequest {
+    /// Identity provider login URL for browser redirect during bootstrap
+    pub idp_login_url: Option<String>,
+    /// Cookie name (base name, without shard suffix)
+    pub cookie_name: Option<String>,
+    /// Cookie domain for validation
+    pub cookie_domain: Option<String>,
+    /// Vault URL for cookie acquisition redirect
+    ///
+    /// This is the full vault URL (scheme + host + port) where the browser
+    /// should be redirected for SSO cookie acquisition.
+    pub vault_url: Option<String>,
+}
+
 // We manually implement Debug to make sure we don't print sensitive cookie values
 impl std::fmt::Debug for SsoCookieVendorConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {

--- a/crates/bitwarden-server-communication-config/src/config.rs
+++ b/crates/bitwarden-server-communication-config/src/config.rs
@@ -62,10 +62,11 @@ pub struct SsoCookieVendorConfig {
 
 /// Request to set server communication configuration for a hostname
 ///
-/// This is the input type for [`ServerCommunicationConfigClient::set_communication_type`].
+/// This is the input type for
+/// [`ServerCommunicationConfigClient::set_communication_type`](crate::ServerCommunicationConfigClient::set_communication_type).
 /// Unlike [`ServerCommunicationConfig`], this type does not include acquired cookies,
 /// since cookies are managed separately via
-/// [`ServerCommunicationConfigClient::acquire_cookie`].
+/// [`ServerCommunicationConfigClient::acquire_cookie`](crate::ServerCommunicationConfigClient::acquire_cookie).
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(
     feature = "wasm",

--- a/crates/bitwarden-server-communication-config/src/lib.rs
+++ b/crates/bitwarden-server-communication-config/src/lib.rs
@@ -15,7 +15,10 @@ mod platform_api;
 mod repository;
 
 pub use client::ServerCommunicationConfigClient;
-pub use config::{BootstrapConfig, ServerCommunicationConfig, SsoCookieVendorConfig};
+pub use config::{
+    BootstrapConfig, BootstrapConfigRequest, ServerCommunicationConfig,
+    SetCommunicationTypeRequest, SsoCookieVendorConfig, SsoCookieVendorConfigRequest,
+};
 pub use platform_api::{AcquireCookieError, AcquiredCookie, ServerCommunicationConfigPlatformApi};
 pub use repository::{
     ServerCommunicationConfigRepository, ServerCommunicationConfigRepositoryError,

--- a/crates/bitwarden-server-communication-config/src/wasm/client.rs
+++ b/crates/bitwarden-server-communication-config/src/wasm/client.rs
@@ -1,7 +1,7 @@
 use wasm_bindgen::prelude::*;
 
 use crate::{
-    ServerCommunicationConfig, ServerCommunicationConfigClient,
+    ServerCommunicationConfig, ServerCommunicationConfigClient, SetCommunicationTypeRequest,
     wasm::{
         JsServerCommunicationConfigPlatformApi, JsServerCommunicationConfigRepository,
         RawJsServerCommunicationConfigPlatformApi, RawJsServerCommunicationConfigRepository,
@@ -86,11 +86,12 @@ impl JsServerCommunicationConfigClient {
     ///
     /// This method saves the provided communication configuration to the repository.
     /// Typically called when receiving the `/api/config` response from the server.
+    /// Previously acquired cookies are preserved automatically.
     ///
     /// # Arguments
     ///
     /// * `hostname` - The server hostname (e.g., "vault.acme.com")
-    /// * `config` - The server communication configuration to store
+    /// * `request` - The server communication configuration to store
     ///
     /// # Errors
     ///
@@ -99,9 +100,9 @@ impl JsServerCommunicationConfigClient {
     pub async fn set_communication_type(
         &self,
         hostname: String,
-        config: ServerCommunicationConfig,
+        request: SetCommunicationTypeRequest,
     ) -> Result<(), String> {
-        self.client.set_communication_type(hostname, config).await
+        self.client.set_communication_type(hostname, request).await
     }
 
     /// Acquires a cookie from the platform and saves it to the repository

--- a/crates/bitwarden-uniffi/src/platform/server_communication_config.rs
+++ b/crates/bitwarden-uniffi/src/platform/server_communication_config.rs
@@ -2,6 +2,7 @@ use std::sync::Arc;
 
 use bitwarden_server_communication_config::{
     AcquiredCookie, ServerCommunicationConfig, ServerCommunicationConfigPlatformApi,
+    SetCommunicationTypeRequest,
 };
 
 use crate::error::Result;
@@ -59,12 +60,15 @@ impl ServerCommunicationConfigClient {
     ///
     /// This method saves the provided communication configuration to the repository.
     /// Typically called when receiving the `/api/config` response from the server.
+    /// Previously acquired cookies are preserved automatically.
     pub async fn set_communication_type(
         &self,
         hostname: String,
-        config: ServerCommunicationConfig,
+        request: SetCommunicationTypeRequest,
     ) -> Result<()> {
-        self.client.set_communication_type(hostname, config).await?;
+        self.client
+            .set_communication_type(hostname, request)
+            .await?;
         Ok(())
     }
 


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective

During login, the `serverConfig$` observable emits twice (once when `activeUserId$` changes, once when auth status transitions from Locked to Unlocked). Each emission calls `parseBootstrapConfig()` which produces a `ServerCommunicationConfig` with `cookieValue: undefined`, and `setCommunicationType()` saved this directly to the repository, overwriting any previously acquired cookies. This caused `SsoCookieMain` to clear cookies and re-trigger acquisition on every config re-emission.

The fix introduces a `SetCommunicationTypeRequest` type (with `BootstrapConfigRequest` and `SsoCookieVendorConfigRequest`) that structurally excludes `cookie_value`. The `set_communication_type` method now:

1. Accepts this request type, making it impossible for callers to accidentally pass cookie values
2. Preserves any previously acquired `cookie_value` from the repository when saving

Cookies are only ever set through `acquire_cookie`, and this change makes that contract explicit at the type level.

## 🚨 Breaking Changes

`set_communication_type` now accepts `SetCommunicationTypeRequest` instead of `ServerCommunicationConfig`. Callers need to update to use the new request types (`SetCommunicationTypeRequest`, `BootstrapConfigRequest`, `SsoCookieVendorConfigRequest`), which have the same fields minus `cookie_value`.

**Migration**: Replace `ServerCommunicationConfig` / `BootstrapConfig` / `SsoCookieVendorConfig` with their `*Request` counterparts when calling `setCommunicationType()`. The `cookie_value` field is simply removed from the input.