### PR TITLE
[PM-24643] Add an easy to use formatting linting command to the sdk

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -145,8 +145,11 @@ discriminant + optional fields) belongs at the API→domain boundary.
 
 **Format & Lint:**
 
-- `cargo +nightly fmt --workspace` - Code formatting
-- Use `cargo clippy` to lint code and catch common mistakes
+- `npm run lint` - Run every formatting/linting check CI runs (fmt, clippy, sort, udeps, dylint,
+  doc, prettier, dep-ownership, cargo-lock). Matches `.github/workflows/lint.yml`.
+- `npm run lint:fix` - Same set, auto-fixing where the tool supports it.
+- `npm run lint -- --only <check>` - Run a single check (e.g. `--only clippy`).
+- Underlying script: `scripts/lint.sh`.
 
 **WASM Testing:**
 

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -9,6 +9,8 @@
       matchStrings: [
         "cargo install (?<depName>cargo-dylint) (?:[\\w-]+ )?--version (?<currentValue>\\d+\\.\\d+\\.\\d+) --locked",
         "cargo install (?<depName>dylint-link) (?:[\\w-]+ )?--version (?<currentValue>\\d+\\.\\d+\\.\\d+) --locked",
+        "cargo install (?<depName>cargo-sort) --version (?<currentValue>\\d+\\.\\d+\\.\\d+) --locked",
+        "cargo install (?<depName>cargo-udeps) --version (?<currentValue>\\d+\\.\\d+\\.\\d+) --locked",
       ],
       datasourceTemplate: "cargo",
       versioningTemplate: "cargo",
@@ -68,6 +70,8 @@
       matchPackageNames: [
         "async-trait",
         "cargo-dylint",
+        "cargo-sort",
+        "cargo-udeps",
         "ciborium",
         "chrono",
         "data-encoding",

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -27,7 +27,7 @@ jobs:
         include:
           - check: fmt
             needs_rust: true
-            needs_nightly: true
+            needs_rust_nightly: true
           - check: clippy
             needs_rust: true
           - check: sort
@@ -35,7 +35,7 @@ jobs:
             install: cargo install cargo-sort --version 2.0.2 --locked
           - check: udeps
             needs_rust: true
-            needs_nightly: true
+            needs_rust_nightly: true
             install: cargo install cargo-udeps --version 0.1.57 --locked
           - check: dylint
             needs_rust: true
@@ -64,7 +64,7 @@ jobs:
           echo "RUST_TOOLCHAIN=${RUST_TOOLCHAIN}" | tee -a "${GITHUB_OUTPUT}"
 
       - name: Set Rust nightly toolchain version
-        if: matrix.needs_nightly
+        if: matrix.needs_rust_nightly
         id: nightly-toolchain
         shell: bash
         run: |
@@ -79,7 +79,7 @@ jobs:
           components: clippy, rustfmt
 
       - name: Install Rust nightly
-        if: matrix.needs_nightly
+        if: matrix.needs_rust_nightly
         env:
           RUST_NIGHTLY_TOOLCHAIN: ${{ steps.nightly-toolchain.outputs.RUST_NIGHTLY_TOOLCHAIN }}
         run: |

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,6 +12,16 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
+  check:
+    name: Check Style
+    runs-on: ubuntu-24.04
+    needs: style
+    if: always()
+    steps:
+      - name: Verify all style checks passed
+        if: ${{ needs.style.result != 'success' }}
+        run: exit 1
+
   style:
     name: ${{ matrix.check }}
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,7 +13,7 @@ env:
 
 jobs:
   style:
-    name: Check Style
+    name: ${{ matrix.check }}
 
     runs-on: ubuntu-24.04
 
@@ -21,33 +21,65 @@ jobs:
       contents: read
       security-events: write
 
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - check: fmt
+            needs_rust: true
+            needs_nightly: true
+          - check: clippy
+            needs_rust: true
+          - check: sort
+            needs_rust: true
+            install: cargo install cargo-sort --version 2.0.2 --locked
+          - check: udeps
+            needs_rust: true
+            needs_nightly: true
+            install: cargo install cargo-udeps --version 0.1.57 --locked
+          - check: dylint
+            needs_rust: true
+            install: cargo install cargo-dylint dylint-link --version 5.0.0 --locked
+          - check: doc
+            needs_rust: true
+          - check: prettier
+            needs_node: true
+          - check: dep-ownership
+            needs_node: true
+          - check: cargo-lock
+            needs_rust: true
+
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
 
-      - name: Set Rust Toolchain
+      - name: Set Rust toolchain version
+        if: matrix.needs_rust
         id: toolchain
         shell: bash
         run: |
           RUST_TOOLCHAIN="$(grep -oP '^channel.*"(\K.*?)(?=")' rust-toolchain.toml)"
           echo "RUST_TOOLCHAIN=${RUST_TOOLCHAIN}" | tee -a "${GITHUB_OUTPUT}"
 
-      - name: Set Rust Nightly Toolchain
+      - name: Set Rust nightly toolchain version
+        if: matrix.needs_nightly
         id: nightly-toolchain
         shell: bash
         run: |
           RUST_NIGHTLY_TOOLCHAIN="$(grep -oP '^nightly-channel.*"(\K.*?)(?=")' rust-toolchain.toml)"
           echo "RUST_NIGHTLY_TOOLCHAIN=${RUST_NIGHTLY_TOOLCHAIN}" | tee -a "${GITHUB_OUTPUT}"
 
-      - name: Install rust
+      - name: Install Rust
+        if: matrix.needs_rust
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           toolchain: "${{ steps.toolchain.outputs.RUST_TOOLCHAIN }}"
           components: clippy, rustfmt
 
-      - name: Install rust nightly
+      - name: Install Rust nightly
+        if: matrix.needs_nightly
         env:
           RUST_NIGHTLY_TOOLCHAIN: ${{ steps.nightly-toolchain.outputs.RUST_NIGHTLY_TOOLCHAIN }}
         run: |
@@ -55,69 +87,34 @@ jobs:
           rustup component add rustfmt --toolchain "${RUST_NIGHTLY_TOOLCHAIN}"-x86_64-unknown-linux-gnu
 
       - name: Cache cargo registry
+        if: matrix.needs_rust
         uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2.8.2
 
-      - name: Cargo fmt
-        env:
-          RUST_NIGHTLY_TOOLCHAIN: ${{ steps.nightly-toolchain.outputs.RUST_NIGHTLY_TOOLCHAIN }}
-        run: cargo +"${RUST_NIGHTLY_TOOLCHAIN}" fmt --check
+      - name: Install per-check cargo tool
+        if: matrix.install
+        run: ${{ matrix.install }}
 
       - name: Install clippy-sarif and sarif-fmt
+        if: matrix.check == 'clippy'
         run: cargo install clippy-sarif sarif-fmt --locked --git https://github.com/psastras/sarif-rs.git --rev 11c33a53f6ffeaed736856b86fb6b7b09fabdfd8
 
-      - name: Cargo clippy-sarif
-        run: cargo clippy --all-features --all-targets --message-format=json |
-          clippy-sarif | tee clippy_result.sarif | sarif-fmt
+      - name: Run clippy with SARIF output
+        if: matrix.check == 'clippy'
         env:
           RUSTFLAGS: "-D warnings"
+        run: cargo clippy --all-features --all-targets --message-format=json |
+          clippy-sarif | tee clippy_result.sarif | sarif-fmt
 
-      - name: Upload Clippy results to GitHub
+      - name: Upload clippy results to GitHub
+        if: matrix.check == 'clippy'
         uses: github/codeql-action/upload-sarif@6bc82e05fd0ea64601dd4b465378bbcf57de0314 # v4.32.1
         with:
           sarif_file: clippy_result.sarif
           sha: ${{ contains(github.event_name, 'pull_request') && github.event.pull_request.head.sha || github.sha }}
           ref: ${{ contains(github.event_name, 'pull_request') && format('refs/pull/{0}/head', github.event.pull_request.number) || github.ref }}
 
-      # Run it again but this time without the sarif output so that the
-      # status code of the command is caught and reported as failed in GitHub.
-      # This should be cached from the previous step and should be fast.
-      - name: Cargo clippy
-        run: cargo clippy --all-features --all-targets
-        env:
-          RUSTFLAGS: "-D warnings"
-
-      - name: Install cargo-sort
-        run: cargo install cargo-sort --version 2.0.2 --locked
-
-      - name: Cargo sort
-        run: cargo sort --workspace --grouped --check
-
-      - name: Install cargo-udeps
-        run: cargo install cargo-udeps --version 0.1.57 --locked
-
-      - name: Cargo udeps
-        env:
-          RUST_NIGHTLY_TOOLCHAIN: ${{ steps.nightly-toolchain.outputs.RUST_NIGHTLY_TOOLCHAIN }}
-        run: cargo +"${RUST_NIGHTLY_TOOLCHAIN}" udeps --workspace --all-features
-
-      - name: Install cargo-dylint
-        run: cargo install cargo-dylint dylint-link --version 5.0.0 --locked
-
-      - name: Cargo dylint
-        run: cargo dylint --all -- --all-features --all-targets
-        env:
-          RUSTFLAGS: "-D warnings"
-
-      - name: Check Cargo.lock unchanged
-        run: |
-          if git diff --exit-code Cargo.lock; then
-            echo "Cargo.lock is unchanged"
-          else
-            echo "Error: Cargo.lock has been modified. Please run `cargo check` and commit the changes to Cargo.lock."
-            exit 1
-          fi
-
       - name: Set up Node
+        if: matrix.needs_node
         uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
         with:
           cache: "npm"
@@ -125,15 +122,8 @@ jobs:
           node-version: "16"
 
       - name: NPM setup
+        if: matrix.needs_node
         run: npm ci
 
-      - name: Lint unowned dependencies
-        run: npm run lint:dep-ownership
-
-      - name: Node Lint
-        run: npm run lint:prettier
-
-      - name: Verify rust documentation links
-        run: cargo doc --no-deps --all-features --document-private-items
-        env:
-          RUSTDOCFLAGS: "-D warnings"
+      - name: Run lint --only ${{ matrix.check }}
+        run: ./scripts/lint.sh --only ${{ matrix.check }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -131,7 +131,7 @@ jobs:
         run: npm run lint:dep-ownership
 
       - name: Node Lint
-        run: npm run lint
+        run: npm run lint:prettier
 
       - name: Verify rust documentation links
         run: cargo doc --no-deps --all-features --document-private-items

--- a/.prettierignore
+++ b/.prettierignore
@@ -3,8 +3,7 @@ schemas
 about.hbs
 
 # Language bindings
-crates/bitwarden-wasm-internal/npm/bitwarden_wasm_internal_bg.wasm.js
-crates/bitwarden-wasm-internal/bitwarden_license/npm/bitwarden_wasm_internal_bg.wasm.js
+crates/bitwarden-wasm-internal/**/bitwarden_wasm_internal*.js
 crates/bitwarden-uniffi/kotlin/*
 crates/bitwarden-uniffi/swift/*
 

--- a/README.md
+++ b/README.md
@@ -435,10 +435,27 @@ The list of developer tools is:
 This repository uses various tools to check formatting and linting before it's merged. It's
 recommended to run the checks before submitting a PR.
 
+### Running the checks
+
+```
+npm run lint           # run every check (check-only, matches CI)
+npm run lint:fix       # auto-fix where supported, then run the rest
+
+# Run a single check:
+npm run lint -- --only fmt
+npm run lint -- --only clippy
+```
+
+The list of available checks: `fmt`, `clippy`, `sort`, `udeps`, `dylint`, `doc`, `prettier`,
+`dep-ownership`, `cargo-lock`.
+
+The command is implemented in [scripts/lint.sh](./scripts/lint.sh) and mirrors
+[.github/workflows/lint.yml](./.github/workflows/lint.yml), so a local pass means CI will pass.
+
 ### Installation
 
-Please see the [lint.yml](./.github/workflows/lint.yml) file, for example, installation commands and
-versions. Here are the cli tools we use:
+The tools each check needs (and pinned versions) are installed in the lint workflow above. The
+underlying tools are:
 
 - Nightly [cargo fmt](https://github.com/rust-lang/rustfmt) and
   [cargo udeps](https://github.com/est31/cargo-udeps)
@@ -447,20 +464,7 @@ versions. Here are the cli tools we use:
 - [cargo sort](https://github.com/DevinR528/cargo-sort)
 - [prettier](https://github.com/prettier/prettier)
 
-### Checks
-
-To verify if changes need to be made, here are examples for the above tools:
-
-```
-export RUSTFLAGS="-D warnings"
-
-cargo +nightly fmt --check
-cargo +nightly udeps --workspace --all-features
-cargo clippy --all-features --all-targets
-cargo dylint --all -- --all-features --all-targets
-cargo sort --workspace --grouped --check
-npm run lint
-```
+If a tool is missing locally, `npm run lint` will tell you which one and how to install it.
 
 ## Documentation
 

--- a/package.json
+++ b/package.json
@@ -14,7 +14,9 @@
   "author": "Bitwarden Inc. <hello@bitwarden.com> (https://bitwarden.com)",
   "main": "index.js",
   "scripts": {
-    "lint": "prettier --check .",
+    "lint": "bash scripts/lint.sh",
+    "lint:fix": "bash scripts/lint.sh --fix",
+    "lint:prettier": "prettier --check .",
     "lint:dep-ownership": "tsx scripts/dep-ownership.ts",
     "prettier": "prettier --write .",
     "test": "echo \"Error: no test specified\" && exit 1",

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -1,0 +1,147 @@
+#!/usr/bin/env bash
+#
+# Unified lint/format runner for the Bitwarden SDK.
+# Mirrors the checks in .github/workflows/lint.yml so local runs match CI.
+#
+# Usage:
+#   scripts/lint.sh                Run every check (check-only).
+#   scripts/lint.sh --fix          Auto-fix where supported; still run check-only tools.
+#   scripts/lint.sh --only <name>  Run a single check. Composes with --fix.
+#
+# Available checks: fmt clippy sort udeps dylint doc prettier dep-ownership cargo-lock
+
+set -euo pipefail
+
+CHECKS=(fmt clippy sort udeps dylint doc prettier dep-ownership cargo-lock)
+
+FIX=0
+ONLY=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --fix) FIX=1; shift ;;
+    --only) ONLY="${2:-}"; shift 2 ;;
+    --only=*) ONLY="${1#*=}"; shift ;;
+    -h|--help)
+      sed -n '2,12p' "$0" | sed 's/^# \{0,1\}//'
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [[ -n "$ONLY" ]]; then
+  if ! printf '%s\n' "${CHECKS[@]}" | grep -qx -- "$ONLY"; then
+    echo "Unknown check: $ONLY" >&2
+    echo "Available: ${CHECKS[*]}" >&2
+    exit 2
+  fi
+fi
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+# Portable parse (BSD grep on macOS has no -P).
+RUST_NIGHTLY_TOOLCHAIN="$(awk -F'"' '/^nightly-channel/ {print $2}' rust-toolchain.toml)"
+if [[ -z "$RUST_NIGHTLY_TOOLCHAIN" ]]; then
+  echo "Could not read nightly-channel from rust-toolchain.toml" >&2
+  exit 1
+fi
+
+export RUSTFLAGS="-D warnings"
+export RUSTDOCFLAGS="-D warnings"
+
+section() { printf '\n\033[1;34m==> %s\033[0m\n' "$1"; }
+
+should_run() {
+  [[ -z "$ONLY" || "$ONLY" == "$1" ]]
+}
+
+require_tool() {
+  local tool="$1" install_hint="$2"
+  if ! command -v "$tool" >/dev/null 2>&1; then
+    echo "Required tool not found on PATH: $tool" >&2
+    echo "Install with: $install_hint" >&2
+    exit 1
+  fi
+}
+
+run_fmt() {
+  if (( FIX )); then
+    cargo "+$RUST_NIGHTLY_TOOLCHAIN" fmt
+  else
+    cargo "+$RUST_NIGHTLY_TOOLCHAIN" fmt --check
+  fi
+}
+
+run_clippy() {
+  if (( FIX )); then
+    cargo clippy --fix --allow-dirty --allow-staged --all-features --all-targets
+  else
+    cargo clippy --all-features --all-targets
+  fi
+}
+
+run_sort() {
+  require_tool cargo-sort "cargo install cargo-sort --locked"
+  if (( FIX )); then
+    cargo sort --workspace --grouped
+  else
+    cargo sort --workspace --grouped --check
+  fi
+}
+
+run_udeps() {
+  require_tool cargo-udeps "cargo install cargo-udeps --locked"
+  cargo "+$RUST_NIGHTLY_TOOLCHAIN" udeps --workspace --all-features
+}
+
+run_dylint() {
+  require_tool cargo-dylint "cargo install cargo-dylint dylint-link --locked"
+  cargo dylint --all -- --all-features --all-targets
+}
+
+run_doc() {
+  cargo doc --no-deps --all-features --document-private-items
+}
+
+run_prettier() {
+  if (( FIX )); then
+    npm run prettier
+  else
+    npm run lint:prettier
+  fi
+}
+
+run_dep_ownership() {
+  npm run lint:dep-ownership
+}
+
+run_cargo_lock() {
+  # --fix may legitimately update Cargo.lock; skip the guard in that mode.
+  if (( FIX )); then
+    return 0
+  fi
+  if ! git diff --exit-code Cargo.lock; then
+    echo "Error: Cargo.lock has been modified. Run \`cargo check\` and commit the change." >&2
+    return 1
+  fi
+}
+
+for check in "${CHECKS[@]}"; do
+  should_run "$check" || continue
+  section "$check"
+  case "$check" in
+    fmt) run_fmt ;;
+    clippy) run_clippy ;;
+    sort) run_sort ;;
+    udeps) run_udeps ;;
+    dylint) run_dylint ;;
+    doc) run_doc ;;
+    prettier) run_prettier ;;
+    dep-ownership) run_dep_ownership ;;
+    cargo-lock) run_cargo_lock ;;
+  esac
+done

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -124,10 +124,9 @@ run_cargo_lock() {
   if (( FIX )); then
     return 0
   fi
-  if ! git diff --exit-code Cargo.lock; then
-    echo "Error: Cargo.lock has been modified. Run \`cargo check\` and commit the change." >&2
-    return 1
-  fi
+  # `--locked` makes cargo fail if Cargo.lock is out of sync with Cargo.toml.
+  # Works in isolation (no prior cargo run needed), unlike `git diff Cargo.lock`.
+  cargo metadata --locked --format-version 1 >/dev/null
 }
 
 for check in "${CHECKS[@]}"; do


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective

- Makes linting easier by using the same script for CI and local checks
- Makes linting faster in CI (17m -> 8m) by parallelizing the checks

## 🚨 Breaking Changes

<!-- Does this PR introduce any breaking changes? If so, please describe the impact and migration path for clients.

If you're unsure, the automated TypeScript compatibility check will run when you open/update this PR and provide feedback.

For breaking changes:
1. Describe what changed in the client interface
2. Explain why the change was necessary
3. Provide migration steps for client developers
4. Link to any paired client PRs if needed

Otherwise, you can remove this section. -->
