### PR TITLE
[PM-30214] Add key connector support to user key rotation

### DIFF
--- a/crates/bitwarden-user-crypto-management/src/key_rotation/mod.rs
+++ b/crates/bitwarden-user-crypto-management/src/key_rotation/mod.rs
@@ -56,6 +56,8 @@ pub enum RotateUserKeysError {
     Crypto,
     #[error("Invalid public key provided during key rotation")]
     InvalidPublicKey,
+    #[error("Key Connector API error during key rotation")]
+    KeyConnectorApi,
     #[error("Untrusted key encountered during key rotation")]
     UntrustedKey,
     #[error("Unimplemented key rotation method")]

--- a/crates/bitwarden-user-crypto-management/src/key_rotation/rotate_user_keys.rs
+++ b/crates/bitwarden-user-crypto-management/src/key_rotation/rotate_user_keys.rs
@@ -1,7 +1,7 @@
 //! Client implementation for rotating user keys without a password change.
 use bitwarden_api_api::models::RotateUserKeysRequestModel;
 use bitwarden_core::key_management::KeySlotIds;
-use bitwarden_crypto::{KeyStore, PublicKey};
+use bitwarden_crypto::{KeyConnectorKey, KeyStore, PublicKey};
 use serde::{Deserialize, Serialize};
 use tracing::{info, instrument};
 #[cfg(feature = "wasm")]
@@ -28,10 +28,8 @@ use crate::{
 pub enum KeyRotationMethod {
     /// Master password user, key rotation without a password change.
     Password { password: String },
-    /// Key connector user, key rotation without a password change.
-    /// NOTE: This is not yet implemented and will return a
-    /// RotateUserKeysError::UnimplementedKeyRotationMethod error if used.
-    KeyConnector,
+    /// Key Connector user, key rotation without a password change.
+    KeyConnector { key_connector_url: String },
     /// TDE user, key rotation without a password change.
     /// NOTE: This is not yet implemented and will return a
     /// RotateUserKeysError::UnimplementedKeyRotationMethod error if used.
@@ -71,7 +69,27 @@ impl UserCryptoManagementClient {
     ) -> Result<(), RotateUserKeysError> {
         let api_client = &self.client.internal.get_api_configurations().api_client;
         let key_store = self.client.internal.get_key_store();
-        internal_rotate_user_keys(key_store, api_client, request).await
+
+        let key_connector_api_client =
+            if let KeyRotationMethod::KeyConnector { key_connector_url } =
+                &request.key_rotation_method
+            {
+                Some(
+                    self.client
+                        .internal
+                        .get_key_connector_client(key_connector_url.clone()),
+                )
+            } else {
+                None
+            };
+
+        internal_rotate_user_keys(
+            key_store,
+            api_client,
+            key_connector_api_client.as_ref(),
+            request,
+        )
+        .await
     }
 }
 
@@ -79,17 +97,11 @@ impl UserCryptoManagementClient {
 async fn internal_rotate_user_keys(
     key_store: &KeyStore<KeySlotIds>,
     api_client: &bitwarden_api_api::apis::ApiClient,
+    key_connector_api_client: Option<&bitwarden_api_key_connector::apis::ApiClient>,
     request: RotateUserKeysRequest,
 ) -> Result<(), RotateUserKeysError> {
-    // This guard should be removed once other key rotation methods are implemented.
-    match &request.key_rotation_method {
-        KeyRotationMethod::KeyConnector => {
-            return Err(RotateUserKeysError::UnimplementedKeyRotationMethod);
-        }
-        KeyRotationMethod::Tde => {
-            return Err(RotateUserKeysError::UnimplementedKeyRotationMethod);
-        }
-        KeyRotationMethod::Password { .. } => {}
+    if matches!(request.key_rotation_method, KeyRotationMethod::Tde) {
+        return Err(RotateUserKeysError::UnimplementedKeyRotationMethod);
     }
 
     let sync = sync_current_account_data(api_client)
@@ -98,6 +110,27 @@ async fn internal_rotate_user_keys(
 
     // Fail early if any cipher has old attachments that would become irrecoverable
     check_for_old_attachments(&sync.ciphers)?;
+
+    // For Key Connector users, fetch the existing KC key from the KC server.
+    // This must happen before the synchronous key store scope below.
+    let key_connector_key = if matches!(
+        request.key_rotation_method,
+        KeyRotationMethod::KeyConnector { .. }
+    ) {
+        let key_connector_client =
+            key_connector_api_client.ok_or(RotateUserKeysError::KeyConnectorApi)?;
+        info!("Fetching Key Connector key for key rotation");
+        let response = key_connector_client
+            .user_keys_api()
+            .get_user_key()
+            .await
+            .map_err(|_| RotateUserKeysError::KeyConnectorApi)?;
+        let key_connector_key =
+            KeyConnectorKey::try_from(response).map_err(|_| RotateUserKeysError::Crypto)?;
+        Some(key_connector_key)
+    } else {
+        None
+    };
 
     // Create a separate scope so that the mutable context is not held across the await point
     let post_request = {
@@ -132,9 +165,11 @@ async fn internal_rotate_user_keys(
         .map_err(|_| RotateUserKeysError::Crypto)?;
 
         info!("Re-encrypting account primary unlock method for user key rotation");
-        let unlock_method_input =
-            PrimaryUnlockMethod::from_key_rotation_method(request.key_rotation_method, &sync)
-                .map_err(|_| RotateUserKeysError::Api)?;
+        let unlock_method_input = PrimaryUnlockMethod::from_key_rotation_method(
+            request.key_rotation_method,
+            &sync,
+            key_connector_key,
+        )?;
         let unlock_method_data = reencrypt_unlock_method_data(
             unlock_method_input,
             rotation_context.new_user_key_id,
@@ -290,38 +325,6 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_rotate_user_keys_key_connector_returns_unimplemented() {
-        let key_store: KeyStore<KeySlotIds> = KeyStore::default();
-        let api_client = ApiClient::new_mocked(|mock| {
-            mock.sync_api.expect_get().never();
-            mock.accounts_key_management_api
-                .expect_rotate_user_keys()
-                .never();
-        });
-
-        let result = internal_rotate_user_keys(
-            &key_store,
-            &api_client,
-            RotateUserKeysRequest {
-                key_rotation_method: KeyRotationMethod::KeyConnector,
-                trusted_organization_public_keys: vec![],
-                trusted_emergency_access_public_keys: vec![],
-                upgrade_token_action: None,
-            },
-        )
-        .await;
-
-        assert!(matches!(
-            result,
-            Err(RotateUserKeysError::UnimplementedKeyRotationMethod)
-        ));
-        if let ApiClient::Mock(mut mock) = api_client {
-            mock.sync_api.checkpoint();
-            mock.accounts_key_management_api.checkpoint();
-        }
-    }
-
-    #[tokio::test]
     async fn test_rotate_user_keys_tde_returns_unimplemented() {
         let key_store: KeyStore<KeySlotIds> = KeyStore::default();
         let api_client = ApiClient::new_mocked(|mock| {
@@ -334,6 +337,7 @@ mod tests {
         let result = internal_rotate_user_keys(
             &key_store,
             &api_client,
+            None,
             RotateUserKeysRequest {
                 key_rotation_method: KeyRotationMethod::Tde,
                 trusted_organization_public_keys: vec![],
@@ -368,6 +372,7 @@ mod tests {
         let result = internal_rotate_user_keys(
             &key_store,
             &api_client,
+            None,
             RotateUserKeysRequest {
                 key_rotation_method: KeyRotationMethod::Password {
                     password: "test".to_string(),
@@ -404,6 +409,7 @@ mod tests {
         let result = internal_rotate_user_keys(
             &key_store,
             &api_client,
+            None,
             RotateUserKeysRequest {
                 key_rotation_method: KeyRotationMethod::Password {
                     password: "test_password".to_string(),
@@ -446,6 +452,7 @@ mod tests {
         let result = internal_rotate_user_keys(
             &key_store,
             &api_client,
+            None,
             RotateUserKeysRequest {
                 key_rotation_method: KeyRotationMethod::Password {
                     password: "test_password".to_string(),
@@ -493,6 +500,7 @@ mod tests {
         let result = internal_rotate_user_keys(
             &key_store,
             &api_client,
+            None,
             RotateUserKeysRequest {
                 key_rotation_method: KeyRotationMethod::Password {
                     password: "test_password".to_string(),
@@ -540,6 +548,7 @@ mod tests {
         let result = internal_rotate_user_keys(
             &key_store,
             &api_client,
+            None,
             RotateUserKeysRequest {
                 key_rotation_method: KeyRotationMethod::Password {
                     password: "test_password".to_string(),
@@ -587,6 +596,7 @@ mod tests {
         let result = internal_rotate_user_keys(
             &key_store,
             &api_client,
+            None,
             RotateUserKeysRequest {
                 key_rotation_method: KeyRotationMethod::Password {
                     password: "test_password".to_string(),
@@ -650,6 +660,7 @@ mod tests {
         let result = internal_rotate_user_keys(
             &key_store,
             &api_client,
+            None,
             RotateUserKeysRequest {
                 key_rotation_method: KeyRotationMethod::Password {
                     password: "test_password".to_string(),
@@ -669,6 +680,146 @@ mod tests {
             mock.devices_api.checkpoint();
             mock.web_authn_api.checkpoint();
             mock.accounts_key_management_api.checkpoint();
+        }
+    }
+
+    #[tokio::test]
+    async fn test_rotate_user_keys_key_connector_success() {
+        let (key_store, sync_response) = make_test_key_store_and_sync_response();
+
+        let key_connector_key = KeyConnectorKey::make();
+        let key_connector_api_client = bitwarden_api_key_connector::apis::ApiClient::new_mocked(
+            |mock| {
+                let key_connector_key_clone = key_connector_key.clone();
+                mock.user_keys_api
+                    .expect_get_user_key()
+                    .once()
+                    .returning(move || {
+                        let encoded: bitwarden_encoding::B64 =
+                            key_connector_key_clone.clone().into();
+                        Ok(
+                            bitwarden_api_key_connector::models::user_key_response_model::UserKeyResponseModel {
+                                key: encoded.to_string(),
+                            },
+                        )
+                    });
+            },
+        );
+
+        let api_client = ApiClient::new_mocked(|mock| {
+            mock.sync_api
+                .expect_get()
+                .once()
+                .returning(move |_| Ok(sync_response.clone()));
+            mock_empty_sync_calls(mock);
+            mock.accounts_key_management_api
+                .expect_rotate_user_keys()
+                .once()
+                .returning(|req| {
+                    let req = req.expect("request body should be present");
+                    assert!(
+                        req.unlock_method_data
+                            .key_connector_key_wrapped_user_key
+                            .is_some(),
+                        "key_connector_key_wrapped_user_key should be set for KC rotation"
+                    );
+                    assert!(
+                        req.unlock_method_data.master_password_unlock_data.is_none(),
+                        "master_password_unlock_data should be None for KC rotation"
+                    );
+                    Ok(())
+                });
+        });
+
+        let result = internal_rotate_user_keys(
+            &key_store,
+            &api_client,
+            Some(&key_connector_api_client),
+            RotateUserKeysRequest {
+                key_rotation_method: KeyRotationMethod::KeyConnector {
+                    key_connector_url: "https://kc.example.com".to_string(),
+                },
+                trusted_organization_public_keys: vec![],
+                trusted_emergency_access_public_keys: vec![],
+                upgrade_token_action: None,
+            },
+        )
+        .await;
+
+        assert!(result.is_ok());
+        if let ApiClient::Mock(mut mock) = api_client {
+            mock.sync_api.checkpoint();
+            mock.organizations_api.checkpoint();
+            mock.emergency_access_api.checkpoint();
+            mock.devices_api.checkpoint();
+            mock.web_authn_api.checkpoint();
+            mock.accounts_key_management_api.checkpoint();
+        }
+        if let bitwarden_api_key_connector::apis::ApiClient::Mock(mut mock) =
+            key_connector_api_client
+        {
+            mock.user_keys_api.checkpoint();
+        }
+    }
+
+    #[tokio::test]
+    async fn test_rotate_user_keys_key_connector_api_failure() {
+        let (key_store, sync_response) = make_test_key_store_and_sync_response();
+
+        let key_connector_api_client =
+            bitwarden_api_key_connector::apis::ApiClient::new_mocked(|mock| {
+                mock.user_keys_api
+                    .expect_get_user_key()
+                    .once()
+                    .returning(move || {
+                        Err(bitwarden_api_key_connector::apis::Error::ResponseError(
+                            bitwarden_api_key_connector::apis::ResponseContent {
+                                status: reqwest::StatusCode::INTERNAL_SERVER_ERROR,
+                                content: "Server Error".to_string(),
+                            },
+                        ))
+                    });
+            });
+
+        let api_client = ApiClient::new_mocked(|mock| {
+            mock.sync_api
+                .expect_get()
+                .once()
+                .returning(move |_| Ok(sync_response.clone()));
+            mock_empty_sync_calls(mock);
+            mock.accounts_key_management_api
+                .expect_rotate_user_keys()
+                .never();
+        });
+
+        let result = internal_rotate_user_keys(
+            &key_store,
+            &api_client,
+            Some(&key_connector_api_client),
+            RotateUserKeysRequest {
+                key_rotation_method: KeyRotationMethod::KeyConnector {
+                    key_connector_url: "https://kc.example.com".to_string(),
+                },
+                trusted_organization_public_keys: vec![],
+                trusted_emergency_access_public_keys: vec![],
+                upgrade_token_action: None,
+            },
+        )
+        .await;
+
+        assert!(matches!(result, Err(RotateUserKeysError::KeyConnectorApi)));
+        if let ApiClient::Mock(mut mock) = api_client {
+            mock.sync_api.checkpoint();
+            mock.organizations_api.checkpoint();
+            mock.emergency_access_api.checkpoint();
+            mock.devices_api.checkpoint();
+            mock.web_authn_api.checkpoint();
+            mock.accounts_key_management_api.checkpoint();
+        }
+        if let bitwarden_api_key_connector::apis::ApiClient::Mock(mut mock) =
+            key_connector_api_client
+        {
+            mock.user_keys_api.checkpoint();
         }
     }
 }

--- a/crates/bitwarden-user-crypto-management/src/key_rotation/unlock.rs
+++ b/crates/bitwarden-user-crypto-management/src/key_rotation/unlock.rs
@@ -50,6 +50,8 @@ pub(super) enum ReencryptError {
     KeysetUnlockDataReencryption,
     /// Failed to update the unlock data for emergency access or organization membership
     KeySharingError,
+    /// Failed to wrap the user key with the Key Connector key
+    KeyConnectorWrapping,
     /// Failed to create v2 upgrade token
     UpgradeTokenCreation,
 }

--- a/crates/bitwarden-user-crypto-management/src/key_rotation/unlock_method.rs
+++ b/crates/bitwarden-user-crypto-management/src/key_rotation/unlock_method.rs
@@ -2,7 +2,7 @@
 
 use bitwarden_api_api::models::{self, UnlockMethodRequestModel};
 use bitwarden_core::key_management::{KeySlotIds, MasterPasswordUnlockData, SymmetricKeySlotId};
-use bitwarden_crypto::{Kdf, KeyStoreContext};
+use bitwarden_crypto::{Kdf, KeyConnectorKey, KeyStoreContext};
 
 use crate::key_rotation::{
     RotateUserKeysError, rotate_user_keys::KeyRotationMethod, sync::SyncedAccountData,
@@ -18,13 +18,16 @@ pub(super) enum PrimaryUnlockMethod {
         kdf: Kdf,
         salt: String,
     },
-    // Add key connector and TDE unlock methods here and the inputs needed to rotate them.
+    /// The Key Connector based unlock method.
+    KeyConnector { key_connector_key: KeyConnectorKey },
+    // Add TDE unlock method here and the inputs needed to rotate it.
 }
 
 impl PrimaryUnlockMethod {
     pub(super) fn from_key_rotation_method(
         method: KeyRotationMethod,
         synced_account_data: &SyncedAccountData,
+        key_connector_key: Option<KeyConnectorKey>,
     ) -> Result<Self, RotateUserKeysError> {
         match method {
             KeyRotationMethod::Password { password } => {
@@ -38,8 +41,10 @@ impl PrimaryUnlockMethod {
                     salt,
                 })
             }
-            KeyRotationMethod::KeyConnector => {
-                Err(RotateUserKeysError::UnimplementedKeyRotationMethod)
+            KeyRotationMethod::KeyConnector { .. } => {
+                let key_connector_key =
+                    key_connector_key.ok_or(RotateUserKeysError::KeyConnectorApi)?;
+                Ok(PrimaryUnlockMethod::KeyConnector { key_connector_key })
             }
             KeyRotationMethod::Tde => Err(RotateUserKeysError::UnimplementedKeyRotationMethod),
         }
@@ -68,6 +73,17 @@ pub(super) fn reencrypt_unlock_method_data(
                 key_connector_key_wrapped_user_key: None,
             })
         }
+        PrimaryUnlockMethod::KeyConnector { key_connector_key } => {
+            let wrapped_user_key = key_connector_key
+                .wrap_user_key(new_user_key_id, ctx)
+                .map_err(|_| ReencryptError::KeyConnectorWrapping)?;
+
+            Ok(UnlockMethodRequestModel {
+                unlock_method: models::UnlockMethod::KeyConnector,
+                master_password_unlock_data: None,
+                key_connector_key_wrapped_user_key: Some(wrapped_user_key.to_string()),
+            })
+        }
     }
 }
 
@@ -80,7 +96,7 @@ mod tests {
         KeySlotIds, MasterPasswordUnlockData,
         account_cryptographic_state::WrappedAccountCryptographicState,
     };
-    use bitwarden_crypto::{Kdf, KeyStore, KeyStoreContext};
+    use bitwarden_crypto::{Kdf, KeyConnectorKey, KeyStore, KeyStoreContext};
 
     use super::*;
     use crate::key_rotation::{rotate_user_keys::KeyRotationMethod, sync::SyncedAccountData};
@@ -145,20 +161,21 @@ mod tests {
                 password: "pass".to_string(),
             },
             &synced_data,
+            None,
         );
 
         let input = result.expect("should succeed");
-        match input {
-            PrimaryUnlockMethod::Password {
-                password,
-                kdf: result_kdf,
-                salt: result_salt,
-            } => {
-                assert_eq!(password, "pass");
-                assert_eq!(result_kdf, kdf);
-                assert_eq!(result_salt, salt);
-            }
-        }
+        let PrimaryUnlockMethod::Password {
+            password,
+            kdf: result_kdf,
+            salt: result_salt,
+        } = input
+        else {
+            panic!("expected Password variant");
+        };
+        assert_eq!(password, "pass");
+        assert_eq!(result_kdf, kdf);
+        assert_eq!(result_salt, salt);
     }
 
     #[test]
@@ -170,32 +187,59 @@ mod tests {
                 password: "pass".to_string(),
             },
             &synced_data,
+            None,
         );
 
         assert!(matches!(result, Err(RotateUserKeysError::Api)));
     }
 
     #[test]
-    fn test_from_key_rotation_method_key_connector_returns_error() {
+    fn test_from_key_rotation_method_key_connector_returns_input() {
+        let synced_data = make_synced_account_data(None);
+        let key = KeyConnectorKey::make();
+        let expected_b64: bitwarden_encoding::B64 = key.clone().into();
+
+        let result = PrimaryUnlockMethod::from_key_rotation_method(
+            KeyRotationMethod::KeyConnector {
+                key_connector_url: "https://kc.example.com".to_string(),
+            },
+            &synced_data,
+            Some(key),
+        );
+
+        let PrimaryUnlockMethod::KeyConnector { key_connector_key } =
+            result.expect("should succeed")
+        else {
+            panic!("expected KeyConnector variant");
+        };
+        let actual_b64: bitwarden_encoding::B64 = key_connector_key.into();
+        assert_eq!(actual_b64.to_string(), expected_b64.to_string());
+    }
+
+    #[test]
+    fn test_from_key_rotation_method_key_connector_no_key_returns_error() {
         let synced_data = make_synced_account_data(None);
 
         let result = PrimaryUnlockMethod::from_key_rotation_method(
-            KeyRotationMethod::KeyConnector,
+            KeyRotationMethod::KeyConnector {
+                key_connector_url: "https://kc.example.com".to_string(),
+            },
             &synced_data,
+            None,
         );
 
-        assert!(matches!(
-            result,
-            Err(RotateUserKeysError::UnimplementedKeyRotationMethod)
-        ));
+        assert!(matches!(result, Err(RotateUserKeysError::KeyConnectorApi)));
     }
 
     #[test]
     fn test_from_key_rotation_method_tde_returns_error() {
         let synced_data = make_synced_account_data(None);
 
-        let result =
-            PrimaryUnlockMethod::from_key_rotation_method(KeyRotationMethod::Tde, &synced_data);
+        let result = PrimaryUnlockMethod::from_key_rotation_method(
+            KeyRotationMethod::Tde,
+            &synced_data,
+            None,
+        );
 
         assert!(matches!(
             result,
@@ -276,5 +320,33 @@ mod tests {
             .unwrap_to_context(&mock_password, &mut ctx)
             .expect("unwrap should succeed");
         assert_symmetric_keys_equal(user_key_id, decrypted_user_key, &mut ctx);
+    }
+
+    #[test]
+    fn test_reencrypt_unlock_method_data_key_connector() {
+        let key_connector_key = KeyConnectorKey::make();
+        let store: KeyStore<KeySlotIds> = KeyStore::default();
+        let mut ctx = store.context_mut();
+        let user_key_id = ctx.generate_symmetric_key();
+
+        let input = PrimaryUnlockMethod::KeyConnector {
+            key_connector_key: key_connector_key.clone(),
+        };
+
+        let result = reencrypt_unlock_method_data(input, user_key_id, &mut ctx);
+
+        let model = result.expect("should be ok");
+        assert_eq!(model.unlock_method, UnlockMethod::KeyConnector);
+        assert!(model.master_password_unlock_data.is_none());
+        let wrapped_user_key_str = model
+            .key_connector_key_wrapped_user_key
+            .expect("should be present");
+        let wrapped_user_key: bitwarden_crypto::EncString =
+            wrapped_user_key_str.parse().expect("should parse");
+
+        let unwrapped_user_key_id = key_connector_key
+            .unwrap_user_key(wrapped_user_key, &mut ctx)
+            .expect("unwrap should succeed");
+        assert_symmetric_keys_equal(user_key_id, unwrapped_user_key_id, &mut ctx);
     }
 }


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-30214
Server PR: https://github.com/bitwarden/server/pull/7618

## 📔 Objective

Add key connector support to user key rotation.

## 🚨 Breaking Changes

<!-- Does this PR introduce any breaking changes? If so, please describe the impact and migration path for clients.

If you're unsure, the automated TypeScript compatibility check will run when you open/update this PR and provide feedback.

For breaking changes:
1. Describe what changed in the client interface
2. Explain why the change was necessary
3. Provide migration steps for client developers
4. Link to any paired client PRs if needed

Otherwise, you can remove this section. -->
