### PR TITLE
Add more KM state to state bridge

### DIFF
--- a/crates/bitwarden-core/src/key_management/state_bridge.rs
+++ b/crates/bitwarden-core/src/key_management/state_bridge.rs
@@ -11,7 +11,13 @@ use bitwarden_crypto::{EncString, SymmetricCryptoKey, safe::PasswordProtectedKey
 #[cfg(feature = "wasm")]
 use wasm_bindgen::prelude::*;
 
-use crate::Client;
+use crate::{
+    Client,
+    key_management::{
+        MasterPasswordUnlockData, V2UpgradeToken,
+        account_cryptographic_state::WrappedAccountCryptographicState,
+    },
+};
 
 /// Thread-safe wrapper around the registered [`StateBridgeImpl`] instance.
 pub struct StateBridge {
@@ -120,4 +126,7 @@ bitwarden_state_bridge_macro::state_bridge! {
     persistent_pin_envelope: PasswordProtectedKeyEnvelope as ts "PasswordProtectedKeyEnvelope",
     ephemeral_pin_envelope: PasswordProtectedKeyEnvelope as ts "PasswordProtectedKeyEnvelope",
     encrypted_pin: EncString as ts "EncString",
+    v2_upgrade_token: V2UpgradeToken as ts "V2UpgradeToken",
+    account_cryptographic_state: WrappedAccountCryptographicState as ts "WrappedAccountCryptographicState",
+    masterpassword_unlock_data: MasterPasswordUnlockData as ts "MasterPasswordUnlockData",
 }


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
[no ticket]

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
Adds the UpgradeToken, MPUnlockData, AccountCryptographicState to the state bridge. 
Mainly, the upgrade token is required for the PIN migration after key rotation.

Since this seems trivial, there is no ticket

## 🚨 Breaking Changes

<!-- Does this PR introduce any breaking changes? If so, please describe the impact and migration path for clients.

If you're unsure, the automated TypeScript compatibility check will run when you open/update this PR and provide feedback.

For breaking changes:
1. Describe what changed in the client interface
2. Explain why the change was necessary
3. Provide migration steps for client developers
4. Link to any paired client PRs if needed

Otherwise, you can remove this section. -->
