### PR TITLE
Fix swapped private and public keys

### DIFF
--- a/crates/bitwarden-auth/src/registration.rs
+++ b/crates/bitwarden-auth/src/registration.rs
@@ -546,7 +546,7 @@ mod tests {
                     let body = body.unwrap();
                     assert!(matches!(
                         EncString::from_str(body.encrypted_private_key.as_str()).unwrap(),
-                        EncString::Aes256Cbc_B64 { .. }
+                        EncString::Aes256Cbc_HmacSha256_B64 { .. }
                     ));
                     assert!(matches!(
                         EncString::from_str(body.encrypted_public_key.as_str()).unwrap(),

--- a/crates/bitwarden-auth/src/registration.rs
+++ b/crates/bitwarden-auth/src/registration.rs
@@ -201,20 +201,20 @@ async fn internal_post_keys_for_tde_registration(
             .devices_api()
             .put_keys(
                 request.device_identifier.as_str(),
-                Some(DeviceKeysRequestModel::new(
-                    tde_registration_crypto_result
+                Some(DeviceKeysRequestModel {
+                    encrypted_user_key: tde_registration_crypto_result
                         .trusted_device_keys
                         .protected_user_key
                         .to_string(),
-                    tde_registration_crypto_result
+                    encrypted_public_key: tde_registration_crypto_result
                         .trusted_device_keys
                         .protected_device_public_key
                         .to_string(),
-                    tde_registration_crypto_result
+                    encrypted_private_key: tde_registration_crypto_result
                         .trusted_device_keys
                         .protected_device_private_key
                         .to_string(),
-                )),
+                },
             )
             .await
             .map_err(|e| {

--- a/crates/bitwarden-auth/src/registration.rs
+++ b/crates/bitwarden-auth/src/registration.rs
@@ -214,7 +214,7 @@ async fn internal_post_keys_for_tde_registration(
                         .trusted_device_keys
                         .protected_device_private_key
                         .to_string(),
-                },
+                }),
             )
             .await
             .map_err(|e| {

--- a/crates/bitwarden-auth/src/registration.rs
+++ b/crates/bitwarden-auth/src/registration.rs
@@ -208,11 +208,11 @@ async fn internal_post_keys_for_tde_registration(
                         .to_string(),
                     tde_registration_crypto_result
                         .trusted_device_keys
-                        .protected_device_private_key
+                        .protected_device_public_key
                         .to_string(),
                     tde_registration_crypto_result
                         .trusted_device_keys
-                        .protected_device_public_key
+                        .protected_device_private_key
                         .to_string(),
                 )),
             )
@@ -483,7 +483,7 @@ pub enum RegistrationError {
 
 #[cfg(test)]
 mod tests {
-    use std::num::NonZeroU32;
+    use std::{num::NonZeroU32, str::FromStr};
 
     use bitwarden_api_api::{
         apis::ApiClient,
@@ -542,7 +542,17 @@ mod tests {
             mock.devices_api
                 .expect_put_keys()
                 .once()
-                .returning(move |_device_id, _body| {
+                .returning(move |_device_id, body| {
+                    let body = body.unwrap();
+                    assert!(matches!(
+                        EncString::from_str(body.encrypted_private_key.as_str()).unwrap(),
+                        EncString::Aes256Cbc_B64 { .. }
+                    ));
+                    assert!(matches!(
+                        EncString::from_str(body.encrypted_public_key.as_str()).unwrap(),
+                        EncString::Cose_Encrypt0_B64 { .. }
+                    ));
+
                     Ok(DeviceResponseModel {
                         object: None,
                         id: None,


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.slack.com/archives/C054ZQSBS49/p1776869829733399

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
I'm not sure how this happened since we regression tested the TDE flows on clients, however the private and public key in the request model conversions were swapped, leading to a broken state.

This swaps them back.

## 🚨 Breaking Changes

<!-- Does this PR introduce any breaking changes? If so, please describe the impact and migration path for clients.

If you're unsure, the automated TypeScript compatibility check will run when you open/update this PR and provide feedback.

For breaking changes:
1. Describe what changed in the client interface
2. Explain why the change was necessary
3. Provide migration steps for client developers
4. Link to any paired client PRs if needed

Otherwise, you can remove this section. -->
