### PR TITLE
use tokio runtime on uniffi exports

### DIFF
--- a/crates/bitwarden-uniffi/src/auth/registration.rs
+++ b/crates/bitwarden-uniffi/src/auth/registration.rs
@@ -11,7 +11,7 @@ use crate::error::BitwardenError;
 #[derive(uniffi::Object)]
 pub struct RegistrationClient(pub(crate) bitwarden_core::Client);
 
-#[uniffi::export]
+#[uniffi::export(async_runtime = "tokio")]
 impl RegistrationClient {
     /// Initializes a new cryptographic state for a user and posts it to the server; enrolls in
     /// admin password reset and finally enrolls the user to TDE unlock.

--- a/crates/bitwarden-uniffi/src/platform/fido2.rs
+++ b/crates/bitwarden-uniffi/src/platform/fido2.rs
@@ -60,7 +60,7 @@ pub struct ClientFido2Authenticator(
     pub(crate) Arc<dyn Fido2CredentialStore>,
 );
 
-#[uniffi::export]
+#[uniffi::export(async_runtime = "tokio")]
 impl ClientFido2Authenticator {
     pub async fn make_credential(
         &self,
@@ -121,7 +121,7 @@ impl ClientFido2Authenticator {
 #[derive(uniffi::Object)]
 pub struct ClientFido2Client(pub(crate) ClientFido2Authenticator);
 
-#[uniffi::export]
+#[uniffi::export(async_runtime = "tokio")]
 impl ClientFido2Client {
     pub async fn register(
         &self,

--- a/crates/bitwarden-uniffi/src/platform/mod.rs
+++ b/crates/bitwarden-uniffi/src/platform/mod.rs
@@ -23,7 +23,7 @@ pub use server_communication_config::{
 #[derive(uniffi::Object)]
 pub struct PlatformClient(pub(crate) bitwarden_core::Client);
 
-#[uniffi::export]
+#[uniffi::export(async_runtime = "tokio")]
 impl PlatformClient {
     /// Fingerprint (public key)
     pub fn fingerprint(&self, req: FingerprintRequest) -> Result<String> {

--- a/crates/bitwarden-uniffi/src/platform/server_communication_config.rs
+++ b/crates/bitwarden-uniffi/src/platform/server_communication_config.rs
@@ -34,7 +34,7 @@ impl ServerCommunicationConfigClient {
     }
 }
 
-#[uniffi::export]
+#[uniffi::export(async_runtime = "tokio")]
 impl ServerCommunicationConfigClient {
     /// Retrieves the server communication configuration for a hostname
     pub async fn get_config(&self, hostname: String) -> Result<ServerCommunicationConfig> {

--- a/crates/bitwarden-uniffi/src/tool/mod.rs
+++ b/crates/bitwarden-uniffi/src/tool/mod.rs
@@ -37,7 +37,7 @@ impl GeneratorClients {
 #[derive(uniffi::Object)]
 pub struct ExporterClient(pub(crate) bitwarden_exporters::ExporterClient);
 
-#[uniffi::export]
+#[uniffi::export(async_runtime = "tokio")]
 impl ExporterClient {
     /// Export user vault
     pub async fn export_vault(


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.slack.com/archives/C054ZQSBS49/p1775837561537339?thread_ts=1775586953.115189&cid=C054ZQSBS49

## 📔 Objective

Some of the async functions on UniFFI were not using the tokio runtime and instead relied on the default basic runtime to run. This is okay for any async function that doesn't rely on functionality provided by the tokio runtime, but crashes when using reqwest for example. This PR enables the tokio runtime for all the async functions in the uniffi crate. Some of them aren't needed now, but I'd rather play it safe.

## 🚨 Breaking Changes

<!-- Does this PR introduce any breaking changes? If so, please describe the impact and migration path for clients.

If you're unsure, the automated TypeScript compatibility check will run when you open/update this PR and provide feedback.

For breaking changes:
1. Describe what changed in the client interface
2. Explain why the change was necessary
3. Provide migration steps for client developers
4. Link to any paired client PRs if needed

Otherwise, you can remove this section. -->
