### PR TITLE
Configurable log level for uniffi

### DIFF
--- a/crates/bitwarden-uniffi/examples/callback_demo.rs
+++ b/crates/bitwarden-uniffi/examples/callback_demo.rs
@@ -49,7 +49,7 @@ fn main() {
 
     // Initialize logger with callback BEFORE creating any clients
     println!("Step 1: Initialize SDK logger with callback...\n");
-    bitwarden_uniffi::init_logger(Some(callback));
+    bitwarden_uniffi::init_logger(Some(callback), None);
 
     println!("Step 2: Create SDK client...\n");
     let _client = Client::new(Arc::new(DemoTokenProvider), None);

--- a/crates/bitwarden-uniffi/src/lib.rs
+++ b/crates/bitwarden-uniffi/src/lib.rs
@@ -48,7 +48,7 @@ impl Client {
         token_provider: Arc<dyn ClientManagedTokens>,
         settings: Option<ClientSettings>,
     ) -> Self {
-        init_logger(None);
+        init_logger(None, None);
         setup_error_converter();
 
         #[cfg(target_os = "android")]
@@ -120,6 +120,33 @@ impl Client {
 
 static INIT: Once = Once::new();
 
+/// Log level for SDK logging
+#[derive(uniffi::Enum)]
+pub enum LogLevel {
+    /// Most verbose: all trace, debug, info, warn, and error messages
+    Trace,
+    /// Verbose: debug, info, warn, and error messages
+    Debug,
+    /// Default: info, warn, and error messages
+    Info,
+    /// Only warn and error messages
+    Warn,
+    /// Only error messages
+    Error,
+}
+
+impl LogLevel {
+    fn as_str(&self) -> &'static str {
+        match self {
+            LogLevel::Trace => "trace",
+            LogLevel::Debug => "debug",
+            LogLevel::Info => "info",
+            LogLevel::Warn => "warn",
+            LogLevel::Error => "error",
+        }
+    }
+}
+
 /// Initialize the SDK logger
 ///
 /// This function should be called once before creating any SDK clients.
@@ -129,11 +156,13 @@ static INIT: Once = Once::new();
 /// # Parameters
 /// - `callback`: Optional callback to receive SDK log events. Pass `None` to use only platform
 ///   loggers (oslog on iOS, logcat on Android).
+/// - `level`: Optional log level. Defaults to `Info` if not specified. Can be overridden by
+///   `RUST_LOG` environment variable at runtime or compile time.
 ///
 /// # Example
 /// ```kotlin
-/// // Initialize with callback before creating clients
-/// initLogger(FlightRecorderCallback())
+/// // Initialize with callback and trace-level logging before creating clients
+/// initLogger(FlightRecorderCallback(), LogLevel.TRACE)
 /// val client = Client(tokenProvider, settings)
 /// ```
 ///
@@ -142,18 +171,20 @@ static INIT: Once = Once::new();
 /// - If not called explicitly, logging is auto-initialized when first client is created
 /// - Platform loggers (oslog/logcat) are always enabled regardless of callback
 #[uniffi::export]
-pub fn init_logger(callback: Option<Arc<dyn LogCallback>>) {
+pub fn init_logger(callback: Option<Arc<dyn LogCallback>>, level: Option<LogLevel>) {
     use tracing_subscriber::{EnvFilter, layer::SubscriberExt as _, util::SubscriberInitExt as _};
 
     INIT.call_once(|| {
         // the log level prioritization is determined by:
         //    1. if RUST_LOG is detected at runtime
         //    2. if RUST_LOG is provided at compile time
-        //    3. default to INFO
+        //    3. the level parameter passed by the caller
+        //    4. default to INFO
+        let level = level.as_ref().map(|l| l.as_str()).unwrap_or("info");
         let filter = EnvFilter::builder()
             .with_default_directive(
                 option_env!("RUST_LOG")
-                    .unwrap_or("info")
+                    .unwrap_or(level)
                     .parse()
                     .expect("should provide valid log level at compile time."),
             )
@@ -249,7 +280,7 @@ mod tests {
         let callback = Arc::new(TestLogCallback { logs: logs.clone() });
 
         // Initialize logger with callback before creating client
-        init_logger(Some(callback));
+        init_logger(Some(callback), None);
 
         // Create client
         let _client = Client::new(Arc::new(MockTokenProvider), None);

--- a/crates/bitwarden-uniffi/tests/callback_error_handling.rs
+++ b/crates/bitwarden-uniffi/tests/callback_error_handling.rs
@@ -37,7 +37,7 @@ impl LogCallback for FailingCallback {
 #[test]
 fn test_callback_error_does_not_crash_sdk() {
     // Initialize logger with failing callback
-    init_logger(Some(Arc::new(FailingCallback)));
+    init_logger(Some(Arc::new(FailingCallback)), None);
 
     // Create client
     let client = Client::new(Arc::new(MockTokenProvider), None);

--- a/crates/bitwarden-uniffi/tests/callback_field_coverage.rs
+++ b/crates/bitwarden-uniffi/tests/callback_field_coverage.rs
@@ -46,7 +46,7 @@ fn test_message_visitor_captures_message_field() {
     let callback = Arc::new(TestCallback { logs: logs.clone() });
 
     // Initialize logger with callback
-    init_logger(Some(callback));
+    init_logger(Some(callback), None);
 
     let _client = Client::new(Arc::new(MockTokenProvider), None);
 

--- a/crates/bitwarden-uniffi/tests/callback_happy_path.rs
+++ b/crates/bitwarden-uniffi/tests/callback_happy_path.rs
@@ -43,7 +43,7 @@ fn test_callback_happy_path() {
     let callback = Arc::new(TestCallback { logs: logs.clone() });
 
     // Initialize logger with callback
-    init_logger(Some(callback));
+    init_logger(Some(callback), None);
 
     // Create client
     let _client = Client::new(Arc::new(MockTokenProvider), None);

--- a/crates/bitwarden-uniffi/tests/callback_multiple_levels.rs
+++ b/crates/bitwarden-uniffi/tests/callback_multiple_levels.rs
@@ -43,7 +43,7 @@ fn test_callback_receives_multiple_log_levels() {
     let callback = Arc::new(TestCallback { logs: logs.clone() });
 
     // Initialize logger with callback
-    init_logger(Some(callback));
+    init_logger(Some(callback), None);
 
     let _client = Client::new(Arc::new(MockTokenProvider), None);
 

--- a/crates/bitwarden-uniffi/tests/callback_thread_safety.rs
+++ b/crates/bitwarden-uniffi/tests/callback_thread_safety.rs
@@ -46,7 +46,7 @@ fn test_callback_thread_safety() {
     let callback = Arc::new(TestCallback { logs: logs.clone() });
 
     // Initialize logger with callback
-    init_logger(Some(callback));
+    init_logger(Some(callback), None);
 
     let _client = Client::new(Arc::new(MockTokenProvider), None);
 


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective

Configurable log level for uniffi. 
Optional, defaults to info, as before.

Why the change ? The `RUST_LOG` env variable is not feasable to be set at runtime for android.

## 🚨 Breaking Changes

The `init_logger` function is not used explicitly anywhere, but indirectly when new uniffi `Client` is created. Since the function can take effect only once, on first usage, the function would need to be explicitly called before `Client` creation and set appropriate log level - unless it's added as a parameter for `Client::new` or into `ClientSettings`.

On android likely in https://github.com/bitwarden/android/blob/main/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/manager/SdkClientManagerImpl.kt#L49

<!-- Does this PR introduce any breaking changes? If so, please describe the impact and migration path for clients.

If you're unsure, the automated TypeScript compatibility check will run when you open/update this PR and provide feedback.

For breaking changes:
1. Describe what changed in the client interface
2. Explain why the change was necessary
3. Provide migration steps for client developers
4. Link to any paired client PRs if needed

Otherwise, you can remove this section. -->
