### PR TITLE
[PM-36047] Add tech-leads group as owners of the CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -13,6 +13,9 @@
 # Platform is the default owner for all files
 * @bitwarden/team-platform-dev
 
+# CODEOWNERS owners
+.github/CODEOWNERS @bitwarden/tech-leads
+
 # Auto-generated bindings
 # For these bindings, we want Platform to continue to own everything except the auto-generated code.
 # Bindings for our API do not have an owner as the API is shared between teams.
@@ -75,4 +78,3 @@ crates/bw/src/vault/** @bitwarden/team-vault-dev @bitwarden/team-sdk-sme
 /Cargo.toml
 /package-lock.json
 /package.json
-


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-36047

## 📔 Objective

For some existing repositories, there is no owner for the CODEOWNERS file itself. This presents a couple of concerns. The main initial concern is that a team’s ownership can change without them knowing or being approvers of the change.

This could be fixed in multiple ways, but two were discussed:

1. CODEOWNERS changes require approval from all teams whose ownership is changing. This is the better solution, but GitHub doesn’t seem to provide this capability. Something custom would have to be created, so this option is more effort.
2. CODEOWNERS changes require approval from the Tech Lead group. This is a less ideal solution compared to `#1`, but it should help provide more approval from the tech lead owners of files, and give them notifications on any changes.

For now, this change goes route `#2`. We aim to apply these changes only on monorepos. Team specific repositories shouldn't have this change.
