### PR TITLE
[PM-37212] Add LAST_SYNC setting key in bitwarden-sync

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1102,11 +1102,14 @@ dependencies = [
  "bitwarden-api-api",
  "bitwarden-api-identity",
  "bitwarden-core",
+ "bitwarden-state",
+ "chrono",
  "reqwest",
  "reqwest-middleware",
  "serde",
  "thiserror 2.0.18",
  "tokio",
+ "tracing",
 ]
 
 [[package]]

--- a/crates/bitwarden-sync/Cargo.toml
+++ b/crates/bitwarden-sync/Cargo.toml
@@ -18,9 +18,12 @@ keywords.workspace = true
 async-trait = { workspace = true }
 bitwarden-api-api = { workspace = true }
 bitwarden-core = { workspace = true, features = ["internal"] }
+bitwarden-state = { workspace = true }
+chrono = { workspace = true }
 serde = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["sync"] }
+tracing = { workspace = true }
 
 [dev-dependencies]
 bitwarden-api-api = { workspace = true, features = ["mockall"] }

--- a/crates/bitwarden-sync/src/lib.rs
+++ b/crates/bitwarden-sync/src/lib.rs
@@ -2,6 +2,7 @@
 
 mod handler;
 mod registry;
+mod state;
 mod sync_client;
 
 pub use handler::{SyncErrorHandler, SyncHandler, SyncHandlerError};

--- a/crates/bitwarden-sync/src/state.rs
+++ b/crates/bitwarden-sync/src/state.rs
@@ -1,0 +1,9 @@
+//! Persisted state setting keys for the sync domain.
+
+use bitwarden_state::register_setting_key;
+use chrono::{DateTime, Utc};
+
+register_setting_key!(
+    /// Setting key for the timestamp of the last successful sync (or skip).
+    pub(crate) const LAST_SYNC: DateTime<Utc> = "last_sync"
+);

--- a/crates/bitwarden-sync/src/sync_client.rs
+++ b/crates/bitwarden-sync/src/sync_client.rs
@@ -5,11 +5,15 @@ use bitwarden_core::{
     Client,
     client::{ApiConfigurations, FromClientPart},
 };
+use bitwarden_state::Setting;
+use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use tokio::sync::Mutex;
 
-use crate::{SyncErrorHandler, SyncHandler, SyncHandlerError, registry::HandlerRegistry};
+use crate::{
+    SyncErrorHandler, SyncHandler, SyncHandlerError, registry::HandlerRegistry, state::LAST_SYNC,
+};
 
 #[allow(missing_docs)]
 #[derive(Debug, Error)]
@@ -38,6 +42,7 @@ pub struct SyncClient {
     sync_handlers: HandlerRegistry<dyn SyncHandler>,
     error_handlers: HandlerRegistry<dyn SyncErrorHandler>,
     sync_lock: Mutex<()>,
+    last_sync: Option<Setting<DateTime<Utc>>>,
 }
 
 impl SyncClient {
@@ -48,6 +53,18 @@ impl SyncClient {
             sync_handlers: HandlerRegistry::new(),
             error_handlers: HandlerRegistry::new(),
             sync_lock: Mutex::new(()),
+            last_sync: client.platform().state().setting(LAST_SYNC).ok(),
+        }
+    }
+
+    /// Get the timestamp of the last successful sync, if any.
+    pub async fn last_sync(&self) -> Option<DateTime<Utc>> {
+        match self.last_sync.as_ref()?.get().await {
+            Ok(value) => value,
+            Err(e) => {
+                tracing::warn!("Failed to read last sync timestamp: {e}");
+                None
+            }
         }
     }
 
@@ -214,6 +231,7 @@ mod tests {
             sync_handlers: HandlerRegistry::new(),
             error_handlers: HandlerRegistry::new(),
             sync_lock: tokio::sync::Mutex::new(()),
+            last_sync: None,
         }
     }
 


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-37212

## 📔 Objective

Adds a `LAST_SYNC` persisted setting key (`DateTime<Utc>`) in the `bitwarden-sync` crate to track the timestamp of the last successful sync. 

This key is internal to the crate, but external readers can access it through `SyncClient::last_sync()`. This keeps the storage key an implementation detail of the sync crate while giving consumers (e.g. `bw status`, `bw sync --last`) a way to read it.