### PR TITLE
[PM-32429] Introduce cipher blob encryption module

### DIFF
--- a/crates/bitwarden-core/src/key_management/mod.rs
+++ b/crates/bitwarden-core/src/key_management/mod.rs
@@ -34,7 +34,8 @@ pub use master_password::{
 mod security_state;
 #[cfg(feature = "internal")]
 pub use security_state::{
-    MINIMUM_ENFORCE_ICON_URI_HASH_VERSION, SecurityState, SignedSecurityState,
+    BLOB_SECURITY_VERSION, MINIMUM_ENFORCE_ICON_URI_HASH_VERSION, SecurityState,
+    SignedSecurityState,
 };
 #[cfg(feature = "internal")]
 mod user_decryption;

--- a/crates/bitwarden-core/src/key_management/security_state.rs
+++ b/crates/bitwarden-core/src/key_management/security_state.rs
@@ -32,6 +32,9 @@ use serde::{Deserialize, Serialize};
 /// Icon URI hashes are enforced starting with this security state version.
 pub const MINIMUM_ENFORCE_ICON_URI_HASH_VERSION: u64 = 2;
 
+/// Cipher blob encryption is enabled starting with this security state version.
+pub const BLOB_SECURITY_VERSION: u64 = 2;
+
 #[cfg(feature = "wasm")]
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_CUSTOM_TYPES: &'static str = r#"

--- a/crates/bitwarden-vault/src/cipher/blob/conversions/bank_account.rs
+++ b/crates/bitwarden-vault/src/cipher/blob/conversions/bank_account.rs
@@ -1,0 +1,62 @@
+use super::{BankAccountDataV1, BankAccountView};
+
+impl_bidirectional_from!(
+    BankAccountView,
+    BankAccountDataV1,
+    [
+        bank_name,
+        name_on_account,
+        account_type,
+        account_number,
+        routing_number,
+        branch_number,
+        pin,
+        swift_code,
+        iban,
+        bank_contact_phone,
+    ]
+);
+
+#[cfg(test)]
+mod tests {
+    use super::super::{CipherBlobV1, test_support::*};
+    use crate::cipher::{bank_account::BankAccountView, cipher::CipherType};
+
+    #[test]
+    fn test_bank_account_cipher_round_trip() {
+        let (key_store, key_id) = create_test_key_store();
+        let mut ctx = key_store.context_mut();
+
+        let original = crate::CipherView {
+            name: "My Bank Account".to_string(),
+            notes: None,
+            r#type: CipherType::BankAccount,
+            bank_account: Some(BankAccountView {
+                bank_name: Some("Test Bank".to_string()),
+                name_on_account: Some("John Doe".to_string()),
+                account_type: Some("Checking".to_string()),
+                account_number: Some("1234567890".to_string()),
+                routing_number: Some("021000021".to_string()),
+                branch_number: None,
+                pin: Some("1234".to_string()),
+                swift_code: None,
+                iban: None,
+                bank_contact_phone: None,
+            }),
+            ..create_shell_cipher_view(CipherType::BankAccount)
+        };
+
+        let blob = CipherBlobV1::from_cipher_view(&original, &mut ctx, key_id).unwrap();
+        let mut restored = create_shell_cipher_view(CipherType::BankAccount);
+        blob.apply_to_cipher_view(&mut restored, &mut ctx, key_id)
+            .unwrap();
+
+        assert_eq!(restored.name, "My Bank Account");
+        assert_eq!(restored.r#type, CipherType::BankAccount);
+        let bank_account = restored.bank_account.unwrap();
+        assert_eq!(bank_account.bank_name, Some("Test Bank".to_string()));
+        assert_eq!(bank_account.account_number, Some("1234567890".to_string()));
+        assert_eq!(bank_account.pin, Some("1234".to_string()));
+        assert!(restored.login.is_none());
+    }
+}

--- a/crates/bitwarden-vault/src/cipher/blob/conversions/mod.rs
+++ b/crates/bitwarden-vault/src/cipher/blob/conversions/mod.rs
@@ -51,7 +51,6 @@ mod secure_note;
 mod ssh_key;
 
 impl CipherBlobV1 {
-    #[allow(dead_code)]
     pub(crate) fn from_cipher_view(
         view: &CipherView,
         ctx: &mut KeyStoreContext<KeySlotIds>,
@@ -135,7 +134,6 @@ impl CipherBlobV1 {
         })
     }
 
-    #[allow(dead_code)]
     pub(crate) fn apply_to_cipher_view(
         &self,
         view: &mut CipherView,
@@ -205,7 +203,7 @@ impl CipherBlobV1 {
 }
 
 #[cfg(test)]
-mod test_support {
+pub(crate) mod test_support {
     use bitwarden_core::key_management::{
         KeySlotIds, SymmetricKeySlotId, create_test_crypto_with_user_key,
     };

--- a/crates/bitwarden-vault/src/cipher/blob/conversions/mod.rs
+++ b/crates/bitwarden-vault/src/cipher/blob/conversions/mod.rs
@@ -5,6 +5,7 @@ use super::v1::*;
 use crate::{
     CipherView, PasswordHistoryView,
     cipher::{
+        bank_account::BankAccountView,
         card::CardView,
         cipher::CipherType,
         field::FieldView,
@@ -44,6 +45,7 @@ impl_bidirectional_from!(
     [password, last_used_date,]
 );
 
+mod bank_account;
 mod card;
 mod identity;
 mod login;
@@ -115,6 +117,13 @@ impl CipherBlobV1 {
                     .ok_or(CryptoError::MissingField("ssh_key"))?;
                 CipherTypeDataV1::SshKey(SshKeyDataV1::from(ssh_key))
             }
+            CipherType::BankAccount => {
+                let bank_account = view
+                    .bank_account
+                    .as_ref()
+                    .ok_or(CryptoError::MissingField("bank_account"))?;
+                CipherTypeDataV1::BankAccount(BankAccountDataV1::from(bank_account))
+            }
         };
 
         Ok(Self {
@@ -155,6 +164,7 @@ impl CipherBlobV1 {
         view.identity = None;
         view.secure_note = None;
         view.ssh_key = None;
+        view.bank_account = None;
 
         match &self.type_data {
             CipherTypeDataV1::Login(login_data) => {
@@ -195,6 +205,10 @@ impl CipherBlobV1 {
             CipherTypeDataV1::SshKey(ssh_key_data) => {
                 view.r#type = CipherType::SshKey;
                 view.ssh_key = Some(SshKeyView::from(ssh_key_data));
+            }
+            CipherTypeDataV1::BankAccount(bank_account_data) => {
+                view.r#type = CipherType::BankAccount;
+                view.bank_account = Some(BankAccountView::from(bank_account_data));
             }
         }
 
@@ -239,6 +253,7 @@ pub(crate) mod test_support {
             card: None,
             secure_note: None,
             ssh_key: None,
+            bank_account: None,
             favorite: false,
             reprompt: CipherRepromptType::None,
             organization_use_totp: false,

--- a/crates/bitwarden-vault/src/cipher/blob/encryption.rs
+++ b/crates/bitwarden-vault/src/cipher/blob/encryption.rs
@@ -124,6 +124,7 @@ pub(crate) fn encrypt_blob_cipher(
         card: None,
         secure_note: None,
         ssh_key: None,
+        bank_account: None,
         fields: None,
         password_history: None,
     })
@@ -183,6 +184,7 @@ pub(crate) fn decrypt_blob_cipher(
         card: None,
         secure_note: None,
         ssh_key: None,
+        bank_account: None,
         fields: None,
         password_history: None,
     };
@@ -200,6 +202,7 @@ mod tests {
     use super::*;
     use crate::{
         cipher::{
+            bank_account::BankAccountView,
             blob::conversions::test_support::{create_shell_cipher_view, create_test_key_store},
             card::CardView,
             cipher::{CipherId, CipherRepromptType, CipherType},
@@ -236,6 +239,7 @@ mod tests {
             card: None,
             secure_note: None,
             ssh_key: None,
+            bank_account: None,
             favorite: false,
             reprompt: CipherRepromptType::None,
             organization_use_totp: false,
@@ -347,6 +351,7 @@ mod tests {
         assert!(cipher.identity.is_none());
         assert!(cipher.secure_note.is_none());
         assert!(cipher.ssh_key.is_none());
+        assert!(cipher.bank_account.is_none());
         assert!(cipher.notes.is_none());
         assert!(cipher.fields.is_none());
         assert!(cipher.password_history.is_none());
@@ -477,6 +482,26 @@ mod tests {
                 private_key: "private".to_string(),
                 public_key: "public".to_string(),
                 fingerprint: "fingerprint".to_string(),
+            });
+            assert!(encrypt_blob_cipher(&mut view, &mut ctx).is_ok());
+        }
+
+        // BankAccount
+        {
+            let mut ctx = key_store.context_mut();
+            let mut view = create_shell_cipher_view(CipherType::BankAccount);
+            view.name = "Bank".to_string();
+            view.bank_account = Some(BankAccountView {
+                bank_name: Some("Bank".to_string()),
+                name_on_account: None,
+                account_type: None,
+                account_number: None,
+                routing_number: None,
+                branch_number: None,
+                pin: None,
+                swift_code: None,
+                iban: None,
+                bank_contact_phone: None,
             });
             assert!(encrypt_blob_cipher(&mut view, &mut ctx).is_ok());
         }

--- a/crates/bitwarden-vault/src/cipher/blob/encryption.rs
+++ b/crates/bitwarden-vault/src/cipher/blob/encryption.rs
@@ -1,0 +1,441 @@
+use bitwarden_core::key_management::KeyIds;
+use bitwarden_crypto::{
+    CompositeEncryptable, CryptoError, IdentifyKey, KeyStoreContext, PrimitiveEncryptable,
+};
+use thiserror::Error;
+
+use super::{CipherBlob, CipherBlobLatest, SealedCipherBlob, SealedCipherBlobError};
+use crate::cipher::cipher::{Cipher, CipherView};
+
+#[derive(Debug, Error)]
+pub(crate) enum BlobEncryptionError {
+    #[error(transparent)]
+    Crypto(#[from] CryptoError),
+    #[error(transparent)]
+    SealedBlob(#[from] SealedCipherBlobError),
+    #[error("Cipher does not contain blob data")]
+    NoBlobData,
+}
+
+/// Returns `true` if the cipher's `data` field contains a valid sealed blob.
+pub(crate) fn is_blob_encrypted(cipher: &Cipher) -> bool {
+    cipher
+        .data
+        .as_ref()
+        .is_some_and(|s| SealedCipherBlob::from_opaque_string(s).is_ok())
+}
+
+/// Returns `true` if the cipher is not blob-encrypted (i.e. uses legacy field-level encryption).
+pub(crate) fn is_legacy_cipher(cipher: &Cipher) -> bool {
+    !is_blob_encrypted(cipher)
+}
+
+/// Seals a `CipherView` into an opaque blob string.
+pub(crate) fn seal_cipher(
+    view: &CipherView,
+    ctx: &mut KeyStoreContext<KeyIds>,
+) -> Result<String, BlobEncryptionError> {
+    let outer_key = view.key_identifier();
+    let cipher_key = Cipher::decrypt_cipher_key(ctx, outer_key, &view.key)?;
+
+    let blob = CipherBlobLatest::from_cipher_view(view, ctx, cipher_key)?;
+    let versioned: CipherBlob = blob.into();
+    let sealed = SealedCipherBlob::seal(versioned, &cipher_key, ctx)?;
+    Ok(sealed.to_opaque_string()?)
+}
+
+/// Unseals a cipher's blob data, returning the latest blob version.
+pub(crate) fn unseal_cipher(
+    cipher: &Cipher,
+    ctx: &mut KeyStoreContext<KeyIds>,
+) -> Result<CipherBlobLatest, BlobEncryptionError> {
+    let outer_key = cipher.key_identifier();
+    let cipher_key = Cipher::decrypt_cipher_key(ctx, outer_key, &cipher.key)?;
+
+    let data = cipher
+        .data
+        .as_ref()
+        .ok_or(BlobEncryptionError::NoBlobData)?;
+    let sealed = SealedCipherBlob::from_opaque_string(data)?;
+    let blob = sealed.unseal(&cipher_key, ctx)?;
+
+    match blob {
+        CipherBlob::CipherBlobV1(v1) => Ok(v1),
+    }
+}
+
+/// Creates a blob-encrypted `Cipher` from a `CipherView`.
+///
+/// Generates a cipher key if missing, seals the sensitive data into a single blob,
+/// and encrypts attachments and local data separately.
+pub(crate) fn create_blob_cipher(
+    view: &mut CipherView,
+    ctx: &mut KeyStoreContext<KeyIds>,
+) -> Result<Cipher, BlobEncryptionError> {
+    if view.key.is_none() {
+        view.generate_cipher_key(ctx, view.key_identifier())?;
+    }
+
+    let outer_key = view.key_identifier();
+    let cipher_key = Cipher::decrypt_cipher_key(ctx, outer_key, &view.key)?;
+
+    let sealed_string = seal_cipher(view, ctx)?;
+
+    let attachments = view.attachments.encrypt_composite(ctx, cipher_key)?;
+    let local_data = view.local_data.encrypt_composite(ctx, cipher_key)?;
+
+    // TODO: Remove this field once the server no longer requires it
+    let name = "".encrypt(ctx, cipher_key)?;
+
+    Ok(Cipher {
+        id: view.id,
+        organization_id: view.organization_id,
+        folder_id: view.folder_id,
+        collection_ids: view.collection_ids.clone(),
+        key: view.key.clone(),
+        name,
+        notes: None,
+        r#type: view.r#type,
+        login: None,
+        identity: None,
+        card: None,
+        secure_note: None,
+        ssh_key: None,
+        favorite: view.favorite,
+        reprompt: view.reprompt,
+        organization_use_totp: view.organization_use_totp,
+        edit: view.edit,
+        permissions: view.permissions,
+        view_password: view.view_password,
+        local_data,
+        attachments,
+        fields: None,
+        password_history: None,
+        creation_date: view.creation_date,
+        deleted_date: view.deleted_date,
+        revision_date: view.revision_date,
+        archived_date: view.archived_date,
+        data: Some(sealed_string),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use bitwarden_crypto::IdentifyKey;
+    use uuid::Uuid;
+
+    use super::*;
+    use crate::cipher::{
+        blob::conversions::test_support::{create_shell_cipher_view, create_test_key_store},
+        card::CardView,
+        cipher::{CipherId, CipherRepromptType, CipherType},
+        identity::IdentityView,
+        login::LoginView,
+        secure_note::{SecureNoteType, SecureNoteView},
+        ssh_key::SshKeyView,
+    };
+
+    fn make_test_cipher_with_data(
+        ctx: &mut KeyStoreContext<KeyIds>,
+        data: Option<String>,
+    ) -> Cipher {
+        let name = "test"
+            .encrypt(ctx, bitwarden_core::key_management::SymmetricKeyId::User)
+            .unwrap();
+        Cipher {
+            id: None,
+            organization_id: None,
+            folder_id: None,
+            collection_ids: vec![],
+            key: None,
+            name,
+            notes: None,
+            r#type: CipherType::SecureNote,
+            login: None,
+            identity: None,
+            card: None,
+            secure_note: None,
+            ssh_key: None,
+            favorite: false,
+            reprompt: CipherRepromptType::None,
+            organization_use_totp: false,
+            edit: true,
+            permissions: None,
+            view_password: true,
+            local_data: None,
+            attachments: None,
+            fields: None,
+            password_history: None,
+            creation_date: chrono::Utc::now(),
+            deleted_date: None,
+            revision_date: chrono::Utc::now(),
+            archived_date: None,
+            data,
+        }
+    }
+
+    #[test]
+    fn test_is_blob_encrypted_true() {
+        let (key_store, _) = create_test_key_store();
+        let mut ctx = key_store.context_mut();
+
+        let mut view = create_shell_cipher_view(CipherType::SecureNote);
+        view.name = "Blob Test".to_string();
+        view.secure_note = Some(SecureNoteView {
+            r#type: SecureNoteType::Generic,
+        });
+
+        let cipher = create_blob_cipher(&mut view, &mut ctx).unwrap();
+        assert!(is_blob_encrypted(&cipher));
+    }
+
+    #[test]
+    fn test_is_blob_encrypted_false_no_data() {
+        let (key_store, _) = create_test_key_store();
+        let mut ctx = key_store.context_mut();
+        let cipher = make_test_cipher_with_data(&mut ctx, None);
+        assert!(!is_blob_encrypted(&cipher));
+    }
+
+    #[test]
+    fn test_is_blob_encrypted_false_invalid_data() {
+        let (key_store, _) = create_test_key_store();
+        let mut ctx = key_store.context_mut();
+        let cipher = make_test_cipher_with_data(&mut ctx, Some("not a valid blob".to_string()));
+        assert!(!is_blob_encrypted(&cipher));
+    }
+
+    #[test]
+    fn test_seal_unseal_round_trip() {
+        let (key_store, _) = create_test_key_store();
+        let mut ctx = key_store.context_mut();
+
+        let mut view = create_shell_cipher_view(CipherType::SecureNote);
+        view.name = "Round Trip".to_string();
+        view.notes = Some("Some notes".to_string());
+        view.secure_note = Some(SecureNoteView {
+            r#type: SecureNoteType::Generic,
+        });
+        view.generate_cipher_key(&mut ctx, view.key_identifier())
+            .unwrap();
+
+        let sealed_string = seal_cipher(&view, &mut ctx).unwrap();
+
+        let mut cipher = make_test_cipher_with_data(&mut ctx, Some(sealed_string));
+        cipher.key = view.key.clone();
+
+        let blob = unseal_cipher(&cipher, &mut ctx).unwrap();
+        assert_eq!(blob.name, "Round Trip");
+        assert_eq!(blob.notes, Some("Some notes".to_string()));
+    }
+
+    #[test]
+    fn test_create_blob_cipher_sets_data() {
+        let (key_store, _) = create_test_key_store();
+        let mut ctx = key_store.context_mut();
+
+        let mut view = create_shell_cipher_view(CipherType::SecureNote);
+        view.name = "Has Data".to_string();
+        view.secure_note = Some(SecureNoteView {
+            r#type: SecureNoteType::Generic,
+        });
+
+        let cipher = create_blob_cipher(&mut view, &mut ctx).unwrap();
+        assert!(cipher.data.is_some());
+    }
+
+    #[test]
+    fn test_create_blob_cipher_clears_legacy_fields() {
+        let (key_store, _) = create_test_key_store();
+        let mut ctx = key_store.context_mut();
+
+        let mut view = create_shell_cipher_view(CipherType::Login);
+        view.name = "Login".to_string();
+        view.login = Some(LoginView {
+            username: Some("user".to_string()),
+            password: Some("pass".to_string()),
+            password_revision_date: None,
+            uris: None,
+            totp: None,
+            autofill_on_page_load: None,
+            fido2_credentials: None,
+        });
+
+        let cipher = create_blob_cipher(&mut view, &mut ctx).unwrap();
+        assert!(cipher.login.is_none());
+        assert!(cipher.card.is_none());
+        assert!(cipher.identity.is_none());
+        assert!(cipher.secure_note.is_none());
+        assert!(cipher.ssh_key.is_none());
+        assert!(cipher.notes.is_none());
+        assert!(cipher.fields.is_none());
+        assert!(cipher.password_history.is_none());
+    }
+
+    #[test]
+    fn test_create_blob_cipher_generates_key() {
+        let (key_store, _) = create_test_key_store();
+        let mut ctx = key_store.context_mut();
+
+        let mut view = create_shell_cipher_view(CipherType::SecureNote);
+        view.secure_note = Some(SecureNoteView {
+            r#type: SecureNoteType::Generic,
+        });
+        assert!(view.key.is_none());
+
+        let cipher = create_blob_cipher(&mut view, &mut ctx).unwrap();
+        assert!(cipher.key.is_some());
+        assert!(view.key.is_some());
+    }
+
+    #[test]
+    fn test_create_blob_cipher_preserves_metadata() {
+        let (key_store, _) = create_test_key_store();
+        let mut ctx = key_store.context_mut();
+
+        let cipher_id = CipherId::new(Uuid::new_v4());
+        let mut view = create_shell_cipher_view(CipherType::SecureNote);
+        view.id = Some(cipher_id);
+        view.favorite = true;
+        view.reprompt = CipherRepromptType::Password;
+        view.name = "Metadata Test".to_string();
+        view.secure_note = Some(SecureNoteView {
+            r#type: SecureNoteType::Generic,
+        });
+
+        let cipher = create_blob_cipher(&mut view, &mut ctx).unwrap();
+        assert_eq!(cipher.id, Some(cipher_id));
+        assert!(cipher.favorite);
+        assert_eq!(cipher.reprompt, CipherRepromptType::Password);
+        assert_eq!(cipher.r#type, CipherType::SecureNote);
+        assert_eq!(cipher.creation_date, view.creation_date);
+        assert_eq!(cipher.revision_date, view.revision_date);
+    }
+
+    #[test]
+    fn test_create_blob_cipher_each_type() {
+        let (key_store, _) = create_test_key_store();
+
+        // Login
+        {
+            let mut ctx = key_store.context_mut();
+            let mut view = create_shell_cipher_view(CipherType::Login);
+            view.name = "Login".to_string();
+            view.login = Some(LoginView {
+                username: Some("user".to_string()),
+                password: None,
+                password_revision_date: None,
+                uris: None,
+                totp: None,
+                autofill_on_page_load: None,
+                fido2_credentials: None,
+            });
+            assert!(create_blob_cipher(&mut view, &mut ctx).is_ok());
+        }
+
+        // Card
+        {
+            let mut ctx = key_store.context_mut();
+            let mut view = create_shell_cipher_view(CipherType::Card);
+            view.name = "Card".to_string();
+            view.card = Some(CardView {
+                cardholder_name: Some("John".to_string()),
+                exp_month: None,
+                exp_year: None,
+                code: None,
+                brand: None,
+                number: None,
+            });
+            assert!(create_blob_cipher(&mut view, &mut ctx).is_ok());
+        }
+
+        // Identity
+        {
+            let mut ctx = key_store.context_mut();
+            let mut view = create_shell_cipher_view(CipherType::Identity);
+            view.name = "Identity".to_string();
+            view.identity = Some(IdentityView {
+                title: None,
+                first_name: Some("Jane".to_string()),
+                middle_name: None,
+                last_name: None,
+                address1: None,
+                address2: None,
+                address3: None,
+                city: None,
+                state: None,
+                postal_code: None,
+                country: None,
+                company: None,
+                email: None,
+                phone: None,
+                ssn: None,
+                username: None,
+                passport_number: None,
+                license_number: None,
+            });
+            assert!(create_blob_cipher(&mut view, &mut ctx).is_ok());
+        }
+
+        // SecureNote
+        {
+            let mut ctx = key_store.context_mut();
+            let mut view = create_shell_cipher_view(CipherType::SecureNote);
+            view.name = "Note".to_string();
+            view.secure_note = Some(SecureNoteView {
+                r#type: SecureNoteType::Generic,
+            });
+            assert!(create_blob_cipher(&mut view, &mut ctx).is_ok());
+        }
+
+        // SshKey
+        {
+            let mut ctx = key_store.context_mut();
+            let mut view = create_shell_cipher_view(CipherType::SshKey);
+            view.name = "SSH".to_string();
+            view.ssh_key = Some(SshKeyView {
+                private_key: "private".to_string(),
+                public_key: "public".to_string(),
+                fingerprint: "fingerprint".to_string(),
+            });
+            assert!(create_blob_cipher(&mut view, &mut ctx).is_ok());
+        }
+    }
+
+    #[test]
+    fn test_end_to_end_round_trip() {
+        let (key_store, _) = create_test_key_store();
+        let mut ctx = key_store.context_mut();
+
+        let mut view = create_shell_cipher_view(CipherType::Login);
+        view.name = "My Login".to_string();
+        view.notes = Some("Secret notes".to_string());
+        view.login = Some(LoginView {
+            username: Some("testuser@example.com".to_string()),
+            password: Some("p@ssw0rd".to_string()),
+            password_revision_date: None,
+            uris: None,
+            totp: None,
+            autofill_on_page_load: None,
+            fido2_credentials: None,
+        });
+
+        let cipher = create_blob_cipher(&mut view, &mut ctx).unwrap();
+        assert!(is_blob_encrypted(&cipher));
+        assert!(!is_legacy_cipher(&cipher));
+
+        let blob = unseal_cipher(&cipher, &mut ctx).unwrap();
+
+        let mut restored = create_shell_cipher_view(CipherType::Login);
+        let cipher_key =
+            Cipher::decrypt_cipher_key(&mut ctx, cipher.key_identifier(), &cipher.key).unwrap();
+        blob.apply_to_cipher_view(&mut restored, &mut ctx, cipher_key)
+            .unwrap();
+
+        assert_eq!(restored.name, "My Login");
+        assert_eq!(restored.notes, Some("Secret notes".to_string()));
+        let login = restored.login.unwrap();
+        assert_eq!(login.username, Some("testuser@example.com".to_string()));
+        assert_eq!(login.password, Some("p@ssw0rd".to_string()));
+    }
+}

--- a/crates/bitwarden-vault/src/cipher/blob/encryption.rs
+++ b/crates/bitwarden-vault/src/cipher/blob/encryption.rs
@@ -1,11 +1,15 @@
 use bitwarden_core::key_management::KeyIds;
 use bitwarden_crypto::{
-    CompositeEncryptable, CryptoError, IdentifyKey, KeyStoreContext, PrimitiveEncryptable,
+    CompositeEncryptable, CryptoError, Decryptable, IdentifyKey, KeyStoreContext,
+    PrimitiveEncryptable,
 };
 use thiserror::Error;
 
 use super::{CipherBlob, CipherBlobLatest, SealedCipherBlob, SealedCipherBlobError};
-use crate::cipher::cipher::{Cipher, CipherView};
+use crate::cipher::{
+    attachment,
+    cipher::{Cipher, CipherView},
+};
 
 #[derive(Debug, Error)]
 pub(crate) enum BlobEncryptionError {
@@ -31,7 +35,7 @@ pub(crate) fn is_legacy_cipher(cipher: &Cipher) -> bool {
 }
 
 /// Seals a `CipherView` into an opaque blob string.
-pub(crate) fn seal_cipher(
+fn seal_cipher(
     view: &CipherView,
     ctx: &mut KeyStoreContext<KeyIds>,
 ) -> Result<String, BlobEncryptionError> {
@@ -45,7 +49,7 @@ pub(crate) fn seal_cipher(
 }
 
 /// Unseals a cipher's blob data, returning the latest blob version.
-pub(crate) fn unseal_cipher(
+fn unseal_cipher(
     cipher: &Cipher,
     ctx: &mut KeyStoreContext<KeyIds>,
 ) -> Result<CipherBlobLatest, BlobEncryptionError> {
@@ -64,11 +68,11 @@ pub(crate) fn unseal_cipher(
     }
 }
 
-/// Creates a blob-encrypted `Cipher` from a `CipherView`.
+/// Encrypts a `CipherView` into a blob-encrypted `Cipher`
 ///
 /// Generates a cipher key if missing, seals the sensitive data into a single blob,
 /// and encrypts attachments and local data separately.
-pub(crate) fn create_blob_cipher(
+pub(crate) fn encrypt_blob_cipher(
     view: &mut CipherView,
     ctx: &mut KeyStoreContext<KeyIds>,
 ) -> Result<Cipher, BlobEncryptionError> {
@@ -88,35 +92,104 @@ pub(crate) fn create_blob_cipher(
     let name = "".encrypt(ctx, cipher_key)?;
 
     Ok(Cipher {
+        // Metadata
         id: view.id,
         organization_id: view.organization_id,
         folder_id: view.folder_id,
         collection_ids: view.collection_ids.clone(),
         key: view.key.clone(),
-        name,
-        notes: None,
         r#type: view.r#type,
-        login: None,
-        identity: None,
-        card: None,
-        secure_note: None,
-        ssh_key: None,
         favorite: view.favorite,
         reprompt: view.reprompt,
         organization_use_totp: view.organization_use_totp,
         edit: view.edit,
         permissions: view.permissions,
         view_password: view.view_password,
-        local_data,
-        attachments,
-        fields: None,
-        password_history: None,
         creation_date: view.creation_date,
         deleted_date: view.deleted_date,
         revision_date: view.revision_date,
         archived_date: view.archived_date,
+
+        // Sensitive data
         data: Some(sealed_string),
+        attachments,
+        local_data,
+
+        // Obsolete fields — sensitive data lives in the blob
+        // TODO: Remove `name` once the server no longer requires it
+        name,
+        notes: None,
+        login: None,
+        identity: None,
+        card: None,
+        secure_note: None,
+        ssh_key: None,
+        fields: None,
+        password_history: None,
     })
+}
+
+/// Decrypts a blob-encrypted `Cipher` into a `CipherView`.
+///
+/// Unseals the blob data, decrypts attachments and local data, then applies
+/// the blob content fields onto the view.
+pub(crate) fn decrypt_blob_cipher(
+    cipher: &Cipher,
+    ctx: &mut KeyStoreContext<KeyIds>,
+) -> Result<CipherView, BlobEncryptionError> {
+    let outer_key = cipher.key_identifier();
+    let cipher_key = Cipher::decrypt_cipher_key(ctx, outer_key, &cipher.key)?;
+
+    let blob = unseal_cipher(cipher, ctx)?;
+
+    let (attachments, attachment_decryption_failures) =
+        attachment::decrypt_attachments_with_failures(
+            cipher.attachments.as_deref().unwrap_or_default(),
+            ctx,
+            cipher_key,
+        );
+
+    let local_data = cipher.local_data.decrypt(ctx, cipher_key).ok().flatten();
+
+    let mut view = CipherView {
+        // Metadata
+        id: cipher.id,
+        organization_id: cipher.organization_id,
+        folder_id: cipher.folder_id,
+        collection_ids: cipher.collection_ids.clone(),
+        key: cipher.key.clone(),
+        r#type: cipher.r#type,
+        favorite: cipher.favorite,
+        reprompt: cipher.reprompt,
+        organization_use_totp: cipher.organization_use_totp,
+        edit: cipher.edit,
+        permissions: cipher.permissions,
+        view_password: cipher.view_password,
+        creation_date: cipher.creation_date,
+        deleted_date: cipher.deleted_date,
+        revision_date: cipher.revision_date,
+        archived_date: cipher.archived_date,
+
+        // Sensitive data — decrypted separately from the blob
+        attachments: Some(attachments),
+        attachment_decryption_failures: Some(attachment_decryption_failures),
+        local_data,
+
+        // Populated by blob.apply_to_cipher_view() below
+        name: String::new(),
+        notes: None,
+        login: None,
+        identity: None,
+        card: None,
+        secure_note: None,
+        ssh_key: None,
+        fields: None,
+        password_history: None,
+    };
+
+    blob.apply_to_cipher_view(&mut view, ctx, cipher_key)?;
+
+    Ok(view)
 }
 
 #[cfg(test)]
@@ -185,7 +258,7 @@ mod tests {
             r#type: SecureNoteType::Generic,
         });
 
-        let cipher = create_blob_cipher(&mut view, &mut ctx).unwrap();
+        let cipher = encrypt_blob_cipher(&mut view, &mut ctx).unwrap();
         assert!(is_blob_encrypted(&cipher));
     }
 
@@ -230,7 +303,7 @@ mod tests {
     }
 
     #[test]
-    fn test_create_blob_cipher_sets_data() {
+    fn test_encrypt_blob_cipher_sets_data() {
         let (key_store, _) = create_test_key_store();
         let mut ctx = key_store.context_mut();
 
@@ -240,12 +313,12 @@ mod tests {
             r#type: SecureNoteType::Generic,
         });
 
-        let cipher = create_blob_cipher(&mut view, &mut ctx).unwrap();
+        let cipher = encrypt_blob_cipher(&mut view, &mut ctx).unwrap();
         assert!(cipher.data.is_some());
     }
 
     #[test]
-    fn test_create_blob_cipher_clears_legacy_fields() {
+    fn test_encrypt_blob_cipher_clears_legacy_fields() {
         let (key_store, _) = create_test_key_store();
         let mut ctx = key_store.context_mut();
 
@@ -261,7 +334,7 @@ mod tests {
             fido2_credentials: None,
         });
 
-        let cipher = create_blob_cipher(&mut view, &mut ctx).unwrap();
+        let cipher = encrypt_blob_cipher(&mut view, &mut ctx).unwrap();
         assert!(cipher.login.is_none());
         assert!(cipher.card.is_none());
         assert!(cipher.identity.is_none());
@@ -273,7 +346,7 @@ mod tests {
     }
 
     #[test]
-    fn test_create_blob_cipher_generates_key() {
+    fn test_encrypt_blob_cipher_generates_key() {
         let (key_store, _) = create_test_key_store();
         let mut ctx = key_store.context_mut();
 
@@ -283,13 +356,13 @@ mod tests {
         });
         assert!(view.key.is_none());
 
-        let cipher = create_blob_cipher(&mut view, &mut ctx).unwrap();
+        let cipher = encrypt_blob_cipher(&mut view, &mut ctx).unwrap();
         assert!(cipher.key.is_some());
         assert!(view.key.is_some());
     }
 
     #[test]
-    fn test_create_blob_cipher_preserves_metadata() {
+    fn test_encrypt_blob_cipher_preserves_metadata() {
         let (key_store, _) = create_test_key_store();
         let mut ctx = key_store.context_mut();
 
@@ -303,7 +376,7 @@ mod tests {
             r#type: SecureNoteType::Generic,
         });
 
-        let cipher = create_blob_cipher(&mut view, &mut ctx).unwrap();
+        let cipher = encrypt_blob_cipher(&mut view, &mut ctx).unwrap();
         assert_eq!(cipher.id, Some(cipher_id));
         assert!(cipher.favorite);
         assert_eq!(cipher.reprompt, CipherRepromptType::Password);
@@ -313,7 +386,7 @@ mod tests {
     }
 
     #[test]
-    fn test_create_blob_cipher_each_type() {
+    fn test_encrypt_blob_cipher_each_type() {
         let (key_store, _) = create_test_key_store();
 
         // Login
@@ -330,7 +403,7 @@ mod tests {
                 autofill_on_page_load: None,
                 fido2_credentials: None,
             });
-            assert!(create_blob_cipher(&mut view, &mut ctx).is_ok());
+            assert!(encrypt_blob_cipher(&mut view, &mut ctx).is_ok());
         }
 
         // Card
@@ -346,7 +419,7 @@ mod tests {
                 brand: None,
                 number: None,
             });
-            assert!(create_blob_cipher(&mut view, &mut ctx).is_ok());
+            assert!(encrypt_blob_cipher(&mut view, &mut ctx).is_ok());
         }
 
         // Identity
@@ -374,7 +447,7 @@ mod tests {
                 passport_number: None,
                 license_number: None,
             });
-            assert!(create_blob_cipher(&mut view, &mut ctx).is_ok());
+            assert!(encrypt_blob_cipher(&mut view, &mut ctx).is_ok());
         }
 
         // SecureNote
@@ -385,7 +458,7 @@ mod tests {
             view.secure_note = Some(SecureNoteView {
                 r#type: SecureNoteType::Generic,
             });
-            assert!(create_blob_cipher(&mut view, &mut ctx).is_ok());
+            assert!(encrypt_blob_cipher(&mut view, &mut ctx).is_ok());
         }
 
         // SshKey
@@ -398,7 +471,7 @@ mod tests {
                 public_key: "public".to_string(),
                 fingerprint: "fingerprint".to_string(),
             });
-            assert!(create_blob_cipher(&mut view, &mut ctx).is_ok());
+            assert!(encrypt_blob_cipher(&mut view, &mut ctx).is_ok());
         }
     }
 
@@ -420,22 +493,95 @@ mod tests {
             fido2_credentials: None,
         });
 
-        let cipher = create_blob_cipher(&mut view, &mut ctx).unwrap();
+        let cipher = encrypt_blob_cipher(&mut view, &mut ctx).unwrap();
         assert!(is_blob_encrypted(&cipher));
         assert!(!is_legacy_cipher(&cipher));
 
-        let blob = unseal_cipher(&cipher, &mut ctx).unwrap();
-
-        let mut restored = create_shell_cipher_view(CipherType::Login);
-        let cipher_key =
-            Cipher::decrypt_cipher_key(&mut ctx, cipher.key_identifier(), &cipher.key).unwrap();
-        blob.apply_to_cipher_view(&mut restored, &mut ctx, cipher_key)
-            .unwrap();
+        let restored = decrypt_blob_cipher(&cipher, &mut ctx).unwrap();
 
         assert_eq!(restored.name, "My Login");
         assert_eq!(restored.notes, Some("Secret notes".to_string()));
         let login = restored.login.unwrap();
         assert_eq!(login.username, Some("testuser@example.com".to_string()));
         assert_eq!(login.password, Some("p@ssw0rd".to_string()));
+    }
+
+    #[test]
+    fn test_decrypt_blob_cipher() {
+        let (key_store, _) = create_test_key_store();
+        let mut ctx = key_store.context_mut();
+
+        let mut view = create_shell_cipher_view(CipherType::Card);
+        view.name = "My Card".to_string();
+        view.notes = Some("Card notes".to_string());
+        view.card = Some(CardView {
+            cardholder_name: Some("John Doe".to_string()),
+            exp_month: Some("12".to_string()),
+            exp_year: Some("2030".to_string()),
+            code: Some("123".to_string()),
+            brand: Some("Visa".to_string()),
+            number: Some("4111111111111111".to_string()),
+        });
+
+        let cipher = encrypt_blob_cipher(&mut view, &mut ctx).unwrap();
+        let restored = decrypt_blob_cipher(&cipher, &mut ctx).unwrap();
+
+        assert_eq!(restored.name, "My Card");
+        assert_eq!(restored.notes, Some("Card notes".to_string()));
+        let card = restored.card.unwrap();
+        assert_eq!(card.cardholder_name, Some("John Doe".to_string()));
+        assert_eq!(card.number, Some("4111111111111111".to_string()));
+        assert_eq!(card.code, Some("123".to_string()));
+        assert_eq!(card.brand, Some("Visa".to_string()));
+    }
+
+    #[test]
+    fn test_decrypt_blob_cipher_preserves_metadata() {
+        let (key_store, _) = create_test_key_store();
+        let mut ctx = key_store.context_mut();
+
+        let cipher_id = CipherId::new(Uuid::new_v4());
+        let mut view = create_shell_cipher_view(CipherType::SecureNote);
+        view.id = Some(cipher_id);
+        view.favorite = true;
+        view.reprompt = CipherRepromptType::Password;
+        view.organization_use_totp = true;
+        view.edit = false;
+        view.view_password = false;
+        view.name = "Metadata".to_string();
+        view.secure_note = Some(SecureNoteView {
+            r#type: SecureNoteType::Generic,
+        });
+        let creation_date = view.creation_date;
+        let revision_date = view.revision_date;
+
+        let cipher = encrypt_blob_cipher(&mut view, &mut ctx).unwrap();
+        let restored = decrypt_blob_cipher(&cipher, &mut ctx).unwrap();
+
+        assert_eq!(restored.id, Some(cipher_id));
+        assert!(restored.favorite);
+        assert_eq!(restored.reprompt, CipherRepromptType::Password);
+        assert!(restored.organization_use_totp);
+        assert!(!restored.edit);
+        assert!(!restored.view_password);
+        assert_eq!(restored.r#type, CipherType::SecureNote);
+        assert_eq!(restored.creation_date, creation_date);
+        assert_eq!(restored.revision_date, revision_date);
+        assert!(restored.key.is_some());
+    }
+
+    #[test]
+    fn test_decrypt_blob_cipher_no_blob_data() {
+        let (key_store, _) = create_test_key_store();
+        let mut ctx = key_store.context_mut();
+
+        let cipher = make_test_cipher_with_data(&mut ctx, None);
+        let result = decrypt_blob_cipher(&cipher, &mut ctx);
+
+        assert!(result.is_err());
+        assert!(
+            matches!(&result.unwrap_err(), BlobEncryptionError::NoBlobData),
+            "Expected NoBlobData error"
+        );
     }
 }

--- a/crates/bitwarden-vault/src/cipher/blob/encryption.rs
+++ b/crates/bitwarden-vault/src/cipher/blob/encryption.rs
@@ -1,4 +1,4 @@
-use bitwarden_core::key_management::KeyIds;
+use bitwarden_core::key_management::KeySlotIds;
 use bitwarden_crypto::{
     CompositeEncryptable, CryptoError, Decryptable, IdentifyKey, KeyStoreContext,
     PrimitiveEncryptable,
@@ -37,7 +37,7 @@ pub(crate) fn is_legacy_cipher(cipher: &Cipher) -> bool {
 /// Seals a `CipherView` into an opaque blob string.
 fn seal_cipher(
     view: &CipherView,
-    ctx: &mut KeyStoreContext<KeyIds>,
+    ctx: &mut KeyStoreContext<KeySlotIds>,
 ) -> Result<String, BlobEncryptionError> {
     let outer_key = view.key_identifier();
     let cipher_key = Cipher::decrypt_cipher_key(ctx, outer_key, &view.key)?;
@@ -51,7 +51,7 @@ fn seal_cipher(
 /// Unseals a cipher's blob data, returning the latest blob version.
 fn unseal_cipher(
     cipher: &Cipher,
-    ctx: &mut KeyStoreContext<KeyIds>,
+    ctx: &mut KeyStoreContext<KeySlotIds>,
 ) -> Result<CipherBlobLatest, BlobEncryptionError> {
     let outer_key = cipher.key_identifier();
     let cipher_key = Cipher::decrypt_cipher_key(ctx, outer_key, &cipher.key)?;
@@ -74,7 +74,7 @@ fn unseal_cipher(
 /// and encrypts attachments and local data separately.
 pub(crate) fn encrypt_blob_cipher(
     view: &mut CipherView,
-    ctx: &mut KeyStoreContext<KeyIds>,
+    ctx: &mut KeyStoreContext<KeySlotIds>,
 ) -> Result<Cipher, BlobEncryptionError> {
     if view.key.is_none() {
         view.generate_cipher_key(ctx, view.key_identifier())?;
@@ -135,7 +135,7 @@ pub(crate) fn encrypt_blob_cipher(
 /// the blob content fields onto the view.
 pub(crate) fn decrypt_blob_cipher(
     cipher: &Cipher,
-    ctx: &mut KeyStoreContext<KeyIds>,
+    ctx: &mut KeyStoreContext<KeySlotIds>,
 ) -> Result<CipherView, BlobEncryptionError> {
     let outer_key = cipher.key_identifier();
     let cipher_key = Cipher::decrypt_cipher_key(ctx, outer_key, &cipher.key)?;
@@ -209,11 +209,14 @@ mod tests {
     };
 
     fn make_test_cipher_with_data(
-        ctx: &mut KeyStoreContext<KeyIds>,
+        ctx: &mut KeyStoreContext<KeySlotIds>,
         data: Option<String>,
     ) -> Cipher {
         let name = "test"
-            .encrypt(ctx, bitwarden_core::key_management::SymmetricKeyId::User)
+            .encrypt(
+                ctx,
+                bitwarden_core::key_management::SymmetricKeySlotId::User,
+            )
             .unwrap();
         Cipher {
             id: None,

--- a/crates/bitwarden-vault/src/cipher/blob/encryption.rs
+++ b/crates/bitwarden-vault/src/cipher/blob/encryption.rs
@@ -198,14 +198,18 @@ mod tests {
     use uuid::Uuid;
 
     use super::*;
-    use crate::cipher::{
-        blob::conversions::test_support::{create_shell_cipher_view, create_test_key_store},
-        card::CardView,
-        cipher::{CipherId, CipherRepromptType, CipherType},
-        identity::IdentityView,
-        login::LoginView,
-        secure_note::{SecureNoteType, SecureNoteView},
-        ssh_key::SshKeyView,
+    use crate::{
+        cipher::{
+            blob::conversions::test_support::{create_shell_cipher_view, create_test_key_store},
+            card::CardView,
+            cipher::{CipherId, CipherRepromptType, CipherType},
+            field::{FieldType, FieldView},
+            identity::IdentityView,
+            login::LoginView,
+            secure_note::{SecureNoteType, SecureNoteView},
+            ssh_key::SshKeyView,
+        },
+        password_history::PasswordHistoryView,
     };
 
     fn make_test_cipher_with_data(
@@ -495,6 +499,17 @@ mod tests {
             autofill_on_page_load: None,
             fido2_credentials: None,
         });
+        view.fields = Some(vec![FieldView {
+            name: Some("custom".to_string()),
+            value: Some("field-value".to_string()),
+            r#type: FieldType::Text,
+            linked_id: None,
+        }]);
+        let history_date = chrono::Utc::now();
+        view.password_history = Some(vec![PasswordHistoryView {
+            password: "old-p@ssw0rd".to_string(),
+            last_used_date: history_date,
+        }]);
 
         let cipher = encrypt_blob_cipher(&mut view, &mut ctx).unwrap();
         assert!(is_blob_encrypted(&cipher));
@@ -507,6 +522,17 @@ mod tests {
         let login = restored.login.unwrap();
         assert_eq!(login.username, Some("testuser@example.com".to_string()));
         assert_eq!(login.password, Some("p@ssw0rd".to_string()));
+
+        let fields = restored.fields.unwrap();
+        assert_eq!(fields.len(), 1);
+        assert_eq!(fields[0].name, Some("custom".to_string()));
+        assert_eq!(fields[0].value, Some("field-value".to_string()));
+        assert_eq!(fields[0].r#type, FieldType::Text);
+
+        let history = restored.password_history.unwrap();
+        assert_eq!(history.len(), 1);
+        assert_eq!(history[0].password, "old-p@ssw0rd");
+        assert_eq!(history[0].last_used_date, history_date);
     }
 
     #[test]

--- a/crates/bitwarden-vault/src/cipher/blob/mod.rs
+++ b/crates/bitwarden-vault/src/cipher/blob/mod.rs
@@ -1,13 +1,16 @@
 mod conversions;
+mod encryption;
 mod sealed;
-#[allow(dead_code)]
 mod v1;
 
 use bitwarden_crypto::{
     generate_versioned_sealable,
     safe::{DataEnvelopeNamespace, SealableData, SealableVersionedData},
 };
-#[allow(unused_imports)]
+pub(crate) use encryption::{
+    BlobEncryptionError, create_blob_cipher, is_blob_encrypted, is_legacy_cipher, seal_cipher,
+    unseal_cipher,
+};
 use sealed::{SealedCipherBlob, SealedCipherBlobError};
 use serde::{Deserialize, Serialize};
 use v1::CipherBlobV1;
@@ -18,7 +21,6 @@ generate_versioned_sealable!(
     [CipherBlobV1 => "1"]
 );
 
-#[allow(dead_code)]
 pub(crate) type CipherBlobLatest = CipherBlobV1;
 
 #[cfg(test)]

--- a/crates/bitwarden-vault/src/cipher/blob/mod.rs
+++ b/crates/bitwarden-vault/src/cipher/blob/mod.rs
@@ -7,8 +7,9 @@ use bitwarden_crypto::{
     generate_versioned_sealable,
     safe::{DataEnvelopeNamespace, SealableData, SealableVersionedData},
 };
+#[allow(unused_imports)]
 pub(crate) use encryption::{
-    BlobEncryptionError, encrypt_blob_cipher, decrypt_blob_cipher, is_blob_encrypted,
+    BlobEncryptionError, decrypt_blob_cipher, encrypt_blob_cipher, is_blob_encrypted,
     is_legacy_cipher,
 };
 use sealed::{SealedCipherBlob, SealedCipherBlobError};

--- a/crates/bitwarden-vault/src/cipher/blob/mod.rs
+++ b/crates/bitwarden-vault/src/cipher/blob/mod.rs
@@ -8,8 +8,8 @@ use bitwarden_crypto::{
     safe::{DataEnvelopeNamespace, SealableData, SealableVersionedData},
 };
 pub(crate) use encryption::{
-    BlobEncryptionError, create_blob_cipher, is_blob_encrypted, is_legacy_cipher, seal_cipher,
-    unseal_cipher,
+    BlobEncryptionError, encrypt_blob_cipher, decrypt_blob_cipher, is_blob_encrypted,
+    is_legacy_cipher,
 };
 use sealed::{SealedCipherBlob, SealedCipherBlobError};
 use serde::{Deserialize, Serialize};

--- a/crates/bitwarden-vault/src/cipher/blob/sealed.rs
+++ b/crates/bitwarden-vault/src/cipher/blob/sealed.rs
@@ -12,9 +12,8 @@ use super::CipherBlob;
 const FORMAT_VERSION: u8 = 1;
 
 /// Error type for `SealedCipherBlob` operations.
-#[allow(dead_code)]
 #[derive(Debug, Error)]
-pub(super) enum SealedCipherBlobError {
+pub(crate) enum SealedCipherBlobError {
     #[error("Unsupported format version: {0}")]
     UnsupportedFormatVersion(u8),
     #[error("CBOR encoding error")]
@@ -30,7 +29,6 @@ pub(super) enum SealedCipherBlobError {
 /// Sealed container that packages a wrapped CEK and encrypted `DataEnvelope` together.
 ///
 /// Serializable into the `Cipher.data: Option<String>` field.
-#[allow(dead_code)]
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub(super) struct SealedCipherBlob {
     format_version: u8,
@@ -38,7 +36,6 @@ pub(super) struct SealedCipherBlob {
     envelope: DataEnvelope,
 }
 
-#[allow(dead_code)]
 impl SealedCipherBlob {
     /// Seals a `CipherBlob` into a `SealedCipherBlob` by encrypting it with a new CEK
     /// wrapped by the provided wrapping key.

--- a/crates/bitwarden-vault/src/cipher/blob/v1.rs
+++ b/crates/bitwarden-vault/src/cipher/blob/v1.rs
@@ -31,6 +31,7 @@ pub(crate) enum CipherTypeDataV1 {
     Identity(IdentityDataV1),
     SecureNote(SecureNoteDataV1),
     SshKey(SshKeyDataV1),
+    BankAccount(BankAccountDataV1),
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
@@ -119,6 +120,21 @@ pub(crate) struct SshKeyDataV1 {
     pub private_key: String,
     pub public_key: String,
     pub fingerprint: String,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct BankAccountDataV1 {
+    pub bank_name: Option<String>,
+    pub name_on_account: Option<String>,
+    pub account_type: Option<String>,
+    pub account_number: Option<String>,
+    pub routing_number: Option<String>,
+    pub branch_number: Option<String>,
+    pub pin: Option<String>,
+    pub swift_code: Option<String>,
+    pub iban: Option<String>,
+    pub bank_contact_phone: Option<String>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]

--- a/crates/bitwarden-vault/src/cipher/cipher.rs
+++ b/crates/bitwarden-vault/src/cipher/cipher.rs
@@ -682,7 +682,7 @@ impl Cipher {
     ///   key
     /// * `ciphers_key` - The encrypted cipher key
     #[instrument(err, skip_all)]
-    pub(super) fn decrypt_cipher_key(
+    pub(crate) fn decrypt_cipher_key(
         ctx: &mut KeyStoreContext<KeySlotIds>,
         key: SymmetricKeySlotId,
         ciphers_key: &Option<EncString>,

--- a/crates/bitwarden-vault/src/cipher/cipher_client/mod.rs
+++ b/crates/bitwarden-vault/src/cipher/cipher_client/mod.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use bitwarden_core::{Client, OrganizationId};
+use bitwarden_core::{Client, OrganizationId, key_management::BLOB_SECURITY_VERSION};
 use bitwarden_crypto::IdentifyKey;
 #[cfg(feature = "wasm")]
 use bitwarden_crypto::{CompositeEncryptable, SymmetricCryptoKey};
@@ -36,6 +36,25 @@ pub struct CiphersClient {
 
 #[cfg_attr(feature = "wasm", wasm_bindgen)]
 impl CiphersClient {
+    /// Returns `true` when cipher data for the given scope should be written in the
+    /// blob-encrypted format. Individual-vault ciphers qualify once the user's security state has
+    /// reached [`BLOB_SECURITY_VERSION`]. Organization-vault support is tracked in PM-32430.
+    #[allow(dead_code)] // Consumed by the encrypt/decrypt wiring ticket.
+    pub(crate) fn should_use_blob_encryption(
+        &self,
+        organization_id: Option<OrganizationId>,
+    ) -> bool {
+        if organization_id.is_some() {
+            return false;
+        }
+        self.client
+            .internal
+            .get_key_store()
+            .context()
+            .get_security_state_version()
+            >= BLOB_SECURITY_VERSION
+    }
+
     #[allow(missing_docs)]
     pub async fn encrypt(
         &self,
@@ -859,5 +878,41 @@ mod tests {
         for ctx in contexts {
             assert_eq!(ctx.encrypted_for, expected_user_id);
         }
+    }
+
+    #[tokio::test]
+    async fn should_use_blob_encryption_individual_above_threshold_returns_true() {
+        let client = Client::init_test_account(test_bitwarden_com_account()).await;
+        client
+            .internal
+            .get_key_store()
+            .set_security_state_version(BLOB_SECURITY_VERSION);
+
+        assert!(client.vault().ciphers().should_use_blob_encryption(None));
+    }
+
+    #[tokio::test]
+    async fn should_use_blob_encryption_individual_below_threshold_returns_false() {
+        let client = Client::init_test_account(test_bitwarden_com_account()).await;
+        // Default KeyStore security_state_version is 1, below BLOB_SECURITY_VERSION (2).
+
+        assert!(!client.vault().ciphers().should_use_blob_encryption(None));
+    }
+
+    #[tokio::test]
+    async fn should_use_blob_encryption_organization_returns_false() {
+        let client = Client::init_test_account(test_bitwarden_com_account()).await;
+        client
+            .internal
+            .get_key_store()
+            .set_security_state_version(BLOB_SECURITY_VERSION);
+        let org_id: OrganizationId = "1bc9ac1e-f5aa-45f2-94bf-b181009709b8".parse().unwrap();
+
+        assert!(
+            !client
+                .vault()
+                .ciphers()
+                .should_use_blob_encryption(Some(org_id))
+        );
     }
 }

--- a/crates/bitwarden-vault/src/cipher/mod.rs
+++ b/crates/bitwarden-vault/src/cipher/mod.rs
@@ -1,6 +1,7 @@
 pub(crate) mod attachment;
 pub(crate) mod attachment_client;
 pub(crate) mod bank_account;
+#[allow(dead_code)]
 pub(crate) mod blob;
 pub(crate) mod card;
 #[allow(clippy::module_inception)]


### PR DESCRIPTION
## 🎟️ Tracking

[PM-32429](https://bitwarden.atlassian.net/browse/PM-32429)

## 📔 Objective

Implements the blob encryption module which provides the public entry points for encrypting a `CipherView` into a sealed-blob `Cipher` and decrypting it back, plus helpers for detecting blob vs. legacy format.

## 🗒️ Changes

- **`crates/bitwarden-vault/src/cipher/blob/encryption.rs`** (new) — blob encryption module:
    - `is_blob_encrypted(cipher)` / `is_legacy_cipher(cipher)` — format detection based on whether `cipher.data` parses as a `SealedCipherBlob`.
    - `encrypt_blob_cipher(view, ctx)` — generates a cipher key if missing, seals sensitive fields into the blob, encrypts `attachments` and `local_data` separately, and clears the legacy per-field columns on the resulting `Cipher`.
    - `decrypt_blob_cipher(cipher, ctx)` — unseals the blob, decrypts `attachments`/`local_data`, and applies blob content back onto a new `CipherView`.
- **`crates/bitwarden-vault/src/cipher/cipher.rs`** — bump `Cipher::decrypt_cipher_key` visibility from `pub(super)` to `pub(crate)` so the blob module can reuse it.
- **`crates/bitwarden-vault/src/cipher/blob/mod.rs`** — wire up the new module and re-export the public surface

#981 was merged into this branch to try and avoid the squash/rebase after getting approval from KM.


[PM-32429]: https://bitwarden.atlassian.net/browse/PM-32429?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ