### PR TITLE
fix: wasm_bindgen features were being applied to non-WASM targets

### DIFF
--- a/crates/bitwarden-error-macro/src/full/attribute.rs
+++ b/crates/bitwarden-error-macro/src/full/attribute.rs
@@ -12,7 +12,7 @@ pub(crate) fn bitwarden_error_full(
             .into();
     }
 
-    let wasm_attributes = cfg!(feature = "wasm").then(|| {
+    let wasm_attributes = cfg!(all(feature = "wasm", target_arch = "wasm32")).then(|| {
         quote! {
             #[derive(bitwarden_error::tsify::Tsify)]
             #[tsify(into_wasm_abi)]

--- a/crates/bitwarden-generators/src/generator_client.rs
+++ b/crates/bitwarden-generators/src/generator_client.rs
@@ -9,12 +9,12 @@ use crate::{
 };
 
 #[allow(missing_docs)]
-#[cfg_attr(feature = "wasm", wasm_bindgen)]
+#[cfg_attr(all(feature = "wasm", target_arch = "wasm32"), wasm_bindgen)]
 pub struct GeneratorClient {
     client: Client,
 }
 
-#[cfg_attr(feature = "wasm", wasm_bindgen)]
+#[cfg_attr(all(feature = "wasm", target_arch = "wasm32"), wasm_bindgen)]
 impl GeneratorClient {
     fn new(client: Client) -> Self {
         Self { client }


### PR DESCRIPTION
## 📔 Objective

sdk-sm workflows use the `--all-features` arg for [test workflows](https://github.com/search?q=repo%3Abitwarden%2Fsdk-sm+--all-features+language%3AYAML&type=code&l=YAML) and [schema generation](https://github.com/bitwarden/sdk-sm/blob/9a1eab6b585eac0b2fee42b01613366dd18195b8/package.json#L19). When updating to newer versions of the bitwarden crates used in sdk-sm, I noticed some new build errors that was causing [various workflow failures](https://github.com/bitwarden/sdk-sm/actions?query=branch%3Aupdate-sdk-internal-one-more-time). This seems to occur because it's trying to [generate JsValue](https://github.com/bitwarden/sdk-sm/actions/runs/23445283371/job/68207167578?pr=1490#step:7:784)s, which don't appear to be valid for anything other than WASM targets.

Locking the `cfg!` macro to only generating this code for WASM build targets appears to fix the issue.