### PR TITLE
feat: add project_ids to secret list response

### DIFF
--- a/bitwarden_license/bitwarden-sm/src/secrets/list.rs
+++ b/bitwarden_license/bitwarden-sm/src/secrets/list.rs
@@ -91,8 +91,8 @@ impl SecretIdentifiersResponse {
 pub struct SecretIdentifierResponse {
     pub id: Uuid,
     pub organization_id: Uuid,
-
     pub key: String,
+    pub project_ids: Vec<Uuid>,
 }
 
 impl SecretIdentifierResponse {
@@ -107,9 +107,17 @@ impl SecretIdentifierResponse {
             .parse::<EncString>()?
             .decrypt(ctx, enc_key)?;
 
+        let project_ids = response
+            .projects
+            .unwrap_or_default()
+            .iter()
+            .filter_map(|p| p.id)
+            .collect();
+
         Ok(SecretIdentifierResponse {
             id: require!(response.id),
             organization_id,
+            project_ids,
             key,
         })
     }


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/SM-1938

## 📔 Objective

We use `client.secrets().list(org_id)` to get a list of secret IDs and their names:
```rs
SecretIdentifiersResponse {
        data: [
            SecretIdentifierResponse {
                id: 4966ae42-18f0-415d-8d42-82243279b959,
                organization_id: f4e44a7f-1190-432a-9d4a-af96013127cb,
                key: "DB_PASS",
            },
            SecretIdentifierResponse {
                id: fb8f7998-49d4-40f2-a061-750ae064d2ca,
                organization_id: f4e44a7f-1190-432a-9d4a-af96013127cb,
                key: "DB_PASS",
            },
        ],
    }
}
```

However, users have expressed that they commonly have many secrets in different projects with the same name. This requires them to call `secrets().get(secret_id)` for each secret returned in the list response just to determine which project those secrets belong to.

This change reduces the number of API calls in the above situation by adding project_ids to secret list data:

```rs
SecretIdentifiersResponse {
        data: [
            SecretIdentifierResponse {
                id: 4966ae42-18f0-415d-8d42-82243279b959,
                organization_id: f4e44a7f-1190-432a-9d4a-af96013127cb,
                key: "DB_PASS",
                project_ids: [
                    2fecc644-131b-44b0-8404-15be81361a51, // test environment
                ],
            },
            SecretIdentifierResponse {
                id: fb8f7998-49d4-40f2-a061-750ae064d2ca,
                organization_id: f4e44a7f-1190-432a-9d4a-af96013127cb,
                key: "DB_PASS",
                project_ids: [
                    449cf595-0a57-4af2-b653-df52a0372174, // prod environment
                ],
            },
        ],
    }
}
```