### PR TITLE
[PM-31873] Initialize DB in Client constructors

### DIFF
--- a/crates/bitwarden-core/src/client/client.rs
+++ b/crates/bitwarden-core/src/client/client.rs
@@ -29,7 +29,11 @@ pub struct Client {
 impl Client {
     /// Create a new Bitwarden client with default settings and a no-op token handler.
     pub fn new(settings: Option<ClientSettings>) -> Self {
-        Self::new_internal(settings, Arc::new(NoopTokenHandler), StateRegistry::new_with_memory_db())
+        Self::new_internal(
+            settings,
+            Arc::new(NoopTokenHandler),
+            StateRegistry::new_with_memory_db(),
+        )
     }
 
     /// Create a new Bitwarden client with the specified token handler for managing authentication
@@ -206,11 +210,8 @@ mod tests {
     #[tokio::test]
     async fn client_new_with_token_handler_and_state_uses_supplied_registry() {
         let registry = StateRegistry::new_with_memory_db();
-        let client = Client::new_with_token_handler_and_state(
-            None,
-            Arc::new(NoopTokenHandler),
-            registry,
-        );
+        let client =
+            Client::new_with_token_handler_and_state(None, Arc::new(NoopTokenHandler), registry);
         // Verify the client was constructed successfully with the supplied registry
         let _state = client.platform().state();
     }

--- a/crates/bitwarden-core/src/client/client.rs
+++ b/crates/bitwarden-core/src/client/client.rs
@@ -41,6 +41,17 @@ impl Client {
         Self::new_internal(settings, token_handler, StateRegistry::new_with_memory_db())
     }
 
+    /// Create a new Bitwarden client with the specified token handler and a pre-initialized
+    /// state registry. Use this constructor when restoring a client from persisted state,
+    /// where the state registry has already been loaded from disk.
+    pub fn new_with_token_handler_and_state(
+        settings: Option<ClientSettings>,
+        token_handler: Arc<dyn TokenHandler>,
+        state_registry: StateRegistry,
+    ) -> Self {
+        Self::new_internal(settings, token_handler, state_registry)
+    }
+
     fn new_internal(
         settings_input: Option<ClientSettings>,
         token_handler: Arc<dyn TokenHandler>,
@@ -179,4 +190,28 @@ fn build_default_headers(settings: &ClientSettings) -> header::HeaderMap {
     );
 
     headers
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn client_new_has_accessible_state_registry() {
+        let client = Client::new(None);
+        // Verify state registry is accessible without panicking
+        let _state = client.platform().state();
+    }
+
+    #[tokio::test]
+    async fn client_new_with_token_handler_and_state_uses_supplied_registry() {
+        let registry = StateRegistry::new_with_memory_db();
+        let client = Client::new_with_token_handler_and_state(
+            None,
+            Arc::new(NoopTokenHandler),
+            registry,
+        );
+        // Verify the client was constructed successfully with the supplied registry
+        let _state = client.platform().state();
+    }
 }

--- a/crates/bitwarden-core/src/client/client.rs
+++ b/crates/bitwarden-core/src/client/client.rs
@@ -1,7 +1,6 @@
 use std::sync::{Arc, OnceLock, RwLock};
 
 use bitwarden_crypto::KeyStore;
-#[cfg(feature = "internal")]
 use bitwarden_state::registry::StateRegistry;
 use reqwest::header::{self, HeaderValue};
 
@@ -30,7 +29,7 @@ pub struct Client {
 impl Client {
     /// Create a new Bitwarden client with default settings and a no-op token handler.
     pub fn new(settings: Option<ClientSettings>) -> Self {
-        Self::new_internal(settings, Arc::new(NoopTokenHandler))
+        Self::new_internal(settings, Arc::new(NoopTokenHandler), StateRegistry::new_with_memory_db())
     }
 
     /// Create a new Bitwarden client with the specified token handler for managing authentication
@@ -39,12 +38,13 @@ impl Client {
         settings: Option<ClientSettings>,
         token_handler: Arc<dyn TokenHandler>,
     ) -> Self {
-        Self::new_internal(settings, token_handler)
+        Self::new_internal(settings, token_handler, StateRegistry::new_with_memory_db())
     }
 
     fn new_internal(
         settings_input: Option<ClientSettings>,
         token_handler: Arc<dyn TokenHandler>,
+        state_registry: StateRegistry,
     ) -> Self {
         let settings = settings_input.unwrap_or_default();
 
@@ -97,8 +97,7 @@ impl Client {
                 key_store,
                 #[cfg(feature = "internal")]
                 security_state: RwLock::new(None),
-                #[cfg(feature = "internal")]
-                repository_map: StateRegistry::new(),
+                state_registry,
             }),
         }
     }

--- a/crates/bitwarden-core/src/client/client.rs
+++ b/crates/bitwarden-core/src/client/client.rs
@@ -200,6 +200,7 @@ fn build_default_headers(settings: &ClientSettings) -> header::HeaderMap {
 mod tests {
     use super::*;
 
+    #[cfg(feature = "internal")]
     #[tokio::test]
     async fn client_new_has_accessible_state_registry() {
         let client = Client::new(None);
@@ -207,6 +208,7 @@ mod tests {
         let _state = client.platform().state();
     }
 
+    #[cfg(feature = "internal")]
     #[tokio::test]
     async fn client_new_with_token_handler_and_state_uses_supplied_registry() {
         let registry = StateRegistry::new_with_memory_db();

--- a/crates/bitwarden-core/src/client/internal.rs
+++ b/crates/bitwarden-core/src/client/internal.rs
@@ -7,7 +7,6 @@ use bitwarden_crypto::SymmetricCryptoKey;
 use bitwarden_crypto::{
     EncString, Kdf, MasterKey, PinKey, UnsignedSharedKey, safe::PasswordProtectedKeyEnvelope,
 };
-#[cfg(feature = "internal")]
 use bitwarden_state::registry::StateRegistry;
 #[cfg(feature = "internal")]
 use tracing::{debug, info, instrument};
@@ -110,8 +109,7 @@ pub struct InternalClient {
     #[cfg(feature = "internal")]
     pub(crate) security_state: RwLock<Option<SecurityState>>,
 
-    #[cfg(feature = "internal")]
-    pub(crate) repository_map: StateRegistry,
+    pub(crate) state_registry: StateRegistry,
 }
 
 impl InternalClient {

--- a/crates/bitwarden-core/src/platform/state_client.rs
+++ b/crates/bitwarden-core/src/platform/state_client.rs
@@ -21,7 +21,7 @@ impl StateClient {
     ) {
         self.client
             .internal
-            .repository_map
+            .state_registry
             .register_client_managed(store)
     }
 
@@ -33,7 +33,7 @@ impl StateClient {
     ) -> Result<(), StateRegistryError> {
         self.client
             .internal
-            .repository_map
+            .state_registry
             .initialize_database(configuration, migrations)
             .await
     }
@@ -49,7 +49,7 @@ impl StateClient {
     where
         T: RepositoryItem,
     {
-        self.client.internal.repository_map.get()
+        self.client.internal.state_registry.get()
     }
 
     /// Get a handle to a setting by its type-safe key.
@@ -75,7 +75,7 @@ impl StateClient {
     /// # }
     /// ```
     pub fn setting<T>(&self, key: Key<T>) -> Result<Setting<T>, SettingsError> {
-        let repository = self.client.internal.repository_map.get::<SettingItem>()?;
+        let repository = self.client.internal.state_registry.get::<SettingItem>()?;
         Ok(Setting::new(repository, key))
     }
 }

--- a/crates/bitwarden-state/src/registry.rs
+++ b/crates/bitwarden-state/src/registry.rs
@@ -53,14 +53,6 @@ impl StateRegistry {
     }
 
     /// Creates a new `StateRegistry` backed by an in-memory database.
-    ///
-    /// This is a synchronous constructor suitable for use in `Client::new_internal()`
-    /// and other sync contexts. The in-memory database requires no I/O or async
-    /// initialization.
-    ///
-    /// Note: The `sdk_managed` Vec is not populated (no migration steps for memory).
-    /// Callers can use `register_client_managed` or access repositories
-    /// directly via `get::<T>()`.
     pub fn new_with_memory_db() -> Self {
         let registry = Self::new();
         // OnceLock::set returns Err only if already set.
@@ -104,14 +96,6 @@ impl StateRegistry {
     }
 
     /// Get a handle to a setting by its type-safe key.
-    ///
-    /// Returns a [`Setting`] handle that can be used to get, update, or delete
-    /// the setting value directly from the registry, without requiring a
-    /// `StateClient` wrapper.
-    ///
-    /// # Errors
-    /// Returns an error if the database is not initialized or the repository
-    /// is not accessible.
     pub fn setting<T>(&self, key: Key<T>) -> Result<Setting<T>, SettingsError> {
         let repository = self.get::<SettingItem>()?;
         Ok(Setting::new(repository, key))

--- a/crates/bitwarden-state/src/registry.rs
+++ b/crates/bitwarden-state/src/registry.rs
@@ -10,7 +10,7 @@ use thiserror::Error;
 use crate::{
     repository::{Repository, RepositoryItem, RepositoryItemData, RepositoryMigrations},
     sdk_managed::{Database, DatabaseConfiguration, MemoryDatabase, SystemDatabase},
-    settings::{Key, Setting, SettingItem, SettingsError},
+    settings::{Key, Setting, SettingItem},
 };
 
 /// A registry that contains repositories for different types of items.
@@ -96,9 +96,9 @@ impl StateRegistry {
     }
 
     /// Get a handle to a setting by its type-safe key.
-    pub fn setting<T>(&self, key: Key<T>) -> Result<Setting<T>, SettingsError> {
-        let repository = self.get::<SettingItem>()?;
-        Ok(Setting::new(repository, key))
+    pub fn setting<T>(&self, key: Key<T>) -> Setting<T> {
+        let repo = self.get::<SettingItem>().expect("DB is always initialized");
+        Setting::new(repo, key)
     }
 
     /// Registers a client-managed repository into the map, associating it with its type.
@@ -294,7 +294,7 @@ mod tests {
         register_setting_key!(const TEST_SETTING: String = "test_registry_setting_key");
 
         let registry = StateRegistry::new_with_memory_db();
-        let setting = registry.setting(TEST_SETTING).unwrap();
+        let setting = registry.setting(TEST_SETTING);
 
         // Value must not exist initially
         assert_eq!(setting.get().await.unwrap(), None::<String>);

--- a/crates/bitwarden-state/src/registry.rs
+++ b/crates/bitwarden-state/src/registry.rs
@@ -9,7 +9,8 @@ use thiserror::Error;
 
 use crate::{
     repository::{Repository, RepositoryItem, RepositoryItemData, RepositoryMigrations},
-    sdk_managed::{Database, DatabaseConfiguration, SystemDatabase},
+    sdk_managed::{Database, DatabaseConfiguration, MemoryDatabase, SystemDatabase},
+    settings::{Key, Setting, SettingItem, SettingsError},
 };
 
 /// A registry that contains repositories for different types of items.
@@ -51,6 +52,26 @@ impl StateRegistry {
         }
     }
 
+    /// Creates a new `StateRegistry` backed by an in-memory database.
+    ///
+    /// This is a synchronous constructor suitable for use in `Client::new_internal()`
+    /// and other sync contexts. The in-memory database requires no I/O or async
+    /// initialization.
+    ///
+    /// Note: The `sdk_managed` Vec is not populated (no migration steps for memory).
+    /// Callers can use `register_client_managed` or rely on the OnceLock database
+    /// directly via `get_sdk_managed`.
+    pub fn new_with_memory_db() -> Self {
+        let registry = Self::new();
+        // SAFETY: OnceLock::set returns Err only if already set.
+        // new() guarantees the OnceLock is unset. We ignore the result
+        // because there is no failure scenario here.
+        let _ = registry
+            .database
+            .set(SystemDatabase::Memory(MemoryDatabase::new()));
+        registry
+    }
+
     // TODO: Ideally we'd do this in new, but that would mean making the client initialization
     // async.
     // TODO: This function needs to be provided some configuration to know where to open the
@@ -80,6 +101,20 @@ impl StateRegistry {
             .expect("RwLock should not be poisoned") = migrations.into_repository_items();
 
         Ok(())
+    }
+
+    /// Get a handle to a setting by its type-safe key.
+    ///
+    /// Returns a [`Setting`] handle that can be used to get, update, or delete
+    /// the setting value directly from the registry, without requiring a
+    /// `StateClient` wrapper.
+    ///
+    /// # Errors
+    /// Returns an error if the database is not initialized or the repository
+    /// is not accessible.
+    pub fn setting<T>(&self, key: Key<T>) -> Result<Setting<T>, SettingsError> {
+        let repository = self.get::<SettingItem>()?;
+        Ok(Setting::new(repository, key))
     }
 
     /// Registers a client-managed repository into the map, associating it with its type.
@@ -255,5 +290,37 @@ mod tests {
             result,
             Err(StateRegistryError::DatabaseNotInitialized)
         ));
+    }
+
+    #[tokio::test]
+    async fn test_new_with_memory_db_sync() {
+        // Construct in sync context (no .await on the constructor itself)
+        let registry = StateRegistry::new_with_memory_db();
+        // Database must be accessible via async get after sync construction
+        let repo = registry.get::<TestItem<usize>>().unwrap();
+        let result = repo.get(String::new()).await;
+        // Should return Ok(None) — key not found, not an error
+        // (Note: TestItem<usize> is registered in this test module already)
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_setting_on_memory_db() {
+        use crate::register_setting_key;
+        register_setting_key!(const TEST_SETTING: String = "test_registry_setting_key");
+
+        let registry = StateRegistry::new_with_memory_db();
+        let setting = registry.setting(TEST_SETTING).unwrap();
+
+        // Value must not exist initially
+        assert_eq!(setting.get().await.unwrap(), None::<String>);
+
+        // Update and read back
+        setting.update("hello".to_string()).await.unwrap();
+        assert_eq!(setting.get().await.unwrap(), Some("hello".to_string()));
+
+        // Delete and confirm gone
+        setting.delete().await.unwrap();
+        assert_eq!(setting.get().await.unwrap(), None::<String>);
     }
 }

--- a/crates/bitwarden-state/src/registry.rs
+++ b/crates/bitwarden-state/src/registry.rs
@@ -96,9 +96,9 @@ impl StateRegistry {
     }
 
     /// Get a handle to a setting by its type-safe key.
-    pub fn setting<T>(&self, key: Key<T>) -> Setting<T> {
-        let repo = self.get::<SettingItem>().expect("DB is always initialized");
-        Setting::new(repo, key)
+    pub fn setting<T>(&self, key: Key<T>) -> Result<Setting<T>, StateRegistryError> {
+        let repo = self.get::<SettingItem>()?;
+        Ok(Setting::new(repo, key))
     }
 
     /// Registers a client-managed repository into the map, associating it with its type.
@@ -294,7 +294,7 @@ mod tests {
         register_setting_key!(const TEST_SETTING: String = "test_registry_setting_key");
 
         let registry = StateRegistry::new_with_memory_db();
-        let setting = registry.setting(TEST_SETTING);
+        let setting = registry.setting(TEST_SETTING).unwrap();
 
         // Value must not exist initially
         assert_eq!(setting.get().await.unwrap(), None::<String>);

--- a/crates/bitwarden-state/src/registry.rs
+++ b/crates/bitwarden-state/src/registry.rs
@@ -59,11 +59,11 @@ impl StateRegistry {
     /// initialization.
     ///
     /// Note: The `sdk_managed` Vec is not populated (no migration steps for memory).
-    /// Callers can use `register_client_managed` or rely on the OnceLock database
-    /// directly via `get_sdk_managed`.
+    /// Callers can use `register_client_managed` or access repositories
+    /// directly via `get::<T>()`.
     pub fn new_with_memory_db() -> Self {
         let registry = Self::new();
-        // SAFETY: OnceLock::set returns Err only if already set.
+        // OnceLock::set returns Err only if already set.
         // new() guarantees the OnceLock is unset. We ignore the result
         // because there is no failure scenario here.
         let _ = registry

--- a/crates/bitwarden-state/src/sdk_managed/configuration.rs
+++ b/crates/bitwarden-state/src/sdk_managed/configuration.rs
@@ -18,4 +18,8 @@ pub enum DatabaseConfiguration {
         /// names to avoid conflicts.
         db_name: String,
     },
+
+    /// In-memory configuration — no fields needed.
+    /// Data is stored in process RAM only and is not persisted.
+    Memory,
 }

--- a/crates/bitwarden-state/src/sdk_managed/memory.rs
+++ b/crates/bitwarden-state/src/sdk_managed/memory.rs
@@ -1,0 +1,255 @@
+use std::{any::TypeId, collections::HashMap, sync::Arc};
+
+use serde::{Serialize, de::DeserializeOwned};
+use tokio::sync::Mutex;
+
+use crate::{
+    repository::{RepositoryItem, RepositoryMigrations},
+    sdk_managed::{Database, DatabaseConfiguration, DatabaseError},
+};
+
+/// In-memory database backend implementing the [[Database]] trait.
+///
+/// Stores data in process RAM using a [[TypeId]]-keyed nested HashMap.
+/// Intended for testing, development, and cross-platform use cases where
+/// persistent storage is not required.
+///
+/// All data is lost when the instance is dropped.
+#[derive(Clone)]
+pub struct MemoryDatabase(Arc<Mutex<HashMap<TypeId, HashMap<String, String>>>>);
+
+impl MemoryDatabase {
+    /// Create a new, empty in-memory database.
+    pub fn new() -> Self {
+        MemoryDatabase(Arc::new(Mutex::new(HashMap::new())))
+    }
+}
+
+impl Database for MemoryDatabase {
+    async fn initialize(
+        _configuration: DatabaseConfiguration,
+        _migrations: RepositoryMigrations,
+    ) -> Result<Self, DatabaseError> {
+        // Memory database requires no I/O or schema initialization.
+        // Migrations are intentionally ignored — there is no schema to version.
+        Ok(MemoryDatabase::new())
+    }
+
+    async fn get<T: Serialize + DeserializeOwned + RepositoryItem>(
+        &self,
+        key: &str,
+    ) -> Result<Option<T>, DatabaseError> {
+        let store = self.0.lock().await;
+        let type_map = store.get(&TypeId::of::<T>());
+        match type_map.and_then(|m| m.get(key)) {
+            Some(json) => Ok(Some(serde_json::from_str(json)?)),
+            None => Ok(None),
+        }
+    }
+
+    async fn list<T: Serialize + DeserializeOwned + RepositoryItem>(
+        &self,
+    ) -> Result<Vec<T>, DatabaseError> {
+        let store = self.0.lock().await;
+        match store.get(&TypeId::of::<T>()) {
+            None => Ok(vec![]),
+            Some(type_map) => {
+                let mut results = Vec::with_capacity(type_map.len());
+                for json in type_map.values() {
+                    results.push(serde_json::from_str(json)?);
+                }
+                Ok(results)
+            }
+        }
+    }
+
+    async fn set<T: Serialize + DeserializeOwned + RepositoryItem>(
+        &self,
+        key: &str,
+        value: T,
+    ) -> Result<(), DatabaseError> {
+        let json = serde_json::to_string(&value)?;
+        let mut store = self.0.lock().await;
+        store
+            .entry(TypeId::of::<T>())
+            .or_default()
+            .insert(key.to_string(), json);
+        Ok(())
+    }
+
+    async fn set_bulk<T: Serialize + DeserializeOwned + RepositoryItem>(
+        &self,
+        values: Vec<(String, T)>,
+    ) -> Result<(), DatabaseError> {
+        let mut store = self.0.lock().await;
+        let type_map = store.entry(TypeId::of::<T>()).or_default();
+        for (key, value) in values {
+            let json = serde_json::to_string(&value)?;
+            type_map.insert(key, json);
+        }
+        Ok(())
+    }
+
+    async fn remove<T: Serialize + DeserializeOwned + RepositoryItem>(
+        &self,
+        key: &str,
+    ) -> Result<(), DatabaseError> {
+        let mut store = self.0.lock().await;
+        if let Some(type_map) = store.get_mut(&TypeId::of::<T>()) {
+            type_map.remove(key);
+        }
+        Ok(())
+    }
+
+    async fn remove_bulk<T: Serialize + DeserializeOwned + RepositoryItem>(
+        &self,
+        keys: Vec<String>,
+    ) -> Result<(), DatabaseError> {
+        let mut store = self.0.lock().await;
+        if let Some(type_map) = store.get_mut(&TypeId::of::<T>()) {
+            for key in keys {
+                type_map.remove(&key);
+            }
+        }
+        Ok(())
+    }
+
+    async fn remove_all<T: Serialize + DeserializeOwned + RepositoryItem>(
+        &self,
+    ) -> Result<(), DatabaseError> {
+        let mut store = self.0.lock().await;
+        store.remove(&TypeId::of::<T>());
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::register_repository_item;
+
+    #[derive(Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+    struct TypeA(String);
+    register_repository_item!(String => TypeA, "MemTypeA");
+
+    #[derive(Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+    struct TypeB(u64);
+    register_repository_item!(String => TypeB, "MemTypeB");
+
+    #[tokio::test]
+    async fn test_memory_database_get_set_remove() {
+        let db = MemoryDatabase::new();
+        assert_eq!(db.get::<TypeA>("key1").await.unwrap(), None);
+        db.set("key1", TypeA("hello".to_string())).await.unwrap();
+        assert_eq!(
+            db.get::<TypeA>("key1").await.unwrap(),
+            Some(TypeA("hello".to_string()))
+        );
+        db.remove::<TypeA>("key1").await.unwrap();
+        assert_eq!(db.get::<TypeA>("key1").await.unwrap(), None);
+    }
+
+    #[tokio::test]
+    async fn test_memory_database_type_isolation() {
+        let db = MemoryDatabase::new();
+        // Same string key for both types — must not interfere
+        db.set("key1", TypeA("value_a".to_string())).await.unwrap();
+        db.set("key1", TypeB(42)).await.unwrap();
+        assert_eq!(
+            db.get::<TypeA>("key1").await.unwrap(),
+            Some(TypeA("value_a".to_string()))
+        );
+        assert_eq!(db.get::<TypeB>("key1").await.unwrap(), Some(TypeB(42)));
+    }
+
+    #[tokio::test]
+    async fn test_memory_database_clone_shares_store() {
+        let db1 = MemoryDatabase::new();
+        let db2 = db1.clone();
+        db1.set("key1", TypeA("shared".to_string())).await.unwrap();
+        assert_eq!(
+            db2.get::<TypeA>("key1").await.unwrap(),
+            Some(TypeA("shared".to_string()))
+        );
+    }
+
+    #[tokio::test]
+    async fn test_memory_database_list() {
+        let db = MemoryDatabase::new();
+        db.set("a", TypeA("1".to_string())).await.unwrap();
+        db.set("b", TypeA("2".to_string())).await.unwrap();
+        db.set("c", TypeB(99)).await.unwrap();
+        let mut list_a = db.list::<TypeA>().await.unwrap();
+        list_a.sort_by_key(|x| x.0.clone());
+        assert_eq!(list_a, vec![TypeA("1".to_string()), TypeA("2".to_string())]);
+        // TypeB must not appear in TypeA list
+        assert_eq!(db.list::<TypeB>().await.unwrap(), vec![TypeB(99)]);
+    }
+
+    #[tokio::test]
+    async fn test_memory_database_set_bulk() {
+        let db = MemoryDatabase::new();
+        db.set_bulk(vec![
+            ("x".to_string(), TypeA("v1".to_string())),
+            ("y".to_string(), TypeA("v2".to_string())),
+        ])
+        .await
+        .unwrap();
+        assert_eq!(
+            db.get::<TypeA>("x").await.unwrap(),
+            Some(TypeA("v1".to_string()))
+        );
+        assert_eq!(
+            db.get::<TypeA>("y").await.unwrap(),
+            Some(TypeA("v2".to_string()))
+        );
+    }
+
+    #[tokio::test]
+    async fn test_memory_database_remove_bulk() {
+        let db = MemoryDatabase::new();
+        db.set("a", TypeA("1".to_string())).await.unwrap();
+        db.set("b", TypeA("2".to_string())).await.unwrap();
+        db.set("c", TypeA("3".to_string())).await.unwrap();
+        db.remove_bulk::<TypeA>(vec!["a".to_string(), "b".to_string()])
+            .await
+            .unwrap();
+        assert_eq!(db.get::<TypeA>("a").await.unwrap(), None);
+        assert_eq!(db.get::<TypeA>("b").await.unwrap(), None);
+        assert_eq!(
+            db.get::<TypeA>("c").await.unwrap(),
+            Some(TypeA("3".to_string()))
+        );
+    }
+
+    #[tokio::test]
+    async fn test_memory_database_remove_all() {
+        let db = MemoryDatabase::new();
+        db.set("a", TypeA("1".to_string())).await.unwrap();
+        db.set("b", TypeA("2".to_string())).await.unwrap();
+        db.set("z", TypeB(5)).await.unwrap();
+        db.remove_all::<TypeA>().await.unwrap();
+        assert_eq!(db.list::<TypeA>().await.unwrap(), vec![]);
+        // TypeB must be unaffected
+        assert_eq!(db.list::<TypeB>().await.unwrap(), vec![TypeB(5)]);
+    }
+
+    #[tokio::test]
+    async fn test_memory_database_initialize_is_noop() {
+        let db = MemoryDatabase::initialize(
+            DatabaseConfiguration::Sqlite {
+                db_name: "ignored".to_string(),
+                folder_path: std::path::PathBuf::from("/tmp"),
+            },
+            RepositoryMigrations::new(vec![]),
+        )
+        .await
+        .unwrap();
+        // initialize returns a fresh, working instance regardless of config
+        db.set("k", TypeA("v".to_string())).await.unwrap();
+        assert_eq!(
+            db.get::<TypeA>("k").await.unwrap(),
+            Some(TypeA("v".to_string()))
+        );
+    }
+}

--- a/crates/bitwarden-state/src/sdk_managed/memory.rs
+++ b/crates/bitwarden-state/src/sdk_managed/memory.rs
@@ -30,10 +30,12 @@ impl MemoryDatabase {
 
 impl Database for MemoryDatabase {
     async fn initialize(
-        _configuration: DatabaseConfiguration,
+        configuration: DatabaseConfiguration,
         _migrations: RepositoryMigrations,
     ) -> Result<Self, DatabaseError> {
-        // Migrations are intentionally ignored — there is no schema to version.
+        let DatabaseConfiguration::Memory = configuration else {
+            return Err(DatabaseError::UnsupportedConfiguration(configuration));
+        };
         Ok(MemoryDatabase::new())
     }
 
@@ -237,21 +239,33 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_memory_database_initialize_is_noop() {
+    async fn test_memory_database_initialize_memory_config() {
         let db = MemoryDatabase::initialize(
+            DatabaseConfiguration::Memory,
+            RepositoryMigrations::new(vec![]),
+        )
+        .await
+        .unwrap();
+        db.set("k", TypeA("v".to_string())).await.unwrap();
+        assert_eq!(
+            db.get::<TypeA>("k").await.unwrap(),
+            Some(TypeA("v".to_string()))
+        );
+    }
+
+    #[tokio::test]
+    async fn test_memory_database_initialize_rejects_non_memory_config() {
+        let result = MemoryDatabase::initialize(
             DatabaseConfiguration::Sqlite {
                 db_name: "ignored".to_string(),
                 folder_path: std::path::PathBuf::from("/tmp"),
             },
             RepositoryMigrations::new(vec![]),
         )
-        .await
-        .unwrap();
-        // initialize returns a fresh, working instance regardless of config
-        db.set("k", TypeA("v".to_string())).await.unwrap();
-        assert_eq!(
-            db.get::<TypeA>("k").await.unwrap(),
-            Some(TypeA("v".to_string()))
-        );
+        .await;
+        assert!(matches!(
+            result,
+            Err(DatabaseError::UnsupportedConfiguration(_))
+        ));
     }
 }

--- a/crates/bitwarden-state/src/sdk_managed/memory.rs
+++ b/crates/bitwarden-state/src/sdk_managed/memory.rs
@@ -8,9 +8,9 @@ use crate::{
     sdk_managed::{Database, DatabaseConfiguration, DatabaseError},
 };
 
-/// In-memory database backend implementing the [[Database]] trait.
+/// In-memory database backend implementing the [`Database`] trait.
 ///
-/// Stores data in process RAM using a [[TypeId]]-keyed nested HashMap.
+/// Stores data in process RAM using a [`TypeId`]-keyed nested HashMap.
 /// Intended for testing, development, and cross-platform use cases where
 /// persistent storage is not required.
 ///

--- a/crates/bitwarden-state/src/sdk_managed/memory.rs
+++ b/crates/bitwarden-state/src/sdk_managed/memory.rs
@@ -30,7 +30,6 @@ impl Database for MemoryDatabase {
         _configuration: DatabaseConfiguration,
         _migrations: RepositoryMigrations,
     ) -> Result<Self, DatabaseError> {
-        // Memory database requires no I/O or schema initialization.
         // Migrations are intentionally ignored — there is no schema to version.
         Ok(MemoryDatabase::new())
     }

--- a/crates/bitwarden-state/src/sdk_managed/memory.rs
+++ b/crates/bitwarden-state/src/sdk_managed/memory.rs
@@ -1,7 +1,6 @@
-use std::{any::TypeId, collections::HashMap, sync::Arc};
+use std::{any::TypeId, collections::HashMap, sync::{Arc, Mutex}};
 
 use serde::{Serialize, de::DeserializeOwned};
-use tokio::sync::Mutex;
 
 use crate::{
     repository::{RepositoryItem, RepositoryMigrations},
@@ -38,7 +37,7 @@ impl Database for MemoryDatabase {
         &self,
         key: &str,
     ) -> Result<Option<T>, DatabaseError> {
-        let store = self.0.lock().await;
+        let store = self.0.lock().expect("Mutex is not poisoned");
         let type_map = store.get(&TypeId::of::<T>());
         match type_map.and_then(|m| m.get(key)) {
             Some(json) => Ok(Some(serde_json::from_str(json)?)),
@@ -49,7 +48,7 @@ impl Database for MemoryDatabase {
     async fn list<T: Serialize + DeserializeOwned + RepositoryItem>(
         &self,
     ) -> Result<Vec<T>, DatabaseError> {
-        let store = self.0.lock().await;
+        let store = self.0.lock().expect("Mutex is not poisoned");
         match store.get(&TypeId::of::<T>()) {
             None => Ok(vec![]),
             Some(type_map) => {
@@ -68,7 +67,7 @@ impl Database for MemoryDatabase {
         value: T,
     ) -> Result<(), DatabaseError> {
         let json = serde_json::to_string(&value)?;
-        let mut store = self.0.lock().await;
+        let mut store = self.0.lock().expect("Mutex is not poisoned");
         store
             .entry(TypeId::of::<T>())
             .or_default()
@@ -80,7 +79,7 @@ impl Database for MemoryDatabase {
         &self,
         values: Vec<(String, T)>,
     ) -> Result<(), DatabaseError> {
-        let mut store = self.0.lock().await;
+        let mut store = self.0.lock().expect("Mutex is not poisoned");
         let type_map = store.entry(TypeId::of::<T>()).or_default();
         for (key, value) in values {
             let json = serde_json::to_string(&value)?;
@@ -93,7 +92,7 @@ impl Database for MemoryDatabase {
         &self,
         key: &str,
     ) -> Result<(), DatabaseError> {
-        let mut store = self.0.lock().await;
+        let mut store = self.0.lock().expect("Mutex is not poisoned");
         if let Some(type_map) = store.get_mut(&TypeId::of::<T>()) {
             type_map.remove(key);
         }
@@ -104,7 +103,7 @@ impl Database for MemoryDatabase {
         &self,
         keys: Vec<String>,
     ) -> Result<(), DatabaseError> {
-        let mut store = self.0.lock().await;
+        let mut store = self.0.lock().expect("Mutex is not poisoned");
         if let Some(type_map) = store.get_mut(&TypeId::of::<T>()) {
             for key in keys {
                 type_map.remove(&key);
@@ -116,7 +115,7 @@ impl Database for MemoryDatabase {
     async fn remove_all<T: Serialize + DeserializeOwned + RepositoryItem>(
         &self,
     ) -> Result<(), DatabaseError> {
-        let mut store = self.0.lock().await;
+        let mut store = self.0.lock().expect("Mutex is not poisoned");
         store.remove(&TypeId::of::<T>());
         Ok(())
     }

--- a/crates/bitwarden-state/src/sdk_managed/memory.rs
+++ b/crates/bitwarden-state/src/sdk_managed/memory.rs
@@ -1,4 +1,8 @@
-use std::{any::TypeId, collections::HashMap, sync::{Arc, Mutex}};
+use std::{
+    any::TypeId,
+    collections::HashMap,
+    sync::{Arc, Mutex},
+};
 
 use serde::{Serialize, de::DeserializeOwned};
 

--- a/crates/bitwarden-state/src/sdk_managed/mod.rs
+++ b/crates/bitwarden-state/src/sdk_managed/mod.rs
@@ -10,17 +10,12 @@ pub use configuration::DatabaseConfiguration;
 
 #[cfg(target_arch = "wasm32")]
 mod indexed_db;
-#[cfg(target_arch = "wasm32")]
-pub(super) type SystemDatabase = indexed_db::IndexedDbDatabase;
-#[cfg(target_arch = "wasm32")]
-type InternalError = ::indexed_db::Error<indexed_db::IndexedDbInternalError>;
 
 #[cfg(not(target_arch = "wasm32"))]
 mod sqlite;
-#[cfg(not(target_arch = "wasm32"))]
-pub(super) type SystemDatabase = sqlite::SqliteDatabase;
-#[cfg(not(target_arch = "wasm32"))]
-type InternalError = ::rusqlite::Error;
+
+mod memory;
+pub(super) use memory::MemoryDatabase;
 
 #[bitwarden_error(flat)]
 #[derive(Debug, Error)]
@@ -37,8 +32,22 @@ pub enum DatabaseError {
     #[error("JS error: {0}")]
     JS(String),
 
-    #[error(transparent)]
-    Internal(#[from] InternalError),
+    #[error("Internal error: {0}")]
+    Internal(String),
+}
+
+#[cfg(target_arch = "wasm32")]
+impl From<::indexed_db::Error<indexed_db::IndexedDbInternalError>> for DatabaseError {
+    fn from(e: ::indexed_db::Error<indexed_db::IndexedDbInternalError>) -> Self {
+        DatabaseError::Internal(e.to_string())
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+impl From<rusqlite::Error> for DatabaseError {
+    fn from(e: rusqlite::Error) -> Self {
+        DatabaseError::Internal(e.to_string())
+    }
 }
 
 pub trait Database {
@@ -65,6 +74,109 @@ pub trait Database {
     async fn remove_bulk<T: RepositoryItem>(&self, keys: Vec<String>) -> Result<(), DatabaseError>;
 
     async fn remove_all<T: RepositoryItem>(&self) -> Result<(), DatabaseError>;
+}
+
+#[derive(Clone)]
+pub(super) enum SystemDatabase {
+    #[cfg(not(target_arch = "wasm32"))]
+    Sqlite(sqlite::SqliteDatabase),
+    #[cfg(target_arch = "wasm32")]
+    IndexedDb(indexed_db::IndexedDbDatabase),
+    Memory(MemoryDatabase),
+}
+
+impl Database for SystemDatabase {
+    async fn initialize(
+        configuration: DatabaseConfiguration,
+        migrations: RepositoryMigrations,
+    ) -> Result<Self, DatabaseError> {
+        match configuration {
+            #[cfg(not(target_arch = "wasm32"))]
+            DatabaseConfiguration::Sqlite { .. } => Ok(SystemDatabase::Sqlite(
+                sqlite::SqliteDatabase::initialize(configuration, migrations).await?,
+            )),
+            #[cfg(target_arch = "wasm32")]
+            DatabaseConfiguration::IndexedDb { .. } => Ok(SystemDatabase::IndexedDb(
+                indexed_db::IndexedDbDatabase::initialize(configuration, migrations).await?,
+            )),
+            DatabaseConfiguration::Memory => Ok(SystemDatabase::Memory(MemoryDatabase::new())),
+            #[allow(unreachable_patterns)]
+            other => Err(DatabaseError::UnsupportedConfiguration(other)),
+        }
+    }
+
+    async fn get<T: RepositoryItem>(&self, key: &str) -> Result<Option<T>, DatabaseError> {
+        match self {
+            #[cfg(not(target_arch = "wasm32"))]
+            SystemDatabase::Sqlite(db) => db.get(key).await,
+            #[cfg(target_arch = "wasm32")]
+            SystemDatabase::IndexedDb(db) => db.get(key).await,
+            SystemDatabase::Memory(db) => db.get(key).await,
+        }
+    }
+
+    async fn list<T: RepositoryItem>(&self) -> Result<Vec<T>, DatabaseError> {
+        match self {
+            #[cfg(not(target_arch = "wasm32"))]
+            SystemDatabase::Sqlite(db) => db.list().await,
+            #[cfg(target_arch = "wasm32")]
+            SystemDatabase::IndexedDb(db) => db.list().await,
+            SystemDatabase::Memory(db) => db.list().await,
+        }
+    }
+
+    async fn set<T: RepositoryItem>(&self, key: &str, value: T) -> Result<(), DatabaseError> {
+        match self {
+            #[cfg(not(target_arch = "wasm32"))]
+            SystemDatabase::Sqlite(db) => db.set(key, value).await,
+            #[cfg(target_arch = "wasm32")]
+            SystemDatabase::IndexedDb(db) => db.set(key, value).await,
+            SystemDatabase::Memory(db) => db.set(key, value).await,
+        }
+    }
+
+    async fn set_bulk<T: RepositoryItem>(
+        &self,
+        values: Vec<(String, T)>,
+    ) -> Result<(), DatabaseError> {
+        match self {
+            #[cfg(not(target_arch = "wasm32"))]
+            SystemDatabase::Sqlite(db) => db.set_bulk(values).await,
+            #[cfg(target_arch = "wasm32")]
+            SystemDatabase::IndexedDb(db) => db.set_bulk(values).await,
+            SystemDatabase::Memory(db) => db.set_bulk(values).await,
+        }
+    }
+
+    async fn remove<T: RepositoryItem>(&self, key: &str) -> Result<(), DatabaseError> {
+        match self {
+            #[cfg(not(target_arch = "wasm32"))]
+            SystemDatabase::Sqlite(db) => db.remove::<T>(key).await,
+            #[cfg(target_arch = "wasm32")]
+            SystemDatabase::IndexedDb(db) => db.remove::<T>(key).await,
+            SystemDatabase::Memory(db) => db.remove::<T>(key).await,
+        }
+    }
+
+    async fn remove_bulk<T: RepositoryItem>(&self, keys: Vec<String>) -> Result<(), DatabaseError> {
+        match self {
+            #[cfg(not(target_arch = "wasm32"))]
+            SystemDatabase::Sqlite(db) => db.remove_bulk::<T>(keys).await,
+            #[cfg(target_arch = "wasm32")]
+            SystemDatabase::IndexedDb(db) => db.remove_bulk::<T>(keys).await,
+            SystemDatabase::Memory(db) => db.remove_bulk::<T>(keys).await,
+        }
+    }
+
+    async fn remove_all<T: RepositoryItem>(&self) -> Result<(), DatabaseError> {
+        match self {
+            #[cfg(not(target_arch = "wasm32"))]
+            SystemDatabase::Sqlite(db) => db.remove_all::<T>().await,
+            #[cfg(target_arch = "wasm32")]
+            SystemDatabase::IndexedDb(db) => db.remove_all::<T>().await,
+            SystemDatabase::Memory(db) => db.remove_all::<T>().await,
+        }
+    }
 }
 
 struct DBRepository<T: RepositoryItem> {

--- a/crates/bitwarden-state/src/sdk_managed/sqlite.rs
+++ b/crates/bitwarden-state/src/sdk_managed/sqlite.rs
@@ -19,7 +19,7 @@ fn validate_identifier(name: &'static str) -> Result<&'static str, DatabaseError
         Ok(name)
     } else {
         Err(DatabaseError::Internal(
-            rusqlite::Error::InvalidParameterName(name.to_string()),
+            rusqlite::Error::InvalidParameterName(name.to_string()).to_string(),
         ))
     }
 }

--- a/crates/bitwarden-uniffi/src/platform/mod.rs
+++ b/crates/bitwarden-uniffi/src/platform/mod.rs
@@ -98,6 +98,23 @@ impl StateClient {
 
         Ok(())
     }
+
+    /// Initialize the database for SDK managed repositories using in-memory storage.
+    ///
+    /// Data stored via this backend exists only in process RAM and is not persisted
+    /// between sessions. Intended for testing, development, and cross-platform use
+    /// cases where persistence is not required.
+    pub async fn initialize_state_in_memory(&self) -> Result<()> {
+        self.0
+            .platform()
+            .state()
+            .initialize_database(
+                bitwarden_state::DatabaseConfiguration::Memory,
+                bitwarden_state::repository::RepositoryMigrations::new(vec![]),
+            )
+            .await?;
+        Ok(())
+    }
 }
 
 impl From<SqliteConfiguration> for DatabaseConfiguration {

--- a/crates/bitwarden-uniffi/src/platform/mod.rs
+++ b/crates/bitwarden-uniffi/src/platform/mod.rs
@@ -100,14 +100,6 @@ impl StateClient {
     }
 
     /// Initialize the database for SDK managed repositories using in-memory storage.
-    /// UniFFI binding.
-    ///
-    /// Data stored via this backend exists only in process RAM and is not persisted
-    /// between sessions. Intended for testing, development, and cross-platform use
-    /// cases where persistence is not required.
-    ///
-    /// # Errors
-    /// Returns an error if the database has already been initialized.
     pub async fn initialize_state_in_memory(&self) -> Result<()> {
         self.0
             .platform()

--- a/crates/bitwarden-uniffi/src/platform/mod.rs
+++ b/crates/bitwarden-uniffi/src/platform/mod.rs
@@ -100,10 +100,14 @@ impl StateClient {
     }
 
     /// Initialize the database for SDK managed repositories using in-memory storage.
+    /// UniFFI binding.
     ///
     /// Data stored via this backend exists only in process RAM and is not persisted
     /// between sessions. Intended for testing, development, and cross-platform use
     /// cases where persistence is not required.
+    ///
+    /// # Errors
+    /// Returns an error if the database has already been initialized.
     pub async fn initialize_state_in_memory(&self) -> Result<()> {
         self.0
             .platform()

--- a/crates/bitwarden-wasm-internal/src/platform/mod.rs
+++ b/crates/bitwarden-wasm-internal/src/platform/mod.rs
@@ -92,14 +92,6 @@ impl StateClient {
     }
 
     /// Initialize the database for SDK managed repositories using in-memory storage.
-    /// WASM binding.
-    ///
-    /// Data stored via this backend exists only in process RAM and is not persisted
-    /// between sessions. Intended for testing, development, and cross-platform use
-    /// cases where persistence is not required.
-    ///
-    /// # Errors
-    /// Returns an error if the database has already been initialized.
     pub async fn initialize_state_in_memory(
         &self,
     ) -> Result<(), bitwarden_state::registry::StateRegistryError> {

--- a/crates/bitwarden-wasm-internal/src/platform/mod.rs
+++ b/crates/bitwarden-wasm-internal/src/platform/mod.rs
@@ -90,6 +90,24 @@ impl StateClient {
             .initialize_database(configuration.into(), sdk_managed_repositories)
             .await
     }
+
+    /// Initialize the database for SDK managed repositories using in-memory storage.
+    ///
+    /// Data stored via this backend exists only in process RAM and is not persisted
+    /// between sessions. Intended for testing, development, and cross-platform use
+    /// cases where persistence is not required.
+    pub async fn initialize_state_in_memory(
+        &self,
+    ) -> Result<(), bitwarden_state::registry::StateRegistryError> {
+        self.0
+            .platform()
+            .state()
+            .initialize_database(
+                bitwarden_state::DatabaseConfiguration::Memory,
+                bitwarden_state::repository::RepositoryMigrations::new(vec![]),
+            )
+            .await
+    }
 }
 
 impl From<IndexedDbConfiguration> for DatabaseConfiguration {

--- a/crates/bitwarden-wasm-internal/src/platform/mod.rs
+++ b/crates/bitwarden-wasm-internal/src/platform/mod.rs
@@ -92,10 +92,14 @@ impl StateClient {
     }
 
     /// Initialize the database for SDK managed repositories using in-memory storage.
+    /// WASM binding.
     ///
     /// Data stored via this backend exists only in process RAM and is not persisted
     /// between sessions. Intended for testing, development, and cross-platform use
     /// cases where persistence is not required.
+    ///
+    /// # Errors
+    /// Returns an error if the database has already been initialized.
     pub async fn initialize_state_in_memory(
         &self,
     ) -> Result<(), bitwarden_state::registry::StateRegistryError> {


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-31873

Builds on [PR #871](https://github.com/bitwarden/sdk-internal/pull/871) ([PM-31870] Add in-memory Database backend to bitwarden-state). This PR should be merged after #871.

This PR was generated as part of a Claude Agent Teams test.

## 📔 Objective

Wires the `StateRegistry` and in-memory database introduced in PM-31870 into all `Client` constructors, ensuring consistent state management from the moment any client is constructed.

Key changes:

- **Rename `repository_map` to `state_registry`** in `InternalClient`: aligns field naming with the type it holds (`StateRegistry`) and with the terminology established in PM-31870.
- **`new_internal` accepts `StateRegistry` parameter**: the synchronous internal constructor now takes an explicit `StateRegistry` instead of constructing its own. This is the foundation that lets callers inject a pre-configured registry (including one backed by `MemoryDatabase`).
- **New `new_with_token_handler_and_state` constructor**: a synchronous `Client` constructor accepting both a `TokenHandler` and a `StateRegistry`. Mirrors the existing `new_with_token_handler` but with explicit state injection, enabling callers to provide a fully-configured in-memory or persistent registry at construction time.
- **`state_client.rs` updated**: all references to the renamed `repository_map` field updated to `state_registry` for consistency.
- **Constructor tests gated behind `internal` feature flag**: tests that exercise `new_with_token_handler_and_state` and related internal constructors are now correctly gated behind `#[cfg(feature = "internal")]` to prevent compilation failures in non-internal builds.

The net result: every `Client` construction path (default, token-handler-only, token-handler-plus-state) now initializes its `StateRegistry` consistently, and the in-memory database path is available synchronously without async initialization.

[PM-31870]: https://bitwarden.atlassian.net/browse/PM-31870?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ