### PR TITLE
[PM-37933] refactor: Introduce OrganizationUserPolicyContext model

### DIFF
--- a/crates/bitwarden-policies/src/filter.rs
+++ b/crates/bitwarden-policies/src/filter.rs
@@ -57,15 +57,17 @@ pub trait PolicyFilter: Policy {
     /// This evaluates common business rules (e.g. the policy is enabled),
     /// as well as policy-specific rules according to its [`Policy`].
     ///
-    /// If a policy's organization is not present in `organizations`, the policy is enforced by
-    /// default.
+    /// If a policy's organization is not present in `organization_user_policy_contexts`, the policy
+    /// is enforced by default.
     fn filter<'a>(
         &self,
         policies: &'a [PolicyView],
-        organizations: &[PolicyOrganizationContext],
+        organization_user_policy_contexts: &[PolicyOrganizationContext],
     ) -> Vec<&'a PolicyView> {
-        let org_map: HashMap<&Uuid, &PolicyOrganizationContext> =
-            organizations.iter().map(|o| (&o.id, o)).collect();
+        let org_map: HashMap<&Uuid, &PolicyOrganizationContext> = organization_user_policy_contexts
+            .iter()
+            .map(|o| (&o.id, o))
+            .collect();
 
         policies
             .iter()

--- a/crates/bitwarden-policies/src/filter.rs
+++ b/crates/bitwarden-policies/src/filter.rs
@@ -11,7 +11,7 @@ use bitwarden_organizations::{OrganizationUserStatusType, OrganizationUserType};
 use uuid::Uuid;
 
 use crate::{
-    models::{PolicyOrganizationContext, PolicyView},
+    models::{OrganizationUserPolicyContext, PolicyView},
     policy_type::PolicyType,
 };
 
@@ -62,12 +62,13 @@ pub trait PolicyFilter: Policy {
     fn filter<'a>(
         &self,
         policies: &'a [PolicyView],
-        organization_user_policy_contexts: &[PolicyOrganizationContext],
+        organization_user_policy_contexts: &[OrganizationUserPolicyContext],
     ) -> Vec<&'a PolicyView> {
-        let org_map: HashMap<&Uuid, &PolicyOrganizationContext> = organization_user_policy_contexts
-            .iter()
-            .map(|o| (&o.id, o))
-            .collect();
+        let org_map: HashMap<&Uuid, &OrganizationUserPolicyContext> =
+            organization_user_policy_contexts
+                .iter()
+                .map(|o| (&o.id, o))
+                .collect();
 
         policies
             .iter()
@@ -111,8 +112,8 @@ mod tests {
         user_type: OrganizationUserType,
         status: OrganizationUserStatusType,
         provider: bool,
-    ) -> PolicyOrganizationContext {
-        PolicyOrganizationContext {
+    ) -> OrganizationUserPolicyContext {
+        OrganizationUserPolicyContext {
             id,
             role: user_type,
             status,
@@ -164,7 +165,7 @@ mod tests {
     #[test]
     fn disabled_organization_is_filtered_out() {
         let org_id = Uuid::new_v4();
-        let orgs = [PolicyOrganizationContext {
+        let orgs = [OrganizationUserPolicyContext {
             enabled: false,
             id: org_id,
             role: OrganizationUserType::User,
@@ -211,7 +212,7 @@ mod tests {
     #[test]
     fn use_policies_false_is_filtered_out() {
         let org_id = Uuid::new_v4();
-        let orgs = [PolicyOrganizationContext {
+        let orgs = [OrganizationUserPolicyContext {
             id: org_id,
             role: OrganizationUserType::User,
             status: OrganizationUserStatusType::Confirmed,

--- a/crates/bitwarden-policies/src/filter.rs
+++ b/crates/bitwarden-policies/src/filter.rs
@@ -7,31 +7,13 @@
 
 use std::collections::HashMap;
 
-use bitwarden_organizations::{
-    OrganizationUserStatusType, OrganizationUserType, ProfileOrganization,
-};
-use chrono::{DateTime, Utc};
-use serde::{Deserialize, Serialize};
-#[cfg(feature = "wasm")]
-use tsify::Tsify;
+use bitwarden_organizations::{OrganizationUserStatusType, OrganizationUserType};
 use uuid::Uuid;
 
-use crate::policy_type::PolicyType;
-
-/// An organization policy.
-#[allow(missing_docs)]
-#[derive(Serialize, Deserialize, Debug, Clone)]
-#[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
-#[cfg_attr(feature = "wasm", derive(Tsify), tsify(into_wasm_abi, from_wasm_abi))]
-pub struct PolicyView {
-    pub id: Uuid,
-    pub organization_id: Uuid,
-    pub r#type: PolicyType,
-    /// The policy's raw configuration data as a JSON string, if any.
-    pub data: Option<String>,
-    pub enabled: bool,
-    pub revision_date: Option<DateTime<Utc>>,
-}
+use crate::{
+    models::{PolicyOrganizationContext, PolicyView},
+    policy_type::PolicyType,
+};
 
 /// Defines the filtering behavior for a specific policy type.
 ///
@@ -80,9 +62,9 @@ pub trait PolicyFilter: Policy {
     fn filter<'a>(
         &self,
         policies: &'a [PolicyView],
-        organizations: &[ProfileOrganization],
+        organizations: &[PolicyOrganizationContext],
     ) -> Vec<&'a PolicyView> {
-        let org_map: HashMap<&Uuid, &ProfileOrganization> =
+        let org_map: HashMap<&Uuid, &PolicyOrganizationContext> =
             organizations.iter().map(|o| (&o.id, o)).collect();
 
         policies
@@ -95,7 +77,7 @@ pub trait PolicyFilter: Policy {
                         org.enabled
                             && org.use_policies
                             && self.applicable_statuses().contains(&org.status)
-                            && !self.exempt_roles().contains(&org.r#type)
+                            && !self.exempt_roles().contains(&org.role)
                             && !(org.is_provider_user && self.exempt_providers())
                     }
                     None => true, // Unknown org: enforce by default
@@ -127,14 +109,14 @@ mod tests {
         user_type: OrganizationUserType,
         status: OrganizationUserStatusType,
         provider: bool,
-    ) -> ProfileOrganization {
-        ProfileOrganization {
+    ) -> PolicyOrganizationContext {
+        PolicyOrganizationContext {
             id,
-            r#type: user_type,
+            role: user_type,
             status,
+            enabled: true,
             use_policies: true,
             is_provider_user: provider,
-            ..Default::default()
         }
     }
 
@@ -180,14 +162,13 @@ mod tests {
     #[test]
     fn disabled_organization_is_filtered_out() {
         let org_id = Uuid::new_v4();
-        let orgs = [ProfileOrganization {
+        let orgs = [PolicyOrganizationContext {
             enabled: false,
             id: org_id,
-            r#type: OrganizationUserType::User,
+            role: OrganizationUserType::User,
             status: OrganizationUserStatusType::Confirmed,
             use_policies: true,
             is_provider_user: false,
-            ..Default::default()
         }];
         let policies = [policy_view(org_id, PolicyType::MasterPassword, true)];
 
@@ -228,13 +209,13 @@ mod tests {
     #[test]
     fn use_policies_false_is_filtered_out() {
         let org_id = Uuid::new_v4();
-        let orgs = [ProfileOrganization {
+        let orgs = [PolicyOrganizationContext {
             id: org_id,
-            r#type: OrganizationUserType::User,
+            role: OrganizationUserType::User,
             status: OrganizationUserStatusType::Confirmed,
+            enabled: true,
             use_policies: false,
             is_provider_user: false,
-            ..Default::default()
         }];
         let policies = [policy_view(org_id, PolicyType::MasterPassword, true)];
 

--- a/crates/bitwarden-policies/src/lib.rs
+++ b/crates/bitwarden-policies/src/lib.rs
@@ -7,13 +7,15 @@ mod uniffi_support;
 
 pub mod filter;
 mod master_password_policy_response;
+mod models;
 mod policy_client;
 pub mod policy_overrides;
 mod policy_type;
 mod registry;
 
-pub use filter::{Policy, PolicyView};
+pub use filter::Policy;
 pub use master_password_policy_response::MasterPasswordPolicyResponse;
+pub use models::{PolicyOrganizationContext, PolicyView};
 pub use policy_client::{PoliciesClientExt, PolicyClient};
 pub use policy_overrides::*;
 pub use policy_type::PolicyType;

--- a/crates/bitwarden-policies/src/lib.rs
+++ b/crates/bitwarden-policies/src/lib.rs
@@ -15,7 +15,7 @@ mod registry;
 
 pub use filter::Policy;
 pub use master_password_policy_response::MasterPasswordPolicyResponse;
-pub use models::{PolicyOrganizationContext, PolicyView};
+pub use models::{OrganizationUserPolicyContext, PolicyView};
 pub use policy_client::{PoliciesClientExt, PolicyClient};
 pub use policy_overrides::*;
 pub use policy_type::PolicyType;

--- a/crates/bitwarden-policies/src/models.rs
+++ b/crates/bitwarden-policies/src/models.rs
@@ -1,0 +1,43 @@
+//! Data models for the policy domain.
+//!
+//! These are the inputs to the policy filtering API and are exposed across the
+//! FFI boundary.
+
+use bitwarden_organizations::{OrganizationUserStatusType, OrganizationUserType};
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+#[cfg(feature = "wasm")]
+use tsify::Tsify;
+use uuid::Uuid;
+
+use crate::policy_type::PolicyType;
+
+/// An organization policy.
+#[allow(missing_docs)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
+#[cfg_attr(feature = "wasm", derive(Tsify), tsify(into_wasm_abi, from_wasm_abi))]
+pub struct PolicyView {
+    pub id: Uuid,
+    pub organization_id: Uuid,
+    pub r#type: PolicyType,
+    /// The policy's raw configuration data as a JSON string, if any.
+    pub data: Option<String>,
+    pub enabled: bool,
+    pub revision_date: Option<DateTime<Utc>>,
+}
+
+/// Minimal organization data needed to evaluate organization policies for a
+/// user.
+#[allow(missing_docs)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
+#[cfg_attr(feature = "wasm", derive(Tsify), tsify(into_wasm_abi, from_wasm_abi))]
+pub struct PolicyOrganizationContext {
+    pub id: Uuid,
+    pub status: OrganizationUserStatusType,
+    pub role: OrganizationUserType,
+    pub enabled: bool,
+    pub use_policies: bool,
+    pub is_provider_user: bool,
+}

--- a/crates/bitwarden-policies/src/models.rs
+++ b/crates/bitwarden-policies/src/models.rs
@@ -15,6 +15,7 @@ use crate::policy_type::PolicyType;
 /// An organization policy.
 #[allow(missing_docs)]
 #[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
 #[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
 #[cfg_attr(feature = "wasm", derive(Tsify), tsify(into_wasm_abi, from_wasm_abi))]
 pub struct PolicyView {
@@ -31,6 +32,7 @@ pub struct PolicyView {
 /// user.
 #[allow(missing_docs)]
 #[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
 #[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
 #[cfg_attr(feature = "wasm", derive(Tsify), tsify(into_wasm_abi, from_wasm_abi))]
 pub struct PolicyOrganizationContext {

--- a/crates/bitwarden-policies/src/models.rs
+++ b/crates/bitwarden-policies/src/models.rs
@@ -39,7 +39,7 @@ pub struct PolicyView {
 #[serde(rename_all = "camelCase")]
 #[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
 #[cfg_attr(feature = "wasm", derive(Tsify), tsify(into_wasm_abi, from_wasm_abi))]
-pub struct PolicyOrganizationContext {
+pub struct OrganizationUserPolicyContext {
     /// The organization's unique ID.
     pub id: Uuid,
     /// The user's membership status in the organization.

--- a/crates/bitwarden-policies/src/models.rs
+++ b/crates/bitwarden-policies/src/models.rs
@@ -13,33 +13,44 @@ use uuid::Uuid;
 use crate::policy_type::PolicyType;
 
 /// An organization policy.
-#[allow(missing_docs)]
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
 #[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
 #[cfg_attr(feature = "wasm", derive(Tsify), tsify(into_wasm_abi, from_wasm_abi))]
 pub struct PolicyView {
+    /// The policy's unique ID.
     pub id: Uuid,
+    /// The organization this policy belongs to.
     pub organization_id: Uuid,
+    /// The type of policy.
     pub r#type: PolicyType,
-    /// The policy's raw configuration data as a JSON string, if any.
+    /// The policy's additional configuration data as a JSON string, if any.
     pub data: Option<String>,
+    /// Whether the policy is enabled.
     pub enabled: bool,
+    /// When the policy was last modified.
     pub revision_date: Option<DateTime<Utc>>,
 }
 
-/// Minimal organization data needed to evaluate organization policies for a
-/// user.
-#[allow(missing_docs)]
+/// A minimal set of data for a user in an organization. This provides
+/// the context needed to evaluate the policies that are applied to the
+/// user by the organization.
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
 #[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
 #[cfg_attr(feature = "wasm", derive(Tsify), tsify(into_wasm_abi, from_wasm_abi))]
 pub struct PolicyOrganizationContext {
+    /// The organization's unique ID.
     pub id: Uuid,
+    /// The user's membership status in the organization.
     pub status: OrganizationUserStatusType,
+    /// The user's role within the organization.
     pub role: OrganizationUserType,
+    /// Whether the organization is enabled.
     pub enabled: bool,
+    /// Whether the organization's plan supports policies.
     pub use_policies: bool,
+    /// Whether the user is acting on behalf of a provider
+    /// that manages the organization.
     pub is_provider_user: bool,
 }

--- a/crates/bitwarden-policies/src/policy_client.rs
+++ b/crates/bitwarden-policies/src/policy_client.rs
@@ -53,11 +53,11 @@ impl PolicyClient {
     pub fn filter_by_type(
         &self,
         policies: Vec<PolicyView>,
-        organizations: Vec<PolicyOrganizationContext>,
+        organization_user_policy_contexts: Vec<PolicyOrganizationContext>,
         policy_type: PolicyType,
     ) -> Vec<PolicyView> {
         self.registry
-            .filter_by_type(&policies, &organizations, policy_type)
+            .filter_by_type(&policies, &organization_user_policy_contexts, policy_type)
             .into_iter()
             .cloned()
             .collect()

--- a/crates/bitwarden-policies/src/policy_client.rs
+++ b/crates/bitwarden-policies/src/policy_client.rs
@@ -1,11 +1,13 @@
 //! [`PolicyClient`] and its associated extension trait.
 
 use bitwarden_core::Client;
-use bitwarden_organizations::ProfileOrganization;
 #[cfg(feature = "wasm")]
 use wasm_bindgen::prelude::wasm_bindgen;
 
-use crate::{PolicyType, filter::PolicyView, policy_overrides::*, registry::PolicyRegistry};
+use crate::{
+    PolicyOrganizationContext, PolicyType, PolicyView, policy_overrides::*,
+    registry::PolicyRegistry,
+};
 
 fn build_policy_registry() -> PolicyRegistry {
     PolicyRegistry::builder()
@@ -51,7 +53,7 @@ impl PolicyClient {
     pub fn filter_by_type(
         &self,
         policies: Vec<PolicyView>,
-        organizations: Vec<ProfileOrganization>,
+        organizations: Vec<PolicyOrganizationContext>,
         policy_type: PolicyType,
     ) -> Vec<PolicyView> {
         self.registry
@@ -93,14 +95,14 @@ mod tests {
         }
     }
 
-    fn organization(id: Uuid) -> ProfileOrganization {
-        ProfileOrganization {
+    fn organization(id: Uuid) -> PolicyOrganizationContext {
+        PolicyOrganizationContext {
             id,
-            r#type: OrganizationUserType::User,
+            role: OrganizationUserType::User,
             status: OrganizationUserStatusType::Confirmed,
+            enabled: true,
             use_policies: true,
             is_provider_user: false,
-            ..Default::default()
         }
     }
 
@@ -147,13 +149,13 @@ mod tests {
         let org_id = Uuid::new_v4();
         // Owner — normally exempt, but NoExemptionPolicy removes the exemption
         let policies = vec![policy_view(org_id, PolicyType::MasterPassword, true)];
-        let orgs = vec![ProfileOrganization {
+        let orgs = vec![PolicyOrganizationContext {
             id: org_id,
-            r#type: OrganizationUserType::Owner,
+            role: OrganizationUserType::Owner,
             status: OrganizationUserStatusType::Confirmed,
+            enabled: true,
             use_policies: true,
             is_provider_user: false,
-            ..Default::default()
         }];
 
         let registry = PolicyRegistry::builder()

--- a/crates/bitwarden-policies/src/policy_client.rs
+++ b/crates/bitwarden-policies/src/policy_client.rs
@@ -5,7 +5,7 @@ use bitwarden_core::Client;
 use wasm_bindgen::prelude::wasm_bindgen;
 
 use crate::{
-    PolicyOrganizationContext, PolicyType, PolicyView, policy_overrides::*,
+    OrganizationUserPolicyContext, PolicyType, PolicyView, policy_overrides::*,
     registry::PolicyRegistry,
 };
 
@@ -53,7 +53,7 @@ impl PolicyClient {
     pub fn filter_by_type(
         &self,
         policies: Vec<PolicyView>,
-        organization_user_policy_contexts: Vec<PolicyOrganizationContext>,
+        organization_user_policy_contexts: Vec<OrganizationUserPolicyContext>,
         policy_type: PolicyType,
     ) -> Vec<PolicyView> {
         self.registry
@@ -95,8 +95,8 @@ mod tests {
         }
     }
 
-    fn organization(id: Uuid) -> PolicyOrganizationContext {
-        PolicyOrganizationContext {
+    fn organization(id: Uuid) -> OrganizationUserPolicyContext {
+        OrganizationUserPolicyContext {
             id,
             role: OrganizationUserType::User,
             status: OrganizationUserStatusType::Confirmed,
@@ -149,7 +149,7 @@ mod tests {
         let org_id = Uuid::new_v4();
         // Owner — normally exempt, but NoExemptionPolicy removes the exemption
         let policies = vec![policy_view(org_id, PolicyType::MasterPassword, true)];
-        let orgs = vec![PolicyOrganizationContext {
+        let orgs = vec![OrganizationUserPolicyContext {
             id: org_id,
             role: OrganizationUserType::Owner,
             status: OrganizationUserStatusType::Confirmed,

--- a/crates/bitwarden-policies/src/policy_overrides.rs
+++ b/crates/bitwarden-policies/src/policy_overrides.rs
@@ -56,7 +56,7 @@ pub struct FreeFamiliesSponsorshipPolicy;
 
 impl Policy for FreeFamiliesSponsorshipPolicy {
     fn policy_type(&self) -> PolicyType {
-        PolicyType::FreeFamiliesSponsorshipPolicy
+        PolicyType::FreeFamiliesSponsorship
     }
 
     fn exempt_roles(&self) -> &[OrganizationUserType] {
@@ -210,10 +210,7 @@ mod tests {
     #[test]
     fn free_families_applies_to_owner() {
         let org_id = Uuid::new_v4();
-        let policies = [policy_view(
-            org_id,
-            PolicyType::FreeFamiliesSponsorshipPolicy,
-        )];
+        let policies = [policy_view(org_id, PolicyType::FreeFamiliesSponsorship)];
         let orgs = [org(org_id, OrganizationUserType::Owner)];
         assert_eq!(
             FreeFamiliesSponsorshipPolicy.filter(&policies, &orgs).len(),

--- a/crates/bitwarden-policies/src/policy_overrides.rs
+++ b/crates/bitwarden-policies/src/policy_overrides.rs
@@ -115,7 +115,7 @@ mod tests {
     use uuid::Uuid;
 
     use super::*;
-    use crate::{PolicyOrganizationContext, PolicyView, filter::PolicyFilter};
+    use crate::{OrganizationUserPolicyContext, PolicyView, filter::PolicyFilter};
 
     fn policy_view(organization_id: Uuid, policy_type: PolicyType) -> PolicyView {
         PolicyView {
@@ -128,8 +128,8 @@ mod tests {
         }
     }
 
-    fn org(id: Uuid, user_type: OrganizationUserType) -> PolicyOrganizationContext {
-        PolicyOrganizationContext {
+    fn org(id: Uuid, user_type: OrganizationUserType) -> OrganizationUserPolicyContext {
+        OrganizationUserPolicyContext {
             id,
             role: user_type,
             status: OrganizationUserStatusType::Confirmed,

--- a/crates/bitwarden-policies/src/policy_overrides.rs
+++ b/crates/bitwarden-policies/src/policy_overrides.rs
@@ -86,7 +86,7 @@ pub struct RestrictedItemTypesPolicy;
 
 impl Policy for RestrictedItemTypesPolicy {
     fn policy_type(&self) -> PolicyType {
-        PolicyType::RestrictedItemTypesPolicy
+        PolicyType::RestrictedItemTypes
     }
 
     fn exempt_roles(&self) -> &[OrganizationUserType] {
@@ -111,13 +111,11 @@ impl Policy for AutomaticUserConfirmationPolicy {
 
 #[cfg(test)]
 mod tests {
-    use bitwarden_organizations::{
-        OrganizationUserStatusType, OrganizationUserType, ProfileOrganization,
-    };
+    use bitwarden_organizations::{OrganizationUserStatusType, OrganizationUserType};
     use uuid::Uuid;
 
     use super::*;
-    use crate::filter::{PolicyFilter, PolicyView};
+    use crate::{PolicyOrganizationContext, PolicyView, filter::PolicyFilter};
 
     fn policy_view(organization_id: Uuid, policy_type: PolicyType) -> PolicyView {
         PolicyView {
@@ -130,14 +128,14 @@ mod tests {
         }
     }
 
-    fn org(id: Uuid, user_type: OrganizationUserType) -> ProfileOrganization {
-        ProfileOrganization {
+    fn org(id: Uuid, user_type: OrganizationUserType) -> PolicyOrganizationContext {
+        PolicyOrganizationContext {
             id,
-            r#type: user_type,
+            role: user_type,
             status: OrganizationUserStatusType::Confirmed,
+            enabled: true,
             use_policies: true,
             is_provider_user: false,
-            ..Default::default()
         }
     }
 
@@ -238,7 +236,7 @@ mod tests {
     #[test]
     fn restricted_item_types_applies_to_owner() {
         let org_id = Uuid::new_v4();
-        let policies = [policy_view(org_id, PolicyType::RestrictedItemTypesPolicy)];
+        let policies = [policy_view(org_id, PolicyType::RestrictedItemTypes)];
         let orgs = [org(org_id, OrganizationUserType::Owner)];
         assert_eq!(RestrictedItemTypesPolicy.filter(&policies, &orgs).len(), 1);
     }

--- a/crates/bitwarden-policies/src/policy_type.rs
+++ b/crates/bitwarden-policies/src/policy_type.rs
@@ -50,7 +50,7 @@ pub enum PolicyType {
     /// Prevents members from unlocking the app with a PIN.
     RemoveUnlockWithPin = 14,
     /// Restricts the item types that members can create.
-    RestrictedItemTypesPolicy = 15,
+    RestrictedItemTypes = 15,
     /// Sets the default URI match detection strategy for autofill.
     UriMatchDefaults = 16,
     /// Sets the default behavior for the autotype feature.

--- a/crates/bitwarden-policies/src/policy_type.rs
+++ b/crates/bitwarden-policies/src/policy_type.rs
@@ -46,7 +46,7 @@ pub enum PolicyType {
     /// Automatically logs members into apps using single sign-on.
     AutomaticAppLogIn = 12,
     /// Removes members' access to the free Bitwarden Families sponsorship benefit.
-    FreeFamiliesSponsorshipPolicy = 13,
+    FreeFamiliesSponsorship = 13,
     /// Prevents members from unlocking the app with a PIN.
     RemoveUnlockWithPin = 14,
     /// Restricts the item types that members can create.

--- a/crates/bitwarden-policies/src/registry.rs
+++ b/crates/bitwarden-policies/src/registry.rs
@@ -48,12 +48,12 @@ impl PolicyRegistry {
     pub(crate) fn filter_by_type<'a>(
         &self,
         policies: &'a [PolicyView],
-        organizations: &[PolicyOrganizationContext],
+        organization_user_policy_contexts: &[PolicyOrganizationContext],
         policy_type: PolicyType,
     ) -> Vec<&'a PolicyView> {
         match self.policies.get(&policy_type) {
-            Some(p) => p.filter(policies, organizations),
-            None => DefaultPolicy(policy_type).filter(policies, organizations),
+            Some(p) => p.filter(policies, organization_user_policy_contexts),
+            None => DefaultPolicy(policy_type).filter(policies, organization_user_policy_contexts),
         }
     }
 }

--- a/crates/bitwarden-policies/src/registry.rs
+++ b/crates/bitwarden-policies/src/registry.rs
@@ -8,11 +8,9 @@
 
 use std::collections::HashMap;
 
-use bitwarden_organizations::ProfileOrganization;
-
 use crate::{
-    PolicyType,
-    filter::{Policy, PolicyFilter, PolicyView},
+    PolicyOrganizationContext, PolicyType, PolicyView,
+    filter::{Policy, PolicyFilter},
 };
 
 /// A [`Policy`] that uses the default filtering behavior for any policy type.
@@ -50,7 +48,7 @@ impl PolicyRegistry {
     pub(crate) fn filter_by_type<'a>(
         &self,
         policies: &'a [PolicyView],
-        organizations: &[ProfileOrganization],
+        organizations: &[PolicyOrganizationContext],
         policy_type: PolicyType,
     ) -> Vec<&'a PolicyView> {
         match self.policies.get(&policy_type) {
@@ -111,14 +109,14 @@ mod tests {
         user_type: OrganizationUserType,
         status: OrganizationUserStatusType,
         provider: bool,
-    ) -> ProfileOrganization {
-        ProfileOrganization {
+    ) -> PolicyOrganizationContext {
+        PolicyOrganizationContext {
             id,
-            r#type: user_type,
+            role: user_type,
             status,
+            enabled: true,
             use_policies: true,
             is_provider_user: provider,
-            ..Default::default()
         }
     }
 

--- a/crates/bitwarden-policies/src/registry.rs
+++ b/crates/bitwarden-policies/src/registry.rs
@@ -9,7 +9,7 @@
 use std::collections::HashMap;
 
 use crate::{
-    PolicyOrganizationContext, PolicyType, PolicyView,
+    OrganizationUserPolicyContext, PolicyType, PolicyView,
     filter::{Policy, PolicyFilter},
 };
 
@@ -48,7 +48,7 @@ impl PolicyRegistry {
     pub(crate) fn filter_by_type<'a>(
         &self,
         policies: &'a [PolicyView],
-        organization_user_policy_contexts: &[PolicyOrganizationContext],
+        organization_user_policy_contexts: &[OrganizationUserPolicyContext],
         policy_type: PolicyType,
     ) -> Vec<&'a PolicyView> {
         match self.policies.get(&policy_type) {
@@ -109,8 +109,8 @@ mod tests {
         user_type: OrganizationUserType,
         status: OrganizationUserStatusType,
         provider: bool,
-    ) -> PolicyOrganizationContext {
-        PolicyOrganizationContext {
+    ) -> OrganizationUserPolicyContext {
+        OrganizationUserPolicyContext {
             id,
             role: user_type,
             status,

--- a/crates/bitwarden-uniffi/src/policies.rs
+++ b/crates/bitwarden-uniffi/src/policies.rs
@@ -1,4 +1,4 @@
-use bitwarden_policies::{PolicyClient, PolicyOrganizationContext, PolicyType, PolicyView};
+use bitwarden_policies::{OrganizationUserPolicyContext, PolicyClient, PolicyType, PolicyView};
 
 /// Client for policy domain operations.
 #[derive(uniffi::Object)]
@@ -13,7 +13,7 @@ impl PoliciesClient {
     pub fn filter_by_type(
         &self,
         policies: Vec<PolicyView>,
-        organization_user_policy_contexts: Vec<PolicyOrganizationContext>,
+        organization_user_policy_contexts: Vec<OrganizationUserPolicyContext>,
         policy_type: PolicyType,
     ) -> Vec<PolicyView> {
         self.0

--- a/crates/bitwarden-uniffi/src/policies.rs
+++ b/crates/bitwarden-uniffi/src/policies.rs
@@ -1,5 +1,4 @@
-use bitwarden_organizations::ProfileOrganization;
-use bitwarden_policies::{PolicyClient, PolicyType, PolicyView};
+use bitwarden_policies::{PolicyClient, PolicyOrganizationContext, PolicyType, PolicyView};
 
 /// Client for policy domain operations.
 #[derive(uniffi::Object)]
@@ -14,7 +13,7 @@ impl PoliciesClient {
     pub fn filter_by_type(
         &self,
         policies: Vec<PolicyView>,
-        organizations: Vec<ProfileOrganization>,
+        organizations: Vec<PolicyOrganizationContext>,
         policy_type: PolicyType,
     ) -> Vec<PolicyView> {
         self.0.filter_by_type(policies, organizations, policy_type)

--- a/crates/bitwarden-uniffi/src/policies.rs
+++ b/crates/bitwarden-uniffi/src/policies.rs
@@ -13,9 +13,10 @@ impl PoliciesClient {
     pub fn filter_by_type(
         &self,
         policies: Vec<PolicyView>,
-        organizations: Vec<PolicyOrganizationContext>,
+        organization_user_policy_contexts: Vec<PolicyOrganizationContext>,
         policy_type: PolicyType,
     ) -> Vec<PolicyView> {
-        self.0.filter_by_type(policies, organizations, policy_type)
+        self.0
+            .filter_by_type(policies, organization_user_policy_contexts, policy_type)
     }
 }


### PR DESCRIPTION
## 🎟️ Tracking

[PM-37933](https://bitwarden.atlassian.net/browse/PM-37933)

## 📔 Objective

The policies crate requires the full `ProfileOrganization` sync response model to be passed in for policy evaluation. However, that model is different between mobile and TS clients - the mobile sync model is much smaller because they need fewer admin-related properties. This tight coupling would require mobile to expand their organization model just to meet the interface, even though the logic doesn't actually need all these properties.

The fix is to introduce a domain-specific `PolicyOrganizationContext` in `bitwarden-policies` and switch the filtering APIs and FFI wrapper to use it instead of the 61-field `ProfileOrganization`. The policy domain only needs 6 fields; this gives consumers a small, purpose-built input type to construct at the FFI boundary. This decoupling generally seems like better design for a library crate.

## 🚨 Breaking Changes

The FFI signature of `filter_by_type` now takes `PolicyOrganizationContext` instead of `ProfileOrganization`. **No client is consuming this API yet**, so there is no migration impact in practice.

[PM-37933]: https://bitwarden.atlassian.net/browse/PM-37933?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ