### PR TITLE
[PM-31873] Wire StateRegistry into ClientBuilder and rename repository_map

### DIFF
--- a/crates/bitwarden-core/src/client/builder.rs
+++ b/crates/bitwarden-core/src/client/builder.rs
@@ -1,7 +1,6 @@
 use std::sync::{Arc, OnceLock, RwLock};
 
 use bitwarden_crypto::KeyStore;
-#[cfg(feature = "internal")]
 use bitwarden_state::registry::StateRegistry;
 use reqwest::header::{self, HeaderValue};
 
@@ -92,8 +91,7 @@ impl ClientBuilder {
                 key_store,
                 #[cfg(feature = "internal")]
                 security_state: RwLock::new(None),
-                #[cfg(feature = "internal")]
-                repository_map: StateRegistry::new(),
+                state_registry: StateRegistry::new(),
             }),
         }
     }

--- a/crates/bitwarden-core/src/client/builder.rs
+++ b/crates/bitwarden-core/src/client/builder.rs
@@ -100,7 +100,9 @@ impl ClientBuilder {
                 key_store,
                 #[cfg(feature = "internal")]
                 security_state: RwLock::new(None),
-                state_registry: self.state_registry.unwrap_or_else(StateRegistry::new_with_memory_db),
+                state_registry: self
+                    .state_registry
+                    .unwrap_or_else(StateRegistry::new_with_memory_db),
             }),
         }
     }

--- a/crates/bitwarden-core/src/client/builder.rs
+++ b/crates/bitwarden-core/src/client/builder.rs
@@ -19,6 +19,7 @@ use crate::{
 pub struct ClientBuilder {
     settings: Option<ClientSettings>,
     token_handler: Arc<dyn TokenHandler>,
+    state_registry: Option<StateRegistry>,
 }
 
 impl ClientBuilder {
@@ -27,6 +28,7 @@ impl ClientBuilder {
         Self {
             settings: None,
             token_handler: Arc::new(NoopTokenHandler),
+            state_registry: None,
         }
     }
 
@@ -39,6 +41,13 @@ impl ClientBuilder {
     /// Sets a custom [`TokenHandler`] for managing authentication tokens.
     pub fn with_token_handler(mut self, token_handler: Arc<dyn TokenHandler>) -> Self {
         self.token_handler = token_handler;
+        self
+    }
+
+    /// Sets a custom [`StateRegistry`] for the client being built.
+    /// If not set, defaults to [`StateRegistry::new_with_memory_db`].
+    pub fn with_state(mut self, state_registry: StateRegistry) -> Self {
+        self.state_registry = Some(state_registry);
         self
     }
 
@@ -91,7 +100,7 @@ impl ClientBuilder {
                 key_store,
                 #[cfg(feature = "internal")]
                 security_state: RwLock::new(None),
-                state_registry: StateRegistry::new(),
+                state_registry: self.state_registry.unwrap_or_else(StateRegistry::new_with_memory_db),
             }),
         }
     }
@@ -209,6 +218,23 @@ mod tests {
         let _b = ClientBuilder::new()
             .with_token_handler(Arc::new(NoopTokenHandler) as Arc<dyn TokenHandler>)
             .with_settings(ClientSettings::default())
+            .build();
+    }
+
+    #[test]
+    fn test_client_builder_with_state_builds() {
+        use bitwarden_state::registry::StateRegistry;
+        let registry = StateRegistry::new_with_memory_db();
+        let _client = ClientBuilder::new().with_state(registry).build();
+    }
+
+    #[test]
+    fn test_client_builder_with_state_in_chain() {
+        use bitwarden_state::registry::StateRegistry;
+        let registry = StateRegistry::new_with_memory_db();
+        let _client = ClientBuilder::new()
+            .with_settings(ClientSettings::default())
+            .with_state(registry)
             .build();
     }
 }

--- a/crates/bitwarden-core/src/client/internal.rs
+++ b/crates/bitwarden-core/src/client/internal.rs
@@ -107,6 +107,8 @@ pub struct InternalClient {
     #[cfg(feature = "internal")]
     pub(crate) security_state: RwLock<Option<SecurityState>>,
 
+    // TODO(PM-31876): Remove once Flags are migrated to Setting, which will add an in-crate
+    // read path and satisfy the dead_code lint without suppression.
     #[allow(dead_code)]
     pub(crate) state_registry: StateRegistry,
 }

--- a/crates/bitwarden-core/src/client/internal.rs
+++ b/crates/bitwarden-core/src/client/internal.rs
@@ -107,6 +107,7 @@ pub struct InternalClient {
     #[cfg(feature = "internal")]
     pub(crate) security_state: RwLock<Option<SecurityState>>,
 
+    #[allow(dead_code)]
     pub(crate) state_registry: StateRegistry,
 }
 

--- a/crates/bitwarden-core/src/client/internal.rs
+++ b/crates/bitwarden-core/src/client/internal.rs
@@ -7,7 +7,6 @@ use bitwarden_crypto::SymmetricCryptoKey;
 use bitwarden_crypto::{
     EncString, Kdf, MasterKey, PinKey, UnsignedSharedKey, safe::PasswordProtectedKeyEnvelope,
 };
-#[cfg(feature = "internal")]
 use bitwarden_state::registry::StateRegistry;
 #[cfg(feature = "internal")]
 use tracing::{debug, info, instrument};
@@ -108,8 +107,7 @@ pub struct InternalClient {
     #[cfg(feature = "internal")]
     pub(crate) security_state: RwLock<Option<SecurityState>>,
 
-    #[cfg(feature = "internal")]
-    pub(crate) repository_map: StateRegistry,
+    pub(crate) state_registry: StateRegistry,
 }
 
 impl InternalClient {

--- a/crates/bitwarden-core/src/platform/state_client.rs
+++ b/crates/bitwarden-core/src/platform/state_client.rs
@@ -21,7 +21,7 @@ impl StateClient {
     ) {
         self.client
             .internal
-            .repository_map
+            .state_registry
             .register_client_managed(store)
     }
 
@@ -33,7 +33,7 @@ impl StateClient {
     ) -> Result<(), StateRegistryError> {
         self.client
             .internal
-            .repository_map
+            .state_registry
             .initialize_database(configuration, migrations)
             .await
     }
@@ -49,7 +49,7 @@ impl StateClient {
     where
         T: RepositoryItem,
     {
-        self.client.internal.repository_map.get()
+        self.client.internal.state_registry.get()
     }
 
     /// Get a handle to a setting by its type-safe key.
@@ -75,7 +75,7 @@ impl StateClient {
     /// # }
     /// ```
     pub fn setting<T>(&self, key: Key<T>) -> Result<Setting<T>, SettingsError> {
-        let repository = self.client.internal.repository_map.get::<SettingItem>()?;
+        let repository = self.client.internal.state_registry.get::<SettingItem>()?;
         Ok(Setting::new(repository, key))
     }
 }

--- a/crates/bitwarden-state/src/registry.rs
+++ b/crates/bitwarden-state/src/registry.rs
@@ -213,7 +213,7 @@ mod tests {
     impl_repository!(TestC, TestItem<Vec<u8>>);
 
     #[tokio::test]
-    async fn test_repository_map() {
+    async fn test_state_registry() {
         let a = Arc::new(TestA(145832));
         let b = Arc::new(TestB("test".to_string()));
         let c = Arc::new(TestC(vec![1, 2, 3, 4, 5, 6, 7, 8, 9]));


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-31873

## 📔 Objective

Implements [PM-31873](https://bitwarden.atlassian.net/browse/PM-31873) as part of the [PM-31869](https://bitwarden.atlassian.net/browse/PM-31869) SDK Client Rehydration epic.

This PR:
- Renames the `repository_map` field on `InternalClient` to `state_registry` and removes the `#[cfg(feature = "internal")]` guard
- Updates `state_client.rs` to reference the renamed field at all four call sites
- Adds a `with_state(StateRegistry)` setter method to `ClientBuilder`
- Wires `StateRegistry` through `ClientBuilder::build()`, defaulting to `StateRegistry::new_with_memory_db()` when no registry is injected, preserving backwards-compatible behavior for existing callers

Two new tests exercise both the standalone path (`with_state` only) and the chained path (`with_settings` + `with_state`), confirming the builder compiles and succeeds in both configurations.

[PM-31873]: https://bitwarden.atlassian.net/browse/PM-31873?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PM-31869]: https://bitwarden.atlassian.net/browse/PM-31869?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ