### PR TITLE
[PM-33554] Fix key rotation breaking when name of emergency access grantee is null

### DIFF
--- a/crates/bitwarden-user-crypto-management/src/key_rotation/sync.rs
+++ b/crates/bitwarden-user-crypto-management/src/key_rotation/sync.rs
@@ -148,7 +148,8 @@ pub(crate) async fn sync_emergency_access(
             let public_key = fetch_user_public_key(api_client, user_id).await?;
             Ok(V1EmergencyAccessMembership {
                 id: ea.id.ok_or(SyncError::DataError)?,
-                name: ea.name.ok_or(SyncError::DataError)?,
+                // The name can be null if a user does not set a name.
+                name: ea.name.unwrap_or_else(|| ea.email.unwrap_or_else(|| "Unknown".to_string())),
                 public_key,
             })
         })

--- a/crates/bitwarden-user-crypto-management/src/key_rotation/sync.rs
+++ b/crates/bitwarden-user-crypto-management/src/key_rotation/sync.rs
@@ -149,7 +149,9 @@ pub(crate) async fn sync_emergency_access(
             Ok(V1EmergencyAccessMembership {
                 id: ea.id.ok_or(SyncError::DataError)?,
                 // The name can be null if a user does not set a name.
-                name: ea.name.unwrap_or_else(|| ea.email.unwrap_or_else(|| "Unknown".to_string())),
+                name: ea
+                    .name
+                    .unwrap_or_else(|| ea.email.unwrap_or_else(|| "Unknown".to_string())),
                 public_key,
             })
         })


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-33554

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
When the emergency access grantee does not set a name, then key rotation via the SDK breaks since the value cannot be unwrapped. This uses the email as a fallback, or even "Unknown" (since no email is allowed by the type system, though it should not occur in real users).

## 🚨 Breaking Changes

<!-- Does this PR introduce any breaking changes? If so, please describe the impact and migration path for clients.

If you're unsure, the automated TypeScript compatibility check will run when you open/update this PR and provide feedback.

For breaking changes:
1. Describe what changed in the client interface
2. Explain why the change was necessary
3. Provide migration steps for client developers
4. Link to any paired client PRs if needed

Otherwise, you can remove this section. -->
