### PR TITLE
[PM-35828]  Add missing drivers_license and passport fields to Cipher in tests

### DIFF
--- a/crates/bitwarden-vault/src/cipher/cipher_client/bulk_update_collections.rs
+++ b/crates/bitwarden-vault/src/cipher/cipher_client/bulk_update_collections.rs
@@ -124,6 +124,8 @@ mod tests {
             secure_note: Default::default(),
             ssh_key: Default::default(),
             bank_account: Default::default(),
+            drivers_license: Default::default(),
+            passport: Default::default(),
             organization_use_totp: Default::default(),
             edit: Default::default(),
             permissions: Default::default(),

--- a/crates/bitwarden-vault/src/cipher/cipher_client/move_many.rs
+++ b/crates/bitwarden-vault/src/cipher/cipher_client/move_many.rs
@@ -93,6 +93,8 @@ mod tests {
             secure_note: Default::default(),
             ssh_key: Default::default(),
             bank_account: Default::default(),
+            drivers_license: Default::default(),
+            passport: Default::default(),
             organization_use_totp: Default::default(),
             edit: Default::default(),
             permissions: Default::default(),


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-35828

## 📔 Objective

#992 merged after adding `drivers_license` and `passport` to `Cipher`, which broke a couple of the tests. This adds those back in to fix the build pipelines.
