### PR TITLE
[PM-36839] Replace explicit API error variants by .into()

### DIFF
--- a/crates/bitwarden-auth/src/registration.rs
+++ b/crates/bitwarden-auth/src/registration.rs
@@ -820,9 +820,7 @@ mod tests {
                 .expect_post_keys()
                 .once()
                 .returning(move |_body| {
-                    Err(bitwarden_api_api::apis::Error::Serde(
-                        serde_json::Error::io(std::io::Error::other("API error")),
-                    ))
+                    Err(serde_json::Error::io(std::io::Error::other("API error")).into())
                 });
             // Subsequent API calls should not be made if post_keys fails
             mock.organization_users_api
@@ -876,9 +874,7 @@ mod tests {
                 .expect_put_reset_password_enrollment()
                 .once()
                 .returning(move |_org_id, _user_id, _body| {
-                    Err(bitwarden_api_api::apis::Error::Serde(
-                        serde_json::Error::io(std::io::Error::other("API error")),
-                    ))
+                    Err(serde_json::Error::io(std::io::Error::other("API error")).into())
                 });
             // Device key enrollment should not be made if reset password enrollment fails
             mock.devices_api.expect_put_keys().never();
@@ -933,9 +929,7 @@ mod tests {
                 .expect_put_keys()
                 .once()
                 .returning(move |_device_id, _body| {
-                    Err(bitwarden_api_api::apis::Error::Serde(
-                        serde_json::Error::io(std::io::Error::other("API error")),
-                    ))
+                    Err(serde_json::Error::io(std::io::Error::other("API error")).into())
                 });
         });
 
@@ -1083,9 +1077,7 @@ mod tests {
                 .expect_post_set_key_connector_key()
                 .once()
                 .returning(move |_body| {
-                    Err(bitwarden_api_api::apis::Error::Serde(
-                        serde_json::Error::io(std::io::Error::other("API error")),
-                    ))
+                    Err(serde_json::Error::io(std::io::Error::other("API error")).into())
                 });
         });
 
@@ -1279,9 +1271,7 @@ mod tests {
                 .expect_post_set_password()
                 .once()
                 .returning(move |_body| {
-                    Err(bitwarden_api_api::apis::Error::Serde(
-                        serde_json::Error::io(std::io::Error::other("API error")),
-                    ))
+                    Err(serde_json::Error::io(std::io::Error::other("API error")).into())
                 });
             mock.organization_users_api
                 .expect_put_reset_password_enrollment()
@@ -1330,9 +1320,7 @@ mod tests {
                 .expect_put_reset_password_enrollment()
                 .once()
                 .returning(move |_org_id, _user_id, _body| {
-                    Err(bitwarden_api_api::apis::Error::Serde(
-                        serde_json::Error::io(std::io::Error::other("API error")),
-                    ))
+                    Err(serde_json::Error::io(std::io::Error::other("API error")).into())
                 });
         });
 
@@ -1548,9 +1536,7 @@ mod tests {
                 .expect_post_register_finish()
                 .once()
                 .returning(move |_body| {
-                    Err(bitwarden_api_api::apis::Error::Serde(
-                        serde_json::Error::io(std::io::Error::other("API error")),
-                    ))
+                    Err(serde_json::Error::io(std::io::Error::other("API error")).into())
                 });
         });
 

--- a/crates/bitwarden-send/src/create.rs
+++ b/crates/bitwarden-send/src/create.rs
@@ -288,11 +288,9 @@ mod tests {
         }
 
         let api_client = ApiClient::new_mocked(move |mock| {
-            mock.sends_api.expect_post().returning(move |_model| {
-                Err(bitwarden_api_api::apis::Error::Io(std::io::Error::other(
-                    "Simulated error",
-                )))
-            });
+            mock.sends_api
+                .expect_post()
+                .returning(move |_model| Err(std::io::Error::other("Simulated error").into()));
         });
 
         let repository = MemoryRepository::<Send>::default();

--- a/crates/bitwarden-send/src/edit.rs
+++ b/crates/bitwarden-send/src/edit.rs
@@ -436,11 +436,9 @@ mod tests {
             .unwrap();
 
         let api_client = ApiClient::new_mocked(move |mock| {
-            mock.sends_api.expect_put().returning(move |_id, _model| {
-                Err(bitwarden_api_api::apis::Error::Io(std::io::Error::other(
-                    "Simulated error",
-                )))
-            });
+            mock.sends_api
+                .expect_put()
+                .returning(move |_id, _model| Err(std::io::Error::other("Simulated error").into()));
         });
 
         let result = edit_send(

--- a/crates/bitwarden-sync/src/sync_client.rs
+++ b/crates/bitwarden-sync/src/sync_client.rs
@@ -321,11 +321,9 @@ mod tests {
     #[tokio::test]
     async fn test_sync_error_notifies_error_handlers() {
         let client = test_client(bitwarden_api_api::apis::ApiClient::new_mocked(|mock| {
-            mock.sync_api.expect_get().returning(|_| {
-                Err(bitwarden_api_api::Error::Io(std::io::Error::other(
-                    "test error",
-                )))
-            });
+            mock.sync_api
+                .expect_get()
+                .returning(|_| Err(std::io::Error::other("test error").into()));
         }));
         let error_log = Arc::new(Mutex::new(Vec::new()));
 

--- a/crates/bitwarden-user-crypto-management/src/key_connector_migration.rs
+++ b/crates/bitwarden-user-crypto-management/src/key_connector_migration.rs
@@ -294,9 +294,7 @@ mod tests {
                     wrapped_key
                         .parse::<EncString>()
                         .expect("key_connector_key_wrapped_user_key should be a valid EncString");
-                    Err(bitwarden_api_api::apis::Error::Serde(
-                        serde_json::Error::io(std::io::Error::other("API error")),
-                    ))
+                    Err(serde_json::Error::io(std::io::Error::other("API error")).into())
                 });
         });
 

--- a/crates/bitwarden-user-crypto-management/src/key_rotation/password_change_and_rotate_user_keys.rs
+++ b/crates/bitwarden-user-crypto-management/src/key_rotation/password_change_and_rotate_user_keys.rs
@@ -256,9 +256,7 @@ mod tests {
         let store: KeyStore<KeySlotIds> = KeyStore::default();
         let api_client = ApiClient::new_mocked(|mock| {
             mock.sync_api.expect_get().once().returning(|_| {
-                Err(bitwarden_api_api::apis::Error::Serde(
-                    serde_json::Error::io(std::io::Error::other("network error")),
-                ))
+                Err(serde_json::Error::io(std::io::Error::other("network error")).into())
             });
             mock.accounts_key_management_api
                 .expect_password_change_and_rotate_user_account_keys()
@@ -379,9 +377,7 @@ mod tests {
                 .expect_password_change_and_rotate_user_account_keys()
                 .once()
                 .returning(|_| {
-                    Err(bitwarden_api_api::apis::Error::Serde(
-                        serde_json::Error::io(std::io::Error::other("API error")),
-                    ))
+                    Err(serde_json::Error::io(std::io::Error::other("API error")).into())
                 });
         });
 

--- a/crates/bitwarden-user-crypto-management/src/key_rotation/rotate_user_keys.rs
+++ b/crates/bitwarden-user-crypto-management/src/key_rotation/rotate_user_keys.rs
@@ -335,9 +335,7 @@ mod tests {
         let key_store: KeyStore<KeySlotIds> = KeyStore::default();
         let api_client = ApiClient::new_mocked(|mock| {
             mock.sync_api.expect_get().once().returning(|_| {
-                Err(bitwarden_api_api::apis::Error::Serde(
-                    serde_json::Error::io(std::io::Error::other("network error")),
-                ))
+                Err(serde_json::Error::io(std::io::Error::other("network error")).into())
             });
             mock.accounts_key_management_api
                 .expect_rotate_user_keys()
@@ -416,9 +414,7 @@ mod tests {
                 .expect_rotate_user_keys()
                 .once()
                 .returning(|_| {
-                    Err(bitwarden_api_api::apis::Error::Serde(
-                        serde_json::Error::io(std::io::Error::other("API error")),
-                    ))
+                    Err(serde_json::Error::io(std::io::Error::other("API error")).into())
                 });
         });
 

--- a/crates/bitwarden-user-crypto-management/src/key_rotation/sync.rs
+++ b/crates/bitwarden-user-crypto-management/src/key_rotation/sync.rs
@@ -716,9 +716,7 @@ mod tests {
                 .expect_get()
                 .once()
                 .returning(move |_exclude_domains| {
-                    Err(bitwarden_api_api::apis::Error::Serde(
-                        serde_json::Error::io(std::io::Error::other("API error")),
-                    ))
+                    Err(serde_json::Error::io(std::io::Error::other("API error")).into())
                 });
             mock.organizations_api.expect_get_user().never();
             mock.organizations_api.expect_get_public_key().never();
@@ -805,9 +803,7 @@ mod tests {
                 .expect_get_public_key()
                 .once()
                 .returning(move |_| {
-                    Err(bitwarden_api_api::apis::Error::Serde(
-                        serde_json::Error::io(std::io::Error::other("Network error")),
-                    ))
+                    Err(serde_json::Error::io(std::io::Error::other("Network error")).into())
                 });
         });
 
@@ -911,9 +907,7 @@ mod tests {
                 .expect_get_user()
                 .once()
                 .returning(move || {
-                    Err(bitwarden_api_api::apis::Error::Serde(
-                        serde_json::Error::io(std::io::Error::other("Network error")),
-                    ))
+                    Err(serde_json::Error::io(std::io::Error::other("Network error")).into())
                 });
 
             mock.organizations_api.expect_get_public_key().never();
@@ -953,9 +947,7 @@ mod tests {
                 .expect_get_public_key()
                 .once()
                 .returning(move |_| {
-                    Err(bitwarden_api_api::apis::Error::Serde(
-                        serde_json::Error::io(std::io::Error::other("Network error")),
-                    ))
+                    Err(serde_json::Error::io(std::io::Error::other("Network error")).into())
                 });
         });
 
@@ -1101,9 +1093,7 @@ mod tests {
     async fn test_sync_passkeys_network_error() {
         let api_client = ApiClient::new_mocked(|mock| {
             mock.web_authn_api.expect_get().once().returning(move || {
-                Err(bitwarden_api_api::apis::Error::Serde(
-                    serde_json::Error::io(std::io::Error::other("Network error")),
-                ))
+                Err(serde_json::Error::io(std::io::Error::other("Network error")).into())
             });
         });
 
@@ -1193,9 +1183,7 @@ mod tests {
     async fn test_sync_devices_network_error() {
         let api_client = ApiClient::new_mocked(|mock| {
             mock.devices_api.expect_get_all().once().returning(move || {
-                Err(bitwarden_api_api::apis::Error::Serde(
-                    serde_json::Error::io(std::io::Error::other("Network error")),
-                ))
+                Err(serde_json::Error::io(std::io::Error::other("Network error")).into())
             });
         });
 
@@ -1255,9 +1243,7 @@ mod tests {
                 .expect_get_public_key()
                 .once()
                 .returning(move |_| {
-                    Err(bitwarden_api_api::apis::Error::Serde(
-                        serde_json::Error::io(std::io::Error::other("Network error")),
-                    ))
+                    Err(serde_json::Error::io(std::io::Error::other("Network error")).into())
                 });
         });
 
@@ -1371,9 +1357,7 @@ mod tests {
                 .expect_get_contacts()
                 .once()
                 .returning(move || {
-                    Err(bitwarden_api_api::apis::Error::Serde(
-                        serde_json::Error::io(std::io::Error::other("Network error")),
-                    ))
+                    Err(serde_json::Error::io(std::io::Error::other("Network error")).into())
                 });
 
             mock.users_api.expect_get_public_key().never();
@@ -1418,9 +1402,7 @@ mod tests {
                 .expect_get_public_key()
                 .once()
                 .returning(move |_| {
-                    Err(bitwarden_api_api::apis::Error::Serde(
-                        serde_json::Error::io(std::io::Error::other("Network error")),
-                    ))
+                    Err(serde_json::Error::io(std::io::Error::other("Network error")).into())
                 });
         });
 

--- a/crates/bitwarden-vault/src/cipher/cipher_client/admin/edit.rs
+++ b/crates/bitwarden-vault/src/cipher/cipher_client/admin/edit.rs
@@ -326,11 +326,7 @@ mod tests {
         let api_client = ApiClient::new_mocked(move |mock| {
             mock.ciphers_api
                 .expect_put_admin()
-                .returning(move |_id, _body| {
-                    Err(bitwarden_api_api::apis::Error::Io(std::io::Error::other(
-                        "Simulated error",
-                    )))
-                });
+                .returning(move |_id, _body| Err(std::io::Error::other("Simulated error").into()));
         });
         let orig_cipher_view = generate_test_cipher();
         let cipher_view = orig_cipher_view.clone();

--- a/crates/bitwarden-vault/src/cipher/cipher_client/create.rs
+++ b/crates/bitwarden-vault/src/cipher/cipher_client/create.rs
@@ -336,11 +336,9 @@ mod tests {
         }
 
         let api_client = ApiClient::new_mocked(move |mock| {
-            mock.ciphers_api.expect_post().returning(move |_body| {
-                Err(bitwarden_api_api::apis::Error::Io(std::io::Error::other(
-                    "Simulated error",
-                )))
-            });
+            mock.ciphers_api
+                .expect_post()
+                .returning(move |_body| Err(std::io::Error::other("Simulated error").into()));
         });
 
         let repository = MemoryRepository::<Cipher>::default();

--- a/crates/bitwarden-vault/src/cipher/cipher_client/edit.rs
+++ b/crates/bitwarden-vault/src/cipher/cipher_client/edit.rs
@@ -530,11 +530,9 @@ mod tests {
         let cipher_id: CipherId = "5faa9684-c793-4a2d-8a12-b33900187097".parse().unwrap();
 
         let api_client = ApiClient::new_mocked(move |mock| {
-            mock.ciphers_api.expect_put().returning(move |_id, _body| {
-                Err(bitwarden_api_api::apis::Error::Io(std::io::Error::other(
-                    "Simulated error",
-                )))
-            });
+            mock.ciphers_api
+                .expect_put()
+                .returning(move |_id, _body| Err(std::io::Error::other("Simulated error").into()));
         });
 
         let repository = MemoryRepository::<Cipher>::default();

--- a/crates/bitwarden-vault/src/cipher/cipher_client/share_cipher.rs
+++ b/crates/bitwarden-vault/src/cipher/cipher_client/share_cipher.rs
@@ -639,11 +639,9 @@ mod tests {
     #[tokio::test]
     async fn test_share_cipher_api_handles_404() {
         let api_client = ApiClient::new_mocked(|mock| {
-            mock.ciphers_api.expect_put_share().returning(|_id, _body| {
-                Err(bitwarden_api_api::apis::Error::Io(std::io::Error::other(
-                    "Not found",
-                )))
-            });
+            mock.ciphers_api
+                .expect_put_share()
+                .returning(|_id, _body| Err(std::io::Error::other("Not found").into()));
         });
 
         let repository = MemoryRepository::<Cipher>::default();
@@ -777,11 +775,9 @@ mod tests {
     #[tokio::test]
     async fn test_share_ciphers_bulk_api_handles_error() {
         let api_client = ApiClient::new_mocked(|mock| {
-            mock.ciphers_api.expect_put_share_many().returning(|_body| {
-                Err(bitwarden_api_api::apis::Error::Io(std::io::Error::other(
-                    "Server error",
-                )))
-            });
+            mock.ciphers_api
+                .expect_put_share_many()
+                .returning(|_body| Err(std::io::Error::other("Server error").into()));
         });
 
         let repository = MemoryRepository::<Cipher>::default();

--- a/crates/bitwarden-vault/src/folder/create.rs
+++ b/crates/bitwarden-vault/src/folder/create.rs
@@ -173,11 +173,9 @@ mod tests {
     #[tokio::test]
     async fn test_create_folder_http_error() {
         let client = create_client(ApiClient::new_mocked(move |mock| {
-            mock.folders_api.expect_post().returning(move |_model| {
-                Err(bitwarden_api_api::apis::Error::Io(std::io::Error::other(
-                    "Simulated error",
-                )))
-            });
+            mock.folders_api
+                .expect_post()
+                .returning(move |_model| Err(std::io::Error::other("Simulated error").into()));
         }));
 
         let result = client

--- a/crates/bitwarden-vault/src/folder/edit.rs
+++ b/crates/bitwarden-vault/src/folder/edit.rs
@@ -190,11 +190,9 @@ mod tests {
         let folder_id = FolderId::new(uuid!("25afb11c-9c95-4db5-8bac-c21cb204a3f1"));
 
         let client = create_client(ApiClient::new_mocked(move |mock| {
-            mock.folders_api.expect_put().returning(move |_id, _model| {
-                Err(bitwarden_api_api::apis::Error::Io(std::io::Error::other(
-                    "Simulated error",
-                )))
-            });
+            mock.folders_api
+                .expect_put()
+                .returning(move |_id, _model| Err(std::io::Error::other("Simulated error").into()));
         }));
 
         repository_add_folder(&client, folder_id, "old_name").await;


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-36839

## 📔 Objective

We currently have two `ApiError` enums: one in `bitwarden-api-base` and another one in `bitwarden-core`, which wraps the former and exposes it through UniFFI. 

I'd like to consolidate both of these into one (which would remove a fair amount of error mapping that we're doing), but doing so requires quite extensive changes.

This PR starts building on that by removing explicit usages of the error type and replacing them by `.into()` calls with type inference. This should make the error migration easier, and it also makes the errors simpler to read.

## 🚨 Breaking Changes

<!-- Does this PR introduce any breaking changes? If so, please describe the impact and migration path for clients.

If you're unsure, the automated TypeScript compatibility check will run when you open/update this PR and provide feedback.

For breaking changes:
1. Describe what changed in the client interface
2. Explain why the change was necessary
3. Provide migration steps for client developers
4. Link to any paired client PRs if needed

Otherwise, you can remove this section. -->
