### PR TITLE
Cleanup bitwarden-state

### DIFF
--- a/crates/bitwarden-core/src/platform/state_client.rs
+++ b/crates/bitwarden-core/src/platform/state_client.rs
@@ -1,9 +1,9 @@
 use std::sync::Arc;
 
 use bitwarden_state::{
-    DatabaseConfiguration, Key, Setting, SettingItem, SettingsError,
+    Key, Setting, SettingItem, SettingsError,
     registry::StateRegistryError,
-    repository::{Repository, RepositoryItem, RepositoryMigrations},
+    repository::{Repository, RepositoryItem},
 };
 
 use crate::Client;
@@ -23,19 +23,6 @@ impl StateClient {
             .internal
             .state_registry
             .register_client_managed(store)
-    }
-
-    /// Initialize the database for SDK managed repositories.
-    pub async fn initialize_database(
-        &self,
-        configuration: DatabaseConfiguration,
-        migrations: RepositoryMigrations,
-    ) -> Result<(), StateRegistryError> {
-        self.client
-            .internal
-            .state_registry
-            .initialize_database(configuration, migrations)
-            .await
     }
 
     /// Get a repository with fallback: prefer client-managed, fall back to SDK-managed.

--- a/crates/bitwarden-state/CLAUDE.md
+++ b/crates/bitwarden-state/CLAUDE.md
@@ -8,5 +8,7 @@ Read any available documentation: [README.md](./README.md) for architecture,
 **SDK-managed types require serialization**: Types must implement `Serialize + DeserializeOwned` to
 use SDK-managed storage.
 
-**Initialize database before access**: Call `initialize_database()` before accessing SDK-managed
-repositories or `get_sdk_managed()` returns `DatabaseNotInitialized` error.
+**Choose the right constructor**: Use `StateRegistry::new_with_memory_db()` for in-memory storage
+(sync, suitable for tests or apps that use only client-managed storage). Use
+`StateRegistry::new_with_db(configuration, migrations)` (async) for persistent storage — pass all
+migrations at construction time, not after the fact.

--- a/crates/bitwarden-state/src/registry.rs
+++ b/crates/bitwarden-state/src/registry.rs
@@ -8,7 +8,7 @@ use bitwarden_error::bitwarden_error;
 use thiserror::Error;
 
 use crate::{
-    repository::{Repository, RepositoryItem, RepositoryItemData, RepositoryMigrations},
+    repository::{Repository, RepositoryItem, RepositoryMigrations},
     sdk_managed::{Database, DatabaseConfiguration, DatabaseError, MemoryDatabase, SystemDatabase},
     settings::{Key, Setting, SettingItem},
 };

--- a/crates/bitwarden-state/src/registry.rs
+++ b/crates/bitwarden-state/src/registry.rs
@@ -1,7 +1,7 @@
 use std::{
     any::{Any, TypeId},
     collections::HashMap,
-    sync::{Arc, OnceLock, RwLock},
+    sync::{Arc, RwLock},
 };
 
 use bitwarden_error::bitwarden_error;
@@ -9,17 +9,17 @@ use thiserror::Error;
 
 use crate::{
     repository::{Repository, RepositoryItem, RepositoryItemData, RepositoryMigrations},
-    sdk_managed::{Database, DatabaseConfiguration, MemoryDatabase, SystemDatabase},
+    sdk_managed::{Database, DatabaseConfiguration, DatabaseError, MemoryDatabase, SystemDatabase},
     settings::{Key, Setting, SettingItem},
 };
 
 /// A registry that contains repositories for different types of items.
 /// These repositories can be either managed by the client or by the SDK itself.
 pub struct StateRegistry {
-    sdk_managed: RwLock<Vec<RepositoryItemData>>,
+    database: SystemDatabase,
     client_managed: RwLock<HashMap<TypeId, Box<dyn Any + Send + Sync>>>,
-
-    database: OnceLock<SystemDatabase>,
+    #[allow(dead_code, reason = "Used only during construction")]
+    sdk_managed: RwLock<Vec<RepositoryItemData>>,
 }
 
 impl std::fmt::Debug for StateRegistry {
@@ -32,67 +32,34 @@ impl std::fmt::Debug for StateRegistry {
 #[bitwarden_error(flat)]
 #[derive(Debug, Error)]
 pub enum StateRegistryError {
-    #[error("Database is already initialized")]
-    DatabaseAlreadyInitialized,
     #[error("Database is not initialized")]
     DatabaseNotInitialized,
 
     #[error(transparent)]
-    Database(#[from] crate::sdk_managed::DatabaseError),
+    Database(#[from] DatabaseError),
 }
 
 impl StateRegistry {
-    /// Creates a new empty `StateRegistry`.
-    #[allow(clippy::new_without_default)]
-    pub fn new() -> Self {
+    /// Creates a new `StateRegistry` backed by an in-memory database.
+    pub fn new_with_memory_db() -> Self {
         StateRegistry {
             client_managed: RwLock::new(HashMap::new()),
-            database: OnceLock::new(),
+            database: SystemDatabase::Memory(MemoryDatabase::new()),
             sdk_managed: RwLock::new(Vec::new()),
         }
     }
 
-    /// Creates a new `StateRegistry` backed by an in-memory database.
-    pub fn new_with_memory_db() -> Self {
-        let registry = Self::new();
-        // OnceLock::set returns Err only if already set.
-        // new() guarantees the OnceLock is unset. We ignore the result
-        // because there is no failure scenario here.
-        let _ = registry
-            .database
-            .set(SystemDatabase::Memory(MemoryDatabase::new()));
-        registry
-    }
-
-    // TODO: Ideally we'd do this in new, but that would mean making the client initialization
-    // async.
-    // TODO: This function needs to be provided some configuration to know where to open the
-    // database. For Sqlite:
-    // - A folder path where the files will be stored.
-    // - A user ID to create a unique database file per user?
-    //
-    // For WASM indexedDB:
-    // - A database name to use for the indexedDB (Some prefix to avoid conflicts + user ID?)
-
-    /// Initializes the database used for sdk-managed repositories.
-    pub async fn initialize_database(
-        &self,
+    /// Creates a new `StateRegistry` backed by a database.
+    pub async fn new_with_db(
         configuration: DatabaseConfiguration,
         migrations: RepositoryMigrations,
-    ) -> Result<(), StateRegistryError> {
-        if self.database.get().is_some() {
-            return Err(StateRegistryError::DatabaseAlreadyInitialized);
-        }
-        let _ = self
-            .database
-            .set(SystemDatabase::initialize(configuration, migrations.clone()).await?);
-
-        *self
-            .sdk_managed
-            .write()
-            .expect("RwLock should not be poisoned") = migrations.into_repository_items();
-
-        Ok(())
+    ) -> Result<Self, DatabaseError> {
+        let database = SystemDatabase::initialize(configuration, migrations.clone()).await?;
+        Ok(StateRegistry {
+            client_managed: RwLock::new(HashMap::new()),
+            database,
+            sdk_managed: RwLock::new(migrations.into_repository_items()),
+        })
     }
 
     /// Get a handle to a setting by its type-safe key.
@@ -123,10 +90,7 @@ impl StateRegistry {
     fn get_sdk_managed<T: RepositoryItem>(
         &self,
     ) -> Result<Arc<dyn Repository<T>>, StateRegistryError> {
-        self.database
-            .get()
-            .map(|db| db.get_repository::<T>())
-            .ok_or(StateRegistryError::DatabaseNotInitialized)
+        Ok(self.database.get_repository::<T>())
     }
 
     /// Get a repository with fallback: prefer client-managed, fall back to SDK-managed.
@@ -218,7 +182,7 @@ mod tests {
         let b = Arc::new(TestB("test".to_string()));
         let c = Arc::new(TestC(vec![1, 2, 3, 4, 5, 6, 7, 8, 9]));
 
-        let map = StateRegistry::new();
+        let map = StateRegistry::new_with_memory_db();
 
         async fn get<T: RepositoryItem>(map: &StateRegistry) -> Option<T>
         where
@@ -253,7 +217,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_fallback_client_managed_found() {
-        let registry = StateRegistry::new();
+        let registry = StateRegistry::new_with_memory_db();
         let test_repo = Arc::new(TestA(12345));
 
         registry.register_client_managed(test_repo.clone());
@@ -262,18 +226,6 @@ mod tests {
         let result = repo.get(String::new()).await.unwrap();
 
         assert_eq!(result, Some(TestItem(12345)));
-    }
-
-    #[tokio::test]
-    async fn test_fallback_neither_available() {
-        let registry = StateRegistry::new();
-        // Don't register client-managed or initialize database
-
-        let result = registry.get::<TestItem<usize>>();
-        assert!(matches!(
-            result,
-            Err(StateRegistryError::DatabaseNotInitialized)
-        ));
     }
 
     #[tokio::test]

--- a/crates/bitwarden-state/src/registry.rs
+++ b/crates/bitwarden-state/src/registry.rs
@@ -18,8 +18,6 @@ use crate::{
 pub struct StateRegistry {
     database: SystemDatabase,
     client_managed: RwLock<HashMap<TypeId, Box<dyn Any + Send + Sync>>>,
-    #[allow(dead_code, reason = "Used only during construction")]
-    sdk_managed: RwLock<Vec<RepositoryItemData>>,
 }
 
 impl std::fmt::Debug for StateRegistry {
@@ -43,9 +41,8 @@ impl StateRegistry {
     /// Creates a new `StateRegistry` backed by an in-memory database.
     pub fn new_with_memory_db() -> Self {
         StateRegistry {
-            client_managed: RwLock::new(HashMap::new()),
             database: SystemDatabase::Memory(MemoryDatabase::new()),
-            sdk_managed: RwLock::new(Vec::new()),
+            client_managed: RwLock::new(HashMap::new()),
         }
     }
 
@@ -56,9 +53,8 @@ impl StateRegistry {
     ) -> Result<Self, DatabaseError> {
         let database = SystemDatabase::initialize(configuration, migrations.clone()).await?;
         Ok(StateRegistry {
-            client_managed: RwLock::new(HashMap::new()),
             database,
-            sdk_managed: RwLock::new(migrations.into_repository_items()),
+            client_managed: RwLock::new(HashMap::new()),
         })
     }
 

--- a/crates/bitwarden-state/src/registry.rs
+++ b/crates/bitwarden-state/src/registry.rs
@@ -94,13 +94,8 @@ impl StateRegistry {
     /// This method first attempts to retrieve a client-managed repository. If not found,
     /// it falls back to an SDK-managed repository. Both are returned as `Arc<dyn Repository<T>>`.
     ///
-    /// # Type Requirements
-    /// - `T` must implement `RepositoryItem` (for both types)
-    ///
     /// # Errors
-    /// Returns `StateRegistryError` when:
-    /// - Client-managed repository is not registered, AND
-    /// - SDK-managed repository cannot be retrieved (e.g., database not initialized)
+    /// This method never fails, but returns a Result for backwards compatibility.
     pub fn get<T>(&self) -> Result<Arc<dyn Repository<T>>, StateRegistryError>
     where
         T: RepositoryItem,

--- a/crates/bitwarden-uniffi/src/platform/mod.rs
+++ b/crates/bitwarden-uniffi/src/platform/mod.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 
 use bitwarden_core::{Client, platform::FingerprintRequest};
 use bitwarden_fido::ClientFido2Ext;
-use repository::{UniffiRepositoryBridge, create_uniffi_repositories};
+use repository::create_uniffi_repositories;
 
 use crate::error::Result;
 
@@ -69,12 +69,6 @@ bitwarden_pm::create_client_managed_repositories!(Repositories, create_uniffi_re
 
 #[uniffi::export]
 impl StateClient {
-    #[deprecated(note = "Use `register_client_managed_repositories` instead")]
-    pub fn register_cipher_repository(&self, repository: Arc<dyn CipherRepository>) {
-        let cipher = UniffiRepositoryBridge::new(repository);
-        self.0.platform().state().register_client_managed(cipher);
-    }
-
     pub fn register_client_managed_repositories(&self, repositories: Repositories) {
         repositories.register_all(&self.0.platform().state());
     }

--- a/crates/bitwarden-wasm-internal/src/platform/mod.rs
+++ b/crates/bitwarden-wasm-internal/src/platform/mod.rs
@@ -52,20 +52,6 @@ bitwarden_pm::create_client_managed_repositories!(Repositories, create_wasm_repo
 
 #[wasm_bindgen]
 impl StateClient {
-    #[allow(deprecated)]
-    #[deprecated(note = "Use `register_client_managed_repositories` instead")]
-    pub fn register_cipher_repository(&self, cipher_repository: CipherRepository) {
-        let cipher = cipher_repository.into_channel_impl();
-        self.0.platform().state().register_client_managed(cipher);
-    }
-
-    #[allow(deprecated)]
-    #[deprecated(note = "Use `register_client_managed_repositories` instead")]
-    pub fn register_folder_repository(&self, store: FolderRepository) {
-        let store = store.into_channel_impl();
-        self.0.platform().state().register_client_managed(store)
-    }
-
     pub fn register_client_managed_repositories(&self, repositories: Repositories) {
         repositories.register_all(&self.0.platform().state());
     }


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective

Replaces `OnceLock<SystemDatabase>` in `StateRegistry` with a simple `SystemDatabase` field, making the registry always initialized at construction time. `new_with_memory_db()` is the sync constructor; `new_with_db(configuration, migrations)` is the async constructor for persistent storage. `initialize_database()` is removed entirely and it's up to users of the SDK to ensure the database is initialized in some way.

Removes the deprecated `register_cipher_repository` / `register_folder_repository` methods from the UniFFI and WASM bindings now that `register_client_managed_repositories` is the established API. I checked the WASM/mobile apps and they weren't used.

## 🚨 Breaking Changes

<!-- Does this PR introduce any breaking changes? If so, please describe the impact and migration path for clients.

If you're unsure, the automated TypeScript compatibility check will run when you open/update this PR and provide feedback.

For breaking changes:
1. Describe what changed in the client interface
2. Explain why the change was necessary
3. Provide migration steps for client developers
4. Link to any paired client PRs if needed

Otherwise, you can remove this section. -->
