### PR TITLE
feat: add wasm-only macro

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -792,6 +792,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "bitwarden-ffi"
+version = "2.0.0"
+dependencies = [
+ "bitwarden-ffi-macro",
+]
+
+[[package]]
+name = "bitwarden-ffi-macro"
+version = "2.0.0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "bitwarden-fido"
 version = "2.0.0"
 dependencies = [
@@ -843,6 +859,7 @@ version = "2.0.0"
 dependencies = [
  "async-trait",
  "bitwarden-error",
+ "bitwarden-ffi",
  "bitwarden-threading",
  "erased-serde",
  "js-sys",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -796,6 +796,8 @@ name = "bitwarden-ffi"
 version = "2.0.0"
 dependencies = [
  "bitwarden-ffi-macro",
+ "trybuild",
+ "wasm-bindgen",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,8 @@ bitwarden-encoding = { path = "crates/bitwarden-encoding", version = "=2.0.0" }
 bitwarden-error = { path = "crates/bitwarden-error", version = "=2.0.0" }
 bitwarden-error-macro = { path = "crates/bitwarden-error-macro", version = "=2.0.0" }
 bitwarden-exporters = { path = "crates/bitwarden-exporters", version = "=2.0.0" }
+bitwarden-ffi = { path = "crates/bitwarden-ffi", version = "=2.0.0" }
+bitwarden-ffi-macro = { path = "crates/bitwarden-ffi-macro", version = "=2.0.0" }
 bitwarden-fido = { path = "crates/bitwarden-fido", version = "=2.0.0" }
 bitwarden-generators = { path = "crates/bitwarden-generators", version = "=2.0.0" }
 bitwarden-ipc = { path = "crates/bitwarden-ipc", version = "=2.0.0" }

--- a/crates/bitwarden-ffi-macro/Cargo.toml
+++ b/crates/bitwarden-ffi-macro/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "bitwarden-ffi-macro"
+description = """
+Internal crate for the bitwarden crate. Do not use.
+"""
+
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+readme.workspace = true
+homepage.workspace = true
+repository.workspace = true
+license-file.workspace = true
+keywords.workspace = true
+
+[lib]
+proc-macro = true
+
+[dependencies]
+proc-macro2 = { workspace = true }
+quote = { workspace = true }
+syn = { workspace = true, features = ["full"] }
+
+[lints]
+workspace = true

--- a/crates/bitwarden-ffi-macro/src/lib.rs
+++ b/crates/bitwarden-ffi-macro/src/lib.rs
@@ -1,0 +1,42 @@
+//! Proc macros for FFI bindings (WASM, UniFFI).
+//!
+//! Provides:
+//! - `#[wasm_export]` attribute macro for hiding WASM binding methods from Rust consumers.
+
+use proc_macro::TokenStream;
+
+mod wasm_export;
+
+/// Attribute macro for impl blocks containing WASM bindings.
+///
+/// Methods within the impl block can be marked with `#[wasm_only]` to indicate they are
+/// intended only for JavaScript consumers via `wasm_bindgen`, not for direct Rust usage.
+///
+/// For each `#[wasm_only]` method, the macro:
+/// - Renames it with a `__wasm_only_` prefix (e.g. `subscribe` -> `__wasm_only_subscribe`)
+/// - Adds `#[wasm_bindgen(js_name = "subscribe")]` to preserve the JS API (if no `js_name` is
+///   already set)
+/// - Adds `#[doc(hidden)]` to hide it from Rust documentation
+/// - Adds `#[deprecated]` so it shows with strikethrough in IDE autocomplete
+///
+/// This must be placed **before** (above) the `#[wasm_bindgen]` attribute so it expands first.
+///
+/// # Example
+///
+/// ```ignore
+/// #[wasm_export]
+/// #[wasm_bindgen(js_class = IpcClient)]
+/// impl JsIpcClient {
+///     // Left as-is: Rust code may need to construct this type
+///     #[wasm_bindgen(js_name = newWithSdkInMemorySessions)]
+///     pub fn new_with_sdk_in_memory_sessions(...) -> JsIpcClient { ... }
+///
+///     // Mangled: Rust consumers should use the inner client directly
+///     #[wasm_only]
+///     pub async fn subscribe(&self) -> Result<JsIpcClientSubscription, SubscribeError> { ... }
+/// }
+/// ```
+#[proc_macro_attribute]
+pub fn wasm_export(_attr: TokenStream, item: TokenStream) -> TokenStream {
+    wasm_export::wasm_export(item.into()).into()
+}

--- a/crates/bitwarden-ffi-macro/src/wasm_export.rs
+++ b/crates/bitwarden-ffi-macro/src/wasm_export.rs
@@ -1,0 +1,95 @@
+use proc_macro2::TokenStream;
+use quote::ToTokens;
+use syn::{Attribute, ImplItem, ItemImpl, meta::ParseNestedMeta, parse2};
+
+/// Processes an impl block, transforming methods marked with `#[wasm_only]`.
+///
+/// For each marked method:
+/// - Strips the `#[wasm_only]` marker attribute
+/// - Renames the method with a `__wasm_only_` prefix (e.g. `subscribe` -> `__wasm_only_subscribe`)
+/// - Adds `#[wasm_bindgen(js_name = "original_name")]` if no `js_name` is already present
+/// - Adds `#[doc(hidden)]` to hide it from Rust documentation
+/// - Adds `#[deprecated]` so it shows with strikethrough in IDE autocomplete
+///
+/// This makes the methods effectively unreachable from Rust (hidden, mangled name) while
+/// preserving the original JS-facing API through `wasm_bindgen`'s `js_name` attribute.
+pub(crate) fn wasm_export(item: TokenStream) -> TokenStream {
+    let mut impl_block = match parse2::<ItemImpl>(item) {
+        Ok(block) => block,
+        Err(err) => return err.to_compile_error(),
+    };
+
+    for item in &mut impl_block.items {
+        let ImplItem::Fn(method) = item else {
+            continue;
+        };
+
+        let wasm_only_idx = method
+            .attrs
+            .iter()
+            .position(|attr| attr.path().is_ident("wasm_only"));
+
+        let Some(idx) = wasm_only_idx else {
+            continue;
+        };
+
+        // Extract optional note from #[wasm_only("custom note")] before removing
+        let custom_note = extract_wasm_only_note(&method.attrs[idx]);
+
+        // Remove the #[wasm_only] marker attribute
+        method.attrs.remove(idx);
+
+        let original_name = method.sig.ident.to_string();
+
+        // Add #[wasm_bindgen(js_name = "...")] if not already present,
+        // so JS consumers still see the original name
+        if !has_wasm_bindgen_js_name(&method.attrs) {
+            method
+                .attrs
+                .push(syn::parse_quote!(#[wasm_bindgen(js_name = #original_name)]));
+        }
+
+        // Hide from Rust documentation
+        method.attrs.push(syn::parse_quote!(#[doc(hidden)]));
+
+        // Mark as deprecated so IDEs show strikethrough
+        let note = custom_note.unwrap_or_else(|| {
+            "This is a WASM-only binding. Calling it from Rust is not allowed.".to_string()
+        });
+        method
+            .attrs
+            .push(syn::parse_quote!(#[deprecated(note = #note)]));
+
+        // Suppress the deprecation warning on the definition itself
+        method.attrs.push(syn::parse_quote!(#[allow(deprecated)]));
+
+        // Rename the method with __wasm_only_ prefix to discourage direct Rust usage
+        method.sig.ident = syn::Ident::new(
+            &format!("__wasm_only_{original_name}"),
+            method.sig.ident.span(),
+        );
+    }
+
+    impl_block.into_token_stream()
+}
+
+/// Extracts the optional note from `#[wasm_only(note = "custom note")]`.
+/// Returns `None` for plain `#[wasm_only]`.
+fn extract_wasm_only_note(attr: &Attribute) -> Option<String> {
+    let mut note = None;
+    let parser = |meta: ParseNestedMeta| {
+        if meta.path.is_ident("note") {
+            note = Some(meta.value()?.parse::<syn::LitStr>()?.value());
+        }
+        Ok(())
+    };
+    let _ = attr.parse_nested_meta(parser);
+    note
+}
+
+fn has_wasm_bindgen_js_name(attrs: &[Attribute]) -> bool {
+    attrs.iter().any(|attr| {
+        attr.path().is_ident("wasm_bindgen")
+            && attr.to_token_stream().to_string().contains("js_name")
+    })
+}

--- a/crates/bitwarden-ffi-macro/src/wasm_export.rs
+++ b/crates/bitwarden-ffi-macro/src/wasm_export.rs
@@ -1,6 +1,6 @@
 use proc_macro2::TokenStream;
 use quote::ToTokens;
-use syn::{Attribute, ImplItem, ItemImpl, meta::ParseNestedMeta, parse2};
+use syn::{Attribute, ImplItem, ItemImpl, parse2};
 
 /// Processes an impl block, transforming methods marked with `#[wasm_only]`.
 ///
@@ -33,8 +33,11 @@ pub(crate) fn wasm_export(item: TokenStream) -> TokenStream {
             continue;
         };
 
-        // Extract optional note from #[wasm_only("custom note")] before removing
-        let custom_note = extract_wasm_only_note(&method.attrs[idx]);
+        // Extract optional note from #[wasm_only(note = "custom note")] before removing
+        let custom_note = match extract_wasm_only_note(&method.attrs[idx]) {
+            Ok(note) => note,
+            Err(err) => return err.to_compile_error(),
+        };
 
         // Remove the #[wasm_only] marker attribute
         method.attrs.remove(idx);
@@ -74,17 +77,23 @@ pub(crate) fn wasm_export(item: TokenStream) -> TokenStream {
 }
 
 /// Extracts the optional note from `#[wasm_only(note = "custom note")]`.
-/// Returns `None` for plain `#[wasm_only]`.
-fn extract_wasm_only_note(attr: &Attribute) -> Option<String> {
+/// Returns `None` for plain `#[wasm_only]`, or `Err` for unknown attributes.
+fn extract_wasm_only_note(attr: &Attribute) -> Result<Option<String>, syn::Error> {
+    // Plain #[wasm_only] with no arguments
+    if attr.meta.require_path_only().is_ok() {
+        return Ok(None);
+    }
+
     let mut note = None;
-    let parser = |meta: ParseNestedMeta| {
+    attr.parse_nested_meta(|meta| {
         if meta.path.is_ident("note") {
             note = Some(meta.value()?.parse::<syn::LitStr>()?.value());
+            Ok(())
+        } else {
+            Err(meta.error("unknown attribute, expected `note`"))
         }
-        Ok(())
-    };
-    let _ = attr.parse_nested_meta(parser);
-    note
+    })?;
+    Ok(note)
 }
 
 fn has_wasm_bindgen_js_name(attrs: &[Attribute]) -> bool {

--- a/crates/bitwarden-ffi/Cargo.toml
+++ b/crates/bitwarden-ffi/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "bitwarden-ffi"
+description = """
+Internal crate for the bitwarden crate. Do not use.
+"""
+
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+readme.workspace = true
+homepage.workspace = true
+repository.workspace = true
+license-file.workspace = true
+keywords.workspace = true
+
+[dependencies]
+bitwarden-ffi-macro = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/bitwarden-ffi/Cargo.toml
+++ b/crates/bitwarden-ffi/Cargo.toml
@@ -17,5 +17,9 @@ keywords.workspace = true
 [dependencies]
 bitwarden-ffi-macro = { workspace = true }
 
+[dev-dependencies]
+trybuild = "1.0.101"
+wasm-bindgen = { workspace = true }
+
 [lints]
 workspace = true

--- a/crates/bitwarden-ffi/src/lib.rs
+++ b/crates/bitwarden-ffi/src/lib.rs
@@ -1,0 +1,5 @@
+//! Utilities for FFI bindings (WASM, UniFFI).
+//!
+//! Re-exports proc macros from `bitwarden-ffi-macro`.
+
+pub use bitwarden_ffi_macro::wasm_export;

--- a/crates/bitwarden-ffi/tests/compilation_tests/unknown_wasm_only_attribute.rs
+++ b/crates/bitwarden-ffi/tests/compilation_tests/unknown_wasm_only_attribute.rs
@@ -1,0 +1,11 @@
+use bitwarden_ffi::wasm_export;
+
+struct Foo;
+
+#[wasm_export]
+impl Foo {
+    #[wasm_only(message = "hello")]
+    pub fn bar() {}
+}
+
+fn main() {}

--- a/crates/bitwarden-ffi/tests/compilation_tests/unknown_wasm_only_attribute.stderr
+++ b/crates/bitwarden-ffi/tests/compilation_tests/unknown_wasm_only_attribute.stderr
@@ -1,0 +1,5 @@
+error: unknown attribute, expected `note`
+ --> tests/compilation_tests/unknown_wasm_only_attribute.rs:7:17
+  |
+7 |     #[wasm_only(message = "hello")]
+  |                 ^^^^^^^

--- a/crates/bitwarden-ffi/tests/mod.rs
+++ b/crates/bitwarden-ffi/tests/mod.rs
@@ -1,0 +1,9 @@
+#![allow(missing_docs)]
+
+mod wasm_export;
+
+#[test]
+fn compilation_tests() {
+    let t = trybuild::TestCases::new();
+    t.compile_fail("tests/compilation_tests/*.rs");
+}

--- a/crates/bitwarden-ffi/tests/wasm_export.rs
+++ b/crates/bitwarden-ffi/tests/wasm_export.rs
@@ -1,0 +1,58 @@
+#![allow(missing_docs)]
+
+use bitwarden_ffi::wasm_export;
+use wasm_bindgen::prelude::*;
+
+// --- Test: renames wasm_only method ---
+
+#[wasm_bindgen]
+pub struct RenameTarget;
+
+#[wasm_export]
+#[wasm_bindgen]
+impl RenameTarget {
+    #[wasm_only]
+    pub fn bar() {}
+}
+
+#[test]
+#[allow(deprecated)]
+fn renames_wasm_only_method() {
+    RenameTarget::__wasm_only_bar();
+}
+
+// --- Test: custom note is accepted ---
+
+#[wasm_bindgen]
+pub struct CustomNoteTarget;
+
+#[wasm_export]
+#[wasm_bindgen]
+impl CustomNoteTarget {
+    #[wasm_only(note = "Use the native API instead.")]
+    pub fn with_custom_note() {}
+}
+
+#[test]
+#[allow(deprecated)]
+fn custom_note_is_accepted() {
+    CustomNoteTarget::__wasm_only_with_custom_note();
+}
+
+// --- Test: leaves unmarked methods unchanged ---
+
+#[wasm_bindgen]
+pub struct UnmarkedTarget;
+
+#[wasm_export]
+#[wasm_bindgen]
+impl UnmarkedTarget {
+    pub fn untouched() -> i32 {
+        42
+    }
+}
+
+#[test]
+fn leaves_unmarked_methods_unchanged() {
+    assert_eq!(UnmarkedTarget::untouched(), 42);
+}

--- a/crates/bitwarden-ipc/Cargo.toml
+++ b/crates/bitwarden-ipc/Cargo.toml
@@ -22,6 +22,7 @@ wasm = [
 [dependencies]
 async-trait = { workspace = true }
 bitwarden-error = { workspace = true }
+bitwarden-ffi = { workspace = true }
 bitwarden-threading = { workspace = true }
 erased-serde = ">=0.4.6, <0.5"
 js-sys = { workspace = true, optional = true }

--- a/crates/bitwarden-ipc/src/wasm/discover.rs
+++ b/crates/bitwarden-ipc/src/wasm/discover.rs
@@ -11,6 +11,7 @@ use crate::{
 #[wasm_bindgen(js_name = ipcRegisterDiscoverHandler)]
 /// Registers a DiscoverHandler so that the client can respond to DiscoverRequests.
 pub async fn ipc_register_discover_handler(ipc_client: &JsIpcClient, response: DiscoverResponse) {
+    ipc_client.__wasm_only_start().await;
     ipc_client
         .client
         .register_rpc_handler(DiscoverHandler::new(response))

--- a/crates/bitwarden-ipc/src/wasm/discover.rs
+++ b/crates/bitwarden-ipc/src/wasm/discover.rs
@@ -11,7 +11,6 @@ use crate::{
 #[wasm_bindgen(js_name = ipcRegisterDiscoverHandler)]
 /// Registers a DiscoverHandler so that the client can respond to DiscoverRequests.
 pub async fn ipc_register_discover_handler(ipc_client: &JsIpcClient, response: DiscoverResponse) {
-    ipc_client.__wasm_only_start().await;
     ipc_client
         .client
         .register_rpc_handler(DiscoverHandler::new(response))

--- a/crates/bitwarden-ipc/src/wasm/ipc_client.rs
+++ b/crates/bitwarden-ipc/src/wasm/ipc_client.rs
@@ -36,8 +36,12 @@ pub struct JsIpcClientSubscription {
     subscription: IpcClientSubscription,
 }
 
+#[bitwarden_ffi::wasm_export]
 #[wasm_bindgen(js_class = IpcClientSubscription)]
 impl JsIpcClientSubscription {
+    #[wasm_only(
+        note = "Use the `subscribe` method on `IpcClient` to create a subscription instance."
+    )]
     #[allow(missing_docs)]
     pub async fn receive(
         &mut self,
@@ -48,10 +52,12 @@ impl JsIpcClientSubscription {
     }
 }
 
+#[bitwarden_ffi::wasm_export]
 #[wasm_bindgen(js_class = IpcClient)]
 impl JsIpcClient {
     /// Create a new `IpcClient` instance with an in-memory session repository for saving
     /// sessions within the SDK.
+    #[wasm_only]
     #[wasm_bindgen(js_name = newWithSdkInMemorySessions)]
     pub fn new_with_sdk_in_memory_sessions(
         communication_provider: &JsCommunicationBackend,
@@ -68,6 +74,7 @@ impl JsIpcClient {
     }
     /// Create a new `IpcClient` instance with a client-managed session repository for saving
     /// sessions using State Provider.
+    #[wasm_only]
     #[wasm_bindgen(js_name = newWithClientManagedSessions)]
     pub fn new_with_client_managed_sessions(
         communication_provider: &JsCommunicationBackend,
@@ -84,17 +91,20 @@ impl JsIpcClient {
         }
     }
 
+    #[wasm_only]
     #[allow(missing_docs)]
     pub async fn start(&self) {
         self.client.start().await
     }
 
+    #[wasm_only]
     #[wasm_bindgen(js_name = isRunning)]
     #[allow(missing_docs)]
     pub async fn is_running(&self) -> bool {
         self.client.is_running().await
     }
 
+    #[wasm_only]
     #[allow(missing_docs)]
     pub async fn send(&self, message: OutgoingMessage) -> Result<(), JsError> {
         self.client
@@ -103,6 +113,7 @@ impl JsIpcClient {
             .map_err(|e| JsError::new(&e))
     }
 
+    #[wasm_only]
     #[allow(missing_docs)]
     pub async fn subscribe(&self) -> Result<JsIpcClientSubscription, SubscribeError> {
         let subscription = self.client.subscribe(None).await?;


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective

Adds a macro that mangles functions to make them harder to use from Rust

## 🚨 Breaking Changes

<!-- Does this PR introduce any breaking changes? If so, please describe the impact and migration path for clients.

If you're unsure, the automated TypeScript compatibility check will run when you open/update this PR and provide feedback.

For breaking changes:
1. Describe what changed in the client interface
2. Explain why the change was necessary
3. Provide migration steps for client developers
4. Link to any paired client PRs if needed

Otherwise, you can remove this section. -->
