### PR TITLE
[PM-31876] Migrate Flags to Setting

### DIFF
--- a/crates/bitwarden-core/src/client/builder.rs
+++ b/crates/bitwarden-core/src/client/builder.rs
@@ -4,8 +4,6 @@ use bitwarden_crypto::KeyStore;
 use bitwarden_state::registry::StateRegistry;
 use reqwest::header::{self, HeaderValue};
 
-#[cfg(feature = "internal")]
-use crate::client::flags::Flags;
 use crate::{
     auth::auth_tokens::{NoopTokenHandler, TokenHandler},
     client::{
@@ -132,8 +130,6 @@ impl ClientBuilder {
                 user_id: OnceLock::new(),
                 token_handler: self.token_handler,
                 login_method,
-                #[cfg(feature = "internal")]
-                flags: RwLock::new(Flags::default()),
                 api_configurations: ApiConfigurations::new(identity, api, settings.device_type),
                 external_http_client,
                 key_store,

--- a/crates/bitwarden-core/src/client/internal.rs
+++ b/crates/bitwarden-core/src/client/internal.rs
@@ -107,6 +107,8 @@ pub struct InternalClient {
     #[cfg(feature = "internal")]
     pub(crate) security_state: RwLock<Option<SecurityState>>,
 
+    // TODO: Flags have been migrated to Setting but this will have to stay temporarily until the feature flags are removed.
+    #[allow(dead_code)]
     pub(crate) state_registry: StateRegistry,
 }
 

--- a/crates/bitwarden-core/src/client/internal.rs
+++ b/crates/bitwarden-core/src/client/internal.rs
@@ -107,7 +107,8 @@ pub struct InternalClient {
     #[cfg(feature = "internal")]
     pub(crate) security_state: RwLock<Option<SecurityState>>,
 
-    // TODO: Flags have been migrated to Setting but this will have to stay temporarily until the feature flags are removed.
+    // TODO: Flags have been migrated to Setting but this will have to stay temporarily until the
+    // feature flags are removed.
     #[allow(dead_code)]
     pub(crate) state_registry: StateRegistry,
 }

--- a/crates/bitwarden-core/src/client/internal.rs
+++ b/crates/bitwarden-core/src/client/internal.rs
@@ -20,7 +20,9 @@ use crate::{OrganizationId, client::encryption_settings::EncryptionSettings};
 #[cfg(feature = "internal")]
 use crate::{
     client::{
-        encryption_settings::EncryptionSettingsError, flags::Flags, login_method::UserLoginMethod,
+        encryption_settings::EncryptionSettingsError,
+        flags::Flags,
+        login_method::UserLoginMethod,
         persisted_state::{FLAGS, USER_ID},
     },
     error::NotAuthenticatedError,

--- a/crates/bitwarden-core/src/client/internal.rs
+++ b/crates/bitwarden-core/src/client/internal.rs
@@ -21,7 +21,7 @@ use crate::{OrganizationId, client::encryption_settings::EncryptionSettings};
 use crate::{
     client::{
         encryption_settings::EncryptionSettingsError, flags::Flags, login_method::UserLoginMethod,
-        persisted_state::USER_ID,
+        persisted_state::{FLAGS, USER_ID},
     },
     error::NotAuthenticatedError,
     key_management::{
@@ -95,9 +95,6 @@ pub struct InternalClient {
     )]
     pub(crate) login_method: Arc<RwLock<Option<Arc<LoginMethod>>>>,
 
-    #[cfg(feature = "internal")]
-    pub(super) flags: RwLock<Flags>,
-
     pub(super) api_configurations: Arc<ApiConfigurations>,
 
     /// Reqwest client useable for external integrations like email forwarders, HIBP.
@@ -108,9 +105,6 @@ pub struct InternalClient {
     #[cfg(feature = "internal")]
     pub(crate) security_state: RwLock<Option<SecurityState>>,
 
-    // TODO(PM-31876): Remove once Flags are migrated to Setting, which will add an in-crate
-    // read path and satisfy the dead_code lint without suppression.
-    #[allow(dead_code)]
     pub(crate) state_registry: StateRegistry,
 }
 
@@ -118,16 +112,36 @@ impl InternalClient {
     /// Load feature flags. This is intentionally a collection and not the internal `Flag` enum as
     /// we want to avoid changes in feature flags from being a breaking change.
     #[cfg(feature = "internal")]
-    #[expect(clippy::unused_async)]
     pub async fn load_flags(&self, flags: std::collections::HashMap<String, bool>) {
-        *self.flags.write().expect("RwLock is not poisoned") = Flags::load_from_map(flags);
+        let flags = Flags::load_from_map(flags);
+        match self.state_registry.setting(FLAGS) {
+            Ok(setting) => {
+                if let Err(e) = setting.update(flags).await {
+                    tracing::warn!("Failed to persist flags: {e}");
+                }
+            }
+            Err(e) => tracing::warn!("Flags setting unavailable: {e}"),
+        }
     }
 
     /// Retrieve the active feature flags.
     #[cfg(feature = "internal")]
-    #[expect(clippy::unused_async)]
     pub async fn get_flags(&self) -> Flags {
-        self.flags.read().expect("RwLock is not poisoned").clone()
+        let setting = match self.state_registry.setting(FLAGS) {
+            Ok(setting) => setting,
+            Err(e) => {
+                tracing::warn!("Flags setting unavailable, using defaults: {e}");
+                return Flags::default();
+            }
+        };
+        match setting.get().await {
+            Ok(Some(flags)) => flags,
+            Ok(None) => Flags::default(),
+            Err(e) => {
+                tracing::warn!("Failed to read flags, using defaults: {e}");
+                Flags::default()
+            }
+        }
     }
 
     #[cfg(feature = "internal")]

--- a/crates/bitwarden-core/src/client/internal.rs
+++ b/crates/bitwarden-core/src/client/internal.rs
@@ -492,6 +492,44 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn load_flags_round_trips_through_setting() {
+        use std::collections::HashMap;
+
+        use super::*;
+
+        let client = Client::new(None);
+
+        // With no flags loaded yet, get_flags should return defaults.
+        let initial = client.internal.get_flags().await;
+        assert!(!initial.enable_cipher_key_encryption);
+        assert!(!initial.strict_cipher_decryption);
+
+        // Loading flags should persist them via the FLAGS setting.
+        let mut map = HashMap::new();
+        map.insert("enableCipherKeyEncryption".to_string(), true);
+        map.insert("pm-34500-strict-cipher-decryption".to_string(), true);
+        client.internal.load_flags(map).await;
+
+        // get_flags should now return the loaded values.
+        let loaded = client.internal.get_flags().await;
+        assert!(loaded.enable_cipher_key_encryption);
+        assert!(loaded.strict_cipher_decryption);
+
+        // The values should be readable directly from the setting too.
+        let persisted = client
+            .internal
+            .state_registry
+            .setting(FLAGS)
+            .unwrap()
+            .get()
+            .await
+            .unwrap()
+            .expect("flags should be persisted after load_flags");
+        assert!(persisted.enable_cipher_key_encryption);
+        assert!(persisted.strict_cipher_decryption);
+    }
+
+    #[tokio::test]
     async fn test_set_user_master_password_unlock_kdf_updated() {
         let new_kdf = Kdf::Argon2id {
             iterations: NonZeroU32::new(4).unwrap(),


### PR DESCRIPTION
## 🎟️ Tracking
<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-31876

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
- Migrate Flags to Setting - 51dcc04c89a765de1ac5e73f209d70bd8a0d955f
  - Update `load_flags` and `get_flags` to read and persist to `state_registry.setting(FLAGS)`
  - Remove [expect(clippy::unused_async)] attributes from `load_flags` and `get_flags` as they are now awaited
- Add a unit test to verify saving and retrieving flags works as expected - 9b8b2a98d2c046424e161f8764a65e7a60ab0887
- Removed the Flags import and the flags: RwLock::new(Flags::default() initialization - d486eaf83b4c764cd71b74ea1415601134cedebb
