### PR TITLE
Enable codable on swift bindings

### DIFF
--- a/crates/bitwarden-core/uniffi.toml
+++ b/crates/bitwarden-core/uniffi.toml
@@ -9,3 +9,4 @@ omit_checksums = true
 ffi_module_name = "BitwardenCoreFFI"
 module_name = "BitwardenCore"
 generate_immutable_records = true
+generate_codable_conformance = true

--- a/crates/bitwarden-crypto/uniffi.toml
+++ b/crates/bitwarden-crypto/uniffi.toml
@@ -9,3 +9,4 @@ omit_checksums = true
 ffi_module_name = "BitwardenCryptoFFI"
 module_name = "BitwardenCrypto"
 generate_immutable_records = true
+generate_codable_conformance = true


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://github.com/bitwarden/ios/pull/2648#issuecomment-4460930000

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
As per mobile's request, we are enabling codable for the uniffi bindings so that they can directly serialize the structs they get returned from the SDK without having to maintain a seprate copy. Maintaining a separate copy in the past has lead to bugs / incorrect state being saved (https://github.com/bitwarden/ios/pull/2303).

This is safer than mobiles current approach of persisting server request / response models, which do not match what the SDK returns.

## 🚨 Breaking Changes

<!-- Does this PR introduce any breaking changes? If so, please describe the impact and migration path for clients.

If you're unsure, the automated TypeScript compatibility check will run when you open/update this PR and provide feedback.

For breaking changes:
1. Describe what changed in the client interface
2. Explain why the change was necessary
3. Provide migration steps for client developers
4. Link to any paired client PRs if needed

Otherwise, you can remove this section. -->
