### PR TITLE
Zeroize ml-dsa seed on keygen

### DIFF
--- a/crates/bitwarden-crypto/src/signing/signing_key.rs
+++ b/crates/bitwarden-crypto/src/signing/signing_key.rs
@@ -87,14 +87,15 @@ impl SigningKey {
                 ))),
             },
             SignatureAlgorithm::MlDsa44 => {
-                let mut seed = [0u8; 32];
+                // This is heap allocated from the start, so will be zeroized on drop
+                let mut seed = Box::pin(Array::from([0u8; 32]));
                 rand::rng().fill_bytes(&mut seed);
-                let seed = Array::from(seed);
+
                 let kp = MlDsa44::from_seed(&seed);
                 SigningKey {
                     id: KeyId::make(),
                     inner: RawSigningKey::MlDsa44 {
-                        seed: Box::pin(seed),
+                        seed,
                         signing_key: Box::pin(kp.signing_key().clone()),
                         verifying_key: Box::new(kp.verifying_key().clone()),
                     },


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://github.com/bitwarden/sdk-internal/pull/920#discussion_r3118079418

## 📔 Objective
Move the seed into the heap so it is zeroized properly when dropped.

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

## 🚨 Breaking Changes

<!-- Does this PR introduce any breaking changes? If so, please describe the impact and migration path for clients.

If you're unsure, the automated TypeScript compatibility check will run when you open/update this PR and provide feedback.

For breaking changes:
1. Describe what changed in the client interface
2. Explain why the change was necessary
3. Provide migration steps for client developers
4. Link to any paired client PRs if needed

Otherwise, you can remove this section. -->
