### PR TITLE
[PM-37729] Default `view_password` to true (#1113)

### DIFF
--- a/crates/bitwarden-vault/src/cipher/cipher.rs
+++ b/crates/bitwarden-vault/src/cipher/cipher.rs
@@ -1581,7 +1581,7 @@ impl PartialCipher for CipherMiniResponseModel {
             favorite: cipher.map_or(Default::default(), |c| c.favorite),
             edit: cipher.map_or(Default::default(), |c| c.edit),
             permissions: cipher.map_or(Default::default(), |c| c.permissions),
-            view_password: cipher.map_or(Default::default(), |c| c.view_password),
+            view_password: cipher.is_none_or(|c| c.view_password),
             local_data: cipher.map_or(Default::default(), |c| c.local_data.clone()),
             data: cipher.map_or(Default::default(), |c| c.data.clone()),
             collection_ids: cipher.map_or(Default::default(), |c| c.collection_ids.clone()),
@@ -1647,7 +1647,7 @@ impl PartialCipher for CipherMiniDetailsResponseModel {
             favorite: cipher.map_or(Default::default(), |c| c.favorite),
             edit: cipher.map_or(Default::default(), |c| c.edit),
             permissions: cipher.map_or(Default::default(), |c| c.permissions),
-            view_password: cipher.map_or(Default::default(), |c| c.view_password),
+            view_password: cipher.is_none_or(|c: &Cipher| c.view_password),
             data: cipher.map_or(Default::default(), |c| c.data.clone()),
             local_data: cipher.map_or(Default::default(), |c| c.local_data.clone()),
         })
@@ -3044,5 +3044,43 @@ mod tests {
         assert_eq!(decrypted.r#type, CipherType::DriversLicense);
         assert_eq!(decrypted.drivers_license, Some(dl));
         assert!(decrypted.login.is_none());
+    }
+
+    #[test]
+    fn test_mini_response_model_view_password_defaults_to_true() {
+        use chrono::Utc;
+
+        // CipherMiniResponseModel does not include view_password from the API,
+        // so when merge_with_cipher is called with None, it should default to true
+        let mini_response = CipherMiniResponseModel {
+            id: Some(TEST_UUID.parse().unwrap()),
+            name: Some(TEST_CIPHER_NAME.to_string()),
+            r#type: Some(bitwarden_api_api::models::CipherType::Login),
+            creation_date: Some(Utc::now().to_rfc3339()),
+            revision_date: Some(Utc::now().to_rfc3339()),
+            ..Default::default()
+        };
+
+        let cipher = mini_response.merge_with_cipher(None).unwrap();
+        assert!(
+            cipher.view_password,
+            "view_password should default to true for CipherMiniResponseModel"
+        );
+
+        // CipherMiniDetailsResponseModel should also default to true
+        let mini_details_response = CipherMiniDetailsResponseModel {
+            id: Some(TEST_UUID.parse().unwrap()),
+            name: Some(TEST_CIPHER_NAME.to_string()),
+            r#type: Some(bitwarden_api_api::models::CipherType::Login),
+            creation_date: Some(Utc::now().to_rfc3339()),
+            revision_date: Some(Utc::now().to_rfc3339()),
+            ..Default::default()
+        };
+
+        let cipher = mini_details_response.merge_with_cipher(None).unwrap();
+        assert!(
+            cipher.view_password,
+            "view_password should default to true for CipherMiniDetailsResponseModel"
+        );
     }
 }


### PR DESCRIPTION
## 🎟️ Tracking

[PM-37729](https://bitwarden.atlassian.net/browse/PM-37729)

## 📔 Objective

Cherry pick https://github.com/bitwarden/sdk-internal/pull/1113 into `rc`. The branch `rc/2026-05-18` was created from commit e13c4fcc75a608c075b1a2d9e8fc1530a12bc36c, which matches the current version of the SDK in the clients rc cut: 
- npm [version 0.2.0-main.757](https://www.npmjs.com/package/@bitwarden/sdk-internal/v/0.2.0-main.757?activeTab=code)
- [rc package.json](https://github.com/bitwarden/clients/blob/d58b01d96be2abe51c47f69a7d919ab6f63decb8/package.json#L178) 

[PM-37729]: https://bitwarden.atlassian.net/browse/PM-37729?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ