### PR TITLE
[PM-35656] Add copy options to CipherListView

### DIFF
--- a/crates/bitwarden-vault/src/cipher/bank_account.rs
+++ b/crates/bitwarden-vault/src/cipher/bank_account.rs
@@ -104,18 +104,27 @@ impl CipherKind for BankAccount {
 
     fn get_copyable_fields(&self, _: Option<&Cipher>) -> Vec<CopyableCipherFields> {
         [
+            self.name_on_account
+                .as_ref()
+                .map(|_| CopyableCipherFields::BankAccountNameOnAccount),
             self.account_number
                 .as_ref()
                 .map(|_| CopyableCipherFields::BankAccountAccountNumber),
             self.routing_number
                 .as_ref()
                 .map(|_| CopyableCipherFields::BankAccountRoutingNumber),
+            self.branch_number
+                .as_ref()
+                .map(|_| CopyableCipherFields::BankAccountBranchNumber),
             self.pin
                 .as_ref()
                 .map(|_| CopyableCipherFields::BankAccountPin),
             self.iban
                 .as_ref()
                 .map(|_| CopyableCipherFields::BankAccountIban),
+            self.swift_code
+                .as_ref()
+                .map(|_| CopyableCipherFields::BankAccountSwift),
         ]
         .into_iter()
         .flatten()
@@ -271,10 +280,13 @@ mod tests {
         assert_eq!(
             copyable_fields,
             vec![
+                CopyableCipherFields::BankAccountNameOnAccount,
                 CopyableCipherFields::BankAccountAccountNumber,
                 CopyableCipherFields::BankAccountRoutingNumber,
+                CopyableCipherFields::BankAccountBranchNumber,
                 CopyableCipherFields::BankAccountPin,
                 CopyableCipherFields::BankAccountIban,
+                CopyableCipherFields::BankAccountSwift,
             ]
         );
     }

--- a/crates/bitwarden-vault/src/cipher/cipher.rs
+++ b/crates/bitwarden-vault/src/cipher/cipher.rs
@@ -494,11 +494,20 @@ pub enum CopyableCipherFields {
     IdentityAddress,
     SshKey,
     SecureNotes,
+    BankAccountNameOnAccount,
     BankAccountAccountNumber,
     BankAccountRoutingNumber,
+    BankAccountBranchNumber,
     BankAccountPin,
     BankAccountIban,
+    BankAccountSwift,
+    PassportGivenName,
+    PassportSurname,
     PassportPassportNumber,
+    PassportNationalIdentificationNumber,
+    DriversLicenseFirstName,
+    DriversLicenseMiddleName,
+    DriversLicenseLastName,
     DriversLicenseLicenseNumber,
 }
 
@@ -2944,7 +2953,11 @@ mod tests {
         assert_eq!(list_view.subtitle, "Jane Doe");
         assert_eq!(
             list_view.copyable_fields,
-            vec![CopyableCipherFields::PassportPassportNumber]
+            vec![
+                CopyableCipherFields::PassportGivenName,
+                CopyableCipherFields::PassportSurname,
+                CopyableCipherFields::PassportPassportNumber,
+            ]
         );
     }
 
@@ -2972,7 +2985,11 @@ mod tests {
         assert_eq!(list_view.subtitle, "John Doe");
         assert_eq!(
             list_view.copyable_fields,
-            vec![CopyableCipherFields::DriversLicenseLicenseNumber]
+            vec![
+                CopyableCipherFields::DriversLicenseFirstName,
+                CopyableCipherFields::DriversLicenseLastName,
+                CopyableCipherFields::DriversLicenseLicenseNumber,
+            ]
         );
     }
 

--- a/crates/bitwarden-vault/src/cipher/drivers_license.rs
+++ b/crates/bitwarden-vault/src/cipher/drivers_license.rs
@@ -117,10 +117,20 @@ impl CipherKind for DriversLicense {
     }
 
     fn get_copyable_fields(&self, _: Option<&Cipher>) -> Vec<CopyableCipherFields> {
-        [self
-            .license_number
-            .as_ref()
-            .map(|_| CopyableCipherFields::DriversLicenseLicenseNumber)]
+        [
+            self.first_name
+                .as_ref()
+                .map(|_| CopyableCipherFields::DriversLicenseFirstName),
+            self.middle_name
+                .as_ref()
+                .map(|_| CopyableCipherFields::DriversLicenseMiddleName),
+            self.last_name
+                .as_ref()
+                .map(|_| CopyableCipherFields::DriversLicenseLastName),
+            self.license_number
+                .as_ref()
+                .map(|_| CopyableCipherFields::DriversLicenseLicenseNumber),
+        ]
         .into_iter()
         .flatten()
         .collect()
@@ -279,7 +289,12 @@ mod tests {
         let copyable_fields = dl.get_copyable_fields(None);
         assert_eq!(
             copyable_fields,
-            vec![CopyableCipherFields::DriversLicenseLicenseNumber,]
+            vec![
+                CopyableCipherFields::DriversLicenseFirstName,
+                CopyableCipherFields::DriversLicenseMiddleName,
+                CopyableCipherFields::DriversLicenseLastName,
+                CopyableCipherFields::DriversLicenseLicenseNumber,
+            ]
         );
     }
 }

--- a/crates/bitwarden-vault/src/cipher/passport.rs
+++ b/crates/bitwarden-vault/src/cipher/passport.rs
@@ -131,10 +131,20 @@ impl CipherKind for Passport {
     }
 
     fn get_copyable_fields(&self, _: Option<&Cipher>) -> Vec<CopyableCipherFields> {
-        [self
-            .passport_number
-            .as_ref()
-            .map(|_| CopyableCipherFields::PassportPassportNumber)]
+        [
+            self.given_name
+                .as_ref()
+                .map(|_| CopyableCipherFields::PassportGivenName),
+            self.surname
+                .as_ref()
+                .map(|_| CopyableCipherFields::PassportSurname),
+            self.passport_number
+                .as_ref()
+                .map(|_| CopyableCipherFields::PassportPassportNumber),
+            self.national_identification_number
+                .as_ref()
+                .map(|_| CopyableCipherFields::PassportNationalIdentificationNumber),
+        ]
         .into_iter()
         .flatten()
         .collect()
@@ -307,7 +317,12 @@ mod tests {
         let copyable_fields = passport.get_copyable_fields(None);
         assert_eq!(
             copyable_fields,
-            vec![CopyableCipherFields::PassportPassportNumber,]
+            vec![
+                CopyableCipherFields::PassportGivenName,
+                CopyableCipherFields::PassportSurname,
+                CopyableCipherFields::PassportPassportNumber,
+                CopyableCipherFields::PassportNationalIdentificationNumber,
+            ]
         );
     }
 }


### PR DESCRIPTION
## 🎟️ Tracking

[PM-35656](https://bitwarden.atlassian.net/browse/PM-35656)

## 📔 Objective

Updates `copyable_fields` property for `CipherListView` to include fields from new item types that were missed or added after the initial pass through the work.


[PM-35656]: https://bitwarden.atlassian.net/browse/PM-35656?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ