### PR TITLE
[BRE-1670] Replace PAT with app token

### DIFF
--- a/.github/workflows/build-swift.yml
+++ b/.github/workflows/build-swift.yml
@@ -104,7 +104,6 @@ jobs:
     runs-on: ubuntu-24.04
     needs: build
     permissions:
-      contents: 
       actions: write
     steps:
       - name: Trigger Swift release

--- a/.github/workflows/build-swift.yml
+++ b/.github/workflows/build-swift.yml
@@ -113,31 +113,11 @@ jobs:
           subscription_id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
           tenant_id: ${{ secrets.AZURE_TENANT_ID }}
           client_id: ${{ secrets.AZURE_CLIENT_ID }}
-
-      - name: Retrieve github secrets
-        id: retrieve-secret
-        uses: bitwarden/gh-actions/get-keyvault-secrets@main
-        with:
-          keyvault: gh-org-bitwarden
-          secrets: "BW-GHAPP-ID,BW-GHAPP-KEY"
-
-      - name: Log out from Azure
-        uses: bitwarden/gh-actions/azure-logout@main
-
-      - name: Generate GH App token
-        uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1
-        id: app-token
-        with:
-          app-id: ${{ steps.retrieve-secret.outputs.BW-GHAPP-ID }}
-          private-key: ${{ steps.retrieve-secret.outputs.BW-GHAPP-KEY }}
-          owner: ${{ github.repository_owner }}
-          repositories: sdk-internal
-          permission-actions: write
         
       - name: Trigger Swift release
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         with:
-          github-token: ${{ steps.app-token.outputs.token }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             await github.rest.actions.createWorkflowDispatch({
               owner: 'bitwarden',

--- a/.github/workflows/build-swift.yml
+++ b/.github/workflows/build-swift.yml
@@ -106,6 +106,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
+      actions: write
     steps:
       - name: Log in to Azure
         uses: bitwarden/gh-actions/azure-login@main

--- a/.github/workflows/build-swift.yml
+++ b/.github/workflows/build-swift.yml
@@ -115,19 +115,27 @@ jobs:
           client_id: ${{ secrets.AZURE_CLIENT_ID }}
 
       - name: Retrieve github PAT secrets
-        id: retrieve-secret-pat
+        id: retrieve-secret
         uses: bitwarden/gh-actions/get-keyvault-secrets@main
         with:
-          keyvault: "bitwarden-ci"
-          secrets: "github-pat-bitwarden-devops-bot-repo-scope"
+          keyvault: gh-org-bitwarden
+          secrets: "BW-GHAPP-ID,BW-GHAPP-KEY"
 
       - name: Log out from Azure
         uses: bitwarden/gh-actions/azure-logout@main
 
+      - name: Generate GH App token
+        uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1
+        id: app-token
+        with:
+          app-id: ${{ steps.retrieve-secret.outputs.BW-GHAPP-ID }}
+          private-key: ${{ steps.retrieve-secret.outputs.BW-GHAPP-KEY }}
+          owner: ${{ github.repository_owner }}
+        
       - name: Trigger Swift release
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         with:
-          github-token: ${{ steps.retrieve-secret-pat.outputs.github-pat-bitwarden-devops-bot-repo-scope }}
+          github-token: ${{ steps.app-token.outputs.token }}
           script: |
             await github.rest.actions.createWorkflowDispatch({
               owner: 'bitwarden',

--- a/.github/workflows/build-swift.yml
+++ b/.github/workflows/build-swift.yml
@@ -114,7 +114,7 @@ jobs:
           tenant_id: ${{ secrets.AZURE_TENANT_ID }}
           client_id: ${{ secrets.AZURE_CLIENT_ID }}
 
-      - name: Retrieve github PAT secrets
+      - name: Retrieve github secrets
         id: retrieve-secret
         uses: bitwarden/gh-actions/get-keyvault-secrets@main
         with:

--- a/.github/workflows/build-swift.yml
+++ b/.github/workflows/build-swift.yml
@@ -131,6 +131,8 @@ jobs:
           app-id: ${{ steps.retrieve-secret.outputs.BW-GHAPP-ID }}
           private-key: ${{ steps.retrieve-secret.outputs.BW-GHAPP-KEY }}
           owner: ${{ github.repository_owner }}
+          repositories: sdk-internal
+          permission-actions: write
         
       - name: Trigger Swift release
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0

--- a/.github/workflows/build-swift.yml
+++ b/.github/workflows/build-swift.yml
@@ -104,17 +104,9 @@ jobs:
     runs-on: ubuntu-24.04
     needs: build
     permissions:
-      contents: read
-      id-token: write
+      contents: 
       actions: write
     steps:
-      - name: Log in to Azure
-        uses: bitwarden/gh-actions/azure-login@main
-        with:
-          subscription_id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
-          tenant_id: ${{ secrets.AZURE_TENANT_ID }}
-          client_id: ${{ secrets.AZURE_CLIENT_ID }}
-        
       - name: Trigger Swift release
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         with:

--- a/.github/workflows/release-swift.yml
+++ b/.github/workflows/release-swift.yml
@@ -165,7 +165,6 @@ jobs:
           cp --verbose -rf sdk/crates/bitwarden-uniffi/swift/Tests sdk-swift
 
       - name: Add changes
-        id: add-changes
         working-directory: sdk-swift
         run: |
           git add .
@@ -180,7 +179,6 @@ jobs:
           tag_name: "v$_RELEASE_NAME"
 
       - name: Echo changes
-        id: echo-changes
         working-directory: sdk-swift
         env:
           _RELEASE_NAME: ${{ steps.set-release-name.outputs.release_name }}
@@ -191,7 +189,6 @@ jobs:
         run: |
           # NOTE: bitwarden/ios repo expects the full sdk-internal commit hash in sdk-swift commit message
           echo "👀 Commit hash: $_COMMIT_HASH"
-          echo "commit-hash=$_COMMIT_HASH" >> $GITHUB_OUTPUT
           echo "👀 Release Tag: v$_RELEASE_NAME"
 
           echo "# 🚀 Swift SDK Updated Successfully!" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/release-swift.yml
+++ b/.github/workflows/release-swift.yml
@@ -130,12 +130,6 @@ jobs:
           token: ${{ steps.app-token-sdk-swift.outputs.token }}
           persist-credentials: true
 
-      - name: Setup Git
-        working-directory: sdk-swift
-        run: |
-          git config --local user.email "$_BOT_EMAIL"
-          git config --local user.name "$_BOT_NAME"
-
       - name: Download BitwardenSdk sources artifact
         uses: bitwarden/gh-actions/download-artifacts@main
         id: download-artifact
@@ -170,32 +164,41 @@ jobs:
           cp --verbose -rf sdk/crates/bitwarden-uniffi/swift/Sources sdk-swift
           cp --verbose -rf sdk/crates/bitwarden-uniffi/swift/Tests sdk-swift
 
-      - name: Push changes
-        id: push-changes
+      - name: Add changes
+        id: add-changes
+        working-directory: sdk-swift
+        run: |
+          git add .
+
+      - name: Commit changes
+        uses: bitwarden/gh-actions/api-commit@main
+        id: commit-changes
+        with:
+          token: ${{ steps.app-token-sdk-swift.outputs.token }}
+          branch: ${{ inputs.sdk-swift-branch-name }}
+          message: "Release Swift SDK v$_RELEASE_NAME (bitwarden/sdk-internal@$_SDK_INTERNAL_SHORT_REF) - $_SDK_INTERNAL_COMMIT_MSG"
+          tag_name: "v$_RELEASE_NAME"
+
+      - name: Echo changes
+        id: echo-changes
         working-directory: sdk-swift
         env:
           _RELEASE_NAME: ${{ steps.set-release-name.outputs.release_name }}
           _SDK_INTERNAL_REF: ${{ steps.get-sdk-internal-ref.outputs.sha }}
-          _SDK_INTERNAL_COMMIT_MSG: ${{ steps.get-sdk-internal-ref.outputs.commit_message }}
+          _SDK_INTERNAL_COMMIT_MSG: ${{ steps.get-sdk-internal-ref.outputs.commit_message }} 
           _BRANCH_NAME: ${{ inputs.sdk-swift-branch-name }}
+          _COMMIT_HASH: ${{ steps.commit-changes.outputs.commit-sha }}
         run: |
           # NOTE: bitwarden/ios repo expects the full sdk-internal commit hash in sdk-swift commit message
-          git add .
-          git commit -m "bitwarden/sdk-internal@$_SDK_INTERNAL_REF $_RELEASE_NAME - $_SDK_INTERNAL_COMMIT_MSG"
-          git push origin $_BRANCH_NAME
-          COMMIT_HASH=$(git rev-parse HEAD)
-          echo "👀 Commit hash: $COMMIT_HASH"
-          echo "commit-hash=$COMMIT_HASH" >> $GITHUB_OUTPUT
-
-          git tag v$_RELEASE_NAME
-          git push origin v$_RELEASE_NAME
+          echo "👀 Commit hash: $_COMMIT_HASH"
+          echo "commit-hash=$_COMMIT_HASH" >> $GITHUB_OUTPUT
           echo "👀 Release Tag: v$_RELEASE_NAME"
 
           echo "# 🚀 Swift SDK Updated Successfully!" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "📋 **Branch:** [\`$_BRANCH_NAME\`](https://github.com/bitwarden/sdk-swift/commits/$_BRANCH_NAME)" >> $GITHUB_STEP_SUMMARY
-          echo "📝 **Commit:** bitwarden/sdk-swift@$COMMIT_HASH" >> $GITHUB_STEP_SUMMARY
-
+          echo "📝 **Commit:** bitwarden/sdk-swift@$_COMMIT_HASH" >> $GITHUB_STEP_SUMMARY
+      
       - name: Create release
         env:
           GH_TOKEN: ${{ steps.app-token-sdk-swift.outputs.token }}
@@ -224,7 +227,7 @@ jobs:
         if: inputs.update-ios-repo
         env:
           GH_TOKEN: ${{ steps.app-token-ios.outputs.token }}
-          _SDK_SWIFT_REF: ${{ steps.push-changes.outputs.commit-hash }}
+          _SDK_SWIFT_REF: ${{ steps.commit-changes.outputs.commit-sha }}
           _RELEASE_NAME: ${{ steps.set-release-name.outputs.release_name }}
         working-directory: sdk
         run: |

--- a/.github/workflows/release-swift.yml
+++ b/.github/workflows/release-swift.yml
@@ -175,15 +175,14 @@ jobs:
         with:
           token: ${{ steps.app-token-sdk-swift.outputs.token }}
           branch: ${{ inputs.sdk-swift-branch-name }}
-          message: "Release Swift SDK v$_RELEASE_NAME (bitwarden/sdk-internal@$_SDK_INTERNAL_SHORT_REF) - $_SDK_INTERNAL_COMMIT_MSG"
-          tag_name: "v$_RELEASE_NAME"
+          message: "Release Swift SDK v${{ steps.set-release-name.outputs.release_name }} (bitwarden/sdk-internal@${{ steps.get-sdk-internal-ref.outputs.short_sha }}) - ${{ steps.get-sdk-internal-ref.outputs.commit_message }}"
+          tag_name: "v${{ steps.set-release-name.outputs.release_name }}"
 
       - name: Echo changes
         working-directory: sdk-swift
         env:
           _RELEASE_NAME: ${{ steps.set-release-name.outputs.release_name }}
           _SDK_INTERNAL_REF: ${{ steps.get-sdk-internal-ref.outputs.sha }}
-          _SDK_INTERNAL_COMMIT_MSG: ${{ steps.get-sdk-internal-ref.outputs.commit_message }} 
           _BRANCH_NAME: ${{ inputs.sdk-swift-branch-name }}
           _COMMIT_HASH: ${{ steps.commit-changes.outputs.commit-sha }}
         run: |

--- a/.github/workflows/release-swift.yml
+++ b/.github/workflows/release-swift.yml
@@ -28,8 +28,8 @@ jobs:
       contents: read
       id-token: write
     env:
-      _BOT_EMAIL: 106330231+bitwarden-devops-bot@users.noreply.github.com
-      _BOT_NAME: bitwarden-devops-bot
+      _BOT_NAME: "bw-ghapp[bot]"
+      _BOT_EMAIL: "178206702+bw-ghapp[bot]@users.noreply.github.com"
     steps:
       - name: Checkout SDK repo
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -108,13 +108,6 @@ jobs:
           keyvault: gh-org-bitwarden
           secrets: "BW-GHAPP-ID,BW-GHAPP-KEY"
 
-      - name: Get Azure Key Vault secrets - BW CI
-        id: get-kv-secrets-ci
-        uses: bitwarden/gh-actions/get-keyvault-secrets@main
-        with:
-          keyvault: "bitwarden-ci"
-          secrets: "github-gpg-private-key,github-gpg-private-key-passphrase"
-
       - name: Log out from Azure
         uses: bitwarden/gh-actions/azure-logout@main
 
@@ -136,15 +129,6 @@ jobs:
           ref: ${{ inputs.sdk-swift-branch-name }}
           token: ${{ steps.app-token-sdk-swift.outputs.token }}
           persist-credentials: true
-
-      - name: Import GPG key
-        uses: crazy-max/ghaction-import-gpg@2dc316deee8e90f13e1a351ab510b4d5bc0c82cd # v7.0.0
-        with:
-          gpg_private_key: ${{ steps.get-kv-secrets-ci.outputs.github-gpg-private-key }}
-          passphrase: ${{ steps.get-kv-secrets-ci.outputs.github-gpg-private-key-passphrase }}
-          git_user_signingkey: true
-          git_commit_gpgsign: true
-          workdir: sdk-swift
 
       - name: Setup Git
         working-directory: sdk-swift

--- a/.github/workflows/release-swift.yml
+++ b/.github/workflows/release-swift.yml
@@ -194,7 +194,7 @@ jobs:
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "📋 **Branch:** [\`$_BRANCH_NAME\`](https://github.com/bitwarden/sdk-swift/commits/$_BRANCH_NAME)" >> $GITHUB_STEP_SUMMARY
           echo "📝 **Commit:** bitwarden/sdk-swift@$_COMMIT_HASH" >> $GITHUB_STEP_SUMMARY
-      
+
       - name: Create release
         env:
           GH_TOKEN: ${{ steps.app-token-sdk-swift.outputs.token }}

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -61,9 +61,8 @@ jobs:
           app-id: ${{ steps.retrieve-secrets.outputs.BW-GHAPP-ID }}
           private-key: ${{ steps.retrieve-secrets.outputs.BW-GHAPP-KEY }}
           repositories: sdk-internal
-          permissions: >-
-            contents: write
-            pull-requests: write
+          permission-contents: write
+          permission-pull-requests: write
 
       - name: Checkout Branch
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -103,8 +102,8 @@ jobs:
 
       - name: Setup git
         run: |
-          git config --local user.email "106330231+bitwarden-devops-bot@users.noreply.github.com"
-          git config --local user.name "bitwarden-devops-bot"
+          git config --local user.email "178206702+bw-ghapp[bot]@users.noreply.github.com"
+          git config --local user.name "bw-ghapp[bot]"
 
       - name: Check if version changed
         id: version-changed


### PR DESCRIPTION
## 🎟️ Tracking

[BRE-1670](https://bitwarden.atlassian.net/browse/BRE-1670?atlOrigin=eyJpIjoiYWQ0N2Q0OGIzODE5NDU3ZDg3OWI4OGE4ZTQ0ZTRhOGEiLCJwIjoiaiJ9)

## 📔 Objective

Updating github workflows that use PAT to use app token or GITHUB_TOKEN instead.

In some cases, the PAT token was being used for simple repo actions that didn't require further authentication, such as reading from or cloning a public repository.  

GPG Keys:
Github offers native signing of commits when done through the API, so a step importing the GPG key is not needed for signed commits that use the API-commit step. If a commit is later merged by a human reviewing a PR, it doesn't need to be signed as the resulting squashed commit will be signed.


## 🚨 Breaking Changes

<!-- Does this PR introduce any breaking changes? If so, please describe the impact and migration path for clients.

If you're unsure, the automated TypeScript compatibility check will run when you open/update this PR and provide feedback.

For breaking changes:
1. Describe what changed in the client interface
2. Explain why the change was necessary
3. Provide migration steps for client developers
4. Link to any paired client PRs if needed

Otherwise, you can remove this section. -->


[BRE-1670]: https://bitwarden.atlassian.net/browse/BRE-1670?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ