### PR TITLE
[PM-34464] Base64 encoding chunked

### DIFF
--- a/crates/bitwarden-encoding/src/b64.rs
+++ b/crates/bitwarden-encoding/src/b64.rs
@@ -6,7 +6,7 @@ use thiserror::Error;
 #[cfg(feature = "wasm")]
 use tsify::Tsify;
 
-use crate::FromStrVisitor;
+use crate::{FromStrVisitor, chunked::chunked_encode};
 
 /// Base64 encoded data
 ///
@@ -73,7 +73,7 @@ impl From<B64> for String {
 
 impl From<&B64> for String {
     fn from(src: &B64) -> Self {
-        BASE64.encode(&src.0)
+        chunked_encode(&BASE64, &src.0)
     }
 }
 

--- a/crates/bitwarden-encoding/src/b64url.rs
+++ b/crates/bitwarden-encoding/src/b64url.rs
@@ -4,6 +4,8 @@ use data_encoding::BASE64URL_NOPAD;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
+use crate::chunked::chunked_encode;
+
 /// Base64URL encoded data
 ///
 /// Is indifferent about padding when decoding, but always produces padding when encoding.
@@ -48,7 +50,7 @@ impl From<B64Url> for String {
 
 impl From<&B64Url> for String {
     fn from(src: &B64Url) -> Self {
-        BASE64URL_NOPAD.encode(&src.0)
+        chunked_encode(&BASE64URL_NOPAD, &src.0)
     }
 }
 

--- a/crates/bitwarden-encoding/src/chunked.rs
+++ b/crates/bitwarden-encoding/src/chunked.rs
@@ -1,0 +1,90 @@
+use data_encoding::Encoding;
+
+/// Encodes data using the provided encoding, transparently chunking to work around
+/// `data-encoding`'s `encode_len` length assertion (`len <= usize::MAX / 512`, ~8 MB on 32-bit
+/// targets like wasm32). On 64-bit targets the limit is effectively infinite so all input fits in a
+/// single chunk.
+pub(crate) fn chunked_encode(encoding: &Encoding, data: &[u8]) -> String {
+    chunked_encode_with_limit(encoding, data, usize::MAX / 512)
+}
+
+fn chunked_encode_with_limit(encoding: &Encoding, data: &[u8], max_safe: usize) -> String {
+    // Round down to the nearest multiple of `encode_align` so intermediate chunks
+    // produce clean output without spurious padding. Only the final chunk may produce padding.
+    let align = encoding.encode_align();
+    let max_chunk = max_safe - max_safe % align;
+
+    // Base64 output is ~4/3 of input; slightly over-estimate to avoid reallocations.
+    let mut output = String::with_capacity(data.len() / 3 * 4 + 4);
+    for chunk in data.chunks(max_chunk) {
+        encoding.encode_append(chunk, &mut output);
+    }
+    output
+}
+
+#[cfg(test)]
+mod tests {
+    use data_encoding::{BASE64, BASE64URL_NOPAD};
+
+    use super::*;
+
+    #[test]
+    fn single_chunk_matches_direct_encode() {
+        let data = b"Hello, World!";
+        assert_eq!(chunked_encode(&BASE64, data), BASE64.encode(data));
+        assert_eq!(
+            chunked_encode(&BASE64URL_NOPAD, data),
+            BASE64URL_NOPAD.encode(data)
+        );
+    }
+
+    #[test]
+    fn multi_chunk_matches_direct_encode_base64() {
+        // 30 bytes of input, chunked at max_safe=6 → align=3, max_chunk=6
+        // This forces 5 separate chunks.
+        let data: Vec<u8> = (0..30).collect();
+        let expected = BASE64.encode(&data);
+        let result = chunked_encode_with_limit(&BASE64, &data, 6);
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn multi_chunk_matches_direct_encode_base64url() {
+        let data: Vec<u8> = (0..30).collect();
+        let expected = BASE64URL_NOPAD.encode(&data);
+        let result = chunked_encode_with_limit(&BASE64URL_NOPAD, &data, 6);
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn chunk_boundary_not_aligned_to_three() {
+        // max_safe=7 with align=3 → max_chunk=6 (rounds down), same as above
+        // but verifies the alignment rounding logic.
+        let data: Vec<u8> = (0..30).collect();
+        let expected = BASE64.encode(&data);
+        let result = chunked_encode_with_limit(&BASE64, &data, 7);
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn input_exactly_one_chunk() {
+        let data: Vec<u8> = (0..6).collect();
+        let expected = BASE64.encode(&data);
+        let result = chunked_encode_with_limit(&BASE64, &data, 6);
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn input_one_byte_over_chunk() {
+        let data: Vec<u8> = (0..7).collect();
+        let expected = BASE64.encode(&data);
+        let result = chunked_encode_with_limit(&BASE64, &data, 6);
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn empty_input() {
+        assert_eq!(chunked_encode_with_limit(&BASE64, &[], 6), "");
+        assert_eq!(chunked_encode_with_limit(&BASE64URL_NOPAD, &[], 6), "");
+    }
+}

--- a/crates/bitwarden-encoding/src/chunked.rs
+++ b/crates/bitwarden-encoding/src/chunked.rs
@@ -9,16 +9,14 @@ pub(crate) fn chunked_encode(encoding: &Encoding, data: &[u8]) -> String {
 }
 
 fn chunked_encode_with_limit(encoding: &Encoding, data: &[u8], max_safe: usize) -> String {
-    // Round down to the nearest multiple of `encode_align` so intermediate chunks
-    // produce clean output without spurious padding. Only the final chunk may produce padding.
-    let align = encoding.encode_align();
-    let max_chunk = max_safe - max_safe % align;
-
     // Base64 output is ~4/3 of input; slightly over-estimate to avoid reallocations.
     let mut output = String::with_capacity(data.len() / 3 * 4 + 4);
-    for chunk in data.chunks(max_chunk) {
-        encoding.encode_append(chunk, &mut output);
+
+    let mut enc = encoding.new_encoder(&mut output);
+    for chunk in data.chunks(max_safe) {
+        enc.append(chunk);
     }
+    enc.finalize();
     output
 }
 
@@ -40,7 +38,7 @@ mod tests {
 
     #[test]
     fn multi_chunk_matches_direct_encode_base64() {
-        // 30 bytes of input, chunked at max_safe=6 → align=3, max_chunk=6
+        // 30 bytes of input, chunked at max_safe=6
         // This forces 5 separate chunks.
         let data: Vec<u8> = (0..30).collect();
         let expected = BASE64.encode(&data);
@@ -57,9 +55,9 @@ mod tests {
     }
 
     #[test]
-    fn chunk_boundary_not_aligned_to_three() {
-        // max_safe=7 with align=3 → max_chunk=6 (rounds down), same as above
-        // but verifies the alignment rounding logic.
+    fn unaligned_chunk_boundary() {
+        // max_safe=7 is not a multiple of 3 (base64 input group size).
+        // The streaming encoder handles this correctly without manual alignment.
         let data: Vec<u8> = (0..30).collect();
         let expected = BASE64.encode(&data);
         let result = chunked_encode_with_limit(&BASE64, &data, 7);

--- a/crates/bitwarden-encoding/src/lib.rs
+++ b/crates/bitwarden-encoding/src/lib.rs
@@ -2,6 +2,7 @@
 
 mod b64;
 mod b64url;
+mod chunked;
 mod serde;
 
 pub use b64::{B64, NotB64EncodedError};


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-34464

## 📔 Objective

Password-protected exports fail for larger vaults on wasm32 because the encrypted data exceeds the ~8 MB base64 encoding limit, causing a panic. This happens in SDK since all EncStrings are base64 encoded as strings between TS and WASM SDK.
The`data-encoding` library, that we use for base64 encoding, asserts `len <= usize::MAX / 512` in `encode_len`, which translates to ~8 MB on 32-bit targets (wasm32). Any `B64` or `B64Url` encoding of larger inputs panics.

Introduced a `chunked_encode` helper function that splits input into encoder-aligned chunks, each within the safe limit. Moved Base64 encoders to use it instead.
On 64-bit targets the limit is exabytes, so all input fits in a single chunk — effectively a no-op wrapper.
Decoding is unaffected (`decode_len` limit is ~536 MB on wasm32).

Alternatives considered:
- Could potentially use https://crates.io/crates/base64 instead, but the risk of regression is too big.
- [wasm 64-bit target](https://doc.rust-lang.org/rustc/platform-support/wasm64-unknown-unknown.html) is not stable yet, hence can't be used either - also not all browser support WebAssembly 3.0 yet, which comes with the 64 bit support.

## 🚨 Breaking Changes

None expected. Change should be backwards compatible. Have not observed any visible performance impacts.

<!-- Does this PR introduce any breaking changes? If so, please describe the impact and migration path for clients.

If you're unsure, the automated TypeScript compatibility check will run when you open/update this PR and provide feedback.

For breaking changes:
1. Describe what changed in the client interface
2. Explain why the change was necessary
3. Provide migration steps for client developers
4. Link to any paired client PRs if needed

Otherwise, you can remove this section. -->

TS Clients with encrypted export of over 50MB (50.000 ciphers org) working without errors with this SDK build:

https://github.com/user-attachments/assets/48e87f8e-c61c-4fdf-95fd-8c137f0e73d9

