### PR TITLE
[PM-31878] Persist UserId, AccountCrypto, and OrgSharedKeys

### DIFF
--- a/crates/bitwarden-core/src/client/internal.rs
+++ b/crates/bitwarden-core/src/client/internal.rs
@@ -21,6 +21,7 @@ use crate::{OrganizationId, client::encryption_settings::EncryptionSettings};
 use crate::{
     client::{
         encryption_settings::EncryptionSettingsError, flags::Flags, login_method::UserLoginMethod,
+        persisted_state::USER_ID,
     },
     error::NotAuthenticatedError,
     key_management::{
@@ -216,17 +217,24 @@ impl InternalClient {
     }
 
     #[allow(missing_docs)]
-    pub fn init_user_id(&self, user_id: UserId) -> Result<(), UserIdAlreadySetError> {
+    pub async fn init_user_id(&self, user_id: UserId) -> Result<(), UserIdAlreadySetError> {
         let set_uuid = self.user_id.get_or_init(|| user_id);
 
         // Only return an error if the user_id is already set to a different value,
         // as we want an SDK client to be tied to a single user_id.
         // If it's the same value, we can just do nothing.
         if *set_uuid != user_id {
-            Err(UserIdAlreadySetError)
-        } else {
-            Ok(())
+            return Err(UserIdAlreadySetError);
         }
+
+        #[cfg(feature = "internal")]
+        if let Ok(setting) = self.state_registry.setting(USER_ID)
+            && let Err(e) = setting.update(user_id).await
+        {
+            tracing::warn!("Failed to persist user_id: {e}");
+        }
+
+        Ok(())
     }
 
     #[allow(missing_docs)]
@@ -432,23 +440,41 @@ mod tests {
     const TEST_ACCOUNT_EMAIL: &str = "test@bitwarden.com";
     const TEST_ACCOUNT_USER_KEY: &str = "2.Q/2PhzcC7GdeiMHhWguYAQ==|GpqzVdr0go0ug5cZh1n+uixeBC3oC90CIe0hd/HWA/pTRDZ8ane4fmsEIcuc8eMKUt55Y2q/fbNzsYu41YTZzzsJUSeqVjT8/iTQtgnNdpo=|dwI+uyvZ1h/iZ03VQ+/wrGEFYVewBUUl/syYgjsNMbE=";
 
-    #[test]
-    fn initializing_user_multiple_times() {
+    #[tokio::test]
+    async fn initializing_user_multiple_times() {
         use super::*;
+        use crate::client::persisted_state::USER_ID;
 
         let client = Client::new(None);
         let user_id = UserId::new_v4();
 
         // Setting the user ID for the first time should work.
-        assert!(client.internal.init_user_id(user_id).is_ok());
+        assert!(client.internal.init_user_id(user_id).await.is_ok());
         assert_eq!(client.internal.get_user_id(), Some(user_id));
 
+        // The user ID should be persisted to the settings repository.
+        let persisted = client
+            .internal
+            .state_registry
+            .setting(USER_ID)
+            .unwrap()
+            .get()
+            .await
+            .unwrap();
+        assert_eq!(persisted, Some(user_id));
+
         // Trying to set the same user_id again should not return an error.
-        assert!(client.internal.init_user_id(user_id).is_ok());
+        assert!(client.internal.init_user_id(user_id).await.is_ok());
 
         // Trying to set a different user_id should return an error.
         let different_user_id = UserId::new_v4();
-        assert!(client.internal.init_user_id(different_user_id).is_err());
+        assert!(
+            client
+                .internal
+                .init_user_id(different_user_id)
+                .await
+                .is_err()
+        );
     }
 
     #[tokio::test]

--- a/crates/bitwarden-core/src/client/persisted_state.rs
+++ b/crates/bitwarden-core/src/client/persisted_state.rs
@@ -8,7 +8,8 @@ use tsify::Tsify;
 
 use super::{flags::Flags, login_method::UserLoginMethod};
 use crate::{
-    OrganizationId, key_management::account_cryptographic_state::WrappedAccountCryptographicState,
+    OrganizationId, UserId,
+    key_management::account_cryptographic_state::WrappedAccountCryptographicState,
 };
 
 /// A persisted organization encryption key.
@@ -58,7 +59,7 @@ register_setting_key!(
 );
 register_setting_key!(
     /// Setting key for the user ID.
-    pub const USER_ID: String = "user_id"
+    pub const USER_ID: UserId = "user_id"
 );
 register_setting_key!(
     /// Setting key for feature flags.

--- a/crates/bitwarden-core/src/key_management/crypto.rs
+++ b/crates/bitwarden-core/src/key_management/crypto.rs
@@ -31,7 +31,11 @@ use crate::key_management::wasm_unlock_state::{
 };
 use crate::{
     Client, NotAuthenticatedError, OrganizationId, UserId, WrongPasswordError,
-    client::{LoginMethod, UserLoginMethod, encryption_settings::EncryptionSettingsError},
+    client::{
+        LoginMethod, UserLoginMethod,
+        encryption_settings::EncryptionSettingsError,
+        persisted_state::{ACCOUNT_CRYPTO_STATE, OrganizationSharedKey},
+    },
     error::StatefulCryptoError,
     key_management::{
         MasterPasswordError, PrivateKeySlotId, SecurityState, SignedSecurityState,
@@ -193,7 +197,7 @@ pub(super) async fn initialize_user_crypto(
     use crate::auth::{auth_request_decrypt_master_key, auth_request_decrypt_user_key};
 
     if let Some(user_id) = req.user_id {
-        client.internal.init_user_id(user_id)?;
+        client.internal.init_user_id(user_id).await?;
     }
 
     tracing::Span::current().record(
@@ -358,6 +362,12 @@ pub(super) async fn initialize_user_crypto(
         }))
         .await;
 
+    if let Ok(setting) = client.internal.state_registry.setting(ACCOUNT_CRYPTO_STATE)
+        && let Err(e) = setting.update(req.account_cryptographic_state).await
+    {
+        tracing::warn!("Failed to persist account crypto state: {e}");
+    }
+
     info!("User crypto initialized successfully");
 
     Ok(())
@@ -378,8 +388,27 @@ pub(super) async fn initialize_org_crypto(
     client: &Client,
     req: InitOrgCryptoRequest,
 ) -> Result<(), EncryptionSettingsError> {
-    let organization_keys = req.organization_keys.into_iter().collect();
-    client.internal.initialize_org_crypto(organization_keys)?;
+    let organization_keys: Vec<_> = req.organization_keys.into_iter().collect();
+    client
+        .internal
+        .initialize_org_crypto(organization_keys.clone())?;
+
+    // Persist org keys for rehydration
+    if let Ok(repo) = client
+        .internal
+        .state_registry
+        .get::<OrganizationSharedKey>()
+    {
+        for (org_id, key) in organization_keys {
+            if let Err(e) = repo
+                .set(org_id, OrganizationSharedKey { org_id, key })
+                .await
+            {
+                tracing::warn!("Failed to persist org key for {org_id}: {e}");
+            }
+        }
+    }
+
     Ok(())
 }
 
@@ -2212,6 +2241,75 @@ mod tests {
             .decrypt(&mut ctx, SymmetricKeySlotId::LocalUserData)
             .expect("decryption with local user data key should succeed");
         assert_eq!(decrypted, plaintext);
+    }
+
+    #[tokio::test]
+    async fn test_initialize_org_crypto_persists_org_keys() {
+        use crate::{OrganizationId, client::persisted_state::OrganizationSharedKey};
+
+        let client = Client::init_test_account(test_bitwarden_com_account()).await;
+
+        let org_id: OrganizationId = "1bc9ac1e-f5aa-45f2-94bf-b181009709b8".parse().unwrap();
+
+        let repo = client
+            .internal
+            .state_registry
+            .get::<OrganizationSharedKey>()
+            .expect("OrganizationSharedKey repository should be available");
+
+        let persisted = repo
+            .get(org_id)
+            .await
+            .expect("repository get should not fail");
+
+        let entry = persisted.expect("org key should be persisted after initialize_org_crypto");
+        assert_eq!(entry.org_id, org_id);
+    }
+
+    #[tokio::test]
+    async fn test_initialize_user_crypto_persists_account_crypto_state() {
+        use crate::client::persisted_state::ACCOUNT_CRYPTO_STATE;
+
+        let account_crypto_state = WrappedAccountCryptographicState::V1 {
+            private_key: TEST_ACCOUNT_PRIVATE_KEY.parse().unwrap(),
+        };
+
+        let client = Client::new_test(None);
+        initialize_user_crypto(
+            &client,
+            InitUserCryptoRequest {
+                user_id: Some(UserId::new_v4()),
+                kdf_params: Kdf::PBKDF2 {
+                    iterations: 600_000.try_into().unwrap(),
+                },
+                email: TEST_USER_EMAIL.into(),
+                account_cryptographic_state: account_crypto_state.clone(),
+                method: InitUserCryptoMethod::MasterPasswordUnlock {
+                    password: TEST_USER_PASSWORD.into(),
+                    master_password_unlock: MasterPasswordUnlockData {
+                        kdf: Kdf::PBKDF2 {
+                            iterations: 600_000.try_into().unwrap(),
+                        },
+                        master_key_wrapped_user_key: TEST_ACCOUNT_USER_KEY.parse().unwrap(),
+                        salt: TEST_USER_EMAIL.to_string(),
+                    },
+                },
+                upgrade_token: None,
+            },
+        )
+        .await
+        .unwrap();
+
+        let persisted = client
+            .internal
+            .state_registry
+            .setting(ACCOUNT_CRYPTO_STATE)
+            .expect("ACCOUNT_CRYPTO_STATE setting should be available")
+            .get()
+            .await
+            .expect("setting get should not fail");
+
+        assert_eq!(persisted, Some(account_crypto_state));
     }
 
     #[tokio::test]


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-31878
## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

To support session rehydration, write cryptographic state to the SDK's Settings and Repository stores as it is established at runtime:

- `init_user_id` is now async and writes the user ID to the `USER_ID` setting. The `USER_ID` key type is changed from `String` to `UserId` to avoid an unnecessary round-trip through string conversion.

- `initialize_user_crypto` writes `account_cryptographic_state` to the `ACCOUNT_CRYPTO_STATE` setting after the key store is populated.

- `initialize_org_crypto` writes each org key to the `OrganizationSharedKey` repository after the key store is populated.

All three writes are best-effort: failures emit a `tracing::warn` and do not propagate an error to the caller. The registry returning `DatabaseNotInitialized` (e.g. in tests without a backing store) is also silently ignored.

Tests are added for each persistence point:
- `initializing_user_multiple_times` now reads back the `USER_ID` setting and asserts it matches the initialised value.
- `test_initialize_user_crypto_persists_account_crypto_state` verifies the account crypto state round-trips through the setting store.
- `test_initialize_org_crypto_persists_org_keys` verifies that org keys appear in the `OrganizationSharedKey` repository after initialization.

## 🚨 Breaking Changes

<!-- Does this PR introduce any breaking changes? If so, please describe the impact and migration path for clients.

If you're unsure, the automated TypeScript compatibility check will run when you open/update this PR and provide feedback.

For breaking changes:
1. Describe what changed in the client interface
2. Explain why the change was necessary
3. Provide migration steps for client developers
4. Link to any paired client PRs if needed

Otherwise, you can remove this section. -->
