### PR TITLE
refactor(client): Introduce ClientBuilder pattern to fix constructor telescoping

### DIFF
--- a/crates/bitwarden-core/src/client/builder.rs
+++ b/crates/bitwarden-core/src/client/builder.rs
@@ -1,0 +1,241 @@
+use std::sync::{Arc, OnceLock, RwLock};
+
+use bitwarden_crypto::KeyStore;
+#[cfg(feature = "internal")]
+use bitwarden_state::registry::StateRegistry;
+use reqwest::header::{self, HeaderValue};
+
+#[cfg(feature = "internal")]
+use crate::client::flags::Flags;
+use crate::{
+    auth::auth_tokens::{NoopTokenHandler, TokenHandler},
+    client::{
+        client::Client,
+        client_settings::{ClientName, ClientSettings},
+        internal::{ApiConfigurations, InternalClient},
+    },
+};
+
+/// Builder for constructing a [`Client`] with optional configuration.
+///
+/// # Example
+///
+/// ```rust
+/// use bitwarden_core::ClientBuilder;
+///
+/// let client = ClientBuilder::new().build();
+/// ```
+pub struct ClientBuilder {
+    settings: Option<ClientSettings>,
+    token_handler: Arc<dyn TokenHandler>,
+}
+
+impl ClientBuilder {
+    /// Create a new [`ClientBuilder`] with default settings.
+    ///
+    /// Defaults: no custom settings (uses [`ClientSettings::default()`]),
+    /// [`NoopTokenHandler`] for token management.
+    pub fn new() -> Self {
+        Self {
+            settings: None,
+            token_handler: Arc::new(NoopTokenHandler),
+        }
+    }
+
+    /// Set the client settings.
+    pub fn with_settings(mut self, settings: ClientSettings) -> Self {
+        self.settings = Some(settings);
+        self
+    }
+
+    /// Set a custom token handler for authentication token management.
+    pub fn with_token_handler(mut self, token_handler: Arc<dyn TokenHandler>) -> Self {
+        self.token_handler = token_handler;
+        self
+    }
+
+    /// Build the [`Client`].
+    ///
+    /// Consumes the builder. The resulting client is ready for use.
+    pub fn build(self) -> Client {
+        let settings = self.settings.unwrap_or_default();
+
+        let external_http_client = new_http_client_builder()
+            .build()
+            .expect("External HTTP Client build should not fail");
+
+        let headers = build_default_headers(&settings);
+
+        let login_method = Arc::new(RwLock::new(None));
+        let key_store = KeyStore::default();
+
+        // Create the HTTP client for the Identity service, without authentication middleware.
+        let bw_http_client = new_http_client_builder()
+            .default_headers(headers)
+            .build()
+            .expect("Bw HTTP Client build should not fail");
+        let identity = bitwarden_api_identity::Configuration {
+            base_path: settings.identity_url,
+            client: bw_http_client.clone().into(),
+        };
+
+        // Create the client for the API service, with authentication middleware.
+        let auth_middleware = self.token_handler.initialize_middleware(
+            login_method.clone(),
+            identity.clone(),
+            key_store.clone(),
+        );
+        let bw_http_client = reqwest_middleware::ClientBuilder::new(bw_http_client)
+            .with_arc(auth_middleware)
+            .build();
+        let api = bitwarden_api_api::Configuration {
+            base_path: settings.api_url,
+            client: bw_http_client,
+        };
+
+        Client {
+            internal: Arc::new(InternalClient {
+                user_id: OnceLock::new(),
+                token_handler: self.token_handler,
+                login_method,
+                #[cfg(feature = "internal")]
+                flags: RwLock::new(Flags::default()),
+                api_configurations: ApiConfigurations::new(identity, api, settings.device_type),
+                external_http_client,
+                key_store,
+                #[cfg(feature = "internal")]
+                security_state: RwLock::new(None),
+                #[cfg(feature = "internal")]
+                repository_map: StateRegistry::new(),
+            }),
+        }
+    }
+}
+
+impl Default for ClientBuilder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+fn new_http_client_builder() -> reqwest::ClientBuilder {
+    #[allow(unused_mut)]
+    let mut client_builder = reqwest::Client::builder();
+
+    #[cfg(not(target_arch = "wasm32"))]
+    {
+        use rustls::ClientConfig;
+        use rustls_platform_verifier::ConfigVerifierExt;
+        client_builder = client_builder.use_preconfigured_tls(
+            ClientConfig::with_platform_verifier().expect("Failed to create platform verifier"),
+        );
+
+        // Enforce HTTPS for all requests in non-debug builds
+        #[cfg(not(debug_assertions))]
+        {
+            client_builder = client_builder.https_only(true);
+        }
+    }
+
+    client_builder
+}
+
+/// Build default headers for Bitwarden HttpClient
+fn build_default_headers(settings: &ClientSettings) -> header::HeaderMap {
+    let mut headers = header::HeaderMap::new();
+
+    // Handle optional headers
+
+    if let Some(device_identifier) = &settings.device_identifier {
+        headers.append(
+            "Device-Identifier",
+            HeaderValue::from_str(device_identifier)
+                .expect("Device identifier should be a valid header value"),
+        );
+    }
+
+    if let Some(client_type) = Into::<Option<ClientName>>::into(settings.device_type) {
+        headers.append(
+            "Bitwarden-Client-Name",
+            HeaderValue::from_str(&client_type.to_string())
+                .expect("All ASCII strings are valid header values"),
+        );
+    }
+
+    if let Some(version) = &settings.bitwarden_client_version {
+        headers.append(
+            "Bitwarden-Client-Version",
+            HeaderValue::from_str(version).expect("Version should be a valid header value"),
+        );
+    }
+
+    if let Some(package_type) = &settings.bitwarden_package_type {
+        headers.append(
+            "Bitwarden-Package-Type",
+            HeaderValue::from_str(package_type)
+                .expect("Package type should be a valid header value"),
+        );
+    }
+
+    // Handle required headers
+
+    headers.append(
+        "Device-Type",
+        HeaderValue::from_str(&(settings.device_type as u8).to_string())
+            .expect("All numbers are valid ASCII"),
+    );
+
+    headers.append(
+        reqwest::header::USER_AGENT,
+        HeaderValue::from_str(&settings.user_agent)
+            .expect("User agent should be a valid header value"),
+    );
+
+    headers
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Verify that ClientBuilder::new().build() can construct a client without panicking.
+    /// Behavioral equivalence with Client::new(None) is validated implicitly: after Commit 2,
+    /// Client::new(None) delegates to this same code path.
+    #[test]
+    fn test_client_builder_default_builds() {
+        let _client = ClientBuilder::new().build();
+    }
+
+    /// Verify that with_settings() is accepted and does not panic.
+    #[test]
+    fn test_client_builder_with_settings_builds() {
+        let settings = ClientSettings::default();
+        let _client = ClientBuilder::new().with_settings(settings).build();
+    }
+
+    /// Verify that with_token_handler() is accepted and does not panic.
+    #[test]
+    fn test_client_builder_with_token_handler_builds() {
+        let handler: Arc<dyn TokenHandler> = Arc::new(NoopTokenHandler);
+        let _client = ClientBuilder::new().with_token_handler(handler).build();
+    }
+
+    /// Verify that chaining order does not matter: settings then handler == handler then settings.
+    /// Both must produce clients without panicking (behavioral equivalence is the assertion).
+    #[test]
+    fn test_client_builder_chain_order_independence() {
+        let settings_a = ClientSettings::default();
+        let settings_b = ClientSettings::default();
+        let handler_a: Arc<dyn TokenHandler> = Arc::new(NoopTokenHandler);
+        let handler_b: Arc<dyn TokenHandler> = Arc::new(NoopTokenHandler);
+
+        let _client_a = ClientBuilder::new()
+            .with_settings(settings_a)
+            .with_token_handler(handler_a)
+            .build();
+        let _client_b = ClientBuilder::new()
+            .with_token_handler(handler_b)
+            .with_settings(settings_b)
+            .build();
+    }
+}

--- a/crates/bitwarden-core/src/client/builder.rs
+++ b/crates/bitwarden-core/src/client/builder.rs
@@ -16,25 +16,12 @@ use crate::{
     },
 };
 
-/// Builder for constructing a [`Client`] with optional configuration.
-///
-/// # Example
-///
-/// ```rust
-/// use bitwarden_core::ClientBuilder;
-///
-/// let client = ClientBuilder::new().build();
-/// ```
 pub struct ClientBuilder {
     settings: Option<ClientSettings>,
     token_handler: Arc<dyn TokenHandler>,
 }
 
 impl ClientBuilder {
-    /// Create a new [`ClientBuilder`] with default settings.
-    ///
-    /// Defaults: no custom settings (uses [`ClientSettings::default()`]),
-    /// [`NoopTokenHandler`] for token management.
     pub fn new() -> Self {
         Self {
             settings: None,
@@ -42,21 +29,16 @@ impl ClientBuilder {
         }
     }
 
-    /// Set the client settings.
     pub fn with_settings(mut self, settings: ClientSettings) -> Self {
         self.settings = Some(settings);
         self
     }
 
-    /// Set a custom token handler for authentication token management.
     pub fn with_token_handler(mut self, token_handler: Arc<dyn TokenHandler>) -> Self {
         self.token_handler = token_handler;
         self
     }
 
-    /// Build the [`Client`].
-    ///
-    /// Consumes the builder. The resulting client is ready for use.
     pub fn build(self) -> Client {
         let settings = self.settings.unwrap_or_default();
 
@@ -198,44 +180,32 @@ fn build_default_headers(settings: &ClientSettings) -> header::HeaderMap {
 mod tests {
     use super::*;
 
-    /// Verify that ClientBuilder::new().build() can construct a client without panicking.
-    /// Behavioral equivalence with Client::new(None) is validated implicitly: after Commit 2,
-    /// Client::new(None) delegates to this same code path.
     #[test]
     fn test_client_builder_default_builds() {
         let _client = ClientBuilder::new().build();
     }
 
-    /// Verify that with_settings() is accepted and does not panic.
     #[test]
     fn test_client_builder_with_settings_builds() {
         let settings = ClientSettings::default();
         let _client = ClientBuilder::new().with_settings(settings).build();
     }
 
-    /// Verify that with_token_handler() is accepted and does not panic.
     #[test]
     fn test_client_builder_with_token_handler_builds() {
         let handler: Arc<dyn TokenHandler> = Arc::new(NoopTokenHandler);
         let _client = ClientBuilder::new().with_token_handler(handler).build();
     }
 
-    /// Verify that chaining order does not matter: settings then handler == handler then settings.
-    /// Both must produce clients without panicking (behavioral equivalence is the assertion).
     #[test]
     fn test_client_builder_chain_order_independence() {
-        let settings_a = ClientSettings::default();
-        let settings_b = ClientSettings::default();
-        let handler_a: Arc<dyn TokenHandler> = Arc::new(NoopTokenHandler);
-        let handler_b: Arc<dyn TokenHandler> = Arc::new(NoopTokenHandler);
-
-        let _client_a = ClientBuilder::new()
-            .with_settings(settings_a)
-            .with_token_handler(handler_a)
+        let _a = ClientBuilder::new()
+            .with_settings(ClientSettings::default())
+            .with_token_handler(Arc::new(NoopTokenHandler) as Arc<dyn TokenHandler>)
             .build();
-        let _client_b = ClientBuilder::new()
-            .with_token_handler(handler_b)
-            .with_settings(settings_b)
+        let _b = ClientBuilder::new()
+            .with_token_handler(Arc::new(NoopTokenHandler) as Arc<dyn TokenHandler>)
+            .with_settings(ClientSettings::default())
             .build();
     }
 }

--- a/crates/bitwarden-core/src/client/builder.rs
+++ b/crates/bitwarden-core/src/client/builder.rs
@@ -16,12 +16,14 @@ use crate::{
     },
 };
 
+/// Builder for constructing [`Client`] instances with custom configuration.
 pub struct ClientBuilder {
     settings: Option<ClientSettings>,
     token_handler: Arc<dyn TokenHandler>,
 }
 
 impl ClientBuilder {
+    /// Creates a new [`ClientBuilder`] with default settings.
     pub fn new() -> Self {
         Self {
             settings: None,
@@ -29,16 +31,19 @@ impl ClientBuilder {
         }
     }
 
+    /// Sets the [`ClientSettings`] for the client being built.
     pub fn with_settings(mut self, settings: ClientSettings) -> Self {
         self.settings = Some(settings);
         self
     }
 
+    /// Sets a custom [`TokenHandler`] for managing authentication tokens.
     pub fn with_token_handler(mut self, token_handler: Arc<dyn TokenHandler>) -> Self {
         self.token_handler = token_handler;
         self
     }
 
+    /// Consumes the builder and constructs a [`Client`].
     pub fn build(self) -> Client {
         let settings = self.settings.unwrap_or_default();
 

--- a/crates/bitwarden-core/src/client/client.rs
+++ b/crates/bitwarden-core/src/client/client.rs
@@ -1,19 +1,9 @@
-use std::sync::{Arc, OnceLock, RwLock};
-
-use bitwarden_crypto::KeyStore;
-#[cfg(feature = "internal")]
-use bitwarden_state::registry::StateRegistry;
-use reqwest::header::{self, HeaderValue};
+use std::sync::Arc;
 
 use super::internal::InternalClient;
-#[cfg(feature = "internal")]
-use crate::client::flags::Flags;
 use crate::{
-    auth::auth_tokens::{NoopTokenHandler, TokenHandler},
-    client::{
-        client_settings::{ClientName, ClientSettings},
-        internal::ApiConfigurations,
-    },
+    auth::auth_tokens::TokenHandler,
+    client::{builder::ClientBuilder, client_settings::ClientSettings},
 };
 
 /// The main struct to interact with the Bitwarden SDK.
@@ -30,7 +20,11 @@ pub struct Client {
 impl Client {
     /// Create a new Bitwarden client with default settings and a no-op token handler.
     pub fn new(settings: Option<ClientSettings>) -> Self {
-        Self::new_internal(settings, Arc::new(NoopTokenHandler))
+        let mut builder = ClientBuilder::new();
+        if let Some(s) = settings {
+            builder = builder.with_settings(s);
+        }
+        builder.build()
     }
 
     /// Create a new Bitwarden client with the specified token handler for managing authentication
@@ -39,139 +33,14 @@ impl Client {
         settings: Option<ClientSettings>,
         token_handler: Arc<dyn TokenHandler>,
     ) -> Self {
-        Self::new_internal(settings, token_handler)
-    }
-
-    fn new_internal(
-        settings_input: Option<ClientSettings>,
-        token_handler: Arc<dyn TokenHandler>,
-    ) -> Self {
-        let settings = settings_input.unwrap_or_default();
-
-        let external_http_client = new_http_client_builder()
-            .build()
-            .expect("External HTTP Client build should not fail");
-
-        let headers = build_default_headers(&settings);
-
-        let login_method = Arc::new(RwLock::new(None));
-        let key_store = KeyStore::default();
-
-        // Create the HTTP client for the Identity service, without authentication middleware.
-        let bw_http_client = new_http_client_builder()
-            .default_headers(headers)
-            .build()
-            .expect("Bw HTTP Client build should not fail");
-        let identity = bitwarden_api_identity::Configuration {
-            base_path: settings.identity_url,
-            client: bw_http_client.clone().into(),
-        };
-
-        // Create the client for the API service, with authentication middleware.
-        let auth_middleware = token_handler.initialize_middleware(
-            login_method.clone(),
-            identity.clone(),
-            key_store.clone(),
-        );
-        let bw_http_client = reqwest_middleware::ClientBuilder::new(bw_http_client)
-            .with_arc(auth_middleware)
-            .build();
-        let api = bitwarden_api_api::Configuration {
-            base_path: settings.api_url,
-            client: bw_http_client,
-        };
-
-        Self {
-            internal: Arc::new(InternalClient {
-                user_id: OnceLock::new(),
-                token_handler,
-                login_method,
-                #[cfg(feature = "internal")]
-                flags: RwLock::new(Flags::default()),
-                api_configurations: ApiConfigurations::new(identity, api, settings.device_type),
-                external_http_client,
-                key_store,
-                #[cfg(feature = "internal")]
-                security_state: RwLock::new(None),
-                #[cfg(feature = "internal")]
-                repository_map: StateRegistry::new(),
-            }),
+        let mut builder = ClientBuilder::new().with_token_handler(token_handler);
+        if let Some(s) = settings {
+            builder = builder.with_settings(s);
         }
-    }
-}
-
-fn new_http_client_builder() -> reqwest::ClientBuilder {
-    #[allow(unused_mut)]
-    let mut client_builder = reqwest::Client::builder();
-
-    #[cfg(not(target_arch = "wasm32"))]
-    {
-        use rustls::ClientConfig;
-        use rustls_platform_verifier::ConfigVerifierExt;
-        client_builder = client_builder.use_preconfigured_tls(
-            ClientConfig::with_platform_verifier().expect("Failed to create platform verifier"),
-        );
-
-        // Enforce HTTPS for all requests in non-debug builds
-        #[cfg(not(debug_assertions))]
-        {
-            client_builder = client_builder.https_only(true);
-        }
+        builder.build()
     }
 
-    client_builder
-}
-
-/// Build default headers for Bitwarden HttpClient
-fn build_default_headers(settings: &ClientSettings) -> header::HeaderMap {
-    let mut headers = header::HeaderMap::new();
-
-    // Handle optional headers
-
-    if let Some(device_identifier) = &settings.device_identifier {
-        headers.append(
-            "Device-Identifier",
-            HeaderValue::from_str(device_identifier)
-                .expect("Device identifier should be a valid header value"),
-        );
+    pub fn builder() -> ClientBuilder {
+        ClientBuilder::new()
     }
-
-    if let Some(client_type) = Into::<Option<ClientName>>::into(settings.device_type) {
-        headers.append(
-            "Bitwarden-Client-Name",
-            HeaderValue::from_str(&client_type.to_string())
-                .expect("All ASCII strings are valid header values"),
-        );
-    }
-
-    if let Some(version) = &settings.bitwarden_client_version {
-        headers.append(
-            "Bitwarden-Client-Version",
-            HeaderValue::from_str(version).expect("Version should be a valid header value"),
-        );
-    }
-
-    if let Some(package_type) = &settings.bitwarden_package_type {
-        headers.append(
-            "Bitwarden-Package-Type",
-            HeaderValue::from_str(package_type)
-                .expect("Package type should be a valid header value"),
-        );
-    }
-
-    // Handle required headers
-
-    headers.append(
-        "Device-Type",
-        HeaderValue::from_str(&(settings.device_type as u8).to_string())
-            .expect("All numbers are valid ASCII"),
-    );
-
-    headers.append(
-        reqwest::header::USER_AGENT,
-        HeaderValue::from_str(&settings.user_agent)
-            .expect("User agent should be a valid header value"),
-    );
-
-    headers
 }

--- a/crates/bitwarden-core/src/client/client.rs
+++ b/crates/bitwarden-core/src/client/client.rs
@@ -40,6 +40,7 @@ impl Client {
         builder.build()
     }
 
+    /// Returns a [`ClientBuilder`] for constructing a new [`Client`].
     pub fn builder() -> ClientBuilder {
         ClientBuilder::new()
     }

--- a/crates/bitwarden-core/src/client/mod.rs
+++ b/crates/bitwarden-core/src/client/mod.rs
@@ -1,5 +1,6 @@
 //! Bitwarden SDK Client
 
+/// Builder pattern for constructing [`Client`] instances.
 pub mod builder;
 #[allow(clippy::module_inception)]
 mod client;

--- a/crates/bitwarden-core/src/client/mod.rs
+++ b/crates/bitwarden-core/src/client/mod.rs
@@ -1,7 +1,6 @@
 //! Bitwarden SDK Client
 
-/// Builder pattern for constructing [`Client`] instances.
-pub mod builder;
+mod builder;
 #[allow(clippy::module_inception)]
 mod client;
 #[allow(missing_docs)]

--- a/crates/bitwarden-core/src/client/mod.rs
+++ b/crates/bitwarden-core/src/client/mod.rs
@@ -20,6 +20,7 @@ pub(crate) use login_method::{LoginMethod, UserLoginMethod};
 #[cfg(feature = "internal")]
 mod flags;
 
+pub use builder::ClientBuilder;
 pub use client::Client;
 pub use client_settings::{ClientName, ClientSettings, DeviceType};
 

--- a/crates/bitwarden-core/src/client/mod.rs
+++ b/crates/bitwarden-core/src/client/mod.rs
@@ -1,5 +1,6 @@
 //! Bitwarden SDK Client
 
+pub mod builder;
 #[allow(clippy::module_inception)]
 mod client;
 #[allow(missing_docs)]

--- a/crates/bitwarden-core/src/lib.rs
+++ b/crates/bitwarden-core/src/lib.rs
@@ -24,7 +24,7 @@ pub mod secrets_manager;
 /// See [`FromClient`] for usage details.
 pub use bitwarden_core_macro::FromClient;
 pub use bitwarden_crypto::ZeroizingAllocator;
-pub use client::{Client, ClientName, ClientSettings, DeviceType, FromClient};
+pub use client::{Client, ClientBuilder, ClientName, ClientSettings, DeviceType, FromClient};
 
 mod ids;
 pub use ids::*;

--- a/crates/bitwarden-pm/src/builder.rs
+++ b/crates/bitwarden-pm/src/builder.rs
@@ -5,20 +5,24 @@ use bitwarden_core::ClientBuilder;
 
 use crate::PasswordManagerClient;
 
+/// Builder for constructing [`PasswordManagerClient`] instances with custom configuration.
 pub struct PasswordManagerClientBuilder {
     settings: Option<bitwarden_core::ClientSettings>,
 }
 
 impl PasswordManagerClientBuilder {
+    /// Creates a new [`PasswordManagerClientBuilder`] with default settings.
     pub fn new() -> Self {
         Self { settings: None }
     }
 
+    /// Sets the [`ClientSettings`](bitwarden_core::ClientSettings) for the client being built.
     pub fn with_settings(mut self, settings: bitwarden_core::ClientSettings) -> Self {
         self.settings = Some(settings);
         self
     }
 
+    /// Consumes the builder and constructs a [`PasswordManagerClient`].
     pub fn build(self) -> PasswordManagerClient {
         let token_handler = Arc::new(PasswordManagerTokenHandler::default());
         let mut builder = ClientBuilder::new().with_token_handler(token_handler);

--- a/crates/bitwarden-pm/src/builder.rs
+++ b/crates/bitwarden-pm/src/builder.rs
@@ -1,0 +1,54 @@
+use std::sync::Arc;
+
+use bitwarden_auth::token_management::PasswordManagerTokenHandler;
+use bitwarden_core::ClientBuilder;
+
+use crate::PasswordManagerClient;
+
+pub struct PasswordManagerClientBuilder {
+    settings: Option<bitwarden_core::ClientSettings>,
+}
+
+impl PasswordManagerClientBuilder {
+    pub fn new() -> Self {
+        Self { settings: None }
+    }
+
+    pub fn with_settings(mut self, settings: bitwarden_core::ClientSettings) -> Self {
+        self.settings = Some(settings);
+        self
+    }
+
+    pub fn build(self) -> PasswordManagerClient {
+        let token_handler = Arc::new(PasswordManagerTokenHandler::default());
+        let mut builder = ClientBuilder::new().with_token_handler(token_handler);
+        if let Some(s) = self.settings {
+            builder = builder.with_settings(s);
+        }
+        PasswordManagerClient(builder.build())
+    }
+}
+
+impl Default for PasswordManagerClientBuilder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_pm_builder_default_builds() {
+        let _client = PasswordManagerClientBuilder::new().build();
+    }
+
+    #[test]
+    fn test_pm_builder_with_settings_builds() {
+        let settings = bitwarden_core::ClientSettings::default();
+        let _client = PasswordManagerClientBuilder::new()
+            .with_settings(settings)
+            .build();
+    }
+}

--- a/crates/bitwarden-pm/src/lib.rs
+++ b/crates/bitwarden-pm/src/lib.rs
@@ -50,6 +50,7 @@ impl PasswordManagerClient {
         builder.build()
     }
 
+    /// Returns a [`PasswordManagerClientBuilder`] for constructing a new [`PasswordManagerClient`].
     pub fn builder() -> PasswordManagerClientBuilder {
         PasswordManagerClientBuilder::new()
     }

--- a/crates/bitwarden-pm/src/lib.rs
+++ b/crates/bitwarden-pm/src/lib.rs
@@ -5,7 +5,7 @@ mod commercial;
 
 use std::sync::Arc;
 
-use bitwarden_auth::{AuthClientExt as _, token_management::PasswordManagerTokenHandler};
+use bitwarden_auth::AuthClientExt as _;
 use bitwarden_core::{
     FromClient,
     auth::{ClientManagedTokenHandler, ClientManagedTokens},
@@ -33,7 +33,9 @@ pub mod clients {
 #[cfg(feature = "bitwarden-license")]
 pub use commercial::CommercialPasswordManagerClient;
 
+mod builder;
 pub mod migrations;
+pub use builder::PasswordManagerClientBuilder;
 
 /// The main entry point for the Bitwarden Password Manager SDK
 pub struct PasswordManagerClient(pub bitwarden_core::Client);
@@ -41,11 +43,15 @@ pub struct PasswordManagerClient(pub bitwarden_core::Client);
 impl PasswordManagerClient {
     /// Initialize a new instance of the SDK client
     pub fn new(settings: Option<bitwarden_core::ClientSettings>) -> Self {
-        let token_handler = Arc::new(PasswordManagerTokenHandler::default());
-        Self(bitwarden_core::Client::new_with_token_handler(
-            settings,
-            token_handler,
-        ))
+        let mut builder = PasswordManagerClientBuilder::new();
+        if let Some(s) = settings {
+            builder = builder.with_settings(s);
+        }
+        builder.build()
+    }
+
+    pub fn builder() -> PasswordManagerClientBuilder {
+        PasswordManagerClientBuilder::new()
     }
 
     /// Initialize a new instance of the SDK client with client-managed tokens


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-34617

## 📔 Objective

We've got multiple in flight SDK features where part of the design is to create new constructors for clients with different options for provided args.

This PR sets up a builder pattern to replace these. I've left the old constructors and have not marked them deprecated, but all new work will follow this new pattern.