### PR TITLE
Add warning message for breaking changes

### DIFF
--- a/.github/workflows/detect-breaking-changes.yml
+++ b/.github/workflows/detect-breaking-changes.yml
@@ -201,6 +201,8 @@ jobs:
 
           **SDK Version:** \`${SDK_VERSION}\`
 
+          > ⚠️ **If breaking changes are detected, you MUST have a corresponding pull request addressing the breaking changes ready for merge in the affected client repository.**
+
           | Client | Status | Details |
           |--------|--------|---------|
           ${ROW_MARKER}
@@ -364,7 +366,7 @@ jobs:
             "breaking-changes-detected")
               STATUS_EMOJI="❌"
               STATUS_MESSAGE="Breaking changes detected"
-              STATUS_DETAILS="Compilation failed with new SDK version - [View Details](https://github.com/$_CLIENT_REPO/actions/runs/$WORKFLOW_ID)"
+              STATUS_DETAILS="Compilation failed with new SDK version. **A corresponding pull request addressing the breaking changes MUST be ready for merge in $_CLIENT_REPO.** - [View Details](https://github.com/$_CLIENT_REPO/actions/runs/$WORKFLOW_ID)"
               ;;
             "no-breaking-changes")
               STATUS_EMOJI="✅"


### PR DESCRIPTION
## 📔 Objective

Add more stern warning message to breaking change handling on SDK PRs.

## 🚨 Breaking Changes

<!-- Does this PR introduce any breaking changes? If so, please describe the impact and migration path for clients.

If you're unsure, the automated TypeScript compatibility check will run when you open/update this PR and provide feedback.

For breaking changes:
1. Describe what changed in the client interface
2. Explain why the change was necessary
3. Provide migration steps for client developers
4. Link to any paired client PRs if needed

Otherwise, you can remove this section. -->
