### PR TITLE
[PM-34239] Fix dylint warning on cipher/blob/sealed.rs

### DIFF
--- a/crates/bitwarden-vault/src/cipher/blob/sealed.rs
+++ b/crates/bitwarden-vault/src/cipher/blob/sealed.rs
@@ -17,11 +17,11 @@ pub(crate) enum SealedCipherBlobError {
     #[error("Unsupported format version: {0}")]
     UnsupportedFormatVersion(u8),
     #[error("CBOR encoding error")]
-    CborEncodingError,
+    CborEncoding,
     #[error("CBOR decoding error")]
-    CborDecodingError,
+    CborDecoding,
     #[error("Base64 decoding error")]
-    Base64DecodingError,
+    Base64Decoding,
     #[error(transparent)]
     DataEnvelope(#[from] DataEnvelopeError),
 }
@@ -73,17 +73,16 @@ impl SealedCipherBlob {
     pub(super) fn to_opaque_string(&self) -> Result<String, SealedCipherBlobError> {
         let mut buf = Vec::new();
         ciborium::ser::into_writer(self, &mut buf)
-            .map_err(|_| SealedCipherBlobError::CborEncodingError)?;
+            .map_err(|_| SealedCipherBlobError::CborEncoding)?;
         Ok(B64::from(buf).to_string())
     }
 
     /// Deserializes a `SealedCipherBlob` from an opaque base64-encoded CBOR string.
     pub(super) fn from_opaque_string(s: &str) -> Result<Self, SealedCipherBlobError> {
         let bytes = B64::try_from(s)
-            .map_err(|_| SealedCipherBlobError::Base64DecodingError)?
+            .map_err(|_| SealedCipherBlobError::Base64Decoding)?
             .into_bytes();
-        ciborium::de::from_reader(bytes.as_slice())
-            .map_err(|_| SealedCipherBlobError::CborDecodingError)
+        ciborium::de::from_reader(bytes.as_slice()).map_err(|_| SealedCipherBlobError::CborDecoding)
     }
 }
 
@@ -156,20 +155,14 @@ mod tests {
     #[test]
     fn test_invalid_base64() {
         let result = SealedCipherBlob::from_opaque_string("not valid base64!@#$");
-        assert!(matches!(
-            result,
-            Err(SealedCipherBlobError::Base64DecodingError)
-        ));
+        assert!(matches!(result, Err(SealedCipherBlobError::Base64Decoding)));
     }
 
     #[test]
     fn test_invalid_cbor() {
         let not_cbor = B64::from(b"this is not valid cbor data".as_slice()).to_string();
         let result = SealedCipherBlob::from_opaque_string(&not_cbor);
-        assert!(matches!(
-            result,
-            Err(SealedCipherBlobError::CborDecodingError)
-        ));
+        assert!(matches!(result, Err(SealedCipherBlobError::CborDecoding)));
     }
 
     #[test]


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-34239

## 📔 Objective

Rename the error variants to not have an `Error` suffix. This should be caught by our custom lints, but they're not currently enabled in CI so I'm trying to fix them and enable a CI check. The work is split per team to avoid too many conflicts.

https://github.com/bitwarden/sdk-internal/blob/a7c9289e54a930f02f79a11fa133100e0ecf1b9e/support/lints/error_enum/src/lib.rs#L12-L42

## 🚨 Breaking Changes

<!-- Does this PR introduce any breaking changes? If so, please describe the impact and migration path for clients.

If you're unsure, the automated TypeScript compatibility check will run when you open/update this PR and provide feedback.

For breaking changes:
1. Describe what changed in the client interface
2. Explain why the change was necessary
3. Provide migration steps for client developers
4. Link to any paired client PRs if needed

Otherwise, you can remove this section. -->
