### PR TITLE
Reexport new auth registration in uniffi

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1108,6 +1108,7 @@ name = "bitwarden-uniffi"
 version = "0.1.0"
 dependencies = [
  "async-trait",
+ "bitwarden-auth",
  "bitwarden-collections",
  "bitwarden-core",
  "bitwarden-crypto",

--- a/crates/bitwarden-auth/src/login/login_client.rs
+++ b/crates/bitwarden-auth/src/login/login_client.rs
@@ -66,7 +66,6 @@ use wasm_bindgen::prelude::*;
 /// # }
 /// ```
 #[cfg_attr(feature = "wasm", wasm_bindgen)]
-#[cfg_attr(feature = "uniffi", derive(uniffi::Object))]
 pub struct LoginClient {
     pub(crate) client: Client,
 }

--- a/crates/bitwarden-auth/src/login/login_via_password/login_via_password_impl.rs
+++ b/crates/bitwarden-auth/src/login/login_via_password/login_via_password_impl.rs
@@ -10,7 +10,6 @@ use crate::login::{
 };
 
 #[cfg_attr(feature = "wasm", wasm_bindgen)]
-#[cfg_attr(feature = "uniffi", uniffi::export)]
 impl LoginClient {
     /// Authenticates a user via email and master password.
     ///

--- a/crates/bitwarden-auth/src/login/login_via_password/password_prelogin.rs
+++ b/crates/bitwarden-auth/src/login/login_via_password/password_prelogin.rs
@@ -32,7 +32,6 @@ impl From<bitwarden_core::MissingFieldError> for PasswordPreloginError {
 }
 
 #[cfg_attr(feature = "wasm", wasm_bindgen)]
-#[cfg_attr(feature = "uniffi", uniffi::export)]
 impl LoginClient {
     /// Retrieves the data required before authenticating with a password.
     /// This includes the user's KDF configuration needed to properly derive the master key.

--- a/crates/bitwarden-auth/src/registration.rs
+++ b/crates/bitwarden-auth/src/registration.rs
@@ -75,7 +75,6 @@ pub struct JitMasterPasswordRegistrationRequest {
 
 /// Client for initializing a user account.
 #[derive(Clone)]
-#[cfg_attr(feature = "uniffi", derive(uniffi::Object))]
 #[cfg_attr(feature = "wasm", wasm_bindgen)]
 pub struct RegistrationClient {
     #[allow(dead_code)]
@@ -88,7 +87,6 @@ impl RegistrationClient {
     }
 }
 
-#[cfg_attr(feature = "uniffi", uniffi::export)]
 #[cfg_attr(feature = "wasm", wasm_bindgen)]
 impl RegistrationClient {
     /// Initializes a new cryptographic state for a user and posts it to the server; enrolls in

--- a/crates/bitwarden-uniffi/Cargo.toml
+++ b/crates/bitwarden-uniffi/Cargo.toml
@@ -24,6 +24,7 @@ dangerous-crypto-debug = ["bitwarden-core/dangerous-crypto-debug"]
 
 [dependencies]
 async-trait = { workspace = true }
+bitwarden-auth = { workspace = true, features = ["uniffi"] }
 bitwarden-collections = { workspace = true, features = ["uniffi"] }
 bitwarden-core = { workspace = true, features = ["uniffi"] }
 bitwarden-crypto = { workspace = true, features = ["uniffi"] }

--- a/crates/bitwarden-uniffi/src/auth/mod.rs
+++ b/crates/bitwarden-uniffi/src/auth/mod.rs
@@ -17,8 +17,7 @@ pub struct AuthClient(pub(crate) bitwarden_core::Client);
 
 #[uniffi::export(async_runtime = "tokio")]
 impl AuthClient {
-    // Reexport the registration client from the bitwarden-auth AuthClient until everything else
-    // from here is migrated over.
+    /// Client for initializing user account cryptography and unlock methods after JIT provisioning
     pub fn registration(&self) -> RegistrationClient {
         RegistrationClient(self.0.clone())
     }

--- a/crates/bitwarden-uniffi/src/auth/mod.rs
+++ b/crates/bitwarden-uniffi/src/auth/mod.rs
@@ -1,4 +1,3 @@
-use bitwarden_auth::AuthClientExt;
 use bitwarden_core::auth::{
     AuthRequestResponse, KeyConnectorResponse, RegisterKeyResponse, RegisterTdeKeyResponse,
     password::MasterPasswordPolicyOptions,

--- a/crates/bitwarden-uniffi/src/auth/mod.rs
+++ b/crates/bitwarden-uniffi/src/auth/mod.rs
@@ -1,3 +1,4 @@
+use bitwarden_auth::{AuthClientExt, registration::RegistrationClient};
 use bitwarden_core::auth::{
     AuthRequestResponse, KeyConnectorResponse, RegisterKeyResponse, RegisterTdeKeyResponse,
     password::MasterPasswordPolicyOptions,
@@ -15,6 +16,12 @@ pub struct AuthClient(pub(crate) bitwarden_core::Client);
 
 #[uniffi::export(async_runtime = "tokio")]
 impl AuthClient {
+    // Reexport the registration client from the bitwarden-auth AuthClient until everything else
+    // from here is migrated over.
+    pub fn registration(&self) -> RegistrationClient {
+        self.0.auth_new().registration()
+    }
+
     /// Calculate Password Strength
     pub fn password_strength(
         &self,

--- a/crates/bitwarden-uniffi/src/auth/mod.rs
+++ b/crates/bitwarden-uniffi/src/auth/mod.rs
@@ -11,6 +11,8 @@ use bitwarden_encoding::B64;
 
 use crate::error::Result;
 
+mod registration;
+
 #[derive(uniffi::Object)]
 pub struct AuthClient(pub(crate) bitwarden_core::Client);
 

--- a/crates/bitwarden-uniffi/src/auth/mod.rs
+++ b/crates/bitwarden-uniffi/src/auth/mod.rs
@@ -1,4 +1,4 @@
-use bitwarden_auth::{AuthClientExt, registration::RegistrationClient};
+use bitwarden_auth::AuthClientExt;
 use bitwarden_core::auth::{
     AuthRequestResponse, KeyConnectorResponse, RegisterKeyResponse, RegisterTdeKeyResponse,
     password::MasterPasswordPolicyOptions,
@@ -9,7 +9,7 @@ use bitwarden_crypto::{
 };
 use bitwarden_encoding::B64;
 
-use crate::error::Result;
+use crate::{auth::registration::RegistrationClient, error::Result};
 
 mod registration;
 
@@ -21,7 +21,7 @@ impl AuthClient {
     // Reexport the registration client from the bitwarden-auth AuthClient until everything else
     // from here is migrated over.
     pub fn registration(&self) -> RegistrationClient {
-        self.0.auth_new().registration()
+        RegistrationClient(self.0.clone())
     }
 
     /// Calculate Password Strength

--- a/crates/bitwarden-uniffi/src/auth/registration.rs
+++ b/crates/bitwarden-uniffi/src/auth/registration.rs
@@ -1,0 +1,58 @@
+use bitwarden_auth::{
+    AuthClientExt,
+    registration::{
+        JitMasterPasswordRegistrationRequest, JitMasterPasswordRegistrationResponse,
+        KeyConnectorRegistrationResult, TdeRegistrationRequest, TdeRegistrationResponse,
+    },
+};
+
+use crate::error::BitwardenError;
+
+#[derive(uniffi::Object)]
+pub struct RegistrationClient(pub(crate) bitwarden_core::Client);
+
+#[uniffi::export]
+impl RegistrationClient {
+    /// Initializes a new cryptographic state for a user and posts it to the server; enrolls in
+    /// admin password reset and finally enrolls the user to TDE unlock.
+    pub async fn post_keys_for_tde_registration(
+        &self,
+        request: TdeRegistrationRequest,
+    ) -> Result<TdeRegistrationResponse, BitwardenError> {
+        Ok(self
+            .0
+            .auth_new()
+            .registration()
+            .post_keys_for_tde_registration(request)
+            .await?)
+    }
+
+    /// Initializes a new cryptographic state for a user and posts it to the server; enrolls the
+    /// user to key connector unlock.
+    pub async fn post_keys_for_key_connector_registration(
+        &self,
+        key_connector_url: String,
+        sso_org_identifier: String,
+    ) -> Result<KeyConnectorRegistrationResult, BitwardenError> {
+        Ok(self
+            .0
+            .auth_new()
+            .registration()
+            .post_keys_for_key_connector_registration(key_connector_url, sso_org_identifier)
+            .await?)
+    }
+
+    /// Initializes a new cryptographic state for a user and posts it to the server;
+    /// enrolls the user to master password unlock.
+    pub async fn post_keys_for_jit_password_registration(
+        &self,
+        request: JitMasterPasswordRegistrationRequest,
+    ) -> Result<JitMasterPasswordRegistrationResponse, BitwardenError> {
+        Ok(self
+            .0
+            .auth_new()
+            .registration()
+            .post_keys_for_jit_password_registration(request)
+            .await?)
+    }
+}

--- a/crates/bitwarden-uniffi/src/error.rs
+++ b/crates/bitwarden-uniffi/src/error.rs
@@ -28,6 +28,8 @@ pub enum BitwardenError {
     ApproveAuthRequest(#[from] bitwarden_core::auth::ApproveAuthRequestError),
     #[error(transparent)]
     TrustDevice(#[from] bitwarden_core::auth::auth_client::TrustDeviceError),
+    #[error(transparent)]
+    Registration(#[from] bitwarden_auth::registration::RegistrationError),
 
     #[error(transparent)]
     Fingerprint(#[from] bitwarden_core::platform::FingerprintError),


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.slack.com/archives/C054ZQSBS49/p1775586953115189

## 📔 Objective

Export the auth registration client from Uniffi. Because of uniffi error handling constraints that all the clients deal with regarding error handling, the registration API is currently duplicated in the uniffi crate. To avoid duplicate names, I've removed the uniffi::export usages in `bitwarden-auth`

## 🚨 Breaking Changes

<!-- Does this PR introduce any breaking changes? If so, please describe the impact and migration path for clients.

If you're unsure, the automated TypeScript compatibility check will run when you open/update this PR and provide feedback.

For breaking changes:
1. Describe what changed in the client interface
2. Explain why the change was necessary
3. Provide migration steps for client developers
4. Link to any paired client PRs if needed

Otherwise, you can remove this section. -->
