### PR TITLE
Revert "Make get_key_id_for_symmetric_key follow client convention"

### DIFF
--- a/crates/bitwarden-core/src/key_management/crypto_client.rs
+++ b/crates/bitwarden-core/src/key_management/crypto_client.rs
@@ -198,7 +198,6 @@ impl CryptoClient {
     /// Takes a raw key and returns the corresponding key id. This is used for the biometrics
     /// subsystem and should be removed after moving over biometric management to the SDK.
     pub fn get_key_id_for_symmetric_key(
-        &self,
         key: Vec<u8>,
     ) -> Result<Option<Vec<u8>>, CryptoClientError> {
         let symmetric_key = SymmetricCryptoKey::try_from(&BitwardenLegacyKeyBytes::from(key))?;


### PR DESCRIPTION
Reverts bitwarden/sdk-internal#982

https://bitwarden.slack.com/archives/C07HY17HUHE/p1777884400593999?thread_ts=1777605036.339389&cid=C07HY17HUHE