### PR TITLE
[PM-37226] 🍒 Enable uniffi omit_checksums to work around Android binding issue

### DIFF
--- a/bitwarden_license/bitwarden-commercial-vault/uniffi.toml
+++ b/bitwarden_license/bitwarden-commercial-vault/uniffi.toml
@@ -2,6 +2,8 @@
 package_name = "com.bitwarden.commercial.vault"
 generate_immutable_records = true
 android = true
+# Temporary workaround for https://github.com/mozilla/uniffi-rs/issues/2740
+omit_checksums = true
 
 [bindings.swift]
 ffi_module_name = "BitwardenCommercialVaultFFI"

--- a/crates/bitwarden-auth/uniffi.toml
+++ b/crates/bitwarden-auth/uniffi.toml
@@ -2,6 +2,8 @@
 package_name = "com.bitwarden.auth"
 generate_immutable_records = true
 android = true
+# Temporary workaround for https://github.com/mozilla/uniffi-rs/issues/2740
+omit_checksums = true
 
 [bindings.swift]
 ffi_module_name = "BitwardenAuthFFI"

--- a/crates/bitwarden-collections/uniffi.toml
+++ b/crates/bitwarden-collections/uniffi.toml
@@ -2,6 +2,8 @@
 package_name = "com.bitwarden.collections"
 generate_immutable_records = true
 android = true
+# Temporary workaround for https://github.com/mozilla/uniffi-rs/issues/2740
+omit_checksums = true
 
 [bindings.swift]
 ffi_module_name = "BitwardenCollectionsFFI"

--- a/crates/bitwarden-core/uniffi.toml
+++ b/crates/bitwarden-core/uniffi.toml
@@ -2,6 +2,8 @@
 package_name = "com.bitwarden.core"
 generate_immutable_records = true
 android = true
+# Temporary workaround for https://github.com/mozilla/uniffi-rs/issues/2740
+omit_checksums = true
 
 [bindings.swift]
 ffi_module_name = "BitwardenCoreFFI"

--- a/crates/bitwarden-crypto/uniffi.toml
+++ b/crates/bitwarden-crypto/uniffi.toml
@@ -2,6 +2,8 @@
 package_name = "com.bitwarden.crypto"
 generate_immutable_records = true
 android = true
+# Temporary workaround for https://github.com/mozilla/uniffi-rs/issues/2740
+omit_checksums = true
 
 [bindings.swift]
 ffi_module_name = "BitwardenCryptoFFI"

--- a/crates/bitwarden-encoding/uniffi.toml
+++ b/crates/bitwarden-encoding/uniffi.toml
@@ -2,6 +2,8 @@
 package_name = "com.bitwarden.encoding"
 generate_immutable_records = true
 android = true
+# Temporary workaround for https://github.com/mozilla/uniffi-rs/issues/2740
+omit_checksums = true
 
 [bindings.swift]
 ffi_module_name = "BitwardenEncodingFFI"

--- a/crates/bitwarden-exporters/uniffi.toml
+++ b/crates/bitwarden-exporters/uniffi.toml
@@ -2,6 +2,8 @@
 package_name = "com.bitwarden.exporters"
 generate_immutable_records = true
 android = true
+# Temporary workaround for https://github.com/mozilla/uniffi-rs/issues/2740
+omit_checksums = true
 
 [bindings.swift]
 ffi_module_name = "BitwardenExportersFFI"

--- a/crates/bitwarden-fido/uniffi.toml
+++ b/crates/bitwarden-fido/uniffi.toml
@@ -2,6 +2,8 @@
 package_name = "com.bitwarden.fido"
 generate_immutable_records = true
 android = true
+# Temporary workaround for https://github.com/mozilla/uniffi-rs/issues/2740
+omit_checksums = true
 
 [bindings.swift]
 ffi_module_name = "BitwardenFidoFFI"

--- a/crates/bitwarden-generators/uniffi.toml
+++ b/crates/bitwarden-generators/uniffi.toml
@@ -2,6 +2,8 @@
 package_name = "com.bitwarden.generators"
 generate_immutable_records = true
 android = true
+# Temporary workaround for https://github.com/mozilla/uniffi-rs/issues/2740
+omit_checksums = true
 
 [bindings.swift]
 ffi_module_name = "BitwardenGeneratorsFFI"

--- a/crates/bitwarden-pm/uniffi.toml
+++ b/crates/bitwarden-pm/uniffi.toml
@@ -2,6 +2,8 @@
 package_name = "com.bitwarden.pm"
 generate_immutable_records = true
 android = true
+# Temporary workaround for https://github.com/mozilla/uniffi-rs/issues/2740
+omit_checksums = true
 
 [bindings.swift]
 ffi_module_name = "BitwardenPMFFI"

--- a/crates/bitwarden-policies/uniffi.toml
+++ b/crates/bitwarden-policies/uniffi.toml
@@ -2,6 +2,8 @@
 package_name = "com.bitwarden.policies"
 generate_immutable_records = true
 android = true
+# Temporary workaround for https://github.com/mozilla/uniffi-rs/issues/2740
+omit_checksums = true
 
 [bindings.swift]
 ffi_module_name = "BitwardenPoliciesFFI"

--- a/crates/bitwarden-send/uniffi.toml
+++ b/crates/bitwarden-send/uniffi.toml
@@ -2,6 +2,8 @@
 package_name = "com.bitwarden.send"
 generate_immutable_records = true
 android = true
+# Temporary workaround for https://github.com/mozilla/uniffi-rs/issues/2740
+omit_checksums = true
 
 [bindings.swift]
 ffi_module_name = "BitwardenSendFFI"

--- a/crates/bitwarden-server-communication-config/uniffi.toml
+++ b/crates/bitwarden-server-communication-config/uniffi.toml
@@ -2,6 +2,8 @@
 package_name = "com.bitwarden.servercommunicationconfig"
 generate_immutable_records = true
 android = true
+# Temporary workaround for https://github.com/mozilla/uniffi-rs/issues/2740
+omit_checksums = true
 
 [bindings.swift]
 ffi_module_name = "BitwardenServerCommunicationConfigFFI"

--- a/crates/bitwarden-ssh/uniffi.toml
+++ b/crates/bitwarden-ssh/uniffi.toml
@@ -2,6 +2,8 @@
 package_name = "com.bitwarden.ssh"
 generate_immutable_records = true
 android = true
+# Temporary workaround for https://github.com/mozilla/uniffi-rs/issues/2740
+omit_checksums = true
 
 [bindings.swift]
 ffi_module_name = "BitwardenSshFFI"

--- a/crates/bitwarden-state/uniffi.toml
+++ b/crates/bitwarden-state/uniffi.toml
@@ -2,6 +2,8 @@
 package_name = "com.bitwarden.state"
 generate_immutable_records = true
 android = true
+# Temporary workaround for https://github.com/mozilla/uniffi-rs/issues/2740
+omit_checksums = true
 
 [bindings.swift]
 ffi_module_name = "BitwardenStateFFI"

--- a/crates/bitwarden-uniffi/uniffi.toml
+++ b/crates/bitwarden-uniffi/uniffi.toml
@@ -3,6 +3,8 @@ package_name = "com.bitwarden.sdk"
 cdylib_name = "bitwarden_uniffi"
 generate_immutable_records = true
 android = true
+# Temporary workaround for https://github.com/mozilla/uniffi-rs/issues/2740
+omit_checksums = true
 
 [bindings.swift]
 ffi_module_name = "BitwardenFFI"

--- a/crates/bitwarden-user-crypto-management/uniffi.toml
+++ b/crates/bitwarden-user-crypto-management/uniffi.toml
@@ -2,6 +2,8 @@
 package_name = "com.bitwarden.usercryptomanagement"
 generate_immutable_records = true
 android = true
+# Temporary workaround for https://github.com/mozilla/uniffi-rs/issues/2740
+omit_checksums = true
 
 [bindings.swift]
 ffi_module_name = "BitwardenUserCryptoManagementFFI"

--- a/crates/bitwarden-vault/uniffi.toml
+++ b/crates/bitwarden-vault/uniffi.toml
@@ -2,6 +2,8 @@
 package_name = "com.bitwarden.vault"
 generate_immutable_records = true
 android = true
+# Temporary workaround for https://github.com/mozilla/uniffi-rs/issues/2740
+omit_checksums = true
 
 [bindings.swift]
 ffi_module_name = "BitwardenVaultFFI"


### PR DESCRIPTION
## 🎟️ Tracking

[PM-37226](https://bitwarden.atlassian.net/browse/PM-37226)

## 📔 Objective

Hotfix counterpart to [#1070](https://github.com/bitwarden/sdk-internal/pull/1070) (main).

Temporary workaround for [mozilla/uniffi-rs#2740](https://github.com/mozilla/uniffi-rs/issues/2740), which causes checksum mismatches in the Kotlin bindings consumed by the Android client. Adds `omit_checksums = true` under `[bindings.kotlin]` in every `uniffi.toml` manifest present at this revision (18 files — the `bitwarden-organizations` crate does not yet exist on this base). Swift bindings remain unchanged.

## 🧭 Hotfix context

Per the [SDK integration into release candidate process](https://bitwarden.atlassian.net/wiki/spaces/EN/pages/2426503301/SDK+integration+into+release+candidate+process):

- **Base commit:** `f373e7f3` — *Reexport new auth registration in uniffi (#925)* — the SDK version pinned by the Android `release/hotfix-v2026.4.1-bwpm` branch (SDK `2.0.0-6074-f373e7f3`).
- **Base branch:** `release/hotfix-v2026.4.1-bwpm`
- **Head branch:** `hotfix/uniffi-omit-checksums-v2026.4.1-bwpm`
- **Equivalent to:** main PR #1070 (cherry-pick will be re-applied with the actual main merge SHA once #1070 lands).

## 🚚 Next steps after merge

- Trigger the Android SDK build workflow on this branch
- Android team consumes the resulting `com.bitwarden.sdk-android.dev` package
- Revert once the upstream UniFFI fix is released

[PM-37226]: https://bitwarden.atlassian.net/browse/PM-37226?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ