### PR TITLE
[PM-33312] Create FlightRecorderLayer

### DIFF
--- a/crates/bitwarden-logging/Cargo.toml
+++ b/crates/bitwarden-logging/Cargo.toml
@@ -23,11 +23,9 @@ chrono = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 tracing = { workspace = true }
+tracing-subscriber = { workspace = true }
 tsify = { workspace = true, optional = true }
 wasm-bindgen = { workspace = true, optional = true }
-
-[dev-dependencies]
-tracing-subscriber = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/bitwarden-logging/src/circular_buffer.rs
+++ b/crates/bitwarden-logging/src/circular_buffer.rs
@@ -1,0 +1,169 @@
+//! Thread-safe circular buffer implementation.
+
+use std::{collections::VecDeque, num::NonZeroUsize, sync::Mutex};
+
+// Static assertion: CircularBuffer<T> must be Send + Sync for any Send type T.
+// This is required because the buffer is shared across threads via Arc.
+// T only needs Send (not Sync) because Mutex<VecDeque<T>> provides the Sync guarantee.
+const _: () = {
+    fn _assert_send_sync<T: Send + Sync>() {}
+    fn _assert_circular_buffer<T: Send>() {
+        _assert_send_sync::<CircularBuffer<T>>();
+    }
+};
+
+/// A thread-safe circular buffer with FIFO eviction.
+///
+/// When the buffer reaches its capacity, the oldest items are automatically
+/// removed to make room for new ones.
+pub struct CircularBuffer<T> {
+    buffer: Mutex<VecDeque<T>>,
+    capacity: usize,
+}
+
+impl<T> std::fmt::Debug for CircularBuffer<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("CircularBuffer")
+            .field("capacity", &self.capacity)
+            .finish()
+    }
+}
+
+impl<T> CircularBuffer<T> {
+    /// Create a new circular buffer with the given capacity.
+    pub fn new(capacity: NonZeroUsize) -> Self {
+        let capacity = capacity.get();
+        Self {
+            buffer: Mutex::new(VecDeque::with_capacity(capacity)),
+            capacity,
+        }
+    }
+
+    /// Push an item into the buffer.
+    ///
+    /// If the buffer is at capacity, the oldest item is evicted and returned.
+    pub fn push(&self, item: T) -> Option<T> {
+        let mut buffer = self.buffer.lock().expect("CircularBuffer mutex poisoned");
+
+        let evicted = if buffer.len() >= self.capacity {
+            buffer.pop_front()
+        } else {
+            None
+        };
+
+        buffer.push_back(item);
+        evicted
+    }
+
+    /// Get the current number of items in the buffer.
+    #[inline]
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.buffer
+            .lock()
+            .expect("CircularBuffer mutex poisoned")
+            .len()
+    }
+
+    /// Check if the buffer is empty.
+    #[inline]
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.buffer
+            .lock()
+            .expect("CircularBuffer mutex poisoned")
+            .is_empty()
+    }
+}
+
+impl<T: Clone> CircularBuffer<T> {
+    /// Read all items from the buffer.
+    ///
+    /// Returns a snapshot of current buffer contents in order (oldest first).
+    #[must_use]
+    pub fn read(&self) -> Vec<T> {
+        let mut result = Vec::with_capacity(self.capacity);
+        let buffer = self.buffer.lock().expect("CircularBuffer mutex poisoned");
+        result.extend(buffer.iter().cloned());
+        result
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use super::*;
+
+    #[test]
+    fn test_push_and_read() {
+        let buffer = CircularBuffer::new(NonZeroUsize::new(5).unwrap());
+        buffer.push("first".to_string());
+        buffer.push("second".to_string());
+        buffer.push("third".to_string());
+
+        let items = buffer.read();
+        assert_eq!(items, vec!["first", "second", "third"]);
+    }
+
+    #[test]
+    fn test_fifo_eviction() {
+        let buffer = CircularBuffer::new(NonZeroUsize::new(3).unwrap());
+        buffer.push("event1".to_string());
+        buffer.push("event2".to_string());
+        buffer.push("event3".to_string());
+
+        // Fourth push should evict the oldest
+        let evicted = buffer.push("event4".to_string());
+        assert_eq!(evicted, Some("event1".to_string()));
+
+        let contents = buffer.read();
+        assert_eq!(contents, vec!["event2", "event3", "event4"]);
+    }
+
+    #[test]
+    fn test_len_and_is_empty() {
+        let buffer = CircularBuffer::new(NonZeroUsize::new(10).unwrap());
+        assert!(buffer.is_empty());
+        assert_eq!(buffer.len(), 0);
+
+        buffer.push("item".to_string());
+        assert!(!buffer.is_empty());
+        assert_eq!(buffer.len(), 1);
+
+        let items = buffer.read();
+        assert_eq!(items.len(), 1);
+    }
+
+    #[test]
+    fn test_read_preserves_contents() {
+        let buffer = CircularBuffer::new(NonZeroUsize::new(5).unwrap());
+        buffer.push("a".to_string());
+        buffer.push("b".to_string());
+
+        let first_read = buffer.read();
+        let second_read = buffer.read();
+        assert_eq!(first_read, second_read);
+    }
+
+    #[test]
+    fn test_concurrent_push() {
+        let buffer = Arc::new(CircularBuffer::new(NonZeroUsize::new(1000).unwrap()));
+        let handles: Vec<_> = (0..10)
+            .map(|i| {
+                let buf = Arc::clone(&buffer);
+                std::thread::spawn(move || {
+                    for j in 0..100 {
+                        buf.push(format!("thread{i}-event{j}"));
+                    }
+                })
+            })
+            .collect();
+
+        for h in handles {
+            h.join().expect("thread panicked");
+        }
+
+        assert_eq!(buffer.len(), 1000);
+    }
+}

--- a/crates/bitwarden-logging/src/layer.rs
+++ b/crates/bitwarden-logging/src/layer.rs
@@ -1,0 +1,181 @@
+//! Tracing subscriber layer for Flight Recorder.
+
+use std::sync::Arc;
+
+use tracing::{Event, Subscriber};
+use tracing_subscriber::{Layer, layer::Context};
+
+use crate::{CircularBuffer, FlightRecorderConfig, FlightRecorderEvent};
+
+/// A tracing subscriber layer that captures log events into a circular buffer.
+///
+/// This layer intercepts tracing events and stores them in a thread-safe
+/// buffer for later export. Events from the `bitwarden_logging` target
+/// are filtered out to prevent infinite recursion.
+pub struct FlightRecorderLayer {
+    buffer: Arc<CircularBuffer<FlightRecorderEvent>>,
+    level: tracing::Level,
+}
+
+impl std::fmt::Debug for FlightRecorderLayer {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("FlightRecorderLayer")
+            .field("level", &self.level)
+            .field("buffer", &self.buffer)
+            .finish()
+    }
+}
+
+impl FlightRecorderLayer {
+    /// Create a new FlightRecorderLayer with the given configuration.
+    #[must_use]
+    pub fn new(config: FlightRecorderConfig) -> Self {
+        let buffer = Arc::new(CircularBuffer::new(config.buffer_size));
+        Self {
+            buffer,
+            level: config.level,
+        }
+    }
+
+    /// Get a reference to the underlying buffer.
+    ///
+    /// This can be used to access the buffer for reading captured events.
+    pub fn buffer(&self) -> Arc<CircularBuffer<FlightRecorderEvent>> {
+        Arc::clone(&self.buffer)
+    }
+}
+
+impl<S> Layer<S> for FlightRecorderLayer
+where
+    S: Subscriber,
+{
+    fn on_event(&self, event: &Event<'_>, _ctx: Context<'_, S>) {
+        let metadata = event.metadata();
+
+        // Filter out our own logging to prevent recursion
+        if metadata.target().starts_with("bitwarden_logging") {
+            return;
+        }
+
+        // Skip events more verbose than configured level
+        if *metadata.level() > self.level {
+            return;
+        }
+
+        self.buffer.push(event.into());
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::num::NonZeroUsize;
+
+    use tracing_subscriber::layer::SubscriberExt;
+
+    use super::*;
+
+    #[test]
+    fn test_layer_creation() {
+        let config = FlightRecorderConfig::default();
+        let layer = FlightRecorderLayer::new(config);
+        let buffer = layer.buffer();
+
+        assert!(buffer.is_empty());
+        assert_eq!(buffer.len(), 0);
+    }
+
+    #[test]
+    fn test_layer_captures_events() {
+        let config = FlightRecorderConfig::default();
+        let layer = FlightRecorderLayer::new(config);
+        let buffer = layer.buffer();
+
+        let subscriber = tracing_subscriber::registry().with(layer);
+        tracing::subscriber::with_default(subscriber, || {
+            tracing::info!(target: "test::module", "hello from test");
+        });
+
+        let events = buffer.read();
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].message, "hello from test");
+        assert_eq!(events[0].level, "INFO");
+    }
+
+    #[test]
+    fn test_layer_filters_own_crate() {
+        let config = FlightRecorderConfig::default();
+        let layer = FlightRecorderLayer::new(config);
+        let buffer = layer.buffer();
+
+        let subscriber = tracing_subscriber::registry().with(layer);
+        tracing::subscriber::with_default(subscriber, || {
+            tracing::info!(target: "bitwarden_logging::internal", "should be skipped");
+            tracing::info!(target: "bitwarden_logging", "should be skipped");
+            tracing::info!("should be skipped");
+        });
+
+        assert!(buffer.is_empty());
+    }
+
+    #[test]
+    fn test_layer_filters_by_level() {
+        let config = FlightRecorderConfig::new(
+            NonZeroUsize::new(100).expect("non-zero"),
+            tracing::Level::INFO,
+        );
+        let layer = FlightRecorderLayer::new(config);
+        let buffer = layer.buffer();
+
+        let subscriber = tracing_subscriber::registry().with(layer);
+        tracing::subscriber::with_default(subscriber, || {
+            tracing::debug!(target: "test::module", "should be skipped");
+            tracing::info!(target: "test::module", "should be captured");
+            tracing::warn!(target: "test::module", "should also be captured");
+        });
+
+        let events = buffer.read();
+        assert_eq!(events.len(), 2);
+        assert_eq!(events[0].level, "INFO");
+        assert_eq!(events[1].level, "WARN");
+    }
+
+    #[test]
+    fn test_buffer_shared_via_arc() {
+        let config = FlightRecorderConfig::default();
+        let layer = FlightRecorderLayer::new(config);
+        let buffer1 = layer.buffer();
+        let buffer2 = layer.buffer();
+
+        assert!(Arc::ptr_eq(&buffer1, &buffer2));
+
+        let subscriber = tracing_subscriber::registry().with(layer);
+        tracing::subscriber::with_default(subscriber, || {
+            tracing::warn!(target: "test::module", "shared buffer test");
+        });
+
+        // Both handles see the same events
+        assert_eq!(buffer1.read().len(), 1);
+        assert_eq!(buffer2.read().len(), 1);
+    }
+
+    #[test]
+    fn test_layer_captures_structured_fields() {
+        let config = FlightRecorderConfig::default();
+        let layer = FlightRecorderLayer::new(config);
+        let buffer = layer.buffer();
+
+        let subscriber = tracing_subscriber::registry().with(layer);
+        tracing::subscriber::with_default(subscriber, || {
+            tracing::info!(target: "test::module", user_id = "abc-123", "login attempt");
+        });
+
+        let events = buffer.read();
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].message, "login attempt");
+        assert_eq!(events[0].target, "test::module");
+        assert_eq!(
+            events[0].fields.get("user_id"),
+            Some(&"abc-123".to_string())
+        );
+    }
+}

--- a/crates/bitwarden-logging/src/lib.rs
+++ b/crates/bitwarden-logging/src/lib.rs
@@ -1,9 +1,13 @@
 #![doc = include_str!("../README.md")]
 
+mod circular_buffer;
 mod config;
 mod event;
+mod layer;
 mod visitor;
 
+pub use circular_buffer::CircularBuffer;
 pub use config::FlightRecorderConfig;
 pub use event::FlightRecorderEvent;
+pub use layer::FlightRecorderLayer;
 pub use visitor::MessageVisitor;


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-33312

## 📔 Objective

Implement a circular event buffer and the tracing layer for flight recorder on `bitwarden-logging`. 

Note that the flight recorder layer has its own configurable log level, independent of the application's log level. This allows scenarios like running the application at debug/trace level while keeping the flight recorder at info level, preventing it from being overwhelmed with verbose logs.

## 🚨 Breaking Changes

<!-- Does this PR introduce any breaking changes? If so, please describe the impact and migration path for clients.

If you're unsure, the automated TypeScript compatibility check will run when you open/update this PR and provide feedback.

For breaking changes:
1. Describe what changed in the client interface
2. Explain why the change was necessary
3. Provide migration steps for client developers
4. Link to any paired client PRs if needed

Otherwise, you can remove this section. -->
