### PR TITLE
Attempt to fix fragile play test

### DIFF
--- a/crates/bitwarden-test/src/play/play.rs
+++ b/crates/bitwarden-test/src/play/play.rs
@@ -427,11 +427,6 @@ mod tests {
     #[tokio::test]
     async fn test_clean() {
         let server = MockServer::start().await;
-        Mock::given(method("DELETE"))
-            .respond_with(ResponseTemplate::new(200))
-            .expect(1)
-            .mount(&server)
-            .await;
 
         let config = PlayConfig::new(
             "https://api.example.com",
@@ -439,6 +434,13 @@ mod tests {
             server.uri(),
         );
         let play = Play::new_internal(config);
+
+        Mock::given(method("DELETE"))
+            .and(path(format!("/seed/{}", play.play_id())))
+            .respond_with(ResponseTemplate::new(200))
+            .expect(1)
+            .mount(&server)
+            .await;
 
         assert!(play.clean().await.is_ok());
     }


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

We've observed some fragile tests related to wiremocking in play. This attempts to improve it.

```txt
---- play::play::tests::test_clean stdout ----

thread 'play::play::tests::test_clean' (6819) panicked at /home/runner/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/wiremock-0.6.5/src/mock_server/exposed_server.rs:367:17:
Verifications failed:
- Mock #0.
	Expected range of matching incoming requests: == 1
	Number of matched incoming requests: 2

Received requests:
- Request #1
	DELETE http://localhost/seed/bb8f9d70-3088-44a3-96ab-2395b4638072
x-play-id: bb8f9d70-3088-44a3-96ab-2395b4638072
accept: */*
host: 127.0.0.1:43469
error: test failed, to rerun pass `-p bitwarden-test --lib`

- Request #2
	DELETE http://localhost/seed/725a2369-c05b-49da-babf-a685814b954d
x-play-id: 725a2369-c05b-49da-babf-a685814b954d
accept: */*
host: 127.0.0.1:43469
```

## 🚨 Breaking Changes

<!-- Does this PR introduce any breaking changes? If so, please describe the impact and migration path for clients.

If you're unsure, the automated TypeScript compatibility check will run when you open/update this PR and provide feedback.

For breaking changes:
1. Describe what changed in the client interface
2. Explain why the change was necessary
3. Provide migration steps for client developers
4. Link to any paired client PRs if needed

Otherwise, you can remove this section. -->
