### PR TITLE
chore: add platform ownership for uniffi.toml files in CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -74,6 +74,9 @@ crates/bw/src/vault/** @bitwarden/team-vault-dev
 **/entrypoint.sh @bitwarden/team-appsec @bitwarden/dept-bre
 **/docker-compose.yml @bitwarden/team-appsec @bitwarden/dept-bre
 
+# UniFFI config files. Platform owns to avoid review bingo when they are all changed.
+**/uniffi.toml @bitwarden/team-platform-dev
+
 ## No ownership for root dependency management files to allow Renovate to manage updates
 /Cargo.lock
 /Cargo.toml


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-37231

## 📔 Objective

Each crate in the SDK ships its own uniffi.toml config file. Without explicit ownership in CODEOWNERS, changes to these files start a review bingo. Platform team owns the UniFFI layer, mirroring the pattern where we own ts/jest configs in clients.