### PR TITLE
[PM-31119] Expose get_user_encryption_key to wasm

### DIFF
--- a/crates/bitwarden-core/src/key_management/crypto.rs
+++ b/crates/bitwarden-core/src/key_management/crypto.rs
@@ -385,7 +385,8 @@ pub(super) async fn initialize_org_crypto(
 pub(super) async fn get_user_encryption_key(client: &Client) -> Result<B64, CryptoClientError> {
     let key_store = client.internal.get_key_store();
     let ctx = key_store.context();
-    // This is needed because the mobile clients need access to the user encryption key
+    // This is needed because the clients need access to the user encryption key
+    // in order to set side-effects such as biometrics, and never-lock
     #[allow(deprecated)]
     let user_key = ctx.dangerous_get_symmetric_key(SymmetricKeyId::User)?;
 

--- a/crates/bitwarden-core/src/key_management/crypto_client.rs
+++ b/crates/bitwarden-core/src/key_management/crypto_client.rs
@@ -179,15 +179,19 @@ impl CryptoClient {
             .decrypt(&mut ctx, SymmetricKeyId::LocalUserData)
             .map_err(CryptoClientError::Crypto)
     }
-}
 
-impl CryptoClient {
+    /// ⚠️⚠️⚠️ HAZMAT WARNING: DO NOT USE THIS ⚠️⚠️⚠️
+    ///
     /// Get the uses's decrypted encryption key. Note: It's very important
-    /// to keep this key safe, as it can be used to decrypt all of the user's data
+    /// to keep this key safe, as it can be used to decrypt all of the user's data. It is
+    /// only permitted to use for a transition period where side effects such as biometrics
+    /// and never-lock are set from within the client code.
     pub async fn get_user_encryption_key(&self) -> Result<B64, CryptoClientError> {
         get_user_encryption_key(&self.client).await
     }
+}
 
+impl CryptoClient {
     /// Create the data necessary to update the user's password. The user's encryption key is
     /// re-encrypted with the new password. This returns the new encrypted user key and the new
     /// password hash but does not update sdk state.


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://github.com/bitwarden/clients/pull/20004
https://bitwarden.atlassian.net/browse/PM-31119

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

The biometrics subsystem and never lock are not ported to the clients. Because of hot observables / state provides, we cannot just read the user-key from state directly after setting it via SDK-unlock. Therefore, we set it by reading it from the SDK instance we used for unlock. For this, we have to expose `get_user_encryption_key` to wasm. We DO NOT want consumers on it, aside from the side-effect logic. There is a HAZMAT WARNING comment to guide users to not use this function.

## 🚨 Breaking Changes

<!-- Does this PR introduce any breaking changes? If so, please describe the impact and migration path for clients.

If you're unsure, the automated TypeScript compatibility check will run when you open/update this PR and provide feedback.

For breaking changes:
1. Describe what changed in the client interface
2. Explain why the change was necessary
3. Provide migration steps for client developers
4. Link to any paired client PRs if needed

Otherwise, you can remove this section. -->
