### PR TITLE
[PM-35239] bitwarden-ipc: fix 'occured' -> 'occurred' in error derive string

### DIFF
--- a/crates/bitwarden-ipc/src/error.rs
+++ b/crates/bitwarden-ipc/src/error.rs
@@ -81,6 +81,6 @@ pub enum RequestError {
     #[error("Failed to send message: {0}")]
     Send(String),
 
-    #[error("Error occured on the remote target: {0}")]
+    #[error("Error occurred on the remote target: {0}")]
     Rpc(#[from] RpcError),
 }


### PR DESCRIPTION
`#[error]` derive string in `crates/bitwarden-ipc/src/error.rs` line 84 reads `Error occured on the remote target`. Fixed to `occurred`. Error-display-only change.