### PR TITLE
[PM-37862] Change PolicyType from newtype to enum

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -926,6 +926,7 @@ dependencies = [
  "bitwarden-organizations",
  "chrono",
  "serde",
+ "serde_repr",
  "tsify",
  "uniffi",
  "uuid",

--- a/crates/bitwarden-policies/Cargo.toml
+++ b/crates/bitwarden-policies/Cargo.toml
@@ -33,6 +33,7 @@ bitwarden-core = { workspace = true }
 bitwarden-organizations = { workspace = true }
 chrono = { workspace = true }
 serde = { workspace = true }
+serde_repr = { workspace = true }
 tsify = { workspace = true, optional = true }
 uniffi = { workspace = true, optional = true }
 uuid = { workspace = true }

--- a/crates/bitwarden-policies/src/filter.rs
+++ b/crates/bitwarden-policies/src/filter.rs
@@ -16,13 +16,7 @@ use serde::{Deserialize, Serialize};
 use tsify::Tsify;
 use uuid::Uuid;
 
-/// A newtype representing the policy type.
-#[derive(PartialEq, Eq, Hash, Serialize, Deserialize, Debug, Copy, Clone)]
-#[cfg_attr(feature = "wasm", derive(Tsify), tsify(into_wasm_abi, from_wasm_abi))]
-pub struct PolicyType(
-    /// The raw integer value as defined by the server.
-    pub u8,
-);
+use crate::policy_type::PolicyType;
 
 /// An organization policy.
 #[allow(missing_docs)]
@@ -117,11 +111,11 @@ impl<T: Policy> PolicyFilter for T {}
 mod tests {
     use super::*;
 
-    fn policy_view(organization_id: Uuid, policy_type: u8, enabled: bool) -> PolicyView {
+    fn policy_view(organization_id: Uuid, policy_type: PolicyType, enabled: bool) -> PolicyView {
         PolicyView {
             id: Uuid::new_v4(),
             organization_id,
-            r#type: PolicyType(policy_type),
+            r#type: policy_type,
             data: None,
             enabled,
             revision_date: Default::default(),
@@ -147,7 +141,7 @@ mod tests {
     struct TestPolicy;
     impl Policy for TestPolicy {
         fn policy_type(&self) -> PolicyType {
-            PolicyType(1)
+            PolicyType::MasterPassword
         }
 
         // These happen to match the default impl, but repeating here
@@ -171,7 +165,7 @@ mod tests {
     #[test]
     fn matching_policy_is_returned() {
         let org_id = Uuid::new_v4();
-        let policies = [policy_view(org_id, 1, true)];
+        let policies = [policy_view(org_id, PolicyType::MasterPassword, true)];
         let orgs = [organization(
             org_id,
             OrganizationUserType::User,
@@ -195,7 +189,7 @@ mod tests {
             is_provider_user: false,
             ..Default::default()
         }];
-        let policies = [policy_view(org_id, 1, true)];
+        let policies = [policy_view(org_id, PolicyType::MasterPassword, true)];
 
         let result = TestPolicy.filter(&policies, &orgs);
         assert!(result.is_empty());
@@ -204,7 +198,7 @@ mod tests {
     #[test]
     fn disabled_policy_is_filtered_out() {
         let org_id = Uuid::new_v4();
-        let policies = [policy_view(org_id, 1, false)];
+        let policies = [policy_view(org_id, PolicyType::MasterPassword, false)];
         let orgs = [organization(
             org_id,
             OrganizationUserType::User,
@@ -219,7 +213,7 @@ mod tests {
     #[test]
     fn wrong_policy_type_is_filtered_out() {
         let org_id = Uuid::new_v4();
-        let policies = [policy_view(org_id, 2, true)];
+        let policies = [policy_view(org_id, PolicyType::PasswordGenerator, true)];
         let orgs = [organization(
             org_id,
             OrganizationUserType::User,
@@ -242,7 +236,7 @@ mod tests {
             is_provider_user: false,
             ..Default::default()
         }];
-        let policies = [policy_view(org_id, 1, true)];
+        let policies = [policy_view(org_id, PolicyType::MasterPassword, true)];
 
         let result = TestPolicy.filter(&policies, &orgs);
         assert!(result.is_empty());
@@ -251,7 +245,7 @@ mod tests {
     #[test]
     fn exempt_role_is_filtered_out() {
         let org_id = Uuid::new_v4();
-        let policies = [policy_view(org_id, 1, true)];
+        let policies = [policy_view(org_id, PolicyType::MasterPassword, true)];
         let orgs = [organization(
             org_id,
             OrganizationUserType::Owner,
@@ -266,7 +260,7 @@ mod tests {
     #[test]
     fn non_applicable_status_is_filtered_out() {
         let org_id = Uuid::new_v4();
-        let policies = [policy_view(org_id, 1, true)];
+        let policies = [policy_view(org_id, PolicyType::MasterPassword, true)];
         let orgs = [organization(
             org_id,
             OrganizationUserType::User,
@@ -281,7 +275,7 @@ mod tests {
     #[test]
     fn provider_is_filtered_out() {
         let org_id = Uuid::new_v4();
-        let policies = [policy_view(org_id, 1, true)];
+        let policies = [policy_view(org_id, PolicyType::MasterPassword, true)];
         let orgs = [organization(
             org_id,
             OrganizationUserType::User,
@@ -295,7 +289,11 @@ mod tests {
 
     #[test]
     fn missing_org_enforces_by_default() {
-        let policies = [policy_view(Uuid::new_v4(), 1, true)];
+        let policies = [policy_view(
+            Uuid::new_v4(),
+            PolicyType::MasterPassword,
+            true,
+        )];
 
         let result = TestPolicy.filter(&policies, &[]);
         assert_eq!(result.len(), 1);

--- a/crates/bitwarden-policies/src/lib.rs
+++ b/crates/bitwarden-policies/src/lib.rs
@@ -9,9 +9,11 @@ pub mod filter;
 mod master_password_policy_response;
 mod policy_client;
 pub mod policy_overrides;
+mod policy_type;
 mod registry;
 
-pub use filter::{Policy, PolicyType, PolicyView};
+pub use filter::{Policy, PolicyView};
 pub use master_password_policy_response::MasterPasswordPolicyResponse;
 pub use policy_client::{PoliciesClientExt, PolicyClient};
 pub use policy_overrides::*;
+pub use policy_type::PolicyType;

--- a/crates/bitwarden-policies/src/policy_client.rs
+++ b/crates/bitwarden-policies/src/policy_client.rs
@@ -5,11 +5,7 @@ use bitwarden_organizations::ProfileOrganization;
 #[cfg(feature = "wasm")]
 use wasm_bindgen::prelude::wasm_bindgen;
 
-use crate::{
-    filter::{PolicyType, PolicyView},
-    policy_overrides::*,
-    registry::PolicyRegistry,
-};
+use crate::{PolicyType, filter::PolicyView, policy_overrides::*, registry::PolicyRegistry};
 
 fn build_policy_registry() -> PolicyRegistry {
     PolicyRegistry::builder()
@@ -112,26 +108,26 @@ mod tests {
     fn filter_by_type_delegates_to_registry() {
         let org_id = Uuid::new_v4();
         let policies = vec![
-            policy_view(org_id, PolicyType(1), true),
-            policy_view(org_id, PolicyType(2), true),
+            policy_view(org_id, PolicyType::MasterPassword, true),
+            policy_view(org_id, PolicyType::PasswordGenerator, true),
         ];
         let orgs = vec![organization(org_id)];
 
         let client = PolicyClient::new();
-        let result = client.filter_by_type(policies, orgs, PolicyType(1));
+        let result = client.filter_by_type(policies, orgs, PolicyType::MasterPassword);
 
         assert_eq!(result.len(), 1);
-        assert_eq!(result[0].r#type, PolicyType(1));
+        assert_eq!(result[0].r#type, PolicyType::MasterPassword);
     }
 
     #[test]
     fn filter_by_type_returns_empty_for_no_match() {
         let org_id = Uuid::new_v4();
-        let policies = vec![policy_view(org_id, PolicyType(1), true)];
+        let policies = vec![policy_view(org_id, PolicyType::MasterPassword, true)];
         let orgs = vec![organization(org_id)];
 
         let client = PolicyClient::new();
-        let result = client.filter_by_type(policies, orgs, PolicyType(99));
+        let result = client.filter_by_type(policies, orgs, PolicyType::TwoFactorAuthentication);
 
         assert!(result.is_empty());
     }
@@ -141,7 +137,7 @@ mod tests {
         struct NoExemptionPolicy;
         impl Policy for NoExemptionPolicy {
             fn policy_type(&self) -> PolicyType {
-                PolicyType(1)
+                PolicyType::MasterPassword
             }
             fn exempt_roles(&self) -> &[OrganizationUserType] {
                 &[]
@@ -150,7 +146,7 @@ mod tests {
 
         let org_id = Uuid::new_v4();
         // Owner — normally exempt, but NoExemptionPolicy removes the exemption
-        let policies = vec![policy_view(org_id, PolicyType(1), true)];
+        let policies = vec![policy_view(org_id, PolicyType::MasterPassword, true)];
         let orgs = vec![ProfileOrganization {
             id: org_id,
             r#type: OrganizationUserType::Owner,
@@ -164,7 +160,7 @@ mod tests {
             .register(NoExemptionPolicy)
             .build();
         let client = PolicyClient { registry };
-        let result = client.filter_by_type(policies, orgs, PolicyType(1));
+        let result = client.filter_by_type(policies, orgs, PolicyType::MasterPassword);
 
         assert_eq!(result.len(), 1);
     }

--- a/crates/bitwarden-policies/src/policy_overrides.rs
+++ b/crates/bitwarden-policies/src/policy_overrides.rs
@@ -2,7 +2,7 @@
 
 use bitwarden_organizations::OrganizationUserType;
 
-use crate::filter::{Policy, PolicyType};
+use crate::{PolicyType, filter::Policy};
 
 /// Master Password policy (type 1).
 ///
@@ -11,7 +11,7 @@ pub struct MasterPasswordPolicy;
 
 impl Policy for MasterPasswordPolicy {
     fn policy_type(&self) -> PolicyType {
-        PolicyType(1)
+        PolicyType::MasterPassword
     }
 
     fn exempt_roles(&self) -> &[OrganizationUserType] {
@@ -19,14 +19,14 @@ impl Policy for MasterPasswordPolicy {
     }
 }
 
-/// Password Generator policy (type 2).
+/// Password Generator policy.
 ///
 /// Applies to **everyone**, including Owners and Admins.
 pub struct PasswordGeneratorPolicy;
 
 impl Policy for PasswordGeneratorPolicy {
     fn policy_type(&self) -> PolicyType {
-        PolicyType(2)
+        PolicyType::PasswordGenerator
     }
 
     fn exempt_roles(&self) -> &[OrganizationUserType] {
@@ -34,14 +34,14 @@ impl Policy for PasswordGeneratorPolicy {
     }
 }
 
-/// Maximum Vault Timeout policy (type 9).
+/// Maximum Vault Timeout policy.
 ///
 /// Applies to everyone **except Owners**. Admins are not exempt.
 pub struct MaximumVaultTimeoutPolicy;
 
 impl Policy for MaximumVaultTimeoutPolicy {
     fn policy_type(&self) -> PolicyType {
-        PolicyType(9)
+        PolicyType::MaximumVaultTimeout
     }
 
     fn exempt_roles(&self) -> &[OrganizationUserType] {
@@ -49,14 +49,14 @@ impl Policy for MaximumVaultTimeoutPolicy {
     }
 }
 
-/// Free Families Sponsorship policy (type 13).
+/// Free Families Sponsorship policy.
 ///
 /// Applies to **everyone**, including Owners and Admins.
 pub struct FreeFamiliesSponsorshipPolicy;
 
 impl Policy for FreeFamiliesSponsorshipPolicy {
     fn policy_type(&self) -> PolicyType {
-        PolicyType(13)
+        PolicyType::FreeFamiliesSponsorshipPolicy
     }
 
     fn exempt_roles(&self) -> &[OrganizationUserType] {
@@ -64,14 +64,14 @@ impl Policy for FreeFamiliesSponsorshipPolicy {
     }
 }
 
-/// Remove Unlock with PIN policy (type 14).
+/// Remove Unlock with PIN policy.
 ///
 /// Applies to **everyone**, including Owners and Admins.
 pub struct RemoveUnlockWithPinPolicy;
 
 impl Policy for RemoveUnlockWithPinPolicy {
     fn policy_type(&self) -> PolicyType {
-        PolicyType(14)
+        PolicyType::RemoveUnlockWithPin
     }
 
     fn exempt_roles(&self) -> &[OrganizationUserType] {
@@ -79,14 +79,14 @@ impl Policy for RemoveUnlockWithPinPolicy {
     }
 }
 
-/// Restricted Item Types policy (type 15).
+/// Restricted Item Types policy.
 ///
 /// Applies to **everyone**, including Owners and Admins.
 pub struct RestrictedItemTypesPolicy;
 
 impl Policy for RestrictedItemTypesPolicy {
     fn policy_type(&self) -> PolicyType {
-        PolicyType(15)
+        PolicyType::RestrictedItemTypesPolicy
     }
 
     fn exempt_roles(&self) -> &[OrganizationUserType] {
@@ -94,14 +94,14 @@ impl Policy for RestrictedItemTypesPolicy {
     }
 }
 
-/// Automatic User Confirmation policy (type 18).
+/// Automatic User Confirmation policy.
 ///
 /// Applies to **everyone**, including Owners and Admins.
 pub struct AutomaticUserConfirmationPolicy;
 
 impl Policy for AutomaticUserConfirmationPolicy {
     fn policy_type(&self) -> PolicyType {
-        PolicyType(18)
+        PolicyType::AutomaticUserConfirmation
     }
 
     fn exempt_roles(&self) -> &[OrganizationUserType] {
@@ -119,11 +119,11 @@ mod tests {
     use super::*;
     use crate::filter::{PolicyFilter, PolicyView};
 
-    fn policy_view(organization_id: Uuid, policy_type: u8) -> PolicyView {
+    fn policy_view(organization_id: Uuid, policy_type: PolicyType) -> PolicyView {
         PolicyView {
             id: Uuid::new_v4(),
             organization_id,
-            r#type: PolicyType(policy_type),
+            r#type: policy_type,
             data: None,
             enabled: true,
             revision_date: Default::default(),
@@ -146,7 +146,7 @@ mod tests {
     #[test]
     fn master_password_applies_to_owner() {
         let org_id = Uuid::new_v4();
-        let policies = [policy_view(org_id, 1)];
+        let policies = [policy_view(org_id, PolicyType::MasterPassword)];
         let orgs = [org(org_id, OrganizationUserType::Owner)];
         assert_eq!(MasterPasswordPolicy.filter(&policies, &orgs).len(), 1);
     }
@@ -154,7 +154,7 @@ mod tests {
     #[test]
     fn master_password_applies_to_admin() {
         let org_id = Uuid::new_v4();
-        let policies = [policy_view(org_id, 1)];
+        let policies = [policy_view(org_id, PolicyType::MasterPassword)];
         let orgs = [org(org_id, OrganizationUserType::Admin)];
         assert_eq!(MasterPasswordPolicy.filter(&policies, &orgs).len(), 1);
     }
@@ -164,7 +164,7 @@ mod tests {
     #[test]
     fn password_generator_applies_to_owner() {
         let org_id = Uuid::new_v4();
-        let policies = [policy_view(org_id, 2)];
+        let policies = [policy_view(org_id, PolicyType::PasswordGenerator)];
         let orgs = [org(org_id, OrganizationUserType::Owner)];
         assert_eq!(PasswordGeneratorPolicy.filter(&policies, &orgs).len(), 1);
     }
@@ -172,7 +172,7 @@ mod tests {
     #[test]
     fn password_generator_applies_to_admin() {
         let org_id = Uuid::new_v4();
-        let policies = [policy_view(org_id, 2)];
+        let policies = [policy_view(org_id, PolicyType::PasswordGenerator)];
         let orgs = [org(org_id, OrganizationUserType::Admin)];
         assert_eq!(PasswordGeneratorPolicy.filter(&policies, &orgs).len(), 1);
     }
@@ -182,7 +182,7 @@ mod tests {
     #[test]
     fn maximum_vault_timeout_exempts_owner() {
         let org_id = Uuid::new_v4();
-        let policies = [policy_view(org_id, 9)];
+        let policies = [policy_view(org_id, PolicyType::MaximumVaultTimeout)];
         let orgs = [org(org_id, OrganizationUserType::Owner)];
         assert!(
             MaximumVaultTimeoutPolicy
@@ -194,7 +194,7 @@ mod tests {
     #[test]
     fn maximum_vault_timeout_applies_to_admin() {
         let org_id = Uuid::new_v4();
-        let policies = [policy_view(org_id, 9)];
+        let policies = [policy_view(org_id, PolicyType::MaximumVaultTimeout)];
         let orgs = [org(org_id, OrganizationUserType::Admin)];
         assert_eq!(MaximumVaultTimeoutPolicy.filter(&policies, &orgs).len(), 1);
     }
@@ -202,7 +202,7 @@ mod tests {
     #[test]
     fn maximum_vault_timeout_applies_to_user() {
         let org_id = Uuid::new_v4();
-        let policies = [policy_view(org_id, 9)];
+        let policies = [policy_view(org_id, PolicyType::MaximumVaultTimeout)];
         let orgs = [org(org_id, OrganizationUserType::User)];
         assert_eq!(MaximumVaultTimeoutPolicy.filter(&policies, &orgs).len(), 1);
     }
@@ -212,7 +212,10 @@ mod tests {
     #[test]
     fn free_families_applies_to_owner() {
         let org_id = Uuid::new_v4();
-        let policies = [policy_view(org_id, 13)];
+        let policies = [policy_view(
+            org_id,
+            PolicyType::FreeFamiliesSponsorshipPolicy,
+        )];
         let orgs = [org(org_id, OrganizationUserType::Owner)];
         assert_eq!(
             FreeFamiliesSponsorshipPolicy.filter(&policies, &orgs).len(),
@@ -225,7 +228,7 @@ mod tests {
     #[test]
     fn remove_unlock_with_pin_applies_to_owner() {
         let org_id = Uuid::new_v4();
-        let policies = [policy_view(org_id, 14)];
+        let policies = [policy_view(org_id, PolicyType::RemoveUnlockWithPin)];
         let orgs = [org(org_id, OrganizationUserType::Owner)];
         assert_eq!(RemoveUnlockWithPinPolicy.filter(&policies, &orgs).len(), 1);
     }
@@ -235,7 +238,7 @@ mod tests {
     #[test]
     fn restricted_item_types_applies_to_owner() {
         let org_id = Uuid::new_v4();
-        let policies = [policy_view(org_id, 15)];
+        let policies = [policy_view(org_id, PolicyType::RestrictedItemTypesPolicy)];
         let orgs = [org(org_id, OrganizationUserType::Owner)];
         assert_eq!(RestrictedItemTypesPolicy.filter(&policies, &orgs).len(), 1);
     }
@@ -245,7 +248,7 @@ mod tests {
     #[test]
     fn automatic_user_confirmation_applies_to_owner() {
         let org_id = Uuid::new_v4();
-        let policies = [policy_view(org_id, 18)];
+        let policies = [policy_view(org_id, PolicyType::AutomaticUserConfirmation)];
         let orgs = [org(org_id, OrganizationUserType::Owner)];
         assert_eq!(
             AutomaticUserConfirmationPolicy

--- a/crates/bitwarden-policies/src/policy_type.rs
+++ b/crates/bitwarden-policies/src/policy_type.rs
@@ -1,0 +1,70 @@
+//! The [`PolicyType`] enum.
+
+use serde_repr::{Deserialize_repr, Serialize_repr};
+#[cfg(feature = "wasm")]
+use wasm_bindgen::prelude::wasm_bindgen;
+
+/// The type of an organization policy.
+///
+/// The integer value matches the server's wire format.
+#[derive(PartialEq, Eq, Hash, Serialize_repr, Deserialize_repr, Debug, Copy, Clone)]
+#[cfg_attr(feature = "uniffi", derive(uniffi::Enum))]
+#[cfg_attr(feature = "wasm", wasm_bindgen)]
+#[repr(u8)]
+pub enum PolicyType {
+    /// Requires members to have two-step login enabled on their account.
+    TwoFactorAuthentication = 0,
+    /// Sets minimum requirements for members' master passwords.
+    MasterPassword = 1,
+    /// Sets minimum requirements for the password generator.
+    PasswordGenerator = 2,
+    /// Restricts members to being part of a single organization.
+    SingleOrg = 3,
+    /// Requires members to authenticate with single sign-on.
+    RequireSso = 4,
+    /// Forces newly added or cloned items to be owned by the organization rather than the
+    /// member's personal vault. Also enables My Items functionality.
+    OrganizationDataOwnership = 5,
+    /// Disables the ability to create and edit Bitwarden Sends.
+    ///
+    /// Superseded by [`SendControls`](Self::SendControls) when the
+    /// `pm-31885-send-controls` feature flag is active.
+    DisableSend = 6,
+    /// Sets restrictions or defaults for Bitwarden Sends.
+    ///
+    /// Superseded by [`SendControls`](Self::SendControls) when the
+    /// `pm-31885-send-controls` feature flag is active.
+    SendOptions = 7,
+    /// Allows administrators to recover member accounts.
+    ResetPassword = 8,
+    /// Sets the maximum allowed vault timeout for members.
+    MaximumVaultTimeout = 9,
+    /// Disables members' ability to export their personal vault.
+    DisablePersonalVaultExport = 10,
+    /// Activates autofill on page load in the browser extension.
+    ActivateAutofill = 11,
+    /// Automatically logs members into apps using single sign-on.
+    AutomaticAppLogIn = 12,
+    /// Removes members' access to the free Bitwarden Families sponsorship benefit.
+    FreeFamiliesSponsorshipPolicy = 13,
+    /// Prevents members from unlocking the app with a PIN.
+    RemoveUnlockWithPin = 14,
+    /// Restricts the item types that members can create.
+    RestrictedItemTypesPolicy = 15,
+    /// Sets the default URI match detection strategy for autofill.
+    UriMatchDefaults = 16,
+    /// Sets the default behavior for the autotype feature.
+    AutotypeDefaultSetting = 17,
+    /// Automatically confirms invited users into the organization.
+    AutomaticUserConfirmation = 18,
+    /// Blocks account creation for users with email addresses on claimed domains.
+    BlockClaimedDomainAccountCreation = 19,
+    /// Displays an organization-configured banner message to members in their vault.
+    OrganizationUserNotification = 20,
+    /// Configures Send-related behavior: disabling Sends, email visibility, access controls,
+    /// Send types, and deletion.
+    ///
+    /// Supersedes [`DisableSend`](Self::DisableSend) and [`SendOptions`](Self::SendOptions) when
+    /// the `pm-31885-send-controls` feature flag is active on the server.
+    SendControls = 21,
+}

--- a/crates/bitwarden-policies/src/registry.rs
+++ b/crates/bitwarden-policies/src/registry.rs
@@ -10,7 +10,10 @@ use std::collections::HashMap;
 
 use bitwarden_organizations::ProfileOrganization;
 
-use crate::filter::{Policy, PolicyFilter, PolicyType, PolicyView};
+use crate::{
+    PolicyType,
+    filter::{Policy, PolicyFilter, PolicyView},
+};
 
 /// A [`Policy`] that uses the default filtering behavior for any policy type.
 struct DefaultPolicy(PolicyType);
@@ -92,11 +95,11 @@ mod tests {
 
     use super::*;
 
-    fn policy_view(organization_id: Uuid, policy_type: u8, enabled: bool) -> PolicyView {
+    fn policy_view(organization_id: Uuid, policy_type: PolicyType, enabled: bool) -> PolicyView {
         PolicyView {
             id: Uuid::new_v4(),
             organization_id,
-            r#type: PolicyType(policy_type),
+            r#type: policy_type,
             data: None,
             enabled,
             revision_date: Default::default(),
@@ -125,7 +128,7 @@ mod tests {
         struct AnyPolicy;
         impl Policy for AnyPolicy {
             fn policy_type(&self) -> PolicyType {
-                PolicyType(1)
+                PolicyType::MasterPassword
             }
         }
 
@@ -138,7 +141,7 @@ mod tests {
     #[test]
     fn registry_uses_registered_definition() {
         let org_id = Uuid::new_v4();
-        let policies = [policy_view(org_id, 1, true)];
+        let policies = [policy_view(org_id, PolicyType::MasterPassword, true)];
         // Owner — exempt under default rules, not exempt under NoExemptionPolicy
         let orgs = [organization(
             org_id,
@@ -150,7 +153,7 @@ mod tests {
         struct NoExemptionPolicy;
         impl Policy for NoExemptionPolicy {
             fn policy_type(&self) -> PolicyType {
-                PolicyType(1)
+                PolicyType::MasterPassword
             }
             fn exempt_roles(&self) -> &[OrganizationUserType] {
                 &[]
@@ -161,7 +164,7 @@ mod tests {
             .register(NoExemptionPolicy)
             .build();
 
-        let result = registry.filter_by_type(&policies, &orgs, PolicyType(1));
+        let result = registry.filter_by_type(&policies, &orgs, PolicyType::MasterPassword);
 
         assert_eq!(result.len(), 1);
     }
@@ -169,7 +172,7 @@ mod tests {
     #[test]
     fn registry_uses_default_policy_definition() {
         let org_id = Uuid::new_v4();
-        let policies = [policy_view(org_id, 1, true)];
+        let policies = [policy_view(org_id, PolicyType::MasterPassword, true)];
         let orgs = [organization(
             org_id,
             OrganizationUserType::User,
@@ -180,7 +183,7 @@ mod tests {
         // empty registry
         let registry = PolicyRegistry::builder().build();
 
-        let result = registry.filter_by_type(&policies, &orgs, PolicyType(1));
+        let result = registry.filter_by_type(&policies, &orgs, PolicyType::MasterPassword);
 
         assert_eq!(result.len(), 1);
     }

--- a/crates/bitwarden-policies/src/uniffi_support.rs
+++ b/crates/bitwarden-policies/src/uniffi_support.rs
@@ -1,12 +1,5 @@
 use uuid::Uuid;
 
-use crate::filter::PolicyType;
-
 type DateTime = chrono::DateTime<chrono::Utc>;
 uniffi::use_remote_type!(bitwarden_core::DateTime);
 uniffi::use_remote_type!(bitwarden_core::Uuid);
-
-uniffi::custom_type!(PolicyType, u8, {
-    lower: |p| p.0,
-    try_lift: |v| Ok(PolicyType(v)),
-});


### PR DESCRIPTION
## 🎟️ Tracking

[PM-37862](https://bitwarden.atlassian.net/browse/PM-37862)

## 📔 Objective

Mobile Team notified us that the `PolicyType` newtype was being deserialized to a raw `UByte`, which is a poor interface. After some discussion an enum is just easier to handle here, both at the FFI boundary and also in the Rust code. It should also enable per-policy data models in a more idiomatic way.

Replace the `PolicyType` newtype with an enum instead.

## 🚨 Breaking Changes

Note this is not called anywhere by native code yet, but in principle:

`PolicyType`'s FFI shape changes: UniFFI exposes it as a proper enum (was a `u8` alias), and WASM exposes it as a `wasm_bindgen` enum (was a Tsify newtype). Callers must update construction from `PolicyType(N)` to named variants like `PolicyType.MasterPassword`. JSON wire format is unchanged.

[PM-37862]: https://bitwarden.atlassian.net/browse/PM-37862?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ