### PR TITLE
[PM-34165] Add Aes256CbcHmac support to SymmetricKeyEnvelope

### DIFF
--- a/crates/bitwarden-crypto/src/cose.rs
+++ b/crates/bitwarden-crypto/src/cose.rs
@@ -6,7 +6,7 @@
 use std::fmt::Debug;
 
 use coset::{
-    CborSerializable, ContentType, CoseEncrypt0, CoseEncrypt0Builder, Header, Label,
+    CborSerializable, ContentType, Header, Label,
     iana::{self, CoapContentFormat, KeyOperation},
 };
 use hybrid_array::Array;
@@ -28,6 +28,7 @@ use crate::{
 /// to be able to randomly generate nonces, and to not have to worry about key wearout. Since
 /// the draft was never published as an RFC, we use a private-use value for the algorithm.
 pub(crate) const XCHACHA20_POLY1305: i64 = -70000;
+pub(crate) const AES256_CBC_HMAC: i64 = -70001;
 pub(crate) const ALG_ARGON2ID13: i64 = -71000;
 
 // Custom labels for COSE headers
@@ -102,48 +103,6 @@ pub(crate) trait ContentNamespace: TryFrom<i128> + Into<i128> + PartialEq + Debu
 pub(crate) const SAFE_CONTENT_NAMESPACE: i64 = -80001;
 
 const XCHACHA20_TEXT_PAD_BLOCK_SIZE: usize = 32;
-
-/// Encrypt a plaintext message with a given key
-pub(crate) fn encrypt_cose(
-    cose_encrypt0_builder: CoseEncrypt0Builder,
-    plaintext: &[u8],
-    key: &XChaCha20Poly1305Key,
-) -> CoseEncrypt0 {
-    let mut nonce = [0u8; xchacha20::NONCE_SIZE];
-    cose_encrypt0_builder
-        .create_ciphertext(plaintext, &[], |data, aad| {
-            let ciphertext =
-                crate::xchacha20::encrypt_xchacha20_poly1305(&(*key.enc_key).into(), data, aad);
-            nonce = ciphertext.nonce();
-            ciphertext.encrypted_bytes().to_vec()
-        })
-        .unprotected(coset::HeaderBuilder::new().iv(nonce.to_vec()).build())
-        .build()
-}
-
-pub struct DecryptFailed;
-/// Decrypt a CoseEncrypt0 message with a CoseKey
-pub(crate) fn decrypt_cose(
-    cose_encrypt0: &CoseEncrypt0,
-    key: &XChaCha20Poly1305Key,
-) -> Result<Vec<u8>, DecryptFailed> {
-    let nonce: [u8; xchacha20::NONCE_SIZE] = cose_encrypt0
-        .unprotected
-        .iv
-        .clone()
-        .try_into()
-        .map_err(|_| DecryptFailed)?;
-    cose_encrypt0
-        .clone()
-        .decrypt_ciphertext(
-            &[],
-            || CryptoError::MissingField("ciphertext"),
-            |data, aad| {
-                xchacha20::decrypt_xchacha20_poly1305(&nonce, &(*key.enc_key).into(), data, aad)
-            },
-        )
-        .map_err(|_| DecryptFailed)
-}
 
 /// Encrypts a plaintext message using XChaCha20Poly1305 and returns a COSE Encrypt0 message
 pub(crate) fn encrypt_xchacha20_poly1305(

--- a/crates/bitwarden-crypto/src/error.rs
+++ b/crates/bitwarden-crypto/src/error.rs
@@ -14,6 +14,8 @@ use crate::fingerprint::FingerprintError;
 pub enum CryptoError {
     #[error("The decryption operation failed")]
     Decrypt,
+    #[error("The encryption operation failed")]
+    Encrypt,
     #[error("The provided key is not the expected type")]
     InvalidKey,
     #[error("Error while decrypting EncString")]

--- a/crates/bitwarden-crypto/src/safe/symmetric_key_envelope/mod.rs
+++ b/crates/bitwarden-crypto/src/safe/symmetric_key_envelope/mod.rs
@@ -3,22 +3,23 @@
 use std::str::FromStr;
 
 use bitwarden_encoding::{B64, FromStrVisitor};
-use ciborium::Value;
-use coset::{CborSerializable, CoseEncrypt0Builder, HeaderBuilder};
+use coset::CborSerializable;
 use serde::{Deserialize, Serialize};
+use symmetric_cose_encrypt0_key::{
+    symmetric_key_seal_key_into_cose, symmetric_key_unseal_key_from_cose,
+};
 use thiserror::Error;
 #[cfg(feature = "wasm")]
 use wasm_bindgen::convert::FromWasmAbi;
 
 use crate::{
-    BitwardenLegacyKeyBytes, ContentFormat, CoseKeyBytes, EncodedSymmetricKey, KeySlotIds,
-    KeyStoreContext, SymmetricCryptoKey, XChaCha20Poly1305Key,
-    cose::{CONTAINED_KEY_ID, ContentNamespace, SafeObjectNamespace, XCHACHA20_POLY1305},
+    KeySlotIds, KeyStoreContext,
+    cose::ContentNamespace,
     keys::KeyId,
-    safe::helpers::{
-        debug_fmt, extract_contained_key_id, set_safe_namespaces, validate_safe_namespaces,
-    },
+    safe::helpers::{debug_fmt, extract_contained_key_id},
 };
+
+mod symmetric_cose_encrypt0_key;
 
 /// Errors that can occur when sealing or unsealing a symmetric key with envelope operations.
 #[derive(Debug, Error)]
@@ -41,6 +42,12 @@ pub enum SymmetricKeyEnvelopeError {
     /// The symmetric key envelope namespace is invalid.
     #[error("Invalid namespace")]
     InvalidNamespace,
+    /// Incorrectly structured cose_encrypt0 ciphertext
+    #[error("Ciphertext is not structured correctly")]
+    IncorrectCiphertextStructure,
+    /// Encryption failed while sealing a key
+    #[error("Encryption failed while sealing a key")]
+    EncryptionFailed,
 }
 
 /// A symmetric key protected by another symmetric key
@@ -66,46 +73,7 @@ impl SymmetricKeyEnvelope {
             .get_symmetric_key(sealing_key)
             .map_err(|_| SymmetricKeyEnvelopeError::KeyMissing)?;
 
-        // For now, just XChaCha20Poly1305 is supported as wrapping key
-        let wrapping_key: &XChaCha20Poly1305Key = match wrapping_key {
-            SymmetricCryptoKey::XChaCha20Poly1305Key(key) => key,
-            _ => {
-                return Err(SymmetricKeyEnvelopeError::Parsing(
-                    "Wrapping key must be XChaCha20Poly1305".to_string(),
-                ));
-            }
-        };
-
-        let (content_format, key_bytes) = match key_to_seal.to_encoded_raw() {
-            EncodedSymmetricKey::BitwardenLegacyKey(key_bytes) => {
-                (ContentFormat::BitwardenLegacyKey, key_bytes.to_vec())
-            }
-            EncodedSymmetricKey::CoseKey(key_bytes) => (ContentFormat::CoseKey, key_bytes.to_vec()),
-        };
-
-        let mut header_builder = HeaderBuilder::from(content_format);
-
-        // Only set the contained key ID if the key has one
-        if let Some(key_id) = key_to_seal.key_id() {
-            header_builder =
-                header_builder.value(CONTAINED_KEY_ID, Value::from(Vec::from(&key_id)));
-        }
-
-        let mut protected_header = header_builder.build();
-        set_safe_namespaces(
-            &mut protected_header,
-            SafeObjectNamespace::SymmetricKeyEnvelope,
-            namespace,
-        );
-        protected_header.alg = Some(coset::Algorithm::PrivateUse(XCHACHA20_POLY1305));
-        protected_header.key_id = wrapping_key.key_id.as_slice().into();
-
-        let cose_encrypt0 = crate::cose::encrypt_cose(
-            CoseEncrypt0Builder::new().protected(protected_header),
-            &key_bytes,
-            wrapping_key,
-        );
-
+        let cose_encrypt0 = symmetric_key_seal_key_into_cose(key_to_seal, wrapping_key, namespace)?;
         Ok(SymmetricKeyEnvelope { cose_encrypt0 })
     }
 
@@ -120,53 +88,22 @@ impl SymmetricKeyEnvelope {
             .get_symmetric_key(wrapping_key)
             .map_err(|_| SymmetricKeyEnvelopeError::KeyMissing)?;
 
-        let wrapping_key_inner = match wrapping_key_ref {
-            SymmetricCryptoKey::XChaCha20Poly1305Key(key) => key,
-            _ => {
-                return Err(SymmetricKeyEnvelopeError::Parsing(
-                    "Wrapping key must be XChaCha20Poly1305".to_string(),
-                ));
-            }
-        };
-
-        validate_safe_namespaces(
-            &self.cose_encrypt0.protected.header,
-            SafeObjectNamespace::SymmetricKeyEnvelope,
-            namespace,
-        )
-        .map_err(|_| SymmetricKeyEnvelopeError::InvalidNamespace)?;
-
-        // Validate the content format
-        let content_format = ContentFormat::try_from(&self.cose_encrypt0.protected.header)
-            .map_err(|_| {
-                SymmetricKeyEnvelopeError::Parsing("Invalid content format".to_string())
-            })?;
-
-        // Decrypt the key bytes
-        let key_bytes = crate::cose::decrypt_cose(&self.cose_encrypt0, wrapping_key_inner)
-            .map_err(|_| SymmetricKeyEnvelopeError::WrongKey)?;
-
-        // Reconstruct the encoded symmetric key from the content format
-        let encoded_key = match content_format {
-            ContentFormat::BitwardenLegacyKey => {
-                EncodedSymmetricKey::BitwardenLegacyKey(BitwardenLegacyKeyBytes::from(key_bytes))
-            }
-            ContentFormat::CoseKey => EncodedSymmetricKey::CoseKey(CoseKeyBytes::from(key_bytes)),
-            _ => {
-                return Err(SymmetricKeyEnvelopeError::WrongKeyType);
-            }
-        };
-
-        let key = SymmetricCryptoKey::try_from(encoded_key)
-            .map_err(|_| SymmetricKeyEnvelopeError::WrongKeyType)?;
+        let key =
+            symmetric_key_unseal_key_from_cose(wrapping_key_ref, &self.cose_encrypt0, namespace)?;
 
         Ok(ctx.add_local_symmetric_key(key))
     }
 
     /// Get the key ID of the contained key.
     pub fn contained_key_id(&self) -> Result<Option<KeyId>, SymmetricKeyEnvelopeError> {
-        extract_contained_key_id(&self.cose_encrypt0.protected.header)
-            .map_err(|_| SymmetricKeyEnvelopeError::Parsing("Invalid contained key id".to_string()))
+        match extract_contained_key_id(&self.cose_encrypt0.protected.header).map_err(|_| {
+            SymmetricKeyEnvelopeError::Parsing("Invalid contained key id".to_string())
+        })? {
+            None => extract_contained_key_id(&self.cose_encrypt0.unprotected).map_err(|_| {
+                SymmetricKeyEnvelopeError::Parsing("Invalid contained key id".to_string())
+            }),
+            Some(key_id) => Ok(Some(key_id)),
+        }
     }
 }
 
@@ -329,7 +266,7 @@ impl ContentNamespace for SymmetricKeyEnvelopeNamespace {}
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{KeyStore, SymmetricKeyAlgorithm, traits::tests::TestIds};
+    use crate::{KeyStore, SymmetricCryptoKey, SymmetricKeyAlgorithm, traits::tests::TestIds};
 
     const TEST_VECTOR_SEALING_KEY: &str = "pQEEAlBLD8tcKNRLZaXNSr8OcwkgAzoAARFvBIQDBAUGIFgggG++dwvSRVPaPrIis1+XXXCizFYcakDZxSJP2HlJj0YB";
     const TEST_VECTOR_KEY_TO_SEAL: &str = "pQEEAlCEjXxxMulOVJtq1CSNv1aqAzoAARFvBIQDBAUGIFggwdF1yfFVwesj1CMQlVMhm+tvjwA1pxvTnQVUmfBMlJMB";

--- a/crates/bitwarden-crypto/src/safe/symmetric_key_envelope/symmetric_cose_encrypt0_key.rs
+++ b/crates/bitwarden-crypto/src/safe/symmetric_key_envelope/symmetric_cose_encrypt0_key.rs
@@ -1,0 +1,288 @@
+use ciborium::Value;
+use coset::{CoseEncrypt0, CoseEncrypt0Builder, Header, HeaderBuilder};
+use subtle::ConstantTimeEq;
+
+use crate::{
+    Aes256CbcHmacKey, BitwardenLegacyKeyBytes, ContentFormat, CoseKeyBytes, CryptoError, EncString,
+    EncodedSymmetricKey, SymmetricCryptoKey, XChaCha20Poly1305Key,
+    cose::{AES256_CBC_HMAC, CONTAINED_KEY_ID, SafeObjectNamespace, XCHACHA20_POLY1305},
+    safe::{
+        SymmetricKeyEnvelopeError, SymmetricKeyEnvelopeNamespace,
+        helpers::{set_safe_namespaces, validate_safe_namespaces},
+    },
+    xchacha20,
+};
+
+pub(crate) fn symmetric_key_seal_key_into_cose(
+    key_to_seal: &SymmetricCryptoKey,
+    sealing_key: &SymmetricCryptoKey,
+    namespace: SymmetricKeyEnvelopeNamespace,
+) -> Result<CoseEncrypt0, SymmetricKeyEnvelopeError> {
+    match sealing_key {
+        SymmetricCryptoKey::XChaCha20Poly1305Key(key) => {
+            key.wrap_cose_encrypt0_ciphertext(key_to_seal, namespace)
+        }
+        SymmetricCryptoKey::Aes256CbcHmacKey(key) => {
+            key.wrap_cose_encrypt0_ciphertext(key_to_seal, namespace)
+        }
+        _ => Err(SymmetricKeyEnvelopeError::WrongKeyType),
+    }
+}
+
+pub(crate) fn symmetric_key_unseal_key_from_cose(
+    sealing_key: &SymmetricCryptoKey,
+    ciphertext: &CoseEncrypt0,
+    namespace: SymmetricKeyEnvelopeNamespace,
+) -> Result<SymmetricCryptoKey, SymmetricKeyEnvelopeError> {
+    match sealing_key {
+        SymmetricCryptoKey::XChaCha20Poly1305Key(key) => {
+            key.unwrap_cose_encrypt0_ciphertext(ciphertext, namespace)
+        }
+        SymmetricCryptoKey::Aes256CbcHmacKey(key) => {
+            key.unwrap_cose_encrypt0_ciphertext(ciphertext, namespace)
+        }
+        _ => Err(SymmetricKeyEnvelopeError::WrongKeyType),
+    }
+}
+
+trait SymmetricCoseEncrypt0EnvelopeKey {
+    fn wrap_cose_encrypt0_ciphertext(
+        &self,
+        key_to_seal: &SymmetricCryptoKey,
+        namespace: SymmetricKeyEnvelopeNamespace,
+    ) -> Result<CoseEncrypt0, SymmetricKeyEnvelopeError>;
+    fn unwrap_cose_encrypt0_ciphertext(
+        &self,
+        cose_ciphertext: &CoseEncrypt0,
+        namespace: SymmetricKeyEnvelopeNamespace,
+    ) -> Result<SymmetricCryptoKey, SymmetricKeyEnvelopeError>;
+}
+
+impl SymmetricCoseEncrypt0EnvelopeKey for XChaCha20Poly1305Key {
+    fn wrap_cose_encrypt0_ciphertext(
+        &self,
+        key_to_seal: &SymmetricCryptoKey,
+        namespace: SymmetricKeyEnvelopeNamespace,
+    ) -> Result<CoseEncrypt0, SymmetricKeyEnvelopeError> {
+        let (mut protected_header, key_bytes) = build_cose_encrypt0_header(key_to_seal, namespace);
+        protected_header.alg = Some(coset::Algorithm::PrivateUse(XCHACHA20_POLY1305));
+        protected_header.key_id = self.key_id.as_slice().into();
+
+        let cose_encrypt0_builder = CoseEncrypt0Builder::new().protected(protected_header);
+
+        let mut nonce = [0u8; xchacha20::NONCE_SIZE];
+        Ok(cose_encrypt0_builder
+            .create_ciphertext(&key_bytes, &[], |data, aad| {
+                let ciphertext =
+                    xchacha20::encrypt_xchacha20_poly1305(&(*self.enc_key).into(), data, aad);
+                nonce = ciphertext.nonce();
+                ciphertext.encrypted_bytes().to_vec()
+            })
+            .unprotected(coset::HeaderBuilder::new().iv(nonce.to_vec()).build())
+            .build())
+    }
+
+    fn unwrap_cose_encrypt0_ciphertext(
+        &self,
+        cose_ciphertext: &CoseEncrypt0,
+        namespace: SymmetricKeyEnvelopeNamespace,
+    ) -> Result<SymmetricCryptoKey, SymmetricKeyEnvelopeError> {
+        validate_safe_namespaces(
+            &cose_ciphertext.protected.header,
+            SafeObjectNamespace::SymmetricKeyEnvelope,
+            namespace,
+        )
+        .map_err(|_| SymmetricKeyEnvelopeError::InvalidNamespace)?;
+
+        // Validate the content format
+        let content_format =
+            ContentFormat::try_from(&cose_ciphertext.protected.header).map_err(|_| {
+                SymmetricKeyEnvelopeError::Parsing("Invalid content format".to_string())
+            })?;
+
+        let nonce: [u8; xchacha20::NONCE_SIZE] = cose_ciphertext
+            .unprotected
+            .iv
+            .clone()
+            .try_into()
+            .map_err(|_| SymmetricKeyEnvelopeError::WrongKey)?;
+
+        let key_bytes = cose_ciphertext
+            .clone()
+            .decrypt_ciphertext(
+                &[],
+                || CryptoError::MissingField("ciphertext"),
+                |data, aad| {
+                    xchacha20::decrypt_xchacha20_poly1305(
+                        &nonce,
+                        &(*self.enc_key).into(),
+                        data,
+                        aad,
+                    )
+                },
+            )
+            .map_err(|_| SymmetricKeyEnvelopeError::WrongKey)?;
+
+        // Reconstruct the encoded symmetric key from the content format
+        let encoded_key = match content_format {
+            ContentFormat::BitwardenLegacyKey => {
+                EncodedSymmetricKey::BitwardenLegacyKey(BitwardenLegacyKeyBytes::from(key_bytes))
+            }
+            ContentFormat::CoseKey => EncodedSymmetricKey::CoseKey(CoseKeyBytes::from(key_bytes)),
+            _ => {
+                return Err(SymmetricKeyEnvelopeError::WrongKeyType);
+            }
+        };
+
+        SymmetricCryptoKey::try_from(encoded_key)
+            .map_err(|_| SymmetricKeyEnvelopeError::WrongKeyType)
+    }
+}
+
+impl SymmetricCoseEncrypt0EnvelopeKey for Aes256CbcHmacKey {
+    /// Per [RFC 9052](https://datatracker.ietf.org/doc/rfc9052/)
+    /// Section 5.4, encryption for AE algorithms requires:
+    /// 1. protected field must be a zero-byte string
+    /// 2. verify there was no external aad supplied for this operation
+    fn wrap_cose_encrypt0_ciphertext(
+        &self,
+        key_to_seal: &SymmetricCryptoKey,
+        namespace: SymmetricKeyEnvelopeNamespace,
+    ) -> Result<CoseEncrypt0, SymmetricKeyEnvelopeError> {
+        let (mut unprotected_header, key_bytes) =
+            build_cose_encrypt0_header(key_to_seal, namespace);
+        unprotected_header.alg = Some(coset::Algorithm::PrivateUse(AES256_CBC_HMAC));
+        // no key id to set
+
+        let mut iv = [0u8; 16];
+        let cose_encrypt0_builder =
+            // As per RFC 9052, section 5.4 external aad is empty
+            // and ::new() means that protected header is empty
+            CoseEncrypt0Builder::new().try_create_ciphertext(&key_bytes, &[], |plaintext, _aad| {
+                let mac: [u8; 32];
+                let data: Vec<u8>;
+
+                (iv, mac, data) =
+                    crate::aes::encrypt_aes256_hmac(plaintext, &self.mac_key, &self.enc_key)
+                        .map_err(|_| CryptoError::Encrypt)?;
+
+                EncString::Aes256Cbc_HmacSha256_B64 { iv, mac, data }
+                    .to_buffer()
+            }).map_err(|_| SymmetricKeyEnvelopeError::EncryptionFailed)?;
+
+        unprotected_header.iv = iv.to_vec();
+
+        let cose_encrypt0 = cose_encrypt0_builder
+            .unprotected(unprotected_header)
+            .build();
+
+        Ok(cose_encrypt0)
+    }
+
+    /// In order to properly and securely decrypt an AE cose encrypt0:
+    /// 1. Verify that the "protected" field is a zero-length string
+    /// 2. Verify no additional external aad is supplied during this operation
+    fn unwrap_cose_encrypt0_ciphertext(
+        &self,
+        cose_ciphertext: &CoseEncrypt0,
+        namespace: SymmetricKeyEnvelopeNamespace,
+    ) -> Result<SymmetricCryptoKey, SymmetricKeyEnvelopeError> {
+        // verify the protected field is empty
+        if !cose_ciphertext.protected.is_empty() {
+            return Err(SymmetricKeyEnvelopeError::IncorrectCiphertextStructure);
+        }
+
+        validate_safe_namespaces(
+            &cose_ciphertext.unprotected,
+            SafeObjectNamespace::SymmetricKeyEnvelope,
+            namespace,
+        )
+        .map_err(|_| SymmetricKeyEnvelopeError::InvalidNamespace)?;
+
+        // Validate the content format
+        let content_format =
+            ContentFormat::try_from(&cose_ciphertext.unprotected).map_err(|_| {
+                SymmetricKeyEnvelopeError::Parsing("Invalid content format".to_string())
+            })?;
+
+        let unprotected_iv: [u8; 16] = cose_ciphertext
+            .unprotected
+            .iv
+            .clone()
+            .try_into()
+            .map_err(|_| SymmetricKeyEnvelopeError::IncorrectCiphertextStructure)?;
+
+        let key_bytes = cose_ciphertext
+            .clone()
+            .decrypt_ciphertext(
+                &[], // external aad is empty as per RFC 9052 section 5.4
+                || CryptoError::MissingField("ciphertext"),
+                |ciphertext, _aad| match EncString::from_buffer(ciphertext)
+                    .map_err(|_| CryptoError::KeyDecrypt)?
+                {
+                    EncString::Aes256Cbc_HmacSha256_B64 { iv, mac, ref data } => {
+                        if iv.ct_ne(&unprotected_iv).into() {
+                            return Err(CryptoError::InvalidKey);
+                        }
+                        crate::aes::decrypt_aes256_hmac(
+                            &iv,
+                            &mac,
+                            data.clone(),
+                            &self.mac_key,
+                            &self.enc_key,
+                        )
+                        .map_err(|_| CryptoError::Decrypt)
+                    }
+                    _ => {
+                        tracing::warn!(
+                            "Unsupported decryption operation for the given key and data"
+                        );
+                        Err(CryptoError::InvalidKey)
+                    }
+                },
+            )
+            .map_err(|_| SymmetricKeyEnvelopeError::WrongKey)?;
+
+        // Reconstruct the encoded symmetric key from the content format
+        let encoded_key = match content_format {
+            ContentFormat::BitwardenLegacyKey => {
+                EncodedSymmetricKey::BitwardenLegacyKey(BitwardenLegacyKeyBytes::from(key_bytes))
+            }
+            ContentFormat::CoseKey => EncodedSymmetricKey::CoseKey(CoseKeyBytes::from(key_bytes)),
+            _ => {
+                return Err(SymmetricKeyEnvelopeError::WrongKeyType);
+            }
+        };
+
+        SymmetricCryptoKey::try_from(encoded_key)
+            .map_err(|_| SymmetricKeyEnvelopeError::WrongKeyType)
+    }
+}
+
+fn build_cose_encrypt0_header(
+    key_to_seal: &SymmetricCryptoKey,
+    namespace: SymmetricKeyEnvelopeNamespace,
+) -> (Header, Vec<u8>) {
+    // set up headers
+    let (content_format, key_bytes) = match key_to_seal.to_encoded_raw() {
+        EncodedSymmetricKey::BitwardenLegacyKey(key_bytes) => {
+            (ContentFormat::BitwardenLegacyKey, key_bytes.to_vec())
+        }
+        EncodedSymmetricKey::CoseKey(key_bytes) => (ContentFormat::CoseKey, key_bytes.to_vec()),
+    };
+
+    let mut header_builder = HeaderBuilder::from(content_format);
+
+    // Only set the contained key ID if the key has one
+    if let Some(key_id) = key_to_seal.key_id() {
+        header_builder = header_builder.value(CONTAINED_KEY_ID, Value::from(Vec::from(&key_id)));
+    }
+
+    let mut header = header_builder.build();
+    set_safe_namespaces(
+        &mut header,
+        SafeObjectNamespace::SymmetricKeyEnvelope,
+        namespace,
+    );
+    (header, key_bytes)
+}


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-34165

## 📔 Objective

We have two concurrent goals: move our APIs over to new, "`safe`", structures and move off of not-as-secure cryptographic protocols. While the second goal (for organization keys) is blocked by our switch to organization signing v2, we can make progress towards the first goal by supporting legacy keys in the new `safe` APIs.

This PR adds support for `SymmetricCryptoKey::Aes256CbcHmac` as the `sealing_key` for `SymmetricKeyEnvelope`. This will allow us to use the `SymmetricKeyEnvelope` for new APIs like the `InviteKeyBundle`. This is done by introducing the `SymmetricCoseEncrypt0EnvelopeKey` trait to simplify the logic flow.