### PR TITLE
Add post_keys_for_user_password_registration in uniffi bindings for registration client

### DIFF
--- a/crates/bitwarden-uniffi/src/auth/registration.rs
+++ b/crates/bitwarden-uniffi/src/auth/registration.rs
@@ -3,6 +3,7 @@ use bitwarden_auth::{
     registration::{
         JitMasterPasswordRegistrationRequest, JitMasterPasswordRegistrationResponse,
         KeyConnectorRegistrationResult, TdeRegistrationRequest, TdeRegistrationResponse,
+        UserMasterPasswordRegistrationRequest, UserMasterPasswordRegistrationResponse,
     },
 };
 
@@ -53,6 +54,20 @@ impl RegistrationClient {
             .auth_new()
             .registration()
             .post_keys_for_jit_password_registration(request)
+            .await?)
+    }
+
+    /// Initializes new password-based cryptographic state for a user
+    /// and posts the state to the server
+    pub async fn post_keys_for_user_password_registration(
+        &self,
+        request: UserMasterPasswordRegistrationRequest,
+    ) -> Result<UserMasterPasswordRegistrationResponse, BitwardenError> {
+        Ok(self
+            .0
+            .auth_new()
+            .registration()
+            .post_keys_for_user_password_registration(request)
             .await?)
     }
 }


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-24221
Originally part of #1018 - separated out to decouple review dependencies.

## 📔 Objective

This PR adds uniffi bindings for the newly created `post_keys_for_user_password_registration` method in the registration client, allowing mobile to access the new v2 registration flow.

This PR stacks on top of #1046 so it can use the correct method API.
