### PR TITLE
[PM-37089] Add lint to detect UniFFI async fns not using tokio

### DIFF
--- a/support/lints/Cargo.lock
+++ b/support/lints/Cargo.lock
@@ -105,7 +105,17 @@ version = "0.1.0"
 dependencies = [
  "bitwarden_error_enum",
  "bitwarden_error_suffix",
+ "bitwarden_uniffi_async_export",
  "dylint_linting",
+]
+
+[[package]]
+name = "bitwarden_uniffi_async_export"
+version = "0.1.0"
+dependencies = [
+ "clippy_utils",
+ "dylint_linting",
+ "dylint_testing",
 ]
 
 [[package]]

--- a/support/lints/Cargo.toml
+++ b/support/lints/Cargo.toml
@@ -12,6 +12,7 @@ crate-type = ["cdylib"]
 [dependencies]
 bitwarden_error_enum = { path = "error_enum", features = ["rlib"] }
 bitwarden_error_suffix = { path = "error_suffix", features = ["rlib"] }
+bitwarden_uniffi_async_export = { path = "uniffi_async_export", features = ["rlib"] }
 dylint_linting = { workspace = true }
 
 [package.metadata.rust-analyzer]

--- a/support/lints/README.md
+++ b/support/lints/README.md
@@ -7,4 +7,5 @@ The following lints are currently available:
 
 - `error_enum`: Forbids enum variants from having the `Error` suffix.
 - `error_suffix`: Ensures that types deriving `std::error::Error` have the `Error` suffix.
-- `uniffi_async_export`: Ensures `#[uniffi::export]` on `async fn`s (free or inside an impl) specifies `async_runtime = "tokio"`.
+- `uniffi_async_export`: Ensures `#[uniffi::export]` on `async fn`s (free or inside an impl)
+  specifies `async_runtime = "tokio"`.

--- a/support/lints/README.md
+++ b/support/lints/README.md
@@ -7,3 +7,4 @@ The following lints are currently available:
 
 - `error_enum`: Forbids enum variants from having the `Error` suffix.
 - `error_suffix`: Ensures that types deriving `std::error::Error` have the `Error` suffix.
+- `uniffi_async_export`: Ensures `#[uniffi::export]` on `async fn`s (free or inside an impl) specifies `async_runtime = "tokio"`.

--- a/support/lints/src/lib.rs
+++ b/support/lints/src/lib.rs
@@ -11,4 +11,5 @@ extern crate rustc_session;
 pub fn register_lints(sess: &rustc_session::Session, lint_store: &mut rustc_lint::LintStore) {
     bitwarden_error_enum::register_lints(sess, lint_store);
     bitwarden_error_suffix::register_lints(sess, lint_store);
+    bitwarden_uniffi_async_export::register_lints(sess, lint_store);
 }

--- a/support/lints/uniffi_async_export/.cargo/config.toml
+++ b/support/lints/uniffi_async_export/.cargo/config.toml
@@ -1,0 +1,6 @@
+[target.'cfg(all())']
+rustflags = ["-C", "linker=dylint-link"]
+
+# For Rust versions 1.74.0 and onward, the following alternative can be used
+# (see https://github.com/rust-lang/cargo/pull/12535):
+# linker = "dylint-link"

--- a/support/lints/uniffi_async_export/Cargo.toml
+++ b/support/lints/uniffi_async_export/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "bitwarden_uniffi_async_export"
+version = "0.1.0"
+authors = ["Bitwarden Inc"]
+description = "Lints validating `#[uniffi::export]` usage on async impl blocks"
+edition = "2021"
+publish = false
+
+[features]
+rlib = ["dylint_linting/constituent"]
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[[example]]
+name = "ui"
+path = "ui/main.rs"
+
+[dependencies]
+clippy_utils = { workspace = true }
+dylint_linting = { workspace = true }
+
+[dev-dependencies]
+dylint_testing = { workspace = true }
+
+[package.metadata.rust-analyzer]
+rustc_private = true

--- a/support/lints/uniffi_async_export/src/lib.rs
+++ b/support/lints/uniffi_async_export/src/lib.rs
@@ -1,0 +1,157 @@
+#![feature(rustc_private)]
+#![warn(unused_extern_crates)]
+
+extern crate rustc_ast;
+extern crate rustc_errors;
+
+use clippy_utils::diagnostics::{span_lint_and_help, span_lint_and_sugg};
+use rustc_ast::ast::{
+    AssocItemKind, AttrArgs, AttrKind, Attribute, CoroutineKind, FnSig, Item, ItemKind,
+};
+use rustc_ast::token::{LitKind, TokenKind};
+use rustc_ast::tokenstream::TokenTree;
+use rustc_errors::Applicability;
+use rustc_lint::{EarlyContext, EarlyLintPass};
+
+dylint_linting::declare_pre_expansion_lint! {
+    /// ### What it does
+    ///
+    /// Warns when `#[uniffi::export]` is applied to an `async fn` (either a
+    /// free function or any `async fn` inside an `impl` block) without
+    /// specifying `async_runtime = "tokio"`.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// UniFFI requires an explicit async runtime when exporting `async fn`s.
+    /// Omitting it produces non-functional bindings or compile errors
+    /// downstream when generating mobile bindings.
+    ///
+    /// ### Example
+    ///
+    /// ```rust,ignore
+    /// #[uniffi::export]
+    /// impl Foo {
+    ///     async fn bar(&self) {}
+    /// }
+    /// ```
+    ///
+    /// Use instead:
+    ///
+    /// ```rust,ignore
+    /// #[uniffi::export(async_runtime = "tokio")]
+    /// impl Foo {
+    ///     async fn bar(&self) {}
+    /// }
+    /// ```
+    pub UNIFFI_ASYNC_EXPORT,
+    Warn,
+    "`#[uniffi::export]` on `async fn`s must specify `async_runtime = \"tokio\"`"
+}
+
+impl EarlyLintPass for UniffiAsyncExport {
+    fn check_item(&mut self, cx: &EarlyContext<'_>, item: &Item) {
+        let Some(attr) = item.attrs.iter().find(|a| is_uniffi_export(a)) else {
+            return;
+        };
+
+        let has_async = match &item.kind {
+            ItemKind::Impl(impl_) => contains_async_fn(impl_),
+            ItemKind::Fn(fn_) => is_async(&fn_.sig),
+            _ => return,
+        };
+
+        if !has_async {
+            return;
+        }
+
+        if has_async_runtime_tokio(attr) {
+            return;
+        }
+
+        emit_lint(cx, attr);
+    }
+}
+
+fn is_async(sig: &FnSig) -> bool {
+    matches!(sig.header.coroutine_kind, Some(CoroutineKind::Async { .. }))
+}
+
+fn is_uniffi_export(attr: &Attribute) -> bool {
+    let AttrKind::Normal(normal) = &attr.kind else {
+        return false;
+    };
+    let segments = &normal.item.path.segments;
+    let len = segments.len();
+    len >= 2
+        && segments[len - 2].ident.name.as_str() == "uniffi"
+        && segments[len - 1].ident.name.as_str() == "export"
+}
+
+fn contains_async_fn(impl_: &rustc_ast::ast::Impl) -> bool {
+    impl_.items.iter().any(|assoc| {
+        let AssocItemKind::Fn(fn_) = &assoc.kind else {
+            return false;
+        };
+        is_async(&fn_.sig)
+    })
+}
+
+fn has_async_runtime_tokio(attr: &Attribute) -> bool {
+    let AttrKind::Normal(normal) = &attr.kind else {
+        return false;
+    };
+    let AttrArgs::Delimited(delim) = &normal.item.args else {
+        return false;
+    };
+
+    let trees: Vec<&TokenTree> = delim.tokens.iter().collect();
+    trees.windows(3).any(|w| {
+        let is_async_runtime_ident = matches!(
+            w[0],
+            TokenTree::Token(t, _) if matches!(t.kind, TokenKind::Ident(name, _) if name.as_str() == "async_runtime")
+        );
+        let is_eq = matches!(w[1], TokenTree::Token(t, _) if matches!(t.kind, TokenKind::Eq));
+        let is_tokio_str = matches!(
+            w[2],
+            TokenTree::Token(t, _) if matches!(
+                t.kind,
+                TokenKind::Literal(lit) if lit.kind == LitKind::Str && lit.symbol.as_str() == "tokio"
+            )
+        );
+        is_async_runtime_ident && is_eq && is_tokio_str
+    })
+}
+
+fn emit_lint(cx: &EarlyContext<'_>, attr: &Attribute) {
+    let AttrKind::Normal(normal) = &attr.kind else {
+        return;
+    };
+    let msg =
+        "`#[uniffi::export]` on `async fn`s must specify `async_runtime = \"tokio\"`";
+
+    if matches!(normal.item.args, AttrArgs::Empty) {
+        span_lint_and_sugg(
+            cx,
+            UNIFFI_ASYNC_EXPORT,
+            attr.span,
+            msg,
+            "specify the tokio async runtime",
+            "#[uniffi::export(async_runtime = \"tokio\")]".to_string(),
+            Applicability::MachineApplicable,
+        );
+    } else {
+        span_lint_and_help(
+            cx,
+            UNIFFI_ASYNC_EXPORT,
+            attr.span,
+            msg,
+            None,
+            "add `async_runtime = \"tokio\"` to the attribute arguments",
+        );
+    }
+}
+
+#[test]
+fn ui() {
+    dylint_testing::ui_test_example(env!("CARGO_PKG_NAME"), "ui");
+}

--- a/support/lints/uniffi_async_export/ui/main.rs
+++ b/support/lints/uniffi_async_export/ui/main.rs
@@ -1,0 +1,81 @@
+// Each case lives in its own `#[cfg(any())]` module so it is parsed by the
+// pre-expansion lint pass but never compiled. This lets us reference
+// `#[uniffi::export]` without pulling `uniffi` in as a dev-dependency.
+
+// Should warn: missing async_runtime entirely.
+#[cfg(any())]
+mod missing_runtime_no_args {
+    pub struct Foo;
+
+    #[uniffi::export]
+    impl Foo {
+        pub async fn bar(&self) {}
+    }
+}
+
+// Should warn: has other args but missing async_runtime.
+#[cfg(any())]
+mod missing_runtime_other_args {
+    pub struct Foo;
+
+    #[uniffi::export(callback_interface)]
+    impl Foo {
+        pub async fn bar(&self) {}
+    }
+}
+
+// Should warn: async_runtime set to a non-tokio value.
+#[cfg(any())]
+mod wrong_runtime_value {
+    pub struct Foo;
+
+    #[uniffi::export(async_runtime = "other")]
+    impl Foo {
+        pub async fn bar(&self) {}
+    }
+}
+
+// Should NOT warn: correct usage.
+#[cfg(any())]
+mod correct_usage {
+    pub struct Foo;
+
+    #[uniffi::export(async_runtime = "tokio")]
+    impl Foo {
+        pub async fn bar(&self) {}
+    }
+}
+
+// Should NOT warn: impl with only sync fns does not require async_runtime.
+#[cfg(any())]
+mod sync_only_impl {
+    pub struct Foo;
+
+    #[uniffi::export]
+    impl Foo {
+        pub fn bar(&self) {}
+    }
+}
+
+// Should warn: free async fn without async_runtime.
+#[cfg(any())]
+mod free_async_fn_missing_runtime {
+    #[uniffi::export]
+    pub async fn bar() {}
+}
+
+// Should NOT warn: free async fn with correct async_runtime.
+#[cfg(any())]
+mod free_async_fn_correct {
+    #[uniffi::export(async_runtime = "tokio")]
+    pub async fn bar() {}
+}
+
+// Should NOT warn: free sync fn does not require async_runtime.
+#[cfg(any())]
+mod free_sync_fn {
+    #[uniffi::export]
+    pub fn bar() {}
+}
+
+fn main() {}

--- a/support/lints/uniffi_async_export/ui/main.stderr
+++ b/support/lints/uniffi_async_export/ui/main.stderr
@@ -1,0 +1,32 @@
+warning: `#[uniffi::export]` on `async fn`s must specify `async_runtime = "tokio"`
+  --> $DIR/main.rs:10:5
+   |
+LL |     #[uniffi::export]
+   |     ^^^^^^^^^^^^^^^^^ help: specify the tokio async runtime: `#[uniffi::export(async_runtime = "tokio")]`
+   |
+   = note: `#[warn(uniffi_async_export)]` on by default
+
+warning: `#[uniffi::export]` on `async fn`s must specify `async_runtime = "tokio"`
+  --> $DIR/main.rs:21:5
+   |
+LL |     #[uniffi::export(callback_interface)]
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: add `async_runtime = "tokio"` to the attribute arguments
+
+warning: `#[uniffi::export]` on `async fn`s must specify `async_runtime = "tokio"`
+  --> $DIR/main.rs:32:5
+   |
+LL |     #[uniffi::export(async_runtime = "other")]
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: add `async_runtime = "tokio"` to the attribute arguments
+
+warning: `#[uniffi::export]` on `async fn`s must specify `async_runtime = "tokio"`
+  --> $DIR/main.rs:63:5
+   |
+LL |     #[uniffi::export]
+   |     ^^^^^^^^^^^^^^^^^ help: specify the tokio async runtime: `#[uniffi::export(async_runtime = "tokio")]`
+
+warning: 4 warnings emitted
+


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-37089

## 📔 Objective

Add a custom dylint lint that warns when `#[uniffi::export]` is applied to an `async fn` (either free or inside an `impl`) without `async_runtime = "tokio"`. This fixes issues where some SDK is expecting a tokio runtime, but one wasn't selected.

An example of that happening was fixed here, where some functions used `reqwest`, which requires `tokio`:
https://github.com/bitwarden/sdk-internal/pull/928

## 🚨 Breaking Changes

<!-- Does this PR introduce any breaking changes? If so, please describe the impact and migration path for clients.

If you're unsure, the automated TypeScript compatibility check will run when you open/update this PR and provide feedback.

For breaking changes:
1. Describe what changed in the client interface
2. Explain why the change was necessary
3. Provide migration steps for client developers
4. Link to any paired client PRs if needed

Otherwise, you can remove this section. -->
