### PR TITLE
Add clippy lint for holding tracing span across await points

### DIFF
--- a/clippy.toml
+++ b/clippy.toml
@@ -8,6 +8,7 @@ Contains a RwLock guard that will limit concurrency and even deadlock when held 
 Instead, prefer to hold a reference to bitwarden_core::KeyStore and use its encrypt/decrypt methods directly.
 If you require access to KeyStoreContext, create short-lived KeyStoreContext instances as needed.
 """ },
+    { path = "tracing::span::EnteredSpan", reason = """Holding a span across await points leads to incorrect traces. Instead, the instrument macro should be used or the span should be exited before the await and re-entered afterward.""" },
 ]
 
 disallowed-macros = [

--- a/crates/bitwarden-user-crypto-management/src/key_rotation/password_change_and_rotate_user_keys.rs
+++ b/crates/bitwarden-user-crypto-management/src/key_rotation/password_change_and_rotate_user_keys.rs
@@ -3,7 +3,7 @@ use bitwarden_api_api::models::RotateUserAccountKeysAndDataRequestModel;
 use bitwarden_core::key_management::{KeySlotIds, MasterPasswordAuthenticationData};
 use bitwarden_crypto::{KeyStore, PublicKey};
 use serde::{Deserialize, Serialize};
-use tracing::{info, info_span};
+use tracing::{info, instrument};
 #[cfg(feature = "wasm")]
 use tsify::Tsify;
 #[cfg(feature = "wasm")]
@@ -48,12 +48,17 @@ impl UserCryptoManagementClient {
     }
 }
 
+#[instrument(
+    name = "password_change_and_rotate_user_keys",
+    level = "info",
+    skip_all,
+    err
+)]
 async fn internal_password_change_and_rotate_user_keys(
     key_store: &KeyStore<KeySlotIds>,
     api_client: &bitwarden_api_api::apis::ApiClient,
     request: PasswordChangeAndRotateUserKeysRequest,
 ) -> Result<(), RotateUserKeysError> {
-    let _span = info_span!("password_change_and_rotate_user_keys").entered();
     let sync = sync_current_account_data(api_client)
         .await
         .map_err(|_| RotateUserKeysError::ApiError)?;


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective

https://github.com/bitwarden/sdk-internal/pull/931#discussion_r3098595725
https://docs.rs/tracing/latest/tracing/span/struct.Span.html#in-asynchronous-code
Holding spans across await points leads to incorrect traces and should be prevented by clippy.

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

## 🚨 Breaking Changes

<!-- Does this PR introduce any breaking changes? If so, please describe the impact and migration path for clients.

If you're unsure, the automated TypeScript compatibility check will run when you open/update this PR and provide feedback.

For breaking changes:
1. Describe what changed in the client interface
2. Explain why the change was necessary
3. Provide migration steps for client developers
4. Link to any paired client PRs if needed

Otherwise, you can remove this section. -->
