### PR TITLE
[PM-31712] Remove generic api error from bindings

### DIFF
--- a/crates/bitwarden-api-base/src/error.rs
+++ b/crates/bitwarden-api-base/src/error.rs
@@ -4,7 +4,7 @@ use std::{error, fmt};
 
 /// Response content from a failed API call.
 #[derive(Debug)]
-pub struct ResponseContent<T> {
+pub struct ResponseContent<T = ()> {
     /// HTTP status code of the response.
     pub status: reqwest::StatusCode,
     /// Raw response body content.
@@ -15,7 +15,7 @@ pub struct ResponseContent<T> {
 
 /// Errors that can occur during API operations.
 #[derive(Debug)]
-pub enum Error<T> {
+pub enum Error<T = ()> {
     /// Error from the reqwest HTTP client.
     Reqwest(reqwest::Error),
     /// Error from the reqwest middleware.

--- a/support/openapi-template/reqwest-trait/api.mustache
+++ b/support/openapi-template/reqwest-trait/api.mustache
@@ -62,7 +62,7 @@ pub trait {{{classname}}}: Send + Sync {
     ### Regular return type
     }}{{^supportMultipleResponses}}{{^returnType}}(){{/returnType}}{{{returnType}}}{{/supportMultipleResponses}}{{!
     ### Error Type
-    }}, Error<{{{vendorExtensions.x-action-name}}}Error>>;
+    }}, Error>;
 {{/vendorExtensions.x-group-parameters}}
 {{/isDeprecated}}
 {{/operation}}
@@ -141,7 +141,7 @@ impl {{classname}} for {{classname}}Client {
     ### Regular return type
     }}{{^supportMultipleResponses}}{{^returnType}}(){{/returnType}}{{{returnType}}}{{/supportMultipleResponses}}{{!
     ### Error Type
-    }}, Error<{{{vendorExtensions.x-action-name}}}Error>> {
+    }}, Error> {
         {{#allParams}}{{#-first}}
         let {{{vendorExtensions.x-action-name}}}Params {
             {{#allParams}}
@@ -176,7 +176,7 @@ impl {{classname}} for {{classname}}Client {
     ### Regular return type
     }}{{^supportMultipleResponses}}{{^returnType}}(){{/returnType}}{{{returnType}}}{{/supportMultipleResponses}}{{!
     ### Regular return type
-    }}, Error<{{{vendorExtensions.x-action-name}}}Error>> {
+    }}, Error> {
     {{/vendorExtensions.x-group-parameters}}
         let local_var_configuration = &self.configuration;
 
@@ -428,50 +428,3 @@ impl {{classname}} for {{classname}}Client {
     {{/operation}}
     {{/operations}}
 }
-
-{{#supportMultipleResponses}}
-{{#operations}}
-{{#operation}}
-{{^isDeprecated}}
-/// struct for typed successes of method [`{{{classname}}}::{{vendorExtensions.x-action-name-snake-case}}`]
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(untagged)]
-pub enum {{{vendorExtensions.x-action-name}}}Success {
-    {{#responses}}
-    {{#is2xx}}
-    Status{{code}}({{#isEnum}}{{{enumName}}}{{/isEnum}}{{^isEnum}}{{{dataType}}}{{/isEnum}}),
-    {{/is2xx}}
-    {{#is3xx}}
-    Status{{code}}({{#isEnum}}{{{enumName}}}{{/isEnum}}{{^isEnum}}{{{dataType}}}{{/isEnum}}),
-    {{/is3xx}}
-    {{/responses}}
-    UnknownValue(serde_json::Value),
-}
-
-{{/isDeprecated}}
-{{/operation}}
-{{/operations}}
-{{/supportMultipleResponses}}
-{{#operations}}
-{{#operation}}
-{{^isDeprecated}}
-/// struct for typed errors of method [`{{{classname}}}::{{vendorExtensions.x-action-name-snake-case}}`]
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(untagged)]
-pub enum {{{vendorExtensions.x-action-name}}}Error {
-    {{#responses}}
-    {{#is4xx}}
-    Status{{code}}({{#isEnum}}{{{enumName}}}{{/isEnum}}{{^isEnum}}{{{dataType}}}{{/isEnum}}),
-    {{/is4xx}}
-    {{#is5xx}}
-    Status{{code}}({{#isEnum}}{{{enumName}}}{{/isEnum}}{{^isEnum}}{{{dataType}}}{{/isEnum}}),
-    {{/is5xx}}
-    {{#isDefault}}
-    DefaultResponse({{#isEnum}}{{{enumName}}}{{/isEnum}}{{^isEnum}}{{{dataType}}}{{/isEnum}}),
-    {{/isDefault}}
-    {{/responses}}
-    UnknownValue(serde_json::Value),
-}
-{{/isDeprecated}}
-{{/operation}}
-{{/operations}}


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-31712

## 📔 Objective

Remove the generic error enums from the API binding templates. The server API doesn't define different error types per request, so these generated enums just add binary and code bloat without providing value.

Since the `Error<T>` type is used by other crates, removing it the generic type directly would be a pretty big breaking change. Instead, this PR adds a default type parameter (T = ()), allowing us to stop creating generic errors in bindings now while deferring the removal of the generic parameter itself to a follow-up PR after the bindings are regenerated.

## 🚨 Breaking Changes

<!-- Does this PR introduce any breaking changes? If so, please describe the impact and migration path for clients.

If you're unsure, the automated TypeScript compatibility check will run when you open/update this PR and provide feedback.

For breaking changes:
1. Describe what changed in the client interface
2. Explain why the change was necessary
3. Provide migration steps for client developers
4. Link to any paired client PRs if needed

Otherwise, you can remove this section. -->
