### PR TITLE
feat(state): feature-gate the SQLite-backed SDK-managed database

### DIFF
--- a/crates/bitwarden-state/Cargo.toml
+++ b/crates/bitwarden-state/Cargo.toml
@@ -13,6 +13,12 @@ license-file.workspace = true
 keywords.workspace = true
 
 [features]
+default = ["sdk-managed-sqlite"]
+# Enable the SQLite-backed SDK-managed database on native platforms.
+# Disabling this drops the rusqlite/libsqlite3-sys dependency, which is
+# useful for downstream consumers that ship their own SQLite (e.g. via
+# sqlx) and would otherwise hit a `links = "sqlite3"` collision.
+sdk-managed-sqlite = ["dep:rusqlite"]
 uniffi = ["dep:uniffi"]
 wasm = ["bitwarden-threading/wasm"]
 
@@ -26,7 +32,7 @@ thiserror = { workspace = true }
 tokio = { workspace = true }
 
 [target.'cfg(not(target_arch="wasm32"))'.dependencies]
-rusqlite = { version = ">=0.37.0, <0.40", features = ["bundled"] }
+rusqlite = { version = ">=0.37.0, <0.40", features = ["bundled"], optional = true }
 uniffi = { workspace = true, optional = true }
 
 [target.'cfg(target_arch="wasm32")'.dependencies]

--- a/crates/bitwarden-state/src/sdk_managed/mod.rs
+++ b/crates/bitwarden-state/src/sdk_managed/mod.rs
@@ -11,7 +11,7 @@ pub use configuration::DatabaseConfiguration;
 #[cfg(target_arch = "wasm32")]
 mod indexed_db;
 
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(all(not(target_arch = "wasm32"), feature = "sdk-managed-sqlite"))]
 mod sqlite;
 
 mod memory;
@@ -43,7 +43,7 @@ impl From<::indexed_db::Error<indexed_db::IndexedDbInternalError>> for DatabaseE
     }
 }
 
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(all(not(target_arch = "wasm32"), feature = "sdk-managed-sqlite"))]
 impl From<rusqlite::Error> for DatabaseError {
     fn from(e: rusqlite::Error) -> Self {
         DatabaseError::Internal(e.to_string())
@@ -78,7 +78,7 @@ pub trait Database {
 
 #[derive(Clone)]
 pub(super) enum SystemDatabase {
-    #[cfg(not(target_arch = "wasm32"))]
+    #[cfg(all(not(target_arch = "wasm32"), feature = "sdk-managed-sqlite"))]
     Sqlite(sqlite::SqliteDatabase),
     #[cfg(target_arch = "wasm32")]
     IndexedDb(indexed_db::IndexedDbDatabase),
@@ -86,12 +86,16 @@ pub(super) enum SystemDatabase {
 }
 
 impl Database for SystemDatabase {
+    #[cfg_attr(
+        not(any(target_arch = "wasm32", feature = "sdk-managed-sqlite")),
+        allow(unused_variables)
+    )]
     async fn initialize(
         configuration: DatabaseConfiguration,
         migrations: RepositoryMigrations,
     ) -> Result<Self, DatabaseError> {
         match configuration {
-            #[cfg(not(target_arch = "wasm32"))]
+            #[cfg(all(not(target_arch = "wasm32"), feature = "sdk-managed-sqlite"))]
             DatabaseConfiguration::Sqlite { .. } => Ok(SystemDatabase::Sqlite(
                 sqlite::SqliteDatabase::initialize(configuration, migrations).await?,
             )),
@@ -107,7 +111,7 @@ impl Database for SystemDatabase {
 
     async fn get<T: RepositoryItem>(&self, key: &str) -> Result<Option<T>, DatabaseError> {
         match self {
-            #[cfg(not(target_arch = "wasm32"))]
+            #[cfg(all(not(target_arch = "wasm32"), feature = "sdk-managed-sqlite"))]
             SystemDatabase::Sqlite(db) => db.get(key).await,
             #[cfg(target_arch = "wasm32")]
             SystemDatabase::IndexedDb(db) => db.get(key).await,
@@ -117,7 +121,7 @@ impl Database for SystemDatabase {
 
     async fn list<T: RepositoryItem>(&self) -> Result<Vec<T>, DatabaseError> {
         match self {
-            #[cfg(not(target_arch = "wasm32"))]
+            #[cfg(all(not(target_arch = "wasm32"), feature = "sdk-managed-sqlite"))]
             SystemDatabase::Sqlite(db) => db.list().await,
             #[cfg(target_arch = "wasm32")]
             SystemDatabase::IndexedDb(db) => db.list().await,
@@ -127,7 +131,7 @@ impl Database for SystemDatabase {
 
     async fn set<T: RepositoryItem>(&self, key: &str, value: T) -> Result<(), DatabaseError> {
         match self {
-            #[cfg(not(target_arch = "wasm32"))]
+            #[cfg(all(not(target_arch = "wasm32"), feature = "sdk-managed-sqlite"))]
             SystemDatabase::Sqlite(db) => db.set(key, value).await,
             #[cfg(target_arch = "wasm32")]
             SystemDatabase::IndexedDb(db) => db.set(key, value).await,
@@ -140,7 +144,7 @@ impl Database for SystemDatabase {
         values: Vec<(String, T)>,
     ) -> Result<(), DatabaseError> {
         match self {
-            #[cfg(not(target_arch = "wasm32"))]
+            #[cfg(all(not(target_arch = "wasm32"), feature = "sdk-managed-sqlite"))]
             SystemDatabase::Sqlite(db) => db.set_bulk(values).await,
             #[cfg(target_arch = "wasm32")]
             SystemDatabase::IndexedDb(db) => db.set_bulk(values).await,
@@ -150,7 +154,7 @@ impl Database for SystemDatabase {
 
     async fn remove<T: RepositoryItem>(&self, key: &str) -> Result<(), DatabaseError> {
         match self {
-            #[cfg(not(target_arch = "wasm32"))]
+            #[cfg(all(not(target_arch = "wasm32"), feature = "sdk-managed-sqlite"))]
             SystemDatabase::Sqlite(db) => db.remove::<T>(key).await,
             #[cfg(target_arch = "wasm32")]
             SystemDatabase::IndexedDb(db) => db.remove::<T>(key).await,
@@ -160,7 +164,7 @@ impl Database for SystemDatabase {
 
     async fn remove_bulk<T: RepositoryItem>(&self, keys: Vec<String>) -> Result<(), DatabaseError> {
         match self {
-            #[cfg(not(target_arch = "wasm32"))]
+            #[cfg(all(not(target_arch = "wasm32"), feature = "sdk-managed-sqlite"))]
             SystemDatabase::Sqlite(db) => db.remove_bulk::<T>(keys).await,
             #[cfg(target_arch = "wasm32")]
             SystemDatabase::IndexedDb(db) => db.remove_bulk::<T>(keys).await,
@@ -170,7 +174,7 @@ impl Database for SystemDatabase {
 
     async fn remove_all<T: RepositoryItem>(&self) -> Result<(), DatabaseError> {
         match self {
-            #[cfg(not(target_arch = "wasm32"))]
+            #[cfg(all(not(target_arch = "wasm32"), feature = "sdk-managed-sqlite"))]
             SystemDatabase::Sqlite(db) => db.remove_all::<T>().await,
             #[cfg(target_arch = "wasm32")]
             SystemDatabase::IndexedDb(db) => db.remove_all::<T>().await,


### PR DESCRIPTION
## 🎟️ Tracking

n/a — fixes a downstream integration block.

## 📔 Objective

`bitwarden-state` unconditionally depends on `rusqlite` with the `bundled` feature on non-wasm targets. `rusqlite` declares `links = "sqlite3"`, which Cargo enforces as exclusive: any downstream graph that already contains a different `libsqlite3-sys` version (e.g. via `sqlx-sqlite`) fails to build with:

```
package `libsqlite3-sys vX.Y.Z` links to the native library `sqlite3`,
but it conflicts with a previous package which links to `sqlite3` as well
```

Concretely this currently blocks anyone composing the bitwarden SDK with `sqlx 0.8.x` — the only `sqlx` line that aligns is `0.9.0-alpha.1`.

The SQLite-backed `SystemDatabase::Sqlite` variant is one of three (`Sqlite`, `IndexedDb`, `Memory`) and only `Memory` is needed for consumers using exclusively client-managed repositories. This PR adds a default-on `sdk-managed-sqlite` feature that gates `rusqlite` and the `SqliteDatabase` impl. Disabling it drops `rusqlite`/`libsqlite3-sys` from the dep graph entirely, leaving `Memory` (and `IndexedDb` on wasm) as the available backends.

When the feature is off, `DatabaseConfiguration::Sqlite { .. }` falls through to `DatabaseError::UnsupportedConfiguration` at runtime, mirroring the existing pattern used for unsupported configurations on a given platform. The `DatabaseConfiguration` enum keeps all variants so the type's shape is unchanged.

### Verification

- `cargo check -p bitwarden-state` (default features): builds, includes `rusqlite`.
- `cargo check -p bitwarden-state --no-default-features`: builds, no `rusqlite` / `libsqlite3-sys` in the dep graph.
- `cargo test -p bitwarden-state --lib`: 17 passed (includes 2 SQLite tests).
- `cargo test -p bitwarden-state --lib --no-default-features`: 15 passed (SQLite tests skipped, as expected).

## 🚨 Breaking Changes

None for existing consumers. The new `sdk-managed-sqlite` feature is in `default`, so the default dependency footprint and runtime behavior are identical.

Consumers that want to opt out add:

```toml
bitwarden-state = { version = "...", default-features = false }
# (re-enable other features as needed, e.g. "uniffi")
```

The public API is unchanged: `DatabaseConfiguration`, `Database`, `StateClient::initialize_database`, etc. all still compile against both feature configurations. Calling `initialize_database` with `DatabaseConfiguration::Sqlite { .. }` while the feature is disabled returns `DatabaseError::UnsupportedConfiguration`, matching the existing semantics for unsupported runtime configurations.
