### PR TITLE
[PM-34152] Add PolicyRegistry for policy filtering

### DIFF
--- a/crates/bitwarden-policies/src/filter.rs
+++ b/crates/bitwarden-policies/src/filter.rs
@@ -14,25 +14,29 @@ use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
 /// A newtype representing the policy type.
-#[derive(PartialEq, Serialize, Deserialize, Debug)]
-pub struct PolicyType(pub u8);
+#[derive(PartialEq, Eq, Hash, Serialize, Deserialize, Debug, Copy, Clone)]
+pub struct PolicyType(
+    /// The raw integer value as defined by the server.
+    pub u8,
+);
 
 /// An organization policy.
+#[allow(missing_docs)]
 #[derive(Serialize, Deserialize, Debug)]
 pub struct PolicyView {
-    id: Uuid,
-    organization_id: Uuid,
-    r#type: PolicyType,
-    data: Option<HashMap<String, serde_json::Value>>,
-    enabled: bool,
+    pub(crate) id: Uuid,
+    pub(crate) organization_id: Uuid,
+    pub(crate) r#type: PolicyType,
+    pub(crate) data: Option<HashMap<String, serde_json::Value>>,
+    pub(crate) enabled: bool,
 }
 
 /// Defines the filtering behavior for a specific policy type.
 ///
 /// Implement this trait to control how a policy is enforced.
 pub trait Policy: Send + Sync + 'static {
-    /// The wire-format integer for this policy type.
-    const TYPE: PolicyType;
+    /// Returns the policy type this definition handles.
+    fn policy_type(&self) -> PolicyType;
 
     /// Returns the organization roles that are exempt from this policy.
     ///
@@ -61,10 +65,10 @@ pub trait Policy: Send + Sync + 'static {
     }
 }
 
-/// Extension trait that adds a [`filter`](PolicyExt::filter) method to every [`Policy`].
+/// Extension trait that adds a [`filter`](PolicyFilter::filter) method to every [`Policy`].
 ///
 /// Implemented automatically for all `T: Policy`.
-pub trait PolicyExt: Policy {
+pub trait PolicyFilter: Policy {
     /// Filters `policies` to those that should be enforced against the user.
     /// This evaluates common business rules (e.g. the policy is enabled),
     /// as well as policy-specific rules according to its [`Policy`].
@@ -81,7 +85,7 @@ pub trait PolicyExt: Policy {
 
         policies
             .iter()
-            .filter(|p| p.r#type == Self::TYPE)
+            .filter(|p| p.r#type == self.policy_type())
             .filter(|p| p.enabled)
             .filter(|p| {
                 match org_map.get(&p.organization_id) {
@@ -99,7 +103,7 @@ pub trait PolicyExt: Policy {
     }
 }
 
-impl<T: Policy> PolicyExt for T {}
+impl<T: Policy> PolicyFilter for T {}
 
 #[cfg(test)]
 mod tests {
@@ -133,7 +137,9 @@ mod tests {
 
     struct TestPolicy;
     impl Policy for TestPolicy {
-        const TYPE: PolicyType = PolicyType(1);
+        fn policy_type(&self) -> PolicyType {
+            PolicyType(1)
+        }
 
         // These happen to match the default impl, but repeating here
         // to decouple the filter tests from the default impl

--- a/crates/bitwarden-policies/src/lib.rs
+++ b/crates/bitwarden-policies/src/lib.rs
@@ -3,7 +3,9 @@
 #[cfg(feature = "uniffi")]
 uniffi::setup_scaffolding!();
 
-mod filter;
+pub mod filter;
 mod master_password_policy_response;
+mod registry;
 
+pub use filter::{Policy, PolicyType, PolicyView};
 pub use master_password_policy_response::MasterPasswordPolicyResponse;

--- a/crates/bitwarden-policies/src/registry.rs
+++ b/crates/bitwarden-policies/src/registry.rs
@@ -65,9 +65,15 @@ pub struct PolicyRegistryBuilder {
 impl PolicyRegistryBuilder {
     /// Registers a [`Policy`] for its policy type.
     ///
-    /// If a definition for the same type is already registered, it is replaced.
+    /// # Panics
+    ///
+    /// Panics if a [`Policy`] for the same [`PolicyType`] has already been registered.
     pub fn register<P: Policy>(mut self, policy: P) -> Self {
-        self.policies.insert(policy.policy_type(), Box::new(policy));
+        let policy_type = policy.policy_type();
+        if self.policies.contains_key(&policy_type) {
+            panic!("policy already registered for type {:?}", policy_type);
+        }
+        self.policies.insert(policy_type, Box::new(policy));
         self
     }
 
@@ -110,6 +116,22 @@ mod tests {
             is_provider_user: provider,
             ..Default::default()
         }
+    }
+
+    #[test]
+    #[should_panic(expected = "policy already registered for type")]
+    fn registry_panics_on_duplicate_registration() {
+        struct AnyPolicy;
+        impl Policy for AnyPolicy {
+            fn policy_type(&self) -> PolicyType {
+                PolicyType(1)
+            }
+        }
+
+        PolicyRegistry::builder()
+            .register(AnyPolicy)
+            .register(AnyPolicy)
+            .build();
     }
 
     #[test]

--- a/crates/bitwarden-policies/src/registry.rs
+++ b/crates/bitwarden-policies/src/registry.rs
@@ -1,0 +1,164 @@
+#![allow(dead_code)]
+
+//! Policy registry for managing [`Policy`] implementations.
+//!
+//! The [`PolicyRegistry`] maps policy types to their definitions
+//! and provides an interface for filtering policies according to their registered definition.
+//! Unregistered policy types fall back to [`DefaultPolicy`].
+
+use std::collections::HashMap;
+
+use bitwarden_organizations::ProfileOrganization;
+
+use crate::filter::{Policy, PolicyFilter, PolicyType, PolicyView};
+
+/// A [`Policy`] that uses the default filtering behavior for any policy type.
+struct DefaultPolicy(PolicyType);
+
+impl Policy for DefaultPolicy {
+    fn policy_type(&self) -> PolicyType {
+        self.0
+    }
+}
+
+/// A registry mapping each [`PolicyType`] to its [`Policy`] implementation.
+///
+/// This is for FFI callers where the [`Policy`] implementation is unknown.
+/// Rust callers should call [`filter`](PolicyFilter::filter)
+/// directly on their desired [`Policy`].
+///
+/// Use [`PolicyRegistry::builder`] to construct an instance.
+pub struct PolicyRegistry {
+    policies: HashMap<PolicyType, Box<dyn PolicyFilter>>,
+}
+
+impl PolicyRegistry {
+    /// Returns a [`PolicyRegistryBuilder`] for constructing a registry.
+    pub fn builder() -> PolicyRegistryBuilder {
+        PolicyRegistryBuilder {
+            policies: HashMap::new(),
+        }
+    }
+
+    /// Filters `policies` to those of `policy_type` that should be enforced.
+    ///
+    /// Uses the registered [`Policy`] for `policy_type` if one exists,
+    /// otherwise falls back to [`DefaultPolicy`].
+    pub(crate) fn filter_by_type<'a>(
+        &self,
+        policies: &'a [PolicyView],
+        organizations: &[ProfileOrganization],
+        policy_type: PolicyType,
+    ) -> Vec<&'a PolicyView> {
+        match self.policies.get(&policy_type) {
+            Some(p) => p.filter(policies, organizations),
+            None => DefaultPolicy(policy_type).filter(policies, organizations),
+        }
+    }
+}
+
+/// Builder for [`PolicyRegistry`].
+pub struct PolicyRegistryBuilder {
+    policies: HashMap<PolicyType, Box<dyn PolicyFilter>>,
+}
+
+impl PolicyRegistryBuilder {
+    /// Registers a [`Policy`] for its policy type.
+    ///
+    /// If a definition for the same type is already registered, it is replaced.
+    pub fn register<P: Policy>(mut self, policy: P) -> Self {
+        self.policies.insert(policy.policy_type(), Box::new(policy));
+        self
+    }
+
+    /// Builds the [`PolicyRegistry`].
+    pub fn build(self) -> PolicyRegistry {
+        PolicyRegistry {
+            policies: self.policies,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use bitwarden_organizations::{OrganizationUserStatusType, OrganizationUserType};
+    use uuid::Uuid;
+
+    use super::*;
+
+    fn policy_view(organization_id: Uuid, policy_type: u8, enabled: bool) -> PolicyView {
+        PolicyView {
+            id: Uuid::new_v4(),
+            organization_id,
+            r#type: PolicyType(policy_type),
+            data: None,
+            enabled,
+        }
+    }
+
+    fn organization(
+        id: Uuid,
+        user_type: OrganizationUserType,
+        status: OrganizationUserStatusType,
+        provider: bool,
+    ) -> ProfileOrganization {
+        ProfileOrganization {
+            id,
+            r#type: user_type,
+            status,
+            use_policies: true,
+            is_provider_user: provider,
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn registry_uses_registered_definition() {
+        let org_id = Uuid::new_v4();
+        let policies = [policy_view(org_id, 1, true)];
+        // Owner — exempt under default rules, not exempt under NoExemptionPolicy
+        let orgs = [organization(
+            org_id,
+            OrganizationUserType::Owner,
+            OrganizationUserStatusType::Confirmed,
+            false,
+        )];
+
+        struct NoExemptionPolicy;
+        impl Policy for NoExemptionPolicy {
+            fn policy_type(&self) -> PolicyType {
+                PolicyType(1)
+            }
+            fn exempt_roles(&self) -> &[OrganizationUserType] {
+                &[]
+            }
+        }
+
+        let registry = PolicyRegistry::builder()
+            .register(NoExemptionPolicy)
+            .build();
+
+        let result = registry.filter_by_type(&policies, &orgs, PolicyType(1));
+
+        assert_eq!(result.len(), 1);
+    }
+
+    #[test]
+    fn registry_uses_default_policy_definition() {
+        let org_id = Uuid::new_v4();
+        let policies = [policy_view(org_id, 1, true)];
+        let orgs = [organization(
+            org_id,
+            OrganizationUserType::User,
+            OrganizationUserStatusType::Confirmed,
+            false,
+        )];
+
+        // empty registry
+        let registry = PolicyRegistry::builder().build();
+
+        let result = registry.filter_by_type(&policies, &orgs, PolicyType(1));
+
+        assert_eq!(result.len(), 1);
+    }
+}


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-34152

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Introduces `PolicyRegistry`, a type-erased registry that maps organization policy types to their filtering logic. This will support an FFI used by native callers to filter applicable policies without needing to know about the corresponding `Policy` implementation, which is a rust concept. (rust callers will likely skip this and just specify the `Policy` directly.)

  - Consumers register `Policy` implementations via `PolicyRegistry::builder().register(...).build()`.
  - At filter time, `filter_by_type` looks up the registered definition for a given policy type and applies its filtering rules (exempted roles, org membership requirements, etc.).
  - If no definition is registered for a type, it falls back to `DefaultPolicy`, which applies reasonable defaults that work for most policy types.

Usage example:

```rust
  let registry = PolicyRegistry::builder()
      .register(MasterPasswordPolicy)
      .register(TwoFactorAuthenticationPolicy)
      .build();

  let enforced = registry.filter_by_type(&raw_policies, &organizations, RawPolicyType(0));
```

## 🚨 Breaking Changes

No breaking changes - code is not wired up yet.