### PR TITLE
Remove blank line in PR comment that breaks breaking change comment

### DIFF
--- a/.github/workflows/detect-breaking-changes.yml
+++ b/.github/workflows/detect-breaking-changes.yml
@@ -195,23 +195,21 @@ jobs:
             echo "comment_id=$EXISTING_ID" >> $GITHUB_OUTPUT
           else
             echo "Creating new comment"
-            NEW_COMMENT=$(cat << EOF
-          ${COMMENT_MARKER}
-          ## 🔍 SDK Breaking Change Detection
-
-          **SDK Version:** \`${SDK_VERSION}\`
-
-          > ⚠️ **If breaking changes are detected, you MUST have a corresponding pull request addressing the breaking changes ready for merge in the affected client repository.**
-
-          | Client | Status | Details |
-          |--------|--------|---------|
-          ${ROW_MARKER}
-          ${OUR_ROW}
-
-          ---
-          *Results update as workflows complete.*
-          EOF
-            )
+            NEW_COMMENT="$(printf '%s\n' \
+              "${COMMENT_MARKER}" \
+              "## 🔍 SDK Breaking Change Detection" \
+              "" \
+              "**SDK Version:** \`${SDK_VERSION}\`" \
+              "" \
+              "> ⚠️ **If breaking changes are detected, you MUST have a corresponding pull request addressing the breaking changes ready for merge in the affected client repository.**" \
+              "" \
+              "| Client | Status | Details |" \
+              "|--------|--------|---------|" \
+              "${ROW_MARKER}" \
+              "${OUR_ROW}" \
+              "---" \
+              "*Results update as workflows complete.*" \
+            )"
 
             COMMENT_ID=$(gh api --method POST "repos/$GITHUB_REPOSITORY/issues/$PR_NUMBER/comments" \
               --field body="$NEW_COMMENT" --jq '.id')

--- a/.github/workflows/detect-breaking-changes.yml
+++ b/.github/workflows/detect-breaking-changes.yml
@@ -195,21 +195,22 @@ jobs:
             echo "comment_id=$EXISTING_ID" >> $GITHUB_OUTPUT
           else
             echo "Creating new comment"
-            NEW_COMMENT="$(printf '%s\n' \
-              "${COMMENT_MARKER}" \
-              "## 🔍 SDK Breaking Change Detection" \
-              "" \
-              "**SDK Version:** \`${SDK_VERSION}\`" \
-              "" \
-              "> ⚠️ **If breaking changes are detected, you MUST have a corresponding pull request addressing the breaking changes ready for merge in the affected client repository.**" \
-              "" \
-              "| Client | Status | Details |" \
-              "|--------|--------|---------|" \
-              "${ROW_MARKER}" \
-              "${OUR_ROW}" \
-              "---" \
-              "*Results update as workflows complete.*" \
-            )"
+            NEW_COMMENT=$(cat << EOF
+          ${COMMENT_MARKER}
+          ## 🔍 SDK Breaking Change Detection
+
+          **SDK Version:** \`${SDK_VERSION}\`
+
+          > ⚠️ **If breaking changes are detected, you MUST have a corresponding pull request addressing the breaking changes ready for merge in the affected client repository.**
+
+          | Client | Status | Details |
+          |--------|--------|---------|
+          ${ROW_MARKER}
+          ${OUR_ROW}
+          ---
+          *Results update as workflows complete.*
+          EOF
+            )
 
             COMMENT_ID=$(gh api --method POST "repos/$GITHUB_REPOSITORY/issues/$PR_NUMBER/comments" \
               --field body="$NEW_COMMENT" --jq '.id')

--- a/.github/workflows/detect-breaking-changes.yml
+++ b/.github/workflows/detect-breaking-changes.yml
@@ -198,13 +198,14 @@ jobs:
 
           **SDK Version:** \`${SDK_VERSION}\`
 
-          > ⚠️ **If breaking changes are detected, you MUST have a corresponding pull request addressing the breaking changes ready for merge in the affected client repository.**
+          > ⚠️ **If breaking changes are detected, a corresponding pull request addressing them must be ready for merge in the affected client repository.**
 
           | Client | Status | Details |
           |--------|--------|---------|
           ${OUR_ROW}
           ---
-          *Results update as workflows complete.*
+            *Breaking change detection uses the build of the SDK from this branch, including any incompatibities pre-existing on `main` or merged into this branch. Check the workflow logs to confirm.*
+            *Results update as workflows complete.*
           EOF
             )
 
@@ -359,7 +360,7 @@ jobs:
             "breaking-changes-detected")
               STATUS_EMOJI="❌"
               STATUS_MESSAGE="Breaking changes detected"
-              STATUS_DETAILS="Compilation failed with new SDK version. **A corresponding pull request addressing the breaking changes MUST be ready for merge in $_CLIENT_REPO.** - [View Details](https://github.com/$_CLIENT_REPO/actions/runs/$WORKFLOW_ID)"
+              STATUS_DETAILS="Compilation failed with new SDK version. **A corresponding pull request addressing the breaking changes must be ready for merge in $_CLIENT_REPO.** - [View Details](https://github.com/$_CLIENT_REPO/actions/runs/$WORKFLOW_ID)"
               ;;
             "no-breaking-changes")
               STATUS_EMOJI="✅"

--- a/.github/workflows/detect-breaking-changes.yml
+++ b/.github/workflows/detect-breaking-changes.yml
@@ -161,7 +161,6 @@ jobs:
           echo "💬 Creating/updating breaking change detection status comment..."
 
           COMMENT_MARKER="<!-- SDK-BREAKING-CHANGE-CHECK -->"
-          ROW_MARKER="<!-- row:${_CLIENT_LABEL} -->"
           OUR_ROW="| ${_CLIENT_LABEL} | ⏳ In progress | [View workflow](https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID) |"
 
           # Check for existing shared comment
@@ -173,18 +172,16 @@ jobs:
             echo "Found existing comment ID: $EXISTING_ID"
             EXISTING_BODY=$(gh api "repos/$GITHUB_REPOSITORY/issues/comments/$EXISTING_ID" --jq '.body')
 
-            # Check if our row marker exists
-            if echo "$EXISTING_BODY" | grep -q "$ROW_MARKER"; then
-              # Update existing row using awk for reliable multiline handling
-              NEW_BODY=$(echo "$EXISTING_BODY" | awk -v marker="$ROW_MARKER" -v newrow="$ROW_MARKER\n$OUR_ROW" '
-                $0 ~ marker { found=1; print newrow; next }
-                found && /^\|/ { found=0; next }
-                found && /^<!-- row:/ { found=0 }
-                !found { print }
+            # Check if a row for this client already exists (match on client label in first column)
+            if echo "$EXISTING_BODY" | grep -q "^| ${_CLIENT_LABEL} |"; then
+              # Update existing row by matching client label in first table cell
+              NEW_BODY=$(echo "$EXISTING_BODY" | awk -v label="${_CLIENT_LABEL}" -v newrow="$OUR_ROW" '
+                /^\|/ && index($0, "| " label " |") { print newrow; next }
+                { print }
               ')
             else
               # Append new row before the closing hr/footer
-              NEW_BODY=$(echo "$EXISTING_BODY" | awk -v newrow="$ROW_MARKER\n$OUR_ROW" '
+              NEW_BODY=$(echo "$EXISTING_BODY" | awk -v newrow="$OUR_ROW" '
                 /^---$/ && !inserted { print newrow; inserted=1 }
                 { print }
               ')
@@ -205,7 +202,6 @@ jobs:
 
           | Client | Status | Details |
           |--------|--------|---------|
-          ${ROW_MARKER}
           ${OUR_ROW}
           ---
           *Results update as workflows complete.*
@@ -358,8 +354,6 @@ jobs:
             exit 0
           fi
 
-          ROW_MARKER="<!-- row:${_CLIENT_LABEL} -->"
-
           # Determine status message
           case "$CLIENT_STATUS" in
             "breaking-changes-detected")
@@ -384,12 +378,10 @@ jobs:
           # Get current comment body
           EXISTING_BODY=$(gh api "repos/$GITHUB_REPOSITORY/issues/comments/$COMMENT_ID" --jq '.body')
 
-          # Update our row using awk
-          NEW_BODY=$(echo "$EXISTING_BODY" | awk -v marker="$ROW_MARKER" -v newrow="$ROW_MARKER\n$OUR_ROW" '
-            $0 ~ marker { found=1; print newrow; next }
-            found && /^\|/ { found=0; next }
-            found && /^<!-- row:/ { found=0 }
-            !found { print }
+          # Update our row by matching client label in first table cell
+          NEW_BODY=$(echo "$EXISTING_BODY" | awk -v label="${_CLIENT_LABEL}" -v newrow="$OUR_ROW" '
+            /^\|/ && index($0, "| " label " |") { print newrow; next }
+            { print }
           ')
 
           gh api --method PATCH "repos/$GITHUB_REPOSITORY/issues/comments/$COMMENT_ID" \


### PR DESCRIPTION
## Tracking

[bitwarden.atlassian.net/browse/PM-27825](https://bitwarden.atlassian.net/browse/PM-27825)

## 📔 Objective

Fixes broken breaking change detection comments, which were added in https://github.com/bitwarden/sdk-internal/pull/892.

See this comment on this PR for an example of the broken behavior: https://github.com/bitwarden/sdk-internal/pull/1013#issuecomment-4347222956.

The <!-- row:... --> HTML comments on separate lines inside the markdown table caused GitHub to terminate the table early, rendering data rows as plain text. Row identification now matches on the client label in the first table cell instead.

### Validation                                                      
   
Tested the `awk` logic locally against simulated comment bodies:     
                                                            
  **Test 1: Update an existing row while leaving others intact**     
  ```bash                                                   
  BODY='| Client | Status | Details |                                
  |--------|--------|---------|                             
  | typescript | ⏳ In progress | link |         
  | android | ✅ No breaking changes | link |
  ---'                                                               
   
  echo "$BODY" | awk -v label="typescript" -v newrow="| typescript | 
  ❌ Breaking changes | new link |" '                       
    /^\|/ && index($0, "| " label " |") { print newrow; next }
    { print }                                                        
  '
```  
Result: typescript row replaced, android row untouched.            
                                                            
 **Test 2: Append a new client row before the footer**
```bash
  BODY='| Client | Status | Details |                                
  |--------|--------|---------|      
  | typescript | ⏳ In progress | link |                             
  ---'                                                      
                                                 
  echo "$BODY" | awk -v newrow="| android | ⏳ In progress | link |"
  '                                                                  
    /^---$/ && !inserted { print newrow; inserted=1 }
    { print }                                                        
  '
```                                                         
  Result: android row appended before ---, table structure preserved.
                                                                     
**Test 3: Verify header row is not a collision risk**                  
 ```bash
 BODY='| Client | Status | Details |                                
  |--------|--------|---------|                                      
  | typescript | ⏳ In progress | link |                             
  ---'                                                      
                                                 
  echo "$BODY" | awk -v label="Client" -v newrow="| Client | OOPS | 
  replaced |" '                                                      
    /^\|/ && index($0, "| " label " |") { print newrow; next }
    { print }                                                        
  '           
```                                              
 Result: header row matches as expected, but this is a non-issue since the workflow only passes typescript or android as the label.      

## 🚨 Breaking Changes

<!-- Does this PR introduce any breaking changes? If so, please describe the impact and migration path for clients.

If you're unsure, the automated TypeScript compatibility check will run when you open/update this PR and provide feedback.

For breaking changes:
1. Describe what changed in the client interface
2. Explain why the change was necessary
3. Provide migration steps for client developers
4. Link to any paired client PRs if needed

Otherwise, you can remove this section. -->
