### PR TITLE
fix(bitwarden-core): make HostPlatformInfo init test order-independent

### DIFF
--- a/crates/bitwarden-core/src/client/client_settings.rs
+++ b/crates/bitwarden-core/src/client/client_settings.rs
@@ -210,17 +210,12 @@ pub fn get_host_platform_info() -> &'static HostPlatformInfo {
 mod tests {
     use super::*;
 
-    // `OnceLock` is process-global, so a single sequential test covers the
-    // not-set, happy-path, and already-set cases without cross-test leakage.
+    // `OnceLock` is process-global. Any test in this binary that calls
+    // `init_host_platform_info` may have run first, so we cannot assert what
+    // value won the first-init race — only that a *subsequent* init does not
+    // change the stored value.
     #[test]
-    fn init_then_get_preserves_first_value() {
-        // Not-set case: `get` must panic before any `init` call.
-        let prev_hook = std::panic::take_hook();
-        std::panic::set_hook(Box::new(|_| {}));
-        let not_set = std::panic::catch_unwind(get_host_platform_info);
-        std::panic::set_hook(prev_hook);
-        assert!(not_set.is_err(), "expected panic before init");
-
+    fn second_init_does_not_overwrite_first() {
         let first = HostPlatformInfo {
             user_agent: "first".into(),
             device_type: DeviceType::SDK,
@@ -228,20 +223,35 @@ mod tests {
             bitwarden_client_version: Some("1.0.0".into()),
             bitwarden_package_type: Some("test".into()),
         };
-        init_host_platform_info(first.clone());
+        init_host_platform_info(first);
 
-        let got = get_host_platform_info();
-        assert_eq!(got.user_agent, first.user_agent);
-        assert_eq!(got.device_type, first.device_type);
-        assert_eq!(got.device_identifier, first.device_identifier);
+        // Capture whatever value won the first-init race (ours or another
+        // test's).
+        let after_first_init = get_host_platform_info().clone();
 
         let second = HostPlatformInfo {
             user_agent: "second".into(),
-            ..first.clone()
+            device_type: DeviceType::SDK,
+            device_identifier: Some("dev-2".into()),
+            bitwarden_client_version: Some("2.0.0".into()),
+            bitwarden_package_type: Some("test".into()),
         };
         init_host_platform_info(second);
 
-        let after = get_host_platform_info();
-        assert_eq!(after.user_agent, first.user_agent);
+        let after_second_init = get_host_platform_info();
+        assert_eq!(after_second_init.user_agent, after_first_init.user_agent);
+        assert_eq!(after_second_init.device_type, after_first_init.device_type);
+        assert_eq!(
+            after_second_init.device_identifier,
+            after_first_init.device_identifier
+        );
+        assert_eq!(
+            after_second_init.bitwarden_client_version,
+            after_first_init.bitwarden_client_version
+        );
+        assert_eq!(
+            after_second_init.bitwarden_package_type,
+            after_first_init.bitwarden_package_type
+        );
     }
 }


### PR DESCRIPTION
## Summary

- `bitwarden-core::client::client_settings::tests::init_then_get_preserves_first_value` is flaky on CI — it raced with `rehydration::tests::ensure_platform_info` on the process-global `HOST_PLATFORM_INFO` `OnceLock`, hitting `left: \"rehydration-tests\", right: \"first\"` when the rehydration tests won the race.
- Rewrite the test (renamed to `second_init_does_not_overwrite_first`) so it only asserts the actual semantic under test — that a *subsequent* init does not overwrite the value — by capturing whatever value won the first-init race instead of asserting a hardcoded `\"first\"`.
- The \"panic before init\" precondition probe is dropped because it cannot be made reliable when another test in the same lib-test binary may already have set the lock.

## Test plan

- [x] `cargo test -p bitwarden-core --lib --all-features` (5 consecutive runs) — 166/166 each
- [x] `cargo check --all-features --all-targets` clean
- [x] `cargo +nightly fmt --all` applied
- [ ] CI green on this PR (the failure reproduces in PR #1104 on the `default` job for ubuntu/macOS/windows)