### PR TITLE
[PM-31870] Add MemoryDatabase implementation to bitwarden-state

### DIFF
--- a/crates/bitwarden-state/src/registry.rs
+++ b/crates/bitwarden-state/src/registry.rs
@@ -82,6 +82,20 @@ impl StateRegistry {
         Ok(())
     }
 
+    /// Creates a new `StateRegistry` pre-initialized with an in-memory database.
+    ///
+    /// The in-memory database requires no async initialization and is immediately
+    /// ready for use. Data is ephemeral and will be lost when this registry is dropped.
+    ///
+    /// Intended for testing and development scenarios.
+    pub fn new_with_memory_db() -> Self {
+        let registry = Self::new();
+        let _ = registry.database.set(SystemDatabase::Memory(
+            crate::sdk_managed::memory::MemoryDatabase::new(),
+        ));
+        registry
+    }
+
     /// Registers a client-managed repository into the map, associating it with its type.
     pub fn register_client_managed<T: RepositoryItem>(&self, value: Arc<dyn Repository<T>>) {
         self.client_managed
@@ -131,6 +145,22 @@ impl StateRegistry {
         }
 
         self.get_sdk_managed::<T>()
+    }
+
+    /// Returns a type-safe handle to a single setting value.
+    ///
+    /// Shortcut equivalent to `StateClient::setting()` for callers holding a
+    /// `StateRegistry` reference directly.
+    ///
+    /// # Errors
+    /// Returns `SettingsError::Registry(DatabaseNotInitialized)` if the database
+    /// has not been initialized.
+    pub fn setting<T>(
+        &self,
+        key: crate::settings::Key<T>,
+    ) -> Result<crate::settings::Setting<T>, crate::settings::SettingsError> {
+        let repository = self.get::<crate::settings::SettingItem>()?;
+        Ok(crate::settings::Setting::new(repository, key))
     }
 }
 

--- a/crates/bitwarden-state/src/sdk_managed/configuration.rs
+++ b/crates/bitwarden-state/src/sdk_managed/configuration.rs
@@ -18,4 +18,8 @@ pub enum DatabaseConfiguration {
         /// names to avoid conflicts.
         db_name: String,
     },
+
+    /// In-memory configuration, used for testing and ephemeral state.
+    /// Data stored in memory is ephemeral and will be lost when the Client is dropped.
+    Memory,
 }

--- a/crates/bitwarden-state/src/sdk_managed/memory.rs
+++ b/crates/bitwarden-state/src/sdk_managed/memory.rs
@@ -1,0 +1,262 @@
+use std::{any::TypeId, collections::HashMap, sync::Arc};
+
+use tokio::sync::Mutex;
+
+use crate::{
+    repository::{RepositoryItem, RepositoryMigrations},
+    sdk_managed::{Database, DatabaseConfiguration, DatabaseError},
+};
+
+/// In-memory HashMap-backed implementation of the Database trait.
+///
+/// Data is ephemeral and will be lost when this instance is dropped (unless
+/// cloned — clones share the same backing store via Arc).
+/// Intended for testing and development scenarios.
+#[derive(Clone)]
+pub struct MemoryDatabase(Arc<Mutex<HashMap<TypeId, HashMap<String, String>>>>);
+
+impl MemoryDatabase {
+    /// Create a new empty MemoryDatabase.
+    pub fn new() -> Self {
+        MemoryDatabase(Arc::new(Mutex::new(HashMap::new())))
+    }
+}
+
+impl Database for MemoryDatabase {
+    async fn initialize(
+        configuration: DatabaseConfiguration,
+        _registrations: RepositoryMigrations,
+    ) -> Result<Self, DatabaseError> {
+        if !matches!(configuration, DatabaseConfiguration::Memory) {
+            return Err(DatabaseError::UnsupportedConfiguration(configuration));
+        }
+        Ok(Self::new())
+    }
+
+    async fn get<T: RepositoryItem>(&self, key: &str) -> Result<Option<T>, DatabaseError> {
+        let store = self.0.lock().await;
+        match store.get(&TypeId::of::<T>()).and_then(|ns| ns.get(key)) {
+            Some(json) => Ok(Some(serde_json::from_str(json)?)),
+            None => Ok(None),
+        }
+    }
+
+    async fn list<T: RepositoryItem>(&self) -> Result<Vec<T>, DatabaseError> {
+        let store = self.0.lock().await;
+        match store.get(&TypeId::of::<T>()) {
+            None => Ok(vec![]),
+            Some(ns) => ns
+                .values()
+                .map(|json| serde_json::from_str(json).map_err(DatabaseError::from))
+                .collect(),
+        }
+    }
+
+    async fn set<T: RepositoryItem>(&self, key: &str, value: T) -> Result<(), DatabaseError> {
+        let json = serde_json::to_string(&value)?;
+        let mut store = self.0.lock().await;
+        store
+            .entry(TypeId::of::<T>())
+            .or_default()
+            .insert(key.to_string(), json);
+        Ok(())
+    }
+
+    async fn set_bulk<T: RepositoryItem>(
+        &self,
+        values: Vec<(String, T)>,
+    ) -> Result<(), DatabaseError> {
+        let mut store = self.0.lock().await;
+        let namespace = store.entry(TypeId::of::<T>()).or_default();
+        for (key, value) in values {
+            let json = serde_json::to_string(&value)?;
+            namespace.insert(key, json);
+        }
+        Ok(())
+    }
+
+    async fn remove<T: RepositoryItem>(&self, key: &str) -> Result<(), DatabaseError> {
+        let mut store = self.0.lock().await;
+        if let Some(namespace) = store.get_mut(&TypeId::of::<T>()) {
+            namespace.remove(key);
+        }
+        Ok(())
+    }
+
+    async fn remove_bulk<T: RepositoryItem>(&self, keys: Vec<String>) -> Result<(), DatabaseError> {
+        let mut store = self.0.lock().await;
+        if let Some(namespace) = store.get_mut(&TypeId::of::<T>()) {
+            for key in keys {
+                namespace.remove(&key);
+            }
+        }
+        Ok(())
+    }
+
+    async fn remove_all<T: RepositoryItem>(&self) -> Result<(), DatabaseError> {
+        let mut store = self.0.lock().await;
+        store.remove(&TypeId::of::<T>());
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::register_repository_item;
+
+    #[derive(Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+    struct TypeA(String);
+    register_repository_item!(String => TypeA, "MemTestTypeA");
+
+    #[derive(Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+    struct TypeB(String);
+    register_repository_item!(String => TypeB, "MemTestTypeB");
+
+    // MEM-01: Initialize with Memory config succeeds
+    #[tokio::test]
+    async fn mem_01_initialize_memory_config_succeeds() {
+        let result = MemoryDatabase::initialize(
+            DatabaseConfiguration::Memory,
+            crate::repository::RepositoryMigrations::new(vec![]),
+        )
+        .await;
+        assert!(result.is_ok());
+    }
+
+    // MEM-02: Initialize with non-Memory config returns UnsupportedConfiguration
+    #[tokio::test]
+    async fn mem_02_initialize_wrong_config_fails() {
+        use std::path::PathBuf;
+        let result = MemoryDatabase::initialize(
+            DatabaseConfiguration::Sqlite {
+                db_name: "test".to_string(),
+                folder_path: PathBuf::from("/tmp"),
+            },
+            crate::repository::RepositoryMigrations::new(vec![]),
+        )
+        .await;
+        assert!(matches!(
+            result,
+            Err(DatabaseError::UnsupportedConfiguration(_))
+        ));
+    }
+
+    // MEM-03: set and get round-trip
+    #[tokio::test]
+    async fn mem_03_set_get_round_trip() {
+        let db = MemoryDatabase::new();
+        db.set("k1", TypeA("hello".to_string())).await.unwrap();
+        let result = db.get::<TypeA>("k1").await.unwrap();
+        assert_eq!(result, Some(TypeA("hello".to_string())));
+    }
+
+    // MEM-04: get on missing key returns Ok(None)
+    #[tokio::test]
+    async fn mem_04_get_missing_key_returns_none() {
+        let db = MemoryDatabase::new();
+        let result = db.get::<TypeA>("nonexistent").await.unwrap();
+        assert_eq!(result, None);
+    }
+
+    // MEM-05: list returns all values in namespace
+    #[tokio::test]
+    async fn mem_05_list_returns_all_values() {
+        let db = MemoryDatabase::new();
+        db.set("k1", TypeA("a".to_string())).await.unwrap();
+        db.set("k2", TypeA("b".to_string())).await.unwrap();
+        let mut result = db.list::<TypeA>().await.unwrap();
+        result.sort_by_key(|v| v.0.clone());
+        assert_eq!(result, vec![TypeA("a".to_string()), TypeA("b".to_string())]);
+    }
+
+    // MEM-06: remove deletes key
+    #[tokio::test]
+    async fn mem_06_remove_deletes_key() {
+        let db = MemoryDatabase::new();
+        db.set("k1", TypeA("val".to_string())).await.unwrap();
+        db.remove::<TypeA>("k1").await.unwrap();
+        assert_eq!(db.get::<TypeA>("k1").await.unwrap(), None);
+    }
+
+    // MEM-07: remove_bulk deletes multiple keys; remaining key still accessible
+    #[tokio::test]
+    async fn mem_07_remove_bulk_deletes_multiple_keys() {
+        let db = MemoryDatabase::new();
+        db.set("k1", TypeA("a".to_string())).await.unwrap();
+        db.set("k2", TypeA("b".to_string())).await.unwrap();
+        db.set("k3", TypeA("c".to_string())).await.unwrap();
+        db.remove_bulk::<TypeA>(vec!["k1".to_string(), "k2".to_string()])
+            .await
+            .unwrap();
+        assert_eq!(db.get::<TypeA>("k1").await.unwrap(), None);
+        assert_eq!(db.get::<TypeA>("k2").await.unwrap(), None);
+        assert_eq!(
+            db.get::<TypeA>("k3").await.unwrap(),
+            Some(TypeA("c".to_string()))
+        );
+    }
+
+    // MEM-08: remove_all clears namespace
+    #[tokio::test]
+    async fn mem_08_remove_all_clears_namespace() {
+        let db = MemoryDatabase::new();
+        db.set("k1", TypeA("a".to_string())).await.unwrap();
+        db.set("k2", TypeA("b".to_string())).await.unwrap();
+        db.remove_all::<TypeA>().await.unwrap();
+        assert!(db.list::<TypeA>().await.unwrap().is_empty());
+    }
+
+    // MEM-09: set_bulk inserts multiple values
+    #[tokio::test]
+    async fn mem_09_set_bulk_inserts_multiple() {
+        let db = MemoryDatabase::new();
+        db.set_bulk(vec![
+            ("k1".to_string(), TypeA("a".to_string())),
+            ("k2".to_string(), TypeA("b".to_string())),
+            ("k3".to_string(), TypeA("c".to_string())),
+        ])
+        .await
+        .unwrap();
+        let mut result = db.list::<TypeA>().await.unwrap();
+        result.sort_by_key(|v| v.0.clone());
+        assert_eq!(
+            result,
+            vec![
+                TypeA("a".to_string()),
+                TypeA("b".to_string()),
+                TypeA("c".to_string()),
+            ]
+        );
+    }
+
+    // MEM-10: TypeId namespace isolation
+    #[tokio::test]
+    async fn mem_10_typeid_namespace_isolation() {
+        let db = MemoryDatabase::new();
+        db.set("shared_key", TypeA("type_a_value".to_string()))
+            .await
+            .unwrap();
+        db.set("shared_key", TypeB("type_b_value".to_string()))
+            .await
+            .unwrap();
+        assert_eq!(
+            db.get::<TypeA>("shared_key").await.unwrap(),
+            Some(TypeA("type_a_value".to_string()))
+        );
+        assert_eq!(
+            db.get::<TypeB>("shared_key").await.unwrap(),
+            Some(TypeB("type_b_value".to_string()))
+        );
+    }
+
+    // MEM-11: Clone shares backing store
+    #[tokio::test]
+    async fn mem_11_clone_shares_backing_store() {
+        let db = MemoryDatabase::new();
+        let clone = db.clone();
+        db.set("k1", TypeA("original".to_string())).await.unwrap();
+        let result = clone.get::<TypeA>("k1").await.unwrap();
+        assert_eq!(result, Some(TypeA("original".to_string())));
+    }
+}

--- a/crates/bitwarden-state/src/sdk_managed/mod.rs
+++ b/crates/bitwarden-state/src/sdk_managed/mod.rs
@@ -50,8 +50,8 @@ impl From<rusqlite::Error> for DatabaseError {
 }
 
 #[cfg(target_arch = "wasm32")]
-impl From<indexed_db::Error<indexed_db::IndexedDbInternalError>> for DatabaseError {
-    fn from(e: indexed_db::Error<indexed_db::IndexedDbInternalError>) -> Self {
+impl From<::indexed_db::Error<indexed_db::IndexedDbInternalError>> for DatabaseError {
+    fn from(e: ::indexed_db::Error<indexed_db::IndexedDbInternalError>) -> Self {
         DatabaseError::Internal(e.to_string())
     }
 }

--- a/crates/bitwarden-state/src/sdk_managed/mod.rs
+++ b/crates/bitwarden-state/src/sdk_managed/mod.rs
@@ -21,6 +21,7 @@ mod sqlite;
 pub(super) type SystemDatabase = sqlite::SqliteDatabase;
 #[cfg(not(target_arch = "wasm32"))]
 type InternalError = ::rusqlite::Error;
+pub(super) mod memory;
 
 #[bitwarden_error(flat)]
 #[derive(Debug, Error)]

--- a/crates/bitwarden-state/src/sdk_managed/mod.rs
+++ b/crates/bitwarden-state/src/sdk_managed/mod.rs
@@ -10,18 +10,18 @@ pub use configuration::DatabaseConfiguration;
 
 #[cfg(target_arch = "wasm32")]
 mod indexed_db;
-#[cfg(target_arch = "wasm32")]
-pub(super) type SystemDatabase = indexed_db::IndexedDbDatabase;
-#[cfg(target_arch = "wasm32")]
-type InternalError = ::indexed_db::Error<indexed_db::IndexedDbInternalError>;
-
+pub(super) mod memory;
 #[cfg(not(target_arch = "wasm32"))]
 mod sqlite;
-#[cfg(not(target_arch = "wasm32"))]
-pub(super) type SystemDatabase = sqlite::SqliteDatabase;
-#[cfg(not(target_arch = "wasm32"))]
-type InternalError = ::rusqlite::Error;
-pub(super) mod memory;
+
+#[derive(Clone)]
+pub(super) enum SystemDatabase {
+    Memory(memory::MemoryDatabase),
+    #[cfg(not(target_arch = "wasm32"))]
+    Sqlite(sqlite::SqliteDatabase),
+    #[cfg(target_arch = "wasm32")]
+    IndexedDb(indexed_db::IndexedDbDatabase),
+}
 
 #[bitwarden_error(flat)]
 #[derive(Debug, Error)]
@@ -38,8 +38,22 @@ pub enum DatabaseError {
     #[error("JS error: {0}")]
     JS(String),
 
-    #[error(transparent)]
-    Internal(#[from] InternalError),
+    #[error("Internal error: {0}")]
+    Internal(String),
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+impl From<rusqlite::Error> for DatabaseError {
+    fn from(e: rusqlite::Error) -> Self {
+        DatabaseError::Internal(e.to_string())
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
+impl From<indexed_db::Error<indexed_db::IndexedDbInternalError>> for DatabaseError {
+    fn from(e: indexed_db::Error<indexed_db::IndexedDbInternalError>) -> Self {
+        DatabaseError::Internal(e.to_string())
+    }
 }
 
 pub trait Database {
@@ -66,6 +80,102 @@ pub trait Database {
     async fn remove_bulk<T: RepositoryItem>(&self, keys: Vec<String>) -> Result<(), DatabaseError>;
 
     async fn remove_all<T: RepositoryItem>(&self) -> Result<(), DatabaseError>;
+}
+
+impl Database for SystemDatabase {
+    async fn initialize(
+        configuration: DatabaseConfiguration,
+        registrations: RepositoryMigrations,
+    ) -> Result<Self, DatabaseError> {
+        match &configuration {
+            DatabaseConfiguration::Memory => Ok(SystemDatabase::Memory(
+                memory::MemoryDatabase::initialize(configuration, registrations).await?,
+            )),
+            #[cfg(not(target_arch = "wasm32"))]
+            DatabaseConfiguration::Sqlite { .. } => Ok(SystemDatabase::Sqlite(
+                sqlite::SqliteDatabase::initialize(configuration, registrations).await?,
+            )),
+            #[cfg(target_arch = "wasm32")]
+            DatabaseConfiguration::IndexedDb { .. } => Ok(SystemDatabase::IndexedDb(
+                indexed_db::IndexedDbDatabase::initialize(configuration, registrations).await?,
+            )),
+            #[allow(unreachable_patterns)]
+            _ => Err(DatabaseError::UnsupportedConfiguration(configuration)),
+        }
+    }
+
+    async fn get<T: RepositoryItem>(&self, key: &str) -> Result<Option<T>, DatabaseError> {
+        match self {
+            SystemDatabase::Memory(db) => db.get::<T>(key).await,
+            #[cfg(not(target_arch = "wasm32"))]
+            SystemDatabase::Sqlite(db) => db.get::<T>(key).await,
+            #[cfg(target_arch = "wasm32")]
+            SystemDatabase::IndexedDb(db) => db.get::<T>(key).await,
+        }
+    }
+
+    async fn list<T: RepositoryItem>(&self) -> Result<Vec<T>, DatabaseError> {
+        match self {
+            SystemDatabase::Memory(db) => db.list::<T>().await,
+            #[cfg(not(target_arch = "wasm32"))]
+            SystemDatabase::Sqlite(db) => db.list::<T>().await,
+            #[cfg(target_arch = "wasm32")]
+            SystemDatabase::IndexedDb(db) => db.list::<T>().await,
+        }
+    }
+
+    async fn set<T: RepositoryItem>(&self, key: &str, value: T) -> Result<(), DatabaseError> {
+        match self {
+            SystemDatabase::Memory(db) => db.set::<T>(key, value).await,
+            #[cfg(not(target_arch = "wasm32"))]
+            SystemDatabase::Sqlite(db) => db.set::<T>(key, value).await,
+            #[cfg(target_arch = "wasm32")]
+            SystemDatabase::IndexedDb(db) => db.set::<T>(key, value).await,
+        }
+    }
+
+    async fn set_bulk<T: RepositoryItem>(
+        &self,
+        values: Vec<(String, T)>,
+    ) -> Result<(), DatabaseError> {
+        match self {
+            SystemDatabase::Memory(db) => db.set_bulk::<T>(values).await,
+            #[cfg(not(target_arch = "wasm32"))]
+            SystemDatabase::Sqlite(db) => db.set_bulk::<T>(values).await,
+            #[cfg(target_arch = "wasm32")]
+            SystemDatabase::IndexedDb(db) => db.set_bulk::<T>(values).await,
+        }
+    }
+
+    async fn remove<T: RepositoryItem>(&self, key: &str) -> Result<(), DatabaseError> {
+        match self {
+            SystemDatabase::Memory(db) => db.remove::<T>(key).await,
+            #[cfg(not(target_arch = "wasm32"))]
+            SystemDatabase::Sqlite(db) => db.remove::<T>(key).await,
+            #[cfg(target_arch = "wasm32")]
+            SystemDatabase::IndexedDb(db) => db.remove::<T>(key).await,
+        }
+    }
+
+    async fn remove_bulk<T: RepositoryItem>(&self, keys: Vec<String>) -> Result<(), DatabaseError> {
+        match self {
+            SystemDatabase::Memory(db) => db.remove_bulk::<T>(keys).await,
+            #[cfg(not(target_arch = "wasm32"))]
+            SystemDatabase::Sqlite(db) => db.remove_bulk::<T>(keys).await,
+            #[cfg(target_arch = "wasm32")]
+            SystemDatabase::IndexedDb(db) => db.remove_bulk::<T>(keys).await,
+        }
+    }
+
+    async fn remove_all<T: RepositoryItem>(&self) -> Result<(), DatabaseError> {
+        match self {
+            SystemDatabase::Memory(db) => db.remove_all::<T>().await,
+            #[cfg(not(target_arch = "wasm32"))]
+            SystemDatabase::Sqlite(db) => db.remove_all::<T>().await,
+            #[cfg(target_arch = "wasm32")]
+            SystemDatabase::IndexedDb(db) => db.remove_all::<T>().await,
+        }
+    }
 }
 
 struct DBRepository<T: RepositoryItem> {

--- a/crates/bitwarden-state/src/sdk_managed/sqlite.rs
+++ b/crates/bitwarden-state/src/sdk_managed/sqlite.rs
@@ -19,7 +19,7 @@ fn validate_identifier(name: &'static str) -> Result<&'static str, DatabaseError
         Ok(name)
     } else {
         Err(DatabaseError::Internal(
-            rusqlite::Error::InvalidParameterName(name.to_string()),
+            rusqlite::Error::InvalidParameterName(name.to_string()).to_string(),
         ))
     }
 }


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-31870

## 📔 Objective

Adds an in-memory database backend to the \`bitwarden-state\` crate, enabling state storage without requiring SQLite or IndexedDB. This supports testing, Secrets Manager (no persistent state outside token cache), and any client that hasn't migrated to SDK-managed state.

### Changes

**\`DatabaseConfiguration::Memory\` variant** (\`configuration.rs\`)
Adds a \`Memory\` variant to \`DatabaseConfiguration\` with no fields — in-memory storage needs no configuration path.

**\`MemoryDatabase\` struct** (\`memory.rs\`)
New \`MemoryDatabase\` backed by \`Arc<Mutex<HashMap<TypeId, HashMap<String, String>>>>\`. Implements the full \`Database\` trait (\`initialize\`, \`get\`, \`set\`, \`set_bulk\`, \`list\`, \`remove\`, \`remove_bulk\`, \`remove_all\`). Values stored as JSON strings, matching the serialization approach of SQLite and IndexedDB. Includes 11 unit tests (MEM-01 through MEM-11).

**\`SystemDatabase\` enum** (\`mod.rs\`)
Converts \`SystemDatabase\` from platform-specific type aliases to an enum with \`Sqlite\`, \`IndexedDb\`, and \`Memory\` variants. Type aliases cannot express an unconditional third variant alongside two cfg-gated variants — an enum with per-variant cfg gates is the only way to add \`Memory\` without breaking the existing dispatch pattern. \`Sqlite\` and \`IndexedDb\` retain their existing \`cfg\` gates (hard platform requirement). \`Memory\` is unconditional.

\`DatabaseError::Internal\` changed from \`Internal(InternalError)\` to \`Internal(String)\` to decouple the error type from platform-specific internal error types. The previous \`InternalError\` type alias pointed to different concrete types per platform (\`rusqlite::Error\` on desktop, \`indexed_db::Error\` on WASM), making it impossible to define a single \`Memory\` variant that didn't drag in platform-specific error types. \`String\` is the common denominator; explicit \`From\` impls on each platform convert their native error into \`String\`.

**Registry helpers** (\`registry.rs\`)
- \`StateRegistry::new_with_memory_db()\` — synchronous constructor, pre-initializes the DB so no async \`initialize_database()\` call is needed
- \`StateRegistry::setting()\` — shortcut returning \`Result<Setting<T>, SettingsError>\`, mirrors \`StateClient::setting()\`

## 🚨 Breaking Changes

\`DatabaseError::Internal\` variant changes from \`Internal(InternalError)\` to \`Internal(String)\`. Internal to \`bitwarden-state\` crate only — not part of the public API surface.