### PR TITLE
[PM-28366] CXP sanitize URIs on exportCxf

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -100,6 +100,7 @@
         "uniffi_internal_macros",
         "uniffi_bindgen",
         "uniffi_build",
+        "url",
         "uuid",
         "validator",
         "wasm-bindgen",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -784,6 +784,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tsify",
  "uniffi",
+ "url",
  "uuid",
  "wasm-bindgen",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -103,6 +103,7 @@ tsify = { version = ">=0.5.5, <0.6", features = [
     "js",
 ], default-features = false }
 uniffi = "=0.29.4"
+url = ">=2.5.8, <3.0"
 uuid = { version = ">=1.3.3, <2.0", features = ["serde", "v4", "js"] }
 validator = { version = ">=0.18.1, <0.21", features = ["derive"] }
 wasm-bindgen = { version = "=0.2.114", features = ["serde-serialize"] }

--- a/crates/bitwarden-exporters/Cargo.toml
+++ b/crates/bitwarden-exporters/Cargo.toml
@@ -16,13 +16,13 @@ license-file.workspace = true
 keywords.workspace = true
 
 [features]
-uniffi = ["dep:uniffi", "bitwarden-core/uniffi"] # Uniffi bindings
+uniffi = ["dep:uniffi", "bitwarden-core/uniffi"]
 wasm = [
     "bitwarden-collections/wasm",
     "bitwarden-vault/wasm",
     "dep:tsify",
     "dep:wasm-bindgen",
-] # WebAssembly bindings
+]
 
 [dependencies]
 bitwarden-collections = { workspace = true }
@@ -42,6 +42,7 @@ serde_json = { workspace = true }
 thiserror = { workspace = true }
 tsify = { workspace = true, optional = true }
 uniffi = { workspace = true, optional = true }
+url = { workspace = true }
 uuid = { workspace = true }
 wasm-bindgen = { workspace = true, optional = true }
 

--- a/crates/bitwarden-exporters/src/export.rs
+++ b/crates/bitwarden-exporters/src/export.rs
@@ -55,10 +55,16 @@ pub(crate) fn export_cxf(
 ) -> Result<String, ExportError> {
     let key_store = client.internal.get_key_store();
 
-    let ciphers: Vec<crate::Cipher> = ciphers
+    let mut ciphers: Vec<crate::Cipher> = ciphers
         .into_iter()
         .flat_map(|c| crate::Cipher::from_cipher(key_store, c))
         .collect();
+
+    for cipher in &mut ciphers {
+        if let crate::CipherType::Login(login) = &mut cipher.r#type {
+            login.sanitize_uris();
+        }
+    }
 
     Ok(build_cxf(account, ciphers)?)
 }

--- a/crates/bitwarden-exporters/src/lib.rs
+++ b/crates/bitwarden-exporters/src/lib.rs
@@ -323,6 +323,50 @@ pub struct Login {
     pub fido2_credentials: Option<Vec<Fido2Credential>>,
 }
 
+impl Login {
+    /// Sanitizes all login URIs by ensuring they have a proper scheme.
+    ///
+    /// URIs that are already valid are left unchanged. For invalid URIs:
+    /// - If the URI is an IP address, `http://` is prepended.
+    /// - Otherwise, `https://` is prepended (unless it already starts with `http`).
+    pub fn sanitize_uris(&mut self) {
+        for login_uri in &mut self.login_uris {
+            if let Some(uri) = &login_uri.uri {
+                login_uri.uri = Some(sanitize_uri(uri));
+            }
+        }
+    }
+}
+
+/// Sanitizes a single URI string by ensuring it has a proper scheme.
+///
+/// Mirrors the logic from the iOS `fixURLIfNeeded()` method:
+/// 1. If the URI is already a valid URL, return as-is.
+/// 2. If prepending `http://` yields a URL whose host is an IPv4 address, use `http://`.
+/// 3. If the URI doesn't already start with `http`, prepend `https://`.
+/// 4. Otherwise, return as-is.
+fn sanitize_uri(uri: &str) -> String {
+    if let Ok(parsed) = url::Url::parse(uri)
+        && parsed.has_host()
+    {
+        return uri.to_string();
+    }
+
+    let with_http = format!("http://{uri}");
+    if let Ok(parsed) = url::Url::parse(&with_http)
+        && let Some(host) = parsed.host()
+        && matches!(host, url::Host::Ipv4(_))
+    {
+        return with_http;
+    }
+
+    if !uri.starts_with("http") {
+        return format!("https://{uri}");
+    }
+
+    uri.to_string()
+}
+
 #[allow(missing_docs)]
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct LoginUri {
@@ -621,5 +665,115 @@ mod tests {
         assert_eq!(identity.first_name, Some("Jane".to_string()));
         assert_eq!(identity.last_name, Some("Smith".to_string()));
         assert_eq!(identity.email, Some("jane@example.com".to_string()));
+    }
+
+    #[test]
+    fn test_sanitize_uri_valid_url_unchanged() {
+        assert_eq!(
+            sanitize_uri("https://bitwarden.com"),
+            "https://bitwarden.com"
+        );
+        assert_eq!(
+            sanitize_uri("https://bitwarden.com/path?q=1"),
+            "https://bitwarden.com/path?q=1"
+        );
+        assert_eq!(
+            sanitize_uri("http://192.168.0.1:8080"),
+            "http://192.168.0.1:8080"
+        );
+    }
+
+    #[test]
+    fn test_sanitize_uri_ip_address_gets_http() {
+        assert_eq!(sanitize_uri("192.168.0.1:8080"), "http://192.168.0.1:8080");
+        assert_eq!(sanitize_uri("10.0.0.1"), "http://10.0.0.1");
+        assert_eq!(
+            sanitize_uri("192.168.0.1:8080/path"),
+            "http://192.168.0.1:8080/path"
+        );
+    }
+
+    #[test]
+    fn test_sanitize_uri_non_ip_gets_https() {
+        assert_eq!(sanitize_uri("bitwarden.com"), "https://bitwarden.com");
+        assert_eq!(
+            sanitize_uri("bitwarden.co.uk/login"),
+            "https://bitwarden.co.uk/login"
+        );
+    }
+
+    #[test]
+    fn test_sanitize_uri_broken_http_prefix_unchanged() {
+        // testing parity with iOS logic: expect http:// prepended to input
+        assert_eq!(
+            sanitize_uri("ht tp://bitwarden.com"),
+            "https://ht tp://bitwarden.com"
+        );
+    }
+
+    #[test]
+    fn test_sanitize_uri_schemeless_host_port() {
+        assert_eq!(sanitize_uri("localhost:8080"), "https://localhost:8080");
+    }
+
+    #[test]
+    fn test_sanitize_uri_scheme_on_string() {
+        assert_eq!(sanitize_uri("foo:bar"), "https://foo:bar");
+    }
+
+    #[test]
+    fn test_sanitize_uri_with_real_schemes_no_change() {
+        assert_eq!(
+            sanitize_uri("ftp://files.example.com"),
+            "ftp://files.example.com"
+        );
+        assert_eq!(
+            sanitize_uri("androidapp://com.example"),
+            "androidapp://com.example"
+        );
+    }
+
+    #[test]
+    fn test_login_sanitize_uris() {
+        let mut login = Login {
+            username: None,
+            password: None,
+            login_uris: vec![
+                LoginUri {
+                    uri: Some("https://bitwarden.com".to_string()),
+                    r#match: None,
+                },
+                LoginUri {
+                    uri: Some("192.168.0.1:8080".to_string()),
+                    r#match: None,
+                },
+                LoginUri {
+                    uri: Some("example.com".to_string()),
+                    r#match: None,
+                },
+                LoginUri {
+                    uri: None,
+                    r#match: None,
+                },
+            ],
+            totp: None,
+            fido2_credentials: None,
+        };
+
+        login.sanitize_uris();
+
+        assert_eq!(
+            login.login_uris[0].uri,
+            Some("https://bitwarden.com".to_string())
+        );
+        assert_eq!(
+            login.login_uris[1].uri,
+            Some("http://192.168.0.1:8080".to_string())
+        );
+        assert_eq!(
+            login.login_uris[2].uri,
+            Some("https://example.com".to_string())
+        );
+        assert_eq!(login.login_uris[3].uri, None);
     }
 }

--- a/crates/bitwarden-exporters/src/lib.rs
+++ b/crates/bitwarden-exporters/src/lib.rs
@@ -360,7 +360,7 @@ fn sanitize_uri(uri: &str) -> String {
         return with_http;
     }
 
-    if !uri.starts_with("http") {
+    if !uri.starts_with("http://") || !uri.starts_with("https://") {
         return format!("https://{uri}");
     }
 


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-28366

## 📔 Objective

This PR aligns the SDK with recent changes introduced to the iOS repository: https://github.com/bitwarden/ios/pull/1911

A [custom decoder](https://github.com/bitwarden/ios/blob/main/BitwardenKit/Core/Platform/Utilities/URLFixingJSONDecoder.swift#L8) was added in iOS which does the following when the URI has no scheme:

- If the URI is an IP address, prepends http scheme to it:  10.0.0.1:8080 => http://10.0.0.1:8080
- Otherwise, prepends https scheme to it: webauthn.io => https://webauthn.io