### PR TITLE
[PM-31872] Define RepositoryItems and Setting keys

### DIFF
--- a/crates/bitwarden-core/src/client/flags.rs
+++ b/crates/bitwarden-core/src/client/flags.rs
@@ -6,7 +6,7 @@
 ///
 /// **Note:** This struct while public, is intended for internal use and may change in future
 /// releases.
-#[derive(Debug, Default, Clone, serde::Deserialize)]
+#[derive(Debug, Default, Clone, serde::Serialize, serde::Deserialize)]
 #[serde(default, rename_all = "kebab-case")]
 pub struct Flags {
     /// Enable cipher key encryption.

--- a/crates/bitwarden-core/src/client/login_method.rs
+++ b/crates/bitwarden-core/src/client/login_method.rs
@@ -2,6 +2,7 @@
 use std::path::PathBuf;
 
 use bitwarden_crypto::Kdf;
+use serde::{Deserialize, Serialize};
 
 #[cfg(feature = "secrets")]
 use crate::{OrganizationId, auth::AccessToken};
@@ -17,7 +18,7 @@ pub enum LoginMethod {
 }
 
 #[allow(dead_code)]
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum UserLoginMethod {
     Username {
         client_id: String,

--- a/crates/bitwarden-core/src/client/mod.rs
+++ b/crates/bitwarden-core/src/client/mod.rs
@@ -19,6 +19,8 @@ pub(crate) use login_method::ServiceAccountLoginMethod;
 pub(crate) use login_method::{LoginMethod, UserLoginMethod};
 #[cfg(feature = "internal")]
 mod flags;
+#[cfg(feature = "internal")]
+pub mod persisted_state;
 
 pub use builder::ClientBuilder;
 pub use client::Client;

--- a/crates/bitwarden-core/src/client/persisted_state.rs
+++ b/crates/bitwarden-core/src/client/persisted_state.rs
@@ -1,0 +1,78 @@
+//! Persisted state types and setting keys for the Bitwarden SDK.
+
+use bitwarden_crypto::{EncString, UnsignedSharedKey};
+use bitwarden_state::{register_repository_item, register_setting_key};
+use serde::{Deserialize, Serialize};
+#[cfg(feature = "wasm")]
+use tsify::Tsify;
+
+use super::{flags::Flags, login_method::UserLoginMethod};
+use crate::{
+    OrganizationId, key_management::account_cryptographic_state::WrappedAccountCryptographicState,
+};
+
+/// A persisted organization encryption key.
+///
+/// Stored in a Repository keyed by [`OrganizationId`].
+/// The `org_id` is included in the struct so it can be recovered from `Repository::list()`.
+#[derive(Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
+#[cfg_attr(feature = "wasm", derive(Tsify), tsify(into_wasm_abi, from_wasm_abi))]
+pub struct OrganizationSharedKey {
+    /// The organization this key belongs to.
+    pub org_id: OrganizationId,
+    /// The organization's shared encryption key.
+    pub key: UnsignedSharedKey,
+}
+
+register_repository_item!(OrganizationId => OrganizationSharedKey, "OrganizationSharedKey");
+
+/// Base API URLs for identity and API services.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BaseUrls {
+    /// The identity service URL.
+    pub identity_url: String,
+    /// The API service URL.
+    pub api_url: String,
+}
+
+/// Authentication tokens for API access.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AuthenticationTokens {
+    /// The access token.
+    pub access_token: String,
+    /// The refresh token.
+    pub refresh_token: Option<String>,
+    /// Unix timestamp when the access token expires.
+    pub expires_on: i64,
+}
+
+// Setting keys
+register_setting_key!(
+    /// Setting key for the user's login method.
+    pub const USER_LOGIN_METHOD: UserLoginMethod = "user_login_method"
+);
+register_setting_key!(
+    /// Setting key for the base API URLs.
+    pub const BASE_URLS: BaseUrls = "base_urls"
+);
+register_setting_key!(
+    /// Setting key for the user ID.
+    pub const USER_ID: String = "user_id"
+);
+register_setting_key!(
+    /// Setting key for feature flags.
+    pub const FLAGS: Flags = "flags"
+);
+register_setting_key!(
+    /// Setting key for authentication tokens.
+    pub const AUTHENTICATION_TOKENS: AuthenticationTokens = "authentication_tokens"
+);
+register_setting_key!(
+    /// Setting key for the account cryptographic state.
+    pub const ACCOUNT_CRYPTO_STATE: WrappedAccountCryptographicState = "account_crypto_state"
+);
+register_setting_key!(
+    /// Setting key for the session-protected user key.
+    pub const SESSION_PROTECTED_USER_KEY: EncString = "session_protected_user_key"
+);

--- a/crates/bitwarden-pm/src/migrations.rs
+++ b/crates/bitwarden-pm/src/migrations.rs
@@ -1,6 +1,8 @@
 //! Manages repository migrations for the Bitwarden SDK.
 
-use bitwarden_core::key_management::UserKeyState;
+use bitwarden_core::{
+    client::persisted_state::OrganizationSharedKey, key_management::UserKeyState,
+};
 use bitwarden_state::{
     SettingItem,
     repository::{RepositoryItem, RepositoryMigrationStep, RepositoryMigrations},
@@ -17,6 +19,7 @@ pub fn get_sdk_managed_migrations() -> RepositoryMigrations {
         Add(Folder::data()),
         Add(UserKeyState::data()),
         Add(SettingItem::data()),
+        Add(OrganizationSharedKey::data()),
     ])
 }
 
@@ -36,6 +39,7 @@ macro_rules! create_client_managed_repositories {
             ::bitwarden_core::key_management::UserKeyState, UserKeyState, user_key_state, UserKeyStateRepository;
             ::bitwarden_core::key_management::LocalUserDataKeyState, LocalUserDataKeyState, local_user_data_key_state, LocalUserDataKeyStateRepository;
             ::bitwarden_core::key_management::EphemeralPinEnvelopeState, EphemeralPinEnvelopeState, ephemeral_pin_envelope_state, EphemeralPinEnvelopeStateRepository;
+            ::bitwarden_core::client::persisted_state::OrganizationSharedKey, OrganizationSharedKey, organization_shared_key, OrganizationSharedKeyRepository;
         }
     };
 }

--- a/crates/bitwarden-state/src/settings/key.rs
+++ b/crates/bitwarden-state/src/settings/key.rs
@@ -25,7 +25,8 @@ use std::marker::PhantomData;
 /// ```
 #[macro_export]
 macro_rules! register_setting_key {
-    ($vis:vis const $name:ident: $ty:ty = $key:literal) => {
+    ($(#[$meta:meta])* $vis:vis const $name:ident: $ty:ty = $key:literal) => {
+        $(#[$meta])*
         $vis const $name: $crate::settings::Key<$ty> = $crate::settings::Key::new($key);
     };
 }


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue -->
https://bitwarden.atlassian.net/browse/PM-31872
## 📔 Objective

Add persisted state infrastructure for the SDK's client layer. This lays the groundwork for persisting user session data (login method, tokens, URLs, flags, crypto state) across SDK restarts.

### Changes

- **`UserLoginMethod`**: Add `Serialize`/`Deserialize` derives so it can be stored via the settings
  system.
- **`Flags`**: Add `Serialize` (already had `Deserialize`) for the same reason.
- **`register_setting_key!` macro**: Extend to accept `#[meta]` attributes (e.g. doc comments) on
  the generated constant.
- **New `persisted_state` module** (`bitwarden-core::client::persisted_state`):
  - `BaseUrls` — identity and API service URLs.
  - `AuthenticationTokens` — access/refresh tokens and expiry.
  - `OrganizationSharedKey` — per-org encryption key, registered as a `RepositoryItem` keyed by
    `OrganizationId`.
  - Seven setting keys: `USER_LOGIN_METHOD`, `BASE_URLS`, `USER_ID`, `FLAGS`,
    `AUTHENTICATION_TOKENS`, `ACCOUNT_CRYPTO_STATE`, `SESSION_PROTECTED_USER_KEY`.
- **Migrations** (`bitwarden-pm`): Register `OrganizationSharedKey` in both SDK-managed migrations
  and the `create_client_managed_repositories!` macro.

## 🚨 Breaking Changes

The `create_client_managed_repositories!` macro now emits an additional repository
(`OrganizationSharedKeyRepository`). Consumers of this macro (uniffi, wasm, bw) will see the new
field on the generated `Repositories` struct and need to supply it (or pass `None`).
