### PR TITLE
[PM-37729] Default `view_password` to true

### DIFF
--- a/crates/bitwarden-vault/src/cipher/cipher.rs
+++ b/crates/bitwarden-vault/src/cipher/cipher.rs
@@ -1590,7 +1590,7 @@ impl PartialCipher for CipherMiniResponseModel {
             favorite: cipher.map_or(Default::default(), |c| c.favorite),
             edit: cipher.map_or(Default::default(), |c| c.edit),
             permissions: cipher.map_or(Default::default(), |c| c.permissions),
-            view_password: cipher.map_or(true, |c| c.view_password),
+            view_password: cipher.is_none_or(|c| c.view_password),
             local_data: cipher.map_or(Default::default(), |c| c.local_data.clone()),
             data: cipher.map_or(Default::default(), |c| c.data.clone()),
             collection_ids: cipher.map_or(Default::default(), |c| c.collection_ids.clone()),
@@ -1656,7 +1656,7 @@ impl PartialCipher for CipherMiniDetailsResponseModel {
             favorite: cipher.map_or(Default::default(), |c| c.favorite),
             edit: cipher.map_or(Default::default(), |c| c.edit),
             permissions: cipher.map_or(Default::default(), |c| c.permissions),
-            view_password: cipher.map_or(true, |c| c.view_password),
+            view_password: cipher.is_none_or(|c: &Cipher| c.view_password),
             data: cipher.map_or(Default::default(), |c| c.data.clone()),
             local_data: cipher.map_or(Default::default(), |c| c.local_data.clone()),
         })

--- a/crates/bitwarden-vault/src/cipher/cipher.rs
+++ b/crates/bitwarden-vault/src/cipher/cipher.rs
@@ -1590,7 +1590,7 @@ impl PartialCipher for CipherMiniResponseModel {
             favorite: cipher.map_or(Default::default(), |c| c.favorite),
             edit: cipher.map_or(Default::default(), |c| c.edit),
             permissions: cipher.map_or(Default::default(), |c| c.permissions),
-            view_password: cipher.map_or(Default::default(), |c| c.view_password),
+            view_password: cipher.map_or(true, |c| c.view_password),
             local_data: cipher.map_or(Default::default(), |c| c.local_data.clone()),
             data: cipher.map_or(Default::default(), |c| c.data.clone()),
             collection_ids: cipher.map_or(Default::default(), |c| c.collection_ids.clone()),
@@ -1656,7 +1656,7 @@ impl PartialCipher for CipherMiniDetailsResponseModel {
             favorite: cipher.map_or(Default::default(), |c| c.favorite),
             edit: cipher.map_or(Default::default(), |c| c.edit),
             permissions: cipher.map_or(Default::default(), |c| c.permissions),
-            view_password: cipher.map_or(Default::default(), |c| c.view_password),
+            view_password: cipher.map_or(true, |c| c.view_password),
             data: cipher.map_or(Default::default(), |c| c.data.clone()),
             local_data: cipher.map_or(Default::default(), |c| c.local_data.clone()),
         })
@@ -3061,5 +3061,43 @@ mod tests {
         assert_eq!(decrypted.r#type, CipherType::DriversLicense);
         assert_eq!(decrypted.drivers_license, Some(dl));
         assert!(decrypted.login.is_none());
+    }
+
+    #[test]
+    fn test_mini_response_model_view_password_defaults_to_true() {
+        use chrono::Utc;
+
+        // CipherMiniResponseModel does not include view_password from the API,
+        // so when merge_with_cipher is called with None, it should default to true
+        let mini_response = CipherMiniResponseModel {
+            id: Some(TEST_UUID.parse().unwrap()),
+            name: Some(TEST_CIPHER_NAME.to_string()),
+            r#type: Some(bitwarden_api_api::models::CipherType::Login),
+            creation_date: Some(Utc::now().to_rfc3339()),
+            revision_date: Some(Utc::now().to_rfc3339()),
+            ..Default::default()
+        };
+
+        let cipher = mini_response.merge_with_cipher(None).unwrap();
+        assert!(
+            cipher.view_password,
+            "view_password should default to true for CipherMiniResponseModel"
+        );
+
+        // CipherMiniDetailsResponseModel should also default to true
+        let mini_details_response = CipherMiniDetailsResponseModel {
+            id: Some(TEST_UUID.parse().unwrap()),
+            name: Some(TEST_CIPHER_NAME.to_string()),
+            r#type: Some(bitwarden_api_api::models::CipherType::Login),
+            creation_date: Some(Utc::now().to_rfc3339()),
+            revision_date: Some(Utc::now().to_rfc3339()),
+            ..Default::default()
+        };
+
+        let cipher = mini_details_response.merge_with_cipher(None).unwrap();
+        assert!(
+            cipher.view_password,
+            "view_password should default to true for CipherMiniDetailsResponseModel"
+        );
     }
 }


### PR DESCRIPTION
## 🎟️ Tracking

[PM-37729](https://bitwarden.atlassian.net/browse/PM-37729)

## 📔 Objective

Access Intelligence is failing to load ciphers because `viewPassword` is being returned as `false`.
Root cause path:
- The reporting logic calls [getAllFromApiForOrganization](https://github.com/bitwarden/clients/blob/0345984b6472d090e0fa308cbe47eef6ebfc69e1/libs/common/src/vault/services/cipher-sdk.service.ts#L407) which reaches to the SDK 
- The [list_org_ciphers](https://github.com/bitwarden/sdk-internal/blob/1256a563b1da44022efda8ae8a9aa82c0765392a/crates/bitwarden-vault/src/cipher/cipher_client/admin/get.rs#L90-L95) method calls merge_with_cipher  with None and accepts all of the defaults for the cipher.
- Thus [view_password](https://github.com/bitwarden/sdk-internal/blob/1256a563b1da44022efda8ae8a9aa82c0765392a/crates/bitwarden-vault/src/cipher/cipher.rs#L1659) will always be false

In the [client.view.ts](https://github.com/bitwarden/clients/blob/0345984b6472d090e0fa308cbe47eef6ebfc69e1/libs/common/src/vault/models/view/cipher.view.ts#L48-L49) and elsewhere in [cipher.rs](https://github.com/bitwarden/sdk-internal/blob/1256a563b1da44022efda8ae8a9aa82c0765392a/crates/bitwarden-vault/src/cipher/cipher.rs#L1389) we default it to true.

## Screenshot

Access Intelligence now populates with data
<img width="943" height="832" alt="Screenshot 2026-05-20 at 9 49 53 PM" src="https://github.com/user-attachments/assets/d14aa6cd-1243-494a-be6f-1c75c4cf176c" />

[PM-37729]: https://bitwarden.atlassian.net/browse/PM-37729?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ