### PR TITLE
[PM-33347] Flight Recorder benchmarking

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -882,6 +882,7 @@ name = "bitwarden-logging"
 version = "2.0.0"
 dependencies = [
  "chrono",
+ "criterion",
  "serde",
  "serde_json",
  "tracing",

--- a/crates/bitwarden-logging/Cargo.toml
+++ b/crates/bitwarden-logging/Cargo.toml
@@ -27,5 +27,12 @@ tracing-subscriber = { workspace = true }
 tsify = { workspace = true, optional = true }
 wasm-bindgen = { workspace = true, optional = true }
 
+[dev-dependencies]
+criterion = "0.8.0"
+
+[[bench]]
+name = "flight_recorder_performance"
+harness = false
+
 [lints]
 workspace = true

--- a/crates/bitwarden-logging/benches/flight_recorder_performance.rs
+++ b/crates/bitwarden-logging/benches/flight_recorder_performance.rs
@@ -1,0 +1,166 @@
+//! Performance benchmarks for the FlightRecorder subsystem.
+//!
+//! These benchmarks measure the overhead of the FlightRecorder tracing layer and circular buffer,
+//! ensuring they stay within acceptable limits for production use.
+//!
+//! ## Performance targets
+//!
+//! | Benchmark     | Target                                      |
+//! |---------------|---------------------------------------------|
+//! | Event capture | <500ns per event (simple messages)          |
+//! | Buffer push   | <100ns per push, <10% variance across sizes |
+//! | Buffer read   | <100ns per event cloned                     |
+//!
+//! ## Running
+//!
+//! ```sh
+//! # Run all benchmarks
+//! cargo bench -p bitwarden-logging
+//!
+//! # Run a specific group
+//! cargo bench -p bitwarden-logging -- event_capture
+//! ```
+//!
+//! After running, Criterion generates HTML reports in `target/criterion/`. Open
+//! `target/criterion/report/index.html` to view detailed graphs and statistical analysis.
+
+#![allow(missing_docs, clippy::unwrap_used)]
+
+use std::{collections::HashMap, hint::black_box, num::NonZeroUsize};
+
+use bitwarden_logging::{
+    CircularBuffer, FlightRecorderConfig, FlightRecorderEvent, FlightRecorderLayer,
+};
+use criterion::{BatchSize, BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+use tracing_subscriber::layer::SubscriberExt;
+
+/// Create a representative event for buffer benchmarks.
+fn test_event() -> FlightRecorderEvent {
+    FlightRecorderEvent {
+        timestamp: 1234567890,
+        level: "INFO".to_string(),
+        target: "bench::module".to_string(),
+        message: "benchmark event".to_string(),
+        fields: HashMap::new(),
+    }
+}
+
+/// Benchmarks the end-to-end cost of a tracing event being captured by FlightRecorderLayer.
+/// This is the hot path in production: every `tracing::info!()` (or similar) call passes through
+/// `on_event`, which constructs a `FlightRecorderEvent` (timestamp, string allocations, field
+/// visitor) and pushes it into the circular buffer.
+///
+/// Target: <500ns per event for simple messages.
+fn bench_event_capture(c: &mut Criterion) {
+    let mut group = c.benchmark_group("event_capture");
+    group.throughput(Throughput::Elements(1));
+
+    let config =
+        FlightRecorderConfig::new(NonZeroUsize::new(10_000).unwrap(), tracing::Level::DEBUG);
+    let layer = FlightRecorderLayer::new(config);
+    let subscriber = tracing_subscriber::registry().with(layer);
+    let _guard = tracing::subscriber::set_default(subscriber);
+
+    // Simple message with no structured fields — the cheapest capture path.
+    group.bench_function("simple_message", |b| {
+        b.iter(|| {
+            tracing::info!(target: "bench::module", "benchmark event");
+        });
+    });
+
+    // Message with structured fields — exercises the MessageVisitor and HashMap
+    // allocation. Most real-world usage includes at least a few fields.
+    group.bench_function("with_structured_fields", |b| {
+        b.iter(|| {
+            tracing::info!(
+                target: "bench::module",
+                user_id = "abc-123",
+                action = "login",
+                success = true,
+                "structured event"
+            );
+        });
+    });
+
+    // Event below the configured level threshold — tests the fast-reject path.
+    // Should be near-zero cost since the layer returns immediately.
+    group.bench_function("filtered_by_level", |b| {
+        b.iter(|| {
+            tracing::trace!(target: "bench::module", "filtered out by level");
+        });
+    });
+
+    group.finish();
+}
+
+/// Benchmarks CircularBuffer::push across different buffer capacities.
+/// Push involves a mutex lock, and when at capacity, a VecDeque::pop_front + push_back.
+/// Both operations are O(1) amortized, so performance should be consistent regardless
+/// of buffer size.
+///
+/// Targets: <100ns per push, <10% variance across capacities.
+fn bench_buffer_push(c: &mut Criterion) {
+    let mut group = c.benchmark_group("buffer_push");
+    group.throughput(Throughput::Elements(1));
+
+    let event = test_event();
+
+    for size in [1_000, 10_000, 100_000] {
+        // Buffer is full — every push evicts the oldest item via pop_front.
+        group.bench_with_input(BenchmarkId::new("at_capacity", size), &size, |b, &size| {
+            let buffer = CircularBuffer::new(NonZeroUsize::new(size).unwrap());
+            for _ in 0..size {
+                buffer.push(event.clone());
+            }
+            b.iter(|| buffer.push(black_box(event.clone())));
+        });
+
+        // Buffer is empty — push appends without eviction.
+        // Uses iter_batched to get a fresh buffer per iteration, otherwise
+        // the buffer fills up across Criterion's millions of iterations.
+        group.bench_with_input(
+            BenchmarkId::new("under_capacity", size),
+            &size,
+            |b, &size| {
+                b.iter_batched(
+                    || CircularBuffer::new(NonZeroUsize::new(size).unwrap()),
+                    |buffer| buffer.push(black_box(event.clone())),
+                    BatchSize::SmallInput,
+                );
+            },
+        );
+    }
+
+    group.finish();
+}
+
+/// Benchmarks CircularBuffer::read, which clones all buffered events into a Vec.
+/// This is the export path used when the flight recorder contents are retrieved
+/// (e.g. for crash reports or diagnostics). Cost scales linearly with buffer size.
+///
+/// Target: <100ns per event cloned.
+fn bench_buffer_read(c: &mut Criterion) {
+    let mut group = c.benchmark_group("buffer_read");
+    let event = test_event();
+
+    for size in [1_000, 10_000, 100_000] {
+        group.throughput(Throughput::Elements(size as u64));
+        group.bench_with_input(BenchmarkId::new("read_full", size), &size, |b, &size| {
+            let buffer = CircularBuffer::new(NonZeroUsize::new(size).unwrap());
+            for _ in 0..size {
+                buffer.push(event.clone());
+            }
+            b.iter(|| black_box(buffer.read()));
+        });
+    }
+
+    group.finish();
+}
+
+criterion_group!(
+    benches,
+    bench_event_capture,
+    bench_buffer_push,
+    bench_buffer_read
+);
+criterion_main!(benches);


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-33347

## 📔 Objective

- Adds Criterion-based performance benchmarks for the `bitwarden-logging` crate's FlightRecorder subsystem
- Establishes baseline performance targets documented in the benchmark file

### Benchmark groups

- **`event_capture`** — End-to-end cost of flight recorder logging, including layer overhead: simple messages, structured fields, and level-filtered events.
- **`buffer_push`** — `CircularBuffer::push` parameterized across capacities [100, 1k, 10k, 100k], both at capacity (eviction path) and under capacity (append-only). We expect O(1) performance based on capacity.
- **`buffer_read`** — `CircularBuffer::read` across buffer sizes [100, 1k, 10k], measuring the clone-all-events export path. This will involve a buffer clone and have O(N) performance, but it is not a hot path.

I've skipped the bulk test mentioned on the ticket description. Criterion already exercises each benchmark with millions of iterations over a 5-second measurement window (e.g., `simple_message` ran ~28M iterations). This provides stronger statistical coverage than a separate bulk test with a fixed iteration count, so a dedicated bulk benchmark would be somewhat redundant.

### Performance targets & results

| Benchmark | Target | Result |
|---|---|---|
| Event capture (simple) | <500ns | ~185ns |
| Event capture (structured fields) | — | ~584ns |
| Event capture (filtered) | — | ~17ns |
| Buffer push | <100ns, <10% variance across sizes | ~104-106ns, ~3% variance |
| Buffer read | <100ns per event cloned | ~81-84ns |

With those numbers, on the hot path we can process ~1.7 million logs/second.

### Possible extra optimizations

I tried to use this benchmark to study possible optimizations of the hot path, and one of the bigger ones is the creation of the `FlightRecorderEvent` struct: lots of `String` allocations and specially `HashMap` which is fairly slow  for low numbers. One big optimization is delaying this construction to the `read()` call when exporting the logs (which is not a hot path) by internally storing a struct with static str and using a Vec instead of a map.

```rust
pub(crate) struct InternalEvent {
    pub timestamp: i64,
    pub level: &'static str,
    pub target: &'static str,
    pub message: String,
    pub fields: Vec<(&'static str, String)>,
}
impl From<InternalEvent> for FlightRecorderEvent {}
```

This improves the performance of the simple event capture benchmark by 35% (~123ns) and of the structured fields benchmark by 48% (~306ns), at the cost of making the `read()` calls about 35% slower.

## 🚨 Breaking Changes

<!-- Does this PR introduce any breaking changes? If so, please describe the impact and migration path for clients.

If you're unsure, the automated TypeScript compatibility check will run when you open/update this PR and provide feedback.

For breaking changes:
1. Describe what changed in the client interface
2. Explain why the change was necessary
3. Provide migration steps for client developers
4. Link to any paired client PRs if needed

Otherwise, you can remove this section. -->
