### PR TITLE
[PM-35036] Rename keyid to keyslotid

### DIFF
--- a/crates/bitwarden-core/src/key_management/master_password.rs
+++ b/crates/bitwarden-core/src/key_management/master_password.rs
@@ -5,7 +5,9 @@ use bitwarden_api_api::models::{
     MasterPasswordUnlockDataRequestModel,
     master_password_unlock_response_model::MasterPasswordUnlockResponseModel,
 };
-use bitwarden_crypto::{EncString, Kdf, KeyIds, KeyStoreContext, MasterKey, SymmetricCryptoKey};
+use bitwarden_crypto::{
+    EncString, Kdf, KeySlotIds, KeyStoreContext, MasterKey, SymmetricCryptoKey,
+};
 use bitwarden_encoding::B64;
 use bitwarden_error::bitwarden_error;
 use serde::{Deserialize, Serialize};
@@ -60,7 +62,7 @@ pub struct MasterPasswordUnlockData {
 
 impl MasterPasswordUnlockData {
     /// Unwrap the user key into the key store context using the provided password.
-    pub fn unwrap_to_context<Ids: KeyIds>(
+    pub fn unwrap_to_context<Ids: KeySlotIds>(
         &self,
         password: &str,
         ctx: &mut KeyStoreContext<Ids>,
@@ -94,7 +96,7 @@ impl MasterPasswordUnlockData {
 
     /// Derive master password unlock data from a password and user key in the key store.
     #[tracing::instrument(skip(password, salt, ctx))]
-    pub fn derive<Ids: KeyIds>(
+    pub fn derive<Ids: KeySlotIds>(
         password: &str,
         kdf: &Kdf,
         salt: &str,

--- a/crates/bitwarden-core/src/key_management/security_state.rs
+++ b/crates/bitwarden-core/src/key_management/security_state.rs
@@ -23,7 +23,7 @@
 use std::{fmt::Debug, str::FromStr};
 
 use bitwarden_crypto::{
-    CoseSerializable, CoseSign1Bytes, CryptoError, EncodingError, KeyIds, KeyStoreContext,
+    CoseSerializable, CoseSign1Bytes, CryptoError, EncodingError, KeySlotIds, KeyStoreContext,
     SignedObject, SigningNamespace, VerifyingKey,
 };
 use bitwarden_encoding::{B64, FromStrVisitor};
@@ -71,7 +71,7 @@ impl SecurityState {
     }
 
     /// Signs the `SecurityState` with the provided signing key ID from the context.
-    pub fn sign<Ids: KeyIds>(
+    pub fn sign<Ids: KeySlotIds>(
         &self,
         signing_key_id: Ids::Signing,
         ctx: &mut KeyStoreContext<Ids>,

--- a/crates/bitwarden-core/src/key_management/v2_upgrade_token.rs
+++ b/crates/bitwarden-core/src/key_management/v2_upgrade_token.rs
@@ -7,7 +7,9 @@
 //! without breaking the other direction's validation.
 
 use bitwarden_api_api::models::V2UpgradeTokenResponseModel;
-use bitwarden_crypto::{Decryptable, EncString, KeyIds, KeyStoreContext, SymmetricKeyAlgorithm};
+use bitwarden_crypto::{
+    Decryptable, EncString, KeySlotIds, KeyStoreContext, SymmetricKeyAlgorithm,
+};
 use thiserror::Error;
 use tracing::instrument;
 
@@ -31,7 +33,7 @@ impl V2UpgradeToken {
     /// (XChaCha20Poly1305) in the KeyStore. Type-checks both keys, then wraps V1 with V2 and
     /// V2 with V1.
     #[instrument(skip(ctx))]
-    pub fn create<Ids: KeyIds>(
+    pub fn create<Ids: KeySlotIds>(
         v1_key_id: Ids::Symmetric,
         v2_key_id: Ids::Symmetric,
         ctx: &KeyStoreContext<Ids>,
@@ -72,7 +74,7 @@ impl V2UpgradeToken {
     /// Unwraps `wrapped_user_key_1` using `v2_key_id`, validates the result can unwrap
     /// `wrapped_user_key_2`, then adds the V1 key to the KeyStore and returns its key ID.
     #[instrument(skip(self, ctx))]
-    pub fn unwrap_v1<Ids: KeyIds>(
+    pub fn unwrap_v1<Ids: KeySlotIds>(
         &self,
         v2_key_id: Ids::Symmetric,
         ctx: &mut KeyStoreContext<Ids>,
@@ -94,7 +96,7 @@ impl V2UpgradeToken {
     /// Unwraps `wrapped_user_key_2` using `v1_key_id`, validates the result can unwrap
     /// `wrapped_user_key_1`, then adds the V2 key to the KeyStore and returns its key ID.
     #[instrument(skip(self, ctx))]
-    pub fn unwrap_v2<Ids: KeyIds>(
+    pub fn unwrap_v2<Ids: KeySlotIds>(
         &self,
         v1_key_id: Ids::Symmetric,
         ctx: &mut KeyStoreContext<Ids>,
@@ -280,7 +282,7 @@ mod tests {
         assert_eq!(serialized, reserialized);
     }
 
-    fn build_response_model<Ids: bitwarden_crypto::KeyIds>(
+    fn build_response_model<Ids: bitwarden_crypto::KeySlotIds>(
         v1_key_id: Ids::Symmetric,
         v2_key_id: Ids::Symmetric,
         ctx: &KeyStoreContext<Ids>,

--- a/crates/bitwarden-crypto/src/content_format.rs
+++ b/crates/bitwarden-crypto/src/content_format.rs
@@ -2,8 +2,9 @@ use bitwarden_encoding::B64;
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    CryptoError, EncString, KeyEncryptable, KeyEncryptableWithContentType, KeyIds, KeyStoreContext,
-    PrimitiveEncryptable, SymmetricCryptoKey, traits::PrimitiveEncryptableWithContentType,
+    CryptoError, EncString, KeyEncryptable, KeyEncryptableWithContentType, KeySlotIds,
+    KeyStoreContext, PrimitiveEncryptable, SymmetricCryptoKey,
+    traits::PrimitiveEncryptableWithContentType,
 };
 
 /// The content format describes the format of the contained bytes. Message encryption always
@@ -242,7 +243,7 @@ impl ConstContentFormat for CoseEncrypt0ContentFormat {
 /// serialized COSE Encrypt0 messages.
 pub type CoseEncrypt0Bytes = Bytes<CoseEncrypt0ContentFormat>;
 
-impl<Ids: KeyIds, T: ConstContentFormat> PrimitiveEncryptable<Ids, Ids::Symmetric, EncString>
+impl<Ids: KeySlotIds, T: ConstContentFormat> PrimitiveEncryptable<Ids, Ids::Symmetric, EncString>
     for Bytes<T>
 {
     fn encrypt(

--- a/crates/bitwarden-crypto/src/enc_string/asymmetric.rs
+++ b/crates/bitwarden-crypto/src/enc_string/asymmetric.rs
@@ -7,7 +7,7 @@ use serde::Deserialize;
 
 use super::{from_b64_vec, split_enc_string};
 use crate::{
-    BitwardenLegacyKeyBytes, KeyIds, KeyStoreContext, PrivateKey, PublicKey, RawPrivateKey,
+    BitwardenLegacyKeyBytes, KeySlotIds, KeyStoreContext, PrivateKey, PublicKey, RawPrivateKey,
     RawPublicKey, SymmetricCryptoKey,
     error::{CryptoError, EncStringParseError, Result},
     rsa::encrypt_rsa2048_oaep_sha1,
@@ -185,7 +185,7 @@ impl UnsignedSharedKey {
     /// Encapsulate a symmetric key, to be shared asymmetrically. Produces a
     /// [UnsignedSharedKey::Rsa2048_OaepSha1_B64] variant. Note, this does not sign the data
     /// and thus does not guarantee sender authenticity.
-    pub fn encapsulate<Ids: KeyIds>(
+    pub fn encapsulate<Ids: KeySlotIds>(
         key_to_encapsulate: Ids::Symmetric,
         encapsulation_key: &PublicKey,
         ctx: &KeyStoreContext<Ids>,
@@ -214,7 +214,7 @@ impl UnsignedSharedKey {
 impl UnsignedSharedKey {
     /// Decapsulate a symmetric key using an asymmetric decapsulation key from the key store.
     /// Returns the key ID of the decapsulated symmetric key added to the context.
-    pub fn decapsulate<Ids: KeyIds>(
+    pub fn decapsulate<Ids: KeySlotIds>(
         &self,
         decapsulation_key: Ids::Private,
         ctx: &mut KeyStoreContext<Ids>,

--- a/crates/bitwarden-crypto/src/keys/key_connector_key.rs
+++ b/crates/bitwarden-crypto/src/keys/key_connector_key.rs
@@ -8,7 +8,7 @@ use tracing::instrument;
 use typenum::U32;
 
 use crate::{
-    BitwardenLegacyKeyBytes, CryptoError, EncString, KeyDecryptable, KeyIds, KeyStoreContext,
+    BitwardenLegacyKeyBytes, CryptoError, EncString, KeyDecryptable, KeySlotIds, KeyStoreContext,
     SymmetricCryptoKey, keys::utils::stretch_key,
 };
 
@@ -31,7 +31,7 @@ impl KeyConnectorKey {
     /// The user key identified by `user_key_id` is read from the context and encrypted.
     #[cfg_attr(feature = "dangerous-crypto-debug", instrument(skip(ctx), err))]
     #[cfg_attr(not(feature = "dangerous-crypto-debug"), instrument(skip_all, err))]
-    pub fn wrap_user_key<Ids: KeyIds>(
+    pub fn wrap_user_key<Ids: KeySlotIds>(
         &self,
         user_key_id: Ids::Symmetric,
         ctx: &KeyStoreContext<Ids>,
@@ -46,7 +46,7 @@ impl KeyConnectorKey {
     /// Returns the local key identifier for the unwrapped user key.
     #[cfg_attr(feature = "dangerous-crypto-debug", instrument(skip(ctx), err))]
     #[cfg_attr(not(feature = "dangerous-crypto-debug"), instrument(skip_all, err))]
-    pub fn unwrap_user_key<Ids: KeyIds>(
+    pub fn unwrap_user_key<Ids: KeySlotIds>(
         &self,
         wrapped_user_key: EncString,
         ctx: &mut KeyStoreContext<Ids>,

--- a/crates/bitwarden-crypto/src/keys/rotateable_key_set.rs
+++ b/crates/bitwarden-crypto/src/keys/rotateable_key_set.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    CryptoError, EncString, KeyDecryptable, KeyEncryptable, KeyIds, KeyStoreContext,
+    CryptoError, EncString, KeyDecryptable, KeyEncryptable, KeySlotIds, KeyStoreContext,
     Pkcs8PrivateKeyBytes, PrivateKey, PublicKey, SpkiPublicKeyBytes, SymmetricCryptoKey,
     UnsignedSharedKey,
 };
@@ -36,7 +36,7 @@ pub struct RotateableKeySet {
 impl RotateableKeySet {
     /// Create a set of keys to allow access to the downstream key via the provided
     /// upstream key while allowing the downstream key to be rotated.
-    pub fn new<Ids: KeyIds>(
+    pub fn new<Ids: KeySlotIds>(
         ctx: &KeyStoreContext<Ids>,
         upstream_key: &SymmetricCryptoKey,
         downstream_key_id: Ids::Symmetric,
@@ -76,7 +76,7 @@ impl RotateableKeySet {
     // TODO: Eventually, the webauthn-login-strategy service should be migrated
     // to use this method, and we can remove the #[allow(dead_code)] attribute.
     #[allow(dead_code)]
-    fn unlock<Ids: KeyIds>(
+    fn unlock<Ids: KeySlotIds>(
         &self,
         ctx: &mut KeyStoreContext<Ids>,
         upstream_key: &SymmetricCryptoKey,
@@ -97,7 +97,7 @@ impl RotateableKeySet {
 }
 
 #[allow(dead_code)]
-fn rotate_key_set<Ids: KeyIds>(
+fn rotate_key_set<Ids: KeySlotIds>(
     ctx: &KeyStoreContext<Ids>,
     key_set: RotateableKeySet,
     old_downstream_key_id: Ids::Symmetric,

--- a/crates/bitwarden-crypto/src/lib.rs
+++ b/crates/bitwarden-crypto/src/lib.rs
@@ -44,7 +44,8 @@ pub use signing::*;
 mod traits;
 mod xchacha20;
 pub use traits::{
-    CompositeEncryptable, Decryptable, IdentifyKey, KeyId, KeyIds, LocalId, PrimitiveEncryptable,
+    CompositeEncryptable, Decryptable, IdentifyKey, KeySlotId, KeySlotIds, LocalId,
+    PrimitiveEncryptable,
 };
 pub use zeroizing_alloc::ZeroAlloc as ZeroizingAllocator;
 

--- a/crates/bitwarden-crypto/src/safe/data_envelope.rs
+++ b/crates/bitwarden-crypto/src/safe/data_envelope.rs
@@ -9,7 +9,7 @@ use thiserror::Error;
 use wasm_bindgen::convert::FromWasmAbi;
 
 use crate::{
-    CONTENT_TYPE_PADDED_CBOR, CoseEncrypt0Bytes, CryptoError, EncString, EncodingError, KeyIds,
+    CONTENT_TYPE_PADDED_CBOR, CoseEncrypt0Bytes, CryptoError, EncString, EncodingError, KeySlotIds,
     SerializedMessage, SymmetricCryptoKey, XChaCha20Poly1305Key,
     cose::{ContentNamespace, SafeObjectNamespace, XCHACHA20_POLY1305},
     safe::helpers::{debug_fmt, set_safe_namespaces, validate_safe_namespaces},
@@ -60,7 +60,7 @@ pub struct DataEnvelope {
 impl DataEnvelope {
     /// Seals a struct into an encrypted blob, and stores the content-encryption-key in the provided
     /// context.
-    pub fn seal<Ids: KeyIds, T>(
+    pub fn seal<Ids: KeySlotIds, T>(
         data: T,
         ctx: &mut crate::store::KeyStoreContext<Ids>,
     ) -> Result<(Self, Ids::Symmetric), DataEnvelopeError>
@@ -76,7 +76,7 @@ impl DataEnvelope {
 
     /// Seals a struct into an encrypted blob. The content encryption key is wrapped with the
     /// provided wrapping key
-    pub fn seal_with_wrapping_key<Ids: KeyIds, T>(
+    pub fn seal_with_wrapping_key<Ids: KeySlotIds, T>(
         data: T,
         wrapping_key: &Ids::Symmetric,
         ctx: &mut crate::store::KeyStoreContext<Ids>,
@@ -155,7 +155,7 @@ impl DataEnvelope {
 
     /// Unseals the data from the encrypted blob using a content-encryption-key stored in the
     /// context.
-    pub fn unseal<Ids: KeyIds, T>(
+    pub fn unseal<Ids: KeySlotIds, T>(
         &self,
         cek_keyslot: Ids::Symmetric,
         ctx: &mut crate::store::KeyStoreContext<Ids>,
@@ -174,7 +174,7 @@ impl DataEnvelope {
     }
 
     /// Unseals the data from the encrypted blob and wrapped content-encryption-key.
-    pub fn unseal_with_wrapping_key<Ids: KeyIds, T>(
+    pub fn unseal_with_wrapping_key<Ids: KeySlotIds, T>(
         &self,
         wrapping_key: &Ids::Symmetric,
         wrapped_cek: &EncString,

--- a/crates/bitwarden-crypto/src/safe/password_protected_key_envelope.rs
+++ b/crates/bitwarden-crypto/src/safe/password_protected_key_envelope.rs
@@ -27,7 +27,7 @@ use wasm_bindgen::convert::FromWasmAbi;
 
 use crate::{
     BitwardenLegacyKeyBytes, ContentFormat, CoseKeyBytes, CryptoError, EncodedSymmetricKey,
-    KEY_ID_SIZE, KeyIds, KeyStoreContext, SymmetricCryptoKey,
+    KEY_ID_SIZE, KeySlotIds, KeyStoreContext, SymmetricCryptoKey,
     cose::{
         ALG_ARGON2ID13, ARGON2_ITERATIONS, ARGON2_MEMORY, ARGON2_PARALLELISM, ARGON2_SALT,
         CONTAINED_KEY_ID, ContentNamespace, CoseExtractError, SafeObjectNamespace, extract_bytes,
@@ -62,7 +62,7 @@ impl PasswordProtectedKeyEnvelope {
     /// salt.
     ///
     /// This should never fail, except for memory allocation error, when running the KDF.
-    pub fn seal<Ids: KeyIds>(
+    pub fn seal<Ids: KeySlotIds>(
         key_to_seal: Ids::Symmetric,
         password: &str,
         namespace: PasswordProtectedKeyEnvelopeNamespace,
@@ -155,7 +155,7 @@ impl PasswordProtectedKeyEnvelope {
 
     /// Unseals a symmetric key from the password-protected envelope, and stores it in the key store
     /// context.
-    pub fn unseal<Ids: KeyIds>(
+    pub fn unseal<Ids: KeySlotIds>(
         &self,
         password: &str,
         namespace: PasswordProtectedKeyEnvelopeNamespace,

--- a/crates/bitwarden-crypto/src/safe/symmetric_key_envelope.rs
+++ b/crates/bitwarden-crypto/src/safe/symmetric_key_envelope.rs
@@ -11,7 +11,7 @@ use thiserror::Error;
 use wasm_bindgen::convert::FromWasmAbi;
 
 use crate::{
-    BitwardenLegacyKeyBytes, ContentFormat, CoseKeyBytes, EncodedSymmetricKey, KeyIds,
+    BitwardenLegacyKeyBytes, ContentFormat, CoseKeyBytes, EncodedSymmetricKey, KeySlotIds,
     KeyStoreContext, SymmetricCryptoKey, XChaCha20Poly1305Key,
     cose::{CONTAINED_KEY_ID, ContentNamespace, SafeObjectNamespace, XCHACHA20_POLY1305},
     keys::KeyId,
@@ -52,7 +52,7 @@ impl SymmetricKeyEnvelope {
     /// Seals a symmetric key with another symmetric key from the key store.
     ///
     /// This should never fail, except for memory allocation errors.
-    pub fn seal<Ids: KeyIds>(
+    pub fn seal<Ids: KeySlotIds>(
         key_to_seal: Ids::Symmetric,
         sealing_key: Ids::Symmetric,
         namespace: SymmetricKeyEnvelopeNamespace,
@@ -110,7 +110,7 @@ impl SymmetricKeyEnvelope {
     }
 
     /// Unseals a symmetric key from the envelope and stores it in the key store context.
-    pub fn unseal<Ids: KeyIds>(
+    pub fn unseal<Ids: KeySlotIds>(
         &self,
         wrapping_key: Ids::Symmetric,
         namespace: SymmetricKeyEnvelopeNamespace,

--- a/crates/bitwarden-crypto/src/store/backend/implementation/basic.rs
+++ b/crates/bitwarden-crypto/src/store/backend/implementation/basic.rs
@@ -1,15 +1,15 @@
 use zeroize::ZeroizeOnDrop;
 
-use crate::{KeyId, store::backend::StoreBackend};
+use crate::{KeySlotId, store::backend::StoreBackend};
 
 /// This is a basic key store backend that stores keys in a HashMap memory.
 /// No protections are provided for the keys stored in this backend, beyond enforcing
 /// zeroization on drop.
-pub(crate) struct BasicBackend<Key: KeyId> {
+pub(crate) struct BasicBackend<Key: KeySlotId> {
     keys: std::collections::HashMap<Key, Key::KeyValue>,
 }
 
-impl<Key: KeyId> BasicBackend<Key> {
+impl<Key: KeySlotId> BasicBackend<Key> {
     pub fn new() -> Self {
         Self {
             keys: std::collections::HashMap::new(),
@@ -17,12 +17,12 @@ impl<Key: KeyId> BasicBackend<Key> {
     }
 }
 
-impl<Key: KeyId> StoreBackend<Key> for BasicBackend<Key> {
-    fn upsert(&mut self, key_id: Key, key: <Key as KeyId>::KeyValue) {
+impl<Key: KeySlotId> StoreBackend<Key> for BasicBackend<Key> {
+    fn upsert(&mut self, key_id: Key, key: <Key as KeySlotId>::KeyValue) {
         self.keys.insert(key_id, key);
     }
 
-    fn get(&self, key_id: Key) -> Option<&<Key as KeyId>::KeyValue> {
+    fn get(&self, key_id: Key) -> Option<&<Key as KeySlotId>::KeyValue> {
         self.keys.get(&key_id)
     }
 
@@ -39,10 +39,10 @@ impl<Key: KeyId> StoreBackend<Key> for BasicBackend<Key> {
     }
 }
 
-/// [KeyId::KeyValue] already implements [ZeroizeOnDrop],
+/// [KeySlotId::KeyValue] already implements [ZeroizeOnDrop],
 /// so we only need to ensure the map is cleared on drop.
-impl<Key: KeyId> ZeroizeOnDrop for BasicBackend<Key> {}
-impl<Key: KeyId> Drop for BasicBackend<Key> {
+impl<Key: KeySlotId> ZeroizeOnDrop for BasicBackend<Key> {}
+impl<Key: KeySlotId> Drop for BasicBackend<Key> {
     fn drop(&mut self) {
         self.clear();
     }

--- a/crates/bitwarden-crypto/src/store/backend/implementation/mod.rs
+++ b/crates/bitwarden-crypto/src/store/backend/implementation/mod.rs
@@ -1,10 +1,10 @@
 use super::StoreBackend;
-use crate::store::KeyId;
+use crate::store::KeySlotId;
 
 mod basic;
 
 /// Initializes a key store backend with the best available implementation for the current platform
-pub fn create_store<Key: KeyId>() -> Box<dyn StoreBackend<Key>> {
+pub fn create_store<Key: KeySlotId>() -> Box<dyn StoreBackend<Key>> {
     Box::new(basic::BasicBackend::<Key>::new())
 }
 

--- a/crates/bitwarden-crypto/src/store/backend/mod.rs
+++ b/crates/bitwarden-crypto/src/store/backend/mod.rs
@@ -1,6 +1,6 @@
 use zeroize::ZeroizeOnDrop;
 
-use crate::store::KeyId;
+use crate::store::KeySlotId;
 
 mod implementation;
 
@@ -18,7 +18,7 @@ pub use implementation::create_store;
 /// memory.
 ///
 /// Other implementations could use secure enclaves, HSMs or OS provided keychains.
-pub trait StoreBackend<Key: KeyId>: ZeroizeOnDrop + Send + Sync {
+pub trait StoreBackend<Key: KeySlotId>: ZeroizeOnDrop + Send + Sync {
     /// Inserts a key into the store. If the key already exists, it will be replaced.
     fn upsert(&mut self, key_id: Key, key: Key::KeyValue);
 

--- a/crates/bitwarden-crypto/src/store/context.rs
+++ b/crates/bitwarden-crypto/src/store/context.rs
@@ -11,7 +11,7 @@ use zeroize::Zeroizing;
 use super::KeyStoreInner;
 use crate::{
     BitwardenLegacyKeyBytes, ContentFormat, CoseEncrypt0Bytes, CoseKeyBytes, CoseSerializable,
-    CryptoError, EncString, KeyDecryptable, KeyEncryptable, KeyId, KeyIds, LocalId,
+    CryptoError, EncString, KeyDecryptable, KeyEncryptable, KeySlotId, KeySlotIds, LocalId,
     Pkcs8PrivateKeyBytes, PrivateKey, PublicKey, PublicKeyEncryptionAlgorithm, Result,
     RotatedUserKeys, Signature, SignatureAlgorithm, SignedObject, SignedPublicKey,
     SignedPublicKeyMessage, SigningKey, SymmetricCryptoKey, SymmetricKeyAlgorithm, VerifyingKey,
@@ -77,7 +77,7 @@ use crate::{
 /// }
 /// ```
 #[must_use]
-pub struct KeyStoreContext<'a, Ids: KeyIds> {
+pub struct KeyStoreContext<'a, Ids: KeySlotIds> {
     pub(super) global_keys: GlobalKeys<'a, Ids>,
 
     pub(super) local_symmetric_keys: Box<dyn StoreBackend<Ids::Symmetric>>,
@@ -95,12 +95,12 @@ pub struct KeyStoreContext<'a, Ids: KeyIds> {
 /// encryption/decryption. We also have the option to create a read/write context, which allows us
 /// to modify the global keys, but only allows one context at a time. This is controlled by a
 /// [std::sync::RwLock] on the global keys, and this struct stores both types of guards.
-pub(crate) enum GlobalKeys<'a, Ids: KeyIds> {
+pub(crate) enum GlobalKeys<'a, Ids: KeySlotIds> {
     ReadOnly(RwLockReadGuard<'a, KeyStoreInner<Ids>>),
     ReadWrite(RwLockWriteGuard<'a, KeyStoreInner<Ids>>),
 }
 
-impl<Ids: KeyIds> GlobalKeys<'_, Ids> {
+impl<Ids: KeySlotIds> GlobalKeys<'_, Ids> {
     /// Get a shared reference to the underlying `KeyStoreInner`.
     ///
     /// This returns a shared reference regardless of whether the global keys were locked
@@ -129,7 +129,7 @@ impl<Ids: KeyIds> GlobalKeys<'_, Ids> {
     }
 }
 
-impl<Ids: KeyIds> KeyStoreContext<'_, Ids> {
+impl<Ids: KeySlotIds> KeyStoreContext<'_, Ids> {
     /// Clears all the local keys stored in this context
     /// This will not affect the global keys even if this context has write access.
     /// To clear the global keys, you need to use [super::KeyStore::clear] instead.

--- a/crates/bitwarden-crypto/src/store/key_rotation.rs
+++ b/crates/bitwarden-crypto/src/store/key_rotation.rs
@@ -1,5 +1,5 @@
 use crate::{
-    CoseKeyBytes, CoseSerializable, CryptoError, EncString, KeyEncryptable, KeyIds,
+    CoseKeyBytes, CoseSerializable, CryptoError, EncString, KeyEncryptable, KeySlotIds,
     KeyStoreContext, SignedPublicKey, SignedPublicKeyMessage, SpkiPublicKeyBytes,
     SymmetricCryptoKey,
 };
@@ -22,7 +22,7 @@ pub struct RotatedUserKeys {
 
 /// Generates a new user key and re-encrypts the current private and signing keys with it.
 #[deprecated(note = "Use AccountCryptographicState::rotate instead")]
-pub fn dangerous_get_v2_rotated_account_keys<Ids: KeyIds>(
+pub fn dangerous_get_v2_rotated_account_keys<Ids: KeySlotIds>(
     current_user_private_key_id: Ids::Private,
     current_user_signing_key_id: Ids::Signing,
     ctx: &KeyStoreContext<Ids>,

--- a/crates/bitwarden-crypto/src/store/mod.rs
+++ b/crates/bitwarden-crypto/src/store/mod.rs
@@ -26,7 +26,7 @@ use std::sync::{Arc, RwLock};
 
 use rayon::{iter::Either, prelude::*};
 
-use crate::{CompositeEncryptable, Decryptable, IdentifyKey, KeyId, KeyIds};
+use crate::{CompositeEncryptable, Decryptable, IdentifyKey, KeySlotId, KeySlotIds};
 
 mod backend;
 mod context;
@@ -40,8 +40,8 @@ pub use key_rotation::*;
 
 /// An in-memory key store that provides a safe and secure way to store keys and use them for
 /// encryption/decryption operations. The store API is designed to work only on key identifiers
-/// ([KeyId]). These identifiers are user-defined types that contain no key material, which means
-/// the API users don't have to worry about accidentally leaking keys.
+/// ([KeySlotId]). These identifiers are user-defined types that contain no key material, which
+/// means the API users don't have to worry about accidentally leaking keys.
 ///
 /// Each store is designed to be used by a single user and should not be shared between users, but
 /// the store itself is thread safe and can be cloned to share between threads.
@@ -95,14 +95,14 @@ pub use key_rotation::*;
 /// let decrypted = Data("Hello, World!".to_string());
 /// let encrypted = store.encrypt(decrypted).unwrap();
 /// ```
-pub struct KeyStore<Ids: KeyIds> {
+pub struct KeyStore<Ids: KeySlotIds> {
     // We use an Arc<> to make it easier to pass this store around, as we can
     // clone it instead of passing references
     inner: Arc<RwLock<KeyStoreInner<Ids>>>,
 }
 
 // Manually implement Clone to avoid requiring Ids: Clone
-impl<Ids: KeyIds> Clone for KeyStore<Ids> {
+impl<Ids: KeySlotIds> Clone for KeyStore<Ids> {
     fn clone(&self) -> Self {
         KeyStore {
             inner: Arc::clone(&self.inner),
@@ -111,13 +111,13 @@ impl<Ids: KeyIds> Clone for KeyStore<Ids> {
 }
 
 /// [KeyStore] contains sensitive data, provide a dummy [Debug] implementation.
-impl<Ids: KeyIds> std::fmt::Debug for KeyStore<Ids> {
+impl<Ids: KeySlotIds> std::fmt::Debug for KeyStore<Ids> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("KeyStore").finish()
     }
 }
 
-struct KeyStoreInner<Ids: KeyIds> {
+struct KeyStoreInner<Ids: KeySlotIds> {
     symmetric_keys: Box<dyn StoreBackend<Ids::Symmetric>>,
     private_keys: Box<dyn StoreBackend<Ids::Private>>,
     signing_keys: Box<dyn StoreBackend<Ids::Signing>>,
@@ -125,7 +125,7 @@ struct KeyStoreInner<Ids: KeyIds> {
 }
 
 /// Create a new key store with the best available implementation for the current platform.
-impl<Ids: KeyIds> Default for KeyStore<Ids> {
+impl<Ids: KeySlotIds> Default for KeyStore<Ids> {
     fn default() -> Self {
         Self {
             inner: Arc::new(RwLock::new(KeyStoreInner {
@@ -138,7 +138,7 @@ impl<Ids: KeyIds> Default for KeyStore<Ids> {
     }
 }
 
-impl<Ids: KeyIds> KeyStore<Ids> {
+impl<Ids: KeySlotIds> KeyStore<Ids> {
     /// Clear all keys from the store. This can be used to clear all keys from memory in case of
     /// lock/logout, and is equivalent to destroying the store and creating a new one.
     pub fn clear(&self) {
@@ -234,7 +234,11 @@ impl<Ids: KeyIds> KeyStore<Ids> {
     /// already be present in the store, otherwise this will return an error.
     /// This method is not parallelized, and is meant for single item decryption.
     /// If you need to decrypt multiple items, use `decrypt_list` instead.
-    pub fn decrypt<Key: KeyId, Data: Decryptable<Ids, Key, Output> + IdentifyKey<Key>, Output>(
+    pub fn decrypt<
+        Key: KeySlotId,
+        Data: Decryptable<Ids, Key, Output> + IdentifyKey<Key>,
+        Output,
+    >(
         &self,
         data: &Data,
     ) -> Result<Output, crate::CryptoError> {
@@ -247,7 +251,7 @@ impl<Ids: KeyIds> KeyStore<Ids> {
     /// This method is not parallelized, and is meant for single item encryption.
     /// If you need to encrypt multiple items, use `encrypt_list` instead.
     pub fn encrypt<
-        Key: KeyId,
+        Key: KeySlotId,
         Data: CompositeEncryptable<Ids, Key, Output> + IdentifyKey<Key>,
         Output,
     >(
@@ -263,7 +267,7 @@ impl<Ids: KeyIds> KeyStore<Ids> {
     /// return an error. This method will try to parallelize the decryption of the items, for
     /// better performance on large lists.
     pub fn decrypt_list<
-        Key: KeyId,
+        Key: KeySlotId,
         Data: Decryptable<Ids, Key, Output> + IdentifyKey<Key> + Send + Sync,
         Output: Send + Sync,
     >(
@@ -302,7 +306,7 @@ impl<Ids: KeyIds> KeyStore<Ids> {
     /// and the second vector contains the original items that failed to decrypt.
     pub fn decrypt_list_with_failures<
         'a,
-        Key: KeyId,
+        Key: KeySlotId,
         Data: Decryptable<Ids, Key, Output> + IdentifyKey<Key> + Send + Sync + 'a,
         Output: Send + Sync,
     >(
@@ -339,7 +343,7 @@ impl<Ids: KeyIds> KeyStore<Ids> {
     /// better performance on large lists. This method is not parallelized, and is meant for
     /// single item encryption.
     pub fn encrypt_list<
-        Key: KeyId,
+        Key: KeySlotId,
         Data: CompositeEncryptable<Ids, Key, Output> + IdentifyKey<Key> + Send + Sync,
         Output: Send + Sync,
     >(

--- a/crates/bitwarden-crypto/src/traits/decryptable.rs
+++ b/crates/bitwarden-crypto/src/traits/decryptable.rs
@@ -1,16 +1,16 @@
 use tracing::instrument;
 
-use crate::{CryptoError, EncString, KeyId, KeyIds, store::KeyStoreContext};
+use crate::{CryptoError, EncString, KeySlotId, KeySlotIds, store::KeyStoreContext};
 
 /// A decryption operation that takes the input value and decrypts it into the output value.
 /// Implementations should generally consist of calling [Decryptable::decrypt] for all the fields of
 /// the type.
-pub trait Decryptable<Ids: KeyIds, Key: KeyId, Output> {
+pub trait Decryptable<Ids: KeySlotIds, Key: KeySlotId, Output> {
     #[allow(missing_docs)]
     fn decrypt(&self, ctx: &mut KeyStoreContext<Ids>, key: Key) -> Result<Output, CryptoError>;
 }
 
-impl<Ids: KeyIds> Decryptable<Ids, Ids::Symmetric, Vec<u8>> for EncString {
+impl<Ids: KeySlotIds> Decryptable<Ids, Ids::Symmetric, Vec<u8>> for EncString {
     #[instrument(err, skip_all)]
     fn decrypt(
         &self,
@@ -21,7 +21,7 @@ impl<Ids: KeyIds> Decryptable<Ids, Ids::Symmetric, Vec<u8>> for EncString {
     }
 }
 
-impl<Ids: KeyIds> Decryptable<Ids, Ids::Symmetric, String> for EncString {
+impl<Ids: KeySlotIds> Decryptable<Ids, Ids::Symmetric, String> for EncString {
     #[instrument(err, skip_all)]
     fn decrypt(
         &self,
@@ -33,7 +33,7 @@ impl<Ids: KeyIds> Decryptable<Ids, Ids::Symmetric, String> for EncString {
     }
 }
 
-impl<Ids: KeyIds, Key: KeyId, T: Decryptable<Ids, Key, Output>, Output>
+impl<Ids: KeySlotIds, Key: KeySlotId, T: Decryptable<Ids, Key, Output>, Output>
     Decryptable<Ids, Key, Option<Output>> for Option<T>
 {
     fn decrypt(
@@ -47,7 +47,7 @@ impl<Ids: KeyIds, Key: KeyId, T: Decryptable<Ids, Key, Output>, Output>
     }
 }
 
-impl<Ids: KeyIds, Key: KeyId, T: Decryptable<Ids, Key, Output>, Output>
+impl<Ids: KeySlotIds, Key: KeySlotId, T: Decryptable<Ids, Key, Output>, Output>
     Decryptable<Ids, Key, Vec<Output>> for Vec<T>
 {
     fn decrypt(

--- a/crates/bitwarden-crypto/src/traits/encryptable.rs
+++ b/crates/bitwarden-crypto/src/traits/encryptable.rs
@@ -17,13 +17,13 @@
 //! checking of the content format, and the risk of using the wrong content format is limited to
 //! converting untyped bytes into a `Bytes<C>`
 
-use crate::{ContentFormat, CryptoError, EncString, KeyId, KeyIds, store::KeyStoreContext};
+use crate::{ContentFormat, CryptoError, EncString, KeySlotId, KeySlotIds, store::KeyStoreContext};
 
 /// An encryption operation that takes the input value and encrypts the fields on it recursively.
 /// Implementations should generally consist of calling [PrimitiveEncryptable::encrypt] for all the
 /// fields of the type. Sometimes, it is necessary to call
 /// [CompositeEncryptable::encrypt_composite], if the object is not a flat struct.
-pub trait CompositeEncryptable<Ids: KeyIds, Key: KeyId, Output> {
+pub trait CompositeEncryptable<Ids: KeySlotIds, Key: KeySlotId, Output> {
     /// # ⚠️ IMPORTANT NOTE ⚠️
     /// This is not intended to be used for new designs, and only meant to support old designs.
     /// Composite encryption does not provide integrity over the entire document, just individual
@@ -39,7 +39,7 @@ pub trait CompositeEncryptable<Ids: KeyIds, Key: KeyId, Output> {
     ) -> Result<Output, CryptoError>;
 }
 
-impl<Ids: KeyIds, Key: KeyId, T: CompositeEncryptable<Ids, Key, Output>, Output>
+impl<Ids: KeySlotIds, Key: KeySlotId, T: CompositeEncryptable<Ids, Key, Output>, Output>
     CompositeEncryptable<Ids, Key, Option<Output>> for Option<T>
 {
     fn encrypt_composite(
@@ -53,7 +53,7 @@ impl<Ids: KeyIds, Key: KeyId, T: CompositeEncryptable<Ids, Key, Output>, Output>
     }
 }
 
-impl<Ids: KeyIds, Key: KeyId, T: CompositeEncryptable<Ids, Key, Output>, Output>
+impl<Ids: KeySlotIds, Key: KeySlotId, T: CompositeEncryptable<Ids, Key, Output>, Output>
     CompositeEncryptable<Ids, Key, Vec<Output>> for Vec<T>
 {
     fn encrypt_composite(
@@ -69,7 +69,7 @@ impl<Ids: KeyIds, Key: KeyId, T: CompositeEncryptable<Ids, Key, Output>, Output>
 
 /// An encryption operation that takes the input value - a primitive such as `String` and encrypts
 /// it into the output value. The implementation decides the content format.
-pub trait PrimitiveEncryptable<Ids: KeyIds, Key: KeyId, Output> {
+pub trait PrimitiveEncryptable<Ids: KeySlotIds, Key: KeySlotId, Output> {
     /// # ⚠️ IMPORTANT NOTE ⚠️
     /// Most likely, you do not want to use this but want to use [`crate::safe::DataEnvelope`]
     /// instead.
@@ -78,7 +78,7 @@ pub trait PrimitiveEncryptable<Ids: KeyIds, Key: KeyId, Output> {
     fn encrypt(&self, ctx: &mut KeyStoreContext<Ids>, key: Key) -> Result<Output, CryptoError>;
 }
 
-impl<Ids: KeyIds, Key: KeyId, T: PrimitiveEncryptable<Ids, Key, Output>, Output>
+impl<Ids: KeySlotIds, Key: KeySlotId, T: PrimitiveEncryptable<Ids, Key, Output>, Output>
     PrimitiveEncryptable<Ids, Key, Option<Output>> for Option<T>
 {
     fn encrypt(
@@ -92,7 +92,7 @@ impl<Ids: KeyIds, Key: KeyId, T: PrimitiveEncryptable<Ids, Key, Output>, Output>
     }
 }
 
-impl<Ids: KeyIds> PrimitiveEncryptable<Ids, Ids::Symmetric, EncString> for &str {
+impl<Ids: KeySlotIds> PrimitiveEncryptable<Ids, Ids::Symmetric, EncString> for &str {
     fn encrypt(
         &self,
         ctx: &mut KeyStoreContext<Ids>,
@@ -102,7 +102,7 @@ impl<Ids: KeyIds> PrimitiveEncryptable<Ids, Ids::Symmetric, EncString> for &str 
     }
 }
 
-impl<Ids: KeyIds> PrimitiveEncryptable<Ids, Ids::Symmetric, EncString> for String {
+impl<Ids: KeySlotIds> PrimitiveEncryptable<Ids, Ids::Symmetric, EncString> for String {
     fn encrypt(
         &self,
         ctx: &mut KeyStoreContext<Ids>,
@@ -114,7 +114,7 @@ impl<Ids: KeyIds> PrimitiveEncryptable<Ids, Ids::Symmetric, EncString> for Strin
 
 /// An encryption operation that takes the input value - a primitive such as `Vec<u8>` - and
 /// encrypts it into the output value. The caller must specify the content format.
-pub(crate) trait PrimitiveEncryptableWithContentType<Ids: KeyIds, Key: KeyId, Output> {
+pub(crate) trait PrimitiveEncryptableWithContentType<Ids: KeySlotIds, Key: KeySlotId, Output> {
     /// # ⚠️ IMPORTANT NOTE ⚠️
     /// Most likely, you do not want to use this but want to use [`crate::safe::DataEnvelope`]
     /// instead.
@@ -128,7 +128,9 @@ pub(crate) trait PrimitiveEncryptableWithContentType<Ids: KeyIds, Key: KeyId, Ou
     ) -> Result<Output, CryptoError>;
 }
 
-impl<Ids: KeyIds> PrimitiveEncryptableWithContentType<Ids, Ids::Symmetric, EncString> for &[u8] {
+impl<Ids: KeySlotIds> PrimitiveEncryptableWithContentType<Ids, Ids::Symmetric, EncString>
+    for &[u8]
+{
     fn encrypt(
         &self,
         ctx: &mut KeyStoreContext<Ids>,
@@ -139,7 +141,9 @@ impl<Ids: KeyIds> PrimitiveEncryptableWithContentType<Ids, Ids::Symmetric, EncSt
     }
 }
 
-impl<Ids: KeyIds> PrimitiveEncryptableWithContentType<Ids, Ids::Symmetric, EncString> for Vec<u8> {
+impl<Ids: KeySlotIds> PrimitiveEncryptableWithContentType<Ids, Ids::Symmetric, EncString>
+    for Vec<u8>
+{
     fn encrypt(
         &self,
         ctx: &mut KeyStoreContext<Ids>,
@@ -150,8 +154,12 @@ impl<Ids: KeyIds> PrimitiveEncryptableWithContentType<Ids, Ids::Symmetric, EncSt
     }
 }
 
-impl<Ids: KeyIds, Key: KeyId, T: PrimitiveEncryptableWithContentType<Ids, Key, Output>, Output>
-    PrimitiveEncryptableWithContentType<Ids, Key, Option<Output>> for Option<T>
+impl<
+    Ids: KeySlotIds,
+    Key: KeySlotId,
+    T: PrimitiveEncryptableWithContentType<Ids, Key, Output>,
+    Output,
+> PrimitiveEncryptableWithContentType<Ids, Key, Option<Output>> for Option<T>
 {
     fn encrypt(
         &self,
@@ -165,8 +173,12 @@ impl<Ids: KeyIds, Key: KeyId, T: PrimitiveEncryptableWithContentType<Ids, Key, O
     }
 }
 
-impl<Ids: KeyIds, Key: KeyId, T: PrimitiveEncryptableWithContentType<Ids, Key, Output>, Output>
-    PrimitiveEncryptableWithContentType<Ids, Key, Vec<Output>> for Vec<T>
+impl<
+    Ids: KeySlotIds,
+    Key: KeySlotId,
+    T: PrimitiveEncryptableWithContentType<Ids, Key, Output>,
+    Output,
+> PrimitiveEncryptableWithContentType<Ids, Key, Vec<Output>> for Vec<T>
 {
     fn encrypt(
         &self,

--- a/crates/bitwarden-crypto/src/traits/keyslot_ids.rs
+++ b/crates/bitwarden-crypto/src/traits/keyslot_ids.rs
@@ -12,10 +12,10 @@ use crate::{CryptoKey, PrivateKey, SigningKey, SymmetricCryptoKey};
 /// implementation
 ///
 /// To implement it manually, note that you need a few types:
-/// - One implementing [KeyId<KeyValue = SymmetricCryptoKey>]
-/// - One implementing [KeyId<KeyValue = PrivateKey>]
-/// - One implementing [KeyIds]
-pub trait KeyId:
+/// - One implementing [KeySlotId<KeyValue = SymmetricCryptoKey>]
+/// - One implementing [KeySlotId<KeyValue = PrivateKey>]
+/// - One implementing [KeySlotIds]
+pub trait KeySlotId:
     Debug + Clone + Copy + Hash + Eq + PartialEq + Ord + PartialOrd + Send + Sync + 'static
 {
     #[allow(missing_docs)]
@@ -30,13 +30,13 @@ pub trait KeyId:
 }
 
 /// Represents a set of all the key identifiers that need to be defined to use a key store.
-pub trait KeyIds {
+pub trait KeySlotIds {
     #[allow(missing_docs)]
-    type Symmetric: KeyId<KeyValue = SymmetricCryptoKey>;
+    type Symmetric: KeySlotId<KeyValue = SymmetricCryptoKey>;
     #[allow(missing_docs)]
-    type Private: KeyId<KeyValue = PrivateKey>;
+    type Private: KeySlotId<KeyValue = PrivateKey>;
     /// Signing keys are used to create detached signatures and to sign objects.
-    type Signing: KeyId<KeyValue = SigningKey>;
+    type Signing: KeySlotId<KeyValue = SigningKey>;
 }
 
 /// An opaque identifier for a local key. Currently only contains a unique ID, but it can be
@@ -104,7 +104,7 @@ macro_rules! key_ids {
                 $variant  $( ($inner) )?,
             )* }
 
-            impl $crate::KeyId for $name {
+            impl $crate::KeySlotId for $name {
                 type KeyValue = key_ids!(@key_type $meta_type);
 
                 fn is_local(&self) -> bool {
@@ -125,7 +125,7 @@ macro_rules! key_ids {
 
         #[allow(missing_docs)]
         $ids_vis struct $ids_name;
-        impl $crate::KeyIds for $ids_name {
+        impl $crate::KeySlotIds for $ids_name {
             type Symmetric = $symm_name;
             type Private = $private_name;
             type Signing = $signing_name;
@@ -150,7 +150,7 @@ macro_rules! key_ids {
 pub(crate) mod tests {
 
     use crate::{
-        KeyId, LocalId,
+        KeySlotId, LocalId,
         traits::tests::{TestPrivateKey, TestSigningKey, TestSymmKey},
     };
 

--- a/crates/bitwarden-crypto/src/traits/mod.rs
+++ b/crates/bitwarden-crypto/src/traits/mod.rs
@@ -4,12 +4,12 @@ pub use encryptable::{CompositeEncryptable, PrimitiveEncryptable};
 mod decryptable;
 pub use decryptable::Decryptable;
 
-pub(crate) mod key_id;
-pub use key_id::{KeyId, KeyIds, LocalId};
+pub(crate) mod keyslot_ids;
+pub use keyslot_ids::{KeySlotId, KeySlotIds, LocalId};
 
 /// Types implementing [IdentifyKey] are capable of knowing which cryptographic key is
 /// needed to encrypt/decrypt them.
-pub trait IdentifyKey<Key: KeyId> {
+pub trait IdentifyKey<Key: KeySlotId> {
     #[allow(missing_docs)]
     fn key_identifier(&self) -> Key;
 }


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-35036
https://bitwarden.slack.com/archives/C090UKMPK6G/p1770896132851739

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
Currently there is KeyId (The ID of a specific key as encoded on the CoseKey, and in the "encrypted by" and "contained key id" COSE Headers), and the KeyId which refers to the key function in the key context / key store. The latter will be renamed to KeySlotId, since it does not refer to a specific key, but a "slot" which a specific key can be set to.

This de-tangles concepts, and also makes it so that we can publicly expose KeyId, which currently has a naming collision.

## 🚨 Breaking Changes

<!-- Does this PR introduce any breaking changes? If so, please describe the impact and migration path for clients.

If you're unsure, the automated TypeScript compatibility check will run when you open/update this PR and provide feedback.

For breaking changes:
1. Describe what changed in the client interface
2. Explain why the change was necessary
3. Provide migration steps for client developers
4. Link to any paired client PRs if needed

Otherwise, you can remove this section. -->
