### PR TITLE
[PM-33313] Expose FlightRecorder to WASM

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1242,6 +1242,7 @@ dependencies = [
  "bitwarden-crypto",
  "bitwarden-error",
  "bitwarden-ipc",
+ "bitwarden-logging",
  "bitwarden-pm",
  "bitwarden-server-communication-config",
  "bitwarden-ssh",

--- a/crates/bitwarden-logging/README.md
+++ b/crates/bitwarden-logging/README.md
@@ -3,3 +3,55 @@
 Flight Recorder infrastructure for capturing and exporting diagnostic logs.
 
 Internal crate for the bitwarden crate. Do not use.
+
+## Working With FlightRecorder
+
+The Flight Recorder captures tracing events into a global circular buffer so they can be exported
+for diagnostics without requiring the caller to hold a direct reference to the buffer.
+
+### Initialization
+
+Call `init_flight_recorder` during SDK startup and add the returned layer to your tracing
+subscriber:
+
+```rust
+use bitwarden_logging::{init_flight_recorder, FlightRecorderConfig};
+use tracing_subscriber::{layer::SubscriberExt as _, util::SubscriberInitExt as _};
+
+let flight_recorder_layer = init_flight_recorder(FlightRecorderConfig::default());
+
+tracing_subscriber::registry()
+    .with(flight_recorder_layer)
+    .init();
+```
+
+The default configuration retains 1 000 events at `DEBUG` level. Use `FlightRecorderConfig::new`
+for custom settings.
+
+### Reading events
+
+Once initialized, events can be read from anywhere in the process:
+
+```rust
+use bitwarden_logging::{read_flight_recorder, flight_recorder_count};
+
+let count = flight_recorder_count();
+let events = read_flight_recorder();
+```
+
+Both functions return safe defaults (`0` / empty `Vec`) if the recorder has not been initialized.
+
+### WASM usage
+
+In `bitwarden-wasm-internal`, the recorder is automatically initialized by `init_sdk()`.
+TypeScript consumers access it through `FlightRecorderClient`:
+
+```typescript
+import { FlightRecorderClient } from "@aspect/bitwarden-wasm-internal";
+
+const recorder = new FlightRecorderClient();
+const count = recorder.count();
+const events = recorder.read();
+```
+
+Each `FlightRecorderEvent` contains `timestamp`, `level`, `target`, `message`, and `fields`.

--- a/crates/bitwarden-logging/README.md
+++ b/crates/bitwarden-logging/README.md
@@ -25,8 +25,8 @@ tracing_subscriber::registry()
     .init();
 ```
 
-The default configuration retains 1 000 events at `DEBUG` level. Use `FlightRecorderConfig::new`
-for custom settings.
+The default configuration retains 1 000 events at `DEBUG` level. Use `FlightRecorderConfig::new` for
+custom settings.
 
 ### Reading events
 
@@ -43,8 +43,8 @@ Both functions return safe defaults (`0` / empty `Vec`) if the recorder has not 
 
 ### WASM usage
 
-In `bitwarden-wasm-internal`, the recorder is automatically initialized by `init_sdk()`.
-TypeScript consumers access it through `FlightRecorderClient`:
+In `bitwarden-wasm-internal`, the recorder is automatically initialized by `init_sdk()`. TypeScript
+consumers access it through `FlightRecorderClient`:
 
 ```typescript
 import { FlightRecorderClient } from "@aspect/bitwarden-wasm-internal";

--- a/crates/bitwarden-logging/src/global.rs
+++ b/crates/bitwarden-logging/src/global.rs
@@ -1,0 +1,73 @@
+//! Global Flight Recorder buffer and convenience accessors.
+
+use std::sync::{Arc, OnceLock};
+
+use crate::{CircularBuffer, FlightRecorderConfig, FlightRecorderEvent, FlightRecorderLayer};
+
+/// Global Flight Recorder buffer, initialized during `init_sdk()`.
+static FLIGHT_RECORDER_BUFFER: OnceLock<Arc<CircularBuffer<FlightRecorderEvent>>> = OnceLock::new();
+
+/// Initialize the global Flight Recorder.
+///
+/// Creates a [`FlightRecorderLayer`] and stores the buffer in a global
+/// [`OnceLock`] so it can be read from anywhere via [`read_flight_recorder`].
+/// Returns the layer to add to a tracing subscriber.
+///
+/// If called more than once, the second call's buffer is **not** stored
+/// globally (the `OnceLock` is already set), but the returned layer is
+/// still independently functional.
+#[must_use]
+pub fn init_flight_recorder(config: FlightRecorderConfig) -> FlightRecorderLayer {
+    let layer = FlightRecorderLayer::new(config);
+    let _ = FLIGHT_RECORDER_BUFFER.set(layer.buffer());
+    layer
+}
+
+/// Get the global Flight Recorder buffer.
+///
+/// Returns `None` if [`init_flight_recorder`] has not been called.
+pub fn get_flight_recorder_buffer() -> Option<Arc<CircularBuffer<FlightRecorderEvent>>> {
+    FLIGHT_RECORDER_BUFFER.get().cloned()
+}
+
+/// Read all events from the global Flight Recorder buffer.
+///
+/// Returns an empty `Vec` if [`init_flight_recorder`] has not been called.
+#[must_use]
+pub fn read_flight_recorder() -> Vec<FlightRecorderEvent> {
+    get_flight_recorder_buffer()
+        .map(|buffer| buffer.read())
+        .unwrap_or_default()
+}
+
+/// Get the current event count without reading event contents.
+///
+/// Returns `0` if [`init_flight_recorder`] has not been called.
+#[must_use]
+pub fn flight_recorder_count() -> usize {
+    get_flight_recorder_buffer()
+        .map(|buffer| buffer.len())
+        .unwrap_or(0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_config_default_values() {
+        let config = FlightRecorderConfig::default();
+        assert_eq!(config.buffer_size.get(), 1000);
+        assert_eq!(config.level, tracing::Level::DEBUG);
+    }
+
+    #[test]
+    fn test_read_before_init_returns_empty() {
+        // A fresh OnceLock (not the global one, which may already be set
+        // by other tests) would return None. We can at least verify the
+        // convenience functions don't panic.
+        let events = read_flight_recorder();
+        // Either empty (not initialized) or non-empty (another test initialized it)
+        let _ = events;
+    }
+}

--- a/crates/bitwarden-logging/src/lib.rs
+++ b/crates/bitwarden-logging/src/lib.rs
@@ -3,11 +3,15 @@
 mod circular_buffer;
 mod config;
 mod event;
+mod global;
 mod layer;
 mod visitor;
 
 pub use circular_buffer::CircularBuffer;
 pub use config::FlightRecorderConfig;
 pub use event::FlightRecorderEvent;
+pub use global::{
+    flight_recorder_count, get_flight_recorder_buffer, init_flight_recorder, read_flight_recorder,
+};
 pub use layer::FlightRecorderLayer;
 pub use visitor::MessageVisitor;

--- a/crates/bitwarden-wasm-internal/Cargo.toml
+++ b/crates/bitwarden-wasm-internal/Cargo.toml
@@ -34,6 +34,7 @@ bitwarden-core = { workspace = true, features = ["wasm", "internal"] }
 bitwarden-crypto = { workspace = true, features = ["wasm"] }
 bitwarden-error = { workspace = true }
 bitwarden-ipc = { workspace = true, features = ["wasm"] }
+bitwarden-logging = { workspace = true, features = ["wasm"] }
 bitwarden-pm = { workspace = true, features = ["wasm"] }
 bitwarden-server-communication-config = { workspace = true, features = ["wasm"] }
 bitwarden-ssh = { workspace = true, features = ["wasm"] }

--- a/crates/bitwarden-wasm-internal/src/flight_recorder.rs
+++ b/crates/bitwarden-wasm-internal/src/flight_recorder.rs
@@ -1,0 +1,36 @@
+//! WASM bindings for the Flight Recorder.
+
+use bitwarden_logging::{FlightRecorderEvent, flight_recorder_count, read_flight_recorder};
+use wasm_bindgen::prelude::*;
+
+/// WASM client for reading Flight Recorder logs.
+///
+/// The underlying buffer is global (initialized in [`init_sdk`](crate::init_sdk)),
+/// so this client is a stateless handle for WASM access.
+#[wasm_bindgen]
+pub struct FlightRecorderClient;
+
+#[wasm_bindgen]
+impl FlightRecorderClient {
+    /// Create a new `FlightRecorderClient`.
+    #[wasm_bindgen(constructor)]
+    pub fn new() -> Self {
+        Self
+    }
+
+    /// Read all events currently in the Flight Recorder buffer.
+    pub fn read(&self) -> Vec<FlightRecorderEvent> {
+        read_flight_recorder()
+    }
+
+    /// Get the current event count without reading event contents.
+    pub fn count(&self) -> usize {
+        flight_recorder_count()
+    }
+}
+
+impl Default for FlightRecorderClient {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/bitwarden-wasm-internal/src/init.rs
+++ b/crates/bitwarden-wasm-internal/src/init.rs
@@ -30,8 +30,8 @@ fn convert_level(level: LogLevel) -> Level {
 ///
 /// - `log_level`: Minimum level for console output. Defaults to `Info`.
 /// - `flight_recorder_level`: Minimum level for the flight recorder. Defaults to `Info`.
-/// - `flight_recorder_buffer_size`: Ring-buffer capacity for the flight recorder.
-///    Defaults to 1000. Pass `0` to disable the flight recorder entirely.
+/// - `flight_recorder_buffer_size`: Ring-buffer capacity for the flight recorder. Defaults to 1000.
+///   Pass `0` to disable the flight recorder entirely.
 #[wasm_bindgen]
 pub fn init_sdk(
     log_level: Option<LogLevel>,

--- a/crates/bitwarden-wasm-internal/src/init.rs
+++ b/crates/bitwarden-wasm-internal/src/init.rs
@@ -1,8 +1,6 @@
 use bitwarden_logging::{FlightRecorderConfig, init_flight_recorder};
 use tracing::Level;
-use tracing_subscriber::{
-    EnvFilter, Layer as _, layer::SubscriberExt as _, util::SubscriberInitExt as _,
-};
+use tracing_subscriber::{EnvFilter, layer::SubscriberExt as _, util::SubscriberInitExt as _};
 use tracing_web::MakeWebConsoleWriter;
 use wasm_bindgen::prelude::*;
 

--- a/crates/bitwarden-wasm-internal/src/init.rs
+++ b/crates/bitwarden-wasm-internal/src/init.rs
@@ -1,5 +1,8 @@
+use bitwarden_logging::{FlightRecorderConfig, init_flight_recorder};
 use tracing::Level;
-use tracing_subscriber::{EnvFilter, layer::SubscriberExt as _, util::SubscriberInitExt as _};
+use tracing_subscriber::{
+    EnvFilter, Layer as _, layer::SubscriberExt as _, util::SubscriberInitExt as _,
+};
 use tracing_web::MakeWebConsoleWriter;
 use wasm_bindgen::prelude::*;
 
@@ -38,7 +41,12 @@ pub fn init_sdk(log_level: Option<LogLevel>) {
         .without_time() // time is not supported in wasm
         .with_writer(MakeWebConsoleWriter::new()); // write events to the console
 
-    let tracing_subscriber = tracing_subscriber::registry().with(filter).with(fmt);
+    let flight_recorder_layer = init_flight_recorder(FlightRecorderConfig::default());
+
+    let tracing_subscriber = tracing_subscriber::registry()
+        .with(flight_recorder_layer)
+        .with(fmt)
+        .with(filter);
     #[cfg(feature = "performance-tracing")]
     let tracing_subscriber = {
         let perf_layer = tracing_web::performance_layer()

--- a/crates/bitwarden-wasm-internal/src/init.rs
+++ b/crates/bitwarden-wasm-internal/src/init.rs
@@ -1,3 +1,5 @@
+use std::num::NonZeroUsize;
+
 use bitwarden_logging::{FlightRecorderConfig, init_flight_recorder};
 use tracing::Level;
 use tracing_subscriber::{EnvFilter, layer::SubscriberExt as _, util::SubscriberInitExt as _};
@@ -23,35 +25,52 @@ fn convert_level(level: LogLevel) -> Level {
     }
 }
 
-#[allow(missing_docs)]
+/// Initialize the SDK. Must be called before using any other API.
+/// Only the first invocation has effect; subsequent calls are ignored.
+///
+/// - `log_level`: Minimum level for console output. Defaults to `Info`.
+/// - `flight_recorder_level`: Minimum level for the flight recorder. Defaults to `Info`.
+/// - `flight_recorder_buffer_size`: Ring-buffer capacity for the flight recorder.
+///    Defaults to 1000. Pass `0` to disable the flight recorder entirely.
 #[wasm_bindgen]
-pub fn init_sdk(log_level: Option<LogLevel>) {
+pub fn init_sdk(
+    log_level: Option<LogLevel>,
+    flight_recorder_level: Option<LogLevel>,
+    flight_recorder_buffer_size: Option<usize>,
+) {
     console_error_panic_hook::set_once();
 
     let log_level = convert_level(log_level.unwrap_or(LogLevel::Info));
+    let flight_recorder_level = convert_level(flight_recorder_level.unwrap_or(LogLevel::Info));
+    let flight_recorder_buffer_size =
+        NonZeroUsize::new(flight_recorder_buffer_size.unwrap_or(1000));
 
-    let filter = EnvFilter::builder()
-        .with_default_directive(log_level.into())
-        .from_env_lossy();
+    // If the flight recorder buffer size we get is zero, we disable the flight recorder entirely.
+    let flight_recorder_layer = flight_recorder_buffer_size.map(|size| {
+        let config = FlightRecorderConfig::new(size, flight_recorder_level);
+        init_flight_recorder(config)
+    });
 
     let fmt = tracing_subscriber::fmt::layer()
         .with_ansi(false) // only partially supported across browsers
         .without_time() // time is not supported in wasm
         .with_writer(MakeWebConsoleWriter::new()); // write events to the console
 
-    let flight_recorder_layer = init_flight_recorder(FlightRecorderConfig::default());
+    let filter = EnvFilter::builder()
+        .with_default_directive(log_level.into())
+        .from_env_lossy();
 
-    let tracing_subscriber = tracing_subscriber::registry()
+    let perf_layer = cfg!(feature = "performance-tracing").then(|| {
+        tracing_web::performance_layer()
+            .with_details_from_fields(tracing_subscriber::fmt::format::Pretty::default())
+    });
+
+    let _ = tracing_subscriber::registry()
         .with(flight_recorder_layer)
         .with(fmt)
-        .with(filter);
-    #[cfg(feature = "performance-tracing")]
-    let tracing_subscriber = {
-        let perf_layer = tracing_web::performance_layer()
-            .with_details_from_fields(tracing_subscriber::fmt::format::Pretty::default());
-        tracing_subscriber.with(perf_layer)
-    };
-    tracing_subscriber.init();
+        .with(filter)
+        .with(perf_layer)
+        .try_init();
 
     #[cfg(feature = "dangerous-crypto-debug")]
     tracing::warn!(

--- a/crates/bitwarden-wasm-internal/src/lib.rs
+++ b/crates/bitwarden-wasm-internal/src/lib.rs
@@ -2,6 +2,7 @@
 
 mod client;
 mod custom_types;
+mod flight_recorder;
 mod init;
 mod platform;
 mod pure_crypto;
@@ -10,4 +11,5 @@ mod ssh;
 pub use bitwarden_ipc::wasm::*;
 pub use bitwarden_server_communication_config::wasm::*;
 pub use client::PasswordManagerClient;
+pub use flight_recorder::FlightRecorderClient;
 pub use init::init_sdk;


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-33313

## 📔 Objective

Expose FlightRecorder to WASM, and initialize it in `init_sdk`. I've exposed recorder level and buffer size as parameters on init_sdk so they can be configured from the web clients directly. Setting buffer size to zero will disable the flight recorder layer entirely, which might be helpful if we find any issues with the implementation.

I've reorganized the tracing subscriber layer attaching a bit, as tracing allows attaching an `Option<Layer>` which does nothing when the value is None. I think this is much clearer than doing something like:
```rust
    let mut  tracing_subscriber = tracing_subscriber::registry();
    if let Some(flight_recorder_layer) = flight_recorder_layer {
        tracing_subscriber = tracing_subscriber.with(flight_recorder_layer);
    }
```

## 🚨 Breaking Changes

<!-- Does this PR introduce any breaking changes? If so, please describe the impact and migration path for clients.

If you're unsure, the automated TypeScript compatibility check will run when you open/update this PR and provide feedback.

For breaking changes:
1. Describe what changed in the client interface
2. Explain why the change was necessary
3. Provide migration steps for client developers
4. Link to any paired client PRs if needed

Otherwise, you can remove this section. -->
