### PR TITLE
Fix small typo in a ipc error message

### DIFF
--- a/crates/bitwarden-ipc/src/error.rs
+++ b/crates/bitwarden-ipc/src/error.rs
@@ -81,6 +81,6 @@ pub enum RequestError {
     #[error("Failed to send message: {0}")]
     Send(String),
 
-    #[error("Error occured on the remote target: {0}")]
+    #[error("Error occurred on the remote target: {0}")]
     Rpc(#[from] RpcError),
 }


### PR DESCRIPTION
## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
Originally brought up with https://github.com/bitwarden/sdk-internal/pull/962 but got closed by the contributor.

This fixes a small typo in a ipc error message.