### PR TITLE
[PM-31714] Extract duplicated OpenAPI code

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -504,8 +504,10 @@ dependencies = [
 name = "bitwarden-api-base"
 version = "2.0.0"
 dependencies = [
+ "http",
  "reqwest",
  "reqwest-middleware",
+ "serde",
  "serde_json",
  "url",
 ]

--- a/crates/bitwarden-api-base/Cargo.toml
+++ b/crates/bitwarden-api-base/Cargo.toml
@@ -15,8 +15,10 @@ license-file.workspace = true
 keywords.workspace = true
 
 [dependencies]
+http = ">=1.4.0, <2"
 reqwest = { workspace = true }
 reqwest-middleware = { workspace = true }
+serde = { workspace = true }
 serde_json = { workspace = true }
 url = ">=2.5, <3"
 

--- a/crates/bitwarden-api-base/src/lib.rs
+++ b/crates/bitwarden-api-base/src/lib.rs
@@ -1,14 +1,11 @@
-//! Base types and utilities for Bitwarden API clients.
-//!
-//! This crate provides common functionality shared across all Bitwarden API client crates:
-//! - Configuration types for API clients
-//! - Error handling types
-//! - URL encoding and query parameter utilities
+#![doc = include_str!("../README.md")]
 
 mod configuration;
 mod error;
+mod request;
 mod util;
 
 pub use configuration::Configuration;
 pub use error::{Error, ResponseContent};
+pub use request::{process_with_empty_response, process_with_json_response};
 pub use util::{AuthRequired, ContentType, parse_deep_object, urlencode};

--- a/crates/bitwarden-api-base/src/request.rs
+++ b/crates/bitwarden-api-base/src/request.rs
@@ -1,0 +1,72 @@
+use http::header::CONTENT_TYPE;
+use serde::de::{DeserializeOwned, Error as _};
+
+use crate::{ContentType, Error, ResponseContent};
+
+fn content_type(response: &reqwest::Response) -> ContentType {
+    response
+        .headers()
+        .get(CONTENT_TYPE)
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("application/octet-stream")
+        .into()
+}
+
+/// [process_with_json_response] is generic, which means it gets monomorphized for every type it's
+/// used with. This function contains the non-generic logic for processing the response so that it
+/// doesn't get duplicated.
+#[inline(never)]
+async fn process_with_json_response_internal<E>(
+    request: reqwest_middleware::RequestBuilder,
+) -> Result<String, crate::Error<E>> {
+    let response = request.send().await?;
+    let status = response.status();
+    let content_type = content_type(&response);
+    let content = response.text().await?;
+
+    if !status.is_client_error() && !status.is_server_error() {
+        match content_type {
+            ContentType::Json => Ok(content),
+            ct => Err(Error::from(serde_json::Error::custom(format!(
+                "Received `{ct:?}` content type response when JSON was expected"
+            )))),
+        }
+    } else {
+        Err(Error::ResponseError(ResponseContent {
+            status,
+            content,
+            entity: None,
+        }))
+    }
+}
+
+/// Sends and processes a request expecting a JSON response, deserializing it into the expected type
+/// `T``.
+pub async fn process_with_json_response<T: DeserializeOwned, E>(
+    request: reqwest_middleware::RequestBuilder,
+) -> Result<T, crate::Error<E>> {
+    process_with_json_response_internal(request)
+        .await
+        .and_then(|content| serde_json::from_str(&content).map_err(Into::into))
+}
+
+/// Sends and processes a request expecting an empty response, returning `Ok(())` if the status code
+/// indicates success.
+#[inline(never)]
+pub async fn process_with_empty_response<E>(
+    request: reqwest_middleware::RequestBuilder,
+) -> Result<(), crate::Error<E>> {
+    let response = request.send().await?;
+    let status = response.status();
+
+    if !status.is_client_error() && !status.is_server_error() {
+        Ok(())
+    } else {
+        let content = response.text().await?;
+        Err(Error::ResponseError(ResponseContent {
+            status,
+            content,
+            entity: None,
+        }))
+    }
+}

--- a/crates/bitwarden-api-base/src/request.rs
+++ b/crates/bitwarden-api-base/src/request.rs
@@ -40,8 +40,7 @@ async fn process_with_json_response_internal<E>(
     }
 }
 
-/// Sends and processes a request expecting a JSON response, deserializing it into the expected type
-/// `T``.
+/// Sends and processes a request expecting a JSON response, deserializing it into the type `T`.
 pub async fn process_with_json_response<T: DeserializeOwned, E>(
     request: reqwest_middleware::RequestBuilder,
 ) -> Result<T, crate::Error<E>> {
@@ -50,8 +49,7 @@ pub async fn process_with_json_response<T: DeserializeOwned, E>(
         .and_then(|content| serde_json::from_str(&content).map_err(Into::into))
 }
 
-/// Sends and processes a request expecting an empty response, returning `Ok(())` if the status code
-/// indicates success.
+/// Sends and processes a request expecting an empty response, returning `Ok(())` when successful.
 #[inline(never)]
 pub async fn process_with_empty_response<E>(
     request: reqwest_middleware::RequestBuilder,

--- a/support/openapi-template/reqwest-trait/api.mustache
+++ b/support/openapi-template/reqwest-trait/api.mustache
@@ -412,49 +412,17 @@ impl {{classname}} for {{classname}}Client {
         {{/bodyParams}}
         {{/hasBodyParam}}
 
-        let local_var_resp = local_var_req_builder.send().await?;
-
-        let local_var_status = local_var_resp.status();
-        {{^supportMultipleResponses}}
-        {{#returnType}}
-        let local_var_content_type = local_var_resp
-            .headers()
-            .get("content-type")
-            .and_then(|v| v.to_str().ok())
-            .unwrap_or("application/octet-stream");
-        let local_var_content_type = super::ContentType::from(local_var_content_type);
+        {{^returnType}}
+        bitwarden_api_base::process_with_empty_response(local_var_req_builder).await
         {{/returnType}}
+        {{#returnType}}
+        {{^supportMultipleResponses}}
+        bitwarden_api_base::process_with_json_response(local_var_req_builder).await
         {{/supportMultipleResponses}}
-        let local_var_content = local_var_resp.text().await?;
-
-        if !local_var_status.is_client_error() && !local_var_status.is_server_error() {
-            {{^supportMultipleResponses}}
-            {{^returnType}}
-            Ok(())
-            {{/returnType}}
-            {{#returnType}}
-            match local_var_content_type {
-                ContentType::Json => serde_json::from_str(&local_var_content).map_err(Error::from),
-                {{#vendorExtensions.x-supports-plain-text}}
-                ContentType::Text => return Ok(local_var_content),
-                {{/vendorExtensions.x-supports-plain-text}}
-                {{^vendorExtensions.x-supports-plain-text}}
-                ContentType::Text => return Err(Error::from(serde_json::Error::custom("Received `text/plain` content type response that cannot be converted to `{{returnType}}`"))),
-                {{/vendorExtensions.x-supports-plain-text}}
-                ContentType::Unsupported(local_var_unknown_type) => return Err(Error::from(serde_json::Error::custom(format!("Received `{local_var_unknown_type}` content type response that cannot be converted to `{{returnType}}`")))),
-            }
-            {{/returnType}}
-            {{/supportMultipleResponses}}
-            {{#supportMultipleResponses}}
-            let local_var_entity: Option<{{{vendorExtensions.x-action-name}}}Success> = serde_json::from_str(&local_var_content).ok();
-            let local_var_result = ResponseContent { status: local_var_status, content: local_var_content, entity: local_var_entity };
-            Ok(local_var_result)
-            {{/supportMultipleResponses}}
-        } else {
-            let local_var_entity: Option<{{{vendorExtensions.x-action-name}}}Error> = serde_json::from_str(&local_var_content).ok();
-            let local_var_error = ResponseContent { status: local_var_status, content: local_var_content, entity: local_var_entity };
-            Err(Error::ResponseError(local_var_error))
-        }
+        {{#supportMultipleResponses}}
+        unimplemented!("Multiple response types are unimplemented")
+        {{/supportMultipleResponses}}
+        {{/returnType}}
     }
     {{/isDeprecated}}
     {{/operation}}


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-31714

## 📔 Objective

Extract the request sending and response processing logic to single functions in the `bitwarden-api-base` crate. This would remove around 13K lines of duplicated logic in `bitwarden-api-api` and `bitwarden-api-identity`, which should have a minor compile time and binary size improvement.

This change is fully backwards compatible so I don't include the updated api crates here, and instead leave it for the workflow run.

## 🚨 Breaking Changes

<!-- Does this PR introduce any breaking changes? If so, please describe the impact and migration path for clients.

If you're unsure, the automated TypeScript compatibility check will run when you open/update this PR and provide feedback.

For breaking changes:
1. Describe what changed in the client interface
2. Explain why the change was necessary
3. Provide migration steps for client developers
4. Link to any paired client PRs if needed

Otherwise, you can remove this section. -->
