### PR TITLE
Persist folder_id and collection_ids when saving editing ciphers

### DIFF
--- a/crates/bitwarden-vault/src/cipher/cipher.rs
+++ b/crates/bitwarden-vault/src/cipher/cipher.rs
@@ -1155,52 +1155,53 @@ impl From<CipherRepromptType> for bitwarden_api_api::models::CipherRepromptType 
     }
 }
 
-impl TryFrom<CipherResponseModel> for Cipher {
-    type Error = VaultParseError;
-
-    fn try_from(cipher: CipherResponseModel) -> Result<Self, Self::Error> {
-        Ok(Self {
-            id: cipher.id.map(CipherId::new),
-            organization_id: cipher.organization_id.map(OrganizationId::new),
-            folder_id: cipher.folder_id.map(FolderId::new),
-            collection_ids: vec![], // CipherResponseModel doesn't include collection_ids
-            name: require!(cipher.name).parse()?,
-            notes: EncString::try_from_optional(cipher.notes)?,
-            r#type: require!(cipher.r#type).try_into()?,
-            login: cipher.login.map(|l| (*l).try_into()).transpose()?,
-            identity: cipher.identity.map(|i| (*i).try_into()).transpose()?,
-            card: cipher.card.map(|c| (*c).try_into()).transpose()?,
-            secure_note: cipher.secure_note.map(|s| (*s).try_into()).transpose()?,
-            ssh_key: cipher.ssh_key.map(|s| (*s).try_into()).transpose()?,
-            favorite: cipher.favorite.unwrap_or(false),
-            reprompt: cipher
+impl PartialCipher for CipherResponseModel {
+    fn merge_with_cipher(self, cipher: Option<Cipher>) -> Result<Cipher, VaultParseError> {
+        Ok(Cipher {
+            collection_ids: cipher
+                .as_ref()
+                .map(|c| c.collection_ids.clone())
+                .unwrap_or_default(),
+            local_data: cipher.and_then(|c| c.local_data),
+            id: self.id.map(CipherId::new),
+            organization_id: self.organization_id.map(OrganizationId::new),
+            folder_id: self.folder_id.map(FolderId::new),
+            name: require!(self.name).parse()?,
+            notes: EncString::try_from_optional(self.notes)?,
+            r#type: require!(self.r#type).try_into()?,
+            login: self.login.map(|l| (*l).try_into()).transpose()?,
+            identity: self.identity.map(|i| (*i).try_into()).transpose()?,
+            card: self.card.map(|c| (*c).try_into()).transpose()?,
+            secure_note: self.secure_note.map(|s| (*s).try_into()).transpose()?,
+            ssh_key: self.ssh_key.map(|s| (*s).try_into()).transpose()?,
+            favorite: self.favorite.unwrap_or(false),
+            reprompt: self
                 .reprompt
                 .map(|r| r.try_into())
                 .transpose()?
                 .unwrap_or(CipherRepromptType::None),
-            organization_use_totp: cipher.organization_use_totp.unwrap_or(false),
-            edit: cipher.edit.unwrap_or(false),
-            permissions: cipher.permissions.map(|p| (*p).try_into()).transpose()?,
-            view_password: cipher.view_password.unwrap_or(true),
-            local_data: None, // Not sent from server
-            attachments: cipher
+            organization_use_totp: self.organization_use_totp.unwrap_or(false),
+            edit: self.edit.unwrap_or(false),
+            permissions: self.permissions.map(|p| (*p).try_into()).transpose()?,
+            view_password: self.view_password.unwrap_or(true),
+            attachments: self
                 .attachments
                 .map(|a| a.into_iter().map(|a| a.try_into()).collect())
                 .transpose()?,
-            fields: cipher
+            fields: self
                 .fields
                 .map(|f| f.into_iter().map(|f| f.try_into()).collect())
                 .transpose()?,
-            password_history: cipher
+            password_history: self
                 .password_history
                 .map(|p| p.into_iter().map(|p| p.try_into()).collect())
                 .transpose()?,
-            creation_date: require!(cipher.creation_date).parse()?,
-            deleted_date: cipher.deleted_date.map(|d| d.parse()).transpose()?,
-            revision_date: require!(cipher.revision_date).parse()?,
-            key: EncString::try_from_optional(cipher.key)?,
-            archived_date: cipher.archived_date.map(|d| d.parse()).transpose()?,
-            data: cipher.data,
+            creation_date: require!(self.creation_date).parse()?,
+            deleted_date: self.deleted_date.map(|d| d.parse()).transpose()?,
+            revision_date: require!(self.revision_date).parse()?,
+            key: EncString::try_from_optional(self.key)?,
+            archived_date: self.archived_date.map(|d| d.parse()).transpose()?,
+            data: self.data,
         })
     }
 }

--- a/crates/bitwarden-vault/src/cipher/cipher_client/admin/edit.rs
+++ b/crates/bitwarden-vault/src/cipher/cipher_client/admin/edit.rs
@@ -55,6 +55,10 @@ async fn edit_cipher(
     request: CipherEditRequest,
 ) -> Result<CipherView, EditCipherAdminError> {
     let cipher_id = request.id;
+    // CipherMiniResponseModel does not include folder_id or favorite — save them from the
+    // request before it is consumed so they can be applied to the merged result.
+    let folder_id = request.folder_id;
+    let favorite = request.favorite;
     let request = CipherEditRequestInternal::new(request, &original_cipher_view);
 
     let mut cipher_request = key_store.encrypt(request)?;
@@ -62,12 +66,15 @@ async fn edit_cipher(
 
     let orig_cipher = key_store.encrypt(original_cipher_view)?;
 
-    let cipher: Cipher = api_client
+    let mut cipher: Cipher = api_client
         .ciphers_api()
         .put_admin(cipher_id.into(), Some(cipher_request))
         .await
         .map_err(ApiError::from)?
         .merge_with_cipher(Some(orig_cipher))?;
+
+    cipher.folder_id = folder_id;
+    cipher.favorite = favorite;
 
     Ok(key_store.decrypt(&cipher)?)
 }
@@ -250,9 +257,15 @@ mod tests {
                 .once();
         });
 
-        let original_cipher_view = generate_test_cipher();
+        let folder_a: crate::FolderId = "a4e13cc0-1234-5678-abcd-b181009709b8".parse().unwrap();
+        let folder_b: crate::FolderId = "b5e13cc0-1234-5678-abcd-b181009709b8".parse().unwrap();
+
+        let mut original_cipher_view = generate_test_cipher();
+        original_cipher_view.folder_id = Some(folder_a);
         let mut cipher_view = original_cipher_view.clone();
         cipher_view.name = "New Cipher Name".to_string();
+        // Change folder: request carries folder_b, original has folder_a.
+        cipher_view.folder_id = Some(folder_b);
 
         let request: CipherEditRequest = cipher_view.try_into().unwrap();
 
@@ -268,6 +281,8 @@ mod tests {
 
         assert_eq!(result.id, Some(cipher_id));
         assert_eq!(result.name, "New Cipher Name");
+        // folder_id must come from the request, not from the original cipher.
+        assert_eq!(result.folder_id, Some(folder_b));
     }
 
     #[tokio::test]

--- a/crates/bitwarden-vault/src/cipher/cipher_client/create.rs
+++ b/crates/bitwarden-vault/src/cipher/cipher_client/create.rs
@@ -21,7 +21,7 @@ use wasm_bindgen::prelude::*;
 use super::CiphersClient;
 use crate::{
     Cipher, CipherRepromptType, CipherView, FieldView, FolderId, VaultParseError,
-    cipher_view_type::CipherViewType,
+    cipher::cipher::PartialCipher, cipher_view_type::CipherViewType,
 };
 
 #[allow(missing_docs)]
@@ -231,17 +231,18 @@ async fn create_cipher<R: Repository<Cipher> + ?Sized>(
     let mut cipher_request = key_store.encrypt(request)?;
     cipher_request.encrypted_for = Some(encrypted_for.into());
 
-    let cipher: Cipher;
+    let mut cipher: Cipher;
     if !collection_ids.is_empty() {
         cipher = api_client
             .ciphers_api()
             .post_create(Some(CipherCreateRequestModel {
-                collection_ids: Some(collection_ids.into_iter().map(Into::into).collect()),
+                collection_ids: Some(collection_ids.iter().cloned().map(Into::into).collect()),
                 cipher: Box::new(cipher_request),
             }))
             .await
             .map_err(ApiError::from)?
-            .try_into()?;
+            .merge_with_cipher(None)?;
+        cipher.collection_ids = collection_ids;
         repository.set(require!(cipher.id), cipher.clone()).await?;
     } else {
         cipher = api_client
@@ -249,7 +250,7 @@ async fn create_cipher<R: Repository<Cipher> + ?Sized>(
             .post(Some(cipher_request))
             .await
             .map_err(ApiError::from)?
-            .try_into()?;
+            .merge_with_cipher(None)?;
         repository.set(require!(cipher.id), cipher.clone()).await?;
     }
 

--- a/crates/bitwarden-vault/src/cipher/cipher_client/edit.rs
+++ b/crates/bitwarden-vault/src/cipher/cipher_client/edit.rs
@@ -336,6 +336,9 @@ async fn edit_cipher<R: Repository<Cipher> + ?Sized>(
     let cipher_id = request.id;
 
     let original_cipher = repository.get(cipher_id).await?.ok_or(ItemNotFoundError)?;
+    // Preserve fields not returned by the server's PUT response.
+    let original_collection_ids = original_cipher.collection_ids.clone();
+    let original_local_data = original_cipher.local_data.clone();
     let original_cipher_view: CipherView = key_store.decrypt(&original_cipher)?;
 
     let request = CipherEditRequestInternal::new(request, &original_cipher_view);
@@ -343,12 +346,14 @@ async fn edit_cipher<R: Repository<Cipher> + ?Sized>(
     let mut cipher_request = key_store.encrypt(request)?;
     cipher_request.encrypted_for = Some(encrypted_for.into());
 
-    let cipher: Cipher = api_client
+    let mut cipher: Cipher = api_client
         .ciphers_api()
         .put(cipher_id.into(), Some(cipher_request))
         .await
         .map_err(ApiError::from)?
-        .try_into()?;
+        .merge_with_cipher(Some(original_cipher))?;
+    cipher.collection_ids = original_collection_ids;
+    cipher.local_data = original_local_data;
     debug_assert!(cipher.id.unwrap_or_default() == cipher_id);
     repository.set(cipher_id, cipher.clone()).await?;
 
@@ -610,8 +615,15 @@ mod tests {
                 .once();
         });
 
+        let collection_id: CollectionId = "a4e13cc0-1234-5678-abcd-b181009709b8".parse().unwrap();
+
         let repository = MemoryRepository::<Cipher>::default();
         repository_add_cipher(&repository, &store, cipher_id, "old_name").await;
+        // Update the stored cipher to include a collection_id so we can verify it is preserved.
+        let mut stored = repository.get(cipher_id).await.unwrap().unwrap();
+        stored.collection_ids = vec![collection_id];
+        repository.set(cipher_id, stored).await.unwrap();
+
         let cipher_view = generate_test_cipher();
 
         let request = cipher_view.try_into().unwrap();
@@ -628,6 +640,8 @@ mod tests {
 
         assert_eq!(result.id, Some(cipher_id));
         assert_eq!(result.name, "Test Login");
+        // collection_ids must be preserved even though CipherResponseModel omits them.
+        assert_eq!(result.collection_ids, vec![collection_id]);
     }
 
     #[tokio::test]

--- a/crates/bitwarden-vault/src/cipher/cipher_client/edit.rs
+++ b/crates/bitwarden-vault/src/cipher/cipher_client/edit.rs
@@ -336,9 +336,6 @@ async fn edit_cipher<R: Repository<Cipher> + ?Sized>(
     let cipher_id = request.id;
 
     let original_cipher = repository.get(cipher_id).await?.ok_or(ItemNotFoundError)?;
-    // Preserve fields not returned by the server's PUT response.
-    let original_collection_ids = original_cipher.collection_ids.clone();
-    let original_local_data = original_cipher.local_data.clone();
     let original_cipher_view: CipherView = key_store.decrypt(&original_cipher)?;
 
     let request = CipherEditRequestInternal::new(request, &original_cipher_view);
@@ -346,14 +343,12 @@ async fn edit_cipher<R: Repository<Cipher> + ?Sized>(
     let mut cipher_request = key_store.encrypt(request)?;
     cipher_request.encrypted_for = Some(encrypted_for.into());
 
-    let mut cipher: Cipher = api_client
+    let cipher: Cipher = api_client
         .ciphers_api()
         .put(cipher_id.into(), Some(cipher_request))
         .await
         .map_err(ApiError::from)?
         .merge_with_cipher(Some(original_cipher))?;
-    cipher.collection_ids = original_collection_ids;
-    cipher.local_data = original_local_data;
     debug_assert!(cipher.id.unwrap_or_default() == cipher_id);
     repository.set(cipher_id, cipher.clone()).await?;
 

--- a/crates/bitwarden-vault/src/cipher/cipher_client/restore.rs
+++ b/crates/bitwarden-vault/src/cipher/cipher_client/restore.rs
@@ -41,7 +41,10 @@ pub async fn restore<R: Repository<Cipher> + ?Sized>(
 ) -> Result<CipherView, RestoreCipherError> {
     let api = api_client.ciphers_api();
 
-    let cipher: Cipher = api.put_restore(cipher_id.into()).await?.try_into()?;
+    let cipher: Cipher = api
+        .put_restore(cipher_id.into())
+        .await?
+        .merge_with_cipher(None)?;
     repository.set(cipher_id, cipher.clone()).await?;
 
     Ok(key_store.decrypt(&cipher)?)

--- a/crates/bitwarden-vault/src/cipher/cipher_client/restore.rs
+++ b/crates/bitwarden-vault/src/cipher/cipher_client/restore.rs
@@ -3,6 +3,7 @@ use bitwarden_core::{ApiError, key_management::KeyIds};
 use bitwarden_crypto::{CryptoError, KeyStore};
 use bitwarden_error::bitwarden_error;
 use bitwarden_state::repository::{Repository, RepositoryError};
+use futures::future::OptionFuture;
 use thiserror::Error;
 #[cfg(feature = "wasm")]
 use wasm_bindgen::prelude::wasm_bindgen;
@@ -41,10 +42,11 @@ pub async fn restore<R: Repository<Cipher> + ?Sized>(
 ) -> Result<CipherView, RestoreCipherError> {
     let api = api_client.ciphers_api();
 
+    let existing_cipher = repository.get(cipher_id).await?;
     let cipher: Cipher = api
         .put_restore(cipher_id.into())
         .await?
-        .merge_with_cipher(None)?;
+        .merge_with_cipher(existing_cipher)?;
     repository.set(cipher_id, cipher.clone()).await?;
 
     Ok(key_store.decrypt(&cipher)?)
@@ -59,7 +61,7 @@ pub async fn restore_many<R: Repository<Cipher> + ?Sized>(
 ) -> Result<DecryptCipherListResult, RestoreCipherError> {
     let api = api_client.ciphers_api();
 
-    let ciphers: Vec<Cipher> = api
+    let response_models: Vec<_> = api
         .put_restore_many(Some(CipherBulkRestoreRequestModel {
             ids: cipher_ids.into_iter().map(|id| id.to_string()).collect(),
             organization_id: None,
@@ -68,8 +70,16 @@ pub async fn restore_many<R: Repository<Cipher> + ?Sized>(
         .data
         .into_iter()
         .flatten()
-        .map(|c| c.merge_with_cipher(None))
-        .collect::<Result<Vec<Cipher>, _>>()?;
+        .collect();
+
+    let mut ciphers = Vec::with_capacity(response_models.len());
+    for model in response_models {
+        let existing = OptionFuture::from(model.id.map(|id| repository.get(CipherId::new(id))))
+            .await
+            .transpose()?
+            .flatten();
+        ciphers.push(model.merge_with_cipher(existing)?);
+    }
 
     for cipher in &ciphers {
         if let Some(id) = cipher.id {
@@ -115,6 +125,7 @@ mod tests {
             CipherMiniResponseModel, CipherMiniResponseModelListResponseModel, CipherResponseModel,
         },
     };
+    use bitwarden_collections::collection::CollectionId;
     use bitwarden_core::key_management::{KeyIds, SymmetricKeyId};
     use bitwarden_crypto::{KeyStore, PrimitiveEncryptable, SymmetricCryptoKey};
     use bitwarden_state::repository::Repository;
@@ -316,5 +327,135 @@ mod tests {
         assert!(cipher_2.deleted_date.is_none());
         assert!(cipher_1.revision_date >= start_time && cipher_1.revision_date <= end_time);
         assert!(cipher_2.revision_date >= start_time && cipher_2.revision_date <= end_time);
+    }
+
+    #[tokio::test]
+    async fn test_restore_preserves_collection_ids() {
+        let store = setup_key_store();
+        let collection_id: CollectionId = "a4e13cc0-1234-5678-abcd-b181009709b8".parse().unwrap();
+
+        let mut cipher = generate_test_cipher(&store);
+        cipher.deleted_date = Some(Utc::now());
+        cipher.collection_ids = vec![collection_id];
+
+        let cipher_name = cipher.name.to_string();
+        let cipher_type = cipher.r#type;
+
+        let api_client = ApiClient::new_mocked(move |mock| {
+            mock.ciphers_api.expect_put_restore().returning(move |_| {
+                Ok(CipherResponseModel {
+                    id: Some(TEST_CIPHER_ID.try_into().unwrap()),
+                    name: Some(cipher_name.clone()),
+                    r#type: Some(cipher_type.into()),
+                    creation_date: Some("2025-01-01T00:00:00Z".to_string()),
+                    revision_date: Some(Utc::now().to_string()),
+                    ..Default::default()
+                })
+            });
+        });
+
+        let repository: MemoryRepository<Cipher> = Default::default();
+        repository
+            .set(TEST_CIPHER_ID.parse().unwrap(), cipher)
+            .await
+            .unwrap();
+
+        let result = restore(
+            TEST_CIPHER_ID.parse().unwrap(),
+            &api_client,
+            &repository,
+            &store,
+        )
+        .await
+        .unwrap();
+
+        // collection_ids are not returned by the server's restore response — they must
+        // be preserved from the existing cipher in the repository.
+        assert_eq!(result.collection_ids, vec![collection_id]);
+    }
+
+    #[tokio::test]
+    async fn test_restore_many_preserves_collection_ids() {
+        let store = setup_key_store();
+        let cipher_id: CipherId = TEST_CIPHER_ID.parse().unwrap();
+        let cipher_id_2: CipherId = TEST_CIPHER_ID_2.parse().unwrap();
+        let collection_id: CollectionId = "a4e13cc0-1234-5678-abcd-b181009709b8".parse().unwrap();
+        let collection_id_2: CollectionId = "b5e13cc0-1234-5678-abcd-b181009709b8".parse().unwrap();
+
+        let mut cipher_1 = generate_test_cipher(&store);
+        cipher_1.deleted_date = Some(Utc::now());
+        cipher_1.collection_ids = vec![collection_id];
+
+        let mut cipher_2 = generate_test_cipher(&store);
+        cipher_2.id = Some(cipher_id_2);
+        cipher_2.deleted_date = Some(Utc::now());
+        cipher_2.collection_ids = vec![collection_id_2];
+
+        let api_client = {
+            let cipher_1 = cipher_1.clone();
+            let cipher_2 = cipher_2.clone();
+            ApiClient::new_mocked(move |mock| {
+                mock.ciphers_api.expect_put_restore_many().returning({
+                    move |_| {
+                        Ok(CipherMiniResponseModelListResponseModel {
+                            object: None,
+                            data: Some(vec![
+                                CipherMiniResponseModel {
+                                    id: cipher_1.id.map(|id| id.into()),
+                                    name: Some(cipher_1.name.to_string()),
+                                    r#type: Some(cipher_1.r#type.into()),
+                                    login: cipher_1.login.clone().map(|l| Box::new(l.into())),
+                                    creation_date: cipher_1.creation_date.to_string().into(),
+                                    deleted_date: None,
+                                    revision_date: Some(Utc::now().to_string()),
+                                    ..Default::default()
+                                },
+                                CipherMiniResponseModel {
+                                    id: cipher_2.id.map(|id| id.into()),
+                                    name: Some(cipher_2.name.to_string()),
+                                    r#type: Some(cipher_2.r#type.into()),
+                                    login: cipher_2.login.clone().map(|l| Box::new(l.into())),
+                                    creation_date: cipher_2.creation_date.to_string().into(),
+                                    deleted_date: None,
+                                    revision_date: Some(Utc::now().to_string()),
+                                    ..Default::default()
+                                },
+                            ]),
+                            continuation_token: None,
+                        })
+                    }
+                });
+            })
+        };
+
+        let repository: MemoryRepository<Cipher> = Default::default();
+        repository.set(cipher_id, cipher_1).await.unwrap();
+        repository.set(cipher_id_2, cipher_2).await.unwrap();
+
+        let ciphers = restore_many(
+            vec![cipher_id, cipher_id_2],
+            &api_client,
+            &repository,
+            &store,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(ciphers.successes.len(), 2);
+
+        // collection_ids are not returned by the server's restore response — they must
+        // be preserved from the existing ciphers in the repository.
+        let result_1 = ciphers
+            .successes
+            .iter()
+            .find(|c| c.id == Some(cipher_id))
+            .unwrap();
+        let result_2 = ciphers
+            .successes
+            .iter()
+            .find(|c| c.id == Some(cipher_id_2))
+            .unwrap();
+        assert_eq!(result_1.collection_ids, vec![collection_id]);
+        assert_eq!(result_2.collection_ids, vec![collection_id_2]);
     }
 }

--- a/crates/bitwarden-vault/src/cipher/cipher_client/share_cipher.rs
+++ b/crates/bitwarden-vault/src/cipher/cipher_client/share_cipher.rs
@@ -11,7 +11,7 @@ use wasm_bindgen::prelude::wasm_bindgen;
 
 use crate::{
     Cipher, CipherError, CipherId, CipherRepromptType, CipherView, CiphersClient,
-    EncryptionContext, VaultParseError,
+    EncryptionContext, VaultParseError, cipher::cipher::PartialCipher,
 };
 
 /// Standalone function that shares a cipher to an organization via API call.
@@ -35,7 +35,7 @@ async fn share_cipher(
 
     let response = api_client.put_share(cipher_uuid, Some(req)).await?;
 
-    let mut new_cipher: Cipher = response.try_into()?;
+    let mut new_cipher: Cipher = response.merge_with_cipher(None)?;
     new_cipher.collection_ids = collection_ids;
 
     repository.set(cipher_id, new_cipher.clone()).await?;


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-34141

## 📔 Objective

When `pm-27632-cipher-crud-operations-to-sdk` is enabled, the web clients use the SDK to interface with the Cipher APIs. The response types in some operations omit the `folder_id` and `collection_ids` fields, which causes them to be dropped when converting the service response types to `Cipher`/`CipherView` types. While this didn't affect the data server-side, it causes the repository / local state to lose those values until a sync or refresh.

This PR updates those affected operations to fill in the `folder_id` / `collection_id` values with the previously known values (or values passed with the request, for some operations).
