### PR TITLE
[PM-31870] Add in-memory database backend to bitwarden-state

### DIFF
--- a/crates/bitwarden-state/src/registry.rs
+++ b/crates/bitwarden-state/src/registry.rs
@@ -10,6 +10,7 @@ use thiserror::Error;
 use crate::{
     repository::{Repository, RepositoryItem, RepositoryItemData, RepositoryMigrations},
     sdk_managed::{Database, DatabaseConfiguration, SystemDatabase},
+    settings::{Key, Setting, SettingItem, SettingsError},
 };
 
 /// A registry that contains repositories for different types of items.
@@ -49,6 +50,27 @@ impl StateRegistry {
             database: OnceLock::new(),
             sdk_managed: RwLock::new(Vec::new()),
         }
+    }
+
+    /// Creates a new `StateRegistry` with an in-memory database pre-initialized.
+    /// Data stored in memory is ephemeral and will be lost when the registry is dropped.
+    /// Intended for testing and development use cases.
+    pub fn new_with_memory_db() -> Self {
+        let database = OnceLock::new();
+        let _ = database.set(crate::sdk_managed::SystemDatabase::new_memory());
+        StateRegistry {
+            client_managed: RwLock::new(HashMap::new()),
+            database,
+            sdk_managed: RwLock::new(
+                RepositoryMigrations::new(vec![]).into_repository_items(),
+            ),
+        }
+    }
+
+    /// Get a type-safe handle to a setting value.
+    pub fn setting<T>(&self, key: Key<T>) -> Result<Setting<T>, SettingsError> {
+        let repository = self.get::<SettingItem>()?;
+        Ok(Setting::new(repository, key))
     }
 
     // TODO: Ideally we'd do this in new, but that would mean making the client initialization

--- a/crates/bitwarden-state/src/registry.rs
+++ b/crates/bitwarden-state/src/registry.rs
@@ -9,7 +9,7 @@ use thiserror::Error;
 
 use crate::{
     repository::{Repository, RepositoryItem, RepositoryItemData, RepositoryMigrations},
-    sdk_managed::{Database, DatabaseConfiguration, SystemDatabase},
+    sdk_managed::{DatabaseConfiguration, SystemDatabase},
     settings::{Key, Setting, SettingItem, SettingsError},
 };
 
@@ -61,9 +61,7 @@ impl StateRegistry {
         StateRegistry {
             client_managed: RwLock::new(HashMap::new()),
             database,
-            sdk_managed: RwLock::new(
-                RepositoryMigrations::new(vec![]).into_repository_items(),
-            ),
+            sdk_managed: RwLock::new(RepositoryMigrations::new(vec![]).into_repository_items()),
         }
     }
 

--- a/crates/bitwarden-state/src/sdk_managed/configuration.rs
+++ b/crates/bitwarden-state/src/sdk_managed/configuration.rs
@@ -18,4 +18,9 @@ pub enum DatabaseConfiguration {
         /// names to avoid conflicts.
         db_name: String,
     },
+
+    /// In-memory database configuration, platform-agnostic.
+    /// Data is ephemeral and will be lost when the Client is dropped.
+    /// Intended for testing and development use cases.
+    Memory,
 }

--- a/crates/bitwarden-state/src/sdk_managed/memory.rs
+++ b/crates/bitwarden-state/src/sdk_managed/memory.rs
@@ -17,7 +17,7 @@ impl MemoryDatabase {
         MemoryDatabase(Arc::new(Mutex::new(HashMap::new())))
     }
 
-    fn store(&self) -> std::sync::MutexGuard<HashMap<TypeId, HashMap<String, String>>> {
+    fn store(&self) -> std::sync::MutexGuard<'_, HashMap<TypeId, HashMap<String, String>>> {
         self.0
             .lock()
             .expect("MemoryDatabase mutex should not be poisoned")

--- a/crates/bitwarden-state/src/sdk_managed/memory.rs
+++ b/crates/bitwarden-state/src/sdk_managed/memory.rs
@@ -18,7 +18,9 @@ impl MemoryDatabase {
     }
 
     fn store(&self) -> std::sync::MutexGuard<HashMap<TypeId, HashMap<String, String>>> {
-        self.0.lock().expect("MemoryDatabase mutex should not be poisoned")
+        self.0
+            .lock()
+            .expect("MemoryDatabase mutex should not be poisoned")
     }
 }
 
@@ -33,10 +35,7 @@ impl Database for MemoryDatabase {
         Ok(MemoryDatabase::new())
     }
 
-    async fn get<T: RepositoryItem>(
-        &self,
-        key: &str,
-    ) -> Result<Option<T>, DatabaseError> {
+    async fn get<T: RepositoryItem>(&self, key: &str) -> Result<Option<T>, DatabaseError> {
         let store = self.store();
         match store.get(&TypeId::of::<T>()).and_then(|ns| ns.get(key)) {
             Some(json) => Ok(Some(serde_json::from_str(json)?)),
@@ -44,9 +43,7 @@ impl Database for MemoryDatabase {
         }
     }
 
-    async fn list<T: RepositoryItem>(
-        &self,
-    ) -> Result<Vec<T>, DatabaseError> {
+    async fn list<T: RepositoryItem>(&self) -> Result<Vec<T>, DatabaseError> {
         let store = self.store();
         match store.get(&TypeId::of::<T>()) {
             None => Ok(Vec::new()),
@@ -57,13 +54,12 @@ impl Database for MemoryDatabase {
         }
     }
 
-    async fn set<T: RepositoryItem>(
-        &self,
-        key: &str,
-        value: T,
-    ) -> Result<(), DatabaseError> {
+    async fn set<T: RepositoryItem>(&self, key: &str, value: T) -> Result<(), DatabaseError> {
         let json = serde_json::to_string(&value)?;
-        self.store().entry(TypeId::of::<T>()).or_default().insert(key.to_string(), json);
+        self.store()
+            .entry(TypeId::of::<T>())
+            .or_default()
+            .insert(key.to_string(), json);
         Ok(())
     }
 
@@ -79,20 +75,14 @@ impl Database for MemoryDatabase {
         Ok(())
     }
 
-    async fn remove<T: RepositoryItem>(
-        &self,
-        key: &str,
-    ) -> Result<(), DatabaseError> {
+    async fn remove<T: RepositoryItem>(&self, key: &str) -> Result<(), DatabaseError> {
         if let Some(namespace) = self.store().get_mut(&TypeId::of::<T>()) {
             namespace.remove(key);
         }
         Ok(())
     }
 
-    async fn remove_bulk<T: RepositoryItem>(
-        &self,
-        keys: Vec<String>,
-    ) -> Result<(), DatabaseError> {
+    async fn remove_bulk<T: RepositoryItem>(&self, keys: Vec<String>) -> Result<(), DatabaseError> {
         if let Some(namespace) = self.store().get_mut(&TypeId::of::<T>()) {
             for key in &keys {
                 namespace.remove(key.as_str());
@@ -101,9 +91,7 @@ impl Database for MemoryDatabase {
         Ok(())
     }
 
-    async fn remove_all<T: RepositoryItem>(
-        &self,
-    ) -> Result<(), DatabaseError> {
+    async fn remove_all<T: RepositoryItem>(&self) -> Result<(), DatabaseError> {
         self.store().remove(&TypeId::of::<T>());
         Ok(())
     }
@@ -122,31 +110,46 @@ mod tests {
     struct ItemB(u32);
     register_repository_item!(String => ItemB, "ItemB");
 
-    fn make_db() -> MemoryDatabase { MemoryDatabase::new() }
+    fn make_db() -> MemoryDatabase {
+        MemoryDatabase::new()
+    }
 
     #[tokio::test]
     async fn mem_01_initialize_memory_config_succeeds() {
         let result = MemoryDatabase::initialize(
             DatabaseConfiguration::Memory,
             crate::repository::RepositoryMigrations::new(vec![]),
-        ).await;
+        )
+        .await;
         assert!(result.is_ok());
     }
 
     #[tokio::test]
     async fn mem_02_initialize_non_memory_config_fails() {
         let result = MemoryDatabase::initialize(
-            DatabaseConfiguration::Sqlite { db_name: "test".to_string(), folder_path: "/tmp".into() },
+            DatabaseConfiguration::Sqlite {
+                db_name: "test".to_string(),
+                folder_path: "/tmp".into(),
+            },
             crate::repository::RepositoryMigrations::new(vec![]),
-        ).await;
-        assert!(matches!(result, Err(DatabaseError::UnsupportedConfiguration(_))));
+        )
+        .await;
+        assert!(matches!(
+            result,
+            Err(DatabaseError::UnsupportedConfiguration(_))
+        ));
     }
 
     #[tokio::test]
     async fn mem_03_set_get_round_trip() {
         let db = make_db();
-        db.set::<ItemA>("k1", ItemA("hello".to_string())).await.unwrap();
-        assert_eq!(db.get::<ItemA>("k1").await.unwrap(), Some(ItemA("hello".to_string())));
+        db.set::<ItemA>("k1", ItemA("hello".to_string()))
+            .await
+            .unwrap();
+        assert_eq!(
+            db.get::<ItemA>("k1").await.unwrap(),
+            Some(ItemA("hello".to_string()))
+        );
     }
 
     #[tokio::test]
@@ -168,7 +171,9 @@ mod tests {
     #[tokio::test]
     async fn mem_06_remove_deletes_key() {
         let db = make_db();
-        db.set::<ItemA>("k1", ItemA("hello".to_string())).await.unwrap();
+        db.set::<ItemA>("k1", ItemA("hello".to_string()))
+            .await
+            .unwrap();
         db.remove::<ItemA>("k1").await.unwrap();
         assert_eq!(db.get::<ItemA>("k1").await.unwrap(), None);
     }
@@ -179,10 +184,15 @@ mod tests {
         db.set::<ItemA>("k1", ItemA("a".to_string())).await.unwrap();
         db.set::<ItemA>("k2", ItemA("b".to_string())).await.unwrap();
         db.set::<ItemA>("k3", ItemA("c".to_string())).await.unwrap();
-        db.remove_bulk::<ItemA>(vec!["k1".to_string(), "k2".to_string()]).await.unwrap();
+        db.remove_bulk::<ItemA>(vec!["k1".to_string(), "k2".to_string()])
+            .await
+            .unwrap();
         assert_eq!(db.get::<ItemA>("k1").await.unwrap(), None);
         assert_eq!(db.get::<ItemA>("k2").await.unwrap(), None);
-        assert_eq!(db.get::<ItemA>("k3").await.unwrap(), Some(ItemA("c".to_string())));
+        assert_eq!(
+            db.get::<ItemA>("k3").await.unwrap(),
+            Some(ItemA("c".to_string()))
+        );
     }
 
     #[tokio::test]
@@ -200,24 +210,39 @@ mod tests {
             ("k1".to_string(), ItemA("a".to_string())),
             ("k2".to_string(), ItemA("b".to_string())),
             ("k3".to_string(), ItemA("c".to_string())),
-        ]).await.unwrap();
+        ])
+        .await
+        .unwrap();
         assert_eq!(db.list::<ItemA>().await.unwrap().len(), 3);
     }
 
     #[tokio::test]
     async fn mem_10_typeid_namespace_isolation() {
         let db = make_db();
-        db.set::<ItemA>("shared_key", ItemA("from_a".to_string())).await.unwrap();
+        db.set::<ItemA>("shared_key", ItemA("from_a".to_string()))
+            .await
+            .unwrap();
         db.set::<ItemB>("shared_key", ItemB(42)).await.unwrap();
-        assert_eq!(db.get::<ItemA>("shared_key").await.unwrap(), Some(ItemA("from_a".to_string())));
-        assert_eq!(db.get::<ItemB>("shared_key").await.unwrap(), Some(ItemB(42)));
+        assert_eq!(
+            db.get::<ItemA>("shared_key").await.unwrap(),
+            Some(ItemA("from_a".to_string()))
+        );
+        assert_eq!(
+            db.get::<ItemB>("shared_key").await.unwrap(),
+            Some(ItemB(42))
+        );
     }
 
     #[tokio::test]
     async fn mem_11_clone_shares_backing_store() {
         let db = make_db();
         let cloned = db.clone();
-        db.set::<ItemA>("k1", ItemA("original".to_string())).await.unwrap();
-        assert_eq!(cloned.get::<ItemA>("k1").await.unwrap(), Some(ItemA("original".to_string())));
+        db.set::<ItemA>("k1", ItemA("original".to_string()))
+            .await
+            .unwrap();
+        assert_eq!(
+            cloned.get::<ItemA>("k1").await.unwrap(),
+            Some(ItemA("original".to_string()))
+        );
     }
 }

--- a/crates/bitwarden-state/src/sdk_managed/memory.rs
+++ b/crates/bitwarden-state/src/sdk_managed/memory.rs
@@ -1,0 +1,223 @@
+use std::{
+    any::TypeId,
+    collections::HashMap,
+    sync::{Arc, Mutex},
+};
+
+use crate::{
+    repository::{RepositoryItem, RepositoryMigrations},
+    sdk_managed::{Database, DatabaseConfiguration, DatabaseError},
+};
+
+#[derive(Clone)]
+pub struct MemoryDatabase(Arc<Mutex<HashMap<TypeId, HashMap<String, String>>>>);
+
+impl MemoryDatabase {
+    pub fn new() -> Self {
+        MemoryDatabase(Arc::new(Mutex::new(HashMap::new())))
+    }
+
+    fn store(&self) -> std::sync::MutexGuard<HashMap<TypeId, HashMap<String, String>>> {
+        self.0.lock().expect("MemoryDatabase mutex should not be poisoned")
+    }
+}
+
+impl Database for MemoryDatabase {
+    async fn initialize(
+        configuration: DatabaseConfiguration,
+        _registrations: RepositoryMigrations,
+    ) -> Result<Self, DatabaseError> {
+        let DatabaseConfiguration::Memory = configuration else {
+            return Err(DatabaseError::UnsupportedConfiguration(configuration));
+        };
+        Ok(MemoryDatabase::new())
+    }
+
+    async fn get<T: RepositoryItem>(
+        &self,
+        key: &str,
+    ) -> Result<Option<T>, DatabaseError> {
+        let store = self.store();
+        match store.get(&TypeId::of::<T>()).and_then(|ns| ns.get(key)) {
+            Some(json) => Ok(Some(serde_json::from_str(json)?)),
+            None => Ok(None),
+        }
+    }
+
+    async fn list<T: RepositoryItem>(
+        &self,
+    ) -> Result<Vec<T>, DatabaseError> {
+        let store = self.store();
+        match store.get(&TypeId::of::<T>()) {
+            None => Ok(Vec::new()),
+            Some(namespace) => namespace
+                .values()
+                .map(|json| serde_json::from_str(json).map_err(DatabaseError::from))
+                .collect(),
+        }
+    }
+
+    async fn set<T: RepositoryItem>(
+        &self,
+        key: &str,
+        value: T,
+    ) -> Result<(), DatabaseError> {
+        let json = serde_json::to_string(&value)?;
+        self.store().entry(TypeId::of::<T>()).or_default().insert(key.to_string(), json);
+        Ok(())
+    }
+
+    async fn set_bulk<T: RepositoryItem>(
+        &self,
+        values: Vec<(String, T)>,
+    ) -> Result<(), DatabaseError> {
+        let mut store = self.store();
+        let namespace = store.entry(TypeId::of::<T>()).or_default();
+        for (key, value) in values {
+            namespace.insert(key, serde_json::to_string(&value)?);
+        }
+        Ok(())
+    }
+
+    async fn remove<T: RepositoryItem>(
+        &self,
+        key: &str,
+    ) -> Result<(), DatabaseError> {
+        if let Some(namespace) = self.store().get_mut(&TypeId::of::<T>()) {
+            namespace.remove(key);
+        }
+        Ok(())
+    }
+
+    async fn remove_bulk<T: RepositoryItem>(
+        &self,
+        keys: Vec<String>,
+    ) -> Result<(), DatabaseError> {
+        if let Some(namespace) = self.store().get_mut(&TypeId::of::<T>()) {
+            for key in &keys {
+                namespace.remove(key.as_str());
+            }
+        }
+        Ok(())
+    }
+
+    async fn remove_all<T: RepositoryItem>(
+        &self,
+    ) -> Result<(), DatabaseError> {
+        self.store().remove(&TypeId::of::<T>());
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::register_repository_item;
+
+    #[derive(Debug, PartialEq, serde::Serialize, serde::Deserialize)]
+    struct ItemA(String);
+    register_repository_item!(String => ItemA, "ItemA");
+
+    #[derive(Debug, PartialEq, serde::Serialize, serde::Deserialize)]
+    struct ItemB(u32);
+    register_repository_item!(String => ItemB, "ItemB");
+
+    fn make_db() -> MemoryDatabase { MemoryDatabase::new() }
+
+    #[tokio::test]
+    async fn mem_01_initialize_memory_config_succeeds() {
+        let result = MemoryDatabase::initialize(
+            DatabaseConfiguration::Memory,
+            crate::repository::RepositoryMigrations::new(vec![]),
+        ).await;
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn mem_02_initialize_non_memory_config_fails() {
+        let result = MemoryDatabase::initialize(
+            DatabaseConfiguration::Sqlite { db_name: "test".to_string(), folder_path: "/tmp".into() },
+            crate::repository::RepositoryMigrations::new(vec![]),
+        ).await;
+        assert!(matches!(result, Err(DatabaseError::UnsupportedConfiguration(_))));
+    }
+
+    #[tokio::test]
+    async fn mem_03_set_get_round_trip() {
+        let db = make_db();
+        db.set::<ItemA>("k1", ItemA("hello".to_string())).await.unwrap();
+        assert_eq!(db.get::<ItemA>("k1").await.unwrap(), Some(ItemA("hello".to_string())));
+    }
+
+    #[tokio::test]
+    async fn mem_04_get_missing_key_returns_none() {
+        let db = make_db();
+        assert_eq!(db.get::<ItemA>("nope").await.unwrap(), None);
+    }
+
+    #[tokio::test]
+    async fn mem_05_list_returns_all_values() {
+        let db = make_db();
+        db.set::<ItemA>("k1", ItemA("a".to_string())).await.unwrap();
+        db.set::<ItemA>("k2", ItemA("b".to_string())).await.unwrap();
+        let mut list = db.list::<ItemA>().await.unwrap();
+        list.sort_by(|a, b| a.0.cmp(&b.0));
+        assert_eq!(list, vec![ItemA("a".to_string()), ItemA("b".to_string())]);
+    }
+
+    #[tokio::test]
+    async fn mem_06_remove_deletes_key() {
+        let db = make_db();
+        db.set::<ItemA>("k1", ItemA("hello".to_string())).await.unwrap();
+        db.remove::<ItemA>("k1").await.unwrap();
+        assert_eq!(db.get::<ItemA>("k1").await.unwrap(), None);
+    }
+
+    #[tokio::test]
+    async fn mem_07_remove_bulk_deletes_multiple_keys() {
+        let db = make_db();
+        db.set::<ItemA>("k1", ItemA("a".to_string())).await.unwrap();
+        db.set::<ItemA>("k2", ItemA("b".to_string())).await.unwrap();
+        db.set::<ItemA>("k3", ItemA("c".to_string())).await.unwrap();
+        db.remove_bulk::<ItemA>(vec!["k1".to_string(), "k2".to_string()]).await.unwrap();
+        assert_eq!(db.get::<ItemA>("k1").await.unwrap(), None);
+        assert_eq!(db.get::<ItemA>("k2").await.unwrap(), None);
+        assert_eq!(db.get::<ItemA>("k3").await.unwrap(), Some(ItemA("c".to_string())));
+    }
+
+    #[tokio::test]
+    async fn mem_08_remove_all_clears_namespace() {
+        let db = make_db();
+        db.set::<ItemA>("k1", ItemA("a".to_string())).await.unwrap();
+        db.remove_all::<ItemA>().await.unwrap();
+        assert_eq!(db.list::<ItemA>().await.unwrap(), vec![]);
+    }
+
+    #[tokio::test]
+    async fn mem_09_set_bulk_inserts_multiple_values() {
+        let db = make_db();
+        db.set_bulk::<ItemA>(vec![
+            ("k1".to_string(), ItemA("a".to_string())),
+            ("k2".to_string(), ItemA("b".to_string())),
+            ("k3".to_string(), ItemA("c".to_string())),
+        ]).await.unwrap();
+        assert_eq!(db.list::<ItemA>().await.unwrap().len(), 3);
+    }
+
+    #[tokio::test]
+    async fn mem_10_typeid_namespace_isolation() {
+        let db = make_db();
+        db.set::<ItemA>("shared_key", ItemA("from_a".to_string())).await.unwrap();
+        db.set::<ItemB>("shared_key", ItemB(42)).await.unwrap();
+        assert_eq!(db.get::<ItemA>("shared_key").await.unwrap(), Some(ItemA("from_a".to_string())));
+        assert_eq!(db.get::<ItemB>("shared_key").await.unwrap(), Some(ItemB(42)));
+    }
+
+    #[tokio::test]
+    async fn mem_11_clone_shares_backing_store() {
+        let db = make_db();
+        let cloned = db.clone();
+        db.set::<ItemA>("k1", ItemA("original".to_string())).await.unwrap();
+        assert_eq!(cloned.get::<ItemA>("k1").await.unwrap(), Some(ItemA("original".to_string())));
+    }
+}

--- a/crates/bitwarden-state/src/sdk_managed/mod.rs
+++ b/crates/bitwarden-state/src/sdk_managed/mod.rs
@@ -178,22 +178,18 @@ impl SystemDatabase {
     ) -> Result<Self, DatabaseError> {
         match configuration {
             #[cfg(not(target_arch = "wasm32"))]
-            DatabaseConfiguration::Sqlite { .. } => {
-                Ok(SystemDatabase::Sqlite(
-                    sqlite::SqliteDatabase::initialize(configuration, registrations).await?,
-                ))
-            }
+            DatabaseConfiguration::Sqlite { .. } => Ok(SystemDatabase::Sqlite(
+                sqlite::SqliteDatabase::initialize(configuration, registrations).await?,
+            )),
             #[cfg(target_arch = "wasm32")]
-            DatabaseConfiguration::IndexedDb { .. } => {
-                Ok(SystemDatabase::IndexedDb(
-                    indexed_db::IndexedDbDatabase::initialize(configuration, registrations).await?,
-                ))
-            }
-            DatabaseConfiguration::Memory => {
-                Ok(SystemDatabase::Memory(
-                    memory::MemoryDatabase::initialize(configuration, registrations).await?,
-                ))
-            }
+            DatabaseConfiguration::IndexedDb { .. } => Ok(SystemDatabase::IndexedDb(
+                indexed_db::IndexedDbDatabase::initialize(configuration, registrations).await?,
+            )),
+            DatabaseConfiguration::Memory => Ok(SystemDatabase::Memory(
+                memory::MemoryDatabase::initialize(configuration, registrations).await?,
+            )),
+            #[allow(unreachable_patterns)]
+            other => Err(DatabaseError::UnsupportedConfiguration(other)),
         }
     }
 }

--- a/crates/bitwarden-state/src/sdk_managed/mod.rs
+++ b/crates/bitwarden-state/src/sdk_managed/mod.rs
@@ -43,8 +43,8 @@ impl From<rusqlite::Error> for DatabaseError {
 }
 
 #[cfg(target_arch = "wasm32")]
-impl From<indexed_db::error::Error<indexed_db::IndexedDbInternalError>> for DatabaseError {
-    fn from(e: indexed_db::error::Error<indexed_db::IndexedDbInternalError>) -> Self {
+impl From<::indexed_db::Error<indexed_db::IndexedDbInternalError>> for DatabaseError {
+    fn from(e: ::indexed_db::Error<indexed_db::IndexedDbInternalError>) -> Self {
         DatabaseError::Internal(e.to_string())
     }
 }

--- a/crates/bitwarden-state/src/sdk_managed/mod.rs
+++ b/crates/bitwarden-state/src/sdk_managed/mod.rs
@@ -165,6 +165,10 @@ impl<V: RepositoryItem> Repository<V> for DBRepository<V> {
 }
 
 impl SystemDatabase {
+    pub(super) fn new_memory() -> Self {
+        SystemDatabase::Memory(memory::MemoryDatabase::new())
+    }
+
     pub(super) fn get_repository<V: RepositoryItem>(&self) -> Arc<dyn Repository<V>> {
         Arc::new(DBRepository {
             database: self.clone(),

--- a/crates/bitwarden-state/src/sdk_managed/mod.rs
+++ b/crates/bitwarden-state/src/sdk_managed/mod.rs
@@ -43,8 +43,8 @@ impl From<rusqlite::Error> for DatabaseError {
 }
 
 #[cfg(target_arch = "wasm32")]
-impl From<indexed_db::Error<indexed_db::IndexedDbInternalError>> for DatabaseError {
-    fn from(e: indexed_db::Error<indexed_db::IndexedDbInternalError>) -> Self {
+impl From<indexed_db::error::Error<indexed_db::IndexedDbInternalError>> for DatabaseError {
+    fn from(e: indexed_db::error::Error<indexed_db::IndexedDbInternalError>) -> Self {
         DatabaseError::Internal(e.to_string())
     }
 }

--- a/crates/bitwarden-state/src/sdk_managed/mod.rs
+++ b/crates/bitwarden-state/src/sdk_managed/mod.rs
@@ -10,17 +10,11 @@ pub use configuration::DatabaseConfiguration;
 
 #[cfg(target_arch = "wasm32")]
 mod indexed_db;
-#[cfg(target_arch = "wasm32")]
-pub(super) type SystemDatabase = indexed_db::IndexedDbDatabase;
-#[cfg(target_arch = "wasm32")]
-type InternalError = ::indexed_db::Error<indexed_db::IndexedDbInternalError>;
 
 #[cfg(not(target_arch = "wasm32"))]
 mod sqlite;
-#[cfg(not(target_arch = "wasm32"))]
-pub(super) type SystemDatabase = sqlite::SqliteDatabase;
-#[cfg(not(target_arch = "wasm32"))]
-type InternalError = ::rusqlite::Error;
+
+mod memory;
 
 #[bitwarden_error(flat)]
 #[derive(Debug, Error)]
@@ -37,8 +31,22 @@ pub enum DatabaseError {
     #[error("JS error: {0}")]
     JS(String),
 
-    #[error(transparent)]
-    Internal(#[from] InternalError),
+    #[error("Internal error: {0}")]
+    Internal(String),
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+impl From<rusqlite::Error> for DatabaseError {
+    fn from(e: rusqlite::Error) -> Self {
+        DatabaseError::Internal(e.to_string())
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
+impl From<indexed_db::Error<indexed_db::IndexedDbInternalError>> for DatabaseError {
+    fn from(e: indexed_db::Error<indexed_db::IndexedDbInternalError>) -> Self {
+        DatabaseError::Internal(e.to_string())
+    }
 }
 
 pub trait Database {
@@ -67,6 +75,15 @@ pub trait Database {
     async fn remove_all<T: RepositoryItem>(&self) -> Result<(), DatabaseError>;
 }
 
+#[derive(Clone)]
+pub(super) enum SystemDatabase {
+    #[cfg(not(target_arch = "wasm32"))]
+    Sqlite(sqlite::SqliteDatabase),
+    #[cfg(target_arch = "wasm32")]
+    IndexedDb(indexed_db::IndexedDbDatabase),
+    Memory(memory::MemoryDatabase),
+}
+
 struct DBRepository<T: RepositoryItem> {
     database: SystemDatabase,
     _marker: std::marker::PhantomData<T>,
@@ -76,34 +93,74 @@ struct DBRepository<T: RepositoryItem> {
 impl<V: RepositoryItem> Repository<V> for DBRepository<V> {
     async fn get(&self, key: V::Key) -> Result<Option<V>, RepositoryError> {
         let key = key.to_string();
-        let value = self.database.get::<V>(&key).await?;
-        Ok(value)
+        match &self.database {
+            #[cfg(not(target_arch = "wasm32"))]
+            SystemDatabase::Sqlite(db) => Ok(db.get::<V>(&key).await?),
+            #[cfg(target_arch = "wasm32")]
+            SystemDatabase::IndexedDb(db) => Ok(db.get::<V>(&key).await?),
+            SystemDatabase::Memory(db) => Ok(db.get::<V>(&key).await?),
+        }
     }
     async fn list(&self) -> Result<Vec<V>, RepositoryError> {
-        let values = self.database.list::<V>().await?;
-        Ok(values)
+        match &self.database {
+            #[cfg(not(target_arch = "wasm32"))]
+            SystemDatabase::Sqlite(db) => Ok(db.list::<V>().await?),
+            #[cfg(target_arch = "wasm32")]
+            SystemDatabase::IndexedDb(db) => Ok(db.list::<V>().await?),
+            SystemDatabase::Memory(db) => Ok(db.list::<V>().await?),
+        }
     }
     async fn set(&self, key: V::Key, value: V) -> Result<(), RepositoryError> {
         let key = key.to_string();
-        Ok(self.database.set::<V>(&key, value).await?)
+        match &self.database {
+            #[cfg(not(target_arch = "wasm32"))]
+            SystemDatabase::Sqlite(db) => Ok(db.set::<V>(&key, value).await?),
+            #[cfg(target_arch = "wasm32")]
+            SystemDatabase::IndexedDb(db) => Ok(db.set::<V>(&key, value).await?),
+            SystemDatabase::Memory(db) => Ok(db.set::<V>(&key, value).await?),
+        }
     }
     async fn set_bulk(&self, values: Vec<(V::Key, V)>) -> Result<(), RepositoryError> {
         let values = values
             .into_iter()
             .map(|(k, v)| (k.to_string(), v))
             .collect();
-        Ok(self.database.set_bulk::<V>(values).await?)
+        match &self.database {
+            #[cfg(not(target_arch = "wasm32"))]
+            SystemDatabase::Sqlite(db) => Ok(db.set_bulk::<V>(values).await?),
+            #[cfg(target_arch = "wasm32")]
+            SystemDatabase::IndexedDb(db) => Ok(db.set_bulk::<V>(values).await?),
+            SystemDatabase::Memory(db) => Ok(db.set_bulk::<V>(values).await?),
+        }
     }
     async fn remove(&self, key: V::Key) -> Result<(), RepositoryError> {
         let key = key.to_string();
-        Ok(self.database.remove::<V>(&key).await?)
+        match &self.database {
+            #[cfg(not(target_arch = "wasm32"))]
+            SystemDatabase::Sqlite(db) => Ok(db.remove::<V>(&key).await?),
+            #[cfg(target_arch = "wasm32")]
+            SystemDatabase::IndexedDb(db) => Ok(db.remove::<V>(&key).await?),
+            SystemDatabase::Memory(db) => Ok(db.remove::<V>(&key).await?),
+        }
     }
     async fn remove_bulk(&self, keys: Vec<V::Key>) -> Result<(), RepositoryError> {
         let keys = keys.into_iter().map(|k| k.to_string()).collect();
-        Ok(self.database.remove_bulk::<V>(keys).await?)
+        match &self.database {
+            #[cfg(not(target_arch = "wasm32"))]
+            SystemDatabase::Sqlite(db) => Ok(db.remove_bulk::<V>(keys).await?),
+            #[cfg(target_arch = "wasm32")]
+            SystemDatabase::IndexedDb(db) => Ok(db.remove_bulk::<V>(keys).await?),
+            SystemDatabase::Memory(db) => Ok(db.remove_bulk::<V>(keys).await?),
+        }
     }
     async fn remove_all(&self) -> Result<(), RepositoryError> {
-        Ok(self.database.remove_all::<V>().await?)
+        match &self.database {
+            #[cfg(not(target_arch = "wasm32"))]
+            SystemDatabase::Sqlite(db) => Ok(db.remove_all::<V>().await?),
+            #[cfg(target_arch = "wasm32")]
+            SystemDatabase::IndexedDb(db) => Ok(db.remove_all::<V>().await?),
+            SystemDatabase::Memory(db) => Ok(db.remove_all::<V>().await?),
+        }
     }
 }
 
@@ -113,5 +170,30 @@ impl SystemDatabase {
             database: self.clone(),
             _marker: std::marker::PhantomData,
         })
+    }
+
+    pub(super) async fn initialize(
+        configuration: DatabaseConfiguration,
+        registrations: RepositoryMigrations,
+    ) -> Result<Self, DatabaseError> {
+        match configuration {
+            #[cfg(not(target_arch = "wasm32"))]
+            DatabaseConfiguration::Sqlite { .. } => {
+                Ok(SystemDatabase::Sqlite(
+                    sqlite::SqliteDatabase::initialize(configuration, registrations).await?,
+                ))
+            }
+            #[cfg(target_arch = "wasm32")]
+            DatabaseConfiguration::IndexedDb { .. } => {
+                Ok(SystemDatabase::IndexedDb(
+                    indexed_db::IndexedDbDatabase::initialize(configuration, registrations).await?,
+                ))
+            }
+            DatabaseConfiguration::Memory => {
+                Ok(SystemDatabase::Memory(
+                    memory::MemoryDatabase::initialize(configuration, registrations).await?,
+                ))
+            }
+        }
     }
 }

--- a/crates/bitwarden-state/src/sdk_managed/sqlite.rs
+++ b/crates/bitwarden-state/src/sdk_managed/sqlite.rs
@@ -19,7 +19,7 @@ fn validate_identifier(name: &'static str) -> Result<&'static str, DatabaseError
         Ok(name)
     } else {
         Err(DatabaseError::Internal(
-            rusqlite::Error::InvalidParameterName(name.to_string()),
+            rusqlite::Error::InvalidParameterName(name.to_string()).to_string(),
         ))
     }
 }

--- a/crates/bitwarden-uniffi/src/platform/mod.rs
+++ b/crates/bitwarden-uniffi/src/platform/mod.rs
@@ -86,6 +86,19 @@ impl StateClient {
         repositories.register_all(&self.0.platform().state());
     }
 
+    /// Initialize the database for SDK managed repositories using an in-memory store.
+    /// Data stored in memory is ephemeral and will be lost when the Client is dropped.
+    /// Note: calling this method a second time will return an error.
+    pub async fn initialize_state_in_memory(&self) -> Result<()> {
+        let migrations = bitwarden_pm::migrations::get_sdk_managed_migrations();
+        self.0
+            .platform()
+            .state()
+            .initialize_database(DatabaseConfiguration::Memory, migrations)
+            .await?;
+        Ok(())
+    }
+
     /// Initialize the database for SDK managed repositories.
     pub async fn initialize_state(&self, configuration: SqliteConfiguration) -> Result<()> {
         let migrations = bitwarden_pm::migrations::get_sdk_managed_migrations();

--- a/crates/bitwarden-wasm-internal/src/platform/mod.rs
+++ b/crates/bitwarden-wasm-internal/src/platform/mod.rs
@@ -77,6 +77,20 @@ impl StateClient {
         repositories.register_all(&self.0.platform().state());
     }
 
+    /// Initialize the database for SDK managed repositories using an in-memory store.
+    /// Data stored in memory is ephemeral and will be lost when the Client is dropped.
+    /// Note: calling this method a second time will return an error.
+    pub async fn initialize_state_in_memory(
+        &self,
+    ) -> Result<(), bitwarden_state::registry::StateRegistryError> {
+        let sdk_managed_repositories = bitwarden_pm::migrations::get_sdk_managed_migrations();
+        self.0
+            .platform()
+            .state()
+            .initialize_database(DatabaseConfiguration::Memory, sdk_managed_repositories)
+            .await
+    }
+
     /// Initialize the database for SDK managed repositories.
     pub async fn initialize_state(
         &self,


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-31870

## 📔 Objective

Adds a `MemoryDatabase` backend to the `bitwarden-state` crate, providing an ephemeral, platform-agnostic alternative to the SQLite (native) and IndexedDB (WASM) backends. This enables testing and development scenarios where persistent storage is not needed, and exposes the backend to mobile clients via UniFFI and to web clients via WASM bindings.

### Changes

**New**
- `MemoryDatabase` (`crates/bitwarden-state/src/sdk_managed/memory.rs`) — `HashMap`-backed implementation of the `Database` trait backed by `Arc<Mutex<HashMap<TypeId, HashMap<String, String>>>>`. Compiles unconditionally on native and `wasm32` targets; no platform-specific dependencies.
- `DatabaseConfiguration::Memory` variant — zero-field variant added to the existing `DatabaseConfiguration` enum; no `#[cfg]` gate.

**Modified**
- `SystemDatabase` (`crates/bitwarden-state/src/sdk_managed/mod.rs`) — converted from a `cfg`-gated type alias (one concrete type per compilation target) to an enum with runtime dispatch, enabling backend selection at runtime. `Sqlite` and `IndexedDb` variants remain `cfg`-gated; `Memory` variant is unconditional.
- `DatabaseError::Internal` — changed from a transparent `#[from] InternalError` type alias to `Internal(String)` with explicit `cfg`-gated `From` impls for each backend error type, enabling a single variant to represent errors from all backends.
- `StateRegistry` (`crates/bitwarden-state/src/registry.rs`) — gains `new_with_memory_db()` sync constructor (pre-initializes the registry with `MemoryDatabase`) and `setting()` shortcut for ergonomic access to individual settings without the full repository API.
- `StateClient` UniFFI (`crates/bitwarden-uniffi/src/platform/mod.rs`) — gains `initialize_state_in_memory()` zero-argument async method for Swift/Kotlin clients.
- `StateClient` WASM (`crates/bitwarden-wasm-internal/src/platform/mod.rs`) — gains `initialize_state_in_memory()` zero-argument async method for TypeScript/JavaScript clients.

**Unchanged**
- `IndexedDbDatabase` — no changes required.
- `bitwarden-core/src/platform/state_client.rs` — `setting()` already existed; unchanged.

### Design Decisions

- **HashMap backing store, not in-memory SQLite** (ADR-007): The ticket spec mandates `HashMap`. In-memory SQLite is incompatible with the WAL journal mode pragma set by `SqliteDatabase::initialize_internal`, and `rusqlite` carries unnecessary WASM dependency overhead.
- **`SystemDatabase` becomes an enum** (ADR-008): The existing `cfg`-gated type alias supports only one backend per compilation target. Runtime multi-backend selection requires an enum; `Box<dyn Database>` is not viable because the `Database` trait has generic async methods (not object-safe).
- **`DatabaseError::Internal` changes to `String`** (ADR-009): With `SystemDatabase` as an enum, a single `Internal` variant must accommodate errors from multiple backends. `String` with `cfg`-gated `From` impls is the minimal-diff approach that preserves `#[bitwarden_error(flat)]` compatibility.
- **`Memory` variant and `MemoryDatabase` are unconditional** (ADR-010): Zero platform-specific dependencies mean no `cfg` gate is warranted. WASM test harnesses need `MemoryDatabase` without `IndexedDb`; mobile teams need it for non-test integration scenarios.
- **Bindings expose `initialize_state_in_memory()` as a zero-argument method** (ADR-011): Consistent with the existing `initialize_state_*` binding pattern. `DatabaseConfiguration::Memory` has no fields, so no new config record type is needed.

### Testing

Unit tests added in `memory.rs` (MEM-01 through MEM-11) covering `initialize`, `get`/`set` round-trip, `list`, `remove`, `remove_bulk`, `remove_all`, `set_bulk`, `TypeId` namespace isolation, and `Clone` backing-store sharing.

Build verification (post-implementation):
- `cargo build` succeeded (dev profile)
- All workspace tests passed: 503 tests across 20 test suites, 0 failures, 14 ignored
- Existing `sqlite.rs` and `registry.rs` tests continue to pass

> **Note**: Data stored via `initialize_state_in_memory()` is ephemeral and will be lost when the `Client` is dropped. This backend is intended for testing and development use cases only.

## 🚨 Breaking Changes

`DatabaseError::Internal` changes its payload type from a platform-specific type alias (`InternalError`) to `String`. Callers that match on `DatabaseError::Internal` and inspect the inner error type will need to update to work with `String`. The variant is `pub(crate)` within `bitwarden-state`; no external crate exposes or matches on it directly, so no client-facing migration is required.