### PR TITLE
PM-33122: Rename feature flag pm-34500-strict-cipher-decryption

### DIFF
--- a/crates/bitwarden-core/src/client/flags.rs
+++ b/crates/bitwarden-core/src/client/flags.rs
@@ -14,7 +14,7 @@ pub struct Flags {
     pub enable_cipher_key_encryption: bool,
 
     /// Enable strict cipher field decryption (propagates errors instead of nulling fields).
-    #[serde(alias = "PM-34500-strict-cipher-decryption")]
+    #[serde(alias = "pm-34500-strict-cipher-decryption")]
     pub strict_cipher_decryption: bool,
 }
 


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-33122

## 📔 Objective

The feature flag name in LD is different than the key it sends - this fixes the case matching, allowing the flag to pass through.
