### PR TITLE
[PM-27801] Refresh tokens on 401

### DIFF
--- a/crates/bitwarden-auth/src/token_management/middleware.rs
+++ b/crates/bitwarden-auth/src/token_management/middleware.rs
@@ -18,7 +18,9 @@ pub(crate) struct MiddlewareWrapper<T>(pub(crate) T);
 #[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
 #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
 pub(crate) trait MiddlewareExt: 'static + Send + Sync {
-    async fn get_token(&self) -> Result<Option<String>, LoginError>;
+    /// Retrieves the current access token, renewing it if necessary. If `force` is true,
+    /// the token should be renewed regardless of its current expiration time.
+    async fn get_token(&self, force: bool) -> Result<Option<String>, LoginError>;
 }
 
 /// Implements HTTP middleware that attaches authentication tokens to requests.
@@ -33,9 +35,41 @@ impl<T: MiddlewareExt> Middleware for MiddlewareWrapper<T> {
         ext: &mut http::Extensions,
         next: reqwest_middleware::Next<'_>,
     ) -> Result<reqwest::Response, reqwest_middleware::Error> {
+        let required_auth = self.inject_token_if_required(&mut req, ext, false).await;
+
+        let req_clone = req.try_clone();
+        let result = next.clone().run(req, ext).await?;
+
+        // If the request required auth and got a 401 Unauthorized response, the token might have
+        // been invalidated. In that case, we should try to refresh it and retry the request.
+        if required_auth
+            && let Some(mut req_clone) = req_clone
+            && result.status() == http::StatusCode::UNAUTHORIZED
+        {
+            tracing::info!("Received 401 response, attempting token refresh and retrying");
+            self.inject_token_if_required(&mut req_clone, ext, true)
+                .await;
+            return next.run(req_clone, ext).await;
+        }
+
+        Ok(result)
+    }
+}
+
+impl<T: MiddlewareExt> MiddlewareWrapper<T> {
+    /// Attaches an authentication header to `req` based on the [AuthRequired] extension, if any.
+    /// Returns `true` when the request specified an authentication method (regardless of whether
+    /// a token was successfully retrieved and attached) so callers can decide whether to retry on
+    /// auth failures.
+    async fn inject_token_if_required(
+        &self,
+        req: &mut reqwest::Request,
+        ext: &http::Extensions,
+        force: bool,
+    ) -> bool {
         match ext.get::<AuthRequired>() {
             Some(AuthRequired::Bearer) => {
-                match self.0.get_token().await {
+                match self.0.get_token(force).await {
                     Ok(Some(token)) => match format!("Bearer {}", token).parse() {
                         Ok(header_value) => {
                             req.headers_mut()
@@ -52,13 +86,14 @@ impl<T: MiddlewareExt> Middleware for MiddlewareWrapper<T> {
                         tracing::warn!("Failed to get auth token: {e}");
                     }
                 };
+
+                return true;
             }
             Some(auth) => {
                 tracing::warn!(?auth, "Unsupported authentication method in request");
             }
             None => (),
         }
-
-        next.run(req, ext).await
+        false
     }
 }

--- a/crates/bitwarden-auth/src/token_management/password_manager_token_handler.rs
+++ b/crates/bitwarden-auth/src/token_management/password_manager_token_handler.rs
@@ -78,7 +78,7 @@ impl TokenHandler for PasswordManagerTokenHandler {
 #[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
 #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
 impl MiddlewareExt for PasswordManagerTokenHandler {
-    async fn get_token(&self) -> Result<Option<String>, LoginError> {
+    async fn get_token(&self, force: bool) -> Result<Option<String>, LoginError> {
         // We're not holding on to a lock for the duration of the token renewal, so if multiple
         // requests come in at the same time when the token is expired, we may end up renewing the
         // token multiple times. This is not ideal, but it's the behavior of the previous
@@ -96,7 +96,7 @@ impl MiddlewareExt for PasswordManagerTokenHandler {
             .ok_or(NotAuthenticatedError)?;
 
         // Validate the token, returning early if it's still valid.
-        if Utc::now().timestamp() < tokens.expires_on - TOKEN_RENEW_MARGIN_SECONDS {
+        if !force && Utc::now().timestamp() < tokens.expires_on - TOKEN_RENEW_MARGIN_SECONDS {
             return Ok(Some(tokens.access_token.clone()));
         }
 
@@ -128,6 +128,7 @@ impl MiddlewareExt for PasswordManagerTokenHandler {
 
 #[cfg(test)]
 mod tests {
+    use bitwarden_api_api::apis::AuthRequired;
     use bitwarden_core::{
         auth::TokenHandler,
         client::{
@@ -218,5 +219,140 @@ mod tests {
         assert_eq!(auth.as_deref(), Some("Bearer renewed-token"));
         assert_eq!(identity_server.received_requests().await.unwrap().len(), 1);
         assert_eq!(app_server.received_requests().await.unwrap().len(), 1);
+    }
+
+    #[tokio::test]
+    async fn retries_with_renewed_token_on_401() {
+        let app_server = start_app_server_rejecting("stale-token").await;
+        let identity_server = start_renewal_server("renewed-token").await;
+
+        let registry = registry_with_api_key_login().await;
+        // Seed a token that the local handler considers valid (well within the renewal margin),
+        // so the only path to renewal is the 401 retry.
+        seed_tokens(&registry, "stale-token", Some("refresh"), 5000).await;
+
+        let handler = PasswordManagerTokenHandler::default();
+        let client = build_client(handler.initialize_middleware(
+            &registry,
+            identity_config(&identity_server.uri()),
+            KeyStore::<KeySlotIds>::default(),
+        ));
+
+        let response = client
+            .get(format!("{}/test", app_server.uri()))
+            .with_extension(AuthRequired::Bearer)
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(response.status(), 200);
+
+        let requests = app_server.received_requests().await.unwrap();
+        assert_eq!(requests.len(), 2);
+        assert_eq!(
+            requests[0].headers.get("Authorization").unwrap(),
+            "Bearer stale-token"
+        );
+        assert_eq!(
+            requests[1].headers.get("Authorization").unwrap(),
+            "Bearer renewed-token"
+        );
+        assert_eq!(identity_server.received_requests().await.unwrap().len(), 1);
+    }
+
+    #[tokio::test]
+    async fn refreshes_on_retry_when_initial_token_unavailable() {
+        // App server rejects unauthenticated requests with 401 but accepts the renewed token.
+        let app_server = MockServer::start().await;
+        wiremock::Mock::given(wiremock::matchers::header(
+            "Authorization",
+            "Bearer renewed-token",
+        ))
+        .respond_with(wiremock::ResponseTemplate::new(200))
+        .mount(&app_server)
+        .await;
+        wiremock::Mock::given(wiremock::matchers::any())
+            .respond_with(wiremock::ResponseTemplate::new(401))
+            .mount(&app_server)
+            .await;
+
+        // Identity server fails the first renewal and succeeds on the second, so the initial
+        // get_token call returns no token, but the forced refresh on retry produces one.
+        let identity_server = MockServer::start().await;
+        wiremock::Mock::given(wiremock::matchers::method("POST"))
+            .and(wiremock::matchers::path("/connect/token"))
+            .respond_with(wiremock::ResponseTemplate::new(500))
+            .up_to_n_times(1)
+            .mount(&identity_server)
+            .await;
+        wiremock::Mock::given(wiremock::matchers::method("POST"))
+            .and(wiremock::matchers::path("/connect/token"))
+            .respond_with(
+                wiremock::ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                    "access_token": "renewed-token",
+                    "expires_in": 3600,
+                    "token_type": "Bearer",
+                    "scope": "api"
+                })),
+            )
+            .mount(&identity_server)
+            .await;
+
+        let registry = registry_with_api_key_login().await;
+        // Seed expired tokens so get_token reaches the renewal path on both calls.
+        seed_tokens(&registry, "stale-token", Some("refresh"), 0).await;
+
+        let handler = PasswordManagerTokenHandler::default();
+        let client = build_client(handler.initialize_middleware(
+            &registry,
+            identity_config(&identity_server.uri()),
+            KeyStore::<KeySlotIds>::default(),
+        ));
+
+        let response = client
+            .get(format!("{}/test", app_server.uri()))
+            .with_extension(AuthRequired::Bearer)
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(response.status(), 200);
+
+        let requests = app_server.received_requests().await.unwrap();
+        assert_eq!(requests.len(), 2);
+        assert!(requests[0].headers.get("Authorization").is_none());
+        assert_eq!(
+            requests[1].headers.get("Authorization").unwrap(),
+            "Bearer renewed-token"
+        );
+        assert_eq!(identity_server.received_requests().await.unwrap().len(), 2);
+    }
+
+    #[tokio::test]
+    async fn does_not_retry_when_no_auth_extension() {
+        let server = MockServer::start().await;
+        wiremock::Mock::given(wiremock::matchers::any())
+            .respond_with(wiremock::ResponseTemplate::new(401))
+            .mount(&server)
+            .await;
+
+        // Request is sent without the AuthRequired extension, so the middleware never asks
+        // for a token and must not retry on 401.
+        let registry = registry_with_api_key_login().await;
+        let handler = PasswordManagerTokenHandler::default();
+        let client = build_client(handler.initialize_middleware(
+            &registry,
+            identity_config(&server.uri()),
+            KeyStore::<KeySlotIds>::default(),
+        ));
+
+        let response = client
+            .get(format!("{}/test", server.uri()))
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(response.status(), 401);
+
+        let requests = server.received_requests().await.unwrap();
+        assert_eq!(requests.len(), 1);
+        assert!(requests[0].headers.get("Authorization").is_none());
     }
 }

--- a/crates/bitwarden-auth/src/token_management/secrets_manager_token_handler.rs
+++ b/crates/bitwarden-auth/src/token_management/secrets_manager_token_handler.rs
@@ -81,7 +81,7 @@ impl SecretsManagerTokenHandler {
 #[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
 #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
 impl MiddlewareExt for SecretsManagerTokenHandler {
-    async fn get_token(&self) -> Result<Option<String>, LoginError> {
+    async fn get_token(&self, force: bool) -> Result<Option<String>, LoginError> {
         // We're not holding on to a lock for the duration of the token renewal, so if multiple
         // requests come in at the same time when the token is expired, we may end up renewing the
         // token multiple times. This is not ideal, but it's the behavior of the previous
@@ -90,7 +90,8 @@ impl MiddlewareExt for SecretsManagerTokenHandler {
         let inner = self.inner.read().expect("RwLock is not poisoned").clone();
 
         // Validate the token, returning early if it's still valid.
-        if let Some(expires) = inner.expires_on
+        if !force
+            && let Some(expires) = inner.expires_on
             && Utc::now().timestamp() < expires - TOKEN_RENEW_MARGIN_SECONDS
         {
             return Ok(inner.access_token.clone());
@@ -120,6 +121,7 @@ impl MiddlewareExt for SecretsManagerTokenHandler {
 mod tests {
     use std::str::FromStr;
 
+    use bitwarden_api_api::apis::AuthRequired;
     use bitwarden_core::{
         auth::{AccessToken, TokenHandler},
         client::login_method::ServiceAccountLoginMethod,
@@ -196,5 +198,147 @@ mod tests {
         assert_eq!(auth.as_deref(), Some("Bearer renewed-token"));
         assert_eq!(identity_server.received_requests().await.unwrap().len(), 1);
         assert_eq!(app_server.received_requests().await.unwrap().len(), 1);
+    }
+
+    #[tokio::test]
+    async fn retries_with_renewed_token_on_401() {
+        let app_server = start_app_server_rejecting("stale-token").await;
+        let identity_server = start_renewal_server("renewed-token").await;
+
+        let handler = SecretsManagerTokenHandler::default();
+        handler
+            .set_sm_login_method(service_account_login_method())
+            .await;
+        // Token is locally valid; the only renewal path is the 401 retry.
+        handler
+            .set_tokens("stale-token".to_string(), None, 3600)
+            .await;
+
+        let registry = StateRegistry::new_with_memory_db();
+        let client = build_client(handler.initialize_middleware(
+            &registry,
+            identity_config(&identity_server.uri()),
+            KeyStore::<KeySlotIds>::default(),
+        ));
+
+        let response = client
+            .get(format!("{}/test", app_server.uri()))
+            .with_extension(AuthRequired::Bearer)
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(response.status(), 200);
+
+        let requests = app_server.received_requests().await.unwrap();
+        assert_eq!(requests.len(), 2);
+        assert_eq!(
+            requests[0].headers.get("Authorization").unwrap(),
+            "Bearer stale-token"
+        );
+        assert_eq!(
+            requests[1].headers.get("Authorization").unwrap(),
+            "Bearer renewed-token"
+        );
+        assert_eq!(identity_server.received_requests().await.unwrap().len(), 1);
+    }
+
+    #[tokio::test]
+    async fn refreshes_on_retry_when_initial_token_unavailable() {
+        // App server rejects unauthenticated requests with 401 but accepts the renewed token.
+        let app_server = MockServer::start().await;
+        wiremock::Mock::given(wiremock::matchers::header(
+            "Authorization",
+            "Bearer renewed-token",
+        ))
+        .respond_with(wiremock::ResponseTemplate::new(200))
+        .mount(&app_server)
+        .await;
+        wiremock::Mock::given(wiremock::matchers::any())
+            .respond_with(wiremock::ResponseTemplate::new(401))
+            .mount(&app_server)
+            .await;
+
+        // Identity server fails the first renewal and succeeds on the second, so the initial
+        // get_token call returns no token, but the forced refresh on retry produces one.
+        let identity_server = MockServer::start().await;
+        wiremock::Mock::given(wiremock::matchers::method("POST"))
+            .and(wiremock::matchers::path("/connect/token"))
+            .respond_with(wiremock::ResponseTemplate::new(500))
+            .up_to_n_times(1)
+            .mount(&identity_server)
+            .await;
+        wiremock::Mock::given(wiremock::matchers::method("POST"))
+            .and(wiremock::matchers::path("/connect/token"))
+            .respond_with(
+                wiremock::ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                    "access_token": "renewed-token",
+                    "expires_in": 3600,
+                    "token_type": "Bearer",
+                    "scope": "api"
+                })),
+            )
+            .mount(&identity_server)
+            .await;
+
+        let handler = SecretsManagerTokenHandler::default();
+        handler
+            .set_sm_login_method(service_account_login_method())
+            .await;
+        // No tokens seeded -> get_token always reaches the renewal path.
+
+        let registry = StateRegistry::new_with_memory_db();
+        let client = build_client(handler.initialize_middleware(
+            &registry,
+            identity_config(&identity_server.uri()),
+            KeyStore::<KeySlotIds>::default(),
+        ));
+
+        let response = client
+            .get(format!("{}/test", app_server.uri()))
+            .with_extension(AuthRequired::Bearer)
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(response.status(), 200);
+
+        let requests = app_server.received_requests().await.unwrap();
+        assert_eq!(requests.len(), 2);
+        assert!(requests[0].headers.get("Authorization").is_none());
+        assert_eq!(
+            requests[1].headers.get("Authorization").unwrap(),
+            "Bearer renewed-token"
+        );
+        assert_eq!(identity_server.received_requests().await.unwrap().len(), 2);
+    }
+
+    #[tokio::test]
+    async fn does_not_retry_when_no_auth_extension() {
+        let server = MockServer::start().await;
+        wiremock::Mock::given(wiremock::matchers::any())
+            .respond_with(wiremock::ResponseTemplate::new(401))
+            .mount(&server)
+            .await;
+
+        // Request is sent without the AuthRequired extension, so the middleware never asks
+        // for a token and must not retry on 401.
+        let handler = SecretsManagerTokenHandler::default();
+
+        let registry = StateRegistry::new_with_memory_db();
+        let client = build_client(handler.initialize_middleware(
+            &registry,
+            identity_config(&server.uri()),
+            KeyStore::<KeySlotIds>::default(),
+        ));
+
+        let response = client
+            .get(format!("{}/test", server.uri()))
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(response.status(), 401);
+
+        let requests = server.received_requests().await.unwrap();
+        assert_eq!(requests.len(), 1);
+        assert!(requests[0].headers.get("Authorization").is_none());
     }
 }

--- a/crates/bitwarden-auth/src/token_management/test_utils.rs
+++ b/crates/bitwarden-auth/src/token_management/test_utils.rs
@@ -20,6 +20,25 @@ pub async fn start_app_server() -> MockServer {
     server
 }
 
+/// Start a mock app server that returns 401 for requests carrying `stale_token`
+/// in the Authorization header and 200 for any other request. Useful for exercising
+/// the middleware's retry-on-401 path.
+pub async fn start_app_server_rejecting(stale_token: &str) -> MockServer {
+    let server = MockServer::start().await;
+    wiremock::Mock::given(wiremock::matchers::header(
+        "Authorization",
+        format!("Bearer {stale_token}").as_str(),
+    ))
+    .respond_with(wiremock::ResponseTemplate::new(401))
+    .mount(&server)
+    .await;
+    wiremock::Mock::given(wiremock::matchers::any())
+        .respond_with(wiremock::ResponseTemplate::new(200))
+        .mount(&server)
+        .await;
+    server
+}
+
 /// Start a mock identity server that returns a renewed token on POST /connect/token.
 pub async fn start_renewal_server(renewed_token: &str) -> MockServer {
     let server = MockServer::start().await;


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-27801

## 📔 Objective

Retry once with a freshly refreshed token when an authenticated request comes back with a `401 Unauthorized`. Until now the middleware attached whatever token `get_token` returned, including a still-valid-by-clock token that the server had since invalidated, and surfaced the 401 to the caller.

Changes:
- `MiddlewareExt::get_token` takes a `force: bool` flag. When `true`, `PasswordManagerTokenHandler` and `SecretsManagerTokenHandler` bypass the local expiration check and hit `/connect/token` unconditionally.
- `MiddlewareWrapper::handle` clones the request before sending (via `try_clone`, so streaming bodies cleanly opt out) and, on a 401 from a request that required auth, re-injects a forced-refresh token and retries exactly once.
- Token injection moves into a small `inject_token_if_required` helper so the initial-send and retry paths share the same logic. It returns whether the request specified an auth method, which is what gates the retry.

Bounded by construction: at most one retry per request, the retry only happens when the original request actually carried an `AuthRequired` extension, and `try_clone` failing (streaming body) skips the retry instead of erroring. Concurrent refreshes are unchanged from existing behavior and called out in the comment inside `get_token`. We have a tracking issue to follow up on that: https://bitwarden.atlassian.net/browse/PM-32346

Tests cover the three meaningful paths in both handlers: retry succeeds with a renewed token, retry succeeds when the initial `get_token` failed but the forced refresh works, and no retry occurs when the request had no auth extension.

## 🚨 Breaking Changes