### PR TITLE
Add bitwarden-logging-macro with safer instrument wrapper

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -868,14 +868,25 @@ dependencies = [
 name = "bitwarden-logging"
 version = "3.0.0"
 dependencies = [
+ "bitwarden-logging-macro",
  "chrono",
  "criterion",
  "serde",
  "serde_json",
  "tracing",
  "tracing-subscriber",
+ "trybuild",
  "tsify",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "bitwarden-logging-macro"
+version = "3.0.0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,7 @@ bitwarden-fido = { path = "crates/bitwarden-fido", version = "=3.0.0" }
 bitwarden-generators = { path = "crates/bitwarden-generators", version = "=3.0.0" }
 bitwarden-ipc = { path = "crates/bitwarden-ipc", version = "=3.0.0" }
 bitwarden-logging = { path = "crates/bitwarden-logging", version = "=3.0.0" }
+bitwarden-logging-macro = { path = "crates/bitwarden-logging-macro", version = "=3.0.0" }
 bitwarden-organization-crypto = { path = "crates/bitwarden-organization-crypto", version = "=3.0.0" }
 bitwarden-organizations = { path = "crates/bitwarden-organizations", version = "=3.0.0" }
 bitwarden-pm = { path = "crates/bitwarden-pm", version = "=3.0.0" }

--- a/crates/bitwarden-logging-macro/Cargo.toml
+++ b/crates/bitwarden-logging-macro/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "bitwarden-logging-macro"
+description = """
+Internal crate for the bitwarden crate. Do not use.
+"""
+
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+readme.workspace = true
+homepage.workspace = true
+repository.workspace = true
+license-file.workspace = true
+keywords.workspace = true
+
+[lib]
+proc-macro = true
+
+[dependencies]
+proc-macro2 = { workspace = true }
+quote = { workspace = true }
+syn = { workspace = true, features = ["full"] }
+
+[lints]
+workspace = true

--- a/crates/bitwarden-logging-macro/README.md
+++ b/crates/bitwarden-logging-macro/README.md
@@ -6,8 +6,8 @@ By default, `tracing::instrument` records every function argument that implement
 `Debug` as a span field. In a vault-handling SDK this is a foot-gun: forgetting `skip_all` on a
 function like `derive_master_key(password, email, ...)` would log the user's password.
 
-The `#[bitwarden_logging::instrument]` attribute re-emits as `#[tracing::instrument(skip_all, ...)]`,
-making field logging opt-in via `fields(...)`.
+The `#[bitwarden_logging::instrument]` attribute re-emits as
+`#[tracing::instrument(skip_all, ...)]`, making field logging opt-in via `fields(...)`.
 
 ```rust,ignore
 use bitwarden_logging::instrument;
@@ -21,23 +21,23 @@ fn sensitive(password: &str) { /* ... */ }
 fn less_sensitive(id: Uuid, password: &str) { /* ... */ }
 ```
 
-User-supplied `skip(...)` and `skip_all` are rejected at compile time, since `skip_all` is
-already enforced and `fields(...)` is the way to opt in.
+User-supplied `skip(...)` and `skip_all` are rejected at compile time, since `skip_all` is already
+enforced and `fields(...)` is the way to opt in.
 
 ## Lint backstop
 
-A companion dylint rule (`tracing_instrument`) catches any use of `tracing::instrument` that
-slips past the convention. It identifies the macro by its definition in the `tracing_attributes`
-crate, so all of these are caught:
+A companion dylint rule (`tracing_instrument`) catches any use of `tracing::instrument` that slips
+past the convention. It identifies the macro by its definition in the `tracing_attributes` crate, so
+all of these are caught:
 
 - `#[tracing::instrument]`
 - `use tracing::instrument; #[instrument]`
 - `use tracing::instrument as foo; #[foo]`
 
 The wrapper opts out of the lint at its own emission site by including
-`#[allow(unknown_lints, tracing_instrument)]` next to the `#[tracing::instrument]` it
-generates, so the lint can stay general.
+`#[allow(unknown_lints, tracing_instrument)]` next to the `#[tracing::instrument]` it generates, so
+the lint can stay general.
 
-The lint currently defaults to `allow` so existing workspace call sites have time to migrate.
-Crates that have been swept can opt in with `#![warn(tracing_instrument)]` (or `deny`) at the
-crate root. The default will flip to `warn` once the workspace is clean.
+The lint currently defaults to `allow` so existing workspace call sites have time to migrate. Crates
+that have been swept can opt in with `#![warn(tracing_instrument)]` (or `deny`) at the crate root.
+The default will flip to `warn` once the workspace is clean.

--- a/crates/bitwarden-logging-macro/README.md
+++ b/crates/bitwarden-logging-macro/README.md
@@ -34,8 +34,9 @@ crate, so all of these are caught:
 - `use tracing::instrument; #[instrument]`
 - `use tracing::instrument as foo; #[foo]`
 
-Expansions emitted by `bitwarden_logging::instrument` itself (which internally re-emits
-`tracing::instrument`) are filtered out.
+The wrapper opts out of the lint at its own emission site by including
+`#[allow(unknown_lints, tracing_instrument)]` next to the `#[tracing::instrument]` it
+generates, so the lint can stay general.
 
 The lint currently defaults to `allow` so existing workspace call sites have time to migrate.
 Crates that have been swept can opt in with `#![warn(tracing_instrument)]` (or `deny`) at the

--- a/crates/bitwarden-logging-macro/README.md
+++ b/crates/bitwarden-logging-macro/README.md
@@ -10,26 +10,33 @@ The `#[bitwarden_logging::instrument]` attribute re-emits as `#[tracing::instrum
 making field logging opt-in via `fields(...)`.
 
 ```rust,ignore
+use bitwarden_logging::instrument;
+
 // All args skipped by default.
-#[bitwarden_logging::instrument]
+#[instrument]
 fn sensitive(password: &str) { /* ... */ }
 
 // Explicit opt-in.
-#[bitwarden_logging::instrument(fields(user_id = ?id))]
+#[instrument(fields(user_id = ?id))]
 fn less_sensitive(id: Uuid, password: &str) { /* ... */ }
 ```
 
-## Convention: always fully qualify
+User-supplied `skip(...)` and `skip_all` are rejected at compile time, since `skip_all` is
+already enforced and `fields(...)` is the way to opt in.
 
-Always write `#[bitwarden_logging::instrument]` in full. Do **not** write `use
-bitwarden_logging::instrument;` followed by a bare `#[instrument]`, because that form is
-indistinguishable from `use tracing::instrument;` at the call site — which is exactly the
-foot-gun this crate exists to eliminate. The `tracing_instrument` dylint enforces this by
-warning on both `#[tracing::instrument]` and bare `#[instrument]`.
+## Lint backstop
+
+A companion dylint rule (`tracing_instrument`) catches any use of `tracing::instrument` that
+slips past the convention. It identifies the macro by its definition in the `tracing_attributes`
+crate, so all of these are caught:
+
+- `#[tracing::instrument]`
+- `use tracing::instrument; #[instrument]`
+- `use tracing::instrument as foo; #[foo]`
+
+Expansions emitted by `bitwarden_logging::instrument` itself (which internally re-emits
+`tracing::instrument`) are filtered out.
 
 The lint currently defaults to `allow` so existing workspace call sites have time to migrate.
 Crates that have been swept can opt in with `#![warn(tracing_instrument)]` (or `deny`) at the
 crate root. The default will flip to `warn` once the workspace is clean.
-
-User-supplied `skip(...)` and `skip_all` are rejected at compile time, since `skip_all` is
-already enforced and `fields(...)` is the way to opt in.

--- a/crates/bitwarden-logging-macro/README.md
+++ b/crates/bitwarden-logging-macro/README.md
@@ -27,5 +27,9 @@ indistinguishable from `use tracing::instrument;` at the call site — which is 
 foot-gun this crate exists to eliminate. The `tracing_instrument` dylint enforces this by
 warning on both `#[tracing::instrument]` and bare `#[instrument]`.
 
+The lint currently defaults to `allow` so existing workspace call sites have time to migrate.
+Crates that have been swept can opt in with `#![warn(tracing_instrument)]` (or `deny`) at the
+crate root. The default will flip to `warn` once the workspace is clean.
+
 User-supplied `skip(...)` and `skip_all` are rejected at compile time, since `skip_all` is
 already enforced and `fields(...)` is the way to opt in.

--- a/crates/bitwarden-logging-macro/README.md
+++ b/crates/bitwarden-logging-macro/README.md
@@ -1,0 +1,31 @@
+# Bitwarden Logging Macro
+
+Provides a safer wrapper around [`tracing::instrument`] that enforces `skip_all` by default.
+
+By default, `tracing::instrument` records every function argument that implements `Display` or
+`Debug` as a span field. In a vault-handling SDK this is a foot-gun: forgetting `skip_all` on a
+function like `derive_master_key(password, email, ...)` would log the user's password.
+
+The `#[bitwarden_logging::instrument]` attribute re-emits as `#[tracing::instrument(skip_all, ...)]`,
+making field logging opt-in via `fields(...)`.
+
+```rust,ignore
+// All args skipped by default.
+#[bitwarden_logging::instrument]
+fn sensitive(password: &str) { /* ... */ }
+
+// Explicit opt-in.
+#[bitwarden_logging::instrument(fields(user_id = ?id))]
+fn less_sensitive(id: Uuid, password: &str) { /* ... */ }
+```
+
+## Convention: always fully qualify
+
+Always write `#[bitwarden_logging::instrument]` in full. Do **not** write `use
+bitwarden_logging::instrument;` followed by a bare `#[instrument]`, because that form is
+indistinguishable from `use tracing::instrument;` at the call site — which is exactly the
+foot-gun this crate exists to eliminate. The `tracing_instrument` dylint enforces this by
+warning on both `#[tracing::instrument]` and bare `#[instrument]`.
+
+User-supplied `skip(...)` and `skip_all` are rejected at compile time, since `skip_all` is
+already enforced and `fields(...)` is the way to opt in.

--- a/crates/bitwarden-logging-macro/src/lib.rs
+++ b/crates/bitwarden-logging-macro/src/lib.rs
@@ -49,6 +49,10 @@ pub fn instrument(attr: TokenStream, item: TokenStream) -> TokenStream {
 
     let args_iter = args.iter();
     quote! {
+        // Silence the `tracing_instrument` dylint on the wrapper's own emission.
+        // `unknown_lints` is paired with it so plain `cargo check` (which doesn't load
+        // dylint) doesn't warn that `tracing_instrument` is an unknown lint name.
+        #[allow(unknown_lints, tracing_instrument)]
         #[::tracing::instrument(skip_all #(, #args_iter)*)]
         #item2
     }

--- a/crates/bitwarden-logging-macro/src/lib.rs
+++ b/crates/bitwarden-logging-macro/src/lib.rs
@@ -1,4 +1,4 @@
-//! Proc-macro wrapper around [`tracing::instrument`] that enforces `skip_all` by default.
+//! Proc-macro wrapper around `tracing::instrument` that enforces `skip_all` by default.
 //!
 //! Use via the [`bitwarden_logging::instrument`](../bitwarden_logging/attr.instrument.html)
 //! re-export rather than depending on this crate directly.

--- a/crates/bitwarden-logging-macro/src/lib.rs
+++ b/crates/bitwarden-logging-macro/src/lib.rs
@@ -1,0 +1,56 @@
+//! Proc-macro wrapper around [`tracing::instrument`] that enforces `skip_all` by default.
+//!
+//! Use via the [`bitwarden_logging::instrument`](../bitwarden_logging/attr.instrument.html)
+//! re-export rather than depending on this crate directly.
+
+use proc_macro::TokenStream;
+use proc_macro2::TokenStream as TokenStream2;
+use quote::quote;
+use syn::{Meta, Token, parse::Parser, punctuated::Punctuated};
+
+const REJECT_MSG: &str = "`#[bitwarden_logging::instrument]` enforces `skip_all` by default. \
+    Use `fields(name = expr)` to opt in to logging specific arguments.";
+
+/// Drop-in replacement for `#[tracing::instrument]` that defaults to `skip_all`, making
+/// field logging opt-in.
+///
+/// Pass `fields(name = expr)` to record specific values. All other `tracing::instrument`
+/// options (`name`, `level`, `target`, `ret`, `err`, `parent`, `follows_from`) flow through
+/// unchanged.
+///
+/// User-supplied `skip(...)` or `skip_all` are rejected at compile time: `skip_all` is
+/// already enforced and `fields(...)` is the way to opt back in.
+#[proc_macro_attribute]
+pub fn instrument(attr: TokenStream, item: TokenStream) -> TokenStream {
+    let item2: TokenStream2 = item.into();
+
+    let parser = Punctuated::<Meta, Token![,]>::parse_terminated;
+    let args = match parser.parse(attr) {
+        Ok(args) => args,
+        Err(e) => {
+            let err = e.to_compile_error();
+            return quote! { #err #item2 }.into();
+        }
+    };
+
+    let mut errors = TokenStream2::new();
+    for meta in &args {
+        let Some(last) = meta.path().segments.last() else {
+            continue;
+        };
+        if last.ident == "skip" || last.ident == "skip_all" {
+            errors.extend(syn::Error::new_spanned(meta, REJECT_MSG).to_compile_error());
+        }
+    }
+
+    if !errors.is_empty() {
+        return quote! { #errors #item2 }.into();
+    }
+
+    let args_iter = args.iter();
+    quote! {
+        #[::tracing::instrument(skip_all #(, #args_iter)*)]
+        #item2
+    }
+    .into()
+}

--- a/crates/bitwarden-logging/Cargo.toml
+++ b/crates/bitwarden-logging/Cargo.toml
@@ -19,6 +19,7 @@ keywords.workspace = true
 wasm = ["dep:tsify", "dep:wasm-bindgen"]
 
 [dependencies]
+bitwarden-logging-macro = { workspace = true }
 chrono = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
@@ -29,6 +30,7 @@ wasm-bindgen = { workspace = true, optional = true }
 
 [dev-dependencies]
 criterion = "0.8.0"
+trybuild = "1.0.101"
 
 [[bench]]
 name = "flight_recorder_performance"

--- a/crates/bitwarden-logging/src/lib.rs
+++ b/crates/bitwarden-logging/src/lib.rs
@@ -7,6 +7,7 @@ mod global;
 mod layer;
 mod visitor;
 
+pub use bitwarden_logging_macro::instrument;
 pub use circular_buffer::CircularBuffer;
 pub use config::FlightRecorderConfig;
 pub use event::FlightRecorderEvent;

--- a/crates/bitwarden-logging/tests/compilation_tests/skip_all_forbidden.rs
+++ b/crates/bitwarden-logging/tests/compilation_tests/skip_all_forbidden.rs
@@ -1,0 +1,6 @@
+#[bitwarden_logging::instrument(skip_all)]
+fn explicit_skip_all_should_fail(password: &str) {
+    let _ = password;
+}
+
+fn main() {}

--- a/crates/bitwarden-logging/tests/compilation_tests/skip_all_forbidden.stderr
+++ b/crates/bitwarden-logging/tests/compilation_tests/skip_all_forbidden.stderr
@@ -1,0 +1,5 @@
+error: `#[bitwarden_logging::instrument]` enforces `skip_all` by default. Use `fields(name = expr)` to opt in to logging specific arguments.
+ --> tests/compilation_tests/skip_all_forbidden.rs:1:33
+  |
+1 | #[bitwarden_logging::instrument(skip_all)]
+  |                                 ^^^^^^^^

--- a/crates/bitwarden-logging/tests/compilation_tests/skip_and_skip_all.rs
+++ b/crates/bitwarden-logging/tests/compilation_tests/skip_and_skip_all.rs
@@ -1,0 +1,6 @@
+#[bitwarden_logging::instrument(skip(password), skip_all)]
+fn both_should_fail(password: &str) {
+    let _ = password;
+}
+
+fn main() {}

--- a/crates/bitwarden-logging/tests/compilation_tests/skip_and_skip_all.stderr
+++ b/crates/bitwarden-logging/tests/compilation_tests/skip_and_skip_all.stderr
@@ -1,0 +1,11 @@
+error: `#[bitwarden_logging::instrument]` enforces `skip_all` by default. Use `fields(name = expr)` to opt in to logging specific arguments.
+ --> tests/compilation_tests/skip_and_skip_all.rs:1:33
+  |
+1 | #[bitwarden_logging::instrument(skip(password), skip_all)]
+  |                                 ^^^^^^^^^^^^^^
+
+error: `#[bitwarden_logging::instrument]` enforces `skip_all` by default. Use `fields(name = expr)` to opt in to logging specific arguments.
+ --> tests/compilation_tests/skip_and_skip_all.rs:1:49
+  |
+1 | #[bitwarden_logging::instrument(skip(password), skip_all)]
+  |                                                 ^^^^^^^^

--- a/crates/bitwarden-logging/tests/compilation_tests/skip_forbidden.rs
+++ b/crates/bitwarden-logging/tests/compilation_tests/skip_forbidden.rs
@@ -1,0 +1,6 @@
+#[bitwarden_logging::instrument(skip(password))]
+fn explicit_skip_should_fail(password: &str) {
+    let _ = password;
+}
+
+fn main() {}

--- a/crates/bitwarden-logging/tests/compilation_tests/skip_forbidden.stderr
+++ b/crates/bitwarden-logging/tests/compilation_tests/skip_forbidden.stderr
@@ -1,0 +1,5 @@
+error: `#[bitwarden_logging::instrument]` enforces `skip_all` by default. Use `fields(name = expr)` to opt in to logging specific arguments.
+ --> tests/compilation_tests/skip_forbidden.rs:1:33
+  |
+1 | #[bitwarden_logging::instrument(skip(password))]
+  |                                 ^^^^^^^^^^^^^^

--- a/crates/bitwarden-logging/tests/instrument.rs
+++ b/crates/bitwarden-logging/tests/instrument.rs
@@ -1,0 +1,167 @@
+//! Behavior tests for `bitwarden_logging::instrument`.
+//!
+//! The wrapper rewrites to `#[tracing::instrument(skip_all, ...)]`, so all function
+//! arguments should be excluded from span fields unless explicitly opted in via `fields(...)`.
+
+use std::{
+    io,
+    sync::{Arc, Mutex},
+};
+
+use tracing::Level;
+use tracing_subscriber::fmt::MakeWriter;
+
+#[derive(Clone, Default)]
+struct CapturedWriter(Arc<Mutex<Vec<u8>>>);
+
+impl CapturedWriter {
+    fn into_string(self) -> String {
+        let bytes = self.0.lock().expect("writer poisoned").clone();
+        String::from_utf8(bytes).expect("non-utf8 in captured output")
+    }
+}
+
+impl io::Write for CapturedWriter {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.0
+            .lock()
+            .expect("writer poisoned")
+            .extend_from_slice(buf);
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+impl<'a> MakeWriter<'a> for CapturedWriter {
+    type Writer = Self;
+
+    fn make_writer(&'a self) -> Self::Writer {
+        self.clone()
+    }
+}
+
+fn with_capture<F: FnOnce()>(f: F) -> String {
+    let writer = CapturedWriter::default();
+    let subscriber = tracing_subscriber::fmt()
+        .with_writer(writer.clone())
+        .with_max_level(Level::TRACE)
+        .with_ansi(false)
+        .finish();
+    tracing::subscriber::with_default(subscriber, f);
+    writer.into_string()
+}
+
+#[bitwarden_logging::instrument]
+fn args_skipped_by_default(password: &str, email: &str) {
+    tracing::info!("inside");
+    let _ = (password, email);
+}
+
+#[bitwarden_logging::instrument(fields(email = email))]
+fn explicit_field_opt_in(password: &str, email: &str) {
+    tracing::info!("inside");
+    let _ = password;
+}
+
+#[bitwarden_logging::instrument(name = "renamed", level = "debug")]
+fn name_and_level_passthrough(value: i32) {
+    tracing::debug!("inside");
+    let _ = value;
+}
+
+#[bitwarden_logging::instrument(err)]
+fn err_passthrough(should_fail: bool) -> Result<(), &'static str> {
+    if should_fail { Err("boom") } else { Ok(()) }
+}
+
+// Compile-only check: the wrapper must expand correctly for `async fn` bodies. Whether the
+// future is awaited is irrelevant for testing the expansion shape.
+#[bitwarden_logging::instrument]
+#[allow(dead_code)]
+async fn async_expansion_compiles(secret: &str) {
+    tracing::info!("inside");
+    let _ = secret;
+}
+
+// Compile-only check: the wrapper must expand correctly for generic functions.
+#[bitwarden_logging::instrument]
+#[allow(dead_code)]
+fn generic_expansion_compiles<T: std::fmt::Debug>(value: T) {
+    tracing::info!("inside");
+    let _ = value;
+}
+
+#[test]
+fn arguments_are_skipped_by_default() {
+    let output = with_capture(|| args_skipped_by_default("hunter2", "user@example.com"));
+    assert!(
+        !output.contains("hunter2"),
+        "password leaked into span output:\n{output}"
+    );
+    assert!(
+        !output.contains("user@example.com"),
+        "email leaked into span output:\n{output}"
+    );
+}
+
+#[test]
+fn fields_opt_in_is_recorded() {
+    let output = with_capture(|| explicit_field_opt_in("hunter2", "user@example.com"));
+    assert!(
+        output.contains("user@example.com"),
+        "explicit email field missing:\n{output}"
+    );
+    assert!(
+        !output.contains("hunter2"),
+        "password leaked despite no opt-in:\n{output}"
+    );
+}
+
+#[test]
+fn name_and_level_flow_through() {
+    let output = with_capture(|| name_and_level_passthrough(42));
+    assert!(
+        output.contains("renamed"),
+        "renamed span name missing:\n{output}"
+    );
+    // tracing renders recorded fields as `name=value`; absence of the field marker confirms
+    // the argument was not recorded. (Avoiding a bare `"42"` substring check because
+    // timestamps can spuriously match short numeric values.)
+    assert!(
+        !output.contains("value=42"),
+        "argument value leaked into span:\n{output}"
+    );
+}
+
+#[test]
+fn err_flag_records_errors_on_failure() {
+    let output = with_capture(|| {
+        let _ = err_passthrough(true);
+    });
+    assert!(
+        output.contains("boom"),
+        "err return value missing from span:\n{output}"
+    );
+}
+
+#[test]
+fn err_flag_stays_quiet_on_success() {
+    let output = with_capture(|| {
+        let _ = err_passthrough(false);
+    });
+    assert!(
+        !output.contains("boom"),
+        "unexpected error text on success path:\n{output}"
+    );
+}
+
+#[test]
+fn compile_fail_cases() {
+    let t = trybuild::TestCases::new();
+    t.compile_fail("tests/compilation_tests/skip_forbidden.rs");
+    t.compile_fail("tests/compilation_tests/skip_all_forbidden.rs");
+    t.compile_fail("tests/compilation_tests/skip_and_skip_all.rs");
+}

--- a/support/lints/Cargo.lock
+++ b/support/lints/Cargo.lock
@@ -80,6 +80,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
+name = "bitwarden-logging-macro"
+version = "3.0.0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "bitwarden_error_enum"
 version = "0.1.0"
 dependencies = [
@@ -114,9 +123,11 @@ dependencies = [
 name = "bitwarden_tracing_instrument"
 version = "0.1.0"
 dependencies = [
+ "bitwarden-logging-macro",
  "clippy_utils",
  "dylint_linting",
  "dylint_testing",
+ "tracing",
 ]
 
 [[package]]
@@ -1263,7 +1274,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/support/lints/Cargo.lock
+++ b/support/lints/Cargo.lock
@@ -127,6 +127,9 @@ dependencies = [
  "clippy_utils",
  "dylint_linting",
  "dylint_testing",
+ "proc-macro2",
+ "quote",
+ "syn",
  "tracing",
 ]
 

--- a/support/lints/Cargo.lock
+++ b/support/lints/Cargo.lock
@@ -105,8 +105,18 @@ version = "0.1.0"
 dependencies = [
  "bitwarden_error_enum",
  "bitwarden_error_suffix",
+ "bitwarden_tracing_instrument",
  "bitwarden_uniffi_async_export",
  "dylint_linting",
+]
+
+[[package]]
+name = "bitwarden_tracing_instrument"
+version = "0.1.0"
+dependencies = [
+ "clippy_utils",
+ "dylint_linting",
+ "dylint_testing",
 ]
 
 [[package]]

--- a/support/lints/Cargo.toml
+++ b/support/lints/Cargo.toml
@@ -12,6 +12,7 @@ crate-type = ["cdylib"]
 [dependencies]
 bitwarden_error_enum = { path = "error_enum", features = ["rlib"] }
 bitwarden_error_suffix = { path = "error_suffix", features = ["rlib"] }
+bitwarden_tracing_instrument = { path = "tracing_instrument", features = ["rlib"] }
 bitwarden_uniffi_async_export = { path = "uniffi_async_export", features = ["rlib"] }
 dylint_linting = { workspace = true }
 

--- a/support/lints/src/lib.rs
+++ b/support/lints/src/lib.rs
@@ -11,5 +11,6 @@ extern crate rustc_session;
 pub fn register_lints(sess: &rustc_session::Session, lint_store: &mut rustc_lint::LintStore) {
     bitwarden_error_enum::register_lints(sess, lint_store);
     bitwarden_error_suffix::register_lints(sess, lint_store);
+    bitwarden_tracing_instrument::register_lints(sess, lint_store);
     bitwarden_uniffi_async_export::register_lints(sess, lint_store);
 }

--- a/support/lints/tracing_instrument/.cargo/config.toml
+++ b/support/lints/tracing_instrument/.cargo/config.toml
@@ -1,0 +1,6 @@
+[target.'cfg(all())']
+rustflags = ["-C", "linker=dylint-link"]
+
+# For Rust versions 1.74.0 and onward, the following alternative can be used
+# (see https://github.com/rust-lang/cargo/pull/12535):
+# linker = "dylint-link"

--- a/support/lints/tracing_instrument/Cargo.toml
+++ b/support/lints/tracing_instrument/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "bitwarden_tracing_instrument"
+version = "0.1.0"
+authors = ["Bitwarden Inc"]
+description = "Lints forbidding `#[tracing::instrument]` in favor of `#[bitwarden_logging::instrument]`"
+edition = "2021"
+publish = false
+
+[features]
+rlib = ["dylint_linting/constituent"]
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[[example]]
+name = "ui"
+path = "ui/main.rs"
+
+[dependencies]
+clippy_utils = { workspace = true }
+dylint_linting = { workspace = true }
+
+[dev-dependencies]
+dylint_testing = { workspace = true }
+
+[package.metadata.rust-analyzer]
+rustc_private = true

--- a/support/lints/tracing_instrument/Cargo.toml
+++ b/support/lints/tracing_instrument/Cargo.toml
@@ -19,6 +19,9 @@ path = "ui/main.rs"
 [dependencies]
 clippy_utils = { workspace = true }
 dylint_linting = { workspace = true }
+proc-macro2 = "1"
+quote = "1"
+syn = { version = "2", features = ["full"] }
 
 [dev-dependencies]
 bitwarden-logging-macro = { path = "../../../crates/bitwarden-logging-macro" }

--- a/support/lints/tracing_instrument/Cargo.toml
+++ b/support/lints/tracing_instrument/Cargo.toml
@@ -21,7 +21,9 @@ clippy_utils = { workspace = true }
 dylint_linting = { workspace = true }
 
 [dev-dependencies]
+bitwarden-logging-macro = { path = "../../../crates/bitwarden-logging-macro" }
 dylint_testing = { workspace = true }
+tracing = "0.1"
 
 [package.metadata.rust-analyzer]
 rustc_private = true

--- a/support/lints/tracing_instrument/src/lib.rs
+++ b/support/lints/tracing_instrument/src/lib.rs
@@ -1,19 +1,31 @@
 #![feature(rustc_private)]
 #![warn(unused_extern_crates)]
 
-extern crate rustc_ast;
+extern crate rustc_hir;
+extern crate rustc_span;
 
 use clippy_utils::diagnostics::span_lint_and_help;
-use rustc_ast::ast::{AttrKind, Attribute};
-use rustc_lint::{EarlyContext, EarlyLintPass};
+use rustc_hir::{ImplItem, Item, TraitItem};
+use rustc_lint::{LateContext, LateLintPass};
+use rustc_span::{ExpnKind, MacroKind, Span};
 
-dylint_linting::declare_pre_expansion_lint! {
+dylint_linting::declare_late_lint! {
     /// ### What it does
     ///
-    /// Warns when `#[tracing::instrument]` or a bare `#[instrument]` is used. Bitwarden code
-    /// must use the fully-qualified `#[bitwarden_logging::instrument]`, which defaults to
-    /// `skip_all` so function arguments are excluded from span fields unless explicitly
-    /// opted in via `fields(...)`.
+    /// Warns when `tracing::instrument` is used as an attribute macro. Bitwarden code must
+    /// use `bitwarden_logging::instrument` instead, which defaults to `skip_all` so function
+    /// arguments are excluded from span fields unless explicitly opted in via `fields(...)`.
+    ///
+    /// ### Matching
+    ///
+    /// The lint inspects the post-expansion macro backtrace and matches by the macro's
+    /// definition (the `tracing_attributes` crate), not by attribute path. This means every
+    /// way to reach `tracing::instrument` is caught: the fully-qualified `#[tracing::instrument]`,
+    /// the bare `#[instrument]` after `use tracing::instrument`, and aliased imports like
+    /// `use tracing::instrument as foo; #[foo]`. Expansions emitted by our own
+    /// `bitwarden_logging::instrument` wrapper (which internally re-emits `tracing::instrument`)
+    /// are filtered out via a check against the wrapper crate (`bitwarden_logging_macro`) in
+    /// the same backtrace.
     ///
     /// ### Default level
     ///
@@ -28,73 +40,83 @@ dylint_linting::declare_pre_expansion_lint! {
     /// default. In a vault-handling SDK this is a foot-gun: forgetting `skip_all` on a
     /// function like `derive_master_key(password, ...)` would log the user's password.
     ///
-    /// Bare `#[instrument]` is also flagged because `use tracing::instrument;` is the
-    /// classic way to re-introduce the foot-gun without any visible `tracing::` prefix
-    /// at the call site. Always write the fully-qualified path so the safety property
-    /// is visible.
-    ///
     /// ### Example
     ///
     /// ```rust,ignore
     /// #[tracing::instrument]
     /// fn derive_master_key(password: &str) {}
-    ///
-    /// use tracing::instrument;
-    /// #[instrument]
-    /// fn derive_master_key_2(password: &str) {}
     /// ```
     ///
     /// Use instead:
     ///
     /// ```rust,ignore
-    /// #[bitwarden_logging::instrument]
+    /// use bitwarden_logging::instrument;
+    ///
+    /// #[instrument]
     /// fn derive_master_key(password: &str) {}
     /// ```
     pub TRACING_INSTRUMENT,
     Allow,
-    "use the fully-qualified `#[bitwarden_logging::instrument]` instead of `#[tracing::instrument]` or bare `#[instrument]`"
+    "use `bitwarden_logging::instrument` instead of `tracing::instrument`"
 }
 
-impl EarlyLintPass for TracingInstrument {
-    fn check_attribute(&mut self, cx: &EarlyContext<'_>, attr: &Attribute) {
-        if !is_tracing_instrument(attr) {
-            return;
-        }
+const TRACING_ATTRIBUTES_CRATE: &str = "tracing_attributes";
+const WRAPPER_CRATE: &str = "bitwarden_logging_macro";
 
-        span_lint_and_help(
-            cx,
-            TRACING_INSTRUMENT,
-            attr.span,
-            "use the fully-qualified `#[bitwarden_logging::instrument]` instead",
-            None,
-            "`bitwarden_logging::instrument` defaults to `skip_all`, preventing accidental \
-             logging of function arguments. Use `fields(name = expr)` to opt in. \
-             Always write the path fully so the safety property is visible at the call site.",
-        );
+impl<'tcx> LateLintPass<'tcx> for TracingInstrument {
+    fn check_item(&mut self, cx: &LateContext<'tcx>, item: &'tcx Item<'tcx>) {
+        check_span(cx, item.span);
+    }
+
+    fn check_impl_item(&mut self, cx: &LateContext<'tcx>, item: &'tcx ImplItem<'tcx>) {
+        check_span(cx, item.span);
+    }
+
+    fn check_trait_item(&mut self, cx: &LateContext<'tcx>, item: &'tcx TraitItem<'tcx>) {
+        check_span(cx, item.span);
     }
 }
 
-/// Matches `#[tracing::instrument]` (qualified) and `#[instrument]` (bare).
-///
-/// Bare `#[instrument]` is flagged because the most common way to re-introduce the
-/// `tracing::instrument` foot-gun is `use tracing::instrument;` followed by an unqualified
-/// `#[instrument]` attribute. Forcing the fully-qualified `#[bitwarden_logging::instrument]`
-/// at every call site makes the safety property visible and the deviation lintable.
-///
-/// Renamed imports (`use tracing::instrument as foo;`) are not caught — those are explicit
-/// enough that we treat them as opt-out.
-fn is_tracing_instrument(attr: &Attribute) -> bool {
-    let AttrKind::Normal(normal) = &attr.kind else {
-        return false;
-    };
-    let segments = &normal.item.path.segments;
-    match segments.len() {
-        1 => segments[0].ident.name.as_str() == "instrument",
-        2 => {
-            segments[0].ident.name.as_str() == "tracing"
-                && segments[1].ident.name.as_str() == "instrument"
+fn check_span(cx: &LateContext<'_>, span: Span) {
+    let mut tracing_call_site: Option<Span> = None;
+    let mut emitted_by_wrapper = false;
+
+    for expn in span.macro_backtrace() {
+        let ExpnKind::Macro(MacroKind::Attr, _) = expn.kind else {
+            continue;
+        };
+        let Some(def_id) = expn.macro_def_id else {
+            continue;
+        };
+        let crate_name = cx.tcx.crate_name(def_id.krate);
+        match crate_name.as_str() {
+            TRACING_ATTRIBUTES_CRATE => {
+                // Only record the innermost `tracing::instrument` call site so the diagnostic
+                // points at the attribute the user actually wrote.
+                if tracing_call_site.is_none() {
+                    tracing_call_site = Some(expn.call_site);
+                }
+            }
+            WRAPPER_CRATE => {
+                emitted_by_wrapper = true;
+            }
+            _ => {}
         }
-        _ => false,
+    }
+
+    if emitted_by_wrapper {
+        return;
+    }
+    if let Some(call_site) = tracing_call_site {
+        span_lint_and_help(
+            cx,
+            TRACING_INSTRUMENT,
+            call_site,
+            "use `bitwarden_logging::instrument` instead of `tracing::instrument`",
+            None,
+            "`bitwarden_logging::instrument` defaults to `skip_all`, preventing accidental \
+             logging of function arguments. Use `fields(name = expr)` to opt in.",
+        );
     }
 }
 

--- a/support/lints/tracing_instrument/src/lib.rs
+++ b/support/lints/tracing_instrument/src/lib.rs
@@ -1,0 +1,97 @@
+#![feature(rustc_private)]
+#![warn(unused_extern_crates)]
+
+extern crate rustc_ast;
+
+use clippy_utils::diagnostics::span_lint_and_help;
+use rustc_ast::ast::{AttrKind, Attribute};
+use rustc_lint::{EarlyContext, EarlyLintPass};
+
+dylint_linting::declare_pre_expansion_lint! {
+    /// ### What it does
+    ///
+    /// Warns when `#[tracing::instrument]` or a bare `#[instrument]` is used. Bitwarden code
+    /// must use the fully-qualified `#[bitwarden_logging::instrument]`, which defaults to
+    /// `skip_all` so function arguments are excluded from span fields unless explicitly
+    /// opted in via `fields(...)`.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// `tracing::instrument` records every argument that implements `Display`/`Debug` by
+    /// default. In a vault-handling SDK this is a foot-gun: forgetting `skip_all` on a
+    /// function like `derive_master_key(password, ...)` would log the user's password.
+    ///
+    /// Bare `#[instrument]` is also flagged because `use tracing::instrument;` is the
+    /// classic way to re-introduce the foot-gun without any visible `tracing::` prefix
+    /// at the call site. Always write the fully-qualified path so the safety property
+    /// is visible.
+    ///
+    /// ### Example
+    ///
+    /// ```rust,ignore
+    /// #[tracing::instrument]
+    /// fn derive_master_key(password: &str) {}
+    ///
+    /// use tracing::instrument;
+    /// #[instrument]
+    /// fn derive_master_key_2(password: &str) {}
+    /// ```
+    ///
+    /// Use instead:
+    ///
+    /// ```rust,ignore
+    /// #[bitwarden_logging::instrument]
+    /// fn derive_master_key(password: &str) {}
+    /// ```
+    pub TRACING_INSTRUMENT,
+    Warn,
+    "use the fully-qualified `#[bitwarden_logging::instrument]` instead of `#[tracing::instrument]` or bare `#[instrument]`"
+}
+
+impl EarlyLintPass for TracingInstrument {
+    fn check_attribute(&mut self, cx: &EarlyContext<'_>, attr: &Attribute) {
+        if !is_tracing_instrument(attr) {
+            return;
+        }
+
+        span_lint_and_help(
+            cx,
+            TRACING_INSTRUMENT,
+            attr.span,
+            "use the fully-qualified `#[bitwarden_logging::instrument]` instead",
+            None,
+            "`bitwarden_logging::instrument` defaults to `skip_all`, preventing accidental \
+             logging of function arguments. Use `fields(name = expr)` to opt in. \
+             Always write the path fully so the safety property is visible at the call site.",
+        );
+    }
+}
+
+/// Matches `#[tracing::instrument]` (qualified) and `#[instrument]` (bare).
+///
+/// Bare `#[instrument]` is flagged because the most common way to re-introduce the
+/// `tracing::instrument` foot-gun is `use tracing::instrument;` followed by an unqualified
+/// `#[instrument]` attribute. Forcing the fully-qualified `#[bitwarden_logging::instrument]`
+/// at every call site makes the safety property visible and the deviation lintable.
+///
+/// Renamed imports (`use tracing::instrument as foo;`) are not caught — those are explicit
+/// enough that we treat them as opt-out.
+fn is_tracing_instrument(attr: &Attribute) -> bool {
+    let AttrKind::Normal(normal) = &attr.kind else {
+        return false;
+    };
+    let segments = &normal.item.path.segments;
+    match segments.len() {
+        1 => segments[0].ident.name.as_str() == "instrument",
+        2 => {
+            segments[0].ident.name.as_str() == "tracing"
+                && segments[1].ident.name.as_str() == "instrument"
+        }
+        _ => false,
+    }
+}
+
+#[test]
+fn ui() {
+    dylint_testing::ui_test_example(env!("CARGO_PKG_NAME"), "ui");
+}

--- a/support/lints/tracing_instrument/src/lib.rs
+++ b/support/lints/tracing_instrument/src/lib.rs
@@ -15,6 +15,13 @@ dylint_linting::declare_pre_expansion_lint! {
     /// `skip_all` so function arguments are excluded from span fields unless explicitly
     /// opted in via `fields(...)`.
     ///
+    /// ### Default level
+    ///
+    /// Currently defaults to `Allow` to give existing call sites time to migrate without
+    /// breaking CI (the workspace runs `cargo dylint` with `-D warnings`). Crates that have
+    /// already been swept can opt in via `#![warn(tracing_instrument)]` (or `deny`) at the
+    /// crate root. The default will flip to `Warn` once the workspace is clean.
+    ///
     /// ### Why is this bad?
     ///
     /// `tracing::instrument` records every argument that implements `Display`/`Debug` by
@@ -44,7 +51,7 @@ dylint_linting::declare_pre_expansion_lint! {
     /// fn derive_master_key(password: &str) {}
     /// ```
     pub TRACING_INSTRUMENT,
-    Warn,
+    Allow,
     "use the fully-qualified `#[bitwarden_logging::instrument]` instead of `#[tracing::instrument]` or bare `#[instrument]`"
 }
 

--- a/support/lints/tracing_instrument/src/lib.rs
+++ b/support/lints/tracing_instrument/src/lib.rs
@@ -23,22 +23,24 @@ dylint_linting::declare_late_lint! {
     /// ### Matching
     ///
     /// The lint inspects the post-expansion macro backtrace and matches by the macro's
-    /// definition (the `tracing_attributes` crate), not by attribute path. This means every
-    /// way to reach `tracing::instrument` is caught: the fully-qualified `#[tracing::instrument]`,
-    /// the bare `#[instrument]` after `use tracing::instrument`, and aliased imports like
-    /// `use tracing::instrument as foo; #[foo]`. Expansions emitted by our own
-    /// `bitwarden_logging::instrument` wrapper (which internally re-emits `tracing::instrument`)
-    /// are filtered out via a check against the wrapper crate (`bitwarden_logging_macro`) in
-    /// the same backtrace.
+    /// definition (the `tracing_attributes` crate), not by attribute path. Every way to reach
+    /// `tracing::instrument` is caught: the fully-qualified `#[tracing::instrument]`, the
+    /// bare `#[instrument]` after `use tracing::instrument`, and aliased imports like
+    /// `use tracing::instrument as foo; #[foo]`.
+    ///
+    /// The `bitwarden_logging::instrument` wrapper internally re-emits `tracing::instrument`.
+    /// It opts out of this lint at its emission site by including
+    /// `#[allow(unknown_lints, tracing_instrument)]`, so wrappers don't need a special case
+    /// here.
     ///
     /// ### Suggestions
     ///
     /// When the attribute does not use `skip(...)`, the lint emits a machine-applicable
     /// suggestion that swaps the path to `bitwarden_logging::instrument` and drops a
     /// redundant `skip_all` if present. When `skip(...)` is present the lint emits a
-    /// help-only diagnostic, because translating a skip list into the wrapper's
-    /// opt-in `fields(...)` model needs human judgment (the original may have been
-    /// implicitly logging the non-skipped args).
+    /// help-only diagnostic, because translating a skip list into the wrapper's opt-in
+    /// `fields(...)` model needs human judgment (the original may have been implicitly
+    /// logging the non-skipped args).
     ///
     /// ### Default level
     ///
@@ -74,7 +76,6 @@ dylint_linting::declare_late_lint! {
 }
 
 const TRACING_ATTRIBUTES_CRATE: &str = "tracing_attributes";
-const WRAPPER_CRATE: &str = "bitwarden_logging_macro";
 const LINT_MESSAGE: &str = "use `bitwarden_logging::instrument` instead of `tracing::instrument`";
 
 impl<'tcx> LateLintPass<'tcx> for TracingInstrument {
@@ -92,36 +93,16 @@ impl<'tcx> LateLintPass<'tcx> for TracingInstrument {
 }
 
 fn check_span(cx: &LateContext<'_>, span: Span) {
-    let mut tracing_call_site: Option<Span> = None;
-    let mut emitted_by_wrapper = false;
-
-    for expn in span.macro_backtrace() {
+    let call_site = span.macro_backtrace().find_map(|expn| {
         let ExpnKind::Macro(MacroKind::Attr, _) = expn.kind else {
-            continue;
+            return None;
         };
-        let Some(def_id) = expn.macro_def_id else {
-            continue;
-        };
-        let crate_name = cx.tcx.crate_name(def_id.krate);
-        match crate_name.as_str() {
-            TRACING_ATTRIBUTES_CRATE => {
-                // Only record the innermost `tracing::instrument` call site so the diagnostic
-                // points at the attribute the user actually wrote.
-                if tracing_call_site.is_none() {
-                    tracing_call_site = Some(expn.call_site);
-                }
-            }
-            WRAPPER_CRATE => {
-                emitted_by_wrapper = true;
-            }
-            _ => {}
-        }
-    }
+        let def_id = expn.macro_def_id?;
+        (cx.tcx.crate_name(def_id.krate).as_str() == TRACING_ATTRIBUTES_CRATE)
+            .then_some(expn.call_site)
+    });
 
-    if emitted_by_wrapper {
-        return;
-    }
-    let Some(call_site) = tracing_call_site else {
+    let Some(call_site) = call_site else {
         return;
     };
 

--- a/support/lints/tracing_instrument/src/lib.rs
+++ b/support/lints/tracing_instrument/src/lib.rs
@@ -1,13 +1,17 @@
 #![feature(rustc_private)]
 #![warn(unused_extern_crates)]
 
+extern crate rustc_errors;
 extern crate rustc_hir;
 extern crate rustc_span;
 
-use clippy_utils::diagnostics::span_lint_and_help;
+use clippy_utils::diagnostics::{span_lint_and_help, span_lint_and_sugg};
+use quote::ToTokens;
+use rustc_errors::Applicability;
 use rustc_hir::{ImplItem, Item, TraitItem};
-use rustc_lint::{LateContext, LateLintPass};
+use rustc_lint::{LateContext, LateLintPass, LintContext};
 use rustc_span::{ExpnKind, MacroKind, Span};
+use syn::{Meta, Token, parse::Parser, punctuated::Punctuated};
 
 dylint_linting::declare_late_lint! {
     /// ### What it does
@@ -26,6 +30,15 @@ dylint_linting::declare_late_lint! {
     /// `bitwarden_logging::instrument` wrapper (which internally re-emits `tracing::instrument`)
     /// are filtered out via a check against the wrapper crate (`bitwarden_logging_macro`) in
     /// the same backtrace.
+    ///
+    /// ### Suggestions
+    ///
+    /// When the attribute does not use `skip(...)`, the lint emits a machine-applicable
+    /// suggestion that swaps the path to `bitwarden_logging::instrument` and drops a
+    /// redundant `skip_all` if present. When `skip(...)` is present the lint emits a
+    /// help-only diagnostic, because translating a skip list into the wrapper's
+    /// opt-in `fields(...)` model needs human judgment (the original may have been
+    /// implicitly logging the non-skipped args).
     ///
     /// ### Default level
     ///
@@ -62,6 +75,7 @@ dylint_linting::declare_late_lint! {
 
 const TRACING_ATTRIBUTES_CRATE: &str = "tracing_attributes";
 const WRAPPER_CRATE: &str = "bitwarden_logging_macro";
+const LINT_MESSAGE: &str = "use `bitwarden_logging::instrument` instead of `tracing::instrument`";
 
 impl<'tcx> LateLintPass<'tcx> for TracingInstrument {
     fn check_item(&mut self, cx: &LateContext<'tcx>, item: &'tcx Item<'tcx>) {
@@ -107,17 +121,72 @@ fn check_span(cx: &LateContext<'_>, span: Span) {
     if emitted_by_wrapper {
         return;
     }
-    if let Some(call_site) = tracing_call_site {
-        span_lint_and_help(
-            cx,
-            TRACING_INSTRUMENT,
-            call_site,
-            "use `bitwarden_logging::instrument` instead of `tracing::instrument`",
-            None,
-            "`bitwarden_logging::instrument` defaults to `skip_all`, preventing accidental \
-             logging of function arguments. Use `fields(name = expr)` to opt in.",
-        );
+    let Some(call_site) = tracing_call_site else {
+        return;
+    };
+
+    match build_suggestion(cx, call_site) {
+        Some(replacement) => {
+            span_lint_and_sugg(
+                cx,
+                TRACING_INSTRUMENT,
+                call_site,
+                LINT_MESSAGE,
+                "replace with",
+                replacement,
+                Applicability::MachineApplicable,
+            );
+        }
+        None => {
+            span_lint_and_help(
+                cx,
+                TRACING_INSTRUMENT,
+                call_site,
+                LINT_MESSAGE,
+                None,
+                "`bitwarden_logging::instrument` defaults to `skip_all`, so the existing \
+                 `skip(...)` list may need translation into `fields(name = expr)` opt-ins \
+                 for arguments that should still be logged.",
+            );
+        }
     }
+}
+
+/// Builds a machine-applicable replacement for the `#[tracing::instrument(...)]` attribute.
+///
+/// Returns `None` when the existing args contain `skip(...)`, since that case needs human
+/// judgment to decide which (if any) of the skipped/non-skipped args become `fields(...)`
+/// opt-ins under the wrapper's `skip_all` default.
+fn build_suggestion(cx: &LateContext<'_>, call_site: Span) -> Option<String> {
+    let snippet = cx.sess().source_map().span_to_snippet(call_site).ok()?;
+    let inner = snippet.strip_prefix("#[")?.strip_suffix(']')?.trim();
+
+    let args_text = match inner.find('(') {
+        None => return Some("#[bitwarden_logging::instrument]".to_string()),
+        Some(open) => inner[open + 1..].strip_suffix(')')?,
+    };
+
+    let parser = Punctuated::<Meta, Token![,]>::parse_terminated;
+    let args = Parser::parse_str(parser, args_text).ok()?;
+
+    if args
+        .iter()
+        .any(|m| matches!(m, Meta::List(l) if l.path.is_ident("skip")))
+    {
+        return None;
+    }
+
+    let kept: Vec<String> = args
+        .iter()
+        .filter(|m| !matches!(m, Meta::Path(p) if p.is_ident("skip_all")))
+        .map(|m| m.to_token_stream().to_string())
+        .collect();
+
+    Some(if kept.is_empty() {
+        "#[bitwarden_logging::instrument]".to_string()
+    } else {
+        format!("#[bitwarden_logging::instrument({})]", kept.join(", "))
+    })
 }
 
 #[test]

--- a/support/lints/tracing_instrument/ui/main.rs
+++ b/support/lints/tracing_instrument/ui/main.rs
@@ -1,45 +1,39 @@
-// The lint defaults to `allow` so existing workspace call sites have time to migrate.
-// Opt in here so the test fixture actually exercises the lint logic.
+// Real compilation: LateLintPass runs after macro expansion, so the test fixture must
+// actually build against `tracing` and `bitwarden_logging_macro`.
+
 #![warn(tracing_instrument)]
+#![allow(dead_code)]
 
-// Each case lives in its own `#[cfg(any())]` module so it is parsed by the
-// pre-expansion lint pass but never compiled. This lets us reference
-// `#[tracing::instrument]` without pulling `tracing` in as a dev-dependency.
-
-// Should warn: bare `#[tracing::instrument]`.
-#[cfg(any())]
-mod tracing_instrument_no_args {
+// Should warn: fully-qualified `tracing::instrument`.
+mod qualified_tracing {
     #[tracing::instrument]
-    pub fn foo() {}
+    fn foo() {}
 }
 
-// Should warn: `#[tracing::instrument]` with arguments.
-#[cfg(any())]
-mod tracing_instrument_with_args {
-    #[tracing::instrument(skip(self), err)]
-    pub fn foo() {}
-}
+// Should warn: bare `#[instrument]` after `use tracing::instrument`.
+mod imported_tracing {
+    use tracing::instrument;
 
-// Should NOT warn: `#[bitwarden_logging::instrument]` is the blessed form.
-#[cfg(any())]
-mod bitwarden_logging_instrument {
-    #[bitwarden_logging::instrument]
-    pub fn foo() {}
-}
-
-// Should warn: bare `#[instrument]` (e.g. via `use tracing::instrument;`) is the classic
-// way to silently re-introduce the foot-gun. The convention is to always fully qualify.
-#[cfg(any())]
-mod bare_instrument {
     #[instrument]
-    pub fn foo() {}
+    fn foo() {}
 }
 
-// Should NOT warn: an attribute that merely ends in `instrument` but lives elsewhere.
-#[cfg(any())]
-mod other_instrument {
-    #[some_other_crate::instrument]
-    pub fn foo() {}
+// Should warn: aliased `tracing::instrument` import.
+mod aliased_tracing {
+    use tracing::instrument as renamed;
+
+    #[renamed]
+    fn foo() {}
+}
+
+// Should NOT warn: `bitwarden_logging::instrument` is the blessed wrapper, even though it
+// internally expands to `tracing::instrument` — the lint filters out expansions that came
+// through `bitwarden_logging_macro`.
+mod wrapper {
+    #[bitwarden_logging_macro::instrument]
+    fn foo(secret: &str) {
+        let _ = secret;
+    }
 }
 
 fn main() {}

--- a/support/lints/tracing_instrument/ui/main.rs
+++ b/support/lints/tracing_instrument/ui/main.rs
@@ -1,3 +1,7 @@
+// The lint defaults to `allow` so existing workspace call sites have time to migrate.
+// Opt in here so the test fixture actually exercises the lint logic.
+#![warn(tracing_instrument)]
+
 // Each case lives in its own `#[cfg(any())]` module so it is parsed by the
 // pre-expansion lint pass but never compiled. This lets us reference
 // `#[tracing::instrument]` without pulling `tracing` in as a dev-dependency.

--- a/support/lints/tracing_instrument/ui/main.rs
+++ b/support/lints/tracing_instrument/ui/main.rs
@@ -1,0 +1,41 @@
+// Each case lives in its own `#[cfg(any())]` module so it is parsed by the
+// pre-expansion lint pass but never compiled. This lets us reference
+// `#[tracing::instrument]` without pulling `tracing` in as a dev-dependency.
+
+// Should warn: bare `#[tracing::instrument]`.
+#[cfg(any())]
+mod tracing_instrument_no_args {
+    #[tracing::instrument]
+    pub fn foo() {}
+}
+
+// Should warn: `#[tracing::instrument]` with arguments.
+#[cfg(any())]
+mod tracing_instrument_with_args {
+    #[tracing::instrument(skip(self), err)]
+    pub fn foo() {}
+}
+
+// Should NOT warn: `#[bitwarden_logging::instrument]` is the blessed form.
+#[cfg(any())]
+mod bitwarden_logging_instrument {
+    #[bitwarden_logging::instrument]
+    pub fn foo() {}
+}
+
+// Should warn: bare `#[instrument]` (e.g. via `use tracing::instrument;`) is the classic
+// way to silently re-introduce the foot-gun. The convention is to always fully qualify.
+#[cfg(any())]
+mod bare_instrument {
+    #[instrument]
+    pub fn foo() {}
+}
+
+// Should NOT warn: an attribute that merely ends in `instrument` but lives elsewhere.
+#[cfg(any())]
+mod other_instrument {
+    #[some_other_crate::instrument]
+    pub fn foo() {}
+}
+
+fn main() {}

--- a/support/lints/tracing_instrument/ui/main.rs
+++ b/support/lints/tracing_instrument/ui/main.rs
@@ -4,13 +4,43 @@
 #![warn(tracing_instrument)]
 #![allow(dead_code)]
 
-// Should warn: fully-qualified `tracing::instrument`.
+// Should warn with MachineApplicable suggestion: pure path swap, no args.
 mod qualified_tracing {
     #[tracing::instrument]
     fn foo() {}
 }
 
-// Should warn: bare `#[instrument]` after `use tracing::instrument`.
+// Should warn with MachineApplicable suggestion: pass-through args (no `skip(...)`).
+mod with_pass_through_args {
+    #[tracing::instrument(err, level = "debug")]
+    fn foo() -> Result<(), &'static str> {
+        Ok(())
+    }
+}
+
+// Should warn with MachineApplicable suggestion: `skip_all` is dropped (the wrapper
+// already enforces it and rejects an explicit `skip_all`).
+mod with_skip_all {
+    #[tracing::instrument(skip_all, err)]
+    fn foo(secret: &str) -> Result<(), &'static str> {
+        let _ = secret;
+        Ok(())
+    }
+}
+
+// Should warn with HELP only (no suggestion): `skip(...)` needs human judgment to
+// translate into `fields(...)` opt-ins.
+mod with_skip_list {
+    #[tracing::instrument(skip(secret), err)]
+    fn foo(secret: &str, public: u32) -> Result<(), &'static str> {
+        let _ = (secret, public);
+        Ok(())
+    }
+}
+
+// Should warn: bare `#[instrument]` after `use tracing::instrument` is still caught by
+// macro identity. (Auto-fix here leaves a now-unused import; that's fine — `cargo fix`
+// will clean it up on a subsequent pass.)
 mod imported_tracing {
     use tracing::instrument;
 

--- a/support/lints/tracing_instrument/ui/main.stderr
+++ b/support/lints/tracing_instrument/ui/main.stderr
@@ -2,9 +2,8 @@ warning: use `bitwarden_logging::instrument` instead of `tracing::instrument`
   --> $DIR/main.rs:9:5
    |
 LL |     #[tracing::instrument]
-   |     ^^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^^^^^^^ help: replace with: `#[bitwarden_logging::instrument]`
    |
-   = help: `bitwarden_logging::instrument` defaults to `skip_all`, preventing accidental logging of function arguments. Use `fields(name = expr)` to opt in.
 note: the lint level is defined here
   --> $DIR/main.rs:4:9
    |
@@ -12,20 +11,36 @@ LL | #![warn(tracing_instrument)]
    |         ^^^^^^^^^^^^^^^^^^
 
 warning: use `bitwarden_logging::instrument` instead of `tracing::instrument`
-  --> $DIR/main.rs:17:5
+  --> $DIR/main.rs:15:5
    |
-LL |     #[instrument]
-   |     ^^^^^^^^^^^^^
-   |
-   = help: `bitwarden_logging::instrument` defaults to `skip_all`, preventing accidental logging of function arguments. Use `fields(name = expr)` to opt in.
+LL |     #[tracing::instrument(err, level = "debug")]
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace with: `#[bitwarden_logging::instrument(err, level = "debug")]`
 
 warning: use `bitwarden_logging::instrument` instead of `tracing::instrument`
-  --> $DIR/main.rs:25:5
+  --> $DIR/main.rs:24:5
+   |
+LL |     #[tracing::instrument(skip_all, err)]
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace with: `#[bitwarden_logging::instrument(err)]`
+
+warning: use `bitwarden_logging::instrument` instead of `tracing::instrument`
+  --> $DIR/main.rs:34:5
+   |
+LL |     #[tracing::instrument(skip(secret), err)]
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: `bitwarden_logging::instrument` defaults to `skip_all`, so the existing `skip(...)` list may need translation into `fields(name = expr)` opt-ins for arguments that should still be logged.
+
+warning: use `bitwarden_logging::instrument` instead of `tracing::instrument`
+  --> $DIR/main.rs:47:5
+   |
+LL |     #[instrument]
+   |     ^^^^^^^^^^^^^ help: replace with: `#[bitwarden_logging::instrument]`
+
+warning: use `bitwarden_logging::instrument` instead of `tracing::instrument`
+  --> $DIR/main.rs:55:5
    |
 LL |     #[renamed]
-   |     ^^^^^^^^^^
-   |
-   = help: `bitwarden_logging::instrument` defaults to `skip_all`, preventing accidental logging of function arguments. Use `fields(name = expr)` to opt in.
+   |     ^^^^^^^^^^ help: replace with: `#[bitwarden_logging::instrument]`
 
-warning: 3 warnings emitted
+warning: 6 warnings emitted
 

--- a/support/lints/tracing_instrument/ui/main.stderr
+++ b/support/lints/tracing_instrument/ui/main.stderr
@@ -1,0 +1,27 @@
+warning: use the fully-qualified `#[bitwarden_logging::instrument]` instead
+  --> $DIR/main.rs:8:5
+   |
+LL |     #[tracing::instrument]
+   |     ^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: `bitwarden_logging::instrument` defaults to `skip_all`, preventing accidental logging of function arguments. Use `fields(name = expr)` to opt in. Always write the path fully so the safety property is visible at the call site.
+   = note: `#[warn(tracing_instrument)]` on by default
+
+warning: use the fully-qualified `#[bitwarden_logging::instrument]` instead
+  --> $DIR/main.rs:15:5
+   |
+LL |     #[tracing::instrument(skip(self), err)]
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: `bitwarden_logging::instrument` defaults to `skip_all`, preventing accidental logging of function arguments. Use `fields(name = expr)` to opt in. Always write the path fully so the safety property is visible at the call site.
+
+warning: use the fully-qualified `#[bitwarden_logging::instrument]` instead
+  --> $DIR/main.rs:30:5
+   |
+LL |     #[instrument]
+   |     ^^^^^^^^^^^^^
+   |
+   = help: `bitwarden_logging::instrument` defaults to `skip_all`, preventing accidental logging of function arguments. Use `fields(name = expr)` to opt in. Always write the path fully so the safety property is visible at the call site.
+
+warning: 3 warnings emitted
+

--- a/support/lints/tracing_instrument/ui/main.stderr
+++ b/support/lints/tracing_instrument/ui/main.stderr
@@ -1,14 +1,18 @@
 warning: use the fully-qualified `#[bitwarden_logging::instrument]` instead
-  --> $DIR/main.rs:8:5
+  --> $DIR/main.rs:12:5
    |
 LL |     #[tracing::instrument]
    |     ^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: `bitwarden_logging::instrument` defaults to `skip_all`, preventing accidental logging of function arguments. Use `fields(name = expr)` to opt in. Always write the path fully so the safety property is visible at the call site.
-   = note: `#[warn(tracing_instrument)]` on by default
+note: the lint level is defined here
+  --> $DIR/main.rs:3:9
+   |
+LL | #![warn(tracing_instrument)]
+   |         ^^^^^^^^^^^^^^^^^^
 
 warning: use the fully-qualified `#[bitwarden_logging::instrument]` instead
-  --> $DIR/main.rs:15:5
+  --> $DIR/main.rs:19:5
    |
 LL |     #[tracing::instrument(skip(self), err)]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -16,7 +20,7 @@ LL |     #[tracing::instrument(skip(self), err)]
    = help: `bitwarden_logging::instrument` defaults to `skip_all`, preventing accidental logging of function arguments. Use `fields(name = expr)` to opt in. Always write the path fully so the safety property is visible at the call site.
 
 warning: use the fully-qualified `#[bitwarden_logging::instrument]` instead
-  --> $DIR/main.rs:30:5
+  --> $DIR/main.rs:34:5
    |
 LL |     #[instrument]
    |     ^^^^^^^^^^^^^

--- a/support/lints/tracing_instrument/ui/main.stderr
+++ b/support/lints/tracing_instrument/ui/main.stderr
@@ -1,31 +1,31 @@
-warning: use the fully-qualified `#[bitwarden_logging::instrument]` instead
-  --> $DIR/main.rs:12:5
+warning: use `bitwarden_logging::instrument` instead of `tracing::instrument`
+  --> $DIR/main.rs:9:5
    |
 LL |     #[tracing::instrument]
    |     ^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: `bitwarden_logging::instrument` defaults to `skip_all`, preventing accidental logging of function arguments. Use `fields(name = expr)` to opt in. Always write the path fully so the safety property is visible at the call site.
+   = help: `bitwarden_logging::instrument` defaults to `skip_all`, preventing accidental logging of function arguments. Use `fields(name = expr)` to opt in.
 note: the lint level is defined here
-  --> $DIR/main.rs:3:9
+  --> $DIR/main.rs:4:9
    |
 LL | #![warn(tracing_instrument)]
    |         ^^^^^^^^^^^^^^^^^^
 
-warning: use the fully-qualified `#[bitwarden_logging::instrument]` instead
-  --> $DIR/main.rs:19:5
-   |
-LL |     #[tracing::instrument(skip(self), err)]
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = help: `bitwarden_logging::instrument` defaults to `skip_all`, preventing accidental logging of function arguments. Use `fields(name = expr)` to opt in. Always write the path fully so the safety property is visible at the call site.
-
-warning: use the fully-qualified `#[bitwarden_logging::instrument]` instead
-  --> $DIR/main.rs:34:5
+warning: use `bitwarden_logging::instrument` instead of `tracing::instrument`
+  --> $DIR/main.rs:17:5
    |
 LL |     #[instrument]
    |     ^^^^^^^^^^^^^
    |
-   = help: `bitwarden_logging::instrument` defaults to `skip_all`, preventing accidental logging of function arguments. Use `fields(name = expr)` to opt in. Always write the path fully so the safety property is visible at the call site.
+   = help: `bitwarden_logging::instrument` defaults to `skip_all`, preventing accidental logging of function arguments. Use `fields(name = expr)` to opt in.
+
+warning: use `bitwarden_logging::instrument` instead of `tracing::instrument`
+  --> $DIR/main.rs:25:5
+   |
+LL |     #[renamed]
+   |     ^^^^^^^^^^
+   |
+   = help: `bitwarden_logging::instrument` defaults to `skip_all`, preventing accidental logging of function arguments. Use `fields(name = expr)` to opt in.
 
 warning: 3 warnings emitted
 


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective

`tracing::instrument` records every argument that implements `Display`/`Debug` by default, so forgetting `skip_all` on a function like `derive_master_key` would log the user's password. This addresses Architecture's logging concerns.

Introduces `#[bitwarden_logging::instrument]`, a drop-in wrapper that rewrites to `#[tracing::instrument(skip_all, ...)]`, making field logging opt-in via `fields(...)`. User-supplied `skip(...)` or `skip_all` are rejected at compile time so the safety property is enforced and explicit.

A `tracing_instrument` dylint backstops the convention by warning on both `#[tracing::instrument]` and bare `#[instrument]` (which can hide the foot-gun behind a `use tracing::instrument`). Engineers should always write the fully-qualified `#[bitwarden_logging::instrument]` so the safety property is visible at every call site.

Migration of existing call sites is intentionally left for a follow-up.

## 🚨 Breaking Changes

<!-- Does this PR introduce any breaking changes? If so, please describe the impact and migration path for clients.

If you're unsure, the automated TypeScript compatibility check will run when you open/update this PR and provide feedback.

For breaking changes:
1. Describe what changed in the client interface
2. Explain why the change was necessary
3. Provide migration steps for client developers
4. Link to any paired client PRs if needed

Otherwise, you can remove this section. -->
