### PR TITLE
deps(crypto): relax typenum upper bound

### DIFF
--- a/crates/bitwarden-crypto/Cargo.toml
+++ b/crates/bitwarden-crypto/Cargo.toml
@@ -65,7 +65,7 @@ subtle = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
 tsify = { workspace = true, optional = true }
-typenum = ">=1.18.0, <1.20.0"
+typenum = ">=1.18, <2"
 uniffi = { workspace = true, optional = true }
 uuid = { workspace = true }
 wasm-bindgen = { workspace = true, optional = true }


### PR DESCRIPTION
## 🎟️ Tracking

n/a — drive-by dependency-bounds relaxation.

## 📔 Objective

`bitwarden-crypto` currently pins `typenum = ">=1.18.0, <1.20.0"`. The crate only consumes a handful of stable type aliases — `U32`, `U64`, `U8192`, `Unsigned` — that have been part of typenum's public API since well before 1.18, and that have not changed in 1.19 or 1.20. The upper bound therefore prevents downstream graphs that legitimately need newer typenum from compiling, with no benefit to bitwarden-crypto.

In particular, this blocks consumers that pull in `sha2 0.11` (and its transitive `digest 0.11` / `block-buffer 0.12` / `hybrid-array 0.4` chain), which require `typenum ^1.20`.

This PR relaxes the bound to `>=1.18, <2`, allowing any 1.x version while preserving the existing minimum.

### Verification

- `cargo check -p bitwarden-crypto` passes with `typenum 1.20.0` in the lockfile.
- `cargo test -p bitwarden-crypto --lib`: 167 passed, 0 failed (12 ignored, unchanged from main).

## 🚨 Breaking Changes

None. The change strictly widens the allowed range of an existing dependency. Existing consumers continue to resolve the same version they do today.
