### PR TITLE
[PM-34239] Fix dylint warnings on crypto crates

### DIFF
--- a/crates/bitwarden-crypto/src/safe/data_envelope.rs
+++ b/crates/bitwarden-crypto/src/safe/data_envelope.rs
@@ -70,7 +70,7 @@ impl DataEnvelope {
         let (envelope, cek) = Self::seal_ref(&data, T::NAMESPACE)?;
         let cek_id = ctx.generate_symmetric_key();
         ctx.set_symmetric_key_internal(cek_id, SymmetricCryptoKey::XChaCha20Poly1305Key(cek))
-            .map_err(|_| DataEnvelopeError::KeyStoreError)?;
+            .map_err(|_| DataEnvelopeError::KeyStore)?;
         Ok((envelope, cek_id))
     }
 
@@ -88,7 +88,7 @@ impl DataEnvelope {
 
         let wrapped_cek = ctx
             .wrap_symmetric_key(*wrapping_key, cek)
-            .map_err(|_| DataEnvelopeError::EncryptionError)?;
+            .map_err(|_| DataEnvelopeError::Encryption)?;
 
         Ok((envelope, wrapped_cek))
     }
@@ -106,13 +106,13 @@ impl DataEnvelope {
 
         // Serialize the message
         let serialized_message =
-            SerializedMessage::encode(&data).map_err(|_| DataEnvelopeError::EncodingError)?;
+            SerializedMessage::encode(&data).map_err(|_| DataEnvelopeError::Encoding)?;
         if serialized_message.content_type() != coset::iana::CoapContentFormat::Cbor {
             return Err(DataEnvelopeError::UnsupportedContentFormat);
         }
 
-        let serialized_and_padded_message = pad_cbor(serialized_message.as_bytes())
-            .map_err(|_| DataEnvelopeError::EncodingError)?;
+        let serialized_and_padded_message =
+            pad_cbor(serialized_message.as_bytes()).map_err(|_| DataEnvelopeError::Encoding)?;
 
         // Build the COSE headers
         let mut protected_header = coset::HeaderBuilder::new()
@@ -143,7 +143,7 @@ impl DataEnvelope {
         let envelope_data = encrypt0
             .to_vec()
             .map(CoseEncrypt0Bytes::from)
-            .map_err(|_| DataEnvelopeError::EncodingError)?;
+            .map_err(|_| DataEnvelopeError::Encoding)?;
 
         // Disable key operations other than decrypt on the CEK
         cek.disable_key_operation(coset::iana::KeyOperation::Encrypt)
@@ -165,7 +165,7 @@ impl DataEnvelope {
     {
         let cek = ctx
             .get_symmetric_key(cek_keyslot)
-            .map_err(|_| DataEnvelopeError::KeyStoreError)?;
+            .map_err(|_| DataEnvelopeError::KeyStore)?;
 
         match cek {
             SymmetricCryptoKey::XChaCha20Poly1305Key(key) => self.unseal_ref(T::NAMESPACE, key),
@@ -185,7 +185,7 @@ impl DataEnvelope {
     {
         let cek = ctx
             .unwrap_symmetric_key(*wrapping_key, wrapped_cek)
-            .map_err(|_| DataEnvelopeError::DecryptionError)?;
+            .map_err(|_| DataEnvelopeError::Decryption)?;
         self.unseal(cek, ctx)
     }
 
@@ -200,16 +200,16 @@ impl DataEnvelope {
     {
         // Parse the COSE message
         let msg = coset::CoseEncrypt0::from_slice(self.envelope_data.as_ref())
-            .map_err(|_| DataEnvelopeError::CoseDecodingError)?;
+            .map_err(|_| DataEnvelopeError::CoseDecoding)?;
         let content_format =
-            content_format(&msg.protected).map_err(|_| DataEnvelopeError::DecodingError)?;
+            content_format(&msg.protected).map_err(|_| DataEnvelopeError::Decoding)?;
 
         // Validate the message
         if !matches!(
             msg.protected.header.alg,
             Some(coset::Algorithm::PrivateUse(XCHACHA20_POLY1305)),
         ) {
-            return Err(DataEnvelopeError::DecryptionError);
+            return Err(DataEnvelopeError::Decryption);
         }
         if msg.protected.header.key_id != cek.key_id.as_slice() {
             return Err(DataEnvelopeError::WrongKey);
@@ -243,17 +243,17 @@ impl DataEnvelope {
                     )
                 },
             )
-            .map_err(|_| DataEnvelopeError::DecryptionError)?;
+            .map_err(|_| DataEnvelopeError::Decryption)?;
 
         let unpadded_message =
-            unpad_cbor(&decrypted_message).map_err(|_| DataEnvelopeError::DecryptionError)?;
+            unpad_cbor(&decrypted_message).map_err(|_| DataEnvelopeError::Decryption)?;
 
         // Deserialize the message
         let serialized_message =
             SerializedMessage::from_bytes(unpadded_message, CoapContentFormat::Cbor);
         serialized_message
             .decode()
-            .map_err(|_| DataEnvelopeError::DecodingError)
+            .map_err(|_| DataEnvelopeError::Decoding)
     }
 }
 
@@ -346,25 +346,25 @@ pub enum DataEnvelopeError {
     UnsupportedContentFormat,
     /// Indicates that there was an error during decoding of the message.
     #[error("Failed to decode COSE message")]
-    CoseDecodingError,
+    CoseDecoding,
     /// Indicates that there was an error during decoding of the message.
     #[error("Failed to decode the content of the envelope")]
-    DecodingError,
+    Decoding,
     /// Indicates that there was an error during encoding of the message.
     #[error("Encoding error")]
-    EncodingError,
+    Encoding,
     /// Indicates that there was an error with the key store.
     #[error("KeyStore error")]
-    KeyStoreError,
+    KeyStore,
     /// Indicates that there was an error during decryption.
     #[error("Decryption error")]
-    DecryptionError,
+    Decryption,
     /// Indicates that there was an error during encryption.
     #[error("Encryption error")]
-    EncryptionError,
+    Encryption,
     /// Indicates that there was an error parsing the DataEnvelope.
     #[error("Parsing error: {0}")]
-    ParsingError(String),
+    Parsing(String),
     /// Indicates that the data envelope namespace is invalid.
     #[error("Invalid namespace")]
     InvalidNamespace,

--- a/crates/bitwarden-user-crypto-management/src/key_connector_migration.rs
+++ b/crates/bitwarden-user-crypto-management/src/key_connector_migration.rs
@@ -91,7 +91,7 @@ async fn enroll_user_into_key_connector(
         .await
         .map_err(|e| {
             error!("Failed to post key connector migration request: {e:?}");
-            MigrateToKeyConnectorError::ApiError
+            MigrateToKeyConnectorError::Api
         })
 }
 
@@ -127,7 +127,7 @@ async fn post_key_connector_key_to_key_connector(
 
     result.map_err(|e| {
         error!("Failed to post key connector key to key connector server: {e:?}");
-        MigrateToKeyConnectorError::KeyConnectorApiError
+        MigrateToKeyConnectorError::KeyConnectorApi
     })
 }
 
@@ -137,11 +137,11 @@ pub enum MigrateToKeyConnectorError {
     #[error("Current user key is not available")]
     UserKeyNotAvailable,
     #[error("Cryptographic error during key connector migration")]
-    CryptoError,
+    Crypto,
     #[error("Bitwarden API call failed during key connector migration")]
-    ApiError,
+    Api,
     #[error("Key Connector API call failed during key connector migration")]
-    KeyConnectorApiError,
+    KeyConnectorApi,
 }
 
 #[cfg(test)]
@@ -265,7 +265,7 @@ mod tests {
 
         assert!(matches!(
             result,
-            Err(MigrateToKeyConnectorError::KeyConnectorApiError)
+            Err(MigrateToKeyConnectorError::KeyConnectorApi)
         ));
 
         if let ApiClient::Mock(mut mock) = api_client {
@@ -326,7 +326,7 @@ mod tests {
         )
         .await;
 
-        assert!(matches!(result, Err(MigrateToKeyConnectorError::ApiError)));
+        assert!(matches!(result, Err(MigrateToKeyConnectorError::Api)));
 
         if let ApiClient::Mock(mut mock) = api_client {
             mock.accounts_key_management_api.checkpoint();

--- a/crates/bitwarden-user-crypto-management/src/key_rotation/mod.rs
+++ b/crates/bitwarden-user-crypto-management/src/key_rotation/mod.rs
@@ -30,7 +30,7 @@ impl UserCryptoManagementClient {
         let api_client = &self.client.internal.get_api_configurations().api_client;
         let organizations = sync::sync_orgs(api_client)
             .await
-            .map_err(|_| RotateUserKeysError::ApiError)?;
+            .map_err(|_| RotateUserKeysError::Api)?;
         Ok(organizations)
     }
 
@@ -42,7 +42,7 @@ impl UserCryptoManagementClient {
         let api_client = &self.client.internal.get_api_configurations().api_client;
         let emergency_access = sync::sync_emergency_access(api_client)
             .await
-            .map_err(|_| RotateUserKeysError::ApiError)?;
+            .map_err(|_| RotateUserKeysError::Api)?;
         Ok(emergency_access)
     }
 }
@@ -51,13 +51,13 @@ impl UserCryptoManagementClient {
 #[bitwarden_error(flat)]
 pub enum RotateUserKeysError {
     #[error("API error during key rotation")]
-    ApiError,
+    Api,
     #[error("Cryptographic error during key rotation")]
-    CryptoError,
+    Crypto,
     #[error("Invalid public key provided during key rotation")]
     InvalidPublicKey,
     #[error("Untrusted key encountered during key rotation")]
-    UntrustedKeyError,
+    UntrustedKey,
     #[error("Unimplemented key rotation method")]
     UnimplementedKeyRotationMethod,
 }

--- a/crates/bitwarden-user-crypto-management/src/key_rotation/password_change_and_rotate_user_keys.rs
+++ b/crates/bitwarden-user-crypto-management/src/key_rotation/password_change_and_rotate_user_keys.rs
@@ -61,7 +61,7 @@ async fn internal_password_change_and_rotate_user_keys(
 ) -> Result<(), RotateUserKeysError> {
     let sync = sync_current_account_data(api_client)
         .await
-        .map_err(|_| RotateUserKeysError::ApiError)?;
+        .map_err(|_| RotateUserKeysError::Api)?;
 
     // Create a separate scope so that the mutable context is not held across the await point
     let post_request = {
@@ -81,7 +81,7 @@ async fn internal_password_change_and_rotate_user_keys(
             &rotation_context.new_user_key_id,
             &mut ctx,
         )
-        .map_err(|_| RotateUserKeysError::CryptoError)?;
+        .map_err(|_| RotateUserKeysError::Crypto)?;
 
         info!("Re-encrypting account data for user key rotation");
         let account_data_model = reencrypt_data(
@@ -92,10 +92,10 @@ async fn internal_password_change_and_rotate_user_keys(
             rotation_context.new_user_key_id,
             &mut ctx,
         )
-        .map_err(|_| RotateUserKeysError::CryptoError)?;
+        .map_err(|_| RotateUserKeysError::Crypto)?;
 
         info!("Re-encrypting account unlock data for user key rotation");
-        let (kdf, salt) = sync.kdf_and_salt.ok_or(RotateUserKeysError::ApiError)?;
+        let (kdf, salt) = sync.kdf_and_salt.ok_or(RotateUserKeysError::Api)?;
         let unlock_data_model = reencrypt_master_password_change_unlock_data(
             ReencryptMasterPasswordChangeAndUnlockInput {
                 password: request.password,
@@ -113,11 +113,11 @@ async fn internal_password_change_and_rotate_user_keys(
             rotation_context.new_user_key_id,
             &mut ctx,
         )
-        .map_err(|_| RotateUserKeysError::CryptoError)?;
+        .map_err(|_| RotateUserKeysError::Crypto)?;
 
         let old_master_password_authentication_data =
             MasterPasswordAuthenticationData::derive(&request.old_password, &kdf, &salt)
-                .map_err(|_| RotateUserKeysError::CryptoError)?;
+                .map_err(|_| RotateUserKeysError::Crypto)?;
 
         RotateUserAccountKeysAndDataRequestModel {
             old_master_key_authentication_hash: Some(
@@ -136,7 +136,7 @@ async fn internal_password_change_and_rotate_user_keys(
         .accounts_key_management_api()
         .password_change_and_rotate_user_account_keys(Some(post_request))
         .await
-        .map_err(|_| RotateUserKeysError::ApiError)?;
+        .map_err(|_| RotateUserKeysError::Api)?;
     info!("Successfully rotated user account keys and data");
     Ok(())
 }
@@ -280,7 +280,7 @@ mod tests {
         )
         .await;
 
-        assert!(matches!(result, Err(RotateUserKeysError::ApiError)));
+        assert!(matches!(result, Err(RotateUserKeysError::Api)));
         if let ApiClient::Mock(mut mock) = api_client {
             mock.sync_api.checkpoint();
             mock.accounts_key_management_api.checkpoint();
@@ -318,7 +318,7 @@ mod tests {
         )
         .await;
 
-        assert!(matches!(result, Err(RotateUserKeysError::ApiError)));
+        assert!(matches!(result, Err(RotateUserKeysError::Api)));
         if let ApiClient::Mock(mut mock) = api_client {
             mock.sync_api.checkpoint();
             mock.organizations_api.checkpoint();
@@ -400,7 +400,7 @@ mod tests {
         )
         .await;
 
-        assert!(matches!(result, Err(RotateUserKeysError::ApiError)));
+        assert!(matches!(result, Err(RotateUserKeysError::Api)));
         if let ApiClient::Mock(mut mock) = api_client {
             mock.sync_api.checkpoint();
             mock.organizations_api.checkpoint();

--- a/crates/bitwarden-user-crypto-management/src/key_rotation/rotate_user_keys.rs
+++ b/crates/bitwarden-user-crypto-management/src/key_rotation/rotate_user_keys.rs
@@ -79,7 +79,7 @@ async fn internal_rotate_user_keys(
 
     let sync = sync_current_account_data(api_client)
         .await
-        .map_err(|_| RotateUserKeysError::ApiError)?;
+        .map_err(|_| RotateUserKeysError::Api)?;
 
     // Create a separate scope so that the mutable context is not held across the await point
     let post_request = {
@@ -100,7 +100,7 @@ async fn internal_rotate_user_keys(
                 &rotation_context.new_user_key_id,
                 &mut ctx,
             )
-            .map_err(|_| RotateUserKeysError::CryptoError)?;
+            .map_err(|_| RotateUserKeysError::Crypto)?;
 
         info!("Re-encrypting account data for user key rotation");
         let account_data_model = reencrypt_data(
@@ -111,18 +111,18 @@ async fn internal_rotate_user_keys(
             rotation_context.new_user_key_id,
             &mut ctx,
         )
-        .map_err(|_| RotateUserKeysError::CryptoError)?;
+        .map_err(|_| RotateUserKeysError::Crypto)?;
 
         info!("Re-encrypting account primary unlock method for user key rotation");
         let unlock_method_input =
             PrimaryUnlockMethod::from_key_rotation_method(request.key_rotation_method, &sync)
-                .map_err(|_| RotateUserKeysError::ApiError)?;
+                .map_err(|_| RotateUserKeysError::Api)?;
         let unlock_method_data = reencrypt_unlock_method_data(
             unlock_method_input,
             rotation_context.new_user_key_id,
             &mut ctx,
         )
-        .map_err(|_| RotateUserKeysError::CryptoError)?;
+        .map_err(|_| RotateUserKeysError::Crypto)?;
 
         info!("Re-encrypting account common unlock data for user key rotation");
         let common_unlock_data = reencrypt_common_unlock_data(
@@ -136,7 +136,7 @@ async fn internal_rotate_user_keys(
             rotation_context.new_user_key_id,
             &mut ctx,
         )
-        .map_err(|_| RotateUserKeysError::CryptoError)?;
+        .map_err(|_| RotateUserKeysError::Crypto)?;
 
         RotateUserKeysRequestModel {
             wrapped_account_cryptographic_state: Box::new(
@@ -153,7 +153,7 @@ async fn internal_rotate_user_keys(
         .accounts_key_management_api()
         .rotate_user_keys(Some(post_request))
         .await
-        .map_err(|_| RotateUserKeysError::ApiError)?;
+        .map_err(|_| RotateUserKeysError::Api)?;
     info!("Successfully rotated user account keys and data");
     Ok(())
 }
@@ -359,7 +359,7 @@ mod tests {
         )
         .await;
 
-        assert!(matches!(result, Err(RotateUserKeysError::ApiError)));
+        assert!(matches!(result, Err(RotateUserKeysError::Api)));
         if let ApiClient::Mock(mut mock) = api_client {
             mock.sync_api.checkpoint();
             mock.accounts_key_management_api.checkpoint();
@@ -437,7 +437,7 @@ mod tests {
         )
         .await;
 
-        assert!(matches!(result, Err(RotateUserKeysError::ApiError)));
+        assert!(matches!(result, Err(RotateUserKeysError::Api)));
         if let ApiClient::Mock(mut mock) = api_client {
             mock.sync_api.checkpoint();
             mock.organizations_api.checkpoint();

--- a/crates/bitwarden-user-crypto-management/src/key_rotation/rotation_context.rs
+++ b/crates/bitwarden-user-crypto-management/src/key_rotation/rotation_context.rs
@@ -70,13 +70,13 @@ pub(super) fn make_rotation_context(
         sync.organization_memberships.as_slice(),
         trusted_organization_public_keys,
     )
-    .map_err(|_| RotateUserKeysError::UntrustedKeyError)?;
+    .map_err(|_| RotateUserKeysError::UntrustedKey)?;
 
     let v1_emergency_access_memberships = filter_trusted_emergency_access(
         sync.emergency_access_memberships.as_slice(),
         trusted_emergency_access_public_keys,
     )
-    .map_err(|_| RotateUserKeysError::UntrustedKeyError)?;
+    .map_err(|_| RotateUserKeysError::UntrustedKey)?;
 
     info!(
         "Existing user cryptographic version {:?}",
@@ -355,10 +355,7 @@ mod tests {
 
         let result = make_rotation_context(&sync, &[], &[], &mut ctx);
 
-        assert!(matches!(
-            result,
-            Err(RotateUserKeysError::UntrustedKeyError)
-        ));
+        assert!(matches!(result, Err(RotateUserKeysError::UntrustedKey)));
     }
 
     #[test]
@@ -370,9 +367,6 @@ mod tests {
 
         let result = make_rotation_context(&sync, &[], &[], &mut ctx);
 
-        assert!(matches!(
-            result,
-            Err(RotateUserKeysError::UntrustedKeyError)
-        ));
+        assert!(matches!(result, Err(RotateUserKeysError::UntrustedKey)));
     }
 }

--- a/crates/bitwarden-user-crypto-management/src/key_rotation/sync.rs
+++ b/crates/bitwarden-user-crypto-management/src/key_rotation/sync.rs
@@ -50,9 +50,9 @@ pub(super) struct SyncedAccountData {
 #[bitwarden_error(flat)]
 pub(super) enum SyncError {
     #[error("Network error during sync")]
-    NetworkError,
+    Network,
     #[error("Failed to parse sync data")]
-    DataError,
+    Data,
 }
 
 /// Fetch the public key for a single organization
@@ -64,15 +64,15 @@ async fn fetch_organization_public_key(
         .organizations_api()
         .get_public_key(&organization_id.to_string())
         .await
-        .debug_map_err(SyncError::NetworkError)?
+        .debug_map_err(SyncError::Network)?
         .public_key
-        .ok_or(SyncError::DataError)?;
+        .ok_or(SyncError::Data)?;
     PublicKey::from_der(&SpkiPublicKeyBytes::from(
         B64::from_str(&org_details)
-            .debug_map_err(SyncError::DataError)?
+            .debug_map_err(SyncError::Data)?
             .into_bytes(),
     ))
-    .debug_map_err(SyncError::DataError)
+    .debug_map_err(SyncError::Data)
 }
 
 // Download the public keys for the organizations for which reset password is enrolled, since these
@@ -84,19 +84,19 @@ pub(crate) async fn sync_orgs(
         .organizations_api()
         .get_user()
         .await
-        .debug_map_err(SyncError::NetworkError)?
+        .debug_map_err(SyncError::Network)?
         .data
-        .ok_or(SyncError::DataError)?
+        .ok_or(SyncError::Data)?
         .into_iter();
     let organizations = organizations
         .into_iter()
         .filter(|org| org.reset_password_enrolled.unwrap_or(false))
         .map(async |org| {
-            let id = org.id.ok_or(SyncError::DataError)?;
+            let id = org.id.ok_or(SyncError::Data)?;
             let public_key = fetch_organization_public_key(api_client, id).await?;
             Ok(V1OrganizationMembership {
                 organization_id: id,
-                name: org.name.ok_or(SyncError::DataError)?,
+                name: org.name.ok_or(SyncError::Data)?,
                 public_key,
             })
         })
@@ -124,14 +124,14 @@ async fn fetch_user_public_key(
         .users_api()
         .get_public_key(user_id)
         .await
-        .debug_map_err(SyncError::NetworkError)?;
-    let public_key_b64 = user_key_response.public_key.ok_or(SyncError::DataError)?;
+        .debug_map_err(SyncError::Network)?;
+    let public_key_b64 = user_key_response.public_key.ok_or(SyncError::Data)?;
     PublicKey::from_der(&SpkiPublicKeyBytes::from(
         B64::from_str(&public_key_b64)
-            .debug_map_err(SyncError::DataError)?
+            .debug_map_err(SyncError::Data)?
             .into_bytes(),
     ))
-    .debug_map_err(SyncError::DataError)
+    .debug_map_err(SyncError::Data)
 }
 
 /// Download the emergency access memberships and their public keys
@@ -142,9 +142,9 @@ pub(crate) async fn sync_emergency_access(
         .emergency_access_api()
         .get_contacts()
         .await
-        .debug_map_err(SyncError::NetworkError)?
+        .debug_map_err(SyncError::Network)?
         .data
-        .ok_or(SyncError::DataError)?
+        .ok_or(SyncError::Data)?
         .into_iter()
         .filter(|ea| {
             ea.status == Some(EmergencyAccessStatusType::Confirmed)
@@ -152,10 +152,10 @@ pub(crate) async fn sync_emergency_access(
                 || ea.status == Some(EmergencyAccessStatusType::RecoveryApproved)
         })
         .map(async |ea| {
-            let user_id = ea.grantee_id.ok_or(SyncError::DataError)?;
+            let user_id = ea.grantee_id.ok_or(SyncError::Data)?;
             let public_key = fetch_user_public_key(api_client, user_id).await?;
             Ok(V1EmergencyAccessMembership {
-                id: ea.id.ok_or(SyncError::DataError)?,
+                id: ea.id.ok_or(SyncError::Data)?,
                 grantee_id: user_id,
                 // The name can be null if a user does not set a name.
                 name: ea
@@ -185,23 +185,23 @@ async fn sync_passkeys(api_client: &ApiClient) -> Result<Vec<PartialRotateableKe
         .web_authn_api()
         .get()
         .await
-        .debug_map_err(SyncError::NetworkError)?
+        .debug_map_err(SyncError::Network)?
         .data
-        .ok_or(SyncError::DataError)?
+        .ok_or(SyncError::Data)?
         .into_iter()
         .filter(|cred| cred.prf_status == Some(WebAuthnPrfStatus::Enabled))
         .map(|cred| {
             Ok(PartialRotateableKeyset {
-                id: Uuid::from_str(&cred.id.ok_or(SyncError::DataError)?)
-                    .debug_map_err(SyncError::DataError)?,
+                id: Uuid::from_str(&cred.id.ok_or(SyncError::Data)?)
+                    .debug_map_err(SyncError::Data)?,
                 encrypted_public_key: EncString::from_str(
-                    &cred.encrypted_public_key.ok_or(SyncError::DataError)?,
+                    &cred.encrypted_public_key.ok_or(SyncError::Data)?,
                 )
-                .debug_map_err(SyncError::DataError)?,
+                .debug_map_err(SyncError::Data)?,
                 encrypted_user_key: UnsignedSharedKey::from_str(
-                    &cred.encrypted_user_key.ok_or(SyncError::DataError)?,
+                    &cred.encrypted_user_key.ok_or(SyncError::Data)?,
                 )
-                .debug_map_err(SyncError::DataError)?,
+                .debug_map_err(SyncError::Data)?,
             })
         })
         .collect::<Result<Vec<_>, _>>()?;
@@ -215,22 +215,22 @@ async fn sync_devices(api_client: &ApiClient) -> Result<Vec<PartialRotateableKey
         .devices_api()
         .get_all()
         .await
-        .debug_map_err(SyncError::NetworkError)?
+        .debug_map_err(SyncError::Network)?
         .data
-        .ok_or(SyncError::DataError)?
+        .ok_or(SyncError::Data)?
         .into_iter()
         .filter(|device| device.is_trusted.unwrap_or(false))
         .map(|device| {
             Ok(PartialRotateableKeyset {
-                id: device.id.ok_or(SyncError::DataError)?,
+                id: device.id.ok_or(SyncError::Data)?,
                 encrypted_public_key: EncString::from_str(
-                    &device.encrypted_public_key.ok_or(SyncError::DataError)?,
+                    &device.encrypted_public_key.ok_or(SyncError::Data)?,
                 )
-                .debug_map_err(SyncError::DataError)?,
+                .debug_map_err(SyncError::Data)?,
                 encrypted_user_key: UnsignedSharedKey::from_str(
-                    &device.encrypted_user_key.ok_or(SyncError::DataError)?,
+                    &device.encrypted_user_key.ok_or(SyncError::Data)?,
                 )
-                .debug_map_err(SyncError::DataError)?,
+                .debug_map_err(SyncError::Data)?,
             })
         })
         .collect::<Result<Vec<_>, _>>()?;
@@ -242,12 +242,12 @@ fn parse_ciphers(
     ciphers: Option<Vec<bitwarden_api_api::models::CipherDetailsResponseModel>>,
 ) -> Result<Vec<Cipher>, SyncError> {
     let ciphers = ciphers
-        .ok_or(SyncError::DataError)?
+        .ok_or(SyncError::Data)?
         .into_iter()
         .filter(|c| c.organization_id.is_none())
         .map(|c| {
             let _span = debug_span!("deserializing_cipher", cipher_id = ?c.id).entered();
-            Cipher::try_from(c).debug_map_err(SyncError::DataError)
+            Cipher::try_from(c).debug_map_err(SyncError::Data)
         })
         .collect::<Result<Vec<_>, _>>()?;
     info!("Deserialized {} ciphers", ciphers.len());
@@ -258,11 +258,11 @@ fn parse_folders(
     folders: Option<Vec<bitwarden_api_api::models::FolderResponseModel>>,
 ) -> Result<Vec<Folder>, SyncError> {
     let folders = folders
-        .ok_or(SyncError::DataError)?
+        .ok_or(SyncError::Data)?
         .into_iter()
         .map(|f| {
             let _span = debug_span!("deserializing_folder", folder_id = ?f.id).entered();
-            Folder::try_from(f).debug_map_err(SyncError::DataError)
+            Folder::try_from(f).debug_map_err(SyncError::Data)
         })
         .collect::<Result<Vec<_>, _>>()?;
     info!("Deserialized {} folders", folders.len());
@@ -273,11 +273,11 @@ fn parse_sends(
     sends: Option<Vec<bitwarden_api_api::models::SendResponseModel>>,
 ) -> Result<Vec<bitwarden_send::Send>, SyncError> {
     let sends = sends
-        .ok_or(SyncError::DataError)?
+        .ok_or(SyncError::Data)?
         .into_iter()
         .map(|s| {
             let _span = debug_span!("deserializing_send", send_id = ?s.id).entered();
-            bitwarden_send::Send::try_from(s).debug_map_err(SyncError::DataError)
+            bitwarden_send::Send::try_from(s).debug_map_err(SyncError::Data)
         })
         .collect::<Result<Vec<_>, _>>()?;
     info!("Deserialized {} sends", sends.len());
@@ -312,14 +312,10 @@ fn from_kdf(
 fn parse_kdf_and_salt(
     user_decryption: &Option<Box<bitwarden_api_api::models::UserDecryptionResponseModel>>,
 ) -> Result<Option<(Kdf, String)>, SyncError> {
-    let user_decryption_options = user_decryption.as_ref().ok_or(SyncError::DataError)?;
+    let user_decryption_options = user_decryption.as_ref().ok_or(SyncError::Data)?;
     if let Some(master_password_unlock) = &user_decryption_options.master_password_unlock {
-        let kdf =
-            from_kdf(&master_password_unlock.clone().kdf).debug_map_err(SyncError::DataError)?;
-        let salt = master_password_unlock
-            .clone()
-            .salt
-            .ok_or(SyncError::DataError)?;
+        let kdf = from_kdf(&master_password_unlock.clone().kdf).debug_map_err(SyncError::Data)?;
+        let salt = master_password_unlock.clone().salt.ok_or(SyncError::Data)?;
         debug!("Parsed password KDF and salt from sync response");
         Ok(Some((kdf, salt)))
     } else {
@@ -338,21 +334,18 @@ pub(super) async fn sync_current_account_data(
         .sync_api()
         .get(Some(true))
         .await
-        .debug_map_err(SyncError::NetworkError)?;
+        .debug_map_err(SyncError::Network)?;
 
-    let profile = sync.profile.as_ref().ok_or(SyncError::DataError)?;
+    let profile = sync.profile.as_ref().ok_or(SyncError::Data)?;
     // This is optional for master-password-users!
     let kdf_and_salt = parse_kdf_and_salt(&sync.user_decryption)?;
-    let account_cryptographic_state = profile
-        .account_keys
-        .to_owned()
-        .ok_or(SyncError::DataError)?;
+    let account_cryptographic_state = profile.account_keys.to_owned().ok_or(SyncError::Data)?;
     let ciphers = parse_ciphers(sync.ciphers)?;
     let folders = parse_folders(sync.folders)?;
     let sends = parse_sends(sync.sends)?;
     let wrapped_account_cryptographic_state =
         WrappedAccountCryptographicState::try_from(account_cryptographic_state.as_ref())
-            .debug_map_err(SyncError::DataError)?;
+            .debug_map_err(SyncError::Data)?;
 
     // Concurrently sync organization memberships, emergency access memberships, trusted devices,
     // and passkeys
@@ -739,7 +732,7 @@ mod tests {
 
         let result = sync_current_account_data(&api_client).await;
 
-        assert!(matches!(result, Err(SyncError::NetworkError)));
+        assert!(matches!(result, Err(SyncError::Network)));
 
         if let ApiClient::Mock(mut mock) = api_client {
             mock.sync_api.checkpoint();
@@ -822,7 +815,7 @@ mod tests {
 
         let result = fetch_organization_public_key(&api_client, org_id).await;
 
-        assert!(matches!(result, Err(SyncError::NetworkError)));
+        assert!(matches!(result, Err(SyncError::Network)));
 
         if let ApiClient::Mock(mut mock) = api_client {
             mock.organizations_api.checkpoint();
@@ -930,7 +923,7 @@ mod tests {
 
         let result = sync_orgs(&api_client).await;
 
-        assert!(matches!(result, Err(SyncError::NetworkError)));
+        assert!(matches!(result, Err(SyncError::Network)));
 
         if let ApiClient::Mock(mut mock) = api_client {
             mock.organizations_api.checkpoint();
@@ -969,7 +962,7 @@ mod tests {
         });
 
         let result = sync_orgs(&api_client).await;
-        assert!(matches!(result, Err(SyncError::NetworkError)));
+        assert!(matches!(result, Err(SyncError::Network)));
 
         if let ApiClient::Mock(mut mock) = api_client {
             mock.organizations_api.checkpoint();
@@ -1118,7 +1111,7 @@ mod tests {
 
         let result = sync_passkeys(&api_client).await;
 
-        assert!(matches!(result, Err(SyncError::NetworkError)));
+        assert!(matches!(result, Err(SyncError::Network)));
 
         if let ApiClient::Mock(mut mock) = api_client {
             mock.web_authn_api.checkpoint();
@@ -1210,7 +1203,7 @@ mod tests {
 
         let result = sync_devices(&api_client).await;
 
-        assert!(matches!(result, Err(SyncError::NetworkError)));
+        assert!(matches!(result, Err(SyncError::Network)));
 
         if let ApiClient::Mock(mut mock) = api_client {
             mock.devices_api.checkpoint();
@@ -1272,7 +1265,7 @@ mod tests {
 
         let result = fetch_user_public_key(&api_client, user_id).await;
 
-        assert!(matches!(result, Err(SyncError::NetworkError)));
+        assert!(matches!(result, Err(SyncError::Network)));
 
         if let ApiClient::Mock(mut mock) = api_client {
             mock.users_api.checkpoint();
@@ -1390,7 +1383,7 @@ mod tests {
 
         let result = sync_emergency_access(&api_client).await;
 
-        assert!(matches!(result, Err(SyncError::NetworkError)));
+        assert!(matches!(result, Err(SyncError::Network)));
 
         if let ApiClient::Mock(mut mock) = api_client {
             mock.emergency_access_api.checkpoint();
@@ -1434,7 +1427,7 @@ mod tests {
         });
 
         let result = sync_emergency_access(&api_client).await;
-        assert!(matches!(result, Err(SyncError::NetworkError)));
+        assert!(matches!(result, Err(SyncError::Network)));
 
         if let ApiClient::Mock(mut mock) = api_client {
             mock.emergency_access_api.checkpoint();

--- a/crates/bitwarden-user-crypto-management/src/key_rotation/unlock_method.rs
+++ b/crates/bitwarden-user-crypto-management/src/key_rotation/unlock_method.rs
@@ -31,7 +31,7 @@ impl PrimaryUnlockMethod {
                 let (kdf, salt) = synced_account_data
                     .kdf_and_salt
                     .clone()
-                    .ok_or(RotateUserKeysError::ApiError)?;
+                    .ok_or(RotateUserKeysError::Api)?;
                 Ok(PrimaryUnlockMethod::Password {
                     password,
                     kdf,
@@ -172,7 +172,7 @@ mod tests {
             &synced_data,
         );
 
-        assert!(matches!(result, Err(RotateUserKeysError::ApiError)));
+        assert!(matches!(result, Err(RotateUserKeysError::Api)));
     }
 
     #[test]


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-34239

## 📔 Objective

Rename the error variants to not have an `Error` suffix. This should be caught by our custom lints, but they're not currently enabled in CI so I'm trying to fix them and enable a CI check. The work is split per team to avoid too many conflicts.

https://github.com/bitwarden/sdk-internal/blob/a7c9289e54a930f02f79a11fa133100e0ecf1b9e/support/lints/error_enum/src/lib.rs#L12-L42

## 🚨 Breaking Changes

<!-- Does this PR introduce any breaking changes? If so, please describe the impact and migration path for clients.

If you're unsure, the automated TypeScript compatibility check will run when you open/update this PR and provide feedback.

For breaking changes:
1. Describe what changed in the client interface
2. Explain why the change was necessary
3. Provide migration steps for client developers
4. Link to any paired client PRs if needed

Otherwise, you can remove this section. -->
