### PR TITLE
[poc] Client managed value state

### DIFF
--- a/crates/bitwarden-core/src/client/test_accounts.rs
+++ b/crates/bitwarden-core/src/client/test_accounts.rs
@@ -5,7 +5,7 @@ use std::collections::HashMap;
 #[cfg(feature = "test-fixtures")]
 use bitwarden_crypto::{EncString, Kdf};
 #[cfg(feature = "test-fixtures")]
-use bitwarden_test::MemoryRepository;
+use bitwarden_test::{MemoryRepository, MemoryValue};
 
 #[cfg(feature = "test-fixtures")]
 use crate::{
@@ -26,9 +26,7 @@ impl Client {
         client
             .platform()
             .state()
-            .register_client_managed(std::sync::Arc::new(
-                MemoryRepository::<UserKeyState>::default(),
-            ));
+            .register_client_managed_value(std::sync::Arc::new(MemoryValue::<UserKeyState>::default()));
         client
             .platform()
             .state()

--- a/crates/bitwarden-core/src/key_management/mod.rs
+++ b/crates/bitwarden-core/src/key_management/mod.rs
@@ -68,7 +68,7 @@ pub struct UserKeyState {
     decrypted_user_key: B64,
 }
 
-bitwarden_state::register_repository_item!(String => UserKeyState, "UserKey");
+bitwarden_state::register_value_item!(UserKeyState, "UserKey");
 
 /// Represents the local user data key, wrapped by user key.
 /// This key is used to encrypt local user data (e.g., password generator history).
@@ -89,7 +89,7 @@ pub struct EphemeralPinEnvelopeState {
     pin_envelope: PasswordProtectedKeyEnvelope,
 }
 
-bitwarden_state::register_repository_item!(String => EphemeralPinEnvelopeState, "EphemeralPinEnvelope");
+bitwarden_state::register_value_item!(EphemeralPinEnvelopeState, "EphemeralPinEnvelope");
 
 key_slot_ids! {
     #[symmetric]

--- a/crates/bitwarden-core/src/key_management/wasm_unlock_state.rs
+++ b/crates/bitwarden-core/src/key_management/wasm_unlock_state.rs
@@ -14,10 +14,6 @@ use crate::{
     key_management::{self, SymmetricKeySlotId},
 };
 
-// The repository pattern requires us to specify a key. Here we use an empty string as the only
-// key for this repository map.
-const USER_KEY_REPOSITORY_KEY: &str = "";
-
 /// Error indicating inability to set the user key into state
 pub(crate) struct UnableToSetError;
 /// Sets the decrypted user key into the client-managed state, so that it survives re-creation of
@@ -36,17 +32,14 @@ pub(crate) async fn copy_user_key_to_client_managed_state(
             .clone()
     };
 
-    if let Ok(user_key_repository) = client
+    if let Ok(user_key_value) = client
         .platform()
         .state()
-        .get::<key_management::UserKeyState>()
+        .get_value::<key_management::UserKeyState>()
     {
         // We do not want to set the user-key if it is already set as that may trigger an observable
         // loop in the client side which subscribes to the state
-        if let Ok(Some(existing_key)) = user_key_repository
-            .get(USER_KEY_REPOSITORY_KEY.to_string())
-            .await
-        {
+        if let Ok(Some(existing_key)) = user_key_value.get().await {
             if SymmetricCryptoKey::try_from(existing_key.decrypted_user_key)
                 .map_err(|_| UnableToSetError)?
                 == user_key
@@ -60,25 +53,22 @@ pub(crate) async fn copy_user_key_to_client_managed_state(
             info!("No user-key in client managed state, setting it");
         }
     } else {
-        // UserKeyState repository does not exist, older clients should
+        // UserKeyState value does not exist, older clients should
         // just return gracefully.
-        info!("No UserKeyState repository exists in client managed state, exiting gracefully");
+        info!("No UserKeyState value exists in client managed state, exiting gracefully");
         return Ok(());
     }
 
     info!("Setting the user-key to client managed-state from SDK");
-    // Set the user-key into the state repository.
+    // Set the user-key into the state value.
     client
         .platform()
         .state()
-        .get::<key_management::UserKeyState>()
+        .get_value::<key_management::UserKeyState>()
         .map_err(|_| UnableToSetError)?
-        .set(
-            USER_KEY_REPOSITORY_KEY.to_string(),
-            key_management::UserKeyState {
-                decrypted_user_key: user_key.to_base64(),
-            },
-        )
+        .set(key_management::UserKeyState {
+            decrypted_user_key: user_key.to_base64(),
+        })
         .await
         .map_err(|_| UnableToSetError)
 }
@@ -88,13 +78,13 @@ pub(crate) async fn get_user_key_from_client_managed_state(
     client: &Client,
 ) -> Result<SymmetricCryptoKey, UnableToGetError> {
     info!("Getting the user-key from client managed-state in SDK");
-    // Get the user-key from the state repository.
+    // Get the user-key from the state value.
     let user_key_state = client
         .platform()
         .state()
-        .get::<key_management::UserKeyState>()
+        .get_value::<key_management::UserKeyState>()
         .map_err(|_| UnableToGetError)?
-        .get(USER_KEY_REPOSITORY_KEY.to_string())
+        .get()
         .await
         .map_err(|_| UnableToGetError)?
         .ok_or(UnableToGetError)?;

--- a/crates/bitwarden-core/src/platform/state_client.rs
+++ b/crates/bitwarden-core/src/platform/state_client.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use bitwarden_state::{
-    DatabaseConfiguration, Key, Setting, SettingItem, SettingsError,
+    DatabaseConfiguration, Key, Setting, SettingItem, SettingsError, Value, ValueItem,
     registry::StateRegistryError,
     repository::{Repository, RepositoryItem, RepositoryMigrations},
 };
@@ -77,5 +77,24 @@ impl StateClient {
     pub fn setting<T>(&self, key: Key<T>) -> Result<Setting<T>, SettingsError> {
         let repository = self.client.internal.state_registry.get::<SettingItem>()?;
         Ok(Setting::new(repository, key))
+    }
+
+    /// Register a client-managed single-value state store for a specific type.
+    pub fn register_client_managed_value<T: 'static + Value<V>, V: ValueItem>(
+        &self,
+        store: Arc<T>,
+    ) {
+        self.client
+            .internal
+            .state_registry
+            .register_client_managed_value(store)
+    }
+
+    /// Retrieve a client-managed single-value state store for a specific type.
+    ///
+    /// # Errors
+    /// Returns `StateRegistryError::ValueNotRegistered` if no store has been registered for `V`.
+    pub fn get_value<V: ValueItem>(&self) -> Result<Arc<dyn Value<V>>, StateRegistryError> {
+        self.client.internal.state_registry.get_value()
     }
 }

--- a/crates/bitwarden-core/tests/register.rs
+++ b/crates/bitwarden-core/tests/register.rs
@@ -1,7 +1,7 @@
 //! Integration tests for the registration process
 
 use bitwarden_core::key_management::LocalUserDataKeyState;
-use bitwarden_test::MemoryRepository;
+use bitwarden_test::{MemoryRepository, MemoryValue};
 
 /// Integration test for registering a new user and unlocking the vault
 #[cfg(feature = "internal")]
@@ -21,11 +21,11 @@ async fn test_register_initialize_crypto() {
 
     let client = Client::new(None);
 
-    let user_key_repository = MemoryRepository::<UserKeyState>::default();
+    let user_key_value = MemoryValue::<UserKeyState>::default();
     client
         .platform()
         .state()
-        .register_client_managed(std::sync::Arc::new(user_key_repository));
+        .register_client_managed_value(std::sync::Arc::new(user_key_value));
 
     client
         .platform()
@@ -37,7 +37,7 @@ async fn test_register_initialize_crypto() {
     client
         .platform()
         .state()
-        .register_client_managed(std::sync::Arc::new(MemoryRepository::<
+        .register_client_managed_value(std::sync::Arc::new(MemoryValue::<
             EphemeralPinEnvelopeState,
         >::default()));
 

--- a/crates/bitwarden-pm/src/migrations.rs
+++ b/crates/bitwarden-pm/src/migrations.rs
@@ -1,8 +1,6 @@
 //! Manages repository migrations for the Bitwarden SDK.
 
-use bitwarden_core::{
-    client::persisted_state::OrganizationSharedKey, key_management::UserKeyState,
-};
+use bitwarden_core::client::persisted_state::OrganizationSharedKey;
 use bitwarden_state::{
     SettingItem,
     repository::{RepositoryItem, RepositoryMigrationStep, RepositoryMigrations},
@@ -17,7 +15,6 @@ pub fn get_sdk_managed_migrations() -> RepositoryMigrations {
         // requires a separate migration step using `Remove(...)`.
         Add(Cipher::data()),
         Add(Folder::data()),
-        Add(UserKeyState::data()),
         Add(SettingItem::data()),
         Add(OrganizationSharedKey::data()),
     ])
@@ -36,10 +33,25 @@ macro_rules! create_client_managed_repositories {
             // <fully qualified path to the item>, <item type idenfier>, <field name>, <name of the repository implementation>
             ::bitwarden_vault::Cipher, Cipher, cipher, CipherRepository;
             ::bitwarden_vault::Folder, Folder, folder, FolderRepository;
-            ::bitwarden_core::key_management::UserKeyState, UserKeyState, user_key_state, UserKeyStateRepository;
             ::bitwarden_core::key_management::LocalUserDataKeyState, LocalUserDataKeyState, local_user_data_key_state, LocalUserDataKeyStateRepository;
-            ::bitwarden_core::key_management::EphemeralPinEnvelopeState, EphemeralPinEnvelopeState, ephemeral_pin_envelope_state, EphemeralPinEnvelopeStateRepository;
             ::bitwarden_core::client::persisted_state::OrganizationSharedKey, OrganizationSharedKey, organization_shared_key, OrganizationSharedKeyRepository;
+        }
+    };
+}
+
+/// Macro to create the client managed single-value state items for the SDK.
+/// To add a new value, add it to the list in the macro invocation.
+/// This is meant to be used by the final application crates (e.g., bitwarden-uniffi,
+/// bitwarden-wasm-internal, bw).
+#[macro_export]
+macro_rules! create_client_managed_values {
+    ($container_name:ident, $macro:ident) => {
+        $macro! {
+            $container_name;
+            // List any client-managed values here. The format is:
+            // <fully qualified path to the item>, <item type idenfier>, <field name>, <name of the value implementation>
+            ::bitwarden_core::key_management::UserKeyState, UserKeyState, user_key_state, UserKeyStateValue;
+            ::bitwarden_core::key_management::EphemeralPinEnvelopeState, EphemeralPinEnvelopeState, ephemeral_pin_envelope_state, EphemeralPinEnvelopeStateValue;
         }
     };
 }

--- a/crates/bitwarden-state/README.md
+++ b/crates/bitwarden-state/README.md
@@ -245,3 +245,37 @@ async fn example(client: &TestClient) -> Result<(), Box<dyn std::error::Error>> 
 The `Key<T>` type associates a string key name with a value type at compile time, preventing type
 mismatches while maintaining ergonomic usage. The `Setting<T>` handle provides async methods to get,
 update, and delete the setting value.
+
+## Values
+
+For state that is naturally a single value per type (e.g. a session snapshot, feature-flag blob, or
+current-user profile), this crate exposes a [`Value<V>`](crate::value::Value) trait alongside
+`Repository<V>`. Unlike `Repository`, `Value` has no keys and no bulk/list semantics — just `get`,
+`set`, and `remove` for one value.
+
+Values are currently **client-managed only**: the application provides a `Value<V>` implementation
+that the SDK passes through to.
+
+```rust,ignore
+use std::sync::Arc;
+use bitwarden_state::{register_value_item, Value};
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize)]
+struct Session {
+    user: String,
+}
+
+// Register the type once, in the crate that defines it.
+register_value_item!(Session, "Session");
+
+// Application supplies an impl of `Value<Session>` and registers it:
+// client.platform().state().register_client_managed_value(my_session_store);
+
+// SDK-side code retrieves it by type:
+async fn example(client: &bitwarden_core::Client) -> Result<(), Box<dyn std::error::Error>> {
+    let session: Arc<dyn Value<Session>> = client.platform().state().get_value::<Session>()?;
+    let current: Option<Session> = session.get().await?;
+    Ok(())
+}
+```

--- a/crates/bitwarden-state/src/lib.rs
+++ b/crates/bitwarden-state/src/lib.rs
@@ -12,7 +12,11 @@ pub mod registry;
 /// Type-safe settings repository for storing application configuration and state.
 pub mod settings;
 
+/// Single-value state items registered and retrieved by type.
+pub mod value;
+
 pub(crate) mod sdk_managed;
 
 pub use sdk_managed::DatabaseConfiguration;
 pub use settings::{Key, Setting, SettingItem, SettingsError};
+pub use value::{Value, ValueItem};

--- a/crates/bitwarden-state/src/registry.rs
+++ b/crates/bitwarden-state/src/registry.rs
@@ -11,6 +11,7 @@ use crate::{
     repository::{Repository, RepositoryItem, RepositoryItemData, RepositoryMigrations},
     sdk_managed::{Database, DatabaseConfiguration, MemoryDatabase, SystemDatabase},
     settings::{Key, Setting, SettingItem},
+    value::{Value, ValueItem},
 };
 
 /// A registry that contains repositories for different types of items.
@@ -18,6 +19,7 @@ use crate::{
 pub struct StateRegistry {
     sdk_managed: RwLock<Vec<RepositoryItemData>>,
     client_managed: RwLock<HashMap<TypeId, Box<dyn Any + Send + Sync>>>,
+    client_managed_values: RwLock<HashMap<TypeId, Box<dyn Any + Send + Sync>>>,
 
     database: OnceLock<SystemDatabase>,
 }
@@ -36,6 +38,8 @@ pub enum StateRegistryError {
     DatabaseAlreadyInitialized,
     #[error("Database is not initialized")]
     DatabaseNotInitialized,
+    #[error("Value is not registered")]
+    ValueNotRegistered,
 
     #[error(transparent)]
     Database(#[from] crate::sdk_managed::DatabaseError),
@@ -47,6 +51,7 @@ impl StateRegistry {
     pub fn new() -> Self {
         StateRegistry {
             client_managed: RwLock::new(HashMap::new()),
+            client_managed_values: RwLock::new(HashMap::new()),
             database: OnceLock::new(),
             sdk_managed: RwLock::new(Vec::new()),
         }
@@ -150,6 +155,28 @@ impl StateRegistry {
         }
 
         self.get_sdk_managed::<T>()
+    }
+
+    /// Registers a client-managed single-value store, associating it with its type.
+    pub fn register_client_managed_value<T: ValueItem>(&self, value: Arc<dyn Value<T>>) {
+        self.client_managed_values
+            .write()
+            .expect("RwLock should not be poisoned")
+            .insert(TypeId::of::<T>(), Box::new(value));
+    }
+
+    /// Retrieves a client-managed single-value store for the given type.
+    ///
+    /// # Errors
+    /// Returns `StateRegistryError::ValueNotRegistered` if no store has been registered for `T`.
+    pub fn get_value<T: ValueItem>(&self) -> Result<Arc<dyn Value<T>>, StateRegistryError> {
+        self.client_managed_values
+            .read()
+            .expect("RwLock should not be poisoned")
+            .get(&TypeId::of::<T>())
+            .and_then(|boxed| boxed.downcast_ref::<Arc<dyn Value<T>>>())
+            .map(Arc::clone)
+            .ok_or(StateRegistryError::ValueNotRegistered)
     }
 }
 

--- a/crates/bitwarden-state/src/value.rs
+++ b/crates/bitwarden-state/src/value.rs
@@ -1,0 +1,165 @@
+use std::any::TypeId;
+
+use serde::{Serialize, de::DeserializeOwned};
+
+use crate::repository::RepositoryError;
+
+/// This trait represents a single-value store: one value per type, with no key.
+///
+/// Use [`Value`] when state is naturally a singleton (e.g. a session snapshot,
+/// a feature-flag blob, or a current-user profile), rather than a keyed collection.
+/// For keyed collections, use [`crate::repository::Repository`] instead.
+#[async_trait::async_trait]
+pub trait Value<V: ValueItem>: Send + Sync {
+    /// Retrieve the current value, if any has been set.
+    async fn get(&self) -> Result<Option<V>, RepositoryError>;
+    /// Store the value, replacing any previous value.
+    async fn set(&self, value: V) -> Result<(), RepositoryError>;
+    /// Remove the stored value, if present.
+    async fn remove(&self) -> Result<(), RepositoryError>;
+}
+
+/// This trait is used to mark types that can be stored as a single value.
+/// It should not be implemented manually; instead, users should
+/// use the [crate::register_value_item] macro to register their value types.
+pub trait ValueItem: Internal + Serialize + DeserializeOwned + Send + Sync + 'static {
+    /// The name of the type implementing this trait.
+    const NAME: &'static str;
+
+    /// Returns the `TypeId` of the type implementing this trait.
+    fn type_id() -> TypeId {
+        TypeId::of::<Self>()
+    }
+}
+
+/// Register a type for use as a single-value state item. The type must only be registered once
+/// in the crate where it's defined. The provided name must be unique and not be changed.
+#[macro_export]
+macro_rules! register_value_item {
+    ($ty:ty, $name:literal) => {
+        const _: () = {
+            impl $crate::value::___internal::Internal for $ty {}
+            impl $crate::value::ValueItem for $ty {
+                const NAME: &'static str = $name;
+            }
+            assert!(
+                $crate::repository::validate_registry_name($name),
+                concat!(
+                    "Value name '",
+                    $name,
+                    "' must contain only alphabetic characters and underscores"
+                )
+            )
+        };
+    };
+}
+
+/// This code is not meant to be used directly, users of this crate should use the
+/// [crate::register_value_item] macro to register their types.
+#[doc(hidden)]
+pub mod ___internal {
+
+    // This trait is in an internal module to try to forbid users from implementing `ValueItem`
+    // directly.
+    pub trait Internal {}
+}
+pub(crate) use ___internal::Internal;
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{Arc, Mutex};
+
+    use serde::{Deserialize, Serialize};
+
+    use super::*;
+    use crate::registry::StateRegistry;
+
+    #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+    struct Session {
+        user: String,
+    }
+
+    #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+    struct Flags {
+        enabled: bool,
+    }
+
+    register_value_item!(Session, "Session");
+    register_value_item!(Flags, "Flags");
+
+    struct InMemoryValue<T: ValueItem + Clone>(Mutex<Option<T>>);
+
+    #[async_trait::async_trait]
+    impl<T: ValueItem + Clone> Value<T> for InMemoryValue<T> {
+        async fn get(&self) -> Result<Option<T>, RepositoryError> {
+            Ok(self.0.lock().unwrap().clone())
+        }
+        async fn set(&self, value: T) -> Result<(), RepositoryError> {
+            *self.0.lock().unwrap() = Some(value);
+            Ok(())
+        }
+        async fn remove(&self) -> Result<(), RepositoryError> {
+            *self.0.lock().unwrap() = None;
+            Ok(())
+        }
+    }
+
+    #[tokio::test]
+    async fn register_and_get_value() {
+        let registry = StateRegistry::new();
+        let store: Arc<dyn Value<Session>> = Arc::new(InMemoryValue::<Session>(Mutex::new(None)));
+        registry.register_client_managed_value(store);
+
+        let handle = registry.get_value::<Session>().unwrap();
+        assert_eq!(handle.get().await.unwrap(), None);
+
+        handle
+            .set(Session {
+                user: "alice".into(),
+            })
+            .await
+            .unwrap();
+        assert_eq!(
+            handle.get().await.unwrap(),
+            Some(Session {
+                user: "alice".into()
+            })
+        );
+
+        handle.remove().await.unwrap();
+        assert_eq!(handle.get().await.unwrap(), None);
+    }
+
+    #[tokio::test]
+    async fn missing_value_returns_error() {
+        let registry = StateRegistry::new();
+        let result = registry.get_value::<Session>();
+        assert!(matches!(
+            result,
+            Err(crate::registry::StateRegistryError::ValueNotRegistered)
+        ));
+    }
+
+    #[tokio::test]
+    async fn different_value_types_are_isolated() {
+        let registry = StateRegistry::new();
+        registry.register_client_managed_value::<Session>(Arc::new(InMemoryValue::<Session>(
+            Mutex::new(None),
+        )));
+        registry.register_client_managed_value::<Flags>(Arc::new(InMemoryValue::<Flags>(
+            Mutex::new(None),
+        )));
+
+        let session = registry.get_value::<Session>().unwrap();
+        let flags = registry.get_value::<Flags>().unwrap();
+
+        session.set(Session { user: "bob".into() }).await.unwrap();
+        flags.set(Flags { enabled: true }).await.unwrap();
+
+        assert_eq!(
+            session.get().await.unwrap(),
+            Some(Session { user: "bob".into() })
+        );
+        assert_eq!(flags.get().await.unwrap(), Some(Flags { enabled: true }));
+    }
+}

--- a/crates/bitwarden-test/src/lib.rs
+++ b/crates/bitwarden-test/src/lib.rs
@@ -6,4 +6,7 @@ pub use api::*;
 mod repository;
 pub use repository::*;
 
+mod value;
+pub use value::*;
+
 pub mod play;

--- a/crates/bitwarden-test/src/value.rs
+++ b/crates/bitwarden-test/src/value.rs
@@ -1,0 +1,49 @@
+use bitwarden_state::{
+    repository::RepositoryError,
+    value::{Value, ValueItem},
+};
+
+/// A simple in-memory single-value store. The data is only stored in memory and will not
+/// persist beyond the lifetime of the instance.
+///
+/// Primary use case is for unit and integration tests.
+pub struct MemoryValue<V: ValueItem> {
+    store: std::sync::Mutex<Option<V>>,
+}
+
+impl<V: ValueItem + Clone> Default for MemoryValue<V> {
+    fn default() -> Self {
+        Self {
+            store: std::sync::Mutex::new(None),
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl<V: ValueItem + Clone> Value<V> for MemoryValue<V> {
+    async fn get(&self) -> Result<Option<V>, RepositoryError> {
+        let store = self
+            .store
+            .lock()
+            .map_err(|e| RepositoryError::Internal(e.to_string()))?;
+        Ok(store.clone())
+    }
+
+    async fn set(&self, value: V) -> Result<(), RepositoryError> {
+        let mut store = self
+            .store
+            .lock()
+            .map_err(|e| RepositoryError::Internal(e.to_string()))?;
+        *store = Some(value);
+        Ok(())
+    }
+
+    async fn remove(&self) -> Result<(), RepositoryError> {
+        let mut store = self
+            .store
+            .lock()
+            .map_err(|e| RepositoryError::Internal(e.to_string()))?;
+        *store = None;
+        Ok(())
+    }
+}

--- a/crates/bitwarden-uniffi/src/platform/mod.rs
+++ b/crates/bitwarden-uniffi/src/platform/mod.rs
@@ -5,12 +5,14 @@ use std::sync::Arc;
 use bitwarden_core::{Client, platform::FingerprintRequest};
 use bitwarden_fido::ClientFido2Ext;
 use repository::{UniffiRepositoryBridge, create_uniffi_repositories};
+use value::create_uniffi_values;
 
 use crate::error::Result;
 
 mod fido2;
 mod repository;
 mod server_communication_config;
+mod value;
 
 // Re-export ServerCommunicationConfig types for UniFFI bindings
 pub use bitwarden_server_communication_config::{
@@ -66,6 +68,7 @@ impl PlatformClient {
 pub struct StateClient(Client);
 
 bitwarden_pm::create_client_managed_repositories!(Repositories, create_uniffi_repositories);
+bitwarden_pm::create_client_managed_values!(Values, create_uniffi_values);
 
 #[uniffi::export]
 impl StateClient {
@@ -77,5 +80,9 @@ impl StateClient {
 
     pub fn register_client_managed_repositories(&self, repositories: Repositories) {
         repositories.register_all(&self.0.platform().state());
+    }
+
+    pub fn register_client_managed_values(&self, values: Values) {
+        values.register_all(&self.0.platform().state());
     }
 }

--- a/crates/bitwarden-uniffi/src/platform/value.rs
+++ b/crates/bitwarden-uniffi/src/platform/value.rs
@@ -1,0 +1,81 @@
+use std::sync::Arc;
+
+pub struct UniffiValueBridge<T>(pub T);
+
+impl<T: ?Sized> UniffiValueBridge<Arc<T>> {
+    pub fn new(store: Arc<T>) -> Arc<Self> {
+        Arc::new(UniffiValueBridge(store))
+    }
+}
+
+impl<T: std::fmt::Debug> std::fmt::Debug for UniffiValueBridge<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+/// This macro creates a Uniffi value trait and its implementation for the
+/// [bitwarden_state::value::Value] trait
+macro_rules! create_uniffi_values {
+    ( $container_name:ident ; $( $qualified_type_name:ty, $type_name:ident, $field_name:ident, $value_name:ident );+ $(;)? ) => {
+
+        #[derive(::uniffi::Record)]
+        pub struct $container_name {
+            $(
+                pub $field_name: Option<::std::sync::Arc<dyn $value_name>>,
+            )+
+        }
+
+        impl $container_name {
+            pub fn register_all(self, client: &bitwarden_core::platform::StateClient) {
+                $(
+                    if let Some(value) = self.$field_name {
+                        let bridge = $crate::platform::value::UniffiValueBridge::new(value);
+                        client.register_client_managed_value(bridge);
+                    }
+                )+
+            }
+        }
+
+        $(
+            #[::uniffi::export(with_foreign)]
+            #[::async_trait::async_trait]
+            pub trait $value_name: Send + Sync {
+                async fn get(
+                    &self,
+                ) -> Result<Option<$qualified_type_name>, $crate::platform::repository::RepositoryError>;
+                async fn set(
+                    &self,
+                    value: $qualified_type_name,
+                ) -> Result<(), $crate::platform::repository::RepositoryError>;
+                async fn remove(
+                    &self,
+                ) -> Result<(), $crate::platform::repository::RepositoryError>;
+            }
+
+            #[async_trait::async_trait]
+            impl bitwarden_state::value::Value<$qualified_type_name>
+                for $crate::platform::value::UniffiValueBridge<Arc<dyn $value_name>>
+            {
+                async fn get(
+                    &self,
+                ) -> Result<Option<$qualified_type_name>, bitwarden_state::repository::RepositoryError> {
+                    self.0.get().await.map_err(Into::into)
+                }
+                async fn set(
+                    &self,
+                    value: $qualified_type_name,
+                ) -> Result<(), bitwarden_state::repository::RepositoryError> {
+                    self.0.set(value).await.map_err(Into::into)
+                }
+                async fn remove(
+                    &self,
+                ) -> Result<(), bitwarden_state::repository::RepositoryError> {
+                    self.0.remove().await.map_err(Into::into)
+                }
+            }
+        )+
+    };
+}
+
+pub(super) use create_uniffi_values;

--- a/crates/bitwarden-wasm-internal/src/platform/mod.rs
+++ b/crates/bitwarden-wasm-internal/src/platform/mod.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 use tsify::Tsify;
 use wasm_bindgen::{JsValue, prelude::wasm_bindgen};
 
-use crate::platform::repository::create_wasm_repositories;
+use crate::platform::repository::{create_wasm_repositories, create_wasm_values};
 
 mod repository;
 pub mod token_provider;
@@ -49,6 +49,7 @@ impl StateClient {
 }
 
 bitwarden_pm::create_client_managed_repositories!(Repositories, create_wasm_repositories);
+bitwarden_pm::create_client_managed_values!(Values, create_wasm_values);
 
 #[wasm_bindgen]
 impl StateClient {
@@ -68,5 +69,9 @@ impl StateClient {
 
     pub fn register_client_managed_repositories(&self, repositories: Repositories) {
         repositories.register_all(&self.0.platform().state());
+    }
+
+    pub fn register_client_managed_values(&self, values: Values) {
+        values.register_all(&self.0.platform().state());
     }
 }

--- a/crates/bitwarden-wasm-internal/src/platform/repository.rs
+++ b/crates/bitwarden-wasm-internal/src/platform/repository.rs
@@ -35,7 +35,10 @@
 
 use std::{future::Future, marker::PhantomData, rc::Rc};
 
-use bitwarden_state::repository::{Repository, RepositoryError, RepositoryItem};
+use bitwarden_state::{
+    repository::{Repository, RepositoryError, RepositoryItem},
+    value::{Value, ValueItem},
+};
 use bitwarden_threading::ThreadBoundRunner;
 use wasm_bindgen::{JsValue, prelude::wasm_bindgen};
 
@@ -52,6 +55,15 @@ pub(crate) trait WasmRepository<T> {
     async fn remove_all(&self) -> Result<JsValue, JsValue>;
 }
 
+/// This trait defines the methods that a [::wasm_bindgen] value must implement.
+/// The trait itself exists to provide a generic way of handling the [::wasm_bindgen] interface,
+/// which is !Send + !Sync, and only deals with [JsValue].
+pub(crate) trait WasmValue<T> {
+    async fn get(&self) -> Result<JsValue, JsValue>;
+    async fn set(&self, value: T) -> Result<JsValue, JsValue>;
+    async fn remove(&self) -> Result<JsValue, JsValue>;
+}
+
 /// This struct wraps a [WasmRepository] in a [ThreadBoundRunner] to allow it to be used as a
 /// [Repository] in a thread-safe manner. It implements the [Repository] trait directly, by
 /// converting the values as needed with [tsify::serde_wasm_bindgen].
@@ -60,9 +72,20 @@ pub(crate) struct WasmRepositoryChannel<T, R: WasmRepository<T> + 'static>(
     PhantomData<T>,
 );
 
+/// This struct wraps a [WasmValue] in a [ThreadBoundRunner] to allow it to be used as a
+/// [Value] in a thread-safe manner. It implements the [Value] trait directly, by converting
+/// the values as needed with [tsify::serde_wasm_bindgen].
+pub(crate) struct WasmValueChannel<T, V: WasmValue<T> + 'static>(ThreadBoundRunner<V>, PhantomData<T>);
+
 impl<T, R: WasmRepository<T> + 'static> WasmRepositoryChannel<T, R> {
     pub(crate) fn new(repository: R) -> Self {
         Self(ThreadBoundRunner::new(repository), PhantomData)
+    }
+}
+
+impl<T, V: WasmValue<T> + 'static> WasmValueChannel<T, V> {
+    pub(crate) fn new(value: V) -> Self {
+        Self(ThreadBoundRunner::new(value), PhantomData)
     }
 }
 
@@ -113,6 +136,19 @@ impl<T: RepositoryItem, R: WasmRepository<T> + 'static> Repository<T>
     }
 }
 
+#[async_trait::async_trait]
+impl<T: ValueItem, V: WasmValue<T> + 'static> Value<T> for WasmValueChannel<T, V> {
+    async fn get(&self) -> Result<Option<T>, RepositoryError> {
+        run_convert(&self.0, |s| async move { s.get().await }).await
+    }
+    async fn set(&self, value: T) -> Result<(), RepositoryError> {
+        run_convert(&self.0, |s| async move { s.set(value).await.and(UNIT) }).await
+    }
+    async fn remove(&self) -> Result<(), RepositoryError> {
+        run_convert(&self.0, |s| async move { s.remove().await.and(UNIT) }).await
+    }
+}
+
 #[wasm_bindgen(typescript_custom_section)]
 const REPOSITORY_CUSTOM_TS_TYPE: &'static str = r#"
 export interface Repository<T> {
@@ -123,6 +159,15 @@ export interface Repository<T> {
     remove(id: string): Promise<void>;
     removeBulk(keys: string[]): Promise<void>;
     removeAll(): Promise<void>;
+}
+"#;
+
+#[wasm_bindgen(typescript_custom_section)]
+const VALUE_CUSTOM_TS_TYPE: &'static str = r#"
+export interface Value<T> {
+    get(): Promise<T | null>;
+    set(value: T): Promise<void>;
+    remove(): Promise<void>;
 }
 "#;
 
@@ -262,6 +307,95 @@ macro_rules! create_wasm_repositories {
     };
 }
 pub(crate) use create_wasm_repositories;
+
+/// This macro generates a [::wasm_bindgen] interface for a value type, and provides the
+/// implementation of [WasmValue] and a way to convert it into something that implements
+/// the [Value] trait.
+macro_rules! create_wasm_values {
+    ( $container_name:ident ; $( $qualified_type_name:ty, $type_name:ident, $field_name:ident, $value_name:ident );+ $(;)? ) => {
+
+        const _: () = {
+            #[wasm_bindgen(typescript_custom_section)]
+            const VALUES_CUSTOM_TS_TYPE: &'static str = concat!(
+                "export interface ",
+                stringify!($container_name),
+                "{\n",
+                $( stringify!($field_name), ": Value<", stringify!($type_name), "> | null;\n", )+
+                "}\n"
+            );
+        };
+
+        #[wasm_bindgen]
+        extern "C" {
+            #[wasm_bindgen(typescript_type = $container_name)]
+            pub type $container_name;
+
+            $(
+                #[wasm_bindgen(method, getter)]
+                pub fn $field_name(this: &$container_name) -> Option<$value_name>;
+            )+
+        }
+
+        impl $container_name {
+            pub fn register_all(self, client: &bitwarden_core::platform::StateClient) {
+                $(
+                    if let Some(value) = self.$field_name() {
+                        let value = value.into_channel_impl();
+                        client.register_client_managed_value(value);
+                    }
+                )+
+            }
+        }
+
+        $(
+            #[wasm_bindgen]
+            extern "C" {
+                #[wasm_bindgen]
+                pub type $value_name;
+
+                #[wasm_bindgen(method, catch)]
+                async fn get(this: &$value_name)
+                    -> Result<::wasm_bindgen::JsValue, ::wasm_bindgen::JsValue>;
+                #[wasm_bindgen(method, catch)]
+                async fn set(
+                    this: &$value_name,
+                    value: $qualified_type_name,
+                ) -> Result<::wasm_bindgen::JsValue, ::wasm_bindgen::JsValue>;
+                #[wasm_bindgen(method, catch)]
+                async fn remove(
+                    this: &$value_name,
+                ) -> Result<::wasm_bindgen::JsValue, ::wasm_bindgen::JsValue>;
+            }
+
+            impl $crate::platform::repository::WasmValue<$qualified_type_name> for $value_name {
+                async fn get(&self) -> Result<::wasm_bindgen::JsValue, ::wasm_bindgen::JsValue> {
+                    self.get().await
+                }
+                async fn set(
+                    &self,
+                    value: $qualified_type_name,
+                ) -> Result<::wasm_bindgen::JsValue, ::wasm_bindgen::JsValue> {
+                    self.set(value).await
+                }
+                async fn remove(
+                    &self,
+                ) -> Result<::wasm_bindgen::JsValue, ::wasm_bindgen::JsValue> {
+                    self.remove().await
+                }
+            }
+
+            impl $value_name {
+                pub fn into_channel_impl(
+                    self,
+                ) -> ::std::sync::Arc<impl bitwarden_state::value::Value<$qualified_type_name>> {
+                    use $crate::platform::repository::WasmValueChannel;
+                    ::std::sync::Arc::new(WasmValueChannel::new(self))
+                }
+            }
+        )+
+    };
+}
+pub(crate) use create_wasm_values;
 
 const UNIT: Result<JsValue, JsValue> = Ok(JsValue::UNDEFINED);
 


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Currently, the bitwarden-state crate only allows client-managed state via repositories. This works for sets of data, like ciphers, collections, folders. This does not work for single-data such as the user-key, or pin ephemeral state. This PR introduces a second type of client managed state - Value state - which just directly takes the value instead of wrapping it into a key-value store.

This de-risks and speeds up migrations for existing state.

## 🚨 Breaking Changes

<!-- Does this PR introduce any breaking changes? If so, please describe the impact and migration path for clients.

If you're unsure, the automated TypeScript compatibility check will run when you open/update this PR and provide feedback.

For breaking changes:
1. Describe what changed in the client interface
2. Explain why the change was necessary
3. Provide migration steps for client developers
4. Link to any paired client PRs if needed

Otherwise, you can remove this section. -->
