### PR TITLE
Add bank account to blob encryption

### DIFF
--- a/crates/bitwarden-vault/src/cipher/blob/conversions/bank_account.rs
+++ b/crates/bitwarden-vault/src/cipher/blob/conversions/bank_account.rs
@@ -1,0 +1,61 @@
+use super::{BankAccountDataV1, BankAccountView};
+
+impl_bidirectional_from!(
+    BankAccountView,
+    BankAccountDataV1,
+    [
+        bank_name,
+        name_on_account,
+        account_type,
+        account_number,
+        routing_number,
+        branch_number,
+        pin,
+        swift_code,
+        iban,
+        bank_contact_phone,
+    ]
+);
+
+#[cfg(test)]
+mod tests {
+    use super::super::{CipherBlobV1, test_support::*};
+    use crate::cipher::{bank_account::BankAccountView, cipher::CipherType};
+
+    #[test]
+    fn test_bank_account_cipher_round_trip() {
+        let (key_store, key_id) = create_test_key_store();
+        let mut ctx = key_store.context_mut();
+
+        let original = crate::CipherView {
+            name: "My Bank Account".to_string(),
+            notes: None,
+            r#type: CipherType::BankAccount,
+            bank_account: Some(BankAccountView {
+                bank_name: Some("Test Bank".to_string()),
+                name_on_account: Some("John Doe".to_string()),
+                account_type: Some("Checking".to_string()),
+                account_number: Some("1234567890".to_string()),
+                routing_number: Some("021000021".to_string()),
+                branch_number: Some("001".to_string()),
+                pin: Some("1234".to_string()),
+                swift_code: Some("TESTUS33".to_string()),
+                iban: Some("US12345678901234567890".to_string()),
+                bank_contact_phone: Some("555-0123".to_string()),
+            }),
+            ..create_shell_cipher_view(CipherType::BankAccount)
+        };
+
+        let blob = CipherBlobV1::from_cipher_view(&original, &mut ctx, key_id).unwrap();
+        let mut restored = create_shell_cipher_view(CipherType::BankAccount);
+        blob.apply_to_cipher_view(&mut restored, &mut ctx, key_id)
+            .unwrap();
+
+        assert_eq!(restored.name, "My Bank Account");
+        assert_eq!(restored.r#type, CipherType::BankAccount);
+        let bank_account = restored.bank_account.unwrap();
+        assert_eq!(bank_account.bank_name, Some("Test Bank".to_string()));
+        assert_eq!(bank_account.account_number, Some("1234567890".to_string()));
+        assert!(restored.login.is_none());
+    }
+}

--- a/crates/bitwarden-vault/src/cipher/blob/conversions/mod.rs
+++ b/crates/bitwarden-vault/src/cipher/blob/conversions/mod.rs
@@ -5,6 +5,7 @@ use super::v1::*;
 use crate::{
     CipherView, PasswordHistoryView,
     cipher::{
+        bank_account::BankAccountView,
         card::CardView,
         cipher::CipherType,
         field::FieldView,
@@ -44,6 +45,7 @@ impl_bidirectional_from!(
     [password, last_used_date,]
 );
 
+mod bank_account;
 mod card;
 mod identity;
 mod login;
@@ -116,6 +118,13 @@ impl CipherBlobV1 {
                     .ok_or(CryptoError::MissingField("ssh_key"))?;
                 CipherTypeDataV1::SshKey(SshKeyDataV1::from(ssh_key))
             }
+            CipherType::BankAccount => {
+                let bank_account = view
+                    .bank_account
+                    .as_ref()
+                    .ok_or(CryptoError::MissingField("bank_account"))?;
+                CipherTypeDataV1::BankAccount(BankAccountDataV1::from(bank_account))
+            }
         };
 
         Ok(Self {
@@ -157,6 +166,7 @@ impl CipherBlobV1 {
         view.identity = None;
         view.secure_note = None;
         view.ssh_key = None;
+        view.bank_account = None;
 
         match &self.type_data {
             CipherTypeDataV1::Login(login_data) => {
@@ -197,6 +207,10 @@ impl CipherBlobV1 {
             CipherTypeDataV1::SshKey(ssh_key_data) => {
                 view.r#type = CipherType::SshKey;
                 view.ssh_key = Some(SshKeyView::from(ssh_key_data));
+            }
+            CipherTypeDataV1::BankAccount(bank_account_data) => {
+                view.r#type = CipherType::BankAccount;
+                view.bank_account = Some(BankAccountView::from(bank_account_data));
             }
         }
 
@@ -241,6 +255,7 @@ mod test_support {
             card: None,
             secure_note: None,
             ssh_key: None,
+            bank_account: None,
             favorite: false,
             reprompt: CipherRepromptType::None,
             organization_use_totp: false,

--- a/crates/bitwarden-vault/src/cipher/blob/v1.rs
+++ b/crates/bitwarden-vault/src/cipher/blob/v1.rs
@@ -31,6 +31,7 @@ pub(crate) enum CipherTypeDataV1 {
     Identity(IdentityDataV1),
     SecureNote(SecureNoteDataV1),
     SshKey(SshKeyDataV1),
+    BankAccount(BankAccountDataV1),
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
@@ -123,6 +124,21 @@ pub(crate) struct SshKeyDataV1 {
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 #[serde(rename_all = "camelCase")]
+pub(crate) struct BankAccountDataV1 {
+    pub bank_name: Option<String>,
+    pub name_on_account: Option<String>,
+    pub account_type: Option<String>,
+    pub account_number: Option<String>,
+    pub routing_number: Option<String>,
+    pub branch_number: Option<String>,
+    pub pin: Option<String>,
+    pub swift_code: Option<String>,
+    pub iban: Option<String>,
+    pub bank_contact_phone: Option<String>,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[serde(rename_all = "camelCase")]
 pub(crate) struct FieldDataV1 {
     pub name: Option<String>,
     pub value: Option<String>,
@@ -168,6 +184,10 @@ mod tests {
     const TEST_VECTOR_SSH_KEY_CEK: &str =
         "pQEEAlApE2RsnNwb3+3FyIr/kcfWAzoAARFvBIEEIFggDk3igU6wYnicl6jRSYILSaPlDWYCjnRUqMLdqfPkVKAB";
     const TEST_VECTOR_SSH_KEY_ENVELOPE: &str = "g1hLpQE6AAERbwN4I2FwcGxpY2F0aW9uL3guYml0d2FyZGVuLmNib3ItcGFkZGVkBFApE2RsnNwb3+3FyIr/kcfWOgABOIECOgABOIABoQVYGHPwqnuSuDHdwTg3twT5B0b3AXKVK+cySVkBSzorjdnfAdt1aNM32x3BPUg4QMkR99SQum3yc4eIT5eqi2FZjHyvEVPMwxfcWqg26g8UTc3dsRW57RYRF4ajx4+MGcJj+wWTrI8jPmthhLAnEHT11eC2YjYIW1INWKGFJTKnTjwHw1LTVJvEzA9MAZRk2y2NC+qkkdDM3wKmhl4PqoEPmt/x6qBjlR5+rlA4rUqkm9ja+NqqEbz8McGXBw8QWOh99/xE1PorFk7S+o9LW1Kcv1/GL+1wv6X7tTo1dYVYa2uCo9Hp9C8D5zXz/iVLm9w98NQFZQlteO8yibEOp+F/VNpgpsmZjOQzJ6wf0hKabFF2eXIUJ2RT1vJT+zUdcfc+TMkypaBbJEagmAiEBnZFcxVEhQ3tn1ZyJFRUcMzm91azIHQMmQ9cS6h/SqTGFF3z+q0H4+8w2S+yl+D5/OVWQHKcSOFvsPA=";
+
+    const TEST_VECTOR_BANK_ACCOUNT_CEK: &str =
+        "pQEEAlCz1mvOGP9yRKdx0pA5WbP7AzoAARFvBIEEIFggF30KGp58Duu4VcVvoFJ+Lhw1yEpfQvTUW2dvOP+WMd0B";
+    const TEST_VECTOR_BANK_ACCOUNT_ENVELOPE: &str = "g1hLpQE6AAERbwN4I2FwcGxpY2F0aW9uL3guYml0d2FyZGVuLmNib3ItcGFkZGVkBFCz1mvOGP9yRKdx0pA5WbP7OgABOIECOgABOIABoQVYGDbBFtW702QwCdi03+f9Uahq4Xf0bJ8i7VkBQxZB8XgvwLS13sHp8iz3VmTVcWJCyoxp6ycEUNSllpzURnZtfTsm9hkHCM0iFvMAXgDHBamHpI+8cX4sZ1qyjrGx4JDkGL1wDPUKMY7pLIN6alssjgYNl/6ijicWk2uNDneAGVgJdAHmxVKYPKbwYp0e8bLeAjgj6FOSFHaXv1a6TdF82iRCF/r5Uh/Ohx1FEbtRnaCSMJ4tLsf8YC9oq3duarJzSB2aINL9EnGAqqUlJ8cy8lyfkopUxV0OMnRWiHpja4CrEphhNeKKPoFRezsVoDYQ3f7kjryVAQ661gVxsEG3FB03+CcvVsT849QfrDcERxsQoKwy1E9yHaoE2kgWiYTHS+6gCH/gikDw1t4GBBUdjeJhP3bqQJbmM4cgRxWMgyswfFAfZok25kcA15EpHabkczydiPtnG2UW9qfu+bfw";
 
     fn test_blob_secure_note() -> CipherBlobV1 {
         CipherBlobV1 {
@@ -284,6 +304,27 @@ mod tests {
         }
     }
 
+    fn test_blob_bank_account() -> CipherBlobV1 {
+        CipherBlobV1 {
+            name: "Test Bank Account".to_string(),
+            notes: Some("Bank account notes".to_string()),
+            type_data: CipherTypeDataV1::BankAccount(BankAccountDataV1 {
+                bank_name: Some("Test Bank".to_string()),
+                name_on_account: Some("John Doe".to_string()),
+                account_type: Some("Checking".to_string()),
+                account_number: Some("1234567890".to_string()),
+                routing_number: Some("021000021".to_string()),
+                branch_number: Some("001".to_string()),
+                pin: Some("1234".to_string()),
+                swift_code: Some("TESTUS33".to_string()),
+                iban: Some("US12345678901234567890".to_string()),
+                bank_contact_phone: Some("555-0123".to_string()),
+            }),
+            fields: Vec::new(),
+            password_history: Vec::new(),
+        }
+    }
+
     #[test]
     #[ignore]
     fn generate_test_vectors() {
@@ -293,6 +334,7 @@ mod tests {
             ("IDENTITY", test_blob_identity()),
             ("SECURE_NOTE", test_blob_secure_note()),
             ("SSH_KEY", test_blob_ssh_key()),
+            ("BANK_ACCOUNT", test_blob_bank_account()),
         ];
 
         for (name, blob) in blobs {
@@ -373,6 +415,15 @@ mod tests {
             TEST_VECTOR_SSH_KEY_CEK,
             TEST_VECTOR_SSH_KEY_ENVELOPE,
             test_blob_ssh_key(),
+        );
+    }
+
+    #[test]
+    fn test_recorded_bank_account_test_vector() {
+        verify_test_vector(
+            TEST_VECTOR_BANK_ACCOUNT_CEK,
+            TEST_VECTOR_BANK_ACCOUNT_ENVELOPE,
+            test_blob_bank_account(),
         );
     }
 }


### PR DESCRIPTION
## 🎟️ Tracking

N/A

## 📔 Objective

https://github.com/bitwarden/sdk-internal/pull/867 and https://github.com/bitwarden/sdk-internal/pull/949 had overlapping changes but were not merged up to date. This PR adds `Bank Account` to the cipher blob encryption
 
## 🚨 Breaking Changes

No
