### PR TITLE
[PM-33725] Change FromResult to be infallible

### DIFF
--- a/crates/bitwarden-core-macro/src/lib.rs
+++ b/crates/bitwarden-core-macro/src/lib.rs
@@ -31,12 +31,12 @@ use syn::{DeriveInput, parse_macro_input};
 ///
 /// ```ignore
 /// impl FromClient for FoldersClient {
-///     fn from_client(client: &Client) -> Result<Self, String> {
-///         Ok(Self {
-///             key_store: FromClientPart::<KeyStore<KeyIds>>::get_part(client).map_err(|e| e.to_string())?,
-///             api_configs: FromClientPart::<Arc<ApiConfigurations>>::get_part(client).map_err(|e| e.to_string())?,
-///             repository: FromClientPart::<Arc<dyn Repository<Folder>>>::get_part(client).map_err(|e| e.to_string())?,
-///         })
+///     fn from_client(client: &Client) -> Self {
+///         Self {
+///             key_store: FromClientPart::<KeyStore<KeyIds>>::get_part(client),
+///             api_configs: FromClientPart::<Arc<ApiConfigurations>>::get_part(client),
+///             repository: FromClientPart::<Option<Arc<dyn Repository<Folder>>>>::get_part(client),
+///         }
 ///     }
 /// }
 /// ```
@@ -64,16 +64,16 @@ pub fn derive_from_client(item: TokenStream) -> TokenStream {
         let field_name = f.ident.as_ref()?;
         let field_type = &f.ty;
         Some(quote! {
-            #field_name: ::bitwarden_core::client::FromClientPart::<#field_type>::get_part(client).map_err(|e| e.to_string())?
+            #field_name: ::bitwarden_core::client::FromClientPart::<#field_type>::get_part(client)
         })
     });
 
     let expanded = quote! {
         impl #impl_generics ::bitwarden_core::client::FromClient for #struct_name #ty_generics #where_clause {
-            fn from_client(client: &::bitwarden_core::Client) -> Result<Self, String> {
-                Ok(Self {
+            fn from_client(client: &::bitwarden_core::Client) -> Self {
+                Self {
                     #(#field_inits),*
-                })
+                }
             }
         }
     };

--- a/crates/bitwarden-core/src/client/from_client_part.rs
+++ b/crates/bitwarden-core/src/client/from_client_part.rs
@@ -35,11 +35,11 @@ use crate::{client::ApiConfigurations, key_management::KeyIds};
 /// }
 ///
 /// // Usage:
-/// let folders_client = FoldersClient::from_client(&client)?;
+/// let folders_client = FoldersClient::from_client(&client);
 /// ```
 pub trait FromClient: Sized {
     /// Construct this type from a [`Client`] reference.
-    fn from_client(client: &Client) -> Result<Self, String>;
+    fn from_client(client: &Client) -> Self;
 }
 
 /// Trait for extracting parts/dependencies from a [`Client`].
@@ -48,34 +48,25 @@ pub trait FromClient: Sized {
 /// `#[derive(FromClient)]` - users should derive [`FromClient`] rather than using this trait
 /// directly.
 pub trait FromClientPart<T> {
-    /// The error type returned when extraction fails.
-    type Error;
-
     /// Extract a dependency of type `T` from self.
-    fn get_part(&self) -> Result<T, Self::Error>;
+    fn get_part(&self) -> T;
 }
 
 impl FromClientPart<KeyStore<KeyIds>> for Client {
-    type Error = std::convert::Infallible;
-
-    fn get_part(&self) -> Result<KeyStore<KeyIds>, Self::Error> {
-        Ok(self.internal.get_key_store().clone())
+    fn get_part(&self) -> KeyStore<KeyIds> {
+        self.internal.get_key_store().clone()
     }
 }
 
 impl FromClientPart<Arc<ApiConfigurations>> for Client {
-    type Error = std::convert::Infallible;
-
-    fn get_part(&self) -> Result<Arc<ApiConfigurations>, Self::Error> {
-        Ok(self.internal.get_api_configurations())
+    fn get_part(&self) -> Arc<ApiConfigurations> {
+        self.internal.get_api_configurations()
     }
 }
 
 #[cfg(feature = "internal")]
-impl<T: RepositoryItem> FromClientPart<Arc<dyn Repository<T>>> for Client {
-    type Error = bitwarden_state::registry::StateRegistryError;
-
-    fn get_part(&self) -> Result<Arc<dyn Repository<T>>, Self::Error> {
-        self.platform().state().get::<T>()
+impl<T: RepositoryItem> FromClientPart<Option<Arc<dyn Repository<T>>>> for Client {
+    fn get_part(&self) -> Option<Arc<dyn Repository<T>>> {
+        self.platform().state().get::<T>().ok()
     }
 }

--- a/crates/bitwarden-pm/src/lib.rs
+++ b/crates/bitwarden-pm/src/lib.rs
@@ -70,16 +70,16 @@ impl PasswordManagerClient {
     /// registered
     ///
     /// This will eventually replace `new` when the SDK fully owns sync on all clients.
-    pub fn new_with_sync(settings: Option<bitwarden_core::ClientSettings>) -> Result<Self, String> {
+    pub fn new_with_sync(settings: Option<bitwarden_core::ClientSettings>) -> Self {
         let client = Self::new(settings);
 
         client
             .sync()
-            .register_sync_handler(Arc::new(FolderSyncHandler::from_client(&client.0)?));
+            .register_sync_handler(Arc::new(FolderSyncHandler::from_client(&client.0)));
 
         // TODO: Add more sync handlers here!
 
-        Ok(client)
+        client
     }
 
     /// Platform operations

--- a/crates/bitwarden-sync/src/sync_client.rs
+++ b/crates/bitwarden-sync/src/sync_client.rs
@@ -44,9 +44,7 @@ impl SyncClient {
     /// Create a new SyncClient from a Bitwarden client
     pub fn new(client: Client) -> Self {
         Self {
-            api_configurations: client
-                .get_part()
-                .expect("ApiConfigurations should never fail"),
+            api_configurations: client.get_part(),
             sync_handlers: HandlerRegistry::new(),
             error_handlers: HandlerRegistry::new(),
             sync_lock: Mutex::new(()),

--- a/crates/bitwarden-vault/src/folder/folder_sync_handler.rs
+++ b/crates/bitwarden-vault/src/folder/folder_sync_handler.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use bitwarden_core::{FromClient, require};
-use bitwarden_state::repository::Repository;
+use bitwarden_state::repository::{Repository, RepositoryError};
 use bitwarden_sync::{SyncHandler, SyncHandlerError};
 
 use crate::{Folder, FolderId};
@@ -11,7 +11,7 @@ use crate::{Folder, FolderId};
 /// This handler persists folders to SDK-managed storage.
 #[derive(FromClient)]
 pub struct FolderSyncHandler {
-    repository: Arc<dyn Repository<Folder>>,
+    repository: Option<Arc<dyn Repository<Folder>>>,
 }
 
 #[async_trait::async_trait]
@@ -20,6 +20,10 @@ impl SyncHandler for FolderSyncHandler {
         &self,
         response: &bitwarden_api_api::models::SyncResponseModel,
     ) -> Result<(), SyncHandlerError> {
+        let repository = self
+            .repository
+            .as_ref()
+            .ok_or(RepositoryError::Internal("Missing repository".to_string()))?;
         let api_folders = require!(response.folders.as_ref());
 
         let folders: Vec<(FolderId, Folder)> = api_folders
@@ -40,7 +44,7 @@ impl SyncHandler for FolderSyncHandler {
             })
             .collect();
 
-        self.repository.replace_all(folders).await?;
+        repository.replace_all(folders).await?;
 
         Ok(())
     }
@@ -71,7 +75,7 @@ mod tests {
     async fn test_on_sync_replaces_existing_folders() {
         let repository = Arc::new(MemoryRepository::<Folder>::default());
         let handler = FolderSyncHandler {
-            repository: repository.clone(),
+            repository: Some(repository.clone()),
         };
 
         // First sync with two folders
@@ -103,7 +107,7 @@ mod tests {
     async fn test_on_sync_no_folders_returns_error() {
         let repository = Arc::new(MemoryRepository::<Folder>::default());
         let handler = FolderSyncHandler {
-            repository: repository.clone(),
+            repository: Some(repository.clone()),
         };
 
         let response = SyncResponseModel::default();

--- a/crates/bitwarden-vault/src/folder/folder_sync_handler.rs
+++ b/crates/bitwarden-vault/src/folder/folder_sync_handler.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use bitwarden_core::{FromClient, require};
-use bitwarden_state::repository::{Repository, RepositoryError};
+use bitwarden_state::{registry::StateRegistryError, repository::Repository};
 use bitwarden_sync::{SyncHandler, SyncHandlerError};
 
 use crate::{Folder, FolderId};
@@ -23,7 +23,7 @@ impl SyncHandler for FolderSyncHandler {
         let repository = self
             .repository
             .as_ref()
-            .ok_or(RepositoryError::Internal("Missing repository".to_string()))?;
+            .ok_or(StateRegistryError::DatabaseNotInitialized)?;
         let api_folders = require!(response.folders.as_ref());
 
         let folders: Vec<(FolderId, Folder)> = api_folders


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-33725
## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

We need to eliminate the ability of `FromClient` to return `Result` since we have no good way to handle the errors at that point. This changes it so repositories must be `Option` inside client structs and error handling happens at the function levels.
