### PR TITLE
Fix WASM builds on Mac

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5595,7 +5595,6 @@ dependencies = [
  "chacha20poly1305 0.10.1",
  "curve25519-dalek 4.1.3",
  "getrandom 0.3.4",
- "ring",
  "rustc_version",
  "sha2 0.10.9",
  "subtle",

--- a/crates/bitwarden-ipc/Cargo.toml
+++ b/crates/bitwarden-ipc/Cargo.toml
@@ -31,7 +31,11 @@ js-sys = { workspace = true, optional = true }
 serde = { workspace = true }
 serde_bytes = { workspace = true }
 serde_json = { workspace = true }
-snow = { version = "0.10.0", features = ["risky-raw-split"] }
+snow = { version = "0.10.0", default-features = false, features = [
+    "default-resolver",
+    "default-resolver-crypto",
+    "risky-raw-split",
+] }
 thiserror = { workspace = true }
 tokio = { features = ["sync", "time", "rt"], workspace = true }
 tracing = { workspace = true }


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective

The latest version of the `snow` crate is transitively pulling `ring` when using the default `std` feature. This is causing the clang compiler on Mac to try and fail to build it for wasm, breaking WASM builds.

This PR disables the default `std` feature, which means we don't transitively pull `ring` anymore and makes the WASM builds work again.

Feature reference for `snow`: https://github.com/mcginty/snow/blob/8ac60f51cfe3e010c84f0a454cc575ad9204fa12/Cargo.toml#L22-L56

## 🚨 Breaking Changes

<!-- Does this PR introduce any breaking changes? If so, please describe the impact and migration path for clients.

If you're unsure, the automated TypeScript compatibility check will run when you open/update this PR and provide feedback.

For breaking changes:
1. Describe what changed in the client interface
2. Explain why the change was necessary
3. Provide migration steps for client developers
4. Link to any paired client PRs if needed

Otherwise, you can remove this section. -->
