### PR TITLE
[PM-33947] Bugfix: Store cipher key when encrypting CipherEditRequest

### DIFF
--- a/crates/bitwarden-vault/src/cipher/cipher_client/edit.rs
+++ b/crates/bitwarden-vault/src/cipher/cipher_client/edit.rs
@@ -110,9 +110,9 @@ impl CipherEditRequest {
     pub(super) fn generate_cipher_key(
         &mut self,
         ctx: &mut KeyStoreContext<KeyIds>,
-        key: SymmetricKeyId,
+        wrapping_key: SymmetricKeyId,
     ) -> Result<(), CryptoError> {
-        let old_key = Cipher::decrypt_cipher_key(ctx, key, &self.key)?;
+        let old_key = Cipher::decrypt_cipher_key(ctx, wrapping_key, &self.key)?;
 
         let new_key = ctx.generate_symmetric_key();
 
@@ -122,6 +122,7 @@ impl CipherEditRequest {
             .map(|l| l.reencrypt_fido2_credentials(ctx, old_key, new_key))
             .transpose()?;
         AttachmentView::reencrypt_keys(&mut self.attachments, ctx, old_key, new_key)?;
+        self.key = Some(ctx.wrap_symmetric_key(wrapping_key, new_key)?);
         Ok(())
     }
 }


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-33947

## 📔 Objective

When saving a cipher using the SDK operations, the cipher key is created and used to re-encrypt Attachments and Passkeys, but the cipher key is not stored. The rest of the cipher is encrypted with the org or user key, but the attachment and passkeys are corrupted after being encrypted with the discarded key.