### PR TITLE
[PM-32583] Add global HostPlatformInfo with OnceLock init

### DIFF
--- a/crates/bitwarden-core/src/client/client_settings.rs
+++ b/crates/bitwarden-core/src/client/client_settings.rs
@@ -1,4 +1,4 @@
-use std::fmt;
+use std::{fmt, sync::OnceLock};
 
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -158,5 +158,78 @@ impl fmt::Display for ClientName {
             ClientName::Cli => "cli",
         };
         write!(f, "{}", s)
+    }
+}
+
+/// Process-wide, application-provided platform information.
+///
+/// Initialize exactly once at application startup via [`init_host_platform_info`];
+/// read via [`get_host_platform_info`]. Subsequent `init` calls are ignored.
+#[derive(Debug, Clone)]
+pub struct HostPlatformInfo {
+    pub user_agent: String,
+    pub device_type: DeviceType,
+    pub device_identifier: Option<String>,
+    pub bitwarden_client_version: Option<String>,
+    pub bitwarden_package_type: Option<String>,
+}
+
+static HOST_PLATFORM_INFO: OnceLock<HostPlatformInfo> = OnceLock::new();
+
+/// Initialize the global [`HostPlatformInfo`].
+///
+/// Should be called once during application startup, before any
+/// `Client::load_from_state` calls. Subsequent calls are silently ignored.
+pub fn init_host_platform_info(info: HostPlatformInfo) {
+    let _ = HOST_PLATFORM_INFO.set(info);
+}
+
+/// Returns the globally-initialized [`HostPlatformInfo`].
+///
+/// # Panics
+/// Panics if [`init_host_platform_info`] has not yet been called.
+pub fn get_host_platform_info() -> &'static HostPlatformInfo {
+    HOST_PLATFORM_INFO
+        .get()
+        .expect("host platform info to be initialized")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // `OnceLock` is process-global, so a single sequential test covers the
+    // not-set, happy-path, and already-set cases without cross-test leakage.
+    #[test]
+    fn init_then_get_preserves_first_value() {
+        // Not-set case: `get` must panic before any `init` call.
+        let prev_hook = std::panic::take_hook();
+        std::panic::set_hook(Box::new(|_| {}));
+        let not_set = std::panic::catch_unwind(get_host_platform_info);
+        std::panic::set_hook(prev_hook);
+        assert!(not_set.is_err(), "expected panic before init");
+
+        let first = HostPlatformInfo {
+            user_agent: "first".into(),
+            device_type: DeviceType::SDK,
+            device_identifier: Some("dev-1".into()),
+            bitwarden_client_version: Some("1.0.0".into()),
+            bitwarden_package_type: Some("test".into()),
+        };
+        init_host_platform_info(first.clone());
+
+        let got = get_host_platform_info();
+        assert_eq!(got.user_agent, first.user_agent);
+        assert_eq!(got.device_type, first.device_type);
+        assert_eq!(got.device_identifier, first.device_identifier);
+
+        let second = HostPlatformInfo {
+            user_agent: "second".into(),
+            ..first.clone()
+        };
+        init_host_platform_info(second);
+
+        let after = get_host_platform_info();
+        assert_eq!(after.user_agent, first.user_agent);
     }
 }

--- a/crates/bitwarden-core/src/client/mod.rs
+++ b/crates/bitwarden-core/src/client/mod.rs
@@ -24,7 +24,10 @@ pub mod persisted_state;
 
 pub use builder::ClientBuilder;
 pub use client::Client;
-pub use client_settings::{ClientName, ClientSettings, DeviceType};
+pub use client_settings::{
+    ClientName, ClientSettings, DeviceType, HostPlatformInfo, get_host_platform_info,
+    init_host_platform_info,
+};
 
 #[allow(missing_docs)]
 #[cfg(feature = "internal")]

--- a/crates/bitwarden-core/src/lib.rs
+++ b/crates/bitwarden-core/src/lib.rs
@@ -24,7 +24,10 @@ pub mod secrets_manager;
 /// See [`FromClient`] for usage details.
 pub use bitwarden_core_macro::FromClient;
 pub use bitwarden_crypto::ZeroizingAllocator;
-pub use client::{Client, ClientBuilder, ClientName, ClientSettings, DeviceType, FromClient};
+pub use client::{
+    Client, ClientBuilder, ClientName, ClientSettings, DeviceType, FromClient, HostPlatformInfo,
+    get_host_platform_info, init_host_platform_info,
+};
 
 mod ids;
 pub use ids::*;


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-32583
## 📔 Objective

Prerequisite refactor for `Client::load_from_state` (PM-31879). Introduces `HostPlatformInfo` and a process-global `OnceLock` accessor pair (`init_host_platform_info` / `get_host_platform_info`) in `bitwarden-core`.

Platform information (user agent, device type, device identifier, client version, package type) does not change during the application's lifetime. Threading it through every `load_from_state` call is poor UX and inconsistent with how logging is already initialized (`init_logger` / `init_sdk`). With this change, callers initialize platform info once at startup:

```rust
init_host_platform_info(HostPlatformInfo { .. });   // once, at startup
let client = Client::load_from_state(..).await?;     // no platform arg
```

The forthcoming `load_from_state` implementation will read from the static instead of accepting a `HostPlatformInfo` / `AppSettings` parameter.

### Scope

- Adds `HostPlatformInfo` struct with the five host-side fields from the ticket spec (`user_agent`, `device_type`, `device_identifier`, `bitwarden_client_version`, `bitwarden_package_type`).
- Adds `init_host_platform_info` + `get_host_platform_info` backed by a `OnceLock` in `bitwarden-core::client::client_settings`.
- Re-init is silently ignored (`OnceLock::set(..).ok()`), mirroring `init_flight_recorder`.
- `get_*` panics with an actionable message if called before init — this is a programmer error at startup, not a recoverable runtime condition.
- Unit test covers all three cases sequentially (not-set → panic, first-init → preserved, re-init → ignored) in one `#[test]` function, since `OnceLock` state is process-global within a test binary.

### Out of scope (follow-up in PM-31879)

- `RehydrationError` in `persisted_state.rs`.
- `Client::load_from_state` / `Client::save_to_state` implementations.
- `Client::new_with_token_handler_and_state` constructor.
- Roundtrip integration tests.
- UniFFI / WASM bindings for `init_host_platform_info`.
