### PR TITLE
[PM-36565] Refactor CollectionType enum to use wasm_bindgen for better WASM integration

### DIFF
--- a/crates/bitwarden-collections/src/collection.rs
+++ b/crates/bitwarden-collections/src/collection.rs
@@ -54,13 +54,9 @@ pub struct CollectionView {
 
 /// Type of collection
 #[derive(Serialize_repr, Deserialize_repr, Debug, Clone, Eq, PartialEq)]
-#[cfg_attr(feature = "uniffi", derive(uniffi::Enum))]
-#[cfg_attr(
-    feature = "wasm",
-    derive(tsify::Tsify),
-    tsify(into_wasm_abi, from_wasm_abi)
-)]
 #[repr(u8)]
+#[cfg_attr(feature = "uniffi", derive(uniffi::Enum))]
+#[cfg_attr(feature = "wasm", wasm_bindgen)]
 pub enum CollectionType {
     /// Default collection type. Can be assigned by an organization to user(s) or group(s)
     SharedCollection = 0,


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-36565

## 📔 Objective

Fixes up the collection.rs file so the generating via wasm is correct and uses u8 rather than strings for TypeScript