### PR TITLE
[PM-33554] Add grantee id to v1 emergency access membership

### DIFF
--- a/crates/bitwarden-user-crypto-management/src/key_rotation/sync.rs
+++ b/crates/bitwarden-user-crypto-management/src/key_rotation/sync.rs
@@ -148,7 +148,11 @@ pub(crate) async fn sync_emergency_access(
             let public_key = fetch_user_public_key(api_client, user_id).await?;
             Ok(V1EmergencyAccessMembership {
                 id: ea.id.ok_or(SyncError::DataError)?,
-                name: ea.name.ok_or(SyncError::DataError)?,
+                grantee_id: user_id,
+                // The name can be null if a user does not set a name.
+                name: ea
+                    .name
+                    .unwrap_or_else(|| ea.email.unwrap_or_else(|| "Unknown".to_string())),
                 public_key,
             })
         })

--- a/crates/bitwarden-user-crypto-management/src/key_rotation/unlock.rs
+++ b/crates/bitwarden-user-crypto-management/src/key_rotation/unlock.rs
@@ -45,6 +45,7 @@ pub(super) enum MasterkeyUnlockMethod {
 #[cfg_attr(feature = "wasm", derive(Tsify), tsify(into_wasm_abi, from_wasm_abi))]
 pub struct V1EmergencyAccessMembership {
     pub id: uuid::Uuid,
+    pub grantee_id: uuid::Uuid,
     pub name: String,
     pub public_key: PublicKey,
 }
@@ -535,6 +536,7 @@ mod tests {
             ctx.make_private_key(PublicKeyEncryptionAlgorithm::RsaOaepSha1);
         let emergency_access = V1EmergencyAccessMembership {
             id: Uuid::new_v4(),
+            grantee_id: Uuid::new_v4(),
             name: "Test User".to_string(),
             public_key: ctx
                 .get_public_key(organization_private_key)


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-33554

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Clients currently displays a wrong fingerprint. This is because the fingerprint needs both the grantee id but also the grantee user uuid, which it uses as domain separation: https://github.com/bitwarden/clients/blob/8a260537e4ccf99c8a065353358455d5567be035/libs/key-management/src/key.service.ts#L416

This PR exposes the grantee id so that the clients can consume it correctly to display the correct fingerprint.

## 🚨 Breaking Changes

<!-- Does this PR introduce any breaking changes? If so, please describe the impact and migration path for clients.

If you're unsure, the automated TypeScript compatibility check will run when you open/update this PR and provide feedback.

For breaking changes:
1. Describe what changed in the client interface
2. Explain why the change was necessary
3. Provide migration steps for client developers
4. Link to any paired client PRs if needed

Otherwise, you can remove this section. -->
