### PR TITLE
[PM-32689] Introduce CiphersClient::should_use_blob_encryption

### DIFF
--- a/crates/bitwarden-core/src/key_management/mod.rs
+++ b/crates/bitwarden-core/src/key_management/mod.rs
@@ -34,7 +34,8 @@ pub use master_password::{
 mod security_state;
 #[cfg(feature = "internal")]
 pub use security_state::{
-    MINIMUM_ENFORCE_ICON_URI_HASH_VERSION, SecurityState, SignedSecurityState,
+    BLOB_SECURITY_VERSION, MINIMUM_ENFORCE_ICON_URI_HASH_VERSION, SecurityState,
+    SignedSecurityState,
 };
 #[cfg(feature = "internal")]
 mod user_decryption;

--- a/crates/bitwarden-core/src/key_management/security_state.rs
+++ b/crates/bitwarden-core/src/key_management/security_state.rs
@@ -32,6 +32,9 @@ use serde::{Deserialize, Serialize};
 /// Icon URI hashes are enforced starting with this security state version.
 pub const MINIMUM_ENFORCE_ICON_URI_HASH_VERSION: u64 = 2;
 
+/// Cipher blob encryption is enabled starting with this security state version.
+pub const BLOB_SECURITY_VERSION: u64 = 2;
+
 #[cfg(feature = "wasm")]
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TS_CUSTOM_TYPES: &'static str = r#"

--- a/crates/bitwarden-vault/src/cipher/cipher_client/mod.rs
+++ b/crates/bitwarden-vault/src/cipher/cipher_client/mod.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use bitwarden_core::{Client, OrganizationId};
+use bitwarden_core::{Client, OrganizationId, key_management::BLOB_SECURITY_VERSION};
 use bitwarden_crypto::IdentifyKey;
 #[cfg(feature = "wasm")]
 use bitwarden_crypto::{CompositeEncryptable, SymmetricCryptoKey};
@@ -36,6 +36,25 @@ pub struct CiphersClient {
 
 #[cfg_attr(feature = "wasm", wasm_bindgen)]
 impl CiphersClient {
+    /// Returns `true` when cipher data for the given scope should be written in the
+    /// blob-encrypted format. Individual-vault ciphers qualify once the user's security state has
+    /// reached [`BLOB_SECURITY_VERSION`]. Organization-vault support is tracked in PM-32430.
+    #[allow(dead_code)] // Consumed by the encrypt/decrypt wiring ticket.
+    pub(crate) fn should_use_blob_encryption(
+        &self,
+        organization_id: Option<OrganizationId>,
+    ) -> bool {
+        if organization_id.is_some() {
+            return false;
+        }
+        self.client
+            .internal
+            .get_key_store()
+            .context()
+            .get_security_state_version()
+            >= BLOB_SECURITY_VERSION
+    }
+
     #[allow(missing_docs)]
     pub async fn encrypt(
         &self,
@@ -859,5 +878,41 @@ mod tests {
         for ctx in contexts {
             assert_eq!(ctx.encrypted_for, expected_user_id);
         }
+    }
+
+    #[tokio::test]
+    async fn should_use_blob_encryption_individual_above_threshold_returns_true() {
+        let client = Client::init_test_account(test_bitwarden_com_account()).await;
+        client
+            .internal
+            .get_key_store()
+            .set_security_state_version(BLOB_SECURITY_VERSION);
+
+        assert!(client.vault().ciphers().should_use_blob_encryption(None));
+    }
+
+    #[tokio::test]
+    async fn should_use_blob_encryption_individual_below_threshold_returns_false() {
+        let client = Client::init_test_account(test_bitwarden_com_account()).await;
+        // Default KeyStore security_state_version is 1, below BLOB_SECURITY_VERSION (2).
+
+        assert!(!client.vault().ciphers().should_use_blob_encryption(None));
+    }
+
+    #[tokio::test]
+    async fn should_use_blob_encryption_organization_returns_false() {
+        let client = Client::init_test_account(test_bitwarden_com_account()).await;
+        client
+            .internal
+            .get_key_store()
+            .set_security_state_version(BLOB_SECURITY_VERSION);
+        let org_id: OrganizationId = "1bc9ac1e-f5aa-45f2-94bf-b181009709b8".parse().unwrap();
+
+        assert!(
+            !client
+                .vault()
+                .ciphers()
+                .should_use_blob_encryption(Some(org_id))
+        );
     }
 }


### PR DESCRIPTION
## 🎟️ Tracking

[PM-32689](https://bitwarden.atlassian.net/browse/PM-32689)

## 📔 Objective

Introduce `CiphersClient::should_use_blob_encryption` and `BLOB_SECURITY_VERSION` state version which will be used to enforce Blob encryption on accounts that have the necessary security state version.



[PM-32689]: https://bitwarden.atlassian.net/browse/PM-32689?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ