### PR TITLE
[PM-37913] - add archived_date to CipherCreateRequest

### DIFF
--- a/crates/bitwarden-vault/src/cipher/cipher_client/admin/create.rs
+++ b/crates/bitwarden-vault/src/cipher/cipher_client/admin/create.rs
@@ -200,6 +200,7 @@ mod tests {
                 fido2_credentials: None,
             }),
             fields: vec![],
+            archived_date: None,
         });
 
         let response = create_cipher(

--- a/crates/bitwarden-vault/src/cipher/cipher_client/create.rs
+++ b/crates/bitwarden-vault/src/cipher/cipher_client/create.rs
@@ -1,5 +1,4 @@
 use bitwarden_api_api::models::{CipherCreateRequestModel, CipherRequestModel};
-use chrono::{DateTime, Utc};
 use bitwarden_collections::collection::CollectionId;
 use bitwarden_core::{
     ApiError, MissingFieldError, NotAuthenticatedError, OrganizationId, UserId,
@@ -8,6 +7,7 @@ use bitwarden_core::{
 use bitwarden_crypto::{CryptoError, IdentifyKey, KeyStore};
 use bitwarden_error::bitwarden_error;
 use bitwarden_state::repository::{Repository, RepositoryError};
+use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 #[cfg(feature = "wasm")]

--- a/crates/bitwarden-vault/src/cipher/cipher_client/create.rs
+++ b/crates/bitwarden-vault/src/cipher/cipher_client/create.rs
@@ -60,6 +60,7 @@ pub struct CipherCreateRequest {
     pub reprompt: CipherRepromptType,
     pub r#type: CipherViewType,
     pub fields: Vec<FieldView>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub archived_date: Option<DateTime<Utc>>,
 }
 

--- a/crates/bitwarden-vault/src/cipher/cipher_client/create.rs
+++ b/crates/bitwarden-vault/src/cipher/cipher_client/create.rs
@@ -440,35 +440,4 @@ mod tests {
         assert_eq!(response.id, Some(TEST_CIPHER_ID.parse().unwrap()));
         assert_eq!(response.organization_id, Some(TEST_ORG_ID.parse().unwrap()));
     }
-
-    #[test]
-    fn test_convert_request_preserves_archived_date() {
-        let archived = chrono::DateTime::parse_from_rfc3339("2024-06-01T00:00:00Z")
-            .unwrap()
-            .with_timezone(&Utc);
-
-        let request = CipherCreateRequest {
-            name: "Archived Cipher".into(),
-            notes: None,
-            organization_id: None,
-            collection_ids: vec![],
-            folder_id: None,
-            favorite: false,
-            reprompt: CipherRepromptType::None,
-            r#type: CipherViewType::Login(LoginView {
-                username: None,
-                password: None,
-                password_revision_date: None,
-                uris: None,
-                totp: None,
-                autofill_on_page_load: None,
-                fido2_credentials: None,
-            }),
-            fields: vec![],
-            archived_date: Some(archived),
-        };
-
-        let view = convert_request_to_cipher_view(request);
-        assert_eq!(view.archived_date, Some(archived));
-    }
 }

--- a/crates/bitwarden-vault/src/cipher/cipher_client/create.rs
+++ b/crates/bitwarden-vault/src/cipher/cipher_client/create.rs
@@ -440,4 +440,35 @@ mod tests {
         assert_eq!(response.id, Some(TEST_CIPHER_ID.parse().unwrap()));
         assert_eq!(response.organization_id, Some(TEST_ORG_ID.parse().unwrap()));
     }
+
+    #[test]
+    fn test_convert_request_preserves_archived_date() {
+        let archived = chrono::DateTime::parse_from_rfc3339("2024-06-01T00:00:00Z")
+            .unwrap()
+            .with_timezone(&Utc);
+
+        let request = CipherCreateRequest {
+            name: "Archived Cipher".into(),
+            notes: None,
+            organization_id: None,
+            collection_ids: vec![],
+            folder_id: None,
+            favorite: false,
+            reprompt: CipherRepromptType::None,
+            r#type: CipherViewType::Login(LoginView {
+                username: None,
+                password: None,
+                password_revision_date: None,
+                uris: None,
+                totp: None,
+                autofill_on_page_load: None,
+                fido2_credentials: None,
+            }),
+            fields: vec![],
+            archived_date: Some(archived),
+        };
+
+        let view = convert_request_to_cipher_view(request);
+        assert_eq!(view.archived_date, Some(archived));
+    }
 }

--- a/crates/bitwarden-vault/src/cipher/cipher_client/create.rs
+++ b/crates/bitwarden-vault/src/cipher/cipher_client/create.rs
@@ -1,4 +1,5 @@
 use bitwarden_api_api::models::{CipherCreateRequestModel, CipherRequestModel};
+use chrono::{DateTime, Utc};
 use bitwarden_collections::collection::CollectionId;
 use bitwarden_core::{
     ApiError, MissingFieldError, NotAuthenticatedError, OrganizationId, UserId,
@@ -59,6 +60,7 @@ pub struct CipherCreateRequest {
     pub reprompt: CipherRepromptType,
     pub r#type: CipherViewType,
     pub fields: Vec<FieldView>,
+    pub archived_date: Option<DateTime<Utc>>,
 }
 
 /// Internal helper to convert a [`CipherCreateRequest`] into a [`CipherView`]
@@ -102,7 +104,7 @@ pub(crate) fn convert_request_to_cipher_view(r: CipherCreateRequest) -> CipherVi
         creation_date: now,
         deleted_date: None,
         revision_date: now,
-        archived_date: None,
+        archived_date: r.archived_date,
     }
 }
 
@@ -224,6 +226,7 @@ mod tests {
             reprompt: Default::default(),
             fields: Default::default(),
             collection_ids: vec![],
+            archived_date: None,
         }
     }
 
@@ -411,6 +414,7 @@ mod tests {
                 fido2_credentials: None,
             }),
             fields: vec![],
+            archived_date: None,
         };
 
         let response = create_cipher(


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-37913

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
Adds the `archived_date` field to `CipherCreateRequest` so callers can set an archived date when cloning an archived cipher.

Previously, `convert_request_to_cipher_view` hardcoded `archived_date: None`, meaning it was impossible to create a cipher with an archived date set. The field is now passed through from the request.


## 🚨 Breaking Changes

<!-- Does this PR introduce any breaking changes? If so, please describe the impact and migration path for clients.

If you're unsure, the automated TypeScript compatibility check will run when you open/update this PR and provide feedback.

For breaking changes:
1. Describe what changed in the client interface
2. Explain why the change was necessary
3. Provide migration steps for client developers
4. Link to any paired client PRs if needed

Otherwise, you can remove this section. -->
