### PR TITLE
[PM-37226] Enable uniffi omit_checksums to work around Android binding issue

### DIFF
--- a/bitwarden_license/bitwarden-commercial-vault/uniffi.toml
+++ b/bitwarden_license/bitwarden-commercial-vault/uniffi.toml
@@ -2,6 +2,8 @@
 package_name = "com.bitwarden.commercial.vault"
 generate_immutable_records = true
 android = true
+# Temporary workaround for https://github.com/mozilla/uniffi-rs/issues/2740
+omit_checksums = true
 
 [bindings.swift]
 ffi_module_name = "BitwardenCommercialVaultFFI"

--- a/crates/bitwarden-auth/uniffi.toml
+++ b/crates/bitwarden-auth/uniffi.toml
@@ -2,6 +2,8 @@
 package_name = "com.bitwarden.auth"
 generate_immutable_records = true
 android = true
+# Temporary workaround for https://github.com/mozilla/uniffi-rs/issues/2740
+omit_checksums = true
 
 [bindings.swift]
 ffi_module_name = "BitwardenAuthFFI"

--- a/crates/bitwarden-collections/uniffi.toml
+++ b/crates/bitwarden-collections/uniffi.toml
@@ -2,6 +2,8 @@
 package_name = "com.bitwarden.collections"
 generate_immutable_records = true
 android = true
+# Temporary workaround for https://github.com/mozilla/uniffi-rs/issues/2740
+omit_checksums = true
 
 [bindings.swift]
 ffi_module_name = "BitwardenCollectionsFFI"

--- a/crates/bitwarden-core/uniffi.toml
+++ b/crates/bitwarden-core/uniffi.toml
@@ -2,6 +2,8 @@
 package_name = "com.bitwarden.core"
 generate_immutable_records = true
 android = true
+# Temporary workaround for https://github.com/mozilla/uniffi-rs/issues/2740
+omit_checksums = true
 
 [bindings.swift]
 ffi_module_name = "BitwardenCoreFFI"

--- a/crates/bitwarden-crypto/uniffi.toml
+++ b/crates/bitwarden-crypto/uniffi.toml
@@ -2,6 +2,8 @@
 package_name = "com.bitwarden.crypto"
 generate_immutable_records = true
 android = true
+# Temporary workaround for https://github.com/mozilla/uniffi-rs/issues/2740
+omit_checksums = true
 
 [bindings.swift]
 ffi_module_name = "BitwardenCryptoFFI"

--- a/crates/bitwarden-encoding/uniffi.toml
+++ b/crates/bitwarden-encoding/uniffi.toml
@@ -2,6 +2,8 @@
 package_name = "com.bitwarden.encoding"
 generate_immutable_records = true
 android = true
+# Temporary workaround for https://github.com/mozilla/uniffi-rs/issues/2740
+omit_checksums = true
 
 [bindings.swift]
 ffi_module_name = "BitwardenEncodingFFI"

--- a/crates/bitwarden-exporters/uniffi.toml
+++ b/crates/bitwarden-exporters/uniffi.toml
@@ -2,6 +2,8 @@
 package_name = "com.bitwarden.exporters"
 generate_immutable_records = true
 android = true
+# Temporary workaround for https://github.com/mozilla/uniffi-rs/issues/2740
+omit_checksums = true
 
 [bindings.swift]
 ffi_module_name = "BitwardenExportersFFI"

--- a/crates/bitwarden-fido/uniffi.toml
+++ b/crates/bitwarden-fido/uniffi.toml
@@ -2,6 +2,8 @@
 package_name = "com.bitwarden.fido"
 generate_immutable_records = true
 android = true
+# Temporary workaround for https://github.com/mozilla/uniffi-rs/issues/2740
+omit_checksums = true
 
 [bindings.swift]
 ffi_module_name = "BitwardenFidoFFI"

--- a/crates/bitwarden-generators/uniffi.toml
+++ b/crates/bitwarden-generators/uniffi.toml
@@ -2,6 +2,8 @@
 package_name = "com.bitwarden.generators"
 generate_immutable_records = true
 android = true
+# Temporary workaround for https://github.com/mozilla/uniffi-rs/issues/2740
+omit_checksums = true
 
 [bindings.swift]
 ffi_module_name = "BitwardenGeneratorsFFI"

--- a/crates/bitwarden-organizations/uniffi.toml
+++ b/crates/bitwarden-organizations/uniffi.toml
@@ -2,6 +2,8 @@
 package_name = "com.bitwarden.organizations"
 generate_immutable_records = true
 android = true
+# Temporary workaround for https://github.com/mozilla/uniffi-rs/issues/2740
+omit_checksums = true
 
 [bindings.swift]
 ffi_module_name = "BitwardenOrganizationsFFI"

--- a/crates/bitwarden-pm/uniffi.toml
+++ b/crates/bitwarden-pm/uniffi.toml
@@ -2,6 +2,8 @@
 package_name = "com.bitwarden.pm"
 generate_immutable_records = true
 android = true
+# Temporary workaround for https://github.com/mozilla/uniffi-rs/issues/2740
+omit_checksums = true
 
 [bindings.swift]
 ffi_module_name = "BitwardenPMFFI"

--- a/crates/bitwarden-policies/uniffi.toml
+++ b/crates/bitwarden-policies/uniffi.toml
@@ -2,6 +2,8 @@
 package_name = "com.bitwarden.policies"
 generate_immutable_records = true
 android = true
+# Temporary workaround for https://github.com/mozilla/uniffi-rs/issues/2740
+omit_checksums = true
 
 [bindings.swift]
 ffi_module_name = "BitwardenPoliciesFFI"

--- a/crates/bitwarden-send/uniffi.toml
+++ b/crates/bitwarden-send/uniffi.toml
@@ -2,6 +2,8 @@
 package_name = "com.bitwarden.send"
 generate_immutable_records = true
 android = true
+# Temporary workaround for https://github.com/mozilla/uniffi-rs/issues/2740
+omit_checksums = true
 
 [bindings.swift]
 ffi_module_name = "BitwardenSendFFI"

--- a/crates/bitwarden-server-communication-config/uniffi.toml
+++ b/crates/bitwarden-server-communication-config/uniffi.toml
@@ -2,6 +2,8 @@
 package_name = "com.bitwarden.servercommunicationconfig"
 generate_immutable_records = true
 android = true
+# Temporary workaround for https://github.com/mozilla/uniffi-rs/issues/2740
+omit_checksums = true
 
 [bindings.swift]
 ffi_module_name = "BitwardenServerCommunicationConfigFFI"

--- a/crates/bitwarden-ssh/uniffi.toml
+++ b/crates/bitwarden-ssh/uniffi.toml
@@ -2,6 +2,8 @@
 package_name = "com.bitwarden.ssh"
 generate_immutable_records = true
 android = true
+# Temporary workaround for https://github.com/mozilla/uniffi-rs/issues/2740
+omit_checksums = true
 
 [bindings.swift]
 ffi_module_name = "BitwardenSshFFI"

--- a/crates/bitwarden-state/uniffi.toml
+++ b/crates/bitwarden-state/uniffi.toml
@@ -2,6 +2,8 @@
 package_name = "com.bitwarden.state"
 generate_immutable_records = true
 android = true
+# Temporary workaround for https://github.com/mozilla/uniffi-rs/issues/2740
+omit_checksums = true
 
 [bindings.swift]
 ffi_module_name = "BitwardenStateFFI"

--- a/crates/bitwarden-uniffi/uniffi.toml
+++ b/crates/bitwarden-uniffi/uniffi.toml
@@ -3,6 +3,8 @@ package_name = "com.bitwarden.sdk"
 cdylib_name = "bitwarden_uniffi"
 generate_immutable_records = true
 android = true
+# Temporary workaround for https://github.com/mozilla/uniffi-rs/issues/2740
+omit_checksums = true
 
 [bindings.swift]
 ffi_module_name = "BitwardenFFI"

--- a/crates/bitwarden-user-crypto-management/uniffi.toml
+++ b/crates/bitwarden-user-crypto-management/uniffi.toml
@@ -2,6 +2,8 @@
 package_name = "com.bitwarden.usercryptomanagement"
 generate_immutable_records = true
 android = true
+# Temporary workaround for https://github.com/mozilla/uniffi-rs/issues/2740
+omit_checksums = true
 
 [bindings.swift]
 ffi_module_name = "BitwardenUserCryptoManagementFFI"

--- a/crates/bitwarden-vault/uniffi.toml
+++ b/crates/bitwarden-vault/uniffi.toml
@@ -2,6 +2,8 @@
 package_name = "com.bitwarden.vault"
 generate_immutable_records = true
 android = true
+# Temporary workaround for https://github.com/mozilla/uniffi-rs/issues/2740
+omit_checksums = true
 
 [bindings.swift]
 ffi_module_name = "BitwardenVaultFFI"


### PR DESCRIPTION
## 🎟️ Tracking

[PM-37226](https://bitwarden.atlassian.net/browse/PM-37226)

## 📔 Objective

Temporary workaround for [mozilla/uniffi-rs#2740](https://github.com/mozilla/uniffi-rs/issues/2740), which causes checksum mismatches in the Kotlin bindings generated by UniFFI and consumed by the Android client.

Adds `omit_checksums = true` under `[bindings.kotlin]` in every `uniffi.toml` manifest in the workspace (19 files). The Swift `[bindings.swift]` sections are intentionally left unchanged — iOS is not affected by the regression and we want to minimise the scope of the workaround.

This change will also be cherry-picked onto a hotfix branch off the SDK version (`f373e7f3`) currently pinned in the Android `release/hotfix-v2026.4.1-bwpm` branch, per the [SDK integration into release candidate process](https://bitwarden.atlassian.net/wiki/spaces/EN/pages/2426503301/SDK+integration+into+release+candidate+process).

Revert this change once the upstream UniFFI fix is released.

[PM-37226]: https://bitwarden.atlassian.net/browse/PM-37226?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ