### PR TITLE
Bitwarden IPC improvements/refactor

### DIFF
--- a/crates/bitwarden-ipc/Cargo.toml
+++ b/crates/bitwarden-ipc/Cargo.toml
@@ -18,6 +18,7 @@ wasm = [
     "bitwarden-error/wasm",
     "bitwarden-threading/wasm",
 ] # WASM support
+test-support = [] # Expose test utilities (InMemoryCommunicationBackend) for downstream crates
 
 [dependencies]
 async-trait = { workspace = true }

--- a/crates/bitwarden-ipc/src/discover/README.md
+++ b/crates/bitwarden-ipc/src/discover/README.md
@@ -1,0 +1,52 @@
+# Discover
+
+A built-in RPC request/response pair for client discovery and health checking over IPC.
+
+## Purpose
+
+The discover module provides a simple "ping" mechanism that allows one IPC endpoint to check whether
+another endpoint is alive and reachable. The responding endpoint includes its version string, which
+can be used for compatibility checks.
+
+## Types
+
+- **`DiscoverRequest`**: An empty RPC request that acts as a ping. Implements `RpcRequest` with
+  `NAME = "DiscoverRequest"`.
+- **`DiscoverResponse`**: Contains a `version` string identifying the responding client.
+- **`DiscoverHandler`**: A pre-built `RpcHandler` that responds to `DiscoverRequest` with a fixed
+  `DiscoverResponse`. Register it on an `IpcClient` to make that client discoverable.
+
+## Usage
+
+### Responding to discover requests
+
+Register the handler so the client responds to incoming discover requests:
+
+```rust,ignore
+let handler = DiscoverHandler::new(DiscoverResponse {
+    version: "1.0.0".to_string(),
+});
+ipc_client.register_rpc_handler(handler).await;
+```
+
+### Sending a discover request
+
+Send a discover request to a specific endpoint:
+
+```rust,ignore
+let response = ipc_client
+    .request::<DiscoverRequest>(
+        DiscoverRequest,
+        destination_endpoint,
+        None, // optional cancellation token
+    )
+    .await?;
+println!("Remote version: {}", response.version);
+```
+
+### WASM
+
+In WASM contexts, two functions are exported:
+
+- `ipcRegisterDiscoverHandler(client, response)`: registers the handler
+- `ipcRequestDiscover(client, destination, abortSignal?)`: sends a discover request

--- a/crates/bitwarden-ipc/src/discover/README.md
+++ b/crates/bitwarden-ipc/src/discover/README.md
@@ -22,18 +22,23 @@ can be used for compatibility checks.
 
 Register the handler so the client responds to incoming discover requests:
 
-```rust,ignore
+```rust,no_run
+# use bitwarden_ipc::{*, discover::*};
+# async fn test(ipc_client: impl IpcClient) {
 let handler = DiscoverHandler::new(DiscoverResponse {
     version: "1.0.0".to_string(),
 });
 ipc_client.register_rpc_handler(handler).await;
+# }
 ```
 
 ### Sending a discover request
 
 Send a discover request to a specific endpoint:
 
-```rust,ignore
+```rust,no_run
+# use bitwarden_ipc::{*, discover::*};
+# async fn test(ipc_client: impl IpcClient, destination_endpoint: Endpoint) -> Result<(), Box<dyn std::error::Error>> {
 let response = ipc_client
     .request::<DiscoverRequest>(
         DiscoverRequest,
@@ -42,6 +47,8 @@ let response = ipc_client
     )
     .await?;
 println!("Remote version: {}", response.version);
+# Ok(())
+# }
 ```
 
 ### WASM

--- a/crates/bitwarden-ipc/src/discover/mod.rs
+++ b/crates/bitwarden-ipc/src/discover/mod.rs
@@ -1,3 +1,5 @@
+#![doc = include_str!("README.md")]
+
 use serde::{Deserialize, Serialize};
 #[cfg(feature = "wasm")]
 use {tsify::Tsify, wasm_bindgen::prelude::*};
@@ -5,11 +7,14 @@ use {tsify::Tsify, wasm_bindgen::prelude::*};
 use crate::{RpcHandler, rpc::request::RpcRequest};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+/// A request to discover/ping a client.
 pub struct DiscoverRequest;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "wasm", derive(Tsify), tsify(into_wasm_abi, from_wasm_abi))]
+/// The response to a discover/ping request.
 pub struct DiscoverResponse {
+    /// The version of the client that responded to the discover request.
     pub version: String,
 }
 
@@ -19,11 +24,14 @@ impl RpcRequest for DiscoverRequest {
     const NAME: &str = "DiscoverRequest";
 }
 
+/// A simple handler for the `DiscoverRequest` that always returns the same response.
+/// Used to enable discovery/ping functionality and provide version information.
 pub struct DiscoverHandler {
     response: DiscoverResponse,
 }
 
 impl DiscoverHandler {
+    /// Creates a new `DiscoverHandler` with the given response.
     pub fn new(response: DiscoverResponse) -> Self {
         Self { response }
     }

--- a/crates/bitwarden-ipc/src/endpoint.rs
+++ b/crates/bitwarden-ipc/src/endpoint.rs
@@ -2,12 +2,118 @@ use serde::{Deserialize, Serialize};
 #[cfg(feature = "wasm")]
 use {tsify::Tsify, wasm_bindgen::prelude::*};
 
+/// Identifies a host endpoint, one that manages connections for other endpoints.
+///
+/// Host endpoints can be addressed relationally (when the sender has a direct connection
+/// and there is only one from their perspective) or by a specific transport-assigned ID
+/// (when distinguishing between multiple instances).
 #[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "wasm", derive(Tsify), tsify(into_wasm_abi, from_wasm_abi))]
+pub enum HostId {
+    /// The sender's own instance of this endpoint type. Used when there is exactly one
+    /// from the sender's perspective (e.g., a web tab addressing its browser background).
+    Own,
+    /// A specific instance identified by a transport-assigned numeric value
+    /// (e.g., native messaging client ID).
+    Id(i32),
+}
+
+/// IPC destination/source endpoint for SDK clients.
+///
+/// Endpoints are categorized by their role in the connection topology:
+/// - **Host endpoints** ([`HostId`]): Connection hubs that can be addressed relationally or
+///   specifically. ([`BrowserBackground`](Endpoint::BrowserBackground))
+/// - **Leaf endpoints**: Addressed by transport-assigned IDs. ([`Web`](Endpoint::Web),
+///   [`BrowserForeground`](Endpoint::BrowserForeground))
+/// - **Singleton endpoints**: Exactly one instance globally, no ID needed.
+///   ([`DesktopMain`](Endpoint::DesktopMain), [`DesktopRenderer`](Endpoint::DesktopRenderer))
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "wasm", derive(Tsify), tsify(into_wasm_abi, from_wasm_abi))]
 pub enum Endpoint {
-    Web { id: i32 },
-    BrowserForeground,
-    BrowserBackground,
+    /// A web endpoint identified by a Chrome tab ID (for routing via
+    /// `chrome.tabs.sendMessage`) and a document ID (for identity validation).
+    /// The document ID invalidates on navigation, allowing the browser background
+    /// to reject delivery if the page changed since the message was addressed.
+    Web {
+        /// Chrome tab ID used for routing messages to the correct tab.
+        tab_id: i32,
+        /// Document ID (`sender.documentId`) identifying a specific document instance.
+        document_id: String,
+    },
+    /// Browser foreground endpoint (popup, sidebar, or extension page) identified by a
+    /// transport-assigned numeric ID.
+    BrowserForeground {
+        /// Transport-assigned identifier for a browser foreground instance.
+        id: i32,
+    },
+    /// Browser background endpoint (service worker/background context).
+    BrowserBackground {
+        /// Host identifier for addressing this endpoint.
+        id: HostId,
+    },
+    /// Desktop renderer endpoint (singleton).
     DesktopRenderer,
+    /// Desktop main-process endpoint (singleton).
     DesktopMain,
+}
+
+/// Describes the source of an incoming IPC message with per-variant metadata.
+///
+/// `Source` mirrors [`Endpoint`] but carries additional context about the sender
+/// that the application layer needs for security decisions (e.g., checking `origin`
+/// for web sources). Use [`From<Source> for Endpoint`] to convert a source into an
+/// addressable endpoint (dropping the metadata).
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "wasm", derive(Tsify), tsify(into_wasm_abi, from_wasm_abi))]
+pub enum Source {
+    /// A web source identified by tab ID and document ID, with the origin of the sending page.
+    Web {
+        /// Chrome tab ID used for routing messages back to this tab.
+        tab_id: i32,
+        /// Document ID (`sender.documentId`) identifying the specific document instance.
+        document_id: String,
+        /// The origin of the web page (e.g., "https://vault.bitwarden.com").
+        origin: String,
+    },
+    /// Browser foreground source (popup, sidebar, or extension page).
+    BrowserForeground {
+        /// Transport-assigned identifier for the browser foreground instance.
+        id: i32,
+    },
+    /// Browser background source (service worker/background context).
+    BrowserBackground {
+        /// Host identifier for this endpoint.
+        id: HostId,
+    },
+    /// Desktop renderer source (singleton).
+    DesktopRenderer,
+    /// Desktop main-process source (singleton).
+    DesktopMain,
+}
+
+impl Source {
+    /// Convert this source into its corresponding [`Endpoint`], dropping any
+    /// source-specific metadata (such as `origin`).
+    pub fn to_endpoint(&self) -> Endpoint {
+        Endpoint::from(self.clone())
+    }
+}
+
+impl From<Source> for Endpoint {
+    fn from(source: Source) -> Self {
+        match source {
+            Source::Web {
+                tab_id,
+                document_id,
+                ..
+            } => Endpoint::Web {
+                tab_id,
+                document_id,
+            },
+            Source::BrowserForeground { id } => Endpoint::BrowserForeground { id },
+            Source::BrowserBackground { id } => Endpoint::BrowserBackground { id },
+            Source::DesktopRenderer => Endpoint::DesktopRenderer,
+            Source::DesktopMain => Endpoint::DesktopMain,
+        }
+    }
 }

--- a/crates/bitwarden-ipc/src/endpoint.rs
+++ b/crates/bitwarden-ipc/src/endpoint.rs
@@ -72,7 +72,7 @@ pub enum Source {
         tab_id: i32,
         /// Document ID (`sender.documentId`) identifying the specific document instance.
         document_id: String,
-        /// The origin of the web page (e.g., "https://vault.bitwarden.com").
+        /// The origin of the web page (e.g., `"https://vault.bitwarden.com"`).
         origin: String,
     },
     /// Browser foreground source (popup, sidebar, or extension page).

--- a/crates/bitwarden-ipc/src/error.rs
+++ b/crates/bitwarden-ipc/src/error.rs
@@ -1,0 +1,79 @@
+use bitwarden_error::bitwarden_error;
+use thiserror::Error;
+
+use crate::rpc::error::RpcError;
+
+/// Error returned by [`IpcClient::send`](crate::IpcClient::send). Wraps the underlying transport
+/// error as a string.
+#[derive(Debug, Error, Clone, PartialEq, Eq)]
+#[error("{0}")]
+pub struct SendError(pub(crate) String);
+
+#[derive(Debug, Error, Clone, PartialEq, Eq)]
+#[bitwarden_error(flat)]
+#[allow(missing_docs)]
+pub enum SubscribeError {
+    #[error("The IPC processing thread is not running")]
+    NotStarted,
+}
+
+#[derive(Debug, Error, PartialEq, Eq)]
+#[bitwarden_error(flat)]
+#[allow(missing_docs)]
+pub enum ReceiveError {
+    #[error("Failed to subscribe to the IPC channel: {0}")]
+    Channel(#[from] tokio::sync::broadcast::error::RecvError),
+
+    #[error("Timed out while waiting for a message: {0}")]
+    Timeout(#[from] tokio::time::error::Elapsed),
+
+    #[error("Cancelled while waiting for a message")]
+    Cancelled,
+}
+
+#[derive(Debug, Error, PartialEq, Eq)]
+#[bitwarden_error(flat)]
+#[allow(missing_docs)]
+pub enum TypedReceiveError {
+    #[error("Failed to subscribe to the IPC channel: {0}")]
+    Channel(#[from] tokio::sync::broadcast::error::RecvError),
+
+    #[error("Timed out while waiting for a message: {0}")]
+    Timeout(#[from] tokio::time::error::Elapsed),
+
+    #[error("Cancelled while waiting for a message")]
+    Cancelled,
+
+    #[error("Typing error: {0}")]
+    Typing(String),
+}
+
+impl From<ReceiveError> for TypedReceiveError {
+    fn from(value: ReceiveError) -> Self {
+        match value {
+            ReceiveError::Channel(e) => TypedReceiveError::Channel(e),
+            ReceiveError::Timeout(e) => TypedReceiveError::Timeout(e),
+            ReceiveError::Cancelled => TypedReceiveError::Cancelled,
+        }
+    }
+}
+
+#[derive(Debug, Error, PartialEq, Eq)]
+#[bitwarden_error(flat)]
+#[allow(missing_docs)]
+pub enum RequestError {
+    #[error(transparent)]
+    Subscribe(#[from] SubscribeError),
+
+    #[error(transparent)]
+    Receive(#[from] TypedReceiveError),
+
+    #[error("Timed out while waiting for a message: {0}")]
+    Timeout(#[from] tokio::time::error::Elapsed),
+
+    #[error("Failed to send message: {0}")]
+    Send(String),
+
+    #[error("Error occured on the remote target: {0}")]
+    Rpc(#[from] RpcError),
+}

--- a/crates/bitwarden-ipc/src/error.rs
+++ b/crates/bitwarden-ipc/src/error.rs
@@ -3,6 +3,13 @@ use thiserror::Error;
 
 use crate::rpc::error::RpcError;
 
+/// Error returned by [`IpcClient::start`](crate::IpcClient::start). Indicates that the IPC client
+/// is already running.
+#[derive(Debug, Error, Clone, PartialEq, Eq)]
+#[error("IPC client is already running")]
+#[bitwarden_error(basic)]
+pub struct AlreadyRunningError;
+
 /// Error returned by [`IpcClient::send`](crate::IpcClient::send). Wraps the underlying transport
 /// error as a string.
 #[derive(Debug, Error, Clone, PartialEq, Eq)]

--- a/crates/bitwarden-ipc/src/ipc_client.rs
+++ b/crates/bitwarden-ipc/src/ipc_client.rs
@@ -7,7 +7,7 @@ use tokio::select;
 
 use crate::{
     constants::CHANNEL_BUFFER_CAPACITY,
-    error::{ReceiveError, SendError, SubscribeError, TypedReceiveError},
+    error::{AlreadyRunningError, ReceiveError, SendError, SubscribeError, TypedReceiveError},
     message::{
         IncomingMessage, OutgoingMessage, PayloadTypeName, TypedIncomingMessage,
         TypedOutgoingMessage,
@@ -112,7 +112,14 @@ where
     Com: CommunicationBackend,
     Ses: SessionRepository<Crypto::Session>,
 {
-    async fn start(&self, cancellation_token: Option<CancellationToken>) {
+    async fn start(
+        &self,
+        cancellation_token: Option<CancellationToken>,
+    ) -> Result<(), AlreadyRunningError> {
+        if self.is_running() {
+            return Err(AlreadyRunningError);
+        }
+
         let cancellation_token = cancellation_token.unwrap_or_else(CancellationToken::new);
         self.inner
             .cancellation_token
@@ -166,6 +173,8 @@ where
 
         #[cfg(target_arch = "wasm32")]
         wasm_bindgen_futures::spawn_local(future);
+
+        Ok(())
     }
 
     fn is_running(&self) -> bool {
@@ -439,7 +448,7 @@ mod tests {
         let communication_provider = TestCommunicationBackend::new();
         let session_map = TestSessionRepository::new(HashMap::new());
         let client = IpcClientImpl::new(crypto_provider, communication_provider, session_map);
-        client.start(None).await;
+        let _ = client.start(None).await;
 
         let error = client.send(message).await.unwrap_err();
 
@@ -458,7 +467,7 @@ mod tests {
         let session_map = InMemorySessionRepository::new(HashMap::new());
         let client =
             IpcClientImpl::new(crypto_provider, communication_provider.clone(), session_map);
-        client.start(None).await;
+        let _ = client.start(None).await;
 
         client.send(message.clone()).await.unwrap();
 
@@ -483,7 +492,7 @@ mod tests {
         let session_map = InMemorySessionRepository::new(HashMap::new());
         let client =
             IpcClientImpl::new(crypto_provider, communication_provider.clone(), session_map);
-        client.start(None).await;
+        let _ = client.start(None).await;
 
         let mut subscription = client
             .subscribe(None)
@@ -523,7 +532,7 @@ mod tests {
         let session_map = InMemorySessionRepository::new(HashMap::new());
         let client =
             IpcClientImpl::new(crypto_provider, communication_provider.clone(), session_map);
-        client.start(None).await;
+        let _ = client.start(None).await;
         let mut subscription = client
             .subscribe(Some("matching_topic".to_owned()))
             .await
@@ -575,7 +584,7 @@ mod tests {
         let session_map = InMemorySessionRepository::new(HashMap::new());
         let client =
             IpcClientImpl::new(crypto_provider, communication_provider.clone(), session_map);
-        client.start(None).await;
+        let _ = client.start(None).await;
         let mut subscription = client
             .subscribe_typed::<TestPayload>()
             .await
@@ -621,7 +630,7 @@ mod tests {
         let session_map = InMemorySessionRepository::new(HashMap::new());
         let client =
             IpcClientImpl::new(crypto_provider, communication_provider.clone(), session_map);
-        client.start(None).await;
+        let _ = client.start(None).await;
         let mut subscription = client
             .subscribe_typed::<TestPayload>()
             .await
@@ -646,7 +655,7 @@ mod tests {
         let communication_provider = TestCommunicationBackend::new();
         let session_map = TestSessionRepository::new(HashMap::new());
         let client = IpcClientImpl::new(crypto_provider, communication_provider, session_map);
-        client.start(None).await;
+        let _ = client.start(None).await;
 
         let error = client.send(message).await.unwrap_err();
         let is_running = client.is_running();
@@ -665,7 +674,7 @@ mod tests {
         let session_map = TestSessionRepository::new(HashMap::new());
         let client = IpcClientImpl::new(crypto_provider, communication_provider, session_map);
         let cancellation_token = CancellationToken::new();
-        client.start(Some(cancellation_token.clone())).await;
+        let _ = client.start(Some(cancellation_token.clone())).await;
 
         // Give the client some time to process the error
         tokio::time::sleep(Duration::from_millis(100)).await;
@@ -676,7 +685,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn ipc_client_stops_if_cancellation_token_is_cancelled() {
+    async fn ipc_client_is_not_running_if_cancellation_token_is_cancelled() {
         let crypto_provider = TestCryptoProvider {
             send_result: None,
             receive_result: None,
@@ -685,7 +694,7 @@ mod tests {
         let session_map = TestSessionRepository::new(HashMap::new());
         let client = IpcClientImpl::new(crypto_provider, communication_provider, session_map);
         let cancellation_token = CancellationToken::new();
-        client.start(Some(cancellation_token.clone())).await;
+        let _ = client.start(Some(cancellation_token.clone())).await;
 
         // Give the client some time to process
         tokio::time::sleep(Duration::from_millis(100)).await;
@@ -708,7 +717,7 @@ mod tests {
         let session_map = TestSessionRepository::new(HashMap::new());
         let client = IpcClientImpl::new(crypto_provider, communication_provider, session_map);
         let cancellation_token = CancellationToken::new();
-        client.start(Some(cancellation_token.clone())).await;
+        let _ = client.start(Some(cancellation_token.clone())).await;
 
         // Give the client some time to process
         tokio::time::sleep(Duration::from_millis(100)).await;
@@ -716,6 +725,44 @@ mod tests {
 
         assert!(is_running);
         assert!(!cancellation_token.is_cancelled());
+    }
+
+    #[tokio::test]
+    async fn ipc_client_is_not_running_if_not_started() {
+        let crypto_provider = TestCryptoProvider {
+            send_result: None,
+            receive_result: None,
+        };
+        let communication_provider = TestCommunicationBackend::new();
+        let session_map = TestSessionRepository::new(HashMap::new());
+        let client = IpcClientImpl::new(crypto_provider, communication_provider, session_map);
+
+        // Give the client some time to process
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        let is_running = client.is_running();
+
+        assert!(!is_running);
+    }
+
+    #[tokio::test]
+    async fn ipc_client_start_returns_error_if_already_running() {
+        let crypto_provider = TestCryptoProvider {
+            send_result: None,
+            receive_result: None,
+        };
+        let communication_provider = TestCommunicationBackend::new();
+        let session_map = TestSessionRepository::new(HashMap::new());
+        let client = IpcClientImpl::new(crypto_provider, communication_provider, session_map);
+        let cancellation_token = CancellationToken::new();
+        let first_result = client.start(Some(cancellation_token.clone())).await;
+        assert_eq!(first_result, Ok(()));
+
+        // Give the client some time to process
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        assert!(client.is_running());
+
+        let second_result = client.start(Some(cancellation_token.clone())).await;
+        assert_eq!(second_result, Err(AlreadyRunningError));
     }
 
     mod request {
@@ -758,7 +805,7 @@ mod tests {
             let session_map = InMemorySessionRepository::new(HashMap::new());
             let client =
                 IpcClientImpl::new(crypto_provider, communication_provider.clone(), session_map);
-            client.start(None).await;
+            let _ = client.start(None).await;
             let request = TestRequest { a: 1, b: 2 };
             let response = TestResponse { result: 3 };
 
@@ -816,7 +863,7 @@ mod tests {
             let session_map = InMemorySessionRepository::new(HashMap::new());
             let client =
                 IpcClientImpl::new(crypto_provider, communication_provider.clone(), session_map);
-            client.start(None).await;
+            let _ = client.start(None).await;
             let request_id = uuid::Uuid::new_v4().to_string();
             let request = TestRequest { a: 1, b: 2 };
             let response = TestResponse { result: 3 };

--- a/crates/bitwarden-ipc/src/ipc_client.rs
+++ b/crates/bitwarden-ipc/src/ipc_client.rs
@@ -367,7 +367,7 @@ where
 
                 let outgoing = TypedOutgoingMessage {
                     payload: response_message,
-                    destination: incoming_message.source,
+                    destination: incoming_message.source.into(),
                 }
                 .try_into()
                 .map_err(|e: serde_utils::SerializeError| HandleError::Serialize(e.to_string()))?;
@@ -446,7 +446,7 @@ mod tests {
 
     use super::*;
     use crate::{
-        endpoint::Endpoint,
+        endpoint::{Endpoint, HostId, Source},
         traits::{
             InMemorySessionRepository, NoEncryptionCryptoProvider, tests::TestCommunicationBackend,
         },
@@ -502,7 +502,7 @@ mod tests {
     async fn returns_send_error_when_crypto_provider_returns_error() {
         let message = OutgoingMessage {
             payload: vec![],
-            destination: Endpoint::BrowserBackground,
+            destination: Endpoint::BrowserBackground { id: HostId::Own },
             topic: None,
         };
         let crypto_provider = TestCryptoProvider {
@@ -523,7 +523,7 @@ mod tests {
     async fn communication_provider_has_outgoing_message_when_sending_through_ipc_client() {
         let message = OutgoingMessage {
             payload: vec![],
-            destination: Endpoint::BrowserBackground,
+            destination: Endpoint::BrowserBackground { id: HostId::Own },
             topic: None,
         };
         let crypto_provider = NoEncryptionCryptoProvider;
@@ -542,8 +542,12 @@ mod tests {
     async fn returns_received_message_when_received_from_backend() {
         let message = IncomingMessage {
             payload: vec![],
-            source: Endpoint::Web { id: 9001 },
-            destination: Endpoint::BrowserBackground,
+            source: Source::Web {
+                tab_id: 9001,
+                document_id: "doc-1".to_string(),
+                origin: "https://example.com".to_string(),
+            },
+            destination: Endpoint::BrowserBackground { id: HostId::Own },
             topic: None,
         };
         let crypto_provider = NoEncryptionCryptoProvider;
@@ -566,14 +570,22 @@ mod tests {
     async fn skips_non_matching_topics_and_returns_first_matching_message() {
         let non_matching_message = IncomingMessage {
             payload: vec![],
-            source: Endpoint::Web { id: 9001 },
-            destination: Endpoint::BrowserBackground,
+            source: Source::Web {
+                tab_id: 9001,
+                document_id: "doc-1".to_string(),
+                origin: "https://example.com".to_string(),
+            },
+            destination: Endpoint::BrowserBackground { id: HostId::Own },
             topic: Some("non_matching_topic".to_owned()),
         };
         let matching_message = IncomingMessage {
             payload: vec![109],
-            source: Endpoint::Web { id: 9001 },
-            destination: Endpoint::BrowserBackground,
+            source: Source::Web {
+                tab_id: 9001,
+                document_id: "doc-1".to_string(),
+                origin: "https://example.com".to_string(),
+            },
+            destination: Endpoint::BrowserBackground { id: HostId::Own },
             topic: Some("matching_topic".to_owned()),
         };
 
@@ -608,16 +620,24 @@ mod tests {
 
         let unrelated = IncomingMessage {
             payload: vec![],
-            source: Endpoint::Web { id: 9001 },
-            destination: Endpoint::BrowserBackground,
+            source: Source::Web {
+                tab_id: 9001,
+                document_id: "doc-1".to_string(),
+                origin: "https://example.com".to_string(),
+            },
+            destination: Endpoint::BrowserBackground { id: HostId::Own },
             topic: None,
         };
         let typed_message = TypedIncomingMessage {
             payload: TestPayload {
                 some_data: "Hello, world!".to_string(),
             },
-            source: Endpoint::Web { id: 9001 },
-            destination: Endpoint::BrowserBackground,
+            source: Source::Web {
+                tab_id: 9001,
+                document_id: "doc-1".to_string(),
+                origin: "https://example.com".to_string(),
+            },
+            destination: Endpoint::BrowserBackground { id: HostId::Own },
         };
 
         let crypto_provider = NoEncryptionCryptoProvider;
@@ -656,8 +676,12 @@ mod tests {
 
         let non_deserializable_message = IncomingMessage {
             payload: vec![],
-            source: Endpoint::Web { id: 9001 },
-            destination: Endpoint::BrowserBackground,
+            source: Source::Web {
+                tab_id: 9001,
+                document_id: "doc-1".to_string(),
+                origin: "https://example.com".to_string(),
+            },
+            destination: Endpoint::BrowserBackground { id: HostId::Own },
             topic: Some("TestPayload".to_owned()),
         };
 
@@ -680,7 +704,7 @@ mod tests {
     async fn ipc_client_stops_if_crypto_returns_send_error() {
         let message = OutgoingMessage {
             payload: vec![],
-            destination: Endpoint::BrowserBackground,
+            destination: Endpoint::BrowserBackground { id: HostId::Own },
             topic: None,
         };
         let crypto_provider = TestCryptoProvider {
@@ -784,7 +808,11 @@ mod tests {
             let result_handle = tokio::spawn(async move {
                 let client = client.clone();
                 client
-                    .request::<TestRequest>(request_clone, Endpoint::BrowserBackground, None)
+                    .request::<TestRequest>(
+                        request_clone,
+                        Endpoint::BrowserBackground { id: HostId::Own },
+                        None,
+                    )
                     .await
             });
             tokio::time::sleep(Duration::from_millis(100)).await;
@@ -806,8 +834,11 @@ mod tests {
             let simulated_response = IncomingMessage {
                 payload: serde_utils::to_vec(&simulated_response)
                     .expect("Serialization should not fail"),
-                source: Endpoint::BrowserBackground,
-                destination: Endpoint::Web { id: 9001 },
+                source: Source::BrowserBackground { id: HostId::Own },
+                destination: Endpoint::Web {
+                    tab_id: 9001,
+                    document_id: "doc-1".to_string(),
+                },
                 topic: Some(
                     IncomingRpcResponseMessage::<TestRequest>::PAYLOAD_TYPE_NAME.to_owned(),
                 ),
@@ -843,8 +874,12 @@ mod tests {
             let simulated_request_message = IncomingMessage {
                 payload: serde_utils::to_vec(&simulated_request)
                     .expect("Serialization should not fail"),
-                source: Endpoint::Web { id: 9001 },
-                destination: Endpoint::BrowserBackground,
+                source: Source::Web {
+                    tab_id: 9001,
+                    document_id: "doc-1".to_string(),
+                    origin: "https://example.com".to_string(),
+                },
+                destination: Endpoint::BrowserBackground { id: HostId::Own },
                 topic: Some(RPC_REQUEST_PAYLOAD_TYPE_NAME.to_owned()),
             };
             communication_provider.push_incoming(simulated_request_message);

--- a/crates/bitwarden-ipc/src/ipc_client.rs
+++ b/crates/bitwarden-ipc/src/ipc_client.rs
@@ -112,8 +112,8 @@ where
     Com: CommunicationBackend,
     Ses: SessionRepository<Crypto::Session>,
 {
-    async fn start(&self) {
-        let cancellation_token = CancellationToken::new();
+    async fn start(&self, cancellation_token: Option<CancellationToken>) {
+        let cancellation_token = cancellation_token.unwrap_or_else(CancellationToken::new);
         self.inner
             .cancellation_token
             .lock()
@@ -158,7 +158,7 @@ where
                 }
             }
             tracing::debug!("IPC client shutting down");
-            stop_inner(&inner).await;
+            stop_inner(&inner);
         };
 
         #[cfg(not(target_arch = "wasm32"))]
@@ -174,7 +174,9 @@ where
             .incoming
             .lock()
             .expect("Failed to lock incoming mutex")
-            .is_some();
+            .as_ref()
+            .map(|receiver| !receiver.is_closed())
+            .unwrap_or(false);
         let has_cancellation_token = self
             .inner
             .cancellation_token
@@ -182,10 +184,6 @@ where
             .expect("Failed to lock cancellation token mutex")
             .is_some();
         has_incoming && has_cancellation_token
-    }
-
-    async fn stop(&self) {
-        stop_inner(&self.inner).await;
     }
 
     async fn send(&self, message: OutgoingMessage) -> Result<(), SendError> {
@@ -197,7 +195,7 @@ where
 
         if let Err(ref error) = result {
             tracing::error!(?error, "Error sending message");
-            self.stop().await;
+            stop_inner(&self.inner);
         }
 
         result.map_err(|e| SendError(format!("{e:?}")))
@@ -228,7 +226,7 @@ where
     }
 }
 
-async fn stop_inner<Crypto, Com, Ses>(inner: &IpcClientInner<Crypto, Com, Ses>)
+fn stop_inner<Crypto, Com, Ses>(inner: &IpcClientInner<Crypto, Com, Ses>)
 where
     Crypto: CryptoProvider<Com, Ses>,
     Com: CommunicationBackend,
@@ -441,7 +439,7 @@ mod tests {
         let communication_provider = TestCommunicationBackend::new();
         let session_map = TestSessionRepository::new(HashMap::new());
         let client = IpcClientImpl::new(crypto_provider, communication_provider, session_map);
-        client.start().await;
+        client.start(None).await;
 
         let error = client.send(message).await.unwrap_err();
 
@@ -460,7 +458,7 @@ mod tests {
         let session_map = InMemorySessionRepository::new(HashMap::new());
         let client =
             IpcClientImpl::new(crypto_provider, communication_provider.clone(), session_map);
-        client.start().await;
+        client.start(None).await;
 
         client.send(message.clone()).await.unwrap();
 
@@ -485,7 +483,7 @@ mod tests {
         let session_map = InMemorySessionRepository::new(HashMap::new());
         let client =
             IpcClientImpl::new(crypto_provider, communication_provider.clone(), session_map);
-        client.start().await;
+        client.start(None).await;
 
         let mut subscription = client
             .subscribe(None)
@@ -525,7 +523,7 @@ mod tests {
         let session_map = InMemorySessionRepository::new(HashMap::new());
         let client =
             IpcClientImpl::new(crypto_provider, communication_provider.clone(), session_map);
-        client.start().await;
+        client.start(None).await;
         let mut subscription = client
             .subscribe(Some("matching_topic".to_owned()))
             .await
@@ -577,7 +575,7 @@ mod tests {
         let session_map = InMemorySessionRepository::new(HashMap::new());
         let client =
             IpcClientImpl::new(crypto_provider, communication_provider.clone(), session_map);
-        client.start().await;
+        client.start(None).await;
         let mut subscription = client
             .subscribe_typed::<TestPayload>()
             .await
@@ -623,7 +621,7 @@ mod tests {
         let session_map = InMemorySessionRepository::new(HashMap::new());
         let client =
             IpcClientImpl::new(crypto_provider, communication_provider.clone(), session_map);
-        client.start().await;
+        client.start(None).await;
         let mut subscription = client
             .subscribe_typed::<TestPayload>()
             .await
@@ -648,7 +646,7 @@ mod tests {
         let communication_provider = TestCommunicationBackend::new();
         let session_map = TestSessionRepository::new(HashMap::new());
         let client = IpcClientImpl::new(crypto_provider, communication_provider, session_map);
-        client.start().await;
+        client.start(None).await;
 
         let error = client.send(message).await.unwrap_err();
         let is_running = client.is_running();
@@ -666,9 +664,34 @@ mod tests {
         let communication_provider = TestCommunicationBackend::new();
         let session_map = TestSessionRepository::new(HashMap::new());
         let client = IpcClientImpl::new(crypto_provider, communication_provider, session_map);
-        client.start().await;
+        let cancellation_token = CancellationToken::new();
+        client.start(Some(cancellation_token.clone())).await;
 
         // Give the client some time to process the error
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        let is_running = client.is_running();
+
+        assert!(!is_running);
+        assert!(cancellation_token.is_cancelled());
+    }
+
+    #[tokio::test]
+    async fn ipc_client_stops_if_cancellation_token_is_cancelled() {
+        let crypto_provider = TestCryptoProvider {
+            send_result: None,
+            receive_result: None,
+        };
+        let communication_provider = TestCommunicationBackend::new();
+        let session_map = TestSessionRepository::new(HashMap::new());
+        let client = IpcClientImpl::new(crypto_provider, communication_provider, session_map);
+        let cancellation_token = CancellationToken::new();
+        client.start(Some(cancellation_token.clone())).await;
+
+        // Give the client some time to process
+        tokio::time::sleep(Duration::from_millis(100)).await;
+
+        // Cancel the token and give the client some time to process the cancellation
+        cancellation_token.cancel();
         tokio::time::sleep(Duration::from_millis(100)).await;
         let is_running = client.is_running();
 
@@ -684,13 +707,15 @@ mod tests {
         let communication_provider = TestCommunicationBackend::new();
         let session_map = TestSessionRepository::new(HashMap::new());
         let client = IpcClientImpl::new(crypto_provider, communication_provider, session_map);
-        client.start().await;
+        let cancellation_token = CancellationToken::new();
+        client.start(Some(cancellation_token.clone())).await;
 
         // Give the client some time to process
         tokio::time::sleep(Duration::from_millis(100)).await;
         let is_running = client.is_running();
 
         assert!(is_running);
+        assert!(!cancellation_token.is_cancelled());
     }
 
     mod request {
@@ -733,7 +758,7 @@ mod tests {
             let session_map = InMemorySessionRepository::new(HashMap::new());
             let client =
                 IpcClientImpl::new(crypto_provider, communication_provider.clone(), session_map);
-            client.start().await;
+            client.start(None).await;
             let request = TestRequest { a: 1, b: 2 };
             let response = TestResponse { result: 3 };
 
@@ -791,7 +816,7 @@ mod tests {
             let session_map = InMemorySessionRepository::new(HashMap::new());
             let client =
                 IpcClientImpl::new(crypto_provider, communication_provider.clone(), session_map);
-            client.start().await;
+            client.start(None).await;
             let request_id = uuid::Uuid::new_v4().to_string();
             let request = TestRequest { a: 1, b: 2 };
             let response = TestResponse { result: 3 };

--- a/crates/bitwarden-ipc/src/ipc_client.rs
+++ b/crates/bitwarden-ipc/src/ipc_client.rs
@@ -1,9 +1,9 @@
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 
 use bitwarden_threading::cancellation_token::CancellationToken;
 use serde::de::DeserializeOwned;
 use thiserror::Error;
-use tokio::{select, sync::RwLock};
+use tokio::select;
 
 use crate::{
     constants::CHANNEL_BUFFER_CAPACITY,
@@ -51,8 +51,8 @@ where
     sessions: Ses,
 
     handlers: RpcHandlerRegistry,
-    incoming: RwLock<Option<tokio::sync::broadcast::Receiver<IncomingMessage>>>,
-    cancellation_token: RwLock<Option<CancellationToken>>,
+    incoming: Mutex<Option<tokio::sync::broadcast::Receiver<IncomingMessage>>>,
+    cancellation_token: Mutex<Option<CancellationToken>>,
 }
 
 /// An IPC client that handles communication between different components and clients.
@@ -98,8 +98,8 @@ where
                 sessions,
 
                 handlers: RpcHandlerRegistry::new(),
-                incoming: RwLock::new(None),
-                cancellation_token: RwLock::new(None),
+                incoming: Mutex::new(None),
+                cancellation_token: Mutex::new(None),
             }),
         }
     }
@@ -116,14 +116,18 @@ where
         let cancellation_token = CancellationToken::new();
         self.inner
             .cancellation_token
-            .write()
-            .await
+            .lock()
+            .expect("Failed to lock cancellation token mutex")
             .replace(cancellation_token.clone());
 
         let com_receiver = self.inner.communication.subscribe().await;
         let (client_tx, client_rx) = tokio::sync::broadcast::channel(CHANNEL_BUFFER_CAPACITY);
 
-        self.inner.incoming.write().await.replace(client_rx);
+        self.inner
+            .incoming
+            .lock()
+            .expect("Failed to lock incoming mutex")
+            .replace(client_rx);
 
         let inner = self.inner.clone();
         let future = async move {
@@ -164,9 +168,19 @@ where
         wasm_bindgen_futures::spawn_local(future);
     }
 
-    async fn is_running(&self) -> bool {
-        let has_incoming = self.inner.incoming.read().await.is_some();
-        let has_cancellation_token = self.inner.cancellation_token.read().await.is_some();
+    fn is_running(&self) -> bool {
+        let has_incoming = self
+            .inner
+            .incoming
+            .lock()
+            .expect("Failed to lock incoming mutex")
+            .is_some();
+        let has_cancellation_token = self
+            .inner
+            .cancellation_token
+            .lock()
+            .expect("Failed to lock cancellation token mutex")
+            .is_some();
         has_incoming && has_cancellation_token
     }
 
@@ -197,8 +211,8 @@ where
             receiver: self
                 .inner
                 .incoming
-                .read()
-                .await
+                .lock()
+                .expect("Failed to lock incoming mutex")
                 .as_ref()
                 .ok_or(SubscribeError::NotStarted)?
                 .resubscribe(),
@@ -220,10 +234,11 @@ where
     Com: CommunicationBackend,
     Ses: SessionRepository<Crypto::Session>,
 {
-    let mut incoming = inner.incoming.write().await;
-    let _ = incoming.take();
+    let mut cancellation_token = inner
+        .cancellation_token
+        .lock()
+        .expect("Failed to lock cancellation token mutex");
 
-    let mut cancellation_token = inner.cancellation_token.write().await;
     if let Some(cancellation_token) = cancellation_token.take() {
         cancellation_token.cancel();
     }
@@ -636,7 +651,7 @@ mod tests {
         client.start().await;
 
         let error = client.send(message).await.unwrap_err();
-        let is_running = client.is_running().await;
+        let is_running = client.is_running();
 
         assert!(error.to_string().contains("Crypto error"));
         assert!(!is_running);
@@ -655,7 +670,7 @@ mod tests {
 
         // Give the client some time to process the error
         tokio::time::sleep(Duration::from_millis(100)).await;
-        let is_running = client.is_running().await;
+        let is_running = client.is_running();
 
         assert!(!is_running);
     }
@@ -673,7 +688,7 @@ mod tests {
 
         // Give the client some time to process
         tokio::time::sleep(Duration::from_millis(100)).await;
-        let is_running = client.is_running().await;
+        let is_running = client.is_running();
 
         assert!(is_running);
     }

--- a/crates/bitwarden-ipc/src/ipc_client.rs
+++ b/crates/bitwarden-ipc/src/ipc_client.rs
@@ -120,7 +120,7 @@ where
             return Err(AlreadyRunningError);
         }
 
-        let cancellation_token = cancellation_token.unwrap_or_else(CancellationToken::new);
+        let cancellation_token = cancellation_token.unwrap_or_default();
         self.inner
             .cancellation_token
             .lock()

--- a/crates/bitwarden-ipc/src/ipc_client.rs
+++ b/crates/bitwarden-ipc/src/ipc_client.rs
@@ -1,34 +1,46 @@
 use std::sync::Arc;
 
-use bitwarden_error::bitwarden_error;
 use bitwarden_threading::cancellation_token::CancellationToken;
 use serde::de::DeserializeOwned;
 use thiserror::Error;
 use tokio::{select, sync::RwLock};
 
 use crate::{
-    RpcHandler,
     constants::CHANNEL_BUFFER_CAPACITY,
-    endpoint::Endpoint,
+    error::{ReceiveError, SendError, SubscribeError, TypedReceiveError},
     message::{
         IncomingMessage, OutgoingMessage, PayloadTypeName, TypedIncomingMessage,
         TypedOutgoingMessage,
     },
     rpc::{
-        error::RpcError,
-        exec::handler_registry::RpcHandlerRegistry,
-        request::RpcRequest,
-        request_message::{RPC_REQUEST_PAYLOAD_TYPE_NAME, RpcRequestMessage, RpcRequestPayload},
-        response_message::{IncomingRpcResponseMessage, OutgoingRpcResponseMessage},
+        exec::{handler::ErasedRpcHandler, handler_registry::RpcHandlerRegistry},
+        request_message::{RPC_REQUEST_PAYLOAD_TYPE_NAME, RpcRequestPayload},
+        response_message::OutgoingRpcResponseMessage,
     },
     serde_utils,
     traits::{CommunicationBackend, CryptoProvider, SessionRepository},
 };
 
-/// An IPC client that handles communication between different components and clients.
-/// It uses a crypto provider to encrypt and decrypt messages, a communication backend to send and
-/// receive messages, and a session repository to persist sessions.
-pub struct IpcClient<Crypto, Com, Ses>
+/// A subscription to receive messages over IPC.
+/// The subcription will start buffering messages after its creation and return them
+/// when receive() is called. Messages received before the subscription was created will not be
+/// returned.
+pub struct IpcClientSubscription {
+    pub(crate) receiver: tokio::sync::broadcast::Receiver<IncomingMessage>,
+    pub(crate) topic: Option<String>,
+}
+
+/// A subscription to receive messages over IPC.
+/// The subcription will start buffering messages after its creation and return them
+/// when receive() is called. Messages received before the subscription was created will not be
+/// returned.
+pub struct IpcClientTypedSubscription<Payload: DeserializeOwned + PayloadTypeName>(
+    IpcClientSubscription,
+    std::marker::PhantomData<Payload>,
+);
+
+/// Internal shared state for the IPC client.
+struct IpcClientInner<Crypto, Com, Ses>
 where
     Crypto: CryptoProvider<Com, Ses>,
     Com: CommunicationBackend,
@@ -43,94 +55,34 @@ where
     cancellation_token: RwLock<Option<CancellationToken>>,
 }
 
-/// A subscription to receive messages over IPC.
-/// The subcription will start buffering messages after its creation and return them
-/// when receive() is called. Messages received before the subscription was created will not be
-/// returned.
-pub struct IpcClientSubscription {
-    receiver: tokio::sync::broadcast::Receiver<IncomingMessage>,
-    topic: Option<String>,
+/// An IPC client that handles communication between different components and clients.
+/// It uses a crypto provider to encrypt and decrypt messages, a communication backend to send and
+/// receive messages, and a session repository to persist sessions.
+///
+/// This is the concrete implementation of the [`IpcClient`](crate::IpcClient) trait.
+pub struct IpcClientImpl<Crypto, Com, Ses>
+where
+    Crypto: CryptoProvider<Com, Ses>,
+    Com: CommunicationBackend,
+    Ses: SessionRepository<Crypto::Session>,
+{
+    inner: Arc<IpcClientInner<Crypto, Com, Ses>>,
 }
 
-/// A subscription to receive messages over IPC.
-/// The subcription will start buffering messages after its creation and return them
-/// when receive() is called. Messages received before the subscription was created will not be
-/// returned.
-pub struct IpcClientTypedSubscription<Payload: DeserializeOwned + PayloadTypeName>(
-    IpcClientSubscription,
-    std::marker::PhantomData<Payload>,
-);
-
-#[derive(Debug, Error, Clone, PartialEq, Eq)]
-#[bitwarden_error(flat)]
-#[allow(missing_docs)]
-pub enum SubscribeError {
-    #[error("The IPC processing thread is not running")]
-    NotStarted,
-}
-
-#[derive(Debug, Error, PartialEq, Eq)]
-#[bitwarden_error(flat)]
-#[allow(missing_docs)]
-pub enum ReceiveError {
-    #[error("Failed to subscribe to the IPC channel: {0}")]
-    Channel(#[from] tokio::sync::broadcast::error::RecvError),
-
-    #[error("Timed out while waiting for a message: {0}")]
-    Timeout(#[from] tokio::time::error::Elapsed),
-
-    #[error("Cancelled while waiting for a message")]
-    Cancelled,
-}
-
-#[derive(Debug, Error, PartialEq, Eq)]
-#[bitwarden_error(flat)]
-#[allow(missing_docs)]
-pub enum TypedReceiveError {
-    #[error("Failed to subscribe to the IPC channel: {0}")]
-    Channel(#[from] tokio::sync::broadcast::error::RecvError),
-
-    #[error("Timed out while waiting for a message: {0}")]
-    Timeout(#[from] tokio::time::error::Elapsed),
-
-    #[error("Cancelled while waiting for a message")]
-    Cancelled,
-
-    #[error("Typing error: {0}")]
-    Typing(String),
-}
-
-impl From<ReceiveError> for TypedReceiveError {
-    fn from(value: ReceiveError) -> Self {
-        match value {
-            ReceiveError::Channel(e) => TypedReceiveError::Channel(e),
-            ReceiveError::Timeout(e) => TypedReceiveError::Timeout(e),
-            ReceiveError::Cancelled => TypedReceiveError::Cancelled,
+impl<Crypto, Com, Ses> Clone for IpcClientImpl<Crypto, Com, Ses>
+where
+    Crypto: CryptoProvider<Com, Ses>,
+    Com: CommunicationBackend,
+    Ses: SessionRepository<Crypto::Session>,
+{
+    fn clone(&self) -> Self {
+        Self {
+            inner: self.inner.clone(),
         }
     }
 }
 
-#[derive(Debug, Error, PartialEq, Eq)]
-#[bitwarden_error(flat)]
-#[allow(missing_docs)]
-pub enum RequestError {
-    #[error(transparent)]
-    Subscribe(#[from] SubscribeError),
-
-    #[error(transparent)]
-    Receive(#[from] TypedReceiveError),
-
-    #[error("Timed out while waiting for a message: {0}")]
-    Timeout(#[from] tokio::time::error::Elapsed),
-
-    #[error("Failed to send message: {0}")]
-    Send(String),
-
-    #[error("Error occured on the remote target: {0}")]
-    Rpc(#[from] RpcError),
-}
-
-impl<Crypto, Com, Ses> IpcClient<Crypto, Com, Ses>
+impl<Crypto, Com, Ses> IpcClientImpl<Crypto, Com, Ses>
 where
     Crypto: CryptoProvider<Com, Ses>,
     Com: CommunicationBackend,
@@ -138,38 +90,42 @@ where
 {
     /// Create a new IPC client with the provided crypto provider, communication backend, and
     /// session repository.
-    pub fn new(crypto: Crypto, communication: Com, sessions: Ses) -> Arc<Self> {
-        Arc::new(Self {
-            crypto,
-            communication,
-            sessions,
+    pub fn new(crypto: Crypto, communication: Com, sessions: Ses) -> Self {
+        Self {
+            inner: Arc::new(IpcClientInner {
+                crypto,
+                communication,
+                sessions,
 
-            handlers: RpcHandlerRegistry::new(),
-            incoming: RwLock::new(None),
-            cancellation_token: RwLock::new(None),
-        })
+                handlers: RpcHandlerRegistry::new(),
+                incoming: RwLock::new(None),
+                cancellation_token: RwLock::new(None),
+            }),
+        }
     }
+}
 
-    /// Start the IPC client, which will begin listening for incoming messages and processing them.
-    /// This will be done in a separate task, allowing the client to receive messages
-    /// asynchronously. The client will stop automatically if an error occurs during message
-    /// processing or if the cancellation token is triggered.
-    ///
-    /// Note: The client can and will send messages in the background while it is running, even if
-    /// no active subscriptions are present.
-    pub async fn start(self: &Arc<Self>) {
+#[async_trait::async_trait]
+impl<Crypto, Com, Ses> crate::ipc_client_trait::IpcClient for IpcClientImpl<Crypto, Com, Ses>
+where
+    Crypto: CryptoProvider<Com, Ses>,
+    Com: CommunicationBackend,
+    Ses: SessionRepository<Crypto::Session>,
+{
+    async fn start(&self) {
         let cancellation_token = CancellationToken::new();
-        self.cancellation_token
+        self.inner
+            .cancellation_token
             .write()
             .await
             .replace(cancellation_token.clone());
 
-        let com_receiver = self.communication.subscribe().await;
+        let com_receiver = self.inner.communication.subscribe().await;
         let (client_tx, client_rx) = tokio::sync::broadcast::channel(CHANNEL_BUFFER_CAPACITY);
 
-        self.incoming.write().await.replace(client_rx);
+        self.inner.incoming.write().await.replace(client_rx);
 
-        let client = self.clone();
+        let inner = self.inner.clone();
         let future = async move {
             loop {
                 let rpc_topic = RPC_REQUEST_PAYLOAD_TYPE_NAME.to_owned();
@@ -178,10 +134,10 @@ where
                         tracing::debug!("Cancellation signal received, stopping IPC client");
                         break;
                     }
-                    received = client.crypto.receive(&com_receiver, &client.communication, &client.sessions) => {
+                    received = inner.crypto.receive(&com_receiver, &inner.communication, &inner.sessions) => {
                         match received {
                             Ok(message) if message.topic == Some(rpc_topic) => {
-                                client.handle_rpc_request(message)
+                                handle_rpc_request(&inner, message)
                             }
                             Ok(message) => {
                                 if client_tx.send(message).is_err() {
@@ -198,7 +154,7 @@ where
                 }
             }
             tracing::debug!("IPC client shutting down");
-            client.stop().await;
+            stop_inner(&inner).await;
         };
 
         #[cfg(not(target_arch = "wasm32"))]
@@ -208,57 +164,38 @@ where
         wasm_bindgen_futures::spawn_local(future);
     }
 
-    /// Check if the IPC client task is currently running.
-    pub async fn is_running(self: &Arc<Self>) -> bool {
-        let has_incoming = self.incoming.read().await.is_some();
-        let has_cancellation_token = self.cancellation_token.read().await.is_some();
+    async fn is_running(&self) -> bool {
+        let has_incoming = self.inner.incoming.read().await.is_some();
+        let has_cancellation_token = self.inner.cancellation_token.read().await.is_some();
         has_incoming && has_cancellation_token
     }
 
-    /// Stop the IPC client task. This will stop listening for incoming messages.
-    pub async fn stop(self: &Arc<Self>) {
-        let mut incoming = self.incoming.write().await;
-        let _ = incoming.take();
-
-        let mut cancellation_token = self.cancellation_token.write().await;
-        if let Some(cancellation_token) = cancellation_token.take() {
-            cancellation_token.cancel();
-        }
+    async fn stop(&self) {
+        stop_inner(&self.inner).await;
     }
 
-    /// Register a new RPC handler for processing incoming RPC requests.
-    /// The handler will be executed by the IPC client when an RPC request is received and
-    /// the response will be sent back over IPC.
-    pub async fn register_rpc_handler<H>(self: &Arc<Self>, handler: H)
-    where
-        H: RpcHandler + Send + Sync + 'static,
-    {
-        self.handlers.register(handler).await;
-    }
-
-    /// Send a message
-    pub async fn send(self: &Arc<Self>, message: OutgoingMessage) -> Result<(), Crypto::SendError> {
+    async fn send(&self, message: OutgoingMessage) -> Result<(), SendError> {
         let result = self
+            .inner
             .crypto
-            .send(&self.communication, &self.sessions, message)
+            .send(&self.inner.communication, &self.inner.sessions, message)
             .await;
 
-        if result.is_err() {
-            tracing::error!(?result, "Error sending message");
+        if let Err(ref error) = result {
+            tracing::error!(?error, "Error sending message");
             self.stop().await;
         }
 
-        result
+        result.map_err(|e| SendError(format!("{e:?}")))
     }
 
-    /// Create a subscription to receive messages, optionally filtered by topic.
-    /// Setting the topic to `None` will receive all messages.
-    pub async fn subscribe(
-        self: &Arc<Self>,
+    async fn subscribe(
+        &self,
         topic: Option<String>,
     ) -> Result<IpcClientSubscription, SubscribeError> {
         Ok(IpcClientSubscription {
             receiver: self
+                .inner
                 .incoming
                 .read()
                 .await
@@ -269,130 +206,97 @@ where
         })
     }
 
-    /// Create a subscription to receive messages that can be deserialized into the provided payload
-    /// type.
-    pub async fn subscribe_typed<Payload>(
-        self: &Arc<Self>,
-    ) -> Result<IpcClientTypedSubscription<Payload>, SubscribeError>
-    where
-        Payload: DeserializeOwned + PayloadTypeName,
-    {
-        Ok(IpcClientTypedSubscription(
-            self.subscribe(Some(Payload::PAYLOAD_TYPE_NAME.to_owned()))
-                .await?,
-            std::marker::PhantomData,
-        ))
+    async fn register_rpc_handler_erased(&self, name: &str, handler: Box<dyn ErasedRpcHandler>) {
+        self.inner
+            .handlers
+            .register_erased(name.to_owned(), handler)
+            .await;
     }
+}
 
-    /// Send a request to the specified destination and wait for a response.
-    /// The destination must have a registered RPC handler for the request type, otherwise
-    /// an error will be returned by the remote endpoint.
-    pub async fn request<Request>(
-        self: &Arc<Self>,
-        request: Request,
-        destination: Endpoint,
-        cancellation_token: Option<CancellationToken>,
-    ) -> Result<Request::Response, RequestError>
-    where
-        Request: RpcRequest,
-    {
-        let request_id = uuid::Uuid::new_v4().to_string();
-        let mut response_subscription = self
-            .subscribe_typed::<IncomingRpcResponseMessage<_>>()
-            .await?;
+async fn stop_inner<Crypto, Com, Ses>(inner: &IpcClientInner<Crypto, Com, Ses>)
+where
+    Crypto: CryptoProvider<Com, Ses>,
+    Com: CommunicationBackend,
+    Ses: SessionRepository<Crypto::Session>,
+{
+    let mut incoming = inner.incoming.write().await;
+    let _ = incoming.take();
 
-        let request_payload = RpcRequestMessage {
-            request,
-            request_id: request_id.clone(),
-            request_type: Request::NAME.to_owned(),
-        };
+    let mut cancellation_token = inner.cancellation_token.write().await;
+    if let Some(cancellation_token) = cancellation_token.take() {
+        cancellation_token.cancel();
+    }
+}
 
-        let message = TypedOutgoingMessage {
-            payload: request_payload,
-            destination,
+fn handle_rpc_request<Crypto, Com, Ses>(
+    inner: &Arc<IpcClientInner<Crypto, Com, Ses>>,
+    incoming_message: IncomingMessage,
+) where
+    Crypto: CryptoProvider<Com, Ses>,
+    Com: CommunicationBackend,
+    Ses: SessionRepository<Crypto::Session>,
+{
+    let inner = inner.clone();
+    let future = async move {
+        #[derive(Debug, Error)]
+        enum HandleError {
+            #[error("Failed to deserialize request message: {0}")]
+            Deserialize(String),
+
+            #[error("Failed to serialize response message: {0}")]
+            Serialize(String),
         }
-        .try_into()
-        .map_err(|e: serde_utils::DeserializeError| {
-            RequestError::Rpc(RpcError::RequestSerialization(e.to_string()))
-        })?;
 
-        self.send(message)
-            .await
-            .map_err(|e| RequestError::Send(format!("{e:?}")))?;
+        async fn handle(
+            incoming_message: IncomingMessage,
+            handlers: &RpcHandlerRegistry,
+        ) -> Result<OutgoingMessage, HandleError> {
+            let request = RpcRequestPayload::from_slice(incoming_message.payload.clone()).map_err(
+                |e: serde_utils::DeserializeError| HandleError::Deserialize(e.to_string()),
+            )?;
 
-        let response = loop {
-            let received = response_subscription
-                .receive(cancellation_token.clone())
-                .await
-                .map_err(RequestError::Receive)?;
+            let response = handlers.handle(&request).await;
 
-            if received.payload.request_id == request_id {
-                break received;
+            let response_message = OutgoingRpcResponseMessage {
+                request_id: request.request_id(),
+                request_type: request.request_type(),
+                result: response,
+            };
+
+            let outgoing = TypedOutgoingMessage {
+                payload: response_message,
+                destination: incoming_message.source.into(),
             }
-        };
+            .try_into()
+            .map_err(|e: serde_utils::SerializeError| HandleError::Serialize(e.to_string()))?;
 
-        Ok(response.payload.result?)
-    }
+            Ok(outgoing)
+        }
 
-    fn handle_rpc_request(self: &Arc<Self>, incoming_message: IncomingMessage) {
-        let client = self.clone();
-        let future = async move {
-            let client = client.clone();
-
-            #[derive(Debug, Error)]
-            enum HandleError {
-                #[error("Failed to deserialize request message: {0}")]
-                Deserialize(String),
-
-                #[error("Failed to serialize response message: {0}")]
-                Serialize(String),
-            }
-
-            async fn handle(
-                incoming_message: IncomingMessage,
-                handlers: &RpcHandlerRegistry,
-            ) -> Result<OutgoingMessage, HandleError> {
-                let request = RpcRequestPayload::from_slice(incoming_message.payload.clone())
-                    .map_err(|e: serde_utils::DeserializeError| {
-                        HandleError::Deserialize(e.to_string())
-                    })?;
-
-                let response = handlers.handle(&request).await;
-
-                let response_message = OutgoingRpcResponseMessage {
-                    request_id: request.request_id(),
-                    request_type: request.request_type(),
-                    result: response,
-                };
-
-                let outgoing = TypedOutgoingMessage {
-                    payload: response_message,
-                    destination: incoming_message.source.into(),
-                }
-                .try_into()
-                .map_err(|e: serde_utils::SerializeError| HandleError::Serialize(e.to_string()))?;
-
-                Ok(outgoing)
-            }
-
-            match handle(incoming_message, &client.handlers).await {
-                Ok(outgoing_message) => {
-                    if client.send(outgoing_message).await.is_err() {
-                        tracing::error!("Failed to send response message");
-                    }
-                }
-                Err(error) => {
-                    tracing::error!(%error, "Error handling RPC request");
+        match handle(incoming_message, &inner.handlers).await {
+            Ok(outgoing_message) => {
+                // Send response directly through the crypto provider (not through the trait)
+                // since we're inside the background task and don't have a trait object.
+                let result = inner
+                    .crypto
+                    .send(&inner.communication, &inner.sessions, outgoing_message)
+                    .await;
+                if result.is_err() {
+                    tracing::error!("Failed to send response message");
                 }
             }
-        };
+            Err(error) => {
+                tracing::error!(%error, "Error handling RPC request");
+            }
+        }
+    };
 
-        #[cfg(not(target_arch = "wasm32"))]
-        tokio::spawn(future);
+    #[cfg(not(target_arch = "wasm32"))]
+    tokio::spawn(future);
 
-        #[cfg(target_arch = "wasm32")]
-        wasm_bindgen_futures::spawn_local(future);
-    }
+    #[cfg(target_arch = "wasm32")]
+    wasm_bindgen_futures::spawn_local(future);
 }
 
 impl IpcClientSubscription {
@@ -424,6 +328,10 @@ impl<Payload> IpcClientTypedSubscription<Payload>
 where
     Payload: DeserializeOwned + PayloadTypeName,
 {
+    pub(crate) fn new(subscription: IpcClientSubscription) -> Self {
+        Self(subscription, std::marker::PhantomData)
+    }
+
     /// Receive a message.
     /// Setting the cancellation_token to `None` will wait indefinitely.
     pub async fn receive(
@@ -446,10 +354,16 @@ mod tests {
 
     use super::*;
     use crate::{
+        IpcClientExt,
         endpoint::{Endpoint, HostId, Source},
-        traits::{
-            InMemorySessionRepository, NoEncryptionCryptoProvider, tests::TestCommunicationBackend,
+        ipc_client_trait::IpcClient,
+        message::PayloadTypeName,
+        rpc::{
+            request::RpcRequest,
+            request_message::{RPC_REQUEST_PAYLOAD_TYPE_NAME, RpcRequestMessage},
+            response_message::IncomingRpcResponseMessage,
         },
+        traits::{InMemorySessionRepository, NoEncryptionCryptoProvider, TestCommunicationBackend},
     };
 
     struct TestCryptoProvider {
@@ -511,12 +425,12 @@ mod tests {
         };
         let communication_provider = TestCommunicationBackend::new();
         let session_map = TestSessionRepository::new(HashMap::new());
-        let client = IpcClient::new(crypto_provider, communication_provider, session_map);
+        let client = IpcClientImpl::new(crypto_provider, communication_provider, session_map);
         client.start().await;
 
         let error = client.send(message).await.unwrap_err();
 
-        assert_eq!(error, "Crypto error".to_string());
+        assert!(error.to_string().contains("Crypto error"));
     }
 
     #[tokio::test]
@@ -529,7 +443,8 @@ mod tests {
         let crypto_provider = NoEncryptionCryptoProvider;
         let communication_provider = TestCommunicationBackend::new();
         let session_map = InMemorySessionRepository::new(HashMap::new());
-        let client = IpcClient::new(crypto_provider, communication_provider.clone(), session_map);
+        let client =
+            IpcClientImpl::new(crypto_provider, communication_provider.clone(), session_map);
         client.start().await;
 
         client.send(message.clone()).await.unwrap();
@@ -553,7 +468,8 @@ mod tests {
         let crypto_provider = NoEncryptionCryptoProvider;
         let communication_provider = TestCommunicationBackend::new();
         let session_map = InMemorySessionRepository::new(HashMap::new());
-        let client = IpcClient::new(crypto_provider, communication_provider.clone(), session_map);
+        let client =
+            IpcClientImpl::new(crypto_provider, communication_provider.clone(), session_map);
         client.start().await;
 
         let mut subscription = client
@@ -592,7 +508,8 @@ mod tests {
         let crypto_provider = NoEncryptionCryptoProvider;
         let communication_provider = TestCommunicationBackend::new();
         let session_map = InMemorySessionRepository::new(HashMap::new());
-        let client = IpcClient::new(crypto_provider, communication_provider.clone(), session_map);
+        let client =
+            IpcClientImpl::new(crypto_provider, communication_provider.clone(), session_map);
         client.start().await;
         let mut subscription = client
             .subscribe(Some("matching_topic".to_owned()))
@@ -628,7 +545,7 @@ mod tests {
             destination: Endpoint::BrowserBackground { id: HostId::Own },
             topic: None,
         };
-        let typed_message = TypedIncomingMessage {
+        let typed_message = crate::message::TypedIncomingMessage {
             payload: TestPayload {
                 some_data: "Hello, world!".to_string(),
             },
@@ -643,7 +560,8 @@ mod tests {
         let crypto_provider = NoEncryptionCryptoProvider;
         let communication_provider = TestCommunicationBackend::new();
         let session_map = InMemorySessionRepository::new(HashMap::new());
-        let client = IpcClient::new(crypto_provider, communication_provider.clone(), session_map);
+        let client =
+            IpcClientImpl::new(crypto_provider, communication_provider.clone(), session_map);
         client.start().await;
         let mut subscription = client
             .subscribe_typed::<TestPayload>()
@@ -688,7 +606,8 @@ mod tests {
         let crypto_provider = NoEncryptionCryptoProvider;
         let communication_provider = TestCommunicationBackend::new();
         let session_map = InMemorySessionRepository::new(HashMap::new());
-        let client = IpcClient::new(crypto_provider, communication_provider.clone(), session_map);
+        let client =
+            IpcClientImpl::new(crypto_provider, communication_provider.clone(), session_map);
         client.start().await;
         let mut subscription = client
             .subscribe_typed::<TestPayload>()
@@ -713,13 +632,13 @@ mod tests {
         };
         let communication_provider = TestCommunicationBackend::new();
         let session_map = TestSessionRepository::new(HashMap::new());
-        let client = IpcClient::new(crypto_provider, communication_provider, session_map);
+        let client = IpcClientImpl::new(crypto_provider, communication_provider, session_map);
         client.start().await;
 
         let error = client.send(message).await.unwrap_err();
         let is_running = client.is_running().await;
 
-        assert_eq!(error, "Crypto error".to_string());
+        assert!(error.to_string().contains("Crypto error"));
         assert!(!is_running);
     }
 
@@ -731,7 +650,7 @@ mod tests {
         };
         let communication_provider = TestCommunicationBackend::new();
         let session_map = TestSessionRepository::new(HashMap::new());
-        let client = IpcClient::new(crypto_provider, communication_provider, session_map);
+        let client = IpcClientImpl::new(crypto_provider, communication_provider, session_map);
         client.start().await;
 
         // Give the client some time to process the error
@@ -749,7 +668,7 @@ mod tests {
         };
         let communication_provider = TestCommunicationBackend::new();
         let session_map = TestSessionRepository::new(HashMap::new());
-        let client = IpcClient::new(crypto_provider, communication_provider, session_map);
+        let client = IpcClientImpl::new(crypto_provider, communication_provider, session_map);
         client.start().await;
 
         // Give the client some time to process
@@ -761,7 +680,7 @@ mod tests {
 
     mod request {
         use super::*;
-        use crate::rpc::response_message::IncomingRpcResponseMessage;
+        use crate::RpcHandler;
 
         #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
         struct TestRequest {
@@ -798,16 +717,16 @@ mod tests {
             let communication_provider = TestCommunicationBackend::new();
             let session_map = InMemorySessionRepository::new(HashMap::new());
             let client =
-                IpcClient::new(crypto_provider, communication_provider.clone(), session_map);
+                IpcClientImpl::new(crypto_provider, communication_provider.clone(), session_map);
             client.start().await;
             let request = TestRequest { a: 1, b: 2 };
             let response = TestResponse { result: 3 };
 
             // Send the request
             let request_clone = request.clone();
+            let client_clone = client.clone();
             let result_handle = tokio::spawn(async move {
-                let client = client.clone();
-                client
+                client_clone
                     .request::<TestRequest>(
                         request_clone,
                         Endpoint::BrowserBackground { id: HostId::Own },
@@ -856,7 +775,7 @@ mod tests {
             let communication_provider = TestCommunicationBackend::new();
             let session_map = InMemorySessionRepository::new(HashMap::new());
             let client =
-                IpcClient::new(crypto_provider, communication_provider.clone(), session_map);
+                IpcClientImpl::new(crypto_provider, communication_provider.clone(), session_map);
             client.start().await;
             let request_id = uuid::Uuid::new_v4().to_string();
             let request = TestRequest { a: 1, b: 2 };

--- a/crates/bitwarden-ipc/src/ipc_client_ext.rs
+++ b/crates/bitwarden-ipc/src/ipc_client_ext.rs
@@ -1,0 +1,135 @@
+use bitwarden_threading::cancellation_token::CancellationToken;
+use serde::{Serialize, de::DeserializeOwned};
+
+use crate::{
+    RpcHandler,
+    endpoint::Endpoint,
+    error::{RequestError, SubscribeError},
+    ipc_client::IpcClientTypedSubscription,
+    ipc_client_trait::IpcClient,
+    message::{PayloadTypeName, TypedOutgoingMessage},
+    rpc::{
+        error::RpcError, request::RpcRequest, request_message::RpcRequestMessage,
+        response_message::IncomingRpcResponseMessage,
+    },
+    serde_utils,
+};
+
+/// Extension trait providing generic convenience methods on any [`IpcClient`].
+///
+/// This trait is automatically implemented for all types that implement [`IpcClient`],
+/// including `dyn IpcClient`. It provides typed subscriptions, handler registration,
+/// and RPC request functionality with full static type safety.
+pub trait IpcClientExt: IpcClient {
+    /// Register a new RPC handler for processing incoming RPC requests.
+    /// The handler will be executed by the IPC client when an RPC request is received and
+    /// the response will be sent back over IPC.
+    fn register_rpc_handler<H>(&self, handler: H) -> impl std::future::Future<Output = ()> + Send
+    where
+        H: RpcHandler + Send + Sync + 'static,
+    {
+        async move {
+            self.register_rpc_handler_erased(H::Request::NAME, Box::new(handler))
+                .await;
+        }
+    }
+
+    /// Send a message with a payload of any serializable type to the specified destination.
+    fn send_typed<Payload>(
+        &self,
+        payload: Payload,
+        destination: Endpoint,
+    ) -> impl std::future::Future<Output = Result<(), RequestError>> + Send
+    where
+        Payload: Serialize + PayloadTypeName + Send,
+    {
+        async move {
+            let message = TypedOutgoingMessage {
+                payload,
+                destination,
+            }
+            .try_into()
+            .map_err(|e: serde_utils::DeserializeError| {
+                RequestError::Rpc(RpcError::RequestSerialization(e.to_string()))
+            })?;
+
+            self.send(message)
+                .await
+                .map_err(|e| RequestError::Send(format!("{e:?}")))
+        }
+    }
+
+    /// Create a subscription to receive messages that can be deserialized into the provided
+    /// payload type.
+    fn subscribe_typed<Payload>(
+        &self,
+    ) -> impl std::future::Future<
+        Output = Result<IpcClientTypedSubscription<Payload>, SubscribeError>,
+    > + Send
+    where
+        Payload: DeserializeOwned + PayloadTypeName,
+    {
+        async move {
+            Ok(IpcClientTypedSubscription::new(
+                self.subscribe(Some(Payload::PAYLOAD_TYPE_NAME.to_owned()))
+                    .await?,
+            ))
+        }
+    }
+
+    /// Send a request to the specified destination and wait for a response.
+    /// The destination must have a registered RPC handler for the request type, otherwise
+    /// an error will be returned by the remote endpoint.
+    fn request<Request>(
+        &self,
+        request: Request,
+        destination: Endpoint,
+        cancellation_token: Option<CancellationToken>,
+    ) -> impl std::future::Future<Output = Result<Request::Response, RequestError>> + Send
+    where
+        Request: RpcRequest + Send,
+        Request::Response: Send,
+    {
+        async move {
+            let request_id = uuid::Uuid::new_v4().to_string();
+            let mut response_subscription = self
+                .subscribe_typed::<IncomingRpcResponseMessage<Request::Response>>()
+                .await?;
+
+            let request_payload = RpcRequestMessage {
+                request,
+                request_id: request_id.clone(),
+                request_type: Request::NAME.to_owned(),
+            };
+
+            let message = TypedOutgoingMessage {
+                payload: request_payload,
+                destination,
+            }
+            .try_into()
+            .map_err(|e: serde_utils::DeserializeError| {
+                RequestError::Rpc(RpcError::RequestSerialization(e.to_string()))
+            })?;
+
+            self.send(message)
+                .await
+                .map_err(|e| RequestError::Send(format!("{e:?}")))?;
+
+            let response = loop {
+                let received = response_subscription
+                    .receive(cancellation_token.clone())
+                    .await
+                    .map_err(RequestError::Receive)?;
+
+                if received.payload.request_id == request_id {
+                    break received;
+                }
+            };
+
+            Ok(response.payload.result?)
+        }
+    }
+}
+
+/// Blanket implementation: every [`IpcClient`] gets the extension methods for free.
+impl<T: IpcClient + ?Sized> IpcClientExt for T {}

--- a/crates/bitwarden-ipc/src/ipc_client_trait.rs
+++ b/crates/bitwarden-ipc/src/ipc_client_trait.rs
@@ -1,0 +1,42 @@
+use crate::{
+    error::{SendError, SubscribeError},
+    ipc_client::IpcClientSubscription,
+    message::OutgoingMessage,
+    rpc::exec::handler::ErasedRpcHandler,
+};
+
+/// Dyn-compatible trait for IPC client operations.
+///
+/// This trait provides the core IPC operations that consumers can use without
+/// being tied to a specific concrete `IpcClient` implementation. For generic
+/// convenience methods (typed subscriptions, RPC requests), use the
+/// [`IpcClientExt`](crate::IpcClientExt) extension trait which is automatically
+/// implemented for all `IpcClient` implementors.
+#[async_trait::async_trait]
+pub trait IpcClient: Send + Sync {
+    /// Start the IPC client, which will begin listening for incoming messages and processing them.
+    async fn start(&self);
+
+    /// Check if the IPC client task is currently running.
+    async fn is_running(&self) -> bool;
+
+    /// Stop the IPC client task. This will stop listening for incoming messages.
+    async fn stop(&self);
+
+    /// Send a message over IPC.
+    async fn send(&self, message: OutgoingMessage) -> Result<(), SendError>;
+
+    /// Subscribe to receive messages, optionally filtered by topic.
+    /// Setting the topic to `None` will receive all messages.
+    async fn subscribe(
+        &self,
+        topic: Option<String>,
+    ) -> Result<IpcClientSubscription, SubscribeError>;
+
+    /// Register an RPC handler using its type-erased form.
+    /// Prefer using
+    /// [`IpcClientExt::register_rpc_handler`](crate::IpcClientExt::register_rpc_handler)
+    /// instead.
+    #[doc(hidden)]
+    async fn register_rpc_handler_erased(&self, name: &str, handler: Box<dyn ErasedRpcHandler>);
+}

--- a/crates/bitwarden-ipc/src/ipc_client_trait.rs
+++ b/crates/bitwarden-ipc/src/ipc_client_trait.rs
@@ -1,7 +1,7 @@
 use bitwarden_threading::cancellation_token::CancellationToken;
 
 use crate::{
-    error::{SendError, SubscribeError},
+    error::{AlreadyRunningError, SendError, SubscribeError},
     ipc_client::IpcClientSubscription,
     message::OutgoingMessage,
     rpc::exec::handler::ErasedRpcHandler,
@@ -17,7 +17,10 @@ use crate::{
 #[async_trait::async_trait]
 pub trait IpcClient: Send + Sync {
     /// Start the IPC client, which will begin listening for incoming messages and processing them.
-    async fn start(&self, cancellation_token: Option<CancellationToken>);
+    async fn start(
+        &self,
+        cancellation_token: Option<CancellationToken>,
+    ) -> Result<(), AlreadyRunningError>;
 
     /// Check if the IPC client task is currently running.
     fn is_running(&self) -> bool;

--- a/crates/bitwarden-ipc/src/ipc_client_trait.rs
+++ b/crates/bitwarden-ipc/src/ipc_client_trait.rs
@@ -18,7 +18,7 @@ pub trait IpcClient: Send + Sync {
     async fn start(&self);
 
     /// Check if the IPC client task is currently running.
-    async fn is_running(&self) -> bool;
+    fn is_running(&self) -> bool;
 
     /// Stop the IPC client task. This will stop listening for incoming messages.
     async fn stop(&self);

--- a/crates/bitwarden-ipc/src/ipc_client_trait.rs
+++ b/crates/bitwarden-ipc/src/ipc_client_trait.rs
@@ -1,3 +1,5 @@
+use bitwarden_threading::cancellation_token::CancellationToken;
+
 use crate::{
     error::{SendError, SubscribeError},
     ipc_client::IpcClientSubscription,
@@ -15,13 +17,10 @@ use crate::{
 #[async_trait::async_trait]
 pub trait IpcClient: Send + Sync {
     /// Start the IPC client, which will begin listening for incoming messages and processing them.
-    async fn start(&self);
+    async fn start(&self, cancellation_token: Option<CancellationToken>);
 
     /// Check if the IPC client task is currently running.
     fn is_running(&self) -> bool;
-
-    /// Stop the IPC client task. This will stop listening for incoming messages.
-    async fn stop(&self);
 
     /// Send a message over IPC.
     async fn send(&self, message: OutgoingMessage) -> Result<(), SendError>;

--- a/crates/bitwarden-ipc/src/lib.rs
+++ b/crates/bitwarden-ipc/src/lib.rs
@@ -27,3 +27,15 @@ pub use message::{
 #[doc(hidden)]
 pub use rpc::exec::handler::ErasedRpcHandler;
 pub use rpc::{exec::handler::RpcHandler, request::RpcRequest};
+#[cfg(any(test, feature = "test-support"))]
+pub use traits::TestCommunicationBackend;
+pub use traits::{InMemorySessionRepository, NoEncryptionCryptoProvider, NoopCommunicationBackend};
+
+// Test configuration of the IPC client, always available in test and test-support contexts.
+#[cfg(any(test, feature = "test-support"))]
+#[allow(missing_docs)]
+pub type TestIpcClient = ipc_client::IpcClientImpl<
+    crate::traits::NoEncryptionCryptoProvider,
+    crate::traits::TestCommunicationBackend,
+    crate::traits::InMemorySessionRepository<()>,
+>;

--- a/crates/bitwarden-ipc/src/lib.rs
+++ b/crates/bitwarden-ipc/src/lib.rs
@@ -13,8 +13,10 @@ mod traits;
 #[cfg(feature = "wasm")]
 pub mod wasm;
 
+pub use endpoint::{Endpoint, HostId, Source};
 pub use ipc_client::{
     IpcClient, IpcClientSubscription, IpcClientTypedSubscription, ReceiveError, RequestError,
     SubscribeError, TypedReceiveError,
 };
+pub use message::{IncomingMessage, OutgoingMessage};
 pub use rpc::exec::handler::RpcHandler;

--- a/crates/bitwarden-ipc/src/lib.rs
+++ b/crates/bitwarden-ipc/src/lib.rs
@@ -1,7 +1,7 @@
 #![doc = include_str!("../README.md")]
 
 mod constants;
-mod discover;
+pub mod discover;
 mod endpoint;
 mod error;
 mod ipc_client;

--- a/crates/bitwarden-ipc/src/lib.rs
+++ b/crates/bitwarden-ipc/src/lib.rs
@@ -3,7 +3,10 @@
 mod constants;
 mod discover;
 mod endpoint;
+mod error;
 mod ipc_client;
+mod ipc_client_ext;
+mod ipc_client_trait;
 mod message;
 mod rpc;
 mod serde_utils;
@@ -14,9 +17,13 @@ mod traits;
 pub mod wasm;
 
 pub use endpoint::{Endpoint, HostId, Source};
-pub use ipc_client::{
-    IpcClient, IpcClientSubscription, IpcClientTypedSubscription, ReceiveError, RequestError,
-    SubscribeError, TypedReceiveError,
+pub use error::{ReceiveError, RequestError, SendError, SubscribeError, TypedReceiveError};
+pub use ipc_client::{IpcClientImpl, IpcClientSubscription, IpcClientTypedSubscription};
+pub use ipc_client_ext::IpcClientExt;
+pub use ipc_client_trait::IpcClient;
+pub use message::{
+    IncomingMessage, OutgoingMessage, PayloadTypeName, TypedIncomingMessage, TypedOutgoingMessage,
 };
-pub use message::{IncomingMessage, OutgoingMessage};
-pub use rpc::exec::handler::RpcHandler;
+#[doc(hidden)]
+pub use rpc::exec::handler::ErasedRpcHandler;
+pub use rpc::{exec::handler::RpcHandler, request::RpcRequest};

--- a/crates/bitwarden-ipc/src/message.rs
+++ b/crates/bitwarden-ipc/src/message.rs
@@ -2,15 +2,23 @@ use serde::{Deserialize, Serialize, de::DeserializeOwned};
 #[cfg(feature = "wasm")]
 use wasm_bindgen::prelude::*;
 
-use crate::{endpoint::Endpoint, serde_utils};
+use crate::{
+    endpoint::{Endpoint, Source},
+    serde_utils,
+};
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[cfg_attr(test, derive(PartialEq))]
 #[cfg_attr(feature = "wasm", wasm_bindgen)]
+/// An untyped IPC message to be sent to another endpoint.
 pub struct OutgoingMessage {
+    /// Serialized payload bytes.
     #[cfg_attr(feature = "wasm", wasm_bindgen(getter_with_clone))]
     pub payload: Vec<u8>,
+    /// Destination endpoint for this message.
+    #[cfg_attr(feature = "wasm", wasm_bindgen(getter_with_clone))]
     pub destination: Endpoint,
+    /// Optional topic used for routing/dispatch.
     #[cfg_attr(feature = "wasm", wasm_bindgen(getter_with_clone))]
     pub topic: Option<String>,
 }
@@ -18,19 +26,29 @@ pub struct OutgoingMessage {
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[cfg_attr(test, derive(PartialEq))]
 #[cfg_attr(feature = "wasm", wasm_bindgen)]
+/// An untyped IPC message received from another endpoint.
 pub struct IncomingMessage {
+    /// Serialized payload bytes.
     #[cfg_attr(feature = "wasm", wasm_bindgen(getter_with_clone))]
     pub payload: Vec<u8>,
+    /// Destination endpoint that received this message.
+    #[cfg_attr(feature = "wasm", wasm_bindgen(getter_with_clone))]
     pub destination: Endpoint,
-    pub source: Endpoint,
+    /// Source that sent this message, with per-variant metadata.
+    #[cfg_attr(feature = "wasm", wasm_bindgen(getter_with_clone))]
+    pub source: Source,
+    /// Optional topic used for routing/dispatch.
     #[cfg_attr(feature = "wasm", wasm_bindgen(getter_with_clone))]
     pub topic: Option<String>,
 }
 
+/// A typed wrapper around [`OutgoingMessage`] that stores the payload as a deserialized type.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[cfg_attr(test, derive(PartialEq))]
 pub struct TypedOutgoingMessage<Payload> {
+    /// The typed payload of this message.
     pub payload: Payload,
+    /// Destination endpoint for this message.
     pub destination: Endpoint,
 }
 
@@ -63,17 +81,22 @@ where
     }
 }
 
+/// A typed wrapper around [`IncomingMessage`] that stores the payload as a deserialized type.
 #[derive(Clone, Debug)]
 #[cfg_attr(test, derive(PartialEq))]
 pub struct TypedIncomingMessage<Payload: PayloadTypeName> {
+    /// The typed payload of this message.
     pub payload: Payload,
+    /// Destination endpoint that received this message.
     pub destination: Endpoint,
-    pub source: Endpoint,
+    /// Source that sent this message, with per-variant metadata.
+    pub source: Source,
 }
 
 /// This trait is used to ensure that the payload type has a topic associated with it.
 pub trait PayloadTypeName {
-    const PAYLOAD_TYPE_NAME: &str;
+    /// The topic name associated with this payload type, used for routing/dispatch.
+    const PAYLOAD_TYPE_NAME: &'static str;
 }
 
 impl<Payload> TryFrom<IncomingMessage> for TypedIncomingMessage<Payload>

--- a/crates/bitwarden-ipc/src/rpc/exec/handler.rs
+++ b/crates/bitwarden-ipc/src/rpc/exec/handler.rs
@@ -70,8 +70,9 @@ where
     }
 }
 
+#[doc(hidden)]
 #[async_trait::async_trait]
-pub(crate) trait ErasedRpcHandler: Send + Sync {
+pub trait ErasedRpcHandler: Send + Sync {
     async fn handle(
         &self,
         serialized_request: &RpcRequestPayload,

--- a/crates/bitwarden-ipc/src/rpc/exec/handler_registry.rs
+++ b/crates/bitwarden-ipc/src/rpc/exec/handler_registry.rs
@@ -20,7 +20,11 @@ impl RpcHandlerRegistry {
         H: RpcHandler + ErasedRpcHandler + 'static,
     {
         let name = H::Request::NAME.to_owned();
-        self.handlers.write().await.insert(name, Box::new(handler));
+        self.register_erased(name, Box::new(handler)).await;
+    }
+
+    pub async fn register_erased(&self, name: String, handler: Box<dyn ErasedRpcHandler>) {
+        self.handlers.write().await.insert(name, handler);
     }
 
     pub async fn handle(

--- a/crates/bitwarden-ipc/src/rpc/request.rs
+++ b/crates/bitwarden-ipc/src/rpc/request.rs
@@ -1,8 +1,10 @@
 use serde::{Serialize, de::DeserializeOwned};
 
+/// Trait representing an RPC request.
 pub trait RpcRequest: Serialize + DeserializeOwned + 'static {
+    /// The type of the response that will be returned for this request.
     type Response: Serialize + DeserializeOwned + 'static;
 
-    /// Used to identify handlers
+    /// Used to identify handlers. This should be unique across all request types.
     const NAME: &str;
 }

--- a/crates/bitwarden-ipc/src/traits/communication_backend.rs
+++ b/crates/bitwarden-ipc/src/traits/communication_backend.rs
@@ -56,7 +56,7 @@ pub trait CommunicationBackendReceiver: Send + Sync + 'static {
 pub(crate) mod noop {
     use super::*;
 
-    /// A no-op implementation of the [`CommunicationBackend`] trait.
+    /// A no-op implementation of the `CommunicationBackend` trait.
     ///
     /// Sending discards messages silently and receiving blocks forever (the future never resolves).
     /// This is useful as a default backend for platforms that do not need IPC communication.
@@ -98,7 +98,7 @@ pub(crate) mod test_support {
 
     use super::*;
 
-    /// A test implementation of the [`CommunicationBackend`] trait. Provides methods to inject
+    /// A test implementation of the `CommunicationBackend` trait. Provides methods to inject
     /// incoming messages and inspect outgoing messages.
     #[derive(Debug)]
     pub struct TestCommunicationBackend {

--- a/crates/bitwarden-ipc/src/traits/communication_backend.rs
+++ b/crates/bitwarden-ipc/src/traits/communication_backend.rs
@@ -53,8 +53,42 @@ pub trait CommunicationBackendReceiver: Send + Sync + 'static {
     ) -> impl std::future::Future<Output = Result<IncomingMessage, Self::ReceiveError>> + Send + Sync;
 }
 
-#[cfg(test)]
-pub mod tests {
+pub(crate) mod noop {
+    use super::*;
+
+    /// A no-op implementation of the [`CommunicationBackend`] trait.
+    ///
+    /// Sending discards messages silently and receiving blocks forever (the future never resolves).
+    /// This is useful as a default backend for platforms that do not need IPC communication.
+    pub struct NoopCommunicationBackend;
+
+    /// Receiver for [`NoopCommunicationBackend`] that never yields a message.
+    pub struct NoopCommunicationBackendReceiver;
+
+    impl CommunicationBackend for NoopCommunicationBackend {
+        type SendError = std::convert::Infallible;
+        type Receiver = NoopCommunicationBackendReceiver;
+
+        async fn send(&self, _message: OutgoingMessage) -> Result<(), Self::SendError> {
+            Ok(())
+        }
+
+        async fn subscribe(&self) -> Self::Receiver {
+            NoopCommunicationBackendReceiver
+        }
+    }
+
+    impl CommunicationBackendReceiver for NoopCommunicationBackendReceiver {
+        type ReceiveError = std::convert::Infallible;
+
+        async fn receive(&self) -> Result<IncomingMessage, Self::ReceiveError> {
+            std::future::pending().await
+        }
+    }
+}
+
+#[cfg(any(test, feature = "test-support"))]
+pub(crate) mod test_support {
     use std::sync::Arc;
 
     use tokio::sync::{
@@ -64,7 +98,8 @@ pub mod tests {
 
     use super::*;
 
-    /// A mock implementation of the CommunicationBackend trait that can be used for testing.
+    /// A test implementation of the [`CommunicationBackend`] trait. Provides methods to inject
+    /// incoming messages and inspect outgoing messages.
     #[derive(Debug)]
     pub struct TestCommunicationBackend {
         outgoing_tx: Sender<OutgoingMessage>,
@@ -86,10 +121,18 @@ pub mod tests {
         }
     }
 
+    impl Default for TestCommunicationBackend {
+        fn default() -> Self {
+            Self::new()
+        }
+    }
+
+    /// Receiver for [`TestCommunicationBackend`].
     #[derive(Debug)]
     pub struct TestCommunicationBackendReceiver(RwLock<Receiver<IncomingMessage>>);
 
     impl TestCommunicationBackend {
+        /// Create a new test communication backend.
         pub fn new() -> Self {
             let (outgoing_tx, outgoing_rx) = broadcast::channel(10);
             let (incoming_tx, incoming_rx) = broadcast::channel(10);
@@ -102,6 +145,7 @@ pub mod tests {
             }
         }
 
+        /// Inject a message as if it were received from a remote endpoint.
         pub fn push_incoming(&self, message: IncomingMessage) {
             self.incoming_tx
                 .send(message)
@@ -111,6 +155,11 @@ pub mod tests {
         /// Get a copy of all the outgoing messages that have been sent.
         pub async fn outgoing(&self) -> Vec<OutgoingMessage> {
             self.outgoing.read().await.clone()
+        }
+
+        /// Drain all outgoing messages, returning them and clearing the internal buffer.
+        pub async fn drain_outgoing(&self) -> Vec<OutgoingMessage> {
+            self.outgoing.write().await.drain(..).collect()
         }
     }
 

--- a/crates/bitwarden-ipc/src/traits/crypto_provider.rs
+++ b/crates/bitwarden-ipc/src/traits/crypto_provider.rs
@@ -48,6 +48,7 @@ where
     ) -> impl std::future::Future<Output = Result<IncomingMessage, Self::ReceiveError>> + Send + Sync;
 }
 
+/// A no-op crypto provider that performs no encryption and simply passes messages through as-is.
 pub struct NoEncryptionCryptoProvider;
 
 impl<Com, Ses> CryptoProvider<Com, Ses> for NoEncryptionCryptoProvider

--- a/crates/bitwarden-ipc/src/traits/mod.rs
+++ b/crates/bitwarden-ipc/src/traits/mod.rs
@@ -2,8 +2,10 @@ mod communication_backend;
 mod crypto_provider;
 mod session_repository;
 
-#[cfg(test)]
-pub use communication_backend::tests;
-pub use communication_backend::{CommunicationBackend, CommunicationBackendReceiver};
+#[cfg(any(test, feature = "test-support"))]
+pub use communication_backend::test_support::TestCommunicationBackend;
+pub use communication_backend::{
+    CommunicationBackend, CommunicationBackendReceiver, noop::NoopCommunicationBackend,
+};
 pub use crypto_provider::{CryptoProvider, NoEncryptionCryptoProvider};
 pub use session_repository::{InMemorySessionRepository, SessionRepository};

--- a/crates/bitwarden-ipc/src/traits/session_repository.rs
+++ b/crates/bitwarden-ipc/src/traits/session_repository.rs
@@ -24,6 +24,9 @@ pub trait SessionRepository<Session>: Send + Sync + 'static {
     ) -> impl std::future::Future<Output = Result<(), Self::RemoveError>>;
 }
 
+/// An in-memory session repository implementation that stores sessions in a `HashMap` protected by
+/// an `RwLock`. This is a simple implementation that can be used for testing or in scenarios where
+/// persistence is not required.
 pub type InMemorySessionRepository<Session> = RwLock<HashMap<Endpoint, Session>>;
 impl<Session> SessionRepository<Session> for InMemorySessionRepository<Session>
 where

--- a/crates/bitwarden-ipc/src/wasm/discover.rs
+++ b/crates/bitwarden-ipc/src/wasm/discover.rs
@@ -3,7 +3,7 @@ use wasm_bindgen::prelude::wasm_bindgen;
 
 use super::JsIpcClient;
 use crate::{
-    RequestError,
+    IpcClientExt, RequestError,
     discover::{DiscoverHandler, DiscoverRequest, DiscoverResponse},
     endpoint::Endpoint,
 };

--- a/crates/bitwarden-ipc/src/wasm/ipc_client.rs
+++ b/crates/bitwarden-ipc/src/wasm/ipc_client.rs
@@ -100,8 +100,8 @@ impl JsIpcClient {
     #[wasm_only]
     #[wasm_bindgen(js_name = isRunning)]
     #[allow(missing_docs)]
-    pub async fn is_running(&self) -> bool {
-        self.client.is_running().await
+    pub fn is_running(&self) -> bool {
+        self.client.is_running()
     }
 
     #[wasm_only]

--- a/crates/bitwarden-ipc/src/wasm/ipc_client.rs
+++ b/crates/bitwarden-ipc/src/wasm/ipc_client.rs
@@ -6,7 +6,7 @@ use wasm_bindgen::prelude::*;
 use super::communication_backend::JsCommunicationBackend;
 use crate::{
     IpcClientImpl,
-    error::{ReceiveError, SubscribeError},
+    error::{AlreadyRunningError, ReceiveError, SubscribeError},
     ipc_client::IpcClientSubscription,
     ipc_client_trait::IpcClient,
     message::{IncomingMessage, OutgoingMessage},
@@ -93,7 +93,10 @@ impl JsIpcClient {
 
     #[wasm_only]
     #[allow(missing_docs)]
-    pub async fn start(&self, abort_signal: Option<AbortSignal>) {
+    pub async fn start(
+        &self,
+        abort_signal: Option<AbortSignal>,
+    ) -> Result<(), AlreadyRunningError> {
         self.client
             .start(abort_signal.map(|signal| signal.to_cancellation_token()))
             .await

--- a/crates/bitwarden-ipc/src/wasm/ipc_client.rs
+++ b/crates/bitwarden-ipc/src/wasm/ipc_client.rs
@@ -5,8 +5,10 @@ use wasm_bindgen::prelude::*;
 
 use super::communication_backend::JsCommunicationBackend;
 use crate::{
-    IpcClient,
-    ipc_client::{IpcClientSubscription, ReceiveError, SubscribeError},
+    IpcClientImpl,
+    error::{ReceiveError, SubscribeError},
+    ipc_client::IpcClientSubscription,
+    ipc_client_trait::IpcClient,
     message::{IncomingMessage, OutgoingMessage},
     traits::{InMemorySessionRepository, NoEncryptionCryptoProvider},
     wasm::{
@@ -16,7 +18,7 @@ use crate::{
 };
 
 /// JavaScript wrapper around the IPC client. For more information, see the
-/// [IpcClient] documentation.
+/// [`IpcClient`] trait documentation.
 #[wasm_bindgen(js_name = IpcClient)]
 pub struct JsIpcClient {
     #[wasm_bindgen(skip)]
@@ -24,9 +26,7 @@ pub struct JsIpcClient {
     /// that interact with the IPC client, e.g. to register RPC handlers, trigger RPC requests,
     /// send typed messages, etc. For examples see
     /// [wasm::ipc_register_discover_handler](crate::wasm::ipc_register_discover_handler).
-    pub client: Arc<
-        IpcClient<NoEncryptionCryptoProvider, JsCommunicationBackend, GenericSessionRepository>,
-    >,
+    pub client: Arc<dyn IpcClient>,
 }
 
 /// JavaScript wrapper around the IPC client subscription. For more information, see the
@@ -63,13 +63,13 @@ impl JsIpcClient {
         communication_provider: &JsCommunicationBackend,
     ) -> JsIpcClient {
         JsIpcClient {
-            client: IpcClient::new(
+            client: Arc::new(IpcClientImpl::new(
                 NoEncryptionCryptoProvider,
                 communication_provider.clone(),
                 GenericSessionRepository::InMemory(Arc::new(InMemorySessionRepository::new(
                     HashMap::new(),
                 ))),
-            ),
+            )),
         }
     }
     /// Create a new `IpcClient` instance with a client-managed session repository for saving
@@ -81,13 +81,13 @@ impl JsIpcClient {
         session_repository: RawJsSessionRepository,
     ) -> JsIpcClient {
         JsIpcClient {
-            client: IpcClient::new(
+            client: Arc::new(IpcClientImpl::new(
                 NoEncryptionCryptoProvider,
                 communication_provider.clone(),
                 GenericSessionRepository::JsSessionRepository(Arc::new(JsSessionRepository::new(
                     session_repository,
                 ))),
-            ),
+            )),
         }
     }
 
@@ -110,7 +110,7 @@ impl JsIpcClient {
         self.client
             .send(message)
             .await
-            .map_err(|e| JsError::new(&e))
+            .map_err(|e| JsError::new(&e.to_string()))
     }
 
     #[wasm_only]

--- a/crates/bitwarden-ipc/src/wasm/ipc_client.rs
+++ b/crates/bitwarden-ipc/src/wasm/ipc_client.rs
@@ -93,8 +93,10 @@ impl JsIpcClient {
 
     #[wasm_only]
     #[allow(missing_docs)]
-    pub async fn start(&self) {
-        self.client.start().await
+    pub async fn start(&self, abort_signal: Option<AbortSignal>) {
+        self.client
+            .start(abort_signal.map(|signal| signal.to_cancellation_token()))
+            .await
     }
 
     #[wasm_only]

--- a/crates/bitwarden-ipc/src/wasm/message.rs
+++ b/crates/bitwarden-ipc/src/wasm/message.rs
@@ -3,13 +3,14 @@ use std::str;
 use wasm_bindgen::prelude::*;
 
 use crate::{
-    endpoint::Endpoint,
+    endpoint::{Endpoint, Source},
     message::{IncomingMessage, OutgoingMessage},
 };
 
 #[wasm_bindgen]
 impl OutgoingMessage {
     #[wasm_bindgen(constructor)]
+    /// Create an outgoing IPC message from raw payload bytes.
     pub fn new(payload: Vec<u8>, destination: Endpoint, topic: Option<String>) -> OutgoingMessage {
         OutgoingMessage {
             payload,
@@ -40,10 +41,11 @@ impl OutgoingMessage {
 #[wasm_bindgen]
 impl IncomingMessage {
     #[wasm_bindgen(constructor)]
+    /// Create an incoming IPC message from raw payload bytes.
     pub fn new(
         payload: Vec<u8>,
         destination: Endpoint,
-        source: Endpoint,
+        source: Source,
         topic: Option<String>,
     ) -> IncomingMessage {
         IncomingMessage {


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

Client PR: https://github.com/bitwarden/clients/pull/19935

## 📔 Objective

Refactors the `bitwarden-ipc` crate to improve ergonomics for consumers that hold IPC clients through trait objects.

- **Expand `Endpoint` types**: adds `HostId` (for addressing host endpoints relationally vs. by ID), `Source` (mirrors `Endpoint` but carries per-sender metadata such as `origin` for security decisions), and more specific platform variants (`DesktopRenderer`, `DesktopMain`, named fields on existing variants). `IncomingMessage.source` changes from `Endpoint` to `Source`.

- **`IpcClient` dyn-compatible trait + `IpcClientExt` extension**: splits `IpcClient<Crypto, Com, Ses>` struct into three pieces:
  - `IpcClient` trait — dyn-compatible core operations (`start`, `stop`, `send`, `subscribe`, `register_rpc_handler_erased`)
  - `IpcClientImpl<Crypto, Com, Ses>` — concrete implementation; internal state wrapped in `Arc<IpcClientInner>` so the struct is cheaply cloneable without the caller managing `Arc`
  - `IpcClientExt` — blanket extension trait providing typed helpers (`subscribe_typed`, `register_rpc_handler`, `request`, `send_typed`) on any `IpcClient`, including `dyn IpcClient`
  - Error types extracted to a dedicated `error` module

- **`NoopCommunicationBackend`**: a backend that discards sends and never yields messages, useful as a default on platforms that don't need IPC (e.g. make tests compile).

- **`test-support` feature**: opt-in re-export of `TestCommunicationBackend` and `TestIpcClient` type alias for downstream crates.

- **WASM bindings**: `JsIpcClient.client` is now `Arc<dyn IpcClient>`, decoupling the JS wrapper from the concrete type parameters.

## 🚨 Breaking Changes

Modifies the `Endpoint` enum to add support for Desktop <-> Browser communication

<!-- Does this PR introduce any breaking changes? If so, please describe the impact and migration path for clients.

If you're unsure, the automated TypeScript compatibility check will run when you open/update this PR and provide feedback.

For breaking changes:
1. Describe what changed in the client interface
2. Explain why the change was necessary
3. Provide migration steps for client developers
4. Link to any paired client PRs if needed

Otherwise, you can remove this section. -->
