### PR TITLE
[PM-32346] Serialize concurrent token renewals

### DIFF
--- a/crates/bitwarden-auth/Cargo.toml
+++ b/crates/bitwarden-auth/Cargo.toml
@@ -50,6 +50,7 @@ serde = { workspace = true }
 serde_bytes = { workspace = true }
 serde_repr = { workspace = true }
 thiserror = { workspace = true }
+tokio = { workspace = true, features = ["sync"] }
 tracing = { workspace = true }
 tsify = { workspace = true, optional = true }
 uniffi = { workspace = true, optional = true }

--- a/crates/bitwarden-auth/src/token_management/middleware.rs
+++ b/crates/bitwarden-auth/src/token_management/middleware.rs
@@ -90,10 +90,7 @@ impl<T: MiddlewareExt> MiddlewareWrapper<T> {
 
     /// Retry resolution after a 401: if a concurrent retry already renewed (the stored token
     /// differs from `previous`), reuse that result. Otherwise renew.
-    async fn resolve_retry(
-        &self,
-        previous: Option<String>,
-    ) -> Result<Option<String>, LoginError> {
+    async fn resolve_retry(&self, previous: Option<String>) -> Result<Option<String>, LoginError> {
         let mut handler = self.0.lock().await;
         if let Some((access_token, _)) = handler.current_token().await
             && let Some(prev) = &previous

--- a/crates/bitwarden-auth/src/token_management/middleware.rs
+++ b/crates/bitwarden-auth/src/token_management/middleware.rs
@@ -9,18 +9,32 @@ pub(crate) const TOKEN_RENEW_MARGIN_SECONDS: i64 = 5 * 60;
 /// A wrapper that implements [reqwest_middleware::Middleware] by delegating to a [MiddlewareExt]
 /// for token retrieval. We can't implement [Middleware] directly on [MiddlewareExt] because
 /// [Middleware] is defined in an external crate, so we use this wrapper to bridge between them.
-pub(crate) struct MiddlewareWrapper<T>(pub(crate) T);
+///
+/// The inner [tokio::sync::Mutex] serializes all calls to [MiddlewareExt::get_token], ensuring
+/// that at most one token renewal is in-flight at a time and that no request goes out with a
+/// potentially-invalidated token while a renewal is in progress.
+pub(crate) struct MiddlewareWrapper<T>(tokio::sync::Mutex<T>);
+
+impl<T> MiddlewareWrapper<T> {
+    pub(crate) fn new(inner: T) -> Self {
+        Self(tokio::sync::Mutex::new(inner))
+    }
+}
 
 /// Trait used to share over the token attaching middleware. This is implemented by the token
 /// management structs, leaving them responsible for handling token retrieval and renewal logic. The
 /// middleware simply calls [MiddlewareExt::get_token] to get the current token (renewing if
 /// necessary) and attaches it to the request.
+///
+/// All calls to [MiddlewareExt::get_token] are serialized by the [MiddlewareWrapper] mutex,
+/// which guarantees exclusive access (`&mut self`) and prevents both duplicate renewals and
+/// requests going out with stale tokens while a renewal is in progress.
 #[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
 #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
 pub(crate) trait MiddlewareExt: 'static + Send + Sync {
     /// Retrieves the current access token, renewing it if necessary. If `force` is true,
     /// the token should be renewed regardless of its current expiration time.
-    async fn get_token(&self, force: bool) -> Result<Option<String>, LoginError>;
+    async fn get_token(&mut self, force: bool) -> Result<Option<String>, LoginError>;
 }
 
 /// Implements HTTP middleware that attaches authentication tokens to requests.
@@ -69,7 +83,8 @@ impl<T: MiddlewareExt> MiddlewareWrapper<T> {
     ) -> bool {
         match ext.get::<AuthRequired>() {
             Some(AuthRequired::Bearer) => {
-                match self.0.get_token(force).await {
+                let token = self.0.lock().await.get_token(force).await;
+                match token {
                     Ok(Some(token)) => match format!("Bearer {}", token).parse() {
                         Ok(header_value) => {
                             req.headers_mut()

--- a/crates/bitwarden-auth/src/token_management/middleware.rs
+++ b/crates/bitwarden-auth/src/token_management/middleware.rs
@@ -2,17 +2,17 @@
 
 use bitwarden_api_api::apis::AuthRequired;
 use bitwarden_core::auth::login::LoginError;
+use chrono::Utc;
 use reqwest_middleware::Middleware;
 
-pub(crate) const TOKEN_RENEW_MARGIN_SECONDS: i64 = 5 * 60;
+const TOKEN_RENEW_MARGIN_SECONDS: i64 = 5 * 60;
 
-/// A wrapper that implements [reqwest_middleware::Middleware] by delegating to a [MiddlewareExt]
-/// for token retrieval. We can't implement [Middleware] directly on [MiddlewareExt] because
-/// [Middleware] is defined in an external crate, so we use this wrapper to bridge between them.
+/// Bridges a [MiddlewareExt] implementation to [reqwest_middleware::Middleware], which can't be
+/// implemented directly because the trait is defined in an external crate.
 ///
-/// The inner [tokio::sync::Mutex] serializes all calls to [MiddlewareExt::get_token], ensuring
-/// that at most one token renewal is in-flight at a time and that no request goes out with a
-/// potentially-invalidated token while a renewal is in progress.
+/// The inner [tokio::sync::Mutex] serializes token reads and renewals, ensuring at most one
+/// in-flight renewal and that no request goes out with a potentially-invalidated token while a
+/// renewal is in progress.
 pub(crate) struct MiddlewareWrapper<T>(tokio::sync::Mutex<T>);
 
 impl<T> MiddlewareWrapper<T> {
@@ -21,25 +21,21 @@ impl<T> MiddlewareWrapper<T> {
     }
 }
 
-/// Trait used to share over the token attaching middleware. This is implemented by the token
-/// management structs, leaving them responsible for handling token retrieval and renewal logic. The
-/// middleware simply calls [MiddlewareExt::get_token] to get the current token (renewing if
-/// necessary) and attaches it to the request.
-///
-/// All calls to [MiddlewareExt::get_token] are serialized by the [MiddlewareWrapper] mutex,
-/// which guarantees exclusive access (`&mut self`) and prevents both duplicate renewals and
-/// requests going out with stale tokens while a renewal is in progress.
+/// Implemented by token handlers to expose stored token state and a renewal hook. The middleware
+/// owns the coalescing decision under the [MiddlewareWrapper] mutex.
 #[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
 #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
 pub(crate) trait MiddlewareExt: 'static + Send + Sync {
-    /// Retrieves the current access token, renewing it if necessary. If `force` is true,
-    /// the token should be renewed regardless of its current expiration time.
-    async fn get_token(&mut self, force: bool) -> Result<Option<String>, LoginError>;
+    /// Returns the stored access token and its expiration timestamp (Unix seconds), or `None` if
+    /// no token state is available.
+    async fn current_token(&self) -> Option<(String, i64)>;
+
+    /// Renew the access token from the upstream identity service and persist the result.
+    async fn renew_token(&mut self) -> Result<Option<String>, LoginError>;
 }
 
-/// Implements HTTP middleware that attaches authentication tokens to requests.
-/// Delegates to [MiddlewareExt::get_token] to retrieve tokens (which handles renewal).
-/// Only applies to requests marked with [AuthRequired].
+/// Attaches an auth token (when [AuthRequired] is present) and retries once on 401 with a forced
+/// renewal, in case the server invalidated the token out from under us.
 #[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
 #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
 impl<T: MiddlewareExt> Middleware for MiddlewareWrapper<T> {
@@ -49,20 +45,30 @@ impl<T: MiddlewareExt> Middleware for MiddlewareWrapper<T> {
         ext: &mut http::Extensions,
         next: reqwest_middleware::Next<'_>,
     ) -> Result<reqwest::Response, reqwest_middleware::Error> {
-        let required_auth = self.inject_token_if_required(&mut req, ext, false).await;
+        let auth_required = match ext.get::<AuthRequired>() {
+            Some(AuthRequired::Bearer) => true,
+            Some(other) => {
+                tracing::warn!(?other, "Unsupported authentication method in request");
+                false
+            }
+            None => false,
+        };
+
+        let attached = if auth_required {
+            attach_header(&mut req, self.resolve_initial().await)
+        } else {
+            None
+        };
 
         let req_clone = req.try_clone();
         let result = next.clone().run(req, ext).await?;
 
-        // If the request required auth and got a 401 Unauthorized response, the token might have
-        // been invalidated. In that case, we should try to refresh it and retry the request.
-        if required_auth
+        if auth_required
             && let Some(mut req_clone) = req_clone
             && result.status() == http::StatusCode::UNAUTHORIZED
         {
             tracing::info!("Received 401 response, attempting token refresh and retrying");
-            self.inject_token_if_required(&mut req_clone, ext, true)
-                .await;
+            attach_header(&mut req_clone, self.resolve_retry(attached).await);
             return next.run(req_clone, ext).await;
         }
 
@@ -71,44 +77,242 @@ impl<T: MiddlewareExt> Middleware for MiddlewareWrapper<T> {
 }
 
 impl<T: MiddlewareExt> MiddlewareWrapper<T> {
-    /// Attaches an authentication header to `req` based on the [AuthRequired] extension, if any.
-    /// Returns `true` when the request specified an authentication method (regardless of whether
-    /// a token was successfully retrieved and attached) so callers can decide whether to retry on
-    /// auth failures.
-    async fn inject_token_if_required(
-        &self,
-        req: &mut reqwest::Request,
-        ext: &http::Extensions,
-        force: bool,
-    ) -> bool {
-        match ext.get::<AuthRequired>() {
-            Some(AuthRequired::Bearer) => {
-                let token = self.0.lock().await.get_token(force).await;
-                match token {
-                    Ok(Some(token)) => match format!("Bearer {}", token).parse() {
-                        Ok(header_value) => {
-                            req.headers_mut()
-                                .insert(http::header::AUTHORIZATION, header_value);
-                        }
-                        Err(e) => {
-                            tracing::warn!("Failed to parse auth token for header: {e}");
-                        }
-                    },
-                    Ok(None) => {
-                        tracing::warn!("No token available for request requiring authentication");
-                    }
-                    Err(e) => {
-                        tracing::warn!("Failed to get auth token: {e}");
-                    }
-                };
-
-                return true;
-            }
-            Some(auth) => {
-                tracing::warn!(?auth, "Unsupported authentication method in request");
-            }
-            None => (),
+    /// First-attempt resolution: reuse the stored token if it's locally valid, otherwise renew.
+    async fn resolve_initial(&self) -> Result<Option<String>, LoginError> {
+        let mut handler = self.0.lock().await;
+        if let Some((access_token, expires_on)) = handler.current_token().await
+            && Utc::now().timestamp() < expires_on - TOKEN_RENEW_MARGIN_SECONDS
+        {
+            return Ok(Some(access_token));
         }
-        false
+        handler.renew_token().await
+    }
+
+    /// Retry resolution after a 401: if a concurrent retry already renewed (the stored token
+    /// differs from `previous`), reuse that result. Otherwise renew.
+    async fn resolve_retry(
+        &self,
+        previous: Option<String>,
+    ) -> Result<Option<String>, LoginError> {
+        let mut handler = self.0.lock().await;
+        if let Some((access_token, _)) = handler.current_token().await
+            && let Some(prev) = &previous
+            && access_token != *prev
+        {
+            return Ok(Some(access_token));
+        }
+        handler.renew_token().await
+    }
+}
+
+fn attach_header(
+    req: &mut reqwest::Request,
+    token: Result<Option<String>, LoginError>,
+) -> Option<String> {
+    let token = match token {
+        Ok(Some(t)) => t,
+        Ok(None) => {
+            tracing::warn!("No token available for request requiring authentication");
+            return None;
+        }
+        Err(e) => {
+            tracing::warn!("Failed to get auth token: {e}");
+            return None;
+        }
+    };
+    match format!("Bearer {}", token).parse() {
+        Ok(header_value) => {
+            req.headers_mut()
+                .insert(http::header::AUTHORIZATION, header_value);
+            Some(token)
+        }
+        Err(e) => {
+            tracing::warn!("Failed to parse auth token for header: {e}");
+            None
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        collections::VecDeque,
+        sync::{Arc, Mutex},
+    };
+
+    use bitwarden_api_api::apis::AuthRequired;
+    use reqwest_middleware::{ClientBuilder, ClientWithMiddleware};
+    use wiremock::MockServer;
+
+    use super::*;
+
+    #[derive(Default)]
+    struct MockState {
+        /// Current stored token and its expiry.
+        current: Option<(String, i64)>,
+        /// Queue of renewal results.
+        renewals: VecDeque<Result<Option<String>, LoginError>>,
+        /// Number of `renew_token` calls.
+        renew_count: usize,
+    }
+
+    struct MockMiddleware {
+        state: Arc<Mutex<MockState>>,
+    }
+
+    #[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+    #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
+    impl MiddlewareExt for MockMiddleware {
+        async fn current_token(&self) -> Option<(String, i64)> {
+            self.state.lock().unwrap().current.clone()
+        }
+
+        async fn renew_token(&mut self) -> Result<Option<String>, LoginError> {
+            let mut state = self.state.lock().unwrap();
+            state.renew_count += 1;
+            let result = state
+                .renewals
+                .pop_front()
+                .expect("Not enough mock renewals provided for test");
+            if let Ok(Some(ref token)) = result {
+                state.current = Some((token.clone(), Utc::now().timestamp() + 3600));
+            }
+            result
+        }
+    }
+
+    fn build_mock_client(
+        initial: Option<&str>,
+        renewals: Vec<Result<Option<String>, LoginError>>,
+    ) -> (ClientWithMiddleware, Arc<Mutex<MockState>>) {
+        let state = Arc::new(Mutex::new(MockState {
+            current: initial.map(|t| (t.to_string(), Utc::now().timestamp() + 3600)),
+            renewals: renewals.into_iter().collect(),
+            renew_count: 0,
+        }));
+        let ext = MockMiddleware {
+            state: state.clone(),
+        };
+        let client = ClientBuilder::new(reqwest::Client::new())
+            .with_arc(Arc::new(MiddlewareWrapper::new(ext)))
+            .build();
+        (client, state)
+    }
+
+    async fn start_server_returning(status: u16) -> MockServer {
+        let server = MockServer::start().await;
+        wiremock::Mock::given(wiremock::matchers::any())
+            .respond_with(wiremock::ResponseTemplate::new(status))
+            .mount(&server)
+            .await;
+        server
+    }
+
+    #[tokio::test]
+    async fn does_not_renew_when_no_auth_extension() {
+        let server = start_server_returning(401).await;
+        let (client, state) = build_mock_client(None, vec![]);
+
+        let response = client
+            .get(format!("{}/test", server.uri()))
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(response.status(), 401);
+
+        let requests = server.received_requests().await.unwrap();
+        assert_eq!(requests.len(), 1);
+        assert!(requests[0].headers.get("Authorization").is_none());
+        assert_eq!(state.lock().unwrap().renew_count, 0);
+    }
+
+    #[tokio::test]
+    async fn retries_with_renewed_token_on_401() {
+        let server = MockServer::start().await;
+        wiremock::Mock::given(wiremock::matchers::header("Authorization", "Bearer stale"))
+            .respond_with(wiremock::ResponseTemplate::new(401))
+            .mount(&server)
+            .await;
+        wiremock::Mock::given(wiremock::matchers::any())
+            .respond_with(wiremock::ResponseTemplate::new(200))
+            .mount(&server)
+            .await;
+
+        let (client, state) = build_mock_client(Some("stale"), vec![Ok(Some("fresh".into()))]);
+
+        let response = client
+            .get(format!("{}/test", server.uri()))
+            .with_extension(AuthRequired::Bearer)
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(response.status(), 200);
+
+        assert_eq!(state.lock().unwrap().renew_count, 1);
+        let requests = server.received_requests().await.unwrap();
+        assert_eq!(requests.len(), 2);
+        assert_eq!(
+            requests[0].headers.get("Authorization").unwrap(),
+            "Bearer stale"
+        );
+        assert_eq!(
+            requests[1].headers.get("Authorization").unwrap(),
+            "Bearer fresh"
+        );
+    }
+
+    #[tokio::test]
+    async fn surfaces_second_401_without_third_attempt() {
+        let server = start_server_returning(401).await;
+        let (client, state) = build_mock_client(Some("token-a"), vec![Ok(Some("token-b".into()))]);
+
+        let response = client
+            .get(format!("{}/test", server.uri()))
+            .with_extension(AuthRequired::Bearer)
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(response.status(), 401);
+
+        assert_eq!(server.received_requests().await.unwrap().len(), 2);
+        assert_eq!(state.lock().unwrap().renew_count, 1);
+    }
+
+    #[tokio::test]
+    async fn does_not_retry_on_non_401_status() {
+        let server = start_server_returning(500).await;
+        let (client, state) = build_mock_client(Some("token"), vec![]);
+
+        let response = client
+            .get(format!("{}/test", server.uri()))
+            .with_extension(AuthRequired::Bearer)
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(response.status(), 500);
+
+        assert_eq!(server.received_requests().await.unwrap().len(), 1);
+        assert_eq!(state.lock().unwrap().renew_count, 0);
+    }
+
+    #[tokio::test]
+    async fn does_not_retry_when_body_cannot_be_cloned() {
+        let server = start_server_returning(401).await;
+        let (client, state) = build_mock_client(Some("token"), vec![]);
+
+        // Body::wrap forces the Streaming variant, for which try_clone returns None.
+        let streaming_body = reqwest::Body::wrap(reqwest::Body::from("payload"));
+
+        let response = client
+            .post(format!("{}/test", server.uri()))
+            .with_extension(AuthRequired::Bearer)
+            .body(streaming_body)
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(response.status(), 401);
+
+        assert_eq!(server.received_requests().await.unwrap().len(), 1);
+        assert_eq!(state.lock().unwrap().renew_count, 0);
     }
 }

--- a/crates/bitwarden-auth/src/token_management/password_manager_token_handler.rs
+++ b/crates/bitwarden-auth/src/token_management/password_manager_token_handler.rs
@@ -16,7 +16,6 @@ use bitwarden_state::{registry::StateRegistry, settings::Setting};
 use chrono::Utc;
 
 use super::middleware::{MiddlewareExt, MiddlewareWrapper};
-use crate::token_management::middleware::TOKEN_RENEW_MARGIN_SECONDS;
 
 /// Token handler for Bitwarden authentication.
 #[derive(Clone, Default)]
@@ -26,7 +25,7 @@ pub struct PasswordManagerTokenHandler {
 
 #[derive(Clone, Default)]
 struct PasswordManagerTokenHandlerInner {
-    // These are defined as optional as they are filled in when instantiating the middleware.
+    // Filled in by initialize_middleware.
     tokens: Option<Setting<AuthenticationTokens>>,
     login_method: Option<Setting<UserLoginMethod>>,
     identity_config: Option<bitwarden_api_api::Configuration>,
@@ -78,9 +77,13 @@ impl TokenHandler for PasswordManagerTokenHandler {
 #[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
 #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
 impl MiddlewareExt for PasswordManagerTokenHandler {
-    async fn get_token(&mut self, force: bool) -> Result<Option<String>, LoginError> {
-        // Clone and immediately release the RwLock to avoid holding a sync lock across .await
-        // points. Serialization of concurrent renewals is handled by the MiddlewareWrapper mutex.
+    async fn current_token(&self) -> Option<(String, i64)> {
+        let inner = self.inner.read().expect("RwLock is not poisoned").clone();
+        let tokens = inner.tokens?.get().await.ok().flatten()?;
+        Some((tokens.access_token, tokens.expires_on))
+    }
+
+    async fn renew_token(&mut self) -> Result<Option<String>, LoginError> {
         let inner = self.inner.read().expect("RwLock is not poisoned").clone();
 
         let tokens = inner
@@ -92,13 +95,6 @@ impl MiddlewareExt for PasswordManagerTokenHandler {
             .flatten()
             .ok_or(NotAuthenticatedError)?;
 
-        // Validate the token, returning early if it's still valid.
-        if !force && Utc::now().timestamp() < tokens.expires_on - TOKEN_RENEW_MARGIN_SECONDS {
-            return Ok(Some(tokens.access_token.clone()));
-        }
-
-        // These should always be set by initialize_middleware before we get here, but we return an
-        // error if not.
         let login_method = inner.login_method.ok_or(NotAuthenticatedError)?;
         let identity_config = inner.identity_config.ok_or(NotAuthenticatedError)?;
 
@@ -126,15 +122,11 @@ impl MiddlewareExt for PasswordManagerTokenHandler {
 #[cfg(test)]
 mod tests {
     use bitwarden_api_api::apis::AuthRequired;
-    use bitwarden_core::{
-        auth::TokenHandler,
-        client::{
-            login_method::UserLoginMethod,
-            persisted_state::{AuthenticationTokens, USER_LOGIN_METHOD},
-        },
-        key_management::KeySlotIds,
+    use bitwarden_core::client::{
+        login_method::UserLoginMethod,
+        persisted_state::{AuthenticationTokens, USER_LOGIN_METHOD},
     };
-    use bitwarden_crypto::{Kdf, KeyStore};
+    use bitwarden_crypto::Kdf;
     use bitwarden_state::registry::StateRegistry;
     use wiremock::MockServer;
 
@@ -184,11 +176,7 @@ mod tests {
         seed_tokens(&registry, "original-token", Some("refresh"), 5000).await;
 
         let handler = PasswordManagerTokenHandler::default();
-        let client = build_client(handler.initialize_middleware(
-            &registry,
-            identity_config(&identity_server.uri()),
-            KeyStore::<KeySlotIds>::default(),
-        ));
+        let client = build_client(&handler, &registry, &identity_server);
 
         let auth = send_auth_request(&client, &app_server).await;
         assert_eq!(auth.as_deref(), Some("Bearer original-token"));
@@ -202,15 +190,11 @@ mod tests {
         let identity_server = start_renewal_server("renewed-token").await;
 
         let registry = registry_with_api_key_login().await;
-        // expires_in=0 means the token is considered expired as it's less than the margin
+        // expires_in=0 puts the token inside the renewal margin.
         seed_tokens(&registry, "expired-token", Some("old-refresh"), 0).await;
 
         let handler = PasswordManagerTokenHandler::default();
-        let client = build_client(handler.initialize_middleware(
-            &registry,
-            identity_config(&identity_server.uri()),
-            KeyStore::<KeySlotIds>::default(),
-        ));
+        let client = build_client(&handler, &registry, &identity_server);
 
         let auth = send_auth_request(&client, &app_server).await;
         assert_eq!(auth.as_deref(), Some("Bearer renewed-token"));
@@ -224,16 +208,11 @@ mod tests {
         let identity_server = start_renewal_server("renewed-token").await;
 
         let registry = registry_with_api_key_login().await;
-        // Seed a token that the local handler considers valid (well within the renewal margin),
-        // so the only path to renewal is the 401 retry.
+        // Locally-valid token forces renewal through the 401 retry path.
         seed_tokens(&registry, "stale-token", Some("refresh"), 5000).await;
 
         let handler = PasswordManagerTokenHandler::default();
-        let client = build_client(handler.initialize_middleware(
-            &registry,
-            identity_config(&identity_server.uri()),
-            KeyStore::<KeySlotIds>::default(),
-        ));
+        let client = build_client(&handler, &registry, &identity_server);
 
         let response = client
             .get(format!("{}/test", app_server.uri()))
@@ -258,52 +237,16 @@ mod tests {
 
     #[tokio::test]
     async fn refreshes_on_retry_when_initial_token_unavailable() {
-        // App server rejects unauthenticated requests with 401 but accepts the renewed token.
-        let app_server = MockServer::start().await;
-        wiremock::Mock::given(wiremock::matchers::header(
-            "Authorization",
-            "Bearer renewed-token",
-        ))
-        .respond_with(wiremock::ResponseTemplate::new(200))
-        .mount(&app_server)
-        .await;
-        wiremock::Mock::given(wiremock::matchers::any())
-            .respond_with(wiremock::ResponseTemplate::new(401))
-            .mount(&app_server)
-            .await;
-
-        // Identity server fails the first renewal and succeeds on the second, so the initial
-        // get_token call returns no token, but the forced refresh on retry produces one.
-        let identity_server = MockServer::start().await;
-        wiremock::Mock::given(wiremock::matchers::method("POST"))
-            .and(wiremock::matchers::path("/connect/token"))
-            .respond_with(wiremock::ResponseTemplate::new(500))
-            .up_to_n_times(1)
-            .mount(&identity_server)
-            .await;
-        wiremock::Mock::given(wiremock::matchers::method("POST"))
-            .and(wiremock::matchers::path("/connect/token"))
-            .respond_with(
-                wiremock::ResponseTemplate::new(200).set_body_json(serde_json::json!({
-                    "access_token": "renewed-token",
-                    "expires_in": 3600,
-                    "token_type": "Bearer",
-                    "scope": "api"
-                })),
-            )
-            .mount(&identity_server)
-            .await;
+        // First identity call fails, so the initial request goes out unauthenticated and the
+        // forced renewal on retry produces a valid token.
+        let app_server = start_app_server_accepting("renewed-token").await;
+        let identity_server = start_renewal_server_failing_then_succeeding("renewed-token").await;
 
         let registry = registry_with_api_key_login().await;
-        // Seed expired tokens so get_token reaches the renewal path on both calls.
         seed_tokens(&registry, "stale-token", Some("refresh"), 0).await;
 
         let handler = PasswordManagerTokenHandler::default();
-        let client = build_client(handler.initialize_middleware(
-            &registry,
-            identity_config(&identity_server.uri()),
-            KeyStore::<KeySlotIds>::default(),
-        ));
+        let client = build_client(&handler, &registry, &identity_server);
 
         let response = client
             .get(format!("{}/test", app_server.uri()))
@@ -324,9 +267,29 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn concurrent_401s_trigger_a_single_renewal() {
+        // Locally-valid tokens, so renewal only happens via the 401 retry path. Coalescing should
+        // collapse the five retries into a single identity-server call.
+        let app_server = start_app_server_rejecting("stale-token").await;
+        let identity_server =
+            start_renewal_server_with_delay("renewed-token", std::time::Duration::from_millis(100))
+                .await;
+
+        let registry = registry_with_api_key_login().await;
+        seed_tokens(&registry, "stale-token", Some("refresh"), 5000).await;
+
+        let handler = PasswordManagerTokenHandler::default();
+        let client = build_client(&handler, &registry, &identity_server);
+
+        send_concurrent_auth_requests(&client, &app_server, 5).await;
+
+        assert_eq!(identity_server.received_requests().await.unwrap().len(), 1);
+    }
+
+    #[tokio::test]
     async fn concurrent_requests_trigger_a_single_renewal() {
         let app_server = start_app_server().await;
-        // Delay the renewal so that concurrent renewals would overlap if they weren't serialized.
+        // Renewal delay so that concurrent renewals would overlap if not serialized.
         let identity_server =
             start_renewal_server_with_delay("renewed-token", std::time::Duration::from_millis(100))
                 .await;
@@ -335,29 +298,9 @@ mod tests {
         seed_tokens(&registry, "expired-token", Some("refresh"), 0).await;
 
         let handler = PasswordManagerTokenHandler::default();
-        let client = build_client(handler.initialize_middleware(
-            &registry,
-            identity_config(&identity_server.uri()),
-            KeyStore::<KeySlotIds>::default(),
-        ));
+        let client = build_client(&handler, &registry, &identity_server);
 
-        let mut handles = Vec::new();
-        for _ in 0..5 {
-            let client = client.clone();
-            let url = format!("{}/test", app_server.uri());
-            handles.push(tokio::spawn(async move {
-                client
-                    .get(url)
-                    .with_extension(AuthRequired::Bearer)
-                    .send()
-                    .await
-                    .unwrap()
-            }));
-        }
-        for handle in handles {
-            let response = handle.await.unwrap();
-            assert_eq!(response.status(), 200);
-        }
+        send_concurrent_auth_requests(&client, &app_server, 5).await;
 
         assert_eq!(identity_server.received_requests().await.unwrap().len(), 1);
         let app_requests = app_server.received_requests().await.unwrap();
@@ -368,35 +311,5 @@ mod tests {
                 "Bearer renewed-token"
             );
         }
-    }
-
-    #[tokio::test]
-    async fn does_not_retry_when_no_auth_extension() {
-        let server = MockServer::start().await;
-        wiremock::Mock::given(wiremock::matchers::any())
-            .respond_with(wiremock::ResponseTemplate::new(401))
-            .mount(&server)
-            .await;
-
-        // Request is sent without the AuthRequired extension, so the middleware never asks
-        // for a token and must not retry on 401.
-        let registry = registry_with_api_key_login().await;
-        let handler = PasswordManagerTokenHandler::default();
-        let client = build_client(handler.initialize_middleware(
-            &registry,
-            identity_config(&server.uri()),
-            KeyStore::<KeySlotIds>::default(),
-        ));
-
-        let response = client
-            .get(format!("{}/test", server.uri()))
-            .send()
-            .await
-            .unwrap();
-        assert_eq!(response.status(), 401);
-
-        let requests = server.received_requests().await.unwrap();
-        assert_eq!(requests.len(), 1);
-        assert!(requests[0].headers.get("Authorization").is_none());
     }
 }

--- a/crates/bitwarden-auth/src/token_management/password_manager_token_handler.rs
+++ b/crates/bitwarden-auth/src/token_management/password_manager_token_handler.rs
@@ -46,7 +46,7 @@ impl TokenHandler for PasswordManagerTokenHandler {
             inner.login_method = state_registry.setting(USER_LOGIN_METHOD).ok();
             inner.identity_config = Some(identity_config);
         }
-        Arc::new(MiddlewareWrapper(self.clone()))
+        Arc::new(MiddlewareWrapper::new(self.clone()))
     }
 
     async fn set_tokens(
@@ -78,12 +78,9 @@ impl TokenHandler for PasswordManagerTokenHandler {
 #[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
 #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
 impl MiddlewareExt for PasswordManagerTokenHandler {
-    async fn get_token(&self, force: bool) -> Result<Option<String>, LoginError> {
-        // We're not holding on to a lock for the duration of the token renewal, so if multiple
-        // requests come in at the same time when the token is expired, we may end up renewing the
-        // token multiple times. This is not ideal, but it's the behavior of the previous
-        // implementation. We should be able to introduce an async semaphore or something
-        // similar to prevent this if it becomes an issue in practice.
+    async fn get_token(&mut self, force: bool) -> Result<Option<String>, LoginError> {
+        // Clone and immediately release the RwLock to avoid holding a sync lock across .await
+        // points. Serialization of concurrent renewals is handled by the MiddlewareWrapper mutex.
         let inner = self.inner.read().expect("RwLock is not poisoned").clone();
 
         let tokens = inner
@@ -324,6 +321,53 @@ mod tests {
             "Bearer renewed-token"
         );
         assert_eq!(identity_server.received_requests().await.unwrap().len(), 2);
+    }
+
+    #[tokio::test]
+    async fn concurrent_requests_trigger_a_single_renewal() {
+        let app_server = start_app_server().await;
+        // Delay the renewal so that concurrent renewals would overlap if they weren't serialized.
+        let identity_server =
+            start_renewal_server_with_delay("renewed-token", std::time::Duration::from_millis(100))
+                .await;
+
+        let registry = registry_with_api_key_login().await;
+        seed_tokens(&registry, "expired-token", Some("refresh"), 0).await;
+
+        let handler = PasswordManagerTokenHandler::default();
+        let client = build_client(handler.initialize_middleware(
+            &registry,
+            identity_config(&identity_server.uri()),
+            KeyStore::<KeySlotIds>::default(),
+        ));
+
+        let mut handles = Vec::new();
+        for _ in 0..5 {
+            let client = client.clone();
+            let url = format!("{}/test", app_server.uri());
+            handles.push(tokio::spawn(async move {
+                client
+                    .get(url)
+                    .with_extension(AuthRequired::Bearer)
+                    .send()
+                    .await
+                    .unwrap()
+            }));
+        }
+        for handle in handles {
+            let response = handle.await.unwrap();
+            assert_eq!(response.status(), 200);
+        }
+
+        assert_eq!(identity_server.received_requests().await.unwrap().len(), 1);
+        let app_requests = app_server.received_requests().await.unwrap();
+        assert_eq!(app_requests.len(), 5);
+        for req in app_requests {
+            assert_eq!(
+                req.headers.get("Authorization").unwrap(),
+                "Bearer renewed-token"
+            );
+        }
     }
 
     #[tokio::test]

--- a/crates/bitwarden-auth/src/token_management/secrets_manager_token_handler.rs
+++ b/crates/bitwarden-auth/src/token_management/secrets_manager_token_handler.rs
@@ -46,7 +46,7 @@ impl TokenHandler for SecretsManagerTokenHandler {
             inner.identity_config = Some(identity_config);
             inner.key_store = Some(key_store);
         }
-        Arc::new(MiddlewareWrapper(self.clone()))
+        Arc::new(MiddlewareWrapper::new(self.clone()))
     }
 
     async fn set_tokens(
@@ -81,12 +81,9 @@ impl SecretsManagerTokenHandler {
 #[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
 #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
 impl MiddlewareExt for SecretsManagerTokenHandler {
-    async fn get_token(&self, force: bool) -> Result<Option<String>, LoginError> {
-        // We're not holding on to a lock for the duration of the token renewal, so if multiple
-        // requests come in at the same time when the token is expired, we may end up renewing the
-        // token multiple times. This is not ideal, but it's the behavior of the previous
-        // implementation. We should be able to introduce an async semaphore or something
-        // similar to prevent this if it becomes an issue in practice.
+    async fn get_token(&mut self, force: bool) -> Result<Option<String>, LoginError> {
+        // Clone and immediately release the RwLock to avoid holding a sync lock across .await
+        // points. Serialization of concurrent renewals is handled by the MiddlewareWrapper mutex.
         let inner = self.inner.read().expect("RwLock is not poisoned").clone();
 
         // Validate the token, returning early if it's still valid.
@@ -309,6 +306,58 @@ mod tests {
             "Bearer renewed-token"
         );
         assert_eq!(identity_server.received_requests().await.unwrap().len(), 2);
+    }
+
+    #[tokio::test]
+    async fn concurrent_requests_trigger_a_single_renewal() {
+        let app_server = start_app_server().await;
+        // Delay the renewal so that concurrent renewals would overlap if they weren't serialized.
+        let identity_server =
+            start_renewal_server_with_delay("renewed-token", std::time::Duration::from_millis(100))
+                .await;
+
+        let handler = SecretsManagerTokenHandler::default();
+        handler
+            .set_sm_login_method(service_account_login_method())
+            .await;
+        handler
+            .set_tokens("expired-token".to_string(), None, 0)
+            .await;
+
+        let registry = StateRegistry::new_with_memory_db();
+        let client = build_client(handler.initialize_middleware(
+            &registry,
+            identity_config(&identity_server.uri()),
+            KeyStore::<KeySlotIds>::default(),
+        ));
+
+        let mut handles = Vec::new();
+        for _ in 0..5 {
+            let client = client.clone();
+            let url = format!("{}/test", app_server.uri());
+            handles.push(tokio::spawn(async move {
+                client
+                    .get(url)
+                    .with_extension(AuthRequired::Bearer)
+                    .send()
+                    .await
+                    .unwrap()
+            }));
+        }
+        for handle in handles {
+            let response = handle.await.unwrap();
+            assert_eq!(response.status(), 200);
+        }
+
+        assert_eq!(identity_server.received_requests().await.unwrap().len(), 1);
+        let app_requests = app_server.received_requests().await.unwrap();
+        assert_eq!(app_requests.len(), 5);
+        for req in app_requests {
+            assert_eq!(
+                req.headers.get("Authorization").unwrap(),
+                "Bearer renewed-token"
+            );
+        }
     }
 
     #[tokio::test]

--- a/crates/bitwarden-auth/src/token_management/secrets_manager_token_handler.rs
+++ b/crates/bitwarden-auth/src/token_management/secrets_manager_token_handler.rs
@@ -13,7 +13,6 @@ use bitwarden_state::registry::StateRegistry;
 use chrono::Utc;
 
 use super::middleware::{MiddlewareExt, MiddlewareWrapper};
-use crate::token_management::middleware::TOKEN_RENEW_MARGIN_SECONDS;
 
 /// Token handler for Bitwarden authentication.
 #[derive(Clone, Default)]
@@ -26,8 +25,7 @@ struct SecretsManagerTokenHandlerInner {
     access_token: Option<String>,
     expires_on: Option<i64>,
 
-    // The following are passed as optional as they are filled in when instantiating the
-    // middleware.
+    // Filled in by initialize_middleware / set_sm_login_method.
     login_method: Option<Arc<ServiceAccountLoginMethod>>,
     identity_config: Option<bitwarden_api_api::Configuration>,
     key_store: Option<KeyStore<KeySlotIds>>,
@@ -81,21 +79,14 @@ impl SecretsManagerTokenHandler {
 #[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
 #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
 impl MiddlewareExt for SecretsManagerTokenHandler {
-    async fn get_token(&mut self, force: bool) -> Result<Option<String>, LoginError> {
-        // Clone and immediately release the RwLock to avoid holding a sync lock across .await
-        // points. Serialization of concurrent renewals is handled by the MiddlewareWrapper mutex.
+    async fn current_token(&self) -> Option<(String, i64)> {
+        let inner = self.inner.read().expect("RwLock is not poisoned").clone();
+        Some((inner.access_token?, inner.expires_on?))
+    }
+
+    async fn renew_token(&mut self) -> Result<Option<String>, LoginError> {
         let inner = self.inner.read().expect("RwLock is not poisoned").clone();
 
-        // Validate the token, returning early if it's still valid.
-        if !force
-            && let Some(expires) = inner.expires_on
-            && Utc::now().timestamp() < expires - TOKEN_RENEW_MARGIN_SECONDS
-        {
-            return Ok(inner.access_token.clone());
-        }
-
-        // These should always be set by initialize_middleware / set_sm_login_method before we get
-        // here, but we return an error if not.
         let login_method = inner.login_method.ok_or(NotAuthenticatedError)?;
         let identity_config = inner.identity_config.ok_or(NotAuthenticatedError)?;
         let key_store = inner.key_store.ok_or(NotAuthenticatedError)?;
@@ -119,12 +110,7 @@ mod tests {
     use std::str::FromStr;
 
     use bitwarden_api_api::apis::AuthRequired;
-    use bitwarden_core::{
-        auth::{AccessToken, TokenHandler},
-        client::login_method::ServiceAccountLoginMethod,
-        key_management::KeySlotIds,
-    };
-    use bitwarden_crypto::KeyStore;
+    use bitwarden_core::{auth::AccessToken, client::login_method::ServiceAccountLoginMethod};
     use bitwarden_state::registry::StateRegistry;
     use wiremock::MockServer;
 
@@ -158,11 +144,7 @@ mod tests {
             .await;
 
         let registry = StateRegistry::new_with_memory_db();
-        let client = build_client(handler.initialize_middleware(
-            &registry,
-            identity_config(&identity_server.uri()),
-            KeyStore::<KeySlotIds>::default(),
-        ));
+        let client = build_client(&handler, &registry, &identity_server);
 
         let auth = send_auth_request(&client, &app_server).await;
         assert_eq!(auth.as_deref(), Some("Bearer original-token"));
@@ -179,17 +161,13 @@ mod tests {
         handler
             .set_sm_login_method(service_account_login_method())
             .await;
-        // expires_in=0 means the token is immediately considered expired
+        // expires_in=0 puts the token inside the renewal margin.
         handler
             .set_tokens("expired-token".to_string(), None, 0)
             .await;
 
         let registry = StateRegistry::new_with_memory_db();
-        let client = build_client(handler.initialize_middleware(
-            &registry,
-            identity_config(&identity_server.uri()),
-            KeyStore::<KeySlotIds>::default(),
-        ));
+        let client = build_client(&handler, &registry, &identity_server);
 
         let auth = send_auth_request(&client, &app_server).await;
         assert_eq!(auth.as_deref(), Some("Bearer renewed-token"));
@@ -206,17 +184,13 @@ mod tests {
         handler
             .set_sm_login_method(service_account_login_method())
             .await;
-        // Token is locally valid; the only renewal path is the 401 retry.
+        // Locally-valid token forces renewal through the 401 retry path.
         handler
             .set_tokens("stale-token".to_string(), None, 3600)
             .await;
 
         let registry = StateRegistry::new_with_memory_db();
-        let client = build_client(handler.initialize_middleware(
-            &registry,
-            identity_config(&identity_server.uri()),
-            KeyStore::<KeySlotIds>::default(),
-        ));
+        let client = build_client(&handler, &registry, &identity_server);
 
         let response = client
             .get(format!("{}/test", app_server.uri()))
@@ -241,54 +215,18 @@ mod tests {
 
     #[tokio::test]
     async fn refreshes_on_retry_when_initial_token_unavailable() {
-        // App server rejects unauthenticated requests with 401 but accepts the renewed token.
-        let app_server = MockServer::start().await;
-        wiremock::Mock::given(wiremock::matchers::header(
-            "Authorization",
-            "Bearer renewed-token",
-        ))
-        .respond_with(wiremock::ResponseTemplate::new(200))
-        .mount(&app_server)
-        .await;
-        wiremock::Mock::given(wiremock::matchers::any())
-            .respond_with(wiremock::ResponseTemplate::new(401))
-            .mount(&app_server)
-            .await;
-
-        // Identity server fails the first renewal and succeeds on the second, so the initial
-        // get_token call returns no token, but the forced refresh on retry produces one.
-        let identity_server = MockServer::start().await;
-        wiremock::Mock::given(wiremock::matchers::method("POST"))
-            .and(wiremock::matchers::path("/connect/token"))
-            .respond_with(wiremock::ResponseTemplate::new(500))
-            .up_to_n_times(1)
-            .mount(&identity_server)
-            .await;
-        wiremock::Mock::given(wiremock::matchers::method("POST"))
-            .and(wiremock::matchers::path("/connect/token"))
-            .respond_with(
-                wiremock::ResponseTemplate::new(200).set_body_json(serde_json::json!({
-                    "access_token": "renewed-token",
-                    "expires_in": 3600,
-                    "token_type": "Bearer",
-                    "scope": "api"
-                })),
-            )
-            .mount(&identity_server)
-            .await;
+        // First identity call fails, so the initial request goes out unauthenticated and the
+        // forced renewal on retry produces a valid token.
+        let app_server = start_app_server_accepting("renewed-token").await;
+        let identity_server = start_renewal_server_failing_then_succeeding("renewed-token").await;
 
         let handler = SecretsManagerTokenHandler::default();
         handler
             .set_sm_login_method(service_account_login_method())
             .await;
-        // No tokens seeded -> get_token always reaches the renewal path.
 
         let registry = StateRegistry::new_with_memory_db();
-        let client = build_client(handler.initialize_middleware(
-            &registry,
-            identity_config(&identity_server.uri()),
-            KeyStore::<KeySlotIds>::default(),
-        ));
+        let client = build_client(&handler, &registry, &identity_server);
 
         let response = client
             .get(format!("{}/test", app_server.uri()))
@@ -309,9 +247,34 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn concurrent_401s_trigger_a_single_renewal() {
+        // Locally-valid tokens, so renewal only happens via the 401 retry path. Coalescing should
+        // collapse the five retries into a single identity-server call.
+        let app_server = start_app_server_rejecting("stale-token").await;
+        let identity_server =
+            start_renewal_server_with_delay("renewed-token", std::time::Duration::from_millis(100))
+                .await;
+
+        let handler = SecretsManagerTokenHandler::default();
+        handler
+            .set_sm_login_method(service_account_login_method())
+            .await;
+        handler
+            .set_tokens("stale-token".to_string(), None, 3600)
+            .await;
+
+        let registry = StateRegistry::new_with_memory_db();
+        let client = build_client(&handler, &registry, &identity_server);
+
+        send_concurrent_auth_requests(&client, &app_server, 5).await;
+
+        assert_eq!(identity_server.received_requests().await.unwrap().len(), 1);
+    }
+
+    #[tokio::test]
     async fn concurrent_requests_trigger_a_single_renewal() {
         let app_server = start_app_server().await;
-        // Delay the renewal so that concurrent renewals would overlap if they weren't serialized.
+        // Renewal delay so that concurrent renewals would overlap if not serialized.
         let identity_server =
             start_renewal_server_with_delay("renewed-token", std::time::Duration::from_millis(100))
                 .await;
@@ -325,29 +288,9 @@ mod tests {
             .await;
 
         let registry = StateRegistry::new_with_memory_db();
-        let client = build_client(handler.initialize_middleware(
-            &registry,
-            identity_config(&identity_server.uri()),
-            KeyStore::<KeySlotIds>::default(),
-        ));
+        let client = build_client(&handler, &registry, &identity_server);
 
-        let mut handles = Vec::new();
-        for _ in 0..5 {
-            let client = client.clone();
-            let url = format!("{}/test", app_server.uri());
-            handles.push(tokio::spawn(async move {
-                client
-                    .get(url)
-                    .with_extension(AuthRequired::Bearer)
-                    .send()
-                    .await
-                    .unwrap()
-            }));
-        }
-        for handle in handles {
-            let response = handle.await.unwrap();
-            assert_eq!(response.status(), 200);
-        }
+        send_concurrent_auth_requests(&client, &app_server, 5).await;
 
         assert_eq!(identity_server.received_requests().await.unwrap().len(), 1);
         let app_requests = app_server.received_requests().await.unwrap();
@@ -358,36 +301,5 @@ mod tests {
                 "Bearer renewed-token"
             );
         }
-    }
-
-    #[tokio::test]
-    async fn does_not_retry_when_no_auth_extension() {
-        let server = MockServer::start().await;
-        wiremock::Mock::given(wiremock::matchers::any())
-            .respond_with(wiremock::ResponseTemplate::new(401))
-            .mount(&server)
-            .await;
-
-        // Request is sent without the AuthRequired extension, so the middleware never asks
-        // for a token and must not retry on 401.
-        let handler = SecretsManagerTokenHandler::default();
-
-        let registry = StateRegistry::new_with_memory_db();
-        let client = build_client(handler.initialize_middleware(
-            &registry,
-            identity_config(&server.uri()),
-            KeyStore::<KeySlotIds>::default(),
-        ));
-
-        let response = client
-            .get(format!("{}/test", server.uri()))
-            .send()
-            .await
-            .unwrap();
-        assert_eq!(response.status(), 401);
-
-        let requests = server.received_requests().await.unwrap();
-        assert_eq!(requests.len(), 1);
-        assert!(requests[0].headers.get("Authorization").is_none());
     }
 }

--- a/crates/bitwarden-auth/src/token_management/test_utils.rs
+++ b/crates/bitwarden-auth/src/token_management/test_utils.rs
@@ -41,16 +41,27 @@ pub async fn start_app_server_rejecting(stale_token: &str) -> MockServer {
 
 /// Start a mock identity server that returns a renewed token on POST /connect/token.
 pub async fn start_renewal_server(renewed_token: &str) -> MockServer {
+    start_renewal_server_with_delay(renewed_token, std::time::Duration::ZERO).await
+}
+
+/// Start a mock identity server that returns a renewed token after the given delay.
+/// Useful for exercising concurrent renewal paths.
+pub async fn start_renewal_server_with_delay(
+    renewed_token: &str,
+    delay: std::time::Duration,
+) -> MockServer {
     let server = MockServer::start().await;
     wiremock::Mock::given(wiremock::matchers::method("POST"))
         .and(wiremock::matchers::path("/connect/token"))
         .respond_with(
-            wiremock::ResponseTemplate::new(200).set_body_json(serde_json::json!({
-                "access_token": renewed_token,
-                "expires_in": 3600,
-                "token_type": "Bearer",
-                "scope": "api"
-            })),
+            wiremock::ResponseTemplate::new(200)
+                .set_delay(delay)
+                .set_body_json(serde_json::json!({
+                    "access_token": renewed_token,
+                    "expires_in": 3600,
+                    "token_type": "Bearer",
+                    "scope": "api"
+                })),
         )
         .mount(&server)
         .await;

--- a/crates/bitwarden-auth/src/token_management/test_utils.rs
+++ b/crates/bitwarden-auth/src/token_management/test_utils.rs
@@ -1,14 +1,10 @@
-use std::sync::Arc;
+use std::time::Duration;
 
 use bitwarden_api_api::apis::AuthRequired;
+use bitwarden_core::{auth::TokenHandler, key_management::KeySlotIds};
+use bitwarden_crypto::KeyStore;
+use bitwarden_state::registry::StateRegistry;
 use wiremock::MockServer;
-
-pub fn identity_config(server_uri: &str) -> bitwarden_api_api::Configuration {
-    bitwarden_api_api::Configuration {
-        base_path: server_uri.to_string(),
-        client: reqwest::Client::new().into(),
-    }
-}
 
 /// Start a mock server that accepts any request with a 200 response.
 pub async fn start_app_server() -> MockServer {
@@ -39,18 +35,52 @@ pub async fn start_app_server_rejecting(stale_token: &str) -> MockServer {
     server
 }
 
+/// Start a mock app server that returns 200 for requests carrying `valid_token` in the
+/// Authorization header and 401 for everything else (including unauthenticated requests).
+pub async fn start_app_server_accepting(valid_token: &str) -> MockServer {
+    let server = MockServer::start().await;
+    wiremock::Mock::given(wiremock::matchers::header(
+        "Authorization",
+        format!("Bearer {valid_token}").as_str(),
+    ))
+    .respond_with(wiremock::ResponseTemplate::new(200))
+    .mount(&server)
+    .await;
+    wiremock::Mock::given(wiremock::matchers::any())
+        .respond_with(wiremock::ResponseTemplate::new(401))
+        .mount(&server)
+        .await;
+    server
+}
+
 /// Start a mock identity server that returns a renewed token on POST /connect/token.
 pub async fn start_renewal_server(renewed_token: &str) -> MockServer {
-    start_renewal_server_with_delay(renewed_token, std::time::Duration::ZERO).await
+    start_renewal_server_with_delay(renewed_token, Duration::ZERO).await
 }
 
 /// Start a mock identity server that returns a renewed token after the given delay.
 /// Useful for exercising concurrent renewal paths.
-pub async fn start_renewal_server_with_delay(
-    renewed_token: &str,
-    delay: std::time::Duration,
-) -> MockServer {
+pub async fn start_renewal_server_with_delay(renewed_token: &str, delay: Duration) -> MockServer {
     let server = MockServer::start().await;
+    mount_renewal_response(&server, renewed_token, delay).await;
+    server
+}
+
+/// Start a mock identity server that fails the first POST /connect/token with 500 and then
+/// returns a renewed token on subsequent requests.
+pub async fn start_renewal_server_failing_then_succeeding(renewed_token: &str) -> MockServer {
+    let server = MockServer::start().await;
+    wiremock::Mock::given(wiremock::matchers::method("POST"))
+        .and(wiremock::matchers::path("/connect/token"))
+        .respond_with(wiremock::ResponseTemplate::new(500))
+        .up_to_n_times(1)
+        .mount(&server)
+        .await;
+    mount_renewal_response(&server, renewed_token, Duration::ZERO).await;
+    server
+}
+
+async fn mount_renewal_response(server: &MockServer, renewed_token: &str, delay: Duration) {
     wiremock::Mock::given(wiremock::matchers::method("POST"))
         .and(wiremock::matchers::path("/connect/token"))
         .respond_with(
@@ -63,17 +93,54 @@ pub async fn start_renewal_server_with_delay(
                     "scope": "api"
                 })),
         )
-        .mount(&server)
+        .mount(server)
         .await;
-    server
 }
 
-pub fn build_client(
-    middleware: Arc<dyn reqwest_middleware::Middleware>,
+/// Initialize the handler's middleware against `registry` and `identity_server`, then wrap it in
+/// a [reqwest_middleware::ClientWithMiddleware] suitable for sending test requests.
+pub fn build_client<H: TokenHandler>(
+    handler: &H,
+    registry: &StateRegistry,
+    identity_server: &MockServer,
 ) -> reqwest_middleware::ClientWithMiddleware {
+    let middleware = handler.initialize_middleware(
+        registry,
+        bitwarden_api_api::Configuration {
+            base_path: identity_server.uri(),
+            client: reqwest::Client::new().into(),
+        },
+        KeyStore::<KeySlotIds>::default(),
+    );
     reqwest_middleware::ClientBuilder::new(reqwest::Client::new())
         .with_arc(middleware)
         .build()
+}
+
+/// Spawn `count` concurrent authenticated GET requests against `app_server` and assert all
+/// responses return 200. Useful for exercising the middleware's renewal serialization.
+pub async fn send_concurrent_auth_requests(
+    client: &reqwest_middleware::ClientWithMiddleware,
+    app_server: &MockServer,
+    count: usize,
+) {
+    let mut handles = Vec::with_capacity(count);
+    for _ in 0..count {
+        let client = client.clone();
+        let url = format!("{}/test", app_server.uri());
+        handles.push(tokio::spawn(async move {
+            client
+                .get(url)
+                .with_extension(AuthRequired::Bearer)
+                .send()
+                .await
+                .unwrap()
+        }));
+    }
+    for handle in handles {
+        let response = handle.await.unwrap();
+        assert_eq!(response.status(), 200);
+    }
 }
 
 /// Send an authenticated request to the app server and return the Authorization


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-32346

## 📔 Objective

Serialize calls to the auth middleware's `get_token` so that concurrent
requests don't race the renewal path. Previously, if N requests arrived
simultaneously while the access token was expired, each would independently
fire a renewal against the identity server. After the 401-retry path landed
in #1098, a concurrent renewal could also cause an in-flight request to go
out with a token that another task had just invalidated.

`MiddlewareWrapper` now holds a `tokio::sync::Mutex` around the inner
`MiddlewareExt`, and `get_token` takes `&mut self` to encode the
exclusive-access invariant at the trait level. The handlers' internal
`RwLock<Inner>` is unchanged and still protects in-memory state from
sync access paths that don't go through the middleware.