### PR TITLE
[PM-31875] Update `client` get/set to be async

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -789,6 +789,7 @@ dependencies = [
  "url",
  "uuid",
  "wasm-bindgen",
+ "wasm-bindgen-futures",
 ]
 
 [[package]]

--- a/crates/bitwarden-auth/src/token_management/password_manager_token_handler.rs
+++ b/crates/bitwarden-auth/src/token_management/password_manager_token_handler.rs
@@ -85,6 +85,7 @@ impl MiddlewareExt for PasswordManagerTokenHandler {
             .clone()
             .ok_or(NotAuthenticatedError)?;
 
+        #[allow(irrefutable_let_patterns)]
         let LoginMethod::User(user_login_method) = login_method.as_ref() else {
             return Err(NotAuthenticatedError.into());
         };

--- a/crates/bitwarden-core/src/auth/auth_client.rs
+++ b/crates/bitwarden-core/src/auth/auth_client.rs
@@ -83,13 +83,13 @@ impl AuthClient {
     }
 
     #[allow(missing_docs)]
-    pub fn make_register_tde_keys(
+    pub async fn make_register_tde_keys(
         &self,
         email: String,
         org_public_key: B64,
         remember_device: bool,
     ) -> Result<RegisterTdeKeyResponse, EncryptionSettingsError> {
-        make_register_tde_keys(&self.client, email, org_public_key, remember_device)
+        make_register_tde_keys(&self.client, email, org_public_key, remember_device).await
     }
 
     #[allow(missing_docs)]
@@ -130,30 +130,30 @@ impl AuthClient {
     }
 
     #[allow(missing_docs)]
-    pub fn validate_password(
+    pub async fn validate_password(
         &self,
         password: String,
         password_hash: B64,
     ) -> Result<bool, AuthValidateError> {
-        validate_password(&self.client, password, password_hash)
+        validate_password(&self.client, password, password_hash).await
     }
 
     #[allow(missing_docs)]
-    pub fn validate_password_user_key(
+    pub async fn validate_password_user_key(
         &self,
         password: String,
         encrypted_user_key: String,
     ) -> Result<B64, AuthValidateError> {
-        validate_password_user_key(&self.client, password, encrypted_user_key)
+        validate_password_user_key(&self.client, password, encrypted_user_key).await
     }
 
     #[allow(missing_docs)]
-    pub fn validate_pin(
+    pub async fn validate_pin(
         &self,
         pin: String,
         pin_protected_user_key: EncString,
     ) -> Result<bool, AuthValidateError> {
-        validate_pin(&self.client, pin, pin_protected_user_key)
+        validate_pin(&self.client, pin, pin_protected_user_key).await
     }
 
     /// Validates a PIN against a PIN-protected user key envelope.

--- a/crates/bitwarden-core/src/auth/login/access_token.rs
+++ b/crates/bitwarden-core/src/auth/login/access_token.rs
@@ -39,7 +39,8 @@ pub(crate) async fn login_access_token(
                     organization_id,
                     state_file: Some(state_file.to_path_buf()),
                 },
-            ));
+            ))
+            .await;
 
         return Ok(AccessTokenLoginResponse {
             authenticated: true,
@@ -98,7 +99,8 @@ pub(crate) async fn login_access_token(
                     organization_id,
                     state_file: input.state_file.clone(),
                 },
-            ));
+            ))
+            .await;
     }
 
     AccessTokenLoginResponse::process_response(response)

--- a/crates/bitwarden-core/src/auth/login/api_key.rs
+++ b/crates/bitwarden-core/src/auth/login/api_key.rs
@@ -58,7 +58,8 @@ pub(crate) async fn login_api_key(
                     client_secret: input.client_secret.clone(),
                     email: master_password_unlock.salt,
                     kdf: master_password_unlock.kdf,
-                }));
+                }))
+                .await;
         }
     }
 

--- a/crates/bitwarden-core/src/auth/login/password.rs
+++ b/crates/bitwarden-core/src/auth/login/password.rs
@@ -71,7 +71,8 @@ pub(crate) async fn login_password(
                     client_id: "web".to_owned(),
                     email: master_password_unlock.salt,
                     kdf: master_password_unlock.kdf,
-                }));
+                }))
+                .await;
         }
     }
 

--- a/crates/bitwarden-core/src/auth/password/validate.rs
+++ b/crates/bitwarden-core/src/auth/password/validate.rs
@@ -8,7 +8,7 @@ use crate::{
 };
 
 /// Validate if the provided password matches the password hash stored in the client.
-pub(crate) fn validate_password(
+pub(crate) async fn validate_password(
     client: &Client,
     password: String,
     password_hash: B64,
@@ -16,6 +16,7 @@ pub(crate) fn validate_password(
     let login_method = client
         .internal
         .get_login_method()
+        .await
         .ok_or(NotAuthenticatedError)?;
 
     match login_method {
@@ -29,7 +30,7 @@ pub(crate) fn validate_password(
     }
 }
 
-pub(crate) fn validate_password_user_key(
+pub(crate) async fn validate_password_user_key(
     client: &Client,
     password: String,
     encrypted_user_key: String,
@@ -39,6 +40,7 @@ pub(crate) fn validate_password_user_key(
     let login_method = client
         .internal
         .get_login_method()
+        .await
         .ok_or(NotAuthenticatedError)?;
 
     match login_method {
@@ -76,8 +78,8 @@ mod tests {
         },
     };
 
-    #[test]
-    fn test_validate_password() {
+    #[tokio::test]
+    async fn test_validate_password() {
         use std::num::NonZeroU32;
 
         use crate::client::{Client, LoginMethod, UserLoginMethod};
@@ -91,20 +93,21 @@ mod tests {
                     iterations: NonZeroU32::new(100_000).unwrap(),
                 },
                 client_id: "1".to_string(),
-            }));
+            }))
+            .await;
 
         let password = "password123".to_string();
         let password_hash = "7kTqkF1pY/3JeOu73N9kR99fDDe9O1JOZaVc7KH3lsU="
             .parse()
             .unwrap();
 
-        let result = validate_password(&client, password, password_hash);
+        let result = validate_password(&client, password, password_hash).await;
 
         assert!(result.unwrap());
     }
 
-    #[test]
-    fn test_validate_password_user_key() {
+    #[tokio::test]
+    async fn test_validate_password_user_key() {
         use std::num::NonZeroU32;
 
         use bitwarden_crypto::Kdf;
@@ -125,7 +128,8 @@ mod tests {
                 email: email.to_string(),
                 kdf: kdf.clone(),
                 client_id: "1".to_string(),
-            }));
+            }))
+            .await;
 
         let user_key: EncString = "2.Q/2PhzcC7GdeiMHhWguYAQ==|GpqzVdr0go0ug5cZh1n+uixeBC3oC90CIe0hd/HWA/pTRDZ8ane4fmsEIcuc8eMKUt55Y2q/fbNzsYu41YTZzzsJUSeqVjT8/iTQtgnNdpo=|dwI+uyvZ1h/iZ03VQ+/wrGEFYVewBUUl/syYgjsNMbE=".parse().unwrap();
         let private_key = "2.yN7l00BOlUE0Sb0M//Q53w==|EwKG/BduQRQ33Izqc/ogoBROIoI5dmgrxSo82sgzgAMIBt3A2FZ9vPRMY+GWT85JiqytDitGR3TqwnFUBhKUpRRAq4x7rA6A1arHrFp5Tp1p21O3SfjtvB3quiOKbqWk6ZaU1Np9HwqwAecddFcB0YyBEiRX3VwF2pgpAdiPbSMuvo2qIgyob0CUoC/h4Bz1be7Qa7B0Xw9/fMKkB1LpOm925lzqosyMQM62YpMGkjMsbZz0uPopu32fxzDWSPr+kekNNyLt9InGhTpxLmq1go/pXR2uw5dfpXc5yuta7DB0EGBwnQ8Vl5HPdDooqOTD9I1jE0mRyuBpWTTI3FRnu3JUh3rIyGBJhUmHqGZvw2CKdqHCIrQeQkkEYqOeJRJVdBjhv5KGJifqT3BFRwX/YFJIChAQpebNQKXe/0kPivWokHWwXlDB7S7mBZzhaAPidZvnuIhalE2qmTypDwHy22FyqV58T8MGGMchcASDi/QXI6kcdpJzPXSeU9o+NC68QDlOIrMVxKFeE7w7PvVmAaxEo0YwmuAzzKy9QpdlK0aab/xEi8V4iXj4hGepqAvHkXIQd+r3FNeiLfllkb61p6WTjr5urcmDQMR94/wYoilpG5OlybHdbhsYHvIzYoLrC7fzl630gcO6t4nM24vdB6Ymg9BVpEgKRAxSbE62Tqacxqnz9AcmgItb48NiR/He3n3ydGjPYuKk/ihZMgEwAEZvSlNxYONSbYrIGDtOY+8Nbt6KiH3l06wjZW8tcmFeVlWv+tWotnTY9IqlAfvNVTjtsobqtQnvsiDjdEVtNy/s2ci5TH+NdZluca2OVEr91Wayxh70kpM6ib4UGbfdmGgCo74gtKvKSJU0rTHakQ5L9JlaSDD5FamBRyI0qfL43Ad9qOUZ8DaffDCyuaVyuqk7cz9HwmEmvWU3VQ+5t06n/5kRDXttcw8w+3qClEEdGo1KeENcnXCB32dQe3tDTFpuAIMLqwXs6FhpawfZ5kPYvLPczGWaqftIs/RXJ/EltGc0ugw2dmTLpoQhCqrcKEBDoYVk0LDZKsnzitOGdi9mOWse7Se8798ib1UsHFUjGzISEt6upestxOeupSTOh0v4+AjXbDzRUyogHww3V+Bqg71bkcMxtB+WM+pn1XNbVTyl9NR040nhP7KEf6e9ruXAtmrBC2ah5cFEpLIot77VFZ9ilLuitSz+7T8n1yAh1IEG6xxXxninAZIzi2qGbH69O5RSpOJuJTv17zTLJQIIc781JwQ2TTwTGnx5wZLbffhCasowJKd2EVcyMJyhz6ru0PvXWJ4hUdkARJs3Xu8dus9a86N8Xk6aAPzBDqzYb1vyFIfBxP0oO8xFHgd30Cgmz8UrSE3qeWRrF8ftrI6xQnFjHBGWD/JWSvd6YMcQED0aVuQkuNW9ST/DzQThPzRfPUoiL10yAmV7Ytu4fR3x2sF0Yfi87YhHFuCMpV/DsqxmUizyiJuD938eRcH8hzR/VO53Qo3UIsqOLcyXtTv6THjSlTopQ+JOLOnHm1w8dzYbLN44OG44rRsbihMUQp+wUZ6bsI8rrOnm9WErzkbQFbrfAINdoCiNa6cimYIjvvnMTaFWNymqY1vZxGztQiMiHiHYwTfwHTXrb9j0uPM=|09J28iXv9oWzYtzK2LBT6Yht4IT4MijEkk0fwFdrVQ4=".parse().unwrap();
@@ -146,18 +150,23 @@ mod tests {
 
         let result =
             validate_password_user_key(&client, "asdfasdfasdf".to_owned(), user_key.to_string())
+                .await
                 .unwrap();
 
         assert_eq!(
             result.to_string(),
             "aOvkBXFhSdgrBWR3hZCMRoML9+h5yRblU3lFphCdkeA="
         );
-        assert!(validate_password(&client, password.to_owned(), result).unwrap())
+        assert!(
+            validate_password(&client, password.to_owned(), result)
+                .await
+                .unwrap()
+        )
     }
 
     #[cfg(feature = "internal")]
-    #[test]
-    fn test_validate_password_user_key_wrong_password() {
+    #[tokio::test]
+    async fn test_validate_password_user_key_wrong_password() {
         use std::num::NonZeroU32;
 
         use bitwarden_crypto::Kdf;
@@ -178,7 +187,8 @@ mod tests {
                 email: email.to_string(),
                 kdf: kdf.clone(),
                 client_id: "1".to_string(),
-            }));
+            }))
+            .await;
 
         let user_key = "2.Q/2PhzcC7GdeiMHhWguYAQ==|GpqzVdr0go0ug5cZh1n+uixeBC3oC90CIe0hd/HWA/pTRDZ8ane4fmsEIcuc8eMKUt55Y2q/fbNzsYu41YTZzzsJUSeqVjT8/iTQtgnNdpo=|dwI+uyvZ1h/iZ03VQ+/wrGEFYVewBUUl/syYgjsNMbE=";
         let private_key = "2.yN7l00BOlUE0Sb0M//Q53w==|EwKG/BduQRQ33Izqc/ogoBROIoI5dmgrxSo82sgzgAMIBt3A2FZ9vPRMY+GWT85JiqytDitGR3TqwnFUBhKUpRRAq4x7rA6A1arHrFp5Tp1p21O3SfjtvB3quiOKbqWk6ZaU1Np9HwqwAecddFcB0YyBEiRX3VwF2pgpAdiPbSMuvo2qIgyob0CUoC/h4Bz1be7Qa7B0Xw9/fMKkB1LpOm925lzqosyMQM62YpMGkjMsbZz0uPopu32fxzDWSPr+kekNNyLt9InGhTpxLmq1go/pXR2uw5dfpXc5yuta7DB0EGBwnQ8Vl5HPdDooqOTD9I1jE0mRyuBpWTTI3FRnu3JUh3rIyGBJhUmHqGZvw2CKdqHCIrQeQkkEYqOeJRJVdBjhv5KGJifqT3BFRwX/YFJIChAQpebNQKXe/0kPivWokHWwXlDB7S7mBZzhaAPidZvnuIhalE2qmTypDwHy22FyqV58T8MGGMchcASDi/QXI6kcdpJzPXSeU9o+NC68QDlOIrMVxKFeE7w7PvVmAaxEo0YwmuAzzKy9QpdlK0aab/xEi8V4iXj4hGepqAvHkXIQd+r3FNeiLfllkb61p6WTjr5urcmDQMR94/wYoilpG5OlybHdbhsYHvIzYoLrC7fzl630gcO6t4nM24vdB6Ymg9BVpEgKRAxSbE62Tqacxqnz9AcmgItb48NiR/He3n3ydGjPYuKk/ihZMgEwAEZvSlNxYONSbYrIGDtOY+8Nbt6KiH3l06wjZW8tcmFeVlWv+tWotnTY9IqlAfvNVTjtsobqtQnvsiDjdEVtNy/s2ci5TH+NdZluca2OVEr91Wayxh70kpM6ib4UGbfdmGgCo74gtKvKSJU0rTHakQ5L9JlaSDD5FamBRyI0qfL43Ad9qOUZ8DaffDCyuaVyuqk7cz9HwmEmvWU3VQ+5t06n/5kRDXttcw8w+3qClEEdGo1KeENcnXCB32dQe3tDTFpuAIMLqwXs6FhpawfZ5kPYvLPczGWaqftIs/RXJ/EltGc0ugw2dmTLpoQhCqrcKEBDoYVk0LDZKsnzitOGdi9mOWse7Se8798ib1UsHFUjGzISEt6upestxOeupSTOh0v4+AjXbDzRUyogHww3V+Bqg71bkcMxtB+WM+pn1XNbVTyl9NR040nhP7KEf6e9ruXAtmrBC2ah5cFEpLIot77VFZ9ilLuitSz+7T8n1yAh1IEG6xxXxninAZIzi2qGbH69O5RSpOJuJTv17zTLJQIIc781JwQ2TTwTGnx5wZLbffhCasowJKd2EVcyMJyhz6ru0PvXWJ4hUdkARJs3Xu8dus9a86N8Xk6aAPzBDqzYb1vyFIfBxP0oO8xFHgd30Cgmz8UrSE3qeWRrF8ftrI6xQnFjHBGWD/JWSvd6YMcQED0aVuQkuNW9ST/DzQThPzRfPUoiL10yAmV7Ytu4fR3x2sF0Yfi87YhHFuCMpV/DsqxmUizyiJuD938eRcH8hzR/VO53Qo3UIsqOLcyXtTv6THjSlTopQ+JOLOnHm1w8dzYbLN44OG44rRsbihMUQp+wUZ6bsI8rrOnm9WErzkbQFbrfAINdoCiNa6cimYIjvvnMTaFWNymqY1vZxGztQiMiHiHYwTfwHTXrb9j0uPM=|09J28iXv9oWzYtzK2LBT6Yht4IT4MijEkk0fwFdrVQ4=".parse().unwrap();
@@ -199,12 +209,17 @@ mod tests {
 
         let result =
             validate_password_user_key(&client, "asdfasdfasdf".to_string(), user_key.to_string())
+                .await
                 .unwrap();
 
         assert_eq!(
             result.to_string(),
             "aOvkBXFhSdgrBWR3hZCMRoML9+h5yRblU3lFphCdkeA="
         );
-        assert!(validate_password(&client, "asdfasdfasdf".to_string(), result).unwrap())
+        assert!(
+            validate_password(&client, "asdfasdfasdf".to_string(), result)
+                .await
+                .unwrap()
+        )
     }
 }

--- a/crates/bitwarden-core/src/auth/pin.rs
+++ b/crates/bitwarden-core/src/auth/pin.rs
@@ -9,7 +9,7 @@ use crate::{
     key_management::SymmetricKeyId,
 };
 
-pub(crate) fn validate_pin(
+pub(crate) async fn validate_pin(
     client: &Client,
     pin: String,
     pin_protected_user_key: EncString,
@@ -17,6 +17,7 @@ pub(crate) fn validate_pin(
     let login_method = client
         .internal
         .get_login_method()
+        .await
         .ok_or(NotAuthenticatedError)?;
 
     match login_method {
@@ -74,7 +75,7 @@ mod tests {
         },
     };
 
-    fn init_client() -> Client {
+    async fn init_client() -> Client {
         let client = Client::new(None);
 
         let password = "asdfasdfasdf";
@@ -89,7 +90,8 @@ mod tests {
                 email: email.to_string(),
                 kdf: kdf.clone(),
                 client_id: "1".to_string(),
-            }));
+            }))
+            .await;
 
         let user_key = "2.Q/2PhzcC7GdeiMHhWguYAQ==|GpqzVdr0go0ug5cZh1n+uixeBC3oC90CIe0hd/HWA/pTRDZ8ane4fmsEIcuc8eMKUt55Y2q/fbNzsYu41YTZzzsJUSeqVjT8/iTQtgnNdpo=|dwI+uyvZ1h/iZ03VQ+/wrGEFYVewBUUl/syYgjsNMbE=";
         let private_key = "2.yN7l00BOlUE0Sb0M//Q53w==|EwKG/BduQRQ33Izqc/ogoBROIoI5dmgrxSo82sgzgAMIBt3A2FZ9vPRMY+GWT85JiqytDitGR3TqwnFUBhKUpRRAq4x7rA6A1arHrFp5Tp1p21O3SfjtvB3quiOKbqWk6ZaU1Np9HwqwAecddFcB0YyBEiRX3VwF2pgpAdiPbSMuvo2qIgyob0CUoC/h4Bz1be7Qa7B0Xw9/fMKkB1LpOm925lzqosyMQM62YpMGkjMsbZz0uPopu32fxzDWSPr+kekNNyLt9InGhTpxLmq1go/pXR2uw5dfpXc5yuta7DB0EGBwnQ8Vl5HPdDooqOTD9I1jE0mRyuBpWTTI3FRnu3JUh3rIyGBJhUmHqGZvw2CKdqHCIrQeQkkEYqOeJRJVdBjhv5KGJifqT3BFRwX/YFJIChAQpebNQKXe/0kPivWokHWwXlDB7S7mBZzhaAPidZvnuIhalE2qmTypDwHy22FyqV58T8MGGMchcASDi/QXI6kcdpJzPXSeU9o+NC68QDlOIrMVxKFeE7w7PvVmAaxEo0YwmuAzzKy9QpdlK0aab/xEi8V4iXj4hGepqAvHkXIQd+r3FNeiLfllkb61p6WTjr5urcmDQMR94/wYoilpG5OlybHdbhsYHvIzYoLrC7fzl630gcO6t4nM24vdB6Ymg9BVpEgKRAxSbE62Tqacxqnz9AcmgItb48NiR/He3n3ydGjPYuKk/ihZMgEwAEZvSlNxYONSbYrIGDtOY+8Nbt6KiH3l06wjZW8tcmFeVlWv+tWotnTY9IqlAfvNVTjtsobqtQnvsiDjdEVtNy/s2ci5TH+NdZluca2OVEr91Wayxh70kpM6ib4UGbfdmGgCo74gtKvKSJU0rTHakQ5L9JlaSDD5FamBRyI0qfL43Ad9qOUZ8DaffDCyuaVyuqk7cz9HwmEmvWU3VQ+5t06n/5kRDXttcw8w+3qClEEdGo1KeENcnXCB32dQe3tDTFpuAIMLqwXs6FhpawfZ5kPYvLPczGWaqftIs/RXJ/EltGc0ugw2dmTLpoQhCqrcKEBDoYVk0LDZKsnzitOGdi9mOWse7Se8798ib1UsHFUjGzISEt6upestxOeupSTOh0v4+AjXbDzRUyogHww3V+Bqg71bkcMxtB+WM+pn1XNbVTyl9NR040nhP7KEf6e9ruXAtmrBC2ah5cFEpLIot77VFZ9ilLuitSz+7T8n1yAh1IEG6xxXxninAZIzi2qGbH69O5RSpOJuJTv17zTLJQIIc781JwQ2TTwTGnx5wZLbffhCasowJKd2EVcyMJyhz6ru0PvXWJ4hUdkARJs3Xu8dus9a86N8Xk6aAPzBDqzYb1vyFIfBxP0oO8xFHgd30Cgmz8UrSE3qeWRrF8ftrI6xQnFjHBGWD/JWSvd6YMcQED0aVuQkuNW9ST/DzQThPzRfPUoiL10yAmV7Ytu4fR3x2sF0Yfi87YhHFuCMpV/DsqxmUizyiJuD938eRcH8hzR/VO53Qo3UIsqOLcyXtTv6THjSlTopQ+JOLOnHm1w8dzYbLN44OG44rRsbihMUQp+wUZ6bsI8rrOnm9WErzkbQFbrfAINdoCiNa6cimYIjvvnMTaFWNymqY1vZxGztQiMiHiHYwTfwHTXrb9j0uPM=|09J28iXv9oWzYtzK2LBT6Yht4IT4MijEkk0fwFdrVQ4=".parse().unwrap();
@@ -111,32 +113,40 @@ mod tests {
         client
     }
 
-    #[test]
-    fn test_validate_valid_pin() {
+    #[tokio::test]
+    async fn test_validate_valid_pin() {
         let pin = "1234".to_string();
         let pin_protected_user_key = "2.BXgvdBUeEMyvumqAJkAzPA==|JScDPoqOkVdrC1X755Ubt8tS9pC/thvrvNf5CyNcRg8HZtZ466EcRo7aCqwUzLyTVNRkbCYtFYT+09acGGHur8tGuS7Kmg/pYeaUo4K0UKI=|NpIFg5P9z0SN1MffbixD9OQE0l+NiNmnRQJs/kTsyoQ="
         .parse()
         .unwrap();
 
-        let client = init_client();
-        assert!(validate_pin(&client, pin.clone(), pin_protected_user_key).unwrap());
+        let client = init_client().await;
+        assert!(
+            validate_pin(&client, pin.clone(), pin_protected_user_key)
+                .await
+                .unwrap()
+        );
     }
 
-    #[test]
-    fn test_validate_invalid_pin() {
+    #[tokio::test]
+    async fn test_validate_invalid_pin() {
         let pin = "1234".to_string();
         let pin_protected_user_key = "2.BXgvdBUeEMyvumqAJkAyPA==|JScDPoqOkVdrC1X755Ubt8tS9pC/thvrvNf5CyNcRg8HZtZ466EcRo7aCqwUzLyTVNRkbCYtFYT+09acGGHur8tGuS7Kmg/pYeaUo4K0UKI=|NpIFg5P9z0SN1MffbixD9OQE0l+NiNmnRQJs/kTsyoQ="
         .parse()
         .unwrap();
 
-        let client = init_client();
-        assert!(!validate_pin(&client, pin.clone(), pin_protected_user_key).unwrap());
+        let client = init_client().await;
+        assert!(
+            !validate_pin(&client, pin.clone(), pin_protected_user_key)
+                .await
+                .unwrap()
+        );
     }
 
-    #[test]
-    fn test_validate_pin_protected_user_key_envelope_valid_pin() {
+    #[tokio::test]
+    async fn test_validate_pin_protected_user_key_envelope_valid_pin() {
         let pin = "1234";
-        let client = init_client();
+        let client = init_client().await;
 
         // Create a PIN-protected envelope from the user key
         let key_store = client.internal.get_key_store();
@@ -154,11 +164,11 @@ mod tests {
         assert!(result);
     }
 
-    #[test]
-    fn test_validate_pin_protected_user_key_envelope_invalid_pin() {
+    #[tokio::test]
+    async fn test_validate_pin_protected_user_key_envelope_invalid_pin() {
         let correct_pin = "1234";
         let wrong_pin = "5678";
-        let client = init_client();
+        let client = init_client().await;
 
         // Create a PIN-protected envelope with the correct PIN
         let key_store = client.internal.get_key_store();
@@ -177,11 +187,11 @@ mod tests {
         assert!(!result);
     }
 
-    #[test]
-    fn test_validate_pin_protected_user_key_malformed_envelope() {
+    #[tokio::test]
+    async fn test_validate_pin_protected_user_key_malformed_envelope() {
         let pin = "1234";
 
-        let client = init_client();
+        let client = init_client().await;
 
         // Create a PIN-protected envelope with the correct PIN
         let key_store = client.internal.get_key_store();

--- a/crates/bitwarden-core/src/auth/tde.rs
+++ b/crates/bitwarden-core/src/auth/tde.rs
@@ -12,7 +12,7 @@ use crate::{
 /// This function generates a new user key and key pair, initializes the client's crypto with the
 /// generated user key, and encrypts the user key with the organization public key for admin
 /// password reset. If remember_device is true, it also generates a device key.
-pub(super) fn make_register_tde_keys(
+pub(super) async fn make_register_tde_keys(
     client: &Client,
     email: String,
     org_public_key: B64,
@@ -50,7 +50,8 @@ pub(super) fn make_register_tde_keys(
                 email,
                 kdf: Kdf::default_pbkdf2(),
             },
-        ));
+        ))
+        .await;
 
     Ok(RegisterTdeKeyResponse {
         private_key: key_pair.private,

--- a/crates/bitwarden-core/src/client/internal.rs
+++ b/crates/bitwarden-core/src/client/internal.rs
@@ -116,18 +116,21 @@ impl InternalClient {
     /// Load feature flags. This is intentionally a collection and not the internal `Flag` enum as
     /// we want to avoid changes in feature flags from being a breaking change.
     #[cfg(feature = "internal")]
-    pub fn load_flags(&self, flags: std::collections::HashMap<String, bool>) {
+    #[expect(clippy::unused_async)]
+    pub async fn load_flags(&self, flags: std::collections::HashMap<String, bool>) {
         *self.flags.write().expect("RwLock is not poisoned") = Flags::load_from_map(flags);
     }
 
     /// Retrieve the active feature flags.
     #[cfg(feature = "internal")]
-    pub fn get_flags(&self) -> Flags {
+    #[expect(clippy::unused_async)]
+    pub async fn get_flags(&self) -> Flags {
         self.flags.read().expect("RwLock is not poisoned").clone()
     }
 
     #[cfg(feature = "internal")]
-    pub(crate) fn get_login_method(&self) -> Option<UserLoginMethod> {
+    #[expect(clippy::unused_async)]
+    pub(crate) async fn get_login_method(&self) -> Option<UserLoginMethod> {
         let lm = self.login_method.read().expect("RwLock is not poisoned");
         match lm.as_deref()? {
             LoginMethod::User(ulm) => Some(ulm.clone()),
@@ -137,7 +140,8 @@ impl InternalClient {
     }
 
     #[cfg(any(feature = "internal", feature = "secrets"))]
-    pub(crate) fn set_login_method(&self, login_method: LoginMethod) {
+    #[expect(clippy::unused_async)]
+    pub(crate) async fn set_login_method(&self, login_method: LoginMethod) {
         use tracing::debug;
 
         debug!(?login_method, "setting login method.");
@@ -152,7 +156,8 @@ impl InternalClient {
 
     #[allow(missing_docs)]
     #[cfg(feature = "internal")]
-    pub fn get_kdf(&self) -> Result<Kdf, NotAuthenticatedError> {
+    #[expect(clippy::unused_async)]
+    pub async fn get_kdf(&self) -> Result<Kdf, NotAuthenticatedError> {
         match self
             .login_method
             .read()
@@ -362,36 +367,42 @@ impl InternalClient {
     /// Sets the local KDF state for the master password unlock login method.
     /// Salt and user key update is not supported yet.
     #[cfg(feature = "internal")]
-    pub fn set_user_master_password_unlock(
+    pub async fn set_user_master_password_unlock(
         &self,
         master_password_unlock: MasterPasswordUnlockData,
     ) -> Result<(), NotAuthenticatedError> {
         let new_kdf = master_password_unlock.kdf;
 
-        let login_method = self.get_login_method().ok_or(NotAuthenticatedError)?;
+        let login_method = self.get_login_method().await.ok_or(NotAuthenticatedError)?;
 
-        let kdf = self.get_kdf()?;
+        let kdf = self.get_kdf().await?;
 
         if kdf != new_kdf {
             match login_method {
                 UserLoginMethod::Username {
                     client_id, email, ..
-                } => self.set_login_method(LoginMethod::User(UserLoginMethod::Username {
-                    client_id,
-                    email,
-                    kdf: new_kdf,
-                })),
+                } => {
+                    self.set_login_method(LoginMethod::User(UserLoginMethod::Username {
+                        client_id,
+                        email,
+                        kdf: new_kdf,
+                    }))
+                    .await
+                }
                 UserLoginMethod::ApiKey {
                     client_id,
                     client_secret,
                     email,
                     ..
-                } => self.set_login_method(LoginMethod::User(UserLoginMethod::ApiKey {
-                    client_id,
-                    client_secret,
-                    email,
-                    kdf: new_kdf,
-                })),
+                } => {
+                    self.set_login_method(LoginMethod::User(UserLoginMethod::ApiKey {
+                        client_id,
+                        client_secret,
+                        email,
+                        kdf: new_kdf,
+                    }))
+                    .await
+                }
             };
         }
 
@@ -453,9 +464,10 @@ mod tests {
                 master_key_wrapped_user_key: user_key,
                 salt: email,
             })
+            .await
             .unwrap();
 
-        let kdf = client.internal.get_kdf().unwrap();
+        let kdf = client.internal.get_kdf().await.unwrap();
         assert_eq!(kdf, new_kdf);
     }
 
@@ -480,9 +492,10 @@ mod tests {
                 master_key_wrapped_user_key: new_encrypted_user_key,
                 salt: new_email,
             })
+            .await
             .unwrap();
 
-        let login_method = client.internal.get_login_method().unwrap();
+        let login_method = client.internal.get_login_method().await.unwrap();
         match login_method {
             UserLoginMethod::Username { email, .. } => {
                 assert_eq!(*email, expected_email);

--- a/crates/bitwarden-core/src/client/test_accounts.rs
+++ b/crates/bitwarden-core/src/client/test_accounts.rs
@@ -42,10 +42,13 @@ impl Client {
     pub async fn init_test_account(account: TestAccount) -> Self {
         let client = Client::new_test(None);
 
-        client.internal.load_flags(HashMap::from([(
-            "enableCipherKeyEncryption".to_owned(),
-            true,
-        )]));
+        client
+            .internal
+            .load_flags(HashMap::from([(
+                "enableCipherKeyEncryption".to_owned(),
+                true,
+            )]))
+            .await;
 
         client
             .crypto()

--- a/crates/bitwarden-core/src/key_management/crypto.rs
+++ b/crates/bitwarden-core/src/key_management/crypto.rs
@@ -355,7 +355,8 @@ pub(super) async fn initialize_user_crypto(
             client_id: "".to_string(),
             email: req.email,
             kdf: req.kdf_params,
-        }));
+        }))
+        .await;
 
     info!("User crypto initialized successfully");
 
@@ -406,36 +407,39 @@ pub struct UpdateKdfResponse {
     old_master_password_authentication_data: MasterPasswordAuthenticationData,
 }
 
-pub(super) fn make_update_kdf(
+pub(super) async fn make_update_kdf(
     client: &Client,
     password: &str,
     new_kdf: &Kdf,
 ) -> Result<UpdateKdfResponse, CryptoClientError> {
-    let key_store = client.internal.get_key_store();
-    let ctx = key_store.context();
-
     let login_method = client
         .internal
         .get_login_method()
+        .await
         .ok_or(NotAuthenticatedError)?;
     let email = match login_method {
         UserLoginMethod::Username { email, .. } | UserLoginMethod::ApiKey { email, .. } => email,
     };
+
+    let old_authentication_data = MasterPasswordAuthenticationData::derive(
+        password,
+        &client
+            .internal
+            .get_kdf()
+            .await
+            .map_err(|_| NotAuthenticatedError)?,
+        &email,
+    )
+    .map_err(|_| CryptoClientError::InvalidKdfSettings)?;
+
+    let key_store = client.internal.get_key_store();
+    let ctx = key_store.context();
 
     let authentication_data = MasterPasswordAuthenticationData::derive(password, new_kdf, &email)
         .map_err(|_| CryptoClientError::InvalidKdfSettings)?;
     let unlock_data =
         MasterPasswordUnlockData::derive(password, new_kdf, &email, SymmetricKeyId::User, &ctx)
             .map_err(|_| CryptoClientError::InvalidKdfSettings)?;
-    let old_authentication_data = MasterPasswordAuthenticationData::derive(
-        password,
-        &client
-            .internal
-            .get_kdf()
-            .map_err(|_| NotAuthenticatedError)?,
-        &email,
-    )
-    .map_err(|_| CryptoClientError::InvalidKdfSettings)?;
 
     Ok(UpdateKdfResponse {
         master_password_authentication_data: authentication_data,
@@ -456,20 +460,21 @@ pub struct UpdatePasswordResponse {
     new_key: EncString,
 }
 
-pub(super) fn make_update_password(
+pub(super) async fn make_update_password(
     client: &Client,
     new_password: String,
 ) -> Result<UpdatePasswordResponse, CryptoClientError> {
+    let login_method = client
+        .internal
+        .get_login_method()
+        .await
+        .ok_or(NotAuthenticatedError)?;
+
     let key_store = client.internal.get_key_store();
     let ctx = key_store.context();
     // FIXME: [PM-18099] Once MasterKey deals with KeyIds, this should be updated
     #[allow(deprecated)]
     let user_key = ctx.dangerous_get_symmetric_key(SymmetricKeyId::User)?;
-
-    let login_method = client
-        .internal
-        .get_login_method()
-        .ok_or(NotAuthenticatedError)?;
 
     // Derive a new master key from password
     let new_master_key = match login_method {
@@ -536,20 +541,21 @@ pub struct DerivePinKeyResponse {
     encrypted_pin: EncString,
 }
 
-pub(super) fn derive_pin_key(
+pub(super) async fn derive_pin_key(
     client: &Client,
     pin: String,
 ) -> Result<DerivePinKeyResponse, CryptoClientError> {
+    let login_method = client
+        .internal
+        .get_login_method()
+        .await
+        .ok_or(NotAuthenticatedError)?;
+
     let key_store = client.internal.get_key_store();
     let ctx = key_store.context();
     // FIXME: [PM-18099] Once PinKey deals with KeyIds, this should be updated
     #[allow(deprecated)]
     let user_key = ctx.dangerous_get_symmetric_key(SymmetricKeyId::User)?;
-
-    let login_method = client
-        .internal
-        .get_login_method()
-        .ok_or(NotAuthenticatedError)?;
 
     let pin_protected_user_key = derive_pin_protected_user_key(&pin, &login_method, user_key)?;
 
@@ -559,10 +565,16 @@ pub(super) fn derive_pin_key(
     })
 }
 
-pub(super) fn derive_pin_user_key(
+pub(super) async fn derive_pin_user_key(
     client: &Client,
     encrypted_pin: EncString,
 ) -> Result<EncString, CryptoClientError> {
+    let login_method = client
+        .internal
+        .get_login_method()
+        .await
+        .ok_or(NotAuthenticatedError)?;
+
     let key_store = client.internal.get_key_store();
     let ctx = key_store.context();
     // FIXME: [PM-18099] Once PinKey deals with KeyIds, this should be updated
@@ -570,10 +582,6 @@ pub(super) fn derive_pin_user_key(
     let user_key = ctx.dangerous_get_symmetric_key(SymmetricKeyId::User)?;
 
     let pin: String = encrypted_pin.decrypt_with_key(user_key)?;
-    let login_method = client
-        .internal
-        .get_login_method()
-        .ok_or(NotAuthenticatedError)?;
 
     derive_pin_protected_user_key(&pin, &login_method, user_key)
 }
@@ -1186,7 +1194,9 @@ mod tests {
         let new_kdf = Kdf::PBKDF2 {
             iterations: 600_000.try_into().unwrap(),
         };
-        let new_kdf_response = make_update_kdf(&client, "123412341234", &new_kdf).unwrap();
+        let new_kdf_response = make_update_kdf(&client, "123412341234", &new_kdf)
+            .await
+            .unwrap();
 
         let client2 = Client::new_test(None);
 
@@ -1285,7 +1295,9 @@ mod tests {
             .await
             .unwrap();
 
-        let new_password_response = make_update_password(&client, "123412341234".into()).unwrap();
+        let new_password_response = make_update_password(&client, "123412341234".into())
+            .await
+            .unwrap();
 
         let client2 = Client::new_test(None);
 
@@ -1377,7 +1389,7 @@ mod tests {
             .await
             .unwrap();
 
-        let pin_key = derive_pin_key(&client, "1234".into()).unwrap();
+        let pin_key = derive_pin_key(&client, "1234".into()).await.unwrap();
 
         // Verify we can unlock with the pin
         let client2 = Client::new_test(None);
@@ -1423,7 +1435,9 @@ mod tests {
         assert_eq!(client_key, client2_key);
 
         // Verify we can derive the pin protected user key from the encrypted pin
-        let pin_protected_user_key = derive_pin_user_key(&client, pin_key.encrypted_pin).unwrap();
+        let pin_protected_user_key = derive_pin_user_key(&client, pin_key.encrypted_pin)
+            .await
+            .unwrap();
 
         let client3 = Client::new_test(None);
 
@@ -1886,10 +1900,12 @@ mod tests {
         .unwrap();
 
         let key_store = client.internal.get_key_store();
-        let context = key_store.context();
-        assert!(context.has_symmetric_key(SymmetricKeyId::User));
-        assert!(context.has_private_key(PrivateKeyId::UserPrivateKey));
-        let login_method = client.internal.get_login_method().unwrap();
+        {
+            let context = key_store.context();
+            assert!(context.has_symmetric_key(SymmetricKeyId::User));
+            assert!(context.has_private_key(PrivateKeyId::UserPrivateKey));
+        }
+        let login_method = client.internal.get_login_method().await.unwrap();
         if let UserLoginMethod::Username {
             email,
             kdf,

--- a/crates/bitwarden-core/src/key_management/crypto_client.rs
+++ b/crates/bitwarden-core/src/key_management/crypto_client.rs
@@ -100,12 +100,12 @@ impl CryptoClient {
     /// Create the data necessary to update the user's kdf settings. The user's encryption key is
     /// re-encrypted for the password under the new kdf settings. This returns the re-encrypted
     /// user key and the new password hash but does not update sdk state.
-    pub fn make_update_kdf(
+    pub async fn make_update_kdf(
         &self,
         password: String,
         kdf: Kdf,
     ) -> Result<UpdateKdfResponse, CryptoClientError> {
-        make_update_kdf(&self.client, &password, &kdf)
+        make_update_kdf(&self.client, &password, &kdf).await
     }
 
     /// Protects the current user key with the provided PIN. The result can be stored and later
@@ -191,27 +191,30 @@ impl CryptoClient {
     /// Create the data necessary to update the user's password. The user's encryption key is
     /// re-encrypted with the new password. This returns the new encrypted user key and the new
     /// password hash but does not update sdk state.
-    pub fn make_update_password(
+    pub async fn make_update_password(
         &self,
         new_password: String,
     ) -> Result<UpdatePasswordResponse, CryptoClientError> {
-        make_update_password(&self.client, new_password)
+        make_update_password(&self.client, new_password).await
     }
 
     /// Generates a PIN protected user key from the provided PIN. The result can be stored and later
     /// used to initialize another client instance by using the PIN and the PIN key with
     /// `initialize_user_crypto`.
-    pub fn derive_pin_key(&self, pin: String) -> Result<DerivePinKeyResponse, CryptoClientError> {
-        derive_pin_key(&self.client, pin)
+    pub async fn derive_pin_key(
+        &self,
+        pin: String,
+    ) -> Result<DerivePinKeyResponse, CryptoClientError> {
+        derive_pin_key(&self.client, pin).await
     }
 
     /// Derives the pin protected user key from encrypted pin. Used when pin requires master
     /// password on first unlock.
-    pub fn derive_pin_user_key(
+    pub async fn derive_pin_user_key(
         &self,
         encrypted_pin: EncString,
     ) -> Result<EncString, CryptoClientError> {
-        derive_pin_user_key(&self.client, encrypted_pin)
+        derive_pin_user_key(&self.client, encrypted_pin).await
     }
 
     /// Creates a new rotateable key set for the current user key protected

--- a/crates/bitwarden-core/src/platform/get_user_api_key.rs
+++ b/crates/bitwarden-core/src/platform/get_user_api_key.rs
@@ -46,7 +46,7 @@ pub(crate) async fn get_user_api_key(
     info!("Getting Api Key");
     debug!(?input);
 
-    let login_method = get_login_method(client)?;
+    let login_method = get_login_method(client).await?;
     let config = client.internal.get_api_configurations();
 
     let request = build_secret_verification_request(&login_method, input)?;
@@ -59,10 +59,11 @@ pub(crate) async fn get_user_api_key(
     UserApiKeyResponse::process_response(response)
 }
 
-fn get_login_method(client: &Client) -> Result<UserLoginMethod, NotAuthenticatedError> {
+async fn get_login_method(client: &Client) -> Result<UserLoginMethod, NotAuthenticatedError> {
     client
         .internal
         .get_login_method()
+        .await
         .ok_or(NotAuthenticatedError)
 }
 

--- a/crates/bitwarden-exporters/Cargo.toml
+++ b/crates/bitwarden-exporters/Cargo.toml
@@ -22,6 +22,7 @@ wasm = [
     "bitwarden-vault/wasm",
     "dep:tsify",
     "dep:wasm-bindgen",
+    "dep:wasm-bindgen-futures",
 ]
 
 [dependencies]
@@ -45,6 +46,7 @@ uniffi = { workspace = true, optional = true }
 url = { workspace = true }
 uuid = { workspace = true }
 wasm-bindgen = { workspace = true, optional = true }
+wasm-bindgen-futures = { workspace = true, optional = true }
 
 [lints]
 workspace = true

--- a/crates/bitwarden-exporters/README.md
+++ b/crates/bitwarden-exporters/README.md
@@ -55,10 +55,11 @@ use bitwarden_core::Client;
 use bitwarden_exporters::{ExporterClientExt, ExportFormat};
 # use bitwarden_vault::{Cipher, Folder};
 
-fn export(client: &Client, folders: Vec<Folder>, ciphers: Vec<Cipher>) {
+async fn export(client: &Client, folders: Vec<Folder>, ciphers: Vec<Cipher>) {
     let export = client
         .exporters()
         .export_vault(folders, ciphers, ExportFormat::Json)
+        .await
         .unwrap();
 }
 ```

--- a/crates/bitwarden-exporters/src/export.rs
+++ b/crates/bitwarden-exporters/src/export.rs
@@ -11,7 +11,7 @@ use crate::{
     json::export_json,
 };
 
-pub(crate) fn export_vault(
+pub(crate) async fn export_vault(
     client: &Client,
     folders: Vec<Folder>,
     ciphers: Vec<Cipher>,
@@ -34,7 +34,7 @@ pub(crate) fn export_vault(
             folders,
             ciphers,
             password,
-            client.internal.get_kdf()?,
+            client.internal.get_kdf().await?,
         )?),
     }
 }

--- a/crates/bitwarden-exporters/src/exporter_client.rs
+++ b/crates/bitwarden-exporters/src/exporter_client.rs
@@ -22,13 +22,13 @@ impl ExporterClient {
     }
 
     #[allow(missing_docs)]
-    pub fn export_vault(
+    pub async fn export_vault(
         &self,
         folders: Vec<Folder>,
         ciphers: Vec<Cipher>,
         format: ExportFormat,
     ) -> Result<String, ExportError> {
-        export_vault(&self.client, folders, ciphers, format)
+        export_vault(&self.client, folders, ciphers, format).await
     }
 
     #[allow(missing_docs)]

--- a/crates/bitwarden-uniffi/src/auth/mod.rs
+++ b/crates/bitwarden-uniffi/src/auth/mod.rs
@@ -63,7 +63,7 @@ impl AuthClient {
     }
 
     /// Generate keys needed for TDE process
-    pub fn make_register_tde_keys(
+    pub async fn make_register_tde_keys(
         &self,
         email: String,
         org_public_key: B64,
@@ -72,7 +72,8 @@ impl AuthClient {
         Ok(self
             .0
             .auth()
-            .make_register_tde_keys(email, org_public_key, remember_device)?)
+            .make_register_tde_keys(email, org_public_key, remember_device)
+            .await?)
     }
 
     /// Generate keys needed to onboard a new user without master key to key connector
@@ -85,8 +86,12 @@ impl AuthClient {
     /// To retrieve the user's password hash, use [`AuthClient::hash_password`] with
     /// `HashPurpose::LocalAuthentication` during login and persist it. If the login method has no
     /// password, use the email OTP.
-    pub fn validate_password(&self, password: String, password_hash: B64) -> Result<bool> {
-        Ok(self.0.auth().validate_password(password, password_hash)?)
+    pub async fn validate_password(&self, password: String, password_hash: B64) -> Result<bool> {
+        Ok(self
+            .0
+            .auth()
+            .validate_password(password, password_hash)
+            .await?)
     }
 
     /// Validate the user password without knowing the password hash
@@ -95,7 +100,7 @@ impl AuthClient {
     /// password. Some example are login with device or TDE.
     ///
     /// This works by comparing the provided password against the encrypted user key.
-    pub fn validate_password_user_key(
+    pub async fn validate_password_user_key(
         &self,
         password: String,
         encrypted_user_key: String,
@@ -103,7 +108,8 @@ impl AuthClient {
         Ok(self
             .0
             .auth()
-            .validate_password_user_key(password, encrypted_user_key)?)
+            .validate_password_user_key(password, encrypted_user_key)
+            .await?)
     }
 
     /// Validate the user PIN
@@ -113,8 +119,16 @@ impl AuthClient {
     ///
     /// This works by comparing the decrypted user key with the current user key, so the client must
     /// be unlocked.
-    pub fn validate_pin(&self, pin: String, pin_protected_user_key: EncString) -> Result<bool> {
-        Ok(self.0.auth().validate_pin(pin, pin_protected_user_key)?)
+    pub async fn validate_pin(
+        &self,
+        pin: String,
+        pin_protected_user_key: EncString,
+    ) -> Result<bool> {
+        Ok(self
+            .0
+            .auth()
+            .validate_pin(pin, pin_protected_user_key)
+            .await?)
     }
 
     /// Validates a PIN against a PIN-protected user key envelope.

--- a/crates/bitwarden-uniffi/src/crypto.rs
+++ b/crates/bitwarden-uniffi/src/crypto.rs
@@ -37,21 +37,24 @@ impl CryptoClient {
     /// Create the data necessary to update the user's password. The user's encryption key is
     /// re-encrypted with the new password. This returns the new encrypted user key and the new
     /// password hash but does not update sdk state.
-    pub fn make_update_password(&self, new_password: String) -> Result<UpdatePasswordResponse> {
-        Ok(self.0.make_update_password(new_password)?)
+    pub async fn make_update_password(
+        &self,
+        new_password: String,
+    ) -> Result<UpdatePasswordResponse> {
+        Ok(self.0.make_update_password(new_password).await?)
     }
 
     /// Generates a PIN protected user key from the provided PIN. The result can be stored and later
     /// used to initialize another client instance by using the PIN and the PIN key with
     /// `initialize_user_crypto`.
-    pub fn derive_pin_key(&self, pin: String) -> Result<DerivePinKeyResponse> {
-        Ok(self.0.derive_pin_key(pin)?)
+    pub async fn derive_pin_key(&self, pin: String) -> Result<DerivePinKeyResponse> {
+        Ok(self.0.derive_pin_key(pin).await?)
     }
 
     /// Derives the pin protected user key from encrypted pin. Used when pin requires master
     /// password on first unlock.
-    pub fn derive_pin_user_key(&self, encrypted_pin: EncString) -> Result<EncString> {
-        Ok(self.0.derive_pin_user_key(encrypted_pin)?)
+    pub async fn derive_pin_user_key(&self, encrypted_pin: EncString) -> Result<EncString> {
+        Ok(self.0.derive_pin_user_key(encrypted_pin).await?)
     }
 
     /// Protects the current user key with the provided PIN. The result can be stored and later
@@ -91,8 +94,8 @@ impl CryptoClient {
     /// Create the data necessary to update the user's kdf settings. The user's encryption key is
     /// re-encrypted for the password under the new kdf settings. This returns the new encrypted
     /// user key and the new password hash but does not update sdk state.
-    pub fn make_update_kdf(&self, password: String, kdf: Kdf) -> Result<UpdateKdfResponse> {
-        Ok(self.0.make_update_kdf(password, kdf)?)
+    pub async fn make_update_kdf(&self, password: String, kdf: Kdf) -> Result<UpdateKdfResponse> {
+        Ok(self.0.make_update_kdf(password, kdf).await?)
     }
 
     /// Gets the upgraded V2 user key using an upgrade token.

--- a/crates/bitwarden-uniffi/src/platform/mod.rs
+++ b/crates/bitwarden-uniffi/src/platform/mod.rs
@@ -37,8 +37,8 @@ impl PlatformClient {
     }
 
     /// Load feature flags into the client
-    pub fn load_flags(&self, flags: std::collections::HashMap<String, bool>) -> Result<()> {
-        self.0.internal.load_flags(flags);
+    pub async fn load_flags(&self, flags: std::collections::HashMap<String, bool>) -> Result<()> {
+        self.0.internal.load_flags(flags).await;
         Ok(())
     }
 

--- a/crates/bitwarden-uniffi/src/tool/mod.rs
+++ b/crates/bitwarden-uniffi/src/tool/mod.rs
@@ -40,13 +40,13 @@ pub struct ExporterClient(pub(crate) bitwarden_exporters::ExporterClient);
 #[uniffi::export]
 impl ExporterClient {
     /// Export user vault
-    pub fn export_vault(
+    pub async fn export_vault(
         &self,
         folders: Vec<Folder>,
         ciphers: Vec<Cipher>,
         format: ExportFormat,
     ) -> Result<String> {
-        Ok(self.0.export_vault(folders, ciphers, format)?)
+        Ok(self.0.export_vault(folders, ciphers, format).await?)
     }
 
     /// Export organization vault

--- a/crates/bitwarden-uniffi/src/vault/ciphers.rs
+++ b/crates/bitwarden-uniffi/src/vault/ciphers.rs
@@ -11,32 +11,32 @@ use crate::Result;
 #[derive(uniffi::Object)]
 pub struct CiphersClient(pub(crate) bitwarden_vault::CiphersClient);
 
-#[uniffi::export]
+#[uniffi::export(async_runtime = "tokio")]
 impl CiphersClient {
     /// Encrypt cipher
-    pub fn encrypt(&self, cipher_view: CipherView) -> Result<EncryptionContext> {
-        Ok(self.0.encrypt(cipher_view)?)
+    pub async fn encrypt(&self, cipher_view: CipherView) -> Result<EncryptionContext> {
+        Ok(self.0.encrypt(cipher_view).await?)
     }
 
     /// Decrypt cipher
-    pub fn decrypt(&self, cipher: Cipher) -> Result<CipherView> {
-        Ok(self.0.decrypt(cipher)?)
+    pub async fn decrypt(&self, cipher: Cipher) -> Result<CipherView> {
+        Ok(self.0.decrypt(cipher).await?)
     }
 
     /// Decrypt cipher list
-    pub fn decrypt_list(&self, ciphers: Vec<Cipher>) -> Result<Vec<CipherListView>> {
-        Ok(self.0.decrypt_list(ciphers)?)
+    pub async fn decrypt_list(&self, ciphers: Vec<Cipher>) -> Result<Vec<CipherListView>> {
+        Ok(self.0.decrypt_list(ciphers).await?)
     }
 
     /// Decrypt cipher list with failures
     /// Returns both successfully decrypted ciphers and any that failed to decrypt
     // Note that this function still needs to return a Result, as the parameter conversion can still
     // fail
-    pub fn decrypt_list_with_failures(
+    pub async fn decrypt_list_with_failures(
         &self,
         ciphers: Vec<Cipher>,
     ) -> Result<DecryptCipherListResult> {
-        Ok(self.0.decrypt_list_with_failures(ciphers))
+        Ok(self.0.decrypt_list_with_failures(ciphers).await)
     }
 
     pub fn decrypt_fido2_credentials(

--- a/crates/bitwarden-uniffi/swift/iOS/App/ContentView.swift
+++ b/crates/bitwarden-uniffi/swift/iOS/App/ContentView.swift
@@ -222,7 +222,7 @@ struct ContentView: View {
         }
 
         if setupPin {
-            let pinOptions = try clientCrypto.derivePinKey(pin: PIN)
+            let pinOptions = try await clientCrypto.derivePinKey(pin: PIN)
 
             let defaults = UserDefaults.standard
             defaults.set(loginData.PrivateKey, forKey: "privateKey")

--- a/crates/bitwarden-vault/src/cipher/cipher_client/admin/create.rs
+++ b/crates/bitwarden-vault/src/cipher/cipher_client/admin/create.rs
@@ -91,6 +91,7 @@ impl CipherAdminClient {
             .client
             .internal
             .get_flags()
+            .await
             .enable_cipher_key_encryption
         {
             let key = internal_request.key_identifier();
@@ -102,7 +103,7 @@ impl CipherAdminClient {
             user_id,
             &config.api_client,
             key_store,
-            self.is_strict_decrypt(),
+            self.is_strict_decrypt().await,
         )
         .await
     }

--- a/crates/bitwarden-vault/src/cipher/cipher_client/admin/edit.rs
+++ b/crates/bitwarden-vault/src/cipher/cipher_client/admin/edit.rs
@@ -136,6 +136,7 @@ impl CipherAdminClient {
                 .client
                 .internal
                 .get_flags()
+                .await
                 .enable_cipher_key_encryption
         {
             let key = request.key_identifier();
@@ -148,7 +149,7 @@ impl CipherAdminClient {
             user_id,
             original_cipher_view,
             request,
-            self.is_strict_decrypt(),
+            self.is_strict_decrypt().await,
         )
         .await
     }
@@ -164,7 +165,7 @@ impl CipherAdminClient {
             collection_ids,
             &self.client.internal.get_api_configurations().api_client,
             self.client.internal.get_key_store(),
-            self.is_strict_decrypt(),
+            self.is_strict_decrypt().await,
         )
         .await
     }

--- a/crates/bitwarden-vault/src/cipher/cipher_client/admin/mod.rs
+++ b/crates/bitwarden-vault/src/cipher/cipher_client/admin/mod.rs
@@ -17,7 +17,11 @@ pub struct CipherAdminClient {
 }
 
 impl CipherAdminClient {
-    fn is_strict_decrypt(&self) -> bool {
-        self.client.internal.get_flags().strict_cipher_decryption
+    async fn is_strict_decrypt(&self) -> bool {
+        self.client
+            .internal
+            .get_flags()
+            .await
+            .strict_cipher_decryption
     }
 }

--- a/crates/bitwarden-vault/src/cipher/cipher_client/admin/restore.rs
+++ b/crates/bitwarden-vault/src/cipher/cipher_client/admin/restore.rs
@@ -89,7 +89,13 @@ impl CipherAdminClient {
         let api_client = &self.client.internal.get_api_configurations().api_client;
         let key_store = self.client.internal.get_key_store();
 
-        restore_as_admin(cipher_id, api_client, key_store, self.is_strict_decrypt()).await
+        restore_as_admin(
+            cipher_id,
+            api_client,
+            key_store,
+            self.is_strict_decrypt().await,
+        )
+        .await
     }
     /// Restores multiple soft-deleted ciphers on the server.
     pub async fn restore_many(

--- a/crates/bitwarden-vault/src/cipher/cipher_client/create.rs
+++ b/crates/bitwarden-vault/src/cipher/cipher_client/create.rs
@@ -280,6 +280,7 @@ impl CiphersClient {
             .client
             .internal
             .get_flags()
+            .await
             .enable_cipher_key_encryption
         {
             let key = internal_request.key_identifier();

--- a/crates/bitwarden-vault/src/cipher/cipher_client/edit.rs
+++ b/crates/bitwarden-vault/src/cipher/cipher_client/edit.rs
@@ -389,6 +389,7 @@ impl CiphersClient {
                 .client
                 .internal
                 .get_flags()
+                .await
                 .enable_cipher_key_encryption
         {
             let key = request.key_identifier();
@@ -401,7 +402,7 @@ impl CiphersClient {
             repository.as_ref(),
             user_id,
             request,
-            self.is_strict_decrypt(),
+            self.is_strict_decrypt().await,
         )
         .await
     }
@@ -437,7 +438,10 @@ impl CiphersClient {
             response
         };
 
-        Ok(self.decrypt(cipher).map_err(|_| CryptoError::KeyDecrypt)?)
+        Ok(self
+            .decrypt(cipher)
+            .await
+            .map_err(|_| CryptoError::KeyDecrypt)?)
     }
 }
 

--- a/crates/bitwarden-vault/src/cipher/cipher_client/get.rs
+++ b/crates/bitwarden-vault/src/cipher/cipher_client/get.rs
@@ -95,7 +95,7 @@ impl CiphersClient {
             key_store,
             repository.as_ref(),
             cipher_id,
-            self.is_strict_decrypt(),
+            self.is_strict_decrypt().await,
         )
         .await
     }

--- a/crates/bitwarden-vault/src/cipher/cipher_client/mod.rs
+++ b/crates/bitwarden-vault/src/cipher/cipher_client/mod.rs
@@ -37,7 +37,10 @@ pub struct CiphersClient {
 #[cfg_attr(feature = "wasm", wasm_bindgen)]
 impl CiphersClient {
     #[allow(missing_docs)]
-    pub fn encrypt(&self, mut cipher_view: CipherView) -> Result<EncryptionContext, EncryptError> {
+    pub async fn encrypt(
+        &self,
+        mut cipher_view: CipherView,
+    ) -> Result<EncryptionContext, EncryptError> {
         let user_id = self
             .client
             .internal
@@ -52,6 +55,7 @@ impl CiphersClient {
                 .client
                 .internal
                 .get_flags()
+                .await
                 .enable_cipher_key_encryption
         {
             let key = cipher_view.key_identifier();
@@ -76,7 +80,7 @@ impl CiphersClient {
     /// generated using the new key. Otherwise, the cipher's data will be encrypted with the new
     /// key directly.
     #[cfg(feature = "wasm")]
-    pub fn encrypt_cipher_for_rotation(
+    pub async fn encrypt_cipher_for_rotation(
         &self,
         mut cipher_view: CipherView,
         new_key: B64,
@@ -88,19 +92,20 @@ impl CiphersClient {
             .internal
             .get_user_id()
             .ok_or(EncryptError::MissingUserId)?;
+        let enable_cipher_key_encryption = self
+            .client
+            .internal
+            .get_flags()
+            .await
+            .enable_cipher_key_encryption;
+
         let key_store = self.client.internal.get_key_store();
         let mut ctx = key_store.context();
 
         // Set the new key in the key store context
         let new_key_id = ctx.add_local_symmetric_key(new_key);
 
-        if cipher_view.key.is_none()
-            && self
-                .client
-                .internal
-                .get_flags()
-                .enable_cipher_key_encryption
-        {
+        if cipher_view.key.is_none() && enable_cipher_key_encryption {
             cipher_view.generate_cipher_key(&mut ctx, new_key_id)?;
         } else {
             cipher_view.reencrypt_cipher_keys(&mut ctx, new_key_id)?;
@@ -119,7 +124,7 @@ impl CiphersClient {
     /// This method attempts to encrypt all ciphers in the list. If any cipher
     /// fails to encrypt, the entire operation fails and an error is returned.
     #[cfg(feature = "wasm")]
-    pub fn encrypt_list(
+    pub async fn encrypt_list(
         &self,
         cipher_views: Vec<CipherView>,
     ) -> Result<Vec<EncryptionContext>, EncryptError> {
@@ -133,6 +138,7 @@ impl CiphersClient {
             .client
             .internal
             .get_flags()
+            .await
             .enable_cipher_key_encryption;
 
         let mut ctx = key_store.context();
@@ -160,9 +166,9 @@ impl CiphersClient {
     }
 
     #[allow(missing_docs)]
-    pub fn decrypt(&self, cipher: Cipher) -> Result<CipherView, DecryptError> {
+    pub async fn decrypt(&self, cipher: Cipher) -> Result<CipherView, DecryptError> {
         let key_store = self.client.internal.get_key_store();
-        if self.is_strict_decrypt() {
+        if self.is_strict_decrypt().await {
             Ok(key_store.decrypt(&StrictDecrypt(cipher))?)
         } else {
             Ok(key_store.decrypt(&cipher)?)
@@ -170,9 +176,12 @@ impl CiphersClient {
     }
 
     #[allow(missing_docs)]
-    pub fn decrypt_list(&self, ciphers: Vec<Cipher>) -> Result<Vec<CipherListView>, DecryptError> {
+    pub async fn decrypt_list(
+        &self,
+        ciphers: Vec<Cipher>,
+    ) -> Result<Vec<CipherListView>, DecryptError> {
         let key_store = self.client.internal.get_key_store();
-        if self.is_strict_decrypt() {
+        if self.is_strict_decrypt().await {
             let strict: Vec<StrictDecrypt<Cipher>> =
                 ciphers.into_iter().map(StrictDecrypt).collect();
             Ok(key_store.decrypt_list(&strict)?)
@@ -183,9 +192,12 @@ impl CiphersClient {
 
     /// Decrypt cipher list with failures
     /// Returns both successfully decrypted ciphers and any that failed to decrypt
-    pub fn decrypt_list_with_failures(&self, ciphers: Vec<Cipher>) -> DecryptCipherListResult {
+    pub async fn decrypt_list_with_failures(
+        &self,
+        ciphers: Vec<Cipher>,
+    ) -> DecryptCipherListResult {
         let key_store = self.client.internal.get_key_store();
-        if self.is_strict_decrypt() {
+        if self.is_strict_decrypt().await {
             let strict: Vec<StrictDecrypt<Cipher>> =
                 ciphers.into_iter().map(StrictDecrypt).collect();
             let (successes, failures) = key_store.decrypt_list_with_failures(&strict);
@@ -205,9 +217,12 @@ impl CiphersClient {
     /// Decrypt full cipher list
     /// Returns both successfully fully decrypted ciphers and any that failed to decrypt
     #[cfg(feature = "wasm")]
-    pub fn decrypt_list_full_with_failures(&self, ciphers: Vec<Cipher>) -> DecryptCipherResult {
+    pub async fn decrypt_list_full_with_failures(
+        &self,
+        ciphers: Vec<Cipher>,
+    ) -> DecryptCipherResult {
         let key_store = self.client.internal.get_key_store();
-        if self.is_strict_decrypt() {
+        if self.is_strict_decrypt().await {
             let strict: Vec<StrictDecrypt<Cipher>> =
                 ciphers.into_iter().map(StrictDecrypt).collect();
             let (successes, failures) = key_store.decrypt_list_with_failures(&strict);
@@ -288,8 +303,12 @@ impl CiphersClient {
         Ok(self.client.platform().state().get::<Cipher>()?)
     }
 
-    fn is_strict_decrypt(&self) -> bool {
-        self.client.internal.get_flags().strict_cipher_decryption
+    async fn is_strict_decrypt(&self) -> bool {
+        self.client
+            .internal
+            .get_flags()
+            .await
+            .strict_cipher_decryption
     }
 }
 
@@ -449,7 +468,7 @@ mod tests {
                 archived_date: None,
                 data: None,
             }])
-
+            .await
             .unwrap();
 
         assert_eq!(dec[0].name, "Test item");
@@ -464,7 +483,8 @@ mod tests {
         let result = client
             .vault()
             .ciphers()
-            .decrypt_list_with_failures(vec![valid_cipher]);
+            .decrypt_list_with_failures(vec![valid_cipher])
+            .await;
 
         assert_eq!(result.successes.len(), 1);
         assert!(result.failures.is_empty());
@@ -481,7 +501,11 @@ mod tests {
 
         let ciphers = vec![valid_cipher, invalid_cipher.clone()];
 
-        let result = client.vault().ciphers().decrypt_list_with_failures(ciphers);
+        let result = client
+            .vault()
+            .ciphers()
+            .decrypt_list_with_failures(ciphers)
+            .await;
 
         assert_eq!(result.successes.len(), 1);
         assert_eq!(result.failures.len(), 1);
@@ -496,7 +520,12 @@ mod tests {
         let mut cipher = test_cipher();
         cipher.attachments = Some(vec![test_attachment_legacy()]);
 
-        let view = client.vault().ciphers().decrypt(cipher.clone()).unwrap();
+        let view = client
+            .vault()
+            .ciphers()
+            .decrypt(cipher.clone())
+            .await
+            .unwrap();
 
         //  Move cipher to organization
         let res = client.vault().ciphers().move_to_organization(
@@ -515,7 +544,12 @@ mod tests {
         let attachment = test_attachment_legacy();
         cipher.attachments = Some(vec![attachment.clone()]);
 
-        let view = client.vault().ciphers().decrypt(cipher.clone()).unwrap();
+        let view = client
+            .vault()
+            .ciphers()
+            .decrypt(cipher.clone())
+            .await
+            .unwrap();
 
         assert!(cipher.key.is_none());
 
@@ -523,10 +557,10 @@ mod tests {
         let EncryptionContext {
             cipher: new_cipher,
             encrypted_for: _,
-        } = client.vault().ciphers().encrypt(view).unwrap();
+        } = client.vault().ciphers().encrypt(view).await.unwrap();
         assert!(new_cipher.key.is_some());
 
-        let view = client.vault().ciphers().decrypt(new_cipher).unwrap();
+        let view = client.vault().ciphers().decrypt(new_cipher).await.unwrap();
         let attachments = view.clone().attachments.unwrap();
         let attachment_view = attachments.first().unwrap().clone();
         assert!(attachment_view.key.is_none());
@@ -557,7 +591,12 @@ mod tests {
         let attachment = test_attachment_v2();
         cipher.attachments = Some(vec![attachment.clone()]);
 
-        let view = client.vault().ciphers().decrypt(cipher.clone()).unwrap();
+        let view = client
+            .vault()
+            .ciphers()
+            .decrypt(cipher.clone())
+            .await
+            .unwrap();
 
         assert!(cipher.key.is_none());
 
@@ -565,13 +604,14 @@ mod tests {
         let EncryptionContext {
             cipher: new_cipher,
             encrypted_for: _,
-        } = client.vault().ciphers().encrypt(view).unwrap();
+        } = client.vault().ciphers().encrypt(view).await.unwrap();
         assert!(new_cipher.key.is_some());
 
         let view = client
             .vault()
             .ciphers()
             .decrypt(new_cipher.clone())
+            .await
             .unwrap();
         let attachments = view.clone().attachments.unwrap();
         let attachment_view = attachments.first().unwrap().clone();
@@ -612,7 +652,7 @@ mod tests {
         let EncryptionContext {
             cipher: new_cipher,
             encrypted_for: _,
-        } = client.vault().ciphers().encrypt(new_view).unwrap();
+        } = client.vault().ciphers().encrypt(new_view).await.unwrap();
 
         let attachment = new_cipher
             .clone()
@@ -647,7 +687,8 @@ mod tests {
         let result = client
             .vault()
             .ciphers()
-            .decrypt_list_full_with_failures(vec![valid_cipher]);
+            .decrypt_list_full_with_failures(vec![valid_cipher])
+            .await;
 
         assert_eq!(result.successes.len(), 1);
         assert!(result.failures.is_empty());
@@ -668,7 +709,8 @@ mod tests {
         let result = client
             .vault()
             .ciphers()
-            .decrypt_list_full_with_failures(ciphers);
+            .decrypt_list_full_with_failures(ciphers)
+            .await;
 
         assert_eq!(result.successes.len(), 1);
         assert_eq!(result.failures.len(), 1);
@@ -691,7 +733,8 @@ mod tests {
         let result = client
             .vault()
             .ciphers()
-            .decrypt_list_full_with_failures(ciphers);
+            .decrypt_list_full_with_failures(ciphers)
+            .await;
 
         assert!(result.successes.is_empty());
         assert_eq!(result.failures.len(), 2);
@@ -705,7 +748,8 @@ mod tests {
         let result = client
             .vault()
             .ciphers()
-            .decrypt_list_full_with_failures(vec![]);
+            .decrypt_list_full_with_failures(vec![])
+            .await;
 
         assert!(result.successes.is_empty());
         assert!(result.failures.is_empty());
@@ -725,13 +769,14 @@ mod tests {
             .vault()
             .ciphers()
             .encrypt_cipher_for_rotation(cipher_view, new_key_b64)
+            .await
             .unwrap();
 
         assert!(ctx.cipher.key.is_some());
 
         // Decrypting the cipher "normally" will fail because it was encrypted with a new key
         assert!(matches!(
-            client.vault().ciphers().decrypt(ctx.cipher).err(),
+            client.vault().ciphers().decrypt(ctx.cipher).await.err(),
             Some(DecryptError::Crypto(CryptoError::Decrypt))
         ));
     }
@@ -743,7 +788,7 @@ mod tests {
 
         let cipher_views = vec![test_cipher_view(), test_cipher_view()];
 
-        let result = client.vault().ciphers().encrypt_list(cipher_views);
+        let result = client.vault().ciphers().encrypt_list(cipher_views).await;
 
         assert!(result.is_ok());
         let contexts = result.unwrap();
@@ -760,7 +805,7 @@ mod tests {
     async fn test_encrypt_list_empty() {
         let client = Client::init_test_account(test_bitwarden_com_account()).await;
 
-        let result = client.vault().ciphers().encrypt_list(vec![]);
+        let result = client.vault().ciphers().encrypt_list(vec![]).await;
 
         assert!(result.is_ok());
         assert!(result.unwrap().is_empty());
@@ -778,6 +823,7 @@ mod tests {
             .vault()
             .ciphers()
             .encrypt_list(original_views)
+            .await
             .unwrap();
 
         // Decrypt each cipher and verify the name matches
@@ -786,6 +832,7 @@ mod tests {
                 .vault()
                 .ciphers()
                 .decrypt(ctx.cipher.clone())
+                .await
                 .unwrap();
             assert_eq!(&decrypted.name, original_name);
         }
@@ -799,7 +846,12 @@ mod tests {
         let expected_user_id = client.internal.get_user_id().unwrap();
 
         let cipher_views = vec![test_cipher_view(), test_cipher_view(), test_cipher_view()];
-        let contexts = client.vault().ciphers().encrypt_list(cipher_views).unwrap();
+        let contexts = client
+            .vault()
+            .ciphers()
+            .encrypt_list(cipher_views)
+            .await
+            .unwrap();
 
         for ctx in contexts {
             assert_eq!(ctx.encrypted_for, expected_user_id);

--- a/crates/bitwarden-vault/src/cipher/cipher_client/restore.rs
+++ b/crates/bitwarden-vault/src/cipher/cipher_client/restore.rs
@@ -111,7 +111,7 @@ impl CiphersClient {
             api_client,
             &*self.get_repository()?,
             key_store,
-            self.is_strict_decrypt(),
+            self.is_strict_decrypt().await,
         )
         .await
     }

--- a/crates/bitwarden-vault/src/cipher/cipher_client/share_cipher.rs
+++ b/crates/bitwarden-vault/src/cipher/cipher_client/share_cipher.rs
@@ -185,7 +185,7 @@ impl CiphersClient {
         self.update_password_history(&mut cipher_view, original_cipher_view)
             .await?;
 
-        let encrypted_cipher = self.encrypt(cipher_view)?;
+        let encrypted_cipher = self.encrypt(cipher_view).await?;
 
         let api_client = &self.client.internal.get_api_configurations().api_client;
 
@@ -196,7 +196,7 @@ impl CiphersClient {
             collection_ids,
         )
         .await?;
-        Ok(self.decrypt(result_cipher)?)
+        Ok(self.decrypt(result_cipher).await?)
     }
 
     async fn update_password_history(
@@ -204,13 +204,11 @@ impl CiphersClient {
         cipher_view: &mut CipherView,
         mut original_cipher_view: Option<CipherView>,
     ) -> Result<(), CipherError> {
-        if let (Some(cipher_id), None) = (cipher_view.id, &original_cipher_view) {
-            original_cipher_view = self
-                .get_repository()?
-                .get(cipher_id)
-                .await?
-                .map(|cipher| self.decrypt(cipher))
-                .transpose()?;
+        if let Some(cipher_id) = cipher_view.id
+            && original_cipher_view.is_none()
+            && let Some(cipher) = self.get_repository()?.get(cipher_id).await?
+        {
+            original_cipher_view = Some(self.decrypt(cipher).await?);
         }
         if let Some(original_cipher_view) = original_cipher_view {
             cipher_view.update_password_history(&original_cipher_view);
@@ -232,7 +230,7 @@ impl CiphersClient {
                 collection_ids.clone(),
             )?;
             self.update_password_history(&mut cv, None).await?;
-            encrypted_ciphers.push(self.encrypt(cv)?);
+            encrypted_ciphers.push(self.encrypt(cv).await?);
         }
         Ok(encrypted_ciphers)
     }
@@ -277,10 +275,10 @@ impl CiphersClient {
         )
         .await?;
 
-        Ok(result_ciphers
-            .into_iter()
-            .map(|c| self.decrypt(c))
-            .collect::<Result<Vec<_>, _>>()?)
+        Ok(
+            futures::future::try_join_all(result_ciphers.into_iter().map(|c| self.decrypt(c)))
+                .await?,
+        )
     }
 }
 
@@ -477,7 +475,7 @@ mod tests {
         cipher_view_2.organization_id = Some(TEST_ORG_ID.parse().unwrap());
 
         // Encrypt and store cipher_view_1 in repository for password history lookup
-        let encrypted_1 = cipher_client.encrypt(cipher_view_1.clone()).unwrap();
+        let encrypted_1 = cipher_client.encrypt(cipher_view_1.clone()).await.unwrap();
         let repository = cipher_client.get_repository().unwrap();
         repository
             .set(TEST_CIPHER_ID.parse().unwrap(), encrypted_1.cipher.clone())
@@ -808,7 +806,8 @@ mod tests {
             .load_flags(std::collections::HashMap::from([(
                 "enableCipherKeyEncryption".to_owned(),
                 true,
-            )]));
+            )]))
+            .await;
 
         let user_request = InitUserCryptoRequest {
             user_id: Some(UserId::new(uuid::uuid!("060000fb-0922-4dd3-b170-6e15cb5df8c8"))),
@@ -919,7 +918,11 @@ mod tests {
         repository
             .set(
                 TEST_CIPHER_ID.parse().unwrap(),
-                cipher_client.encrypt(original.clone()).unwrap().cipher,
+                cipher_client
+                    .encrypt(original.clone())
+                    .await
+                    .unwrap()
+                    .cipher,
             )
             .await
             .unwrap();
@@ -1029,7 +1032,7 @@ mod tests {
         let repository = std::sync::Arc::new(MemoryRepository::<Cipher>::default());
         let cipher_client = client.vault().ciphers();
 
-        let encrypted_original1 = cipher_client.encrypt(cipher_view1.clone()).unwrap();
+        let encrypted_original1 = cipher_client.encrypt(cipher_view1.clone()).await.unwrap();
         repository
             .set(
                 encrypted_original1.cipher.id.unwrap(),
@@ -1038,7 +1041,7 @@ mod tests {
             .await
             .unwrap();
 
-        let encrypted_original2 = cipher_client.encrypt(cipher_view2.clone()).unwrap();
+        let encrypted_original2 = cipher_client.encrypt(cipher_view2.clone()).await.unwrap();
         repository
             .set(
                 encrypted_original2.cipher.id.unwrap(),

--- a/crates/bitwarden-wasm-internal/src/platform/mod.rs
+++ b/crates/bitwarden-wasm-internal/src/platform/mod.rs
@@ -34,8 +34,8 @@ impl PlatformClient {
     }
 
     /// Load feature flags into the client
-    pub fn load_flags(&self, flags: FeatureFlags) -> Result<(), JsValue> {
-        self.0.internal.load_flags(flags.flags);
+    pub async fn load_flags(&self, flags: FeatureFlags) -> Result<(), JsValue> {
+        self.0.internal.load_flags(flags.flags).await;
         Ok(())
     }
 }


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-31875

## 📔 Objective

Preparatory step for making `InternalClient` state access truly async. This PR makes 6 `InternalClient` methods async (with `#[expect(clippy::unused_async)]` since they don't await yet) and cascades `.await` through all call sites:

- `get_login_method`
- `set_login_method`
- `get_kdf`
- `get_flags`
- `load_flags`
- `set_user_master_password_unlock`

This is a mechanical change — no implementations are modified, only signatures and call sites. By doing this now, the Phase 3 diff (where these methods actually start awaiting) will be significantly smaller.

Additionally, reordered some code in `key_management/crypto.rs` to avoid holding `KeyStoreContext` (which contains `RwLockReadGuard`) across `.await` points, which would cause `!Send` futures and clippy `await_holding_invalid_type` warnings.

## 🚨 Breaking Changes

The following methods become async across FFI boundaries:

**UniFFI (mobile):**
- `PlatformClient::load_flags`
- `AuthClient::validate_password`, `validate_password_user_key`, `validate_pin`, `make_register_tde_keys`
- `CryptoClient::make_update_password`, `make_update_kdf`, `derive_pin_key`, `derive_pin_user_key`
- `CiphersClient::encrypt`, `decrypt`, `decrypt_list`, `decrypt_list_with_failures`
- `ExporterClient::export_vault`

**WASM:**
- `PlatformClient::load_flags`
- `CiphersClient::encrypt`, `decrypt`, `decrypt_list`, `decrypt_list_with_failures`, `decrypt_list_full_with_failures`, `encrypt_cipher_for_rotation`, `encrypt_list`
- `ExporterClient::export_vault`

https://github.com/bitwarden/clients/pull/20032

Mobile and web clients will need to update these call sites to handle async/await.
