### PR TITLE
chore: add bitwarden-sm to version-bump workflow

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -10,6 +10,7 @@ on:
         type: choice
         options:
           - bitwarden-core
+          - bitwarden-sm
       version_number:
         description: "New version (example: '2024.1.0')"
         required: true
@@ -95,6 +96,13 @@ jobs:
         env:
           VERSION_NUMBER: ${{ inputs.version_number }}
         run: cargo set-version -p bitwarden-core "$VERSION_NUMBER"
+
+      ### bitwarden-sm
+      - name: Bump bitwarden-sm crate Version
+        if: ${{ inputs.project == 'bitwarden-sm' }}
+        env:
+          VERSION_NUMBER: ${{ inputs.version_number }}
+        run: cargo set-version -p bitwarden-sm "$VERSION_NUMBER"
 
       ############################
       # VERSION BUMP SECTION END #


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/jira/software/c/projects/BW/boards/138/backlog?assignee=712020%3A691c615d-a7a4-49d7-9905-9dc2c8292466&selectedIssue=PM-37252

## 📔 Objective

To release Secrets Manager we need to update the bitwarden-sm crate on crates.io. This PR updates the version bump workflow to support this. The rest of the pipeline should "just work". Trust me.