### PR TITLE
Remove csharp from recommended extensions

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -2,7 +2,6 @@
   "recommendations": [
     "dbaeumer.vscode-eslint",
     "esbenp.prettier-vscode",
-    "ms-dotnettools.csharp",
     "MS-vsliveshare.vsliveshare",
     "rust-lang.rust-analyzer",
     "streetsidesoftware.code-spell-checker",


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

We do not use any c# in this repo any longer, it was moved to `sdk-sm`.
