### PR TITLE
[PM-38106] Implement streaming decryption for attachments

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1318,14 +1318,10 @@ dependencies = [
  "bitwarden-user-crypto-management",
  "bitwarden-vault",
  "console_error_panic_hook",
- "futures",
- "js-sys",
  "rand 0.10.1",
  "rsa",
  "serde",
  "sha1",
- "tokio",
- "tokio-util",
  "tracing",
  "tracing-subscriber",
  "tracing-web",
@@ -1333,8 +1329,6 @@ dependencies = [
  "uuid",
  "wasm-bindgen",
  "wasm-bindgen-futures",
- "wasm-streams",
- "web-sys",
 ]
 
 [[package]]
@@ -6075,7 +6069,6 @@ checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
 dependencies = [
  "bytes",
  "futures-core",
- "futures-io",
  "futures-sink",
  "pin-project-lite",
  "tokio",
@@ -6942,19 +6935,6 @@ dependencies = [
  "indexmap 2.14.0",
  "wasm-encoder 0.244.0",
  "wasmparser 0.244.0",
-]
-
-[[package]]
-name = "wasm-streams"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
-dependencies = [
- "futures-util",
- "js-sys",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -38,15 +38,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "aead-stream"
-version = "0.6.0-rc.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cc2d8c7d80cce546b635811cc9371c1db8794d36fcc160a08cb1e6824a5eab2"
-dependencies = [
- "aead 0.6.0-rc.10",
-]
-
-[[package]]
 name = "aes"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -668,9 +659,7 @@ dependencies = [
 name = "bitwarden-crypto"
 version = "3.0.0"
 dependencies = [
- "aead-stream",
  "aes 0.9.0",
- "aes-gcm 0.11.0-rc.3",
  "argon2",
  "bitwarden-api-key-connector",
  "bitwarden-encoding",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1318,10 +1318,14 @@ dependencies = [
  "bitwarden-user-crypto-management",
  "bitwarden-vault",
  "console_error_panic_hook",
+ "futures",
+ "js-sys",
  "rand 0.10.1",
  "rsa",
  "serde",
  "sha1",
+ "tokio",
+ "tokio-util",
  "tracing",
  "tracing-subscriber",
  "tracing-web",
@@ -1329,6 +1333,8 @@ dependencies = [
  "uuid",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm-streams",
+ "web-sys",
 ]
 
 [[package]]
@@ -5809,7 +5815,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -6069,6 +6075,7 @@ checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
 dependencies = [
  "bytes",
  "futures-core",
+ "futures-io",
  "futures-sink",
  "pin-project-lite",
  "tokio",
@@ -6935,6 +6942,19 @@ dependencies = [
  "indexmap 2.14.0",
  "wasm-encoder 0.244.0",
  "wasmparser 0.244.0",
+]
+
+[[package]]
+name = "wasm-streams"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -38,6 +38,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "aead-stream"
+version = "0.6.0-rc.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cc2d8c7d80cce546b635811cc9371c1db8794d36fcc160a08cb1e6824a5eab2"
+dependencies = [
+ "aead 0.6.0-rc.10",
+]
+
+[[package]]
 name = "aes"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -659,7 +668,9 @@ dependencies = [
 name = "bitwarden-crypto"
 version = "3.0.0"
 dependencies = [
+ "aead-stream",
  "aes 0.9.0",
+ "aes-gcm 0.11.0-rc.3",
  "argon2",
  "bitwarden-api-key-connector",
  "bitwarden-encoding",
@@ -675,6 +686,7 @@ dependencies = [
  "hkdf",
  "hmac 0.13.0",
  "hybrid-array",
+ "js-sys",
  "ml-dsa",
  "num-bigint",
  "num-traits",
@@ -692,6 +704,7 @@ dependencies = [
  "sha2 0.11.0",
  "subtle",
  "thiserror 2.0.18",
+ "tokio",
  "tracing",
  "tsify",
  "typenum",
@@ -886,7 +899,7 @@ dependencies = [
  "bitwarden-encoding",
  "serde",
  "subtle",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
  "tsify",
  "uuid",
  "wasm-bindgen",
@@ -5807,7 +5820,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.2",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",

--- a/crates/bitwarden-crypto/Cargo.toml
+++ b/crates/bitwarden-crypto/Cargo.toml
@@ -31,9 +31,7 @@ dangerous-crypto-debug = []
 test-utils = []
 
 [dependencies]
-aead-stream = { version = "0.6.0-rc.3", features = ["alloc"] }
 aes = { version = "0.9.0", features = ["zeroize"] }
-aes-gcm = { version = "0.11.0-rc.3", features = ["zeroize"] }
 argon2 = { version = "=0.6.0-rc.8", features = [
     "kdf",
     "zeroize",

--- a/crates/bitwarden-crypto/Cargo.toml
+++ b/crates/bitwarden-crypto/Cargo.toml
@@ -23,7 +23,7 @@ uniffi = [
     "dep:bitwarden-uniffi-error",
     "dep:uniffi",
 ] # Uniffi bindings
-wasm = ["dep:tsify", "dep:wasm-bindgen"] # WASM support
+wasm = ["dep:tsify", "dep:wasm-bindgen", "dep:js-sys"] # WASM support
 # WARNING: This feature is for debugging purposes only and should never be enabled in production.
 # It disables compile-time debug prevention for cryptographic keys, exposing sensitive key material
 # in debug output, and adds tracing debug logs to encrypt/decrypt operations.
@@ -31,7 +31,9 @@ dangerous-crypto-debug = []
 test-utils = []
 
 [dependencies]
+aead-stream = { version = "0.6.0-rc.3", features = ["alloc"] }
 aes = { version = "0.9.0", features = ["zeroize"] }
+aes-gcm = { version = "0.11.0-rc.3", features = ["zeroize"] }
 argon2 = { version = "=0.6.0-rc.8", features = [
     "kdf",
     "zeroize",
@@ -49,6 +51,7 @@ hex = { version = ">=0.4.0, <0.5" }
 hkdf = "0.13.0"
 hmac = { workspace = true, features = ["zeroize"] }
 hybrid-array = { version = "0.4.10", features = ["alloc", "serde", "zeroize"] }
+js-sys = { workspace = true, optional = true }
 ml-dsa = { version = "0.1.0-rc.8", features = ["zeroize"] }
 num-bigint = ">=0.4, <0.5"
 num-traits = ">=0.2.15, <0.3"
@@ -64,6 +67,7 @@ sha1 = { workspace = true, features = ["zeroize"] }
 sha2 = { workspace = true, features = ["zeroize"] }
 subtle = { workspace = true }
 thiserror = { workspace = true }
+tokio = { workspace = true, features = ["io-util"] }
 tracing = { workspace = true }
 tsify = { workspace = true, optional = true }
 typenum = ">=1.18.0, <1.20.0"
@@ -77,6 +81,7 @@ zeroizing-alloc = ">=0.1.0, <0.2"
 criterion = "0.8.0"
 rand_chacha = { workspace = true }
 serde_json = { workspace = true }
+tokio = { workspace = true, features = ["fs", "io-util", "macros", "rt"] }
 
 [[bench]]
 name = "default_allocator"

--- a/crates/bitwarden-crypto/examples/streaming_attachment.rs
+++ b/crates/bitwarden-crypto/examples/streaming_attachment.rs
@@ -1,0 +1,49 @@
+//! This example demonstrates the streaming attachment cipher end-to-end against a
+//! real file on disk: stream plaintext through [`StreamingAttachmentEncryptor`] into
+//! `tokio::fs::File`, then stream the resulting wire bytes back through
+//! [`StreamingAttachmentDecryptor`] reading from the same file.
+
+use std::env::temp_dir;
+
+use bitwarden_crypto::{
+    StreamingAttachmentDecryptor, StreamingAttachmentEncryptor, SymmetricCryptoKey,
+    SymmetricKeyAlgorithm,
+};
+use tokio::{
+    fs::File,
+    io::{AsyncReadExt, AsyncWriteExt},
+};
+
+#[tokio::main(flavor = "current_thread")]
+async fn main() {
+    let key = SymmetricCryptoKey::make(SymmetricKeyAlgorithm::Aes256CbcHmac);
+    let plaintext: Vec<u8> = (0..256_000).map(|i| (i % 251) as u8).collect();
+
+    let path = temp_dir().join("bitwarden-streaming-attachment-example.bin");
+
+    // Encrypt: pipe plaintext through the encryptor into a file on disk.
+    {
+        let file = File::create(&path)
+            .await
+            .expect("create attachment ciphertext file");
+        let mut enc = StreamingAttachmentEncryptor::new(key.clone(), file)
+            .expect("AES-CBC-HMAC key is a supported variant");
+        enc.write_all(&plaintext).await.expect("write_all");
+        enc.shutdown().await.expect("shutdown");
+    }
+
+    // Decrypt: stream the wire bytes back from the file through the decryptor.
+    let roundtripped = {
+        let file = File::open(&path).await.expect("open ciphertext file");
+        let mut dec = StreamingAttachmentDecryptor::new(key, file)
+            .expect("AES-CBC-HMAC key is a supported variant");
+        let mut out = Vec::new();
+        dec.read_to_end(&mut out).await.expect("read_to_end");
+        out
+    };
+
+    assert_eq!(roundtripped, plaintext, "plaintext must roundtrip exactly");
+    tokio::fs::remove_file(&path)
+        .await
+        .expect("remove ciphertext file");
+}

--- a/crates/bitwarden-crypto/examples/streaming_attachment.rs
+++ b/crates/bitwarden-crypto/examples/streaming_attachment.rs
@@ -6,8 +6,8 @@
 use std::env::temp_dir;
 
 use bitwarden_crypto::{
-    StreamingAttachmentDecryptor, StreamingAttachmentEncryptor, SymmetricCryptoKey,
-    SymmetricKeyAlgorithm,
+    KeyStore, StreamingAttachmentDecryptor, StreamingAttachmentEncryptor, SymmetricCryptoKey,
+    SymmetricKeyAlgorithm, key_slot_ids,
 };
 use tokio::{
     fs::File,
@@ -26,8 +26,13 @@ async fn main() {
         let file = File::create(&path)
             .await
             .expect("create attachment ciphertext file");
-        let mut enc = StreamingAttachmentEncryptor::new(key.clone(), file)
-            .expect("AES-CBC-HMAC key is a supported variant");
+        let mut enc = {
+            let key_store: KeyStore<ExampleIds> = KeyStore::default();
+            let mut ctx = key_store.context_mut();
+            let key_slot = ctx.add_local_symmetric_key(key.clone());
+            StreamingAttachmentEncryptor::new(key_slot, ctx, file)
+                .expect("AES-CBC-HMAC key is a supported variant")
+        };
         enc.write_all(&plaintext).await.expect("write_all");
         enc.shutdown().await.expect("shutdown");
     }
@@ -35,8 +40,13 @@ async fn main() {
     // Decrypt: stream the wire bytes back from the file through the decryptor.
     let roundtripped = {
         let file = File::open(&path).await.expect("open ciphertext file");
-        let mut dec = StreamingAttachmentDecryptor::new(key, file)
-            .expect("AES-CBC-HMAC key is a supported variant");
+        let mut dec = {
+            let key_store: KeyStore<ExampleIds> = KeyStore::default();
+            let mut ctx = key_store.context_mut();
+            let key_slot = ctx.add_local_symmetric_key(key.clone());
+            StreamingAttachmentDecryptor::new(key_slot, ctx, file)
+                .expect("AES-CBC-HMAC key is a supported variant")
+        };
         let mut out = Vec::new();
         dec.read_to_end(&mut out).await.expect("read_to_end");
         out
@@ -46,4 +56,27 @@ async fn main() {
     tokio::fs::remove_file(&path)
         .await
         .expect("remove ciphertext file");
+}
+
+key_slot_ids! {
+    #[symmetric]
+    pub enum ExampleSymmetricKey {
+        #[local]
+        ItemKey(LocalId)
+    }
+
+    #[private]
+    pub enum ExamplePrivateKey {
+        Key(u8),
+        #[local]
+        Local(LocalId),
+    }
+
+    #[signing]
+    pub enum ExampleSigningKey {
+        Key(u8),
+        #[local]
+        Local(LocalId),
+    }
+    pub ExampleIds => ExampleSymmetricKey, ExamplePrivateKey, ExampleSigningKey;
 }

--- a/crates/bitwarden-crypto/examples/streaming_attachment.rs
+++ b/crates/bitwarden-crypto/examples/streaming_attachment.rs
@@ -30,7 +30,7 @@ async fn main() {
             let key_store: KeyStore<ExampleIds> = KeyStore::default();
             let mut ctx = key_store.context_mut();
             let key_slot = ctx.add_local_symmetric_key(key.clone());
-            StreamingAttachmentEncryptor::new(key_slot, ctx, file)
+            StreamingAttachmentEncryptor::new(key_slot, ctx, file, plaintext.len())
                 .expect("AES-CBC-HMAC key is a supported variant")
         };
         enc.write_all(&plaintext).await.expect("write_all");

--- a/crates/bitwarden-crypto/src/lib.rs
+++ b/crates/bitwarden-crypto/src/lib.rs
@@ -26,6 +26,8 @@ mod keys;
 pub use keys::*;
 mod rsa;
 pub use crate::rsa::RsaKeyPair;
+mod stream;
+pub use stream::*;
 mod util;
 pub use util::{generate_random_alphanumeric, generate_random_bytes, pbkdf2};
 mod wordlist;

--- a/crates/bitwarden-crypto/src/stream/aes256_cbc_hmac_legacy_stream.rs
+++ b/crates/bitwarden-crypto/src/stream/aes256_cbc_hmac_legacy_stream.rs
@@ -218,7 +218,7 @@ enum DecryptorState {
         key: Aes256CbcHmacKey,
     },
     Streaming {
-        decryptor: CbcDecryptor,
+        decryptor: Box<CbcDecryptor>,
         integrity_validator: HmacStreamValidator,
         expected_mac: Mac,
     },
@@ -241,7 +241,7 @@ impl DecryptorState {
         match self {
             Self::Uninitialized { key } => {
                 *self = Self::Streaming {
-                    decryptor: CbcDecryptor::new(&key.enc_key.0, &header.iv),
+                    decryptor: Box::new(CbcDecryptor::new(&key.enc_key.0, &header.iv)),
                     integrity_validator: HmacStreamValidator::new(&key.mac_key.0, &header.iv),
                     expected_mac: header.mac,
                 };
@@ -508,25 +508,28 @@ impl StreamingAes256CbcHmacEncryptor {
 
 impl StreamingEncryptor for StreamingAes256CbcHmacEncryptor {
     fn update(&mut self, plaintext_chunk: &[u8], last_block: bool) -> ChunkEncryptionResult {
-        let (encryptor, stream_validator, iv): (&mut Box<CbcEncryptor>, &mut HmacStreamValidator, &Iv) =
-            match &mut self.encryptor_state {
-                EncryptorState::Error | EncryptorState::Done => {
-                    return ChunkEncryptionResult::Error;
+        let (encryptor, stream_validator, iv): (
+            &mut Box<CbcEncryptor>,
+            &mut HmacStreamValidator,
+            &Iv,
+        ) = match &mut self.encryptor_state {
+            EncryptorState::Error | EncryptorState::Done => {
+                return ChunkEncryptionResult::Error;
+            }
+            EncryptorState::Emitting => {
+                if let Some(chunk) = self.ciphertext_buffer.emit_chunk() {
+                    return ChunkEncryptionResult::EncryptedChunk(chunk);
+                } else {
+                    self.encryptor_state = EncryptorState::Done;
+                    return ChunkEncryptionResult::FinalEncryptedChunk(Vec::new());
                 }
-                EncryptorState::Emitting => {
-                    if let Some(chunk) = self.ciphertext_buffer.emit_chunk() {
-                        return ChunkEncryptionResult::EncryptedChunk(chunk);
-                    } else {
-                        self.encryptor_state = EncryptorState::Done;
-                        return ChunkEncryptionResult::FinalEncryptedChunk(Vec::new());
-                    }
-                }
-                EncryptorState::Streaming {
-                    encryptor,
-                    integrity_validator,
-                    iv,
-                } => (encryptor, integrity_validator, iv),
-            };
+            }
+            EncryptorState::Streaming {
+                encryptor,
+                integrity_validator,
+                iv,
+            } => (encryptor, integrity_validator, iv),
+        };
 
         self.plaintext_buffer.extend_from_slice(plaintext_chunk);
 

--- a/crates/bitwarden-crypto/src/stream/aes256_cbc_hmac_legacy_stream.rs
+++ b/crates/bitwarden-crypto/src/stream/aes256_cbc_hmac_legacy_stream.rs
@@ -439,7 +439,7 @@ impl CiphertextBuffer {
 
     fn append(&mut self, data: &CbcCiphertextBlock) {
         self.inner
-            .copy_from_slice(self.size..self.size + data.len(), data)
+            .append(data)
             .expect("buffer should grow to fit");
         self.size += data.len();
     }

--- a/crates/bitwarden-crypto/src/stream/aes256_cbc_hmac_legacy_stream.rs
+++ b/crates/bitwarden-crypto/src/stream/aes256_cbc_hmac_legacy_stream.rs
@@ -1,0 +1,706 @@
+//! # AES-256-CBC-HMAC-Legacy-Stream
+//!
+//! Aes256CBC-HMAC-Legacy-Stream is a format for streaming encryption of attachments. It consists of
+//! a header, an AES-CBC stream, and a hmac over IV + CBC ciphertext. Because there is just one HMAC
+//! over the entire stream, it is not permissible to decrypt a partial portion of this stream, as
+//! the integrity of that portion cannot be guaranteed.
+//!
+//! ## Format
+//! The stream looks as follows:
+//! ```
+//! (KEY_E, KEY_A) = KEY
+//! IV | HMAC[KEY_A] (over IV + ciphertext) | AES-CBC[KEY_E]() ciphertext
+//! ```
+//!
+//! ## Limitations
+//!
+//! Because the HMAC is written to the start, encryption must be buffered in memory fully
+//! before emitting out as an encryption stream, since the HMAC can only be calculated
+//! after all ciphertext is produced. This is a limitation to the format.
+//!
+//! Further, the HMAC covers the entire stream, not chunks of it, so the entire stream
+//! must be fully read before the output is used. IMPORTANT: YOU MUST READ THE ENTIRE STREAM
+//! BEFORE USING THE DECRYPTED OUTPUT. This contract cannot be enforced by the interface and
+//! requires the correct usage of the caller.
+//!
+//! NOTE: The attachments, stored on the server contain a header idicating which format they are
+//! encrypted with. This header is *NOT* included in the stream processed by this file, and is
+//! expected to be stripped by the caller before passing the ciphertext to this code.
+//!
+//! Random access is not possible with this format, both because of the use of CBC chaining,
+//! and because of the single HMAC over the entire cipher stream.
+
+use aes::cipher::{BlockModeDecrypt, BlockModeEncrypt, KeyIvInit};
+use hkdf::HmacImpl;
+use hybrid_array::Array;
+use rand::Rng;
+use subtle::ConstantTimeEq;
+use zeroize::ZeroizeOnDrop;
+
+use super::{
+    ChunkDecryptionResult, ChunkEncryptionResult, StreamCreationError, StreamingDecryptor,
+    StreamingEncryptor,
+};
+use crate::{
+    Aes256CbcHmacKey, SymmetricCryptoKey, stream::large_memory_buffer::Buffer,
+    util::PbkdfSha256Hmac,
+};
+
+const AES256_CBC_BLOCK_SIZE: usize = 16;
+const AES256_CBC_IV_SIZE: usize = 16;
+const HMAC_SIZE: usize = 32;
+const HEADER_LENGTH: usize = AES256_CBC_IV_SIZE + HMAC_SIZE;
+const EMISSION_CHUNK_SIZE: usize = 1024 * 1024; // 1 MiB
+
+/// CBC IV
+type Iv = [u8; AES256_CBC_IV_SIZE];
+/// HMAC over IV + Ciphertext
+type Mac = [u8; HMAC_SIZE];
+/// Header is IV || HMAC
+type StreamHeaderBytes = [u8; HEADER_LENGTH];
+type CbcCiphertextBlock = [u8; AES256_CBC_BLOCK_SIZE];
+
+struct CbcDecryptor {
+    decryptor: cbc::Decryptor<aes::Aes256>,
+}
+
+impl CbcDecryptor {
+    fn new(key: &[u8; 32], iv: &Iv) -> Self {
+        Self {
+            decryptor: cbc::Decryptor::<aes::Aes256>::new(key.into(), iv.into()),
+        }
+    }
+
+    fn decrypt_block(&mut self, block: &CbcCiphertextBlock) -> CbcPlaintextBlock {
+        let mut block: Array<u8, _> = (*block).into();
+        self.decryptor.decrypt_block(&mut block);
+        CbcPlaintextBlock(
+            block
+                .as_slice()
+                .try_into()
+                .expect("block size checked by type"),
+        )
+    }
+}
+
+struct CbcEncryptor {
+    encryptor: cbc::Encryptor<aes::Aes256>,
+}
+
+impl CbcEncryptor {
+    fn new(key: &[u8; 32], iv: &Iv) -> Self {
+        Self {
+            encryptor: cbc::Encryptor::<aes::Aes256>::new(key.into(), iv.into()),
+        }
+    }
+
+    fn encrypt_block(&mut self, block: &mut CbcPlaintextBlock) -> CbcCiphertextBlock {
+        let mut block_array: Array<u8, _> = block.0.into();
+        self.encryptor.encrypt_block(&mut block_array);
+        block_array
+            .as_slice()
+            .try_into()
+            .expect("block size checked by type")
+    }
+}
+
+/// A higher level interface over the HMAC validation of the attachment ciphertext
+struct HmacStreamValidator {
+    hmac: PbkdfSha256Hmac,
+}
+
+impl HmacStreamValidator {
+    fn new(mac_key: &[u8; 32], iv: &Iv) -> Self {
+        let mut hmac = PbkdfSha256Hmac::new_from_slice(mac_key);
+        hmac.update(iv);
+        Self { hmac }
+    }
+
+    /// Called on each CBC ciphertext block in order
+    fn read_block(&mut self, data: &CbcCiphertextBlock) {
+        self.hmac.update(data);
+    }
+
+    /// Called after the final block has been ingested by `read_block`, during encryption.
+    fn end_stream(&self) -> Mac {
+        // `HmacImpl::finalize` consumes self; clone so the validator can stay borrowed by the
+        // decryptor state machine and be dropped normally when the state transitions.
+        let mac: Mac = self
+            .hmac
+            .clone()
+            .finalize()
+            .as_slice()
+            .try_into()
+            .expect("hmac output is 32 bytes");
+        mac
+    }
+
+    /// Called after the final block has been ingested by `read_block`, during decryption. Returns
+    /// whether the calculated HMAC matches the expected HMAC from the header.
+    fn validate_stream_end(&self, expected_mac: &Mac) -> bool {
+        // `HmacImpl::finalize` consumes self; clone so the validator can stay borrowed
+        // by the decryptor state machine and be dropped normally when the state transitions.
+        let calculated_mac = self.hmac.clone().finalize();
+        calculated_mac.as_slice().ct_eq(expected_mac).into()
+    }
+}
+
+#[derive(ZeroizeOnDrop, Clone)]
+struct StreamHeader {
+    iv: Iv,
+    mac: Mac,
+}
+
+impl From<&StreamHeader> for StreamHeaderBytes {
+    fn from(header: &StreamHeader) -> Self {
+        let mut out = [0u8; HEADER_LENGTH];
+        out[..AES256_CBC_IV_SIZE].copy_from_slice(&header.iv);
+        out[AES256_CBC_IV_SIZE..].copy_from_slice(&header.mac);
+        out
+    }
+}
+
+impl From<&StreamHeaderBytes> for StreamHeader {
+    fn from(bytes: &StreamHeaderBytes) -> Self {
+        let iv: Iv = bytes[..AES256_CBC_IV_SIZE]
+            .try_into()
+            .expect("slice length checked by type");
+        let mac: Mac = bytes[AES256_CBC_IV_SIZE..]
+            .try_into()
+            .expect("slice length checked by type");
+        StreamHeader { iv, mac }
+    }
+}
+
+enum Pkcs7ValidationResult {
+    // The padding is valid and the containing plaintext is the contained plaintext data in the
+    // last chunk
+    Valid(Vec<u8>),
+    Invalid,
+}
+
+struct CbcPlaintextBlock([u8; AES256_CBC_BLOCK_SIZE]);
+
+impl AsRef<[u8]> for CbcPlaintextBlock {
+    fn as_ref(&self) -> &[u8] {
+        &self.0
+    }
+}
+
+impl CbcPlaintextBlock {
+    /// In PKCS7, the last N bytes of plaintext MUST all have the value N.
+    /// This function validates the padding for the last block and returns the contained plaintext
+    fn is_valid_pkcs7_padding(&self) -> Pkcs7ValidationResult {
+        let data = &self.0;
+        if data.is_empty() {
+            return Pkcs7ValidationResult::Invalid;
+        }
+        let padding_len = *data.last().expect("data is a fixed-size non-empty array") as usize;
+        if padding_len == 0 || padding_len > AES256_CBC_BLOCK_SIZE {
+            return Pkcs7ValidationResult::Invalid;
+        }
+        if data[data.len() - padding_len..]
+            .iter()
+            .all(|&b| b as usize == padding_len)
+        {
+            Pkcs7ValidationResult::Valid(data[..data.len() - padding_len].to_vec())
+        } else {
+            Pkcs7ValidationResult::Invalid
+        }
+    }
+}
+
+/// Streaming AES-256-CBC + HMAC-SHA256 decryptor. The HMAC is verified only at
+/// [`Self::finalize`]; bytes returned from [`Self::update`] are decrypted but **not yet**
+/// authenticated** and must be treated as untrusted until `finalize` returns `Ok`.
+enum DecryptorState {
+    Uninitialized {
+        key: Aes256CbcHmacKey,
+    },
+    Streaming {
+        decryptor: CbcDecryptor,
+        integrity_validator: HmacStreamValidator,
+        expected_mac: Mac,
+    },
+    Done,
+    Error,
+}
+
+enum DecryptorInitializeWithHeaderError {
+    AlreadyInitialized,
+}
+
+impl DecryptorState {
+    /// Initializes the decryptor with the stream header. This
+    /// changes the state from `Uninitialized` to `Streaming`, and must be called before any
+    /// decryption can occur.
+    fn initialize(
+        &mut self,
+        header: StreamHeader,
+    ) -> Result<(), DecryptorInitializeWithHeaderError> {
+        match self {
+            Self::Uninitialized { key } => {
+                *self = Self::Streaming {
+                    decryptor: CbcDecryptor::new(&key.enc_key.0, &header.iv),
+                    integrity_validator: HmacStreamValidator::new(&key.mac_key.0, &header.iv),
+                    expected_mac: header.mac,
+                };
+                Ok(())
+            }
+            _ => Err(DecryptorInitializeWithHeaderError::AlreadyInitialized),
+        }
+    }
+}
+
+/// Reads and removes the first block from the buffer. The size must
+/// be checked by the caller before calling this function, and it may panic otherwise.
+fn read_block_ciphertext(buffer: &mut Vec<u8>) -> CbcCiphertextBlock {
+    buffer
+        .drain(..AES256_CBC_BLOCK_SIZE)
+        .as_slice()
+        .try_into()
+        .expect("slice length checked by external condition")
+}
+
+/// Reads and removes the first block from the buffer. The size must
+/// be checked by the caller before calling this function, and it may panic otherwise.
+fn read_plaintext_block(buffer: &mut Vec<u8>) -> Option<CbcPlaintextBlock> {
+    if buffer.len() < AES256_CBC_BLOCK_SIZE {
+        return None;
+    }
+    Some(CbcPlaintextBlock(
+        buffer
+            .drain(..AES256_CBC_BLOCK_SIZE)
+            .as_slice()
+            .try_into()
+            .expect("slice length checked by condition"),
+    ))
+}
+
+fn read_header(buffer: &mut Vec<u8>) -> Option<StreamHeader> {
+    if buffer.len() >= HEADER_LENGTH {
+        let header_bytes: StreamHeaderBytes = buffer
+            .drain(..HEADER_LENGTH)
+            .as_slice()
+            .try_into()
+            .expect("slice length checked by condition");
+        Some((&header_bytes).into())
+    } else {
+        None
+    }
+}
+
+pub struct StreamingAes256CbcHmacDecryptor {
+    // Bytes that have been passed in but not yet processed by the crypto implementation.
+    // When passing in external data, they are first concatenated to the buffer, then the
+    // crypto implementation reads bytes
+    buffer: Vec<u8>,
+    decryptor_state: DecryptorState,
+}
+
+impl StreamingAes256CbcHmacDecryptor {
+    pub(crate) fn try_new(key: &SymmetricCryptoKey) -> Result<Self, StreamCreationError> {
+        let key = match key {
+            SymmetricCryptoKey::Aes256CbcHmacKey(key) => key,
+            _ => return Err(StreamCreationError::WrongKeyType),
+        };
+        Ok(Self {
+            buffer: Vec::new(),
+            decryptor_state: DecryptorState::Uninitialized { key: key.clone() },
+        })
+    }
+}
+
+impl StreamingDecryptor for StreamingAes256CbcHmacDecryptor {
+    /// Updates the decryptor with a chunk of ciphertext. If `last_block` is false, the chunk must
+    /// not contain the end of the stream, if it is true, it must contain the end of the stream.
+    fn update(&mut self, ciphertext_chunk: &[u8], last_block: bool) -> ChunkDecryptionResult {
+        self.buffer.extend_from_slice(ciphertext_chunk);
+
+        // If the decryptor is in an error or done state, we should not proceed with decryption and
+        // just return an error.
+        if matches!(
+            self.decryptor_state,
+            DecryptorState::Error | DecryptorState::Done
+        ) {
+            return ChunkDecryptionResult::Error;
+        }
+
+        // If the decryptor is uninitialized, it must be initialized before proceeding. The
+        // header bytes live at the start of the wire stream, so they are accumulated in
+        // `self.buffer` and drained from there once enough bytes have arrived.
+        if matches!(self.decryptor_state, DecryptorState::Uninitialized { .. }) {
+            if self.buffer.len() < HEADER_LENGTH {
+                if last_block {
+                    self.decryptor_state = DecryptorState::Error;
+                    return ChunkDecryptionResult::Error;
+                }
+                return ChunkDecryptionResult::NeedMoreData;
+            }
+            let header: StreamHeader =
+                read_header(&mut self.buffer).expect("header length checked by condition above");
+            if self.decryptor_state.initialize(header).is_err() {
+                self.decryptor_state = DecryptorState::Error;
+                return ChunkDecryptionResult::Error;
+            }
+        }
+
+        // The decryptor can now only be Streaming
+        if let DecryptorState::Streaming {
+            decryptor,
+            integrity_validator,
+            expected_mac,
+        } = &mut self.decryptor_state
+        {
+            // Process as many blocks as possible. On non-last calls, hold back one full block
+            // so PKCS7 stripping can run against it at finalize. (The decryptor must not emit
+            // padding bytes to the caller — but it doesn't know which block is the last until
+            // `last_block = true`.)
+            let blocks_to_process = if last_block {
+                self.buffer.len() / AES256_CBC_BLOCK_SIZE
+            } else {
+                self.buffer.len().saturating_sub(1) / AES256_CBC_BLOCK_SIZE
+            };
+
+            let mut decrypted_data = Vec::new();
+            for _ in 0..blocks_to_process {
+                let ciphertext_block: CbcCiphertextBlock = read_block_ciphertext(&mut self.buffer);
+                integrity_validator.read_block(&ciphertext_block);
+                let plaintext_block = decryptor.decrypt_block(&ciphertext_block);
+                decrypted_data.extend_from_slice(plaintext_block.as_ref());
+            }
+
+            if last_block {
+                // Finalize the HMAC validation. If it fails, we should discard all decrypted data
+                // and return an error.
+                if !integrity_validator.validate_stream_end(expected_mac) {
+                    self.decryptor_state = DecryptorState::Error;
+                    return ChunkDecryptionResult::Error;
+                }
+
+                // Strip and validate PKCS7 padding from the trailing decrypted block.
+                if decrypted_data.len() < AES256_CBC_BLOCK_SIZE {
+                    self.decryptor_state = DecryptorState::Error;
+                    return ChunkDecryptionResult::Error;
+                }
+
+                // The end of the stream is guaranteed to be a PKCS7 padding block. This padding
+                // must be validated and stripped.
+                let tail_start = decrypted_data.len() - AES256_CBC_BLOCK_SIZE;
+                let last_block: CbcPlaintextBlock = CbcPlaintextBlock(
+                    decrypted_data
+                        .drain(tail_start..)
+                        .as_slice()
+                        .try_into()
+                        .expect("drained one block"),
+                );
+                match last_block.is_valid_pkcs7_padding() {
+                    Pkcs7ValidationResult::Valid(plaintext) => {
+                        decrypted_data.extend_from_slice(&plaintext);
+                    }
+                    Pkcs7ValidationResult::Invalid => {
+                        self.decryptor_state = DecryptorState::Error;
+                        return ChunkDecryptionResult::Error;
+                    }
+                }
+
+                self.decryptor_state = DecryptorState::Done;
+                return ChunkDecryptionResult::FinalDecryptedChunk(decrypted_data);
+            } else {
+                return ChunkDecryptionResult::DecryptedChunk(decrypted_data);
+            }
+        }
+
+        // This should be unreachable
+        ChunkDecryptionResult::Error
+    }
+}
+
+struct CiphertextBuffer {
+    // Backing store for ciphertext bytes that have been encrypted but not yet emitted. On WASM,
+    // this is a JS Uint8Array to avoid copying between Rust and JS memory; on native, this is a
+    // Vec<u8>.
+    inner: Buffer,
+    // The current size of the buffer. This may be larger than the length of the ciphertext
+    // currently stored in the buffer, since the buffer grows in blocks.
+    size: usize,
+    emitted_bytes: usize,
+}
+
+impl CiphertextBuffer {
+    fn new() -> Self {
+        Self {
+            inner: Buffer::new(),
+            size: 0,
+            emitted_bytes: 0,
+        }
+    }
+
+    fn append(&mut self, data: &CbcCiphertextBlock) {
+        self.inner
+            .copy_from_slice(self.size..self.size + data.len(), data)
+            .expect("buffer should grow to fit");
+        self.size += data.len();
+    }
+
+    fn emit_chunk(&mut self) -> Option<Vec<u8>> {
+        let remaining_bytes = self.size - self.emitted_bytes;
+        if remaining_bytes == 0 {
+            return None;
+        }
+
+        let chunk_size = remaining_bytes.min(EMISSION_CHUNK_SIZE);
+        let chunk = self
+            .inner
+            .index(self.emitted_bytes..self.emitted_bytes + chunk_size)
+            .expect("chunk size is always within bounds of the buffer");
+        self.emitted_bytes += chunk_size;
+        Some(chunk)
+    }
+}
+
+enum EncryptorState {
+    Streaming {
+        encryptor: Box<CbcEncryptor>,
+        integrity_validator: HmacStreamValidator,
+        iv: Iv,
+    },
+    Emitting,
+    Done,
+    Error,
+}
+
+/// Streaming AES-256-CBC + HMAC-SHA256 encryptor. The IV is generated at construction time
+/// and the HMAC is computed over IV || ciphertext, matching the wire format consumed by
+/// [`StreamingAes256CbcHmacDecryptor`]. Because the MAC depends on the entire ciphertext,
+/// the complete wire stream (`IV, ciphertext`) is only emitted once `update` is
+/// called with `last_block = true`, as a single [`ChunkEncryptionResult::FinalEncrypted`].
+pub struct StreamingAes256CbcHmacEncryptor {
+    // Ciphertext bytes that have been encrypted but not yet emitted. The backing store is a
+    // pre-allocated large buffer (released-by-drop on WASM).
+    ciphertext_buffer: CiphertextBuffer,
+    plaintext_buffer: Vec<u8>,
+    encryptor_state: EncryptorState,
+}
+
+impl StreamingAes256CbcHmacEncryptor {
+    /// Creates a new encryptor with a fresh random IV.
+    pub(crate) fn try_new(key: &SymmetricCryptoKey) -> Result<Self, StreamCreationError> {
+        let key = match key {
+            SymmetricCryptoKey::Aes256CbcHmacKey(key) => key,
+            _ => return Err(StreamCreationError::WrongKeyType),
+        };
+
+        let mut iv: Iv = [0u8; AES256_CBC_IV_SIZE];
+        rand::rng().fill_bytes(&mut iv);
+
+        Ok(Self {
+            ciphertext_buffer: CiphertextBuffer::new(),
+            plaintext_buffer: Vec::new(),
+            encryptor_state: EncryptorState::Streaming {
+                encryptor: Box::new(CbcEncryptor::new(&key.enc_key.0, &iv)),
+                integrity_validator: HmacStreamValidator::new(&key.mac_key.0, &iv),
+                iv,
+            },
+        })
+    }
+}
+
+impl StreamingEncryptor for StreamingAes256CbcHmacEncryptor {
+    fn update(&mut self, plaintext_chunk: &[u8], last_block: bool) -> ChunkEncryptionResult {
+        let (encryptor, stream_validator, iv): (&mut Box<CbcEncryptor>, &mut HmacStreamValidator, &Iv) =
+            match &mut self.encryptor_state {
+                EncryptorState::Error | EncryptorState::Done => {
+                    return ChunkEncryptionResult::Error;
+                }
+                EncryptorState::Emitting => {
+                    if let Some(chunk) = self.ciphertext_buffer.emit_chunk() {
+                        return ChunkEncryptionResult::EncryptedChunk(chunk);
+                    } else {
+                        self.encryptor_state = EncryptorState::Done;
+                        return ChunkEncryptionResult::FinalEncryptedChunk(Vec::new());
+                    }
+                }
+                EncryptorState::Streaming {
+                    encryptor,
+                    integrity_validator,
+                    iv,
+                } => (encryptor, integrity_validator, iv),
+            };
+
+        self.plaintext_buffer.extend_from_slice(plaintext_chunk);
+
+        // Encrypt all full blocks currently in the buffer plaintext buffer.
+        while let Some(mut block) = read_plaintext_block(&mut self.plaintext_buffer) {
+            let cipher_block = encryptor.encrypt_block(&mut block);
+            stream_validator.read_block(&cipher_block);
+            self.ciphertext_buffer.append(&cipher_block);
+        }
+
+        if !last_block {
+            return ChunkEncryptionResult::NeedMoreData;
+        }
+
+        // PKCS7: pad to the next block boundary. If the buffer is already block-aligned (or
+        // empty), this appends a full padding block of value BLOCK_SIZE.
+        let padding_len = AES256_CBC_BLOCK_SIZE - self.plaintext_buffer.len();
+        let mut padding = vec![padding_len as u8; padding_len];
+        self.plaintext_buffer.append(&mut padding);
+
+        let Some(mut block) = read_plaintext_block(&mut self.plaintext_buffer) else {
+            // This should be unreachable, since the padding guarantees exactly one block should be
+            // available.
+            self.encryptor_state = EncryptorState::Error;
+            return ChunkEncryptionResult::Error;
+        };
+
+        let cipher_block = encryptor.encrypt_block(&mut block);
+        self.ciphertext_buffer.append(&cipher_block);
+
+        stream_validator.read_block(&cipher_block);
+        let mac = stream_validator.end_stream();
+
+        let header: StreamHeaderBytes = (&StreamHeader { iv: *iv, mac }).into();
+        self.encryptor_state = EncryptorState::Emitting;
+        ChunkEncryptionResult::EncryptedChunk(header.to_vec())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const ENC_KEY: [u8; 32] = [0u8; 32];
+    const MAC_KEY: [u8; 32] = [1u8; 32];
+    const PLAINTEXT: &[u8] = b"This is a test vector text for streaming encryption. It is long enough to require multiple CBC blocks.";
+    const STREAM_TEST_VECTOR: &[u8] = &[
+        202, 35, 233, 113, 188, 138, 45, 92, 122, 28, 38, 85, 31, 242, 192, 113, 213, 46, 222, 105,
+        210, 189, 251, 90, 162, 190, 27, 47, 139, 54, 146, 233, 233, 246, 27, 201, 172, 13, 180,
+        105, 69, 177, 113, 72, 154, 138, 43, 75, 53, 193, 235, 62, 28, 217, 137, 81, 167, 40, 33,
+        95, 241, 1, 154, 92, 69, 252, 151, 218, 106, 46, 189, 208, 154, 123, 192, 207, 253, 155,
+        22, 17, 158, 142, 88, 91, 177, 117, 227, 45, 58, 16, 150, 180, 193, 32, 144, 95, 227, 233,
+        60, 7, 98, 197, 200, 144, 179, 213, 220, 95, 242, 17, 112, 115, 211, 97, 90, 250, 210, 141,
+        200, 157, 156, 71, 133, 165, 246, 161, 110, 127, 232, 225, 121, 190, 235, 121, 228, 4, 31,
+        123, 67, 140, 84, 64, 41, 198, 227, 221, 20, 188, 252, 70, 20, 81, 138, 210, 247, 230, 16,
+        233, 229, 154,
+    ];
+
+    fn test_key() -> SymmetricCryptoKey {
+        SymmetricCryptoKey::Aes256CbcHmacKey(Aes256CbcHmacKey {
+            enc_key: Box::pin(ENC_KEY.into()),
+            mac_key: Box::pin(MAC_KEY.into()),
+        })
+    }
+
+    #[test]
+    #[ignore = "used to generate the test vector constant above; not a unit test"]
+    fn generate_test_vectors() {
+        let key = test_key();
+        let out = encrypt_all(&key, PLAINTEXT, 20);
+        println!("const STREAM_TEST_VECTOR: &[u8] = &{:?};", out);
+    }
+
+    fn encrypt_all(key: &SymmetricCryptoKey, plaintext: &[u8], chunk_size: usize) -> Vec<u8> {
+        let mut encryptor = StreamingAes256CbcHmacEncryptor::try_new(key)
+            .ok()
+            .expect("encryptor construction");
+
+        let mut plaintext_buffer = plaintext.to_vec();
+        let mut ciphertext_buffer = Vec::new();
+
+        loop {
+            let chunk = plaintext_buffer
+                .drain(..chunk_size.min(plaintext_buffer.len()))
+                .collect::<Vec<u8>>();
+            match encryptor.update(&chunk, plaintext_buffer.is_empty()) {
+                ChunkEncryptionResult::NeedMoreData => {}
+                ChunkEncryptionResult::EncryptedChunk(bytes) => {
+                    ciphertext_buffer.extend_from_slice(&bytes);
+                }
+                ChunkEncryptionResult::FinalEncryptedChunk(bytes) => {
+                    ciphertext_buffer.extend_from_slice(&bytes);
+                    break;
+                }
+                ChunkEncryptionResult::Error => panic!("encryption error"),
+            };
+        }
+
+        ciphertext_buffer
+    }
+
+    fn decrypt_all(key: &SymmetricCryptoKey, ciphertext: &[u8], chunk_size: usize) -> Vec<u8> {
+        let mut decryptor = StreamingAes256CbcHmacDecryptor::try_new(key)
+            .ok()
+            .expect("decryptor construction");
+
+        let mut ciphertext_buffer = ciphertext.to_vec();
+        let mut plaintext_buffer = Vec::new();
+
+        loop {
+            let chunk = ciphertext_buffer
+                .drain(..chunk_size.min(ciphertext_buffer.len()))
+                .collect::<Vec<u8>>();
+            match decryptor.update(&chunk, ciphertext_buffer.is_empty()) {
+                ChunkDecryptionResult::NeedMoreData => {}
+                ChunkDecryptionResult::DecryptedChunk(bytes) => {
+                    plaintext_buffer.extend_from_slice(&bytes);
+                }
+                ChunkDecryptionResult::FinalDecryptedChunk(bytes) => {
+                    plaintext_buffer.extend_from_slice(&bytes);
+                    break;
+                }
+                ChunkDecryptionResult::Error => panic!("decryption error"),
+            };
+        }
+
+        plaintext_buffer
+    }
+
+    #[test]
+    fn streaming_encrypt_decrypt_roundtrip() {
+        let key = test_key();
+        let plaintext = PLAINTEXT;
+        let ciphertext = encrypt_all(&key, plaintext, 11);
+        let roundtripped = decrypt_all(&key, &ciphertext, 9);
+
+        assert_eq!(roundtripped, plaintext);
+    }
+
+    #[test]
+    fn streaming_decrypt_with_truncated_ciphertext_fails() {
+        let key = test_key();
+        let ciphertext = STREAM_TEST_VECTOR;
+        let truncated = &ciphertext[..ciphertext.len() - 10];
+        let mut dec = StreamingAes256CbcHmacDecryptor::try_new(&key)
+            .ok()
+            .expect("decryptor construction");
+        let result = dec.update(truncated, true);
+        assert!(matches!(result, ChunkDecryptionResult::Error));
+    }
+
+    #[test]
+    fn streaming_decrypt_with_modified_ciphertext_fails() {
+        let key = test_key();
+        let mut modified = STREAM_TEST_VECTOR.to_vec();
+        // Flip a bit in the middle of the stream
+        modified[50] ^= 0b0000_0001;
+        let mut dec = StreamingAes256CbcHmacDecryptor::try_new(&key)
+            .ok()
+            .expect("decryptor construction");
+        let result = dec.update(&modified, true);
+        assert!(matches!(result, ChunkDecryptionResult::Error));
+    }
+
+    #[test]
+    fn streaming_decrypt_with_modified_header_fails() {
+        let key = test_key();
+        let mut modified = STREAM_TEST_VECTOR.to_vec();
+        // Flip a bit in the header (the IV)
+        modified[5] ^= 0b0000_0001;
+        let mut dec = StreamingAes256CbcHmacDecryptor::try_new(&key)
+            .ok()
+            .expect("decryptor construction");
+        let result = dec.update(&modified, true);
+        assert!(matches!(result, ChunkDecryptionResult::Error));
+    }
+}

--- a/crates/bitwarden-crypto/src/stream/aes256_cbc_hmac_legacy_stream.rs
+++ b/crates/bitwarden-crypto/src/stream/aes256_cbc_hmac_legacy_stream.rs
@@ -35,7 +35,6 @@ use hkdf::HmacImpl;
 use hybrid_array::Array;
 use rand::Rng;
 use subtle::ConstantTimeEq;
-use zeroize::ZeroizeOnDrop;
 
 use super::{
     ChunkDecryptionResult, ChunkEncryptionResult, StreamCreationError, StreamingDecryptor,
@@ -145,7 +144,7 @@ impl HmacStreamValidator {
     }
 }
 
-#[derive(ZeroizeOnDrop, Clone)]
+#[derive(Clone)]
 struct StreamHeader {
     iv: Iv,
     mac: Mac,

--- a/crates/bitwarden-crypto/src/stream/aes256_cbc_hmac_legacy_stream.rs
+++ b/crates/bitwarden-crypto/src/stream/aes256_cbc_hmac_legacy_stream.rs
@@ -210,9 +210,6 @@ impl CbcPlaintextBlock {
     }
 }
 
-/// Streaming AES-256-CBC + HMAC-SHA256 decryptor. The HMAC is verified only at
-/// [`Self::finalize`]; bytes returned from [`Self::update`] are decrypted but **not yet**
-/// authenticated** and must be treated as untrusted until `finalize` returns `Ok`.
 enum DecryptorState {
     Uninitialized {
         key: Aes256CbcHmacKey,
@@ -290,6 +287,11 @@ fn read_header(buffer: &mut Vec<u8>) -> Option<StreamHeader> {
     }
 }
 
+/// Streaming AES-256-CBC + HMAC-SHA256 decryptor. The HMAC is verified only when
+/// [`StreamingDecryptor::update`] is called with `last_block = true`; bytes returned from
+/// earlier `update` calls as [`ChunkDecryptionResult::DecryptedChunk`] are decrypted but **not
+/// yet authenticated** and must be treated as untrusted until the terminal
+/// [`ChunkDecryptionResult::FinalDecryptedChunk`] is observed.
 pub struct StreamingAes256CbcHmacDecryptor {
     // Bytes that have been passed in but not yet processed by the crypto implementation.
     // When passing in external data, they are first concatenated to the buffer, then the
@@ -474,7 +476,7 @@ enum EncryptorState {
 /// and the HMAC is computed over IV || ciphertext, matching the wire format consumed by
 /// [`StreamingAes256CbcHmacDecryptor`]. Because the MAC depends on the entire ciphertext,
 /// the complete wire stream (`IV, ciphertext`) is only emitted once `update` is
-/// called with `last_block = true`, as a single [`ChunkEncryptionResult::FinalEncrypted`].
+/// called with `last_block = true`, as a single [`ChunkEncryptionResult::FinalEncryptedChunk`].
 pub struct StreamingAes256CbcHmacEncryptor {
     // Ciphertext bytes that have been encrypted but not yet emitted. The backing store is a
     // pre-allocated large buffer (released-by-drop on WASM).

--- a/crates/bitwarden-crypto/src/stream/aes256_cbc_hmac_legacy_stream.rs
+++ b/crates/bitwarden-crypto/src/stream/aes256_cbc_hmac_legacy_stream.rs
@@ -7,7 +7,7 @@
 //!
 //! ## Format
 //! The stream looks as follows:
-//! ```
+//! ```text
 //! (KEY_E, KEY_A) = KEY
 //! IV | HMAC[KEY_A] (over IV + ciphertext) | AES-CBC[KEY_E]() ciphertext
 //! ```

--- a/crates/bitwarden-crypto/src/stream/aes256_cbc_hmac_legacy_stream.rs
+++ b/crates/bitwarden-crypto/src/stream/aes256_cbc_hmac_legacy_stream.rs
@@ -41,7 +41,8 @@ use super::{
     StreamEncryptionError, StreamingDecryptor, StreamingEncryptor,
 };
 use crate::{
-    Aes256CbcHmacKey, SymmetricCryptoKey, stream::large_memory_buffer::Buffer,
+    Aes256CbcHmacKey, SymmetricCryptoKey,
+    stream::large_memory_buffer::{Buffer, InvalidIndexError},
     util::PbkdfSha256Hmac,
 };
 
@@ -429,17 +430,18 @@ struct CiphertextBuffer {
 }
 
 impl CiphertextBuffer {
-    fn new() -> Self {
+    fn new(capacity: usize) -> Self {
         Self {
-            inner: Buffer::new(),
+            inner: Buffer::new(capacity),
             size: 0,
             emitted_bytes: 0,
         }
     }
 
-    fn append(&mut self, data: &CbcCiphertextBlock) {
-        self.inner.append(data).expect("buffer should grow to fit");
+    fn append(&mut self, data: &CbcCiphertextBlock) -> Result<(), InvalidIndexError> {
+        self.inner.append(data)?;
         self.size += data.len();
+        Ok(())
     }
 
     fn emit_chunk(&mut self) -> Option<Vec<u8>> {
@@ -483,8 +485,13 @@ pub struct StreamingAes256CbcHmacEncryptor {
 }
 
 impl StreamingAes256CbcHmacEncryptor {
-    /// Creates a new encryptor with a fresh random IV.
-    pub(crate) fn try_new(key: &SymmetricCryptoKey) -> Result<Self, StreamCreationError> {
+    /// Creates a new encryptor with a fresh random IV. `plaintext_size` is the total number of
+    /// plaintext bytes that will be fed to the encryptor; it is used to pre-allocate the ciphertext
+    /// buffer to its exact final size so it never has to be resized.
+    pub(crate) fn try_new(
+        key: &SymmetricCryptoKey,
+        plaintext_size: usize,
+    ) -> Result<Self, StreamCreationError> {
         let key = match key {
             SymmetricCryptoKey::Aes256CbcHmacKey(key) => key,
             _ => return Err(StreamCreationError::WrongKeyType),
@@ -493,8 +500,13 @@ impl StreamingAes256CbcHmacEncryptor {
         let mut iv: Iv = [0u8; AES256_CBC_IV_SIZE];
         rand::rng().fill_bytes(&mut iv);
 
+        // The CBC ciphertext is the PKCS7-padded plaintext, which is always rounded up to the next
+        // full block (a full padding block is added when already block-aligned).
+        let ciphertext_capacity =
+            (plaintext_size / AES256_CBC_BLOCK_SIZE + 1) * AES256_CBC_BLOCK_SIZE;
+
         Ok(Self {
-            ciphertext_buffer: CiphertextBuffer::new(),
+            ciphertext_buffer: CiphertextBuffer::new(ciphertext_capacity),
             plaintext_buffer: Vec::new(),
             encryptor_state: EncryptorState::Streaming {
                 encryptor: Box::new(CbcEncryptor::new(&key.enc_key.0, &iv)),
@@ -536,7 +548,10 @@ impl StreamingEncryptor for StreamingAes256CbcHmacEncryptor {
         while let Some(mut block) = read_plaintext_block(&mut self.plaintext_buffer) {
             let cipher_block = encryptor.encrypt_block(&mut block);
             stream_validator.read_block(&cipher_block);
-            self.ciphertext_buffer.append(&cipher_block);
+            if self.ciphertext_buffer.append(&cipher_block).is_err() {
+                self.encryptor_state = EncryptorState::Error;
+                return ChunkEncryptionResult::Error(StreamEncryptionError);
+            }
         }
 
         if !last_block {
@@ -557,7 +572,10 @@ impl StreamingEncryptor for StreamingAes256CbcHmacEncryptor {
         };
 
         let cipher_block = encryptor.encrypt_block(&mut block);
-        self.ciphertext_buffer.append(&cipher_block);
+        if self.ciphertext_buffer.append(&cipher_block).is_err() {
+            self.encryptor_state = EncryptorState::Error;
+            return ChunkEncryptionResult::Error(StreamEncryptionError);
+        }
 
         stream_validator.read_block(&cipher_block);
         let mac = stream_validator.end_stream();
@@ -603,7 +621,7 @@ mod tests {
     }
 
     fn encrypt_all(key: &SymmetricCryptoKey, plaintext: &[u8], chunk_size: usize) -> Vec<u8> {
-        let mut encryptor = StreamingAes256CbcHmacEncryptor::try_new(key)
+        let mut encryptor = StreamingAes256CbcHmacEncryptor::try_new(key, plaintext.len())
             .ok()
             .expect("encryptor construction");
 

--- a/crates/bitwarden-crypto/src/stream/aes256_cbc_hmac_legacy_stream.rs
+++ b/crates/bitwarden-crypto/src/stream/aes256_cbc_hmac_legacy_stream.rs
@@ -37,8 +37,8 @@ use rand::Rng;
 use subtle::ConstantTimeEq;
 
 use super::{
-    ChunkDecryptionResult, ChunkEncryptionResult, StreamCreationError, StreamingDecryptor,
-    StreamingEncryptor,
+    ChunkDecryptionResult, ChunkEncryptionResult, StreamCreationError, StreamDecryptionError,
+    StreamEncryptionError, StreamingDecryptor, StreamingEncryptor,
 };
 use crate::{
     Aes256CbcHmacKey, SymmetricCryptoKey, stream::large_memory_buffer::Buffer,
@@ -324,7 +324,7 @@ impl StreamingDecryptor for StreamingAes256CbcHmacDecryptor {
             self.decryptor_state,
             DecryptorState::Error | DecryptorState::Done
         ) {
-            return ChunkDecryptionResult::Error;
+            return ChunkDecryptionResult::Error(StreamDecryptionError);
         }
 
         // If the decryptor is uninitialized, it must be initialized before proceeding. The
@@ -334,7 +334,7 @@ impl StreamingDecryptor for StreamingAes256CbcHmacDecryptor {
             if self.buffer.len() < HEADER_LENGTH {
                 if last_block {
                     self.decryptor_state = DecryptorState::Error;
-                    return ChunkDecryptionResult::Error;
+                    return ChunkDecryptionResult::Error(StreamDecryptionError);
                 }
                 return ChunkDecryptionResult::NeedMoreData;
             }
@@ -342,7 +342,7 @@ impl StreamingDecryptor for StreamingAes256CbcHmacDecryptor {
                 read_header(&mut self.buffer).expect("header length checked by condition above");
             if self.decryptor_state.initialize(header).is_err() {
                 self.decryptor_state = DecryptorState::Error;
-                return ChunkDecryptionResult::Error;
+                return ChunkDecryptionResult::Error(StreamDecryptionError);
             }
         }
 
@@ -376,13 +376,13 @@ impl StreamingDecryptor for StreamingAes256CbcHmacDecryptor {
                 // and return an error.
                 if !integrity_validator.validate_stream_end(expected_mac) {
                     self.decryptor_state = DecryptorState::Error;
-                    return ChunkDecryptionResult::Error;
+                    return ChunkDecryptionResult::Error(StreamDecryptionError);
                 }
 
                 // Strip and validate PKCS7 padding from the trailing decrypted block.
                 if decrypted_data.len() < AES256_CBC_BLOCK_SIZE {
                     self.decryptor_state = DecryptorState::Error;
-                    return ChunkDecryptionResult::Error;
+                    return ChunkDecryptionResult::Error(StreamDecryptionError);
                 }
 
                 // The end of the stream is guaranteed to be a PKCS7 padding block. This padding
@@ -401,7 +401,7 @@ impl StreamingDecryptor for StreamingAes256CbcHmacDecryptor {
                     }
                     Pkcs7ValidationResult::Invalid => {
                         self.decryptor_state = DecryptorState::Error;
-                        return ChunkDecryptionResult::Error;
+                        return ChunkDecryptionResult::Error(StreamDecryptionError);
                     }
                 }
 
@@ -413,7 +413,7 @@ impl StreamingDecryptor for StreamingAes256CbcHmacDecryptor {
         }
 
         // This should be unreachable
-        ChunkDecryptionResult::Error
+        ChunkDecryptionResult::Error(StreamDecryptionError)
     }
 }
 
@@ -438,9 +438,7 @@ impl CiphertextBuffer {
     }
 
     fn append(&mut self, data: &CbcCiphertextBlock) {
-        self.inner
-            .append(data)
-            .expect("buffer should grow to fit");
+        self.inner.append(data).expect("buffer should grow to fit");
         self.size += data.len();
     }
 
@@ -515,7 +513,7 @@ impl StreamingEncryptor for StreamingAes256CbcHmacEncryptor {
             &Iv,
         ) = match &mut self.encryptor_state {
             EncryptorState::Error | EncryptorState::Done => {
-                return ChunkEncryptionResult::Error;
+                return ChunkEncryptionResult::Error(StreamEncryptionError);
             }
             EncryptorState::Emitting => {
                 if let Some(chunk) = self.ciphertext_buffer.emit_chunk() {
@@ -555,7 +553,7 @@ impl StreamingEncryptor for StreamingAes256CbcHmacEncryptor {
             // This should be unreachable, since the padding guarantees exactly one block should be
             // available.
             self.encryptor_state = EncryptorState::Error;
-            return ChunkEncryptionResult::Error;
+            return ChunkEncryptionResult::Error(StreamEncryptionError);
         };
 
         let cipher_block = encryptor.encrypt_block(&mut block);
@@ -625,7 +623,7 @@ mod tests {
                     ciphertext_buffer.extend_from_slice(&bytes);
                     break;
                 }
-                ChunkEncryptionResult::Error => panic!("encryption error"),
+                ChunkEncryptionResult::Error(_) => panic!("encryption error"),
             };
         }
 
@@ -653,7 +651,7 @@ mod tests {
                     plaintext_buffer.extend_from_slice(&bytes);
                     break;
                 }
-                ChunkDecryptionResult::Error => panic!("decryption error"),
+                ChunkDecryptionResult::Error(_) => panic!("decryption error"),
             };
         }
 
@@ -679,7 +677,7 @@ mod tests {
             .ok()
             .expect("decryptor construction");
         let result = dec.update(truncated, true);
-        assert!(matches!(result, ChunkDecryptionResult::Error));
+        assert!(matches!(result, ChunkDecryptionResult::Error(_)));
     }
 
     #[test]
@@ -692,7 +690,7 @@ mod tests {
             .ok()
             .expect("decryptor construction");
         let result = dec.update(&modified, true);
-        assert!(matches!(result, ChunkDecryptionResult::Error));
+        assert!(matches!(result, ChunkDecryptionResult::Error(_)));
     }
 
     #[test]
@@ -705,6 +703,6 @@ mod tests {
             .ok()
             .expect("decryptor construction");
         let result = dec.update(&modified, true);
-        assert!(matches!(result, ChunkDecryptionResult::Error));
+        assert!(matches!(result, ChunkDecryptionResult::Error(_)));
     }
 }

--- a/crates/bitwarden-crypto/src/stream/large_memory_buffer.rs
+++ b/crates/bitwarden-crypto/src/stream/large_memory_buffer.rs
@@ -125,7 +125,9 @@ mod tests {
     #[test]
     fn test_buffer() {
         let mut buffer = Buffer::new();
-        buffer.copy_from_slice(0..5, &[1, 2, 3, 4, 5]).expect("range must be valid");
+        buffer
+            .copy_from_slice(0..5, &[1, 2, 3, 4, 5])
+            .expect("range must be valid");
         assert_eq!(&buffer.index(0..5).unwrap(), &[1, 2, 3, 4, 5]);
     }
 
@@ -138,10 +140,14 @@ mod tests {
     #[test]
     fn test_write_past_capacity_grows_in_blocks() {
         let mut buffer = Buffer::new();
-        buffer.copy_from_slice(0..5, &[1, 2, 3, 4, 5]).expect("range must be valid");
+        buffer
+            .copy_from_slice(0..5, &[1, 2, 3, 4, 5])
+            .expect("range must be valid");
 
         let position = BLOCK_SIZE;
-        buffer.copy_from_slice(position..position + 4, &[6, 7, 8, 9]).expect("range must be valid");
+        buffer
+            .copy_from_slice(position..position + 4, &[6, 7, 8, 9])
+            .expect("range must be valid");
 
         assert_eq!(buffer.size, 2 * BLOCK_SIZE);
         assert_eq!(&buffer.index(0..5).unwrap(), &[1, 2, 3, 4, 5]);
@@ -155,7 +161,9 @@ mod tests {
     fn test_grow_spanning_multiple_blocks() {
         let mut buffer = Buffer::new();
         let position = 3 * BLOCK_SIZE + 100;
-        buffer.copy_from_slice(position..position + 3, &[1, 2, 3]).expect("range must be valid");
+        buffer
+            .copy_from_slice(position..position + 3, &[1, 2, 3])
+            .expect("range must be valid");
         assert_eq!(buffer.size, 4 * BLOCK_SIZE);
         assert_eq!(&buffer.index(position..position + 3).unwrap(), &[1, 2, 3]);
     }

--- a/crates/bitwarden-crypto/src/stream/large_memory_buffer.rs
+++ b/crates/bitwarden-crypto/src/stream/large_memory_buffer.rs
@@ -2,19 +2,16 @@
 //! resizing the heap after it has been allocated, so we need to allocate a buffer that can be
 //! released again.
 //!
-//! Allocations are made in 32 MiB blocks. Writes that exceed the current allocation grow the
-//! buffer by additional 32 MiB blocks, preserving previously written data.
+//! Allocations are made exponentially to minimize over-allocation while keeping re-allocations low.
 //!
 //! This is used for streaming encryption in the legacy format.
 
 /// Buffers are allocated and grown in multiples of this value.
-const BLOCK_SIZE: usize = 32 * 1024 * 1024;
-#[cfg(target_arch = "wasm32")]
-const INITIAL_SIZE: usize = 1024 * 1024;
+const INITIAL_SIZE: usize = 8 * 1024 * 1024;
 
 // Gives the size as a multiple of blocks that fits the requested size.
-fn round_up_to_block(size: usize) -> usize {
-    size.div_ceil(BLOCK_SIZE).max(1) * BLOCK_SIZE
+fn next_size(current: usize, required: usize) -> usize {
+    current.saturating_mul(2).max(required).max(INITIAL_SIZE)
 }
 
 pub struct Buffer {
@@ -50,9 +47,9 @@ impl Buffer {
             inner: js_sys::Uint8Array::new_with_length(INITIAL_SIZE as u32).into(),
 
             #[cfg(not(target_arch = "wasm32"))]
-            inner: Vec::new(),
+            inner: vec![0; INITIAL_SIZE],
 
-            size: 0,
+            size: INITIAL_SIZE,
         }
     }
 
@@ -86,8 +83,9 @@ impl Buffer {
 
         #[cfg(target_arch = "wasm32")]
         {
-            let data_uint8_array = js_sys::Uint8Array::from(data);
-            self.inner.set(&data_uint8_array, index.start as u32);
+            self.inner
+                .subarray(index.start as u32, index.end as u32)
+                .copy_from(data);
         }
 
         #[cfg(not(target_arch = "wasm32"))]
@@ -99,7 +97,7 @@ impl Buffer {
     }
 
     fn grow_to_fit(&mut self, required: usize) {
-        let new_size = round_up_to_block(required);
+        let new_size = next_size(self.size, required);
 
         #[cfg(target_arch = "wasm32")]
         {
@@ -132,39 +130,22 @@ mod tests {
     }
 
     #[test]
-    fn test_initial_alloc_rounds_up_to_block_size() {
-        let buffer = Buffer::new();
-        assert_eq!(buffer.size, 0);
-    }
-
-    #[test]
-    fn test_write_past_capacity_grows_in_blocks() {
+    fn test_write_past_capacity_grows() {
         let mut buffer = Buffer::new();
         buffer
             .copy_from_slice(0..5, &[1, 2, 3, 4, 5])
             .expect("range must be valid");
 
-        let position = BLOCK_SIZE;
+        let position = INITIAL_SIZE;
         buffer
             .copy_from_slice(position..position + 4, &[6, 7, 8, 9])
             .expect("range must be valid");
 
-        assert_eq!(buffer.size, 2 * BLOCK_SIZE);
+        assert_eq!(buffer.size, 2 * INITIAL_SIZE);
         assert_eq!(&buffer.index(0..5).unwrap(), &[1, 2, 3, 4, 5]);
         assert_eq!(
             &buffer.index(position..position + 4).unwrap(),
             &[6, 7, 8, 9]
         );
-    }
-
-    #[test]
-    fn test_grow_spanning_multiple_blocks() {
-        let mut buffer = Buffer::new();
-        let position = 3 * BLOCK_SIZE + 100;
-        buffer
-            .copy_from_slice(position..position + 3, &[1, 2, 3])
-            .expect("range must be valid");
-        assert_eq!(buffer.size, 4 * BLOCK_SIZE);
-        assert_eq!(&buffer.index(position..position + 3).unwrap(), &[1, 2, 3]);
     }
 }

--- a/crates/bitwarden-crypto/src/stream/large_memory_buffer.rs
+++ b/crates/bitwarden-crypto/src/stream/large_memory_buffer.rs
@@ -104,7 +104,7 @@ impl Buffer {
         #[cfg(target_arch = "wasm32")]
         {
             let new_array = js_sys::Uint8Array::new_with_length(new_size as u32);
-            let old_array = self.inner;
+            let old_array = self.inner.clone();
             new_array.set(&old_array, 0);
             self.inner = new_array;
         }

--- a/crates/bitwarden-crypto/src/stream/large_memory_buffer.rs
+++ b/crates/bitwarden-crypto/src/stream/large_memory_buffer.rs
@@ -2,17 +2,10 @@
 //! resizing the heap after it has been allocated, so we need to allocate a buffer that can be
 //! released again.
 //!
-//! Allocations are made exponentially to minimize over-allocation while keeping re-allocations low.
+//! The buffer is allocated once to an exact size at construction and is never resized, since
+//! resizing a `Uint8Array` on WASM is slow (it requires allocating a new array and copying).
 //!
 //! This is used for streaming encryption in the legacy format.
-
-/// Buffers are allocated and grown in multiples of this value.
-const INITIAL_SIZE: usize = 8 * 1024 * 1024;
-
-// Gives the size as a multiple of blocks that fits the requested size.
-fn next_size(current: usize, required: usize) -> usize {
-    current.saturating_mul(2).max(required).max(INITIAL_SIZE)
-}
 
 pub struct Buffer {
     // The Uint8Array lives in JS memory, and wasm merely keeps a reference to it in the
@@ -34,27 +27,32 @@ pub struct Buffer {
     #[cfg(not(target_arch = "wasm32"))]
     inner: Vec<u8>,
 
-    size: usize,
+    // Total allocated capacity in bytes. Fixed at construction; the buffer never grows.
+    capacity: usize,
+
+    // Write cursor: the number of bytes appended so far.
+    position: usize,
 }
 
 #[derive(Debug)]
 pub(crate) struct InvalidIndexError;
 
 impl Buffer {
-    pub fn new() -> Self {
+    pub fn new(capacity: usize) -> Self {
         Self {
             #[cfg(target_arch = "wasm32")]
-            inner: js_sys::Uint8Array::new_with_length(INITIAL_SIZE as u32).into(),
+            inner: js_sys::Uint8Array::new_with_length(capacity as u32).into(),
 
             #[cfg(not(target_arch = "wasm32"))]
-            inner: vec![0; INITIAL_SIZE],
+            inner: vec![0; capacity],
 
-            size: INITIAL_SIZE,
+            capacity,
+            position: 0,
         }
     }
 
     pub fn index(&self, index: std::ops::Range<usize>) -> Result<Vec<u8>, InvalidIndexError> {
-        if index.end > self.size || index.start > index.end {
+        if index.end > self.capacity || index.start > index.end {
             return Err(InvalidIndexError);
         }
 
@@ -73,42 +71,24 @@ impl Buffer {
     }
 
     pub fn append(&mut self, data: &[u8]) -> Result<(), InvalidIndexError> {
-        if self.size + data.len() > self.size {
-            self.grow_to_fit(self.size + data.len());
+        if self.position + data.len() > self.capacity {
+            return Err(InvalidIndexError);
         }
 
         #[cfg(target_arch = "wasm32")]
         {
             self.inner
-                .subarray(self.size as u32, (self.size + data.len()) as u32)
+                .subarray(self.position as u32, (self.position + data.len()) as u32)
                 .copy_from(data);
         }
 
         #[cfg(not(target_arch = "wasm32"))]
         {
-            self.inner[self.size..self.size + data.len()].copy_from_slice(data);
+            self.inner[self.position..self.position + data.len()].copy_from_slice(data);
         }
 
+        self.position += data.len();
         Ok(())
-    }
-
-    fn grow_to_fit(&mut self, required: usize) {
-        let new_size = next_size(self.size, required);
-
-        #[cfg(target_arch = "wasm32")]
-        {
-            let new_array = js_sys::Uint8Array::new_with_length(new_size as u32);
-            let old_array = &self.inner;
-            new_array.set(&old_array, 0);
-            self.inner = new_array;
-        }
-
-        #[cfg(not(target_arch = "wasm32"))]
-        {
-            self.inner.resize(new_size, 0);
-        }
-
-        self.size = new_size;
     }
 }
 
@@ -118,7 +98,7 @@ mod tests {
 
     #[test]
     fn test_buffer() {
-        let mut buffer = Buffer::new();
+        let mut buffer = Buffer::new(5);
         buffer
             .append(&[1, 2, 3, 4, 5])
             .expect("range must be valid");
@@ -126,20 +106,18 @@ mod tests {
     }
 
     #[test]
-    fn test_write_past_capacity_grows() {
-        let mut buffer = Buffer::new();
+    fn test_append_advances_write_cursor() {
+        let mut buffer = Buffer::new(9);
         buffer
             .append(&[1, 2, 3, 4, 5])
             .expect("range must be valid");
-
-        let position = INITIAL_SIZE;
         buffer.append(&[6, 7, 8, 9]).expect("range must be valid");
+        assert_eq!(&buffer.index(0..9).unwrap(), &[1, 2, 3, 4, 5, 6, 7, 8, 9]);
+    }
 
-        assert_eq!(buffer.size, 2 * INITIAL_SIZE);
-        assert_eq!(&buffer.index(0..5).unwrap(), &[1, 2, 3, 4, 5]);
-        assert_eq!(
-            &buffer.index(position..position + 4).unwrap(),
-            &[6, 7, 8, 9]
-        );
+    #[test]
+    fn test_append_past_capacity_errors() {
+        let mut buffer = Buffer::new(4);
+        assert!(buffer.append(&[1, 2, 3, 4, 5]).is_err());
     }
 }

--- a/crates/bitwarden-crypto/src/stream/large_memory_buffer.rs
+++ b/crates/bitwarden-crypto/src/stream/large_memory_buffer.rs
@@ -104,7 +104,7 @@ impl Buffer {
         #[cfg(target_arch = "wasm32")]
         {
             let new_array = js_sys::Uint8Array::new_with_length(new_size as u32);
-            let old_array = self.inner.clone();
+            let old_array = &self.inner;
             new_array.set(&old_array, 0);
             self.inner = new_array;
         }

--- a/crates/bitwarden-crypto/src/stream/large_memory_buffer.rs
+++ b/crates/bitwarden-crypto/src/stream/large_memory_buffer.rs
@@ -38,7 +38,7 @@ pub struct Buffer {
 }
 
 #[derive(Debug)]
-pub(crate) struct OutOfBoundsError;
+pub(crate) struct InvalidIndexError;
 
 impl Buffer {
     pub fn new() -> Self {
@@ -53,9 +53,9 @@ impl Buffer {
         }
     }
 
-    pub fn index(&self, index: std::ops::Range<usize>) -> Result<Vec<u8>, OutOfBoundsError> {
-        if index.end > self.size {
-            return Err(OutOfBoundsError);
+    pub fn index(&self, index: std::ops::Range<usize>) -> Result<Vec<u8>, InvalidIndexError> {
+        if index.end > self.size || index.start > index.end {
+            return Err(InvalidIndexError);
         }
 
         #[cfg(target_arch = "wasm32")]
@@ -72,25 +72,24 @@ impl Buffer {
         }
     }
 
-    pub fn copy_from_slice(
+    pub fn append(
         &mut self,
-        index: std::ops::Range<usize>,
         data: &[u8],
-    ) -> Result<(), OutOfBoundsError> {
-        if index.end > self.size {
-            self.grow_to_fit(index.end);
+    ) -> Result<(), InvalidIndexError> {
+        if self.size + data.len() > self.size {
+            self.grow_to_fit(self.size + data.len());
         }
 
         #[cfg(target_arch = "wasm32")]
         {
             self.inner
-                .subarray(index.start as u32, index.end as u32)
+                .subarray(self.size as u32, (self.size + data.len()) as u32)
                 .copy_from(data);
         }
 
         #[cfg(not(target_arch = "wasm32"))]
         {
-            self.inner[index].copy_from_slice(data);
+            self.inner[self.size..self.size + data.len()].copy_from_slice(data);
         }
 
         Ok(())
@@ -124,7 +123,7 @@ mod tests {
     fn test_buffer() {
         let mut buffer = Buffer::new();
         buffer
-            .copy_from_slice(0..5, &[1, 2, 3, 4, 5])
+            .append(&[1, 2, 3, 4, 5])
             .expect("range must be valid");
         assert_eq!(&buffer.index(0..5).unwrap(), &[1, 2, 3, 4, 5]);
     }
@@ -133,12 +132,12 @@ mod tests {
     fn test_write_past_capacity_grows() {
         let mut buffer = Buffer::new();
         buffer
-            .copy_from_slice(0..5, &[1, 2, 3, 4, 5])
+            .append(&[1, 2, 3, 4, 5])
             .expect("range must be valid");
 
         let position = INITIAL_SIZE;
         buffer
-            .copy_from_slice(position..position + 4, &[6, 7, 8, 9])
+            .append(&[6, 7, 8, 9])
             .expect("range must be valid");
 
         assert_eq!(buffer.size, 2 * INITIAL_SIZE);

--- a/crates/bitwarden-crypto/src/stream/large_memory_buffer.rs
+++ b/crates/bitwarden-crypto/src/stream/large_memory_buffer.rs
@@ -1,0 +1,162 @@
+//! A module for allocating large remote buffers not in WASM memory. WASM generally does not support
+//! resizing the heap after it has been allocated, so we need to allocate a buffer that can be
+//! released again.
+//!
+//! Allocations are made in 32 MiB blocks. Writes that exceed the current allocation grow the
+//! buffer by additional 32 MiB blocks, preserving previously written data.
+//!
+//! This is used for streaming encryption in the legacy format.
+
+/// Buffers are allocated and grown in multiples of this value.
+const BLOCK_SIZE: usize = 32 * 1024 * 1024;
+#[cfg(target_arch = "wasm32")]
+const INITIAL_SIZE: usize = 1024 * 1024;
+
+// Gives the size as a multiple of blocks that fits the requested size.
+fn round_up_to_block(size: usize) -> usize {
+    size.div_ceil(BLOCK_SIZE).max(1) * BLOCK_SIZE
+}
+
+pub struct Buffer {
+    // The Uint8Array lives in JS memory, and wasm merely keeps a reference to it in the
+    // wasm-bindgen-glue-code-heap `https://wasm-bindgen.github.io/wasm-bindgen/contributing/design/js-objects-in-rust.html#long-lived-js-objects`
+    // We cannot convert the full arary to slice / Vec because that would require allocating and
+    // copying the data to WASM memory. Instead, we create slice access operations.
+    //
+    // It is freed automatically by the host JS engine's garbage collector, as soon as the rust
+    // side drops the reference. The wasm-bindgen-glue-code-heap releases the JS-side reference
+    // as soon as the rust side reference is
+    //
+    // Please note, while chrome / firefox do release the memory from the JS environment, on the OS
+    // side they may keep the memory allocated for a while regardless.
+    #[cfg(target_arch = "wasm32")]
+    inner: js_sys::Uint8Array,
+
+    // On non-wasm targets, deallocating memory is supported so we can just use a Vec<u8> that
+    // lives on the heap and is managed by regular Rust ownership rules.
+    #[cfg(not(target_arch = "wasm32"))]
+    inner: Vec<u8>,
+
+    size: usize,
+}
+
+#[derive(Debug)]
+pub(crate) struct OutOfBoundsError;
+
+impl Buffer {
+    pub fn new() -> Self {
+        Self {
+            #[cfg(target_arch = "wasm32")]
+            inner: js_sys::Uint8Array::new_with_length(INITIAL_SIZE as u32).into(),
+
+            #[cfg(not(target_arch = "wasm32"))]
+            inner: Vec::new(),
+
+            size: 0,
+        }
+    }
+
+    pub fn index(&self, index: std::ops::Range<usize>) -> Result<Vec<u8>, OutOfBoundsError> {
+        if index.end > self.size {
+            return Err(OutOfBoundsError);
+        }
+
+        #[cfg(target_arch = "wasm32")]
+        {
+            Ok(self
+                .inner
+                .slice(index.start as u32, index.end as u32)
+                .to_vec())
+        }
+
+        #[cfg(not(target_arch = "wasm32"))]
+        {
+            Ok(self.inner[index].to_vec())
+        }
+    }
+
+    pub fn copy_from_slice(
+        &mut self,
+        index: std::ops::Range<usize>,
+        data: &[u8],
+    ) -> Result<(), OutOfBoundsError> {
+        if index.end > self.size {
+            self.grow_to_fit(index.end);
+        }
+
+        #[cfg(target_arch = "wasm32")]
+        {
+            let data_uint8_array = js_sys::Uint8Array::from(data);
+            self.inner.set(&data_uint8_array, index.start as u32);
+        }
+
+        #[cfg(not(target_arch = "wasm32"))]
+        {
+            self.inner[index].copy_from_slice(data);
+        }
+
+        Ok(())
+    }
+
+    fn grow_to_fit(&mut self, required: usize) {
+        let new_size = round_up_to_block(required);
+
+        #[cfg(target_arch = "wasm32")]
+        {
+            let new_array = js_sys::Uint8Array::new_with_length(new_size as u32);
+            let old_array = self.inner;
+            new_array.set(&old_array, 0);
+            self.inner = new_array;
+        }
+
+        #[cfg(not(target_arch = "wasm32"))]
+        {
+            self.inner.resize(new_size, 0);
+        }
+
+        self.size = new_size;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_buffer() {
+        let mut buffer = Buffer::new();
+        buffer.copy_from_slice(0..5, &[1, 2, 3, 4, 5]).expect("range must be valid");
+        assert_eq!(&buffer.index(0..5).unwrap(), &[1, 2, 3, 4, 5]);
+    }
+
+    #[test]
+    fn test_initial_alloc_rounds_up_to_block_size() {
+        let buffer = Buffer::new();
+        assert_eq!(buffer.size, 0);
+    }
+
+    #[test]
+    fn test_write_past_capacity_grows_in_blocks() {
+        let mut buffer = Buffer::new();
+        buffer.copy_from_slice(0..5, &[1, 2, 3, 4, 5]).expect("range must be valid");
+
+        let position = BLOCK_SIZE;
+        buffer.copy_from_slice(position..position + 4, &[6, 7, 8, 9]).expect("range must be valid");
+
+        assert_eq!(buffer.size, 2 * BLOCK_SIZE);
+        assert_eq!(&buffer.index(0..5).unwrap(), &[1, 2, 3, 4, 5]);
+        assert_eq!(
+            &buffer.index(position..position + 4).unwrap(),
+            &[6, 7, 8, 9]
+        );
+    }
+
+    #[test]
+    fn test_grow_spanning_multiple_blocks() {
+        let mut buffer = Buffer::new();
+        let position = 3 * BLOCK_SIZE + 100;
+        buffer.copy_from_slice(position..position + 3, &[1, 2, 3]).expect("range must be valid");
+        assert_eq!(buffer.size, 4 * BLOCK_SIZE);
+        assert_eq!(&buffer.index(position..position + 3).unwrap(), &[1, 2, 3]);
+    }
+}

--- a/crates/bitwarden-crypto/src/stream/large_memory_buffer.rs
+++ b/crates/bitwarden-crypto/src/stream/large_memory_buffer.rs
@@ -72,10 +72,7 @@ impl Buffer {
         }
     }
 
-    pub fn append(
-        &mut self,
-        data: &[u8],
-    ) -> Result<(), InvalidIndexError> {
+    pub fn append(&mut self, data: &[u8]) -> Result<(), InvalidIndexError> {
         if self.size + data.len() > self.size {
             self.grow_to_fit(self.size + data.len());
         }
@@ -136,9 +133,7 @@ mod tests {
             .expect("range must be valid");
 
         let position = INITIAL_SIZE;
-        buffer
-            .append(&[6, 7, 8, 9])
-            .expect("range must be valid");
+        buffer.append(&[6, 7, 8, 9]).expect("range must be valid");
 
         assert_eq!(buffer.size, 2 * INITIAL_SIZE);
         assert_eq!(&buffer.index(0..5).unwrap(), &[1, 2, 3, 4, 5]);

--- a/crates/bitwarden-crypto/src/stream/mod.rs
+++ b/crates/bitwarden-crypto/src/stream/mod.rs
@@ -1,0 +1,99 @@
+/// Large blob encryption and decryption needs to be streamed to keep performance reasonable.
+/// This module implements streamed encryption, that can be plugged into other IO streaming
+/// interfaces, to create a streamed encryption pipeline. Further, it defines the cryptography
+/// behind attachments, with the legacy format for compatibility, and a new format that
+/// supports random-access decryption, and has enhanced security properties.
+use std::ops::Range;
+
+pub(crate) mod aes256_cbc_hmac_legacy_stream;
+mod large_memory_buffer;
+mod streaming_attachment_cipher;
+
+pub use streaming_attachment_cipher::{StreamingAttachmentDecryptor, StreamingAttachmentEncryptor};
+
+/// Error returned by streaming-cipher constructors when the supplied key cannot be used with
+/// that streaming cipher.
+pub(crate) enum StreamCreationError {
+    /// The supplied [`crate::SymmetricCryptoKey`] is not the variant this cipher expects.
+    WrongKeyType,
+}
+
+/// Outcome of feeding one chunk of plaintext to a [`StreamingEncryptor::update`].
+pub(crate) enum ChunkEncryptionResult {
+    /// The encryptor needs more input bytes before it can produce ciphertext.
+    NeedMoreData,
+    /// A chunk of the ciphertext is emitted, but the stream is not yet complete
+    EncryptedChunk(Vec<u8>),
+    /// The last chunk is emitted and the stream is completed. No more calls to `update` should be
+    /// made after this.
+    FinalEncryptedChunk(Vec<u8>),
+    /// Encryption failed. Discard the entire stream.
+    Error,
+}
+
+/// Outcome of feeding one chunk of wire bytes to a [`StreamingDecryptor::update`].
+pub(crate) enum ChunkDecryptionResult {
+    /// The decryptor needs more input bytes before it can produce plaintext.
+    NeedMoreData,
+    /// A chunk of decrypted plaintext. Whether this is already authenticated is
+    /// implementation-defined: chunked-AEAD STREAM authenticates per chunk and these bytes
+    /// can be trusted; AES-CBC + HMAC authenticates only at finalize, and these bytes must be
+    /// treated as untrusted until the terminal [`Self::FinalDecryptedChunk`] is observed.
+    DecryptedChunk(Vec<u8>),
+    /// The final chunk of decrypted, authenticated plaintext.
+    FinalDecryptedChunk(Vec<u8>),
+    /// Decryption failed. Discard the entire stream.
+    Error,
+}
+
+/// A symmetric streaming encryptor.
+pub(crate) trait StreamingEncryptor: Sized {
+    /// Pass in a chunk of any size of the stream. The encryptor buffers and emits as much
+    /// ciphertext as it can. The caller signals the end of the stream by calling `update` with
+    /// `last_block = true`.
+    ///
+    /// The encryptor *MAY* buffer the entire plaintext before emitting any ciphertext depending
+    /// on the underlying algorithm implementation. In this case, the caller must
+    /// keep calling update with an empty chunk until the final encrypted chunk is emitted.
+    fn update(&mut self, plaintext_chunk: &[u8], last_block: bool) -> ChunkEncryptionResult;
+}
+
+/// A symmetric streaming decryptor.
+pub(crate) trait StreamingDecryptor: Sized {
+    /// Pass in a chunk of any size of the stream. The decryptor buffers and emits as much plaintext
+    /// as it can. The caller signals the end of the stream by calling `update` with `last_block =
+    /// true`. The decryptor emits the final chunk of plaintext and performs any final
+    /// authentication checks if required. The caller MUST verify the presence of the final
+    /// decrypted chunk before using the plaintext.
+    fn update(&mut self, ciphertext_chunk: &[u8], last_block: bool) -> ChunkDecryptionResult;
+}
+
+/// A symmetric decryptor that supports random-access reads: given the complete encrypted
+/// wire stream and a plaintext byte range, return only the plaintext covering that range.
+///
+/// Random access is only possible for wire formats whose framing lets the decryptor seek
+/// into the ciphertext without reading the whole stream and whose chunks are individually
+/// authenticated. Chunked-AEAD STREAM qualifies (fixed-size nonce prefix + fixed-size
+/// chunks, each with its own AEAD tag); AES-256-CBC + HMAC-SHA256 does not, because its
+/// trailing MAC covers the entire ciphertext and the stream must be read in full before
+/// any bytes can be trusted.
+#[allow(unused)]
+pub(crate) trait RandomAccessDecryptor<R> {
+    /// Error returned when authentication fails on any read chunk, the wire bytes are
+    /// shorter than the framing requires, or `range` exceeds the plaintext length.
+    type Error;
+
+    /// Decrypt the plaintext bytes covering `range` from the encrypted `ciphertext` byte stream.
+    async fn decrypt_range(&self, data_source: R, range: Range<usize>) -> Result<Vec<u8>, Self::Error>;
+}
+
+/// A data source that supports random-access reads
+#[allow(unused)]
+pub(crate) trait RandomAccessDataSource {
+    /// Error returned when authentication fails on any read chunk, the wire bytes are
+    /// shorter than the framing requires, or `range` exceeds the plaintext length.
+    type Error;
+
+    /// Decrypt the plaintext bytes covering `range` from the encrypted `ciphertext` byte stream.
+    async fn read_range(&self, range: Range<usize>) -> Result<Vec<u8>, Self::Error>;
+}

--- a/crates/bitwarden-crypto/src/stream/mod.rs
+++ b/crates/bitwarden-crypto/src/stream/mod.rs
@@ -10,6 +10,7 @@ mod large_memory_buffer;
 mod streaming_attachment_cipher;
 
 pub use streaming_attachment_cipher::{StreamingAttachmentDecryptor, StreamingAttachmentEncryptor};
+use thiserror::Error;
 
 /// Error returned by streaming-cipher constructors when the supplied key cannot be used with
 /// that streaming cipher.
@@ -17,6 +18,17 @@ pub(crate) enum StreamCreationError {
     /// The supplied [`crate::SymmetricCryptoKey`] is not the variant this cipher expects.
     WrongKeyType,
 }
+
+/// Opaque error returned when a streaming decryptor fails. The reason (HMAC mismatch, invalid
+/// padding, truncation) is intentionally not distinguished, to avoid leaking which check failed.
+#[derive(Debug, Error)]
+#[error("streaming decryption failed")]
+pub(crate) struct StreamDecryptionError;
+
+/// Opaque error returned when a streaming encryptor fails.
+#[derive(Debug, Error)]
+#[error("streaming encryption failed")]
+pub(crate) struct StreamEncryptionError;
 
 /// Outcome of feeding one chunk of plaintext to a [`StreamingEncryptor::update`].
 pub(crate) enum ChunkEncryptionResult {
@@ -28,7 +40,7 @@ pub(crate) enum ChunkEncryptionResult {
     /// made after this.
     FinalEncryptedChunk(Vec<u8>),
     /// Encryption failed. Discard the entire stream.
-    Error,
+    Error(StreamEncryptionError),
 }
 
 /// Outcome of feeding one chunk of wire bytes to a [`StreamingDecryptor::update`].
@@ -43,7 +55,7 @@ pub(crate) enum ChunkDecryptionResult {
     /// The final chunk of decrypted, authenticated plaintext.
     FinalDecryptedChunk(Vec<u8>),
     /// Decryption failed. Discard the entire stream.
-    Error,
+    Error(StreamDecryptionError),
 }
 
 /// A symmetric streaming encryptor.

--- a/crates/bitwarden-crypto/src/stream/mod.rs
+++ b/crates/bitwarden-crypto/src/stream/mod.rs
@@ -84,7 +84,11 @@ pub(crate) trait RandomAccessDecryptor<R> {
     type Error;
 
     /// Decrypt the plaintext bytes covering `range` from the encrypted `ciphertext` byte stream.
-    async fn decrypt_range(&self, data_source: R, range: Range<usize>) -> Result<Vec<u8>, Self::Error>;
+    async fn decrypt_range(
+        &self,
+        data_source: R,
+        range: Range<usize>,
+    ) -> Result<Vec<u8>, Self::Error>;
 }
 
 /// A data source that supports random-access reads

--- a/crates/bitwarden-crypto/src/stream/streaming_attachment_cipher.rs
+++ b/crates/bitwarden-crypto/src/stream/streaming_attachment_cipher.rs
@@ -19,7 +19,7 @@ use std::{
 use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
 
 use crate::{
-    CryptoError, SymmetricCryptoKey,
+    CryptoError, KeySlotIds, KeyStoreContext, SymmetricCryptoKey,
     stream::{
         ChunkDecryptionResult, ChunkEncryptionResult, StreamingDecryptor, StreamingEncryptor,
         aes256_cbc_hmac_legacy_stream::{
@@ -83,11 +83,18 @@ pub struct StreamingAttachmentDecryptor<R> {
 impl<R> StreamingAttachmentDecryptor<R> {
     /// Construct a decryptor. The key variant determines which cipher's wire format is
     /// expected; the discriminator on the wire is validated against it on the first byte.
-    pub fn new(key: SymmetricCryptoKey, inner: R) -> Result<Self, CryptoError> {
+    pub fn new<Ids: KeySlotIds>(
+        key_slot: Ids::Symmetric,
+        ctx: KeyStoreContext<Ids>,
+        inner: R,
+    ) -> Result<Self, CryptoError> {
+        let key = ctx.get_symmetric_key(key_slot)?;
         match &key {
             SymmetricCryptoKey::Aes256CbcHmacKey(_) => Ok(Self {
                 inner,
-                state: StreamDecryptorState::NeedDiscriminator { key },
+                state: StreamDecryptorState::NeedDiscriminator {
+                    key: key.to_owned(),
+                },
                 plaintext_buf: Vec::new(),
                 inner_eof: false,
             }),
@@ -494,7 +501,7 @@ mod tests {
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
     use super::*;
-    use crate::Aes256CbcHmacKey;
+    use crate::{Aes256CbcHmacKey, KeyStore, traits::tests::TestIds};
 
     /// In-memory `AsyncWrite` sink that records all writes into a shared buffer so a test can
     /// inspect the on-wire bytes after the encryptor is dropped.
@@ -539,7 +546,11 @@ mod tests {
     }
 
     async fn decrypt_wire(key: SymmetricCryptoKey, wire: &[u8]) -> io::Result<Vec<u8>> {
-        let mut dec = StreamingAttachmentDecryptor::new(key, wire).expect("decryptor construction");
+        let key_store: KeyStore<TestIds> = KeyStore::default();
+        let mut ctx = key_store.context_mut();
+        let key = ctx.add_local_symmetric_key(key);
+        let mut dec =
+            StreamingAttachmentDecryptor::new(key, ctx, wire).expect("decryptor construction");
         let mut out = Vec::new();
         dec.read_to_end(&mut out).await?;
         Ok(out)
@@ -609,8 +620,11 @@ mod tests {
         let wire = shared.lock().expect("mutex poisoned").clone();
 
         // Read it back in small chunks too.
-        let mut dec = StreamingAttachmentDecryptor::new(aes_key(), &wire[..])
-            .expect("decryptor construction");
+        let key_store: KeyStore<TestIds> = KeyStore::default();
+        let mut ctx = key_store.context_mut();
+        let key = ctx.add_local_symmetric_key(aes_key());
+        let mut dec =
+            StreamingAttachmentDecryptor::new(key, ctx, &wire[..]).expect("decryptor construction");
         let mut out = Vec::new();
         let mut tmp = [0u8; 7];
         loop {

--- a/crates/bitwarden-crypto/src/stream/streaming_attachment_cipher.rs
+++ b/crates/bitwarden-crypto/src/stream/streaming_attachment_cipher.rs
@@ -1,0 +1,632 @@
+//! `AsyncRead` / `AsyncWrite` wrapper around the streaming attachment ciphers.
+//!
+//! ## Wire format
+//!
+//! ```text
+//! [discriminator (1 byte)] [format-specific header] [ciphertext...]
+//! ```
+//!
+//! - `0x02` is AES256-CBC-HMAC-Legacy-Stream
+//!
+//! `0x02` matches the long-standing `EncString::Aes256Cbc_HmacSha256_B64 = 2` numbering.
+
+use std::{
+    io,
+    pin::Pin,
+    task::{Context, Poll},
+};
+
+use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
+
+use crate::{
+    CryptoError, SymmetricCryptoKey,
+    stream::{
+        ChunkDecryptionResult, ChunkEncryptionResult, StreamingDecryptor, StreamingEncryptor,
+        aes256_cbc_hmac_legacy_stream::{
+            StreamingAes256CbcHmacDecryptor, StreamingAes256CbcHmacEncryptor,
+        },
+    },
+};
+
+enum HeaderDiscriminator {
+    Aes256CbcHmacLegacyStream = 0x02,
+}
+
+impl From<HeaderDiscriminator> for u8 {
+    fn from(value: HeaderDiscriminator) -> Self {
+        value as u8
+    }
+}
+
+struct UnknownDiscriminator;
+
+impl TryFrom<u8> for HeaderDiscriminator {
+    type Error = UnknownDiscriminator;
+
+    fn try_from(value: u8) -> Result<Self, Self::Error> {
+         match value {
+            0x02 => Ok(HeaderDiscriminator::Aes256CbcHmacLegacyStream),
+            _ => Err(UnknownDiscriminator),
+        }
+    }
+}
+
+const READ_SCRATCH_SIZE: usize = 8 * 1024;
+
+// An enum representing the state of the streaming attachment decryptor. This is a state machine
+// for attachment stream parsing. As soon as the header bytes are parsed that discriminate the
+// encryption type, the state transitions to the appropriate streaming decryptor.
+enum StreamDecryptorState {
+    /// First byte of the wire has not yet been observed.
+    NeedDiscriminator { key: SymmetricCryptoKey },
+    Aes256CbcHmacLegacyStream {
+        decryptor: Box<StreamingAes256CbcHmacDecryptor>,
+    },
+    /// Underlying decryptor finalized successfully; remaining plaintext is in `plaintext_buf`.
+    Done,
+    /// Discard the stream — decryption failed.
+    Error,
+}
+
+/// AsyncRead adapter that decrypts a streaming-attachment-encrypted wire stream from `R`
+/// and exposes the decrypted plaintext via [`AsyncRead`]. The cipher is selected by the
+/// 1-byte discriminator at the start of the wire and must agree with the supplied key.
+pub struct StreamingAttachmentDecryptor<R> {
+    inner: R,
+    state: StreamDecryptorState,
+    /// Decrypted plaintext awaiting copy into the caller's buffer.
+    plaintext_buf: Vec<u8>,
+    /// Set once the inner reader has returned EOF; triggers the underlying `update(_, true)`.
+    inner_eof: bool,
+}
+
+impl<R> StreamingAttachmentDecryptor<R> {
+    /// Construct a decryptor. The key variant determines which cipher's wire format is
+    /// expected; the discriminator on the wire is validated against it on the first byte.
+    pub fn new(key: SymmetricCryptoKey, inner: R) -> Result<Self, CryptoError> {
+        match &key {
+            SymmetricCryptoKey::Aes256CbcHmacKey(_) => Ok(Self {
+                inner,
+                state: StreamDecryptorState::NeedDiscriminator { key },
+                plaintext_buf: Vec::new(),
+                inner_eof: false,
+            }),
+            _ => Err(CryptoError::OperationNotSupported(
+                crate::error::UnsupportedOperationError::EncryptionNotImplementedForKey,
+            )),
+        }
+    }
+
+    /// Drains the plaintext buffer into the passed in `ReadBuf`. Returns `true` if any bytes were
+    /// drained.
+    fn drain_plaintext_into(&mut self, buf: &mut ReadBuf<'_>) -> bool {
+        let bytes_to_copy = std::cmp::min(buf.remaining(), self.plaintext_buf.len());
+        // All bytes that are available already
+        if bytes_to_copy == 0 {
+            return false;
+        }
+
+        buf.put_slice(&self.plaintext_buf[..bytes_to_copy]);
+        self.plaintext_buf.drain(..bytes_to_copy);
+        true
+    }
+
+    fn feed_bytes_to_decryptor(&mut self, mut data: &[u8]) -> io::Result<()> {
+        if data.is_empty() {
+            return Ok(());
+        }
+
+        if let StreamDecryptorState::NeedDiscriminator { key } = &self.state {
+            let discriminator_byte = HeaderDiscriminator::try_from(data[0]).map_err(|_| {
+                io::Error::other("streaming attachment: unknown header discriminator byte")
+            })?;
+            data = &data[1..];
+
+            match discriminator_byte {
+                HeaderDiscriminator::Aes256CbcHmacLegacyStream => {
+                    let decryptor =
+                        StreamingAes256CbcHmacDecryptor::try_new(key).map_err(|_| {
+                            io::Error::other(
+                                "streaming attachment: key does not match discriminator 0x02",
+                            )
+                        })?;
+                    self.state = StreamDecryptorState::Aes256CbcHmacLegacyStream {
+                        decryptor: Box::new(decryptor),
+                    };
+                }
+            }
+        }
+
+        if data.is_empty() {
+            return Ok(());
+        }
+
+        match &mut self.state {
+            StreamDecryptorState::Aes256CbcHmacLegacyStream { decryptor: dec } => {
+                match dec.update(data, false) {
+                    ChunkDecryptionResult::NeedMoreData => Ok(()),
+                    ChunkDecryptionResult::DecryptedChunk(bytes) => {
+                        self.plaintext_buf.extend_from_slice(&bytes);
+                        Ok(())
+                    }
+                    ChunkDecryptionResult::FinalDecryptedChunk(bytes) => {
+                        self.plaintext_buf.extend_from_slice(&bytes);
+                        self.state = StreamDecryptorState::Done;
+                        Ok(())
+                    }
+                    ChunkDecryptionResult::Error => {
+                        self.state = StreamDecryptorState::Error;
+                        Err(io::Error::other(
+                            "streaming attachment: AES-CBC-HMAC decryption error",
+                        ))
+                    }
+                }
+            }
+            StreamDecryptorState::Error | StreamDecryptorState::Done => Ok(()),
+            StreamDecryptorState::NeedDiscriminator { .. } => unreachable!("handled above"),
+        }
+    }
+
+    fn finalize_underlying(&mut self) -> io::Result<()> {
+        match std::mem::replace(&mut self.state, StreamDecryptorState::Error) {
+            StreamDecryptorState::NeedDiscriminator { .. } => Err(io::Error::other(
+                "streaming attachment: truncated before discriminator",
+            )),
+            StreamDecryptorState::Aes256CbcHmacLegacyStream { decryptor: mut dec } => {
+                match dec.update(&[], true) {
+                    ChunkDecryptionResult::FinalDecryptedChunk(bytes) => {
+                        self.plaintext_buf.extend_from_slice(&bytes);
+                        self.state = StreamDecryptorState::Done;
+                        Ok(())
+                    }
+                    _ => Err(io::Error::other(
+                        "streaming attachment: AES-CBC-HMAC finalize failed (truncated or tampered)",
+                    )),
+                }
+            }
+            StreamDecryptorState::Done => {
+                self.state = StreamDecryptorState::Done;
+                Ok(())
+            }
+            StreamDecryptorState::Error => {
+                Err(io::Error::other("streaming attachment: decryption error"))
+            }
+        }
+    }
+}
+
+impl<R: AsyncRead + Unpin> AsyncRead for StreamingAttachmentDecryptor<R> {
+    fn poll_read(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut ReadBuf<'_>,
+    ) -> Poll<io::Result<()>> {
+        let this = self.get_mut();
+
+        loop {
+            // Drain decrypted plaintext into the caller's buffer first.
+            if this.drain_plaintext_into(buf) {
+                return Poll::Ready(Ok(()));
+            }
+
+            // If we already errored, surface it.
+            if matches!(this.state, StreamDecryptorState::Error) {
+                return Poll::Ready(Err(io::Error::other(
+                    "streaming attachment: decryption error",
+                )));
+            }
+
+            // If we're done draining and the underlying stream is finalized, signal EOF.
+            if matches!(this.state, StreamDecryptorState::Done) {
+                return Poll::Ready(Ok(()));
+            }
+
+            // If the inner reader has hit EOF, run the terminal finalize and loop to drain.
+            if this.inner_eof {
+                if let Err(e) = this.finalize_underlying() {
+                    return Poll::Ready(Err(e));
+                }
+                continue;
+            }
+
+            // Otherwise, pull more bytes from the inner reader, and feed them to the decryptor
+            let mut scratch = [0u8; READ_SCRATCH_SIZE];
+            let mut scratch_buf = ReadBuf::new(&mut scratch);
+            match Pin::new(&mut this.inner).poll_read(cx, &mut scratch_buf) {
+                Poll::Pending => return Poll::Pending,
+                Poll::Ready(Err(e)) => {
+                    this.state = StreamDecryptorState::Error;
+                    return Poll::Ready(Err(e));
+                }
+                Poll::Ready(Ok(())) => {
+                    let filled = scratch_buf.filled();
+                    if filled.is_empty() {
+                        this.inner_eof = true;
+                    } else if let Err(e) = this.feed_bytes_to_decryptor(filled) {
+                        return Poll::Ready(Err(e));
+                    }
+                }
+            }
+        }
+    }
+}
+
+enum StreamEncryptorState {
+    Aes256CbcHmacLegacyStream {
+        encryptor: Box<StreamingAes256CbcHmacEncryptor>,
+    },
+    /// `update(_, true)` has been called; the wire payload is queued in `pending_write`
+    /// and being drained to the inner writer.
+    Finalized,
+    /// All bytes flushed to the inner writer and `inner.poll_shutdown` completed.
+    Done,
+    Error,
+}
+
+/// AsyncWrite adapter that takes plaintext and writes a streaming-attachment-encrypted
+/// wire stream to `W`. The cipher is selected by the [`SymmetricCryptoKey`] variant. The
+/// 1-byte discriminator is emitted before any plaintext is encrypted.
+pub struct StreamingAttachmentEncryptor<W> {
+    inner: W,
+    state: StreamEncryptorState,
+    /// Bytes that need to be written to `inner` before this wrapper can make further progress.
+    /// At construction this holds the 1-byte discriminator; during shutdown it holds the
+    /// finalized wire payload.
+    pending_write: Vec<u8>,
+    pending_head: usize,
+}
+
+impl<W> StreamingAttachmentEncryptor<W> {
+    /// Construct an encryptor. The corresponding discriminator byte is queued as the first
+    /// wire byte.
+    pub fn new(key: SymmetricCryptoKey, inner: W) -> Result<Self, CryptoError> {
+        let (state, discriminator): (StreamEncryptorState, HeaderDiscriminator) = match &key {
+            SymmetricCryptoKey::Aes256CbcHmacKey(_) => {
+                let encryptor = StreamingAes256CbcHmacEncryptor::try_new(&key).map_err(|_| {
+                    CryptoError::OperationNotSupported(
+                        crate::error::UnsupportedOperationError::EncryptionNotImplementedForKey,
+                    )
+                })?;
+                (
+                    StreamEncryptorState::Aes256CbcHmacLegacyStream {
+                        encryptor: Box::new(encryptor),
+                    },
+                    HeaderDiscriminator::Aes256CbcHmacLegacyStream,
+                )
+            }
+            _ => {
+                return Err(CryptoError::OperationNotSupported(
+                    crate::error::UnsupportedOperationError::EncryptionNotImplementedForKey,
+                ));
+            }
+        };
+
+        Ok(Self {
+            inner,
+            state,
+            pending_write: vec![discriminator.into()],
+            pending_head: 0,
+        })
+    }
+}
+
+impl<W: AsyncWrite + Unpin> StreamingAttachmentEncryptor<W> {
+    // Attempt to drain the pending write buffer to the inner writer.
+    fn poll_drain_pending(&mut self, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        while self.pending_head < self.pending_write.len() {
+            let to_write = &self.pending_write[self.pending_head..];
+            match Pin::new(&mut self.inner).poll_write(cx, to_write) {
+                Poll::Pending => return Poll::Pending,
+                Poll::Ready(Err(e)) => {
+                    self.state = StreamEncryptorState::Error;
+                    return Poll::Ready(Err(e));
+                }
+                Poll::Ready(Ok(0)) => {
+                    self.state = StreamEncryptorState::Error;
+                    return Poll::Ready(Err(io::Error::new(
+                        io::ErrorKind::WriteZero,
+                        "streaming attachment: inner writer accepted 0 bytes",
+                    )));
+                }
+                Poll::Ready(Ok(n)) => {
+                    self.pending_head += n;
+                }
+            }
+        }
+        self.pending_write.clear();
+        self.pending_head = 0;
+        Poll::Ready(Ok(()))
+    }
+}
+
+impl<W: AsyncWrite + Unpin> AsyncWrite for StreamingAttachmentEncryptor<W> {
+    fn poll_write(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<io::Result<usize>> {
+        let this = self.get_mut();
+
+        if matches!(this.state, StreamEncryptorState::Error) {
+            return Poll::Ready(Err(io::Error::other(
+                "streaming attachment: encryptor in error state",
+            )));
+        }
+        if matches!(
+            this.state,
+            StreamEncryptorState::Finalized | StreamEncryptorState::Done
+        ) {
+            return Poll::Ready(Err(io::Error::other(
+                "streaming attachment: write after shutdown",
+            )));
+        }
+
+        // Make sure the discriminator (and any other queued bytes) are committed first.
+        if this.poll_drain_pending(cx).is_pending() {
+            return Poll::Pending;
+        }
+        if matches!(this.state, StreamEncryptorState::Error) {
+            return Poll::Ready(Err(io::Error::other(
+                "streaming attachment: encryptor in error state",
+            )));
+        }
+
+        if buf.is_empty() {
+            return Poll::Ready(Ok(0));
+        }
+
+        let result = match &mut this.state {
+            StreamEncryptorState::Aes256CbcHmacLegacyStream { encryptor: enc } => {
+                enc.update(buf, false)
+            }
+            _ => unreachable!("state checked above"),
+        };
+
+        match result {
+            ChunkEncryptionResult::NeedMoreData => Poll::Ready(Ok(buf.len())),
+            ChunkEncryptionResult::EncryptedChunk(bytes) => {
+                this.pending_write = bytes;
+                this.pending_head = 0;
+                Poll::Ready(Ok(buf.len()))
+            }
+            ChunkEncryptionResult::FinalEncryptedChunk(bytes) => {
+                this.pending_write = bytes;
+                this.pending_head = 0;
+                this.state = StreamEncryptorState::Finalized;
+                Poll::Ready(Ok(buf.len()))
+            }
+            ChunkEncryptionResult::Error => {
+                this.state = StreamEncryptorState::Error;
+                Poll::Ready(Err(io::Error::other(
+                    "streaming attachment: encryption error",
+                )))
+            }
+        }
+    }
+
+    fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        let this = self.get_mut();
+
+        // Drain whatever is pending (discriminator at startup, or nothing during steady state),
+        // then flush the inner writer.
+        if this.poll_drain_pending(cx).is_pending() {
+            return Poll::Pending;
+        }
+        Pin::new(&mut this.inner).poll_flush(cx)
+    }
+
+    fn poll_shutdown(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        let this = self.get_mut();
+
+        // Drain any pending bytes
+        if this.poll_drain_pending(cx).is_pending() {
+            return Poll::Pending;
+        }
+        if matches!(this.state, StreamEncryptorState::Error) {
+            return Poll::Ready(Err(io::Error::other(
+                "streaming attachment: encryptor in error state",
+            )));
+        }
+
+        // If we haven't finalized yet, drain all output from the encryptor.
+        if matches!(
+            this.state,
+            StreamEncryptorState::Aes256CbcHmacLegacyStream { .. }
+        ) {
+            let old = std::mem::replace(&mut this.state, StreamEncryptorState::Error);
+            let StreamEncryptorState::Aes256CbcHmacLegacyStream { encryptor: mut enc } = old else {
+                unreachable!("matched above");
+            };
+
+            let mut wire = Vec::new();
+            loop {
+                match enc.update(&[], true) {
+                    ChunkEncryptionResult::EncryptedChunk(bytes) => wire.extend_from_slice(&bytes),
+                    ChunkEncryptionResult::FinalEncryptedChunk(bytes) => {
+                        wire.extend_from_slice(&bytes);
+                        break;
+                    }
+                    ChunkEncryptionResult::NeedMoreData | ChunkEncryptionResult::Error => {
+                        return Poll::Ready(Err(io::Error::other(
+                            "streaming attachment: AES-CBC-HMAC finalize failed",
+                        )));
+                    }
+                }
+            }
+
+            this.pending_write = wire;
+            this.pending_head = 0;
+            this.state = StreamEncryptorState::Finalized;
+        }
+
+        // Drain the finalized wire payload to the inner writer.
+        if this.poll_drain_pending(cx).is_pending() {
+            return Poll::Pending;
+        }
+        if matches!(this.state, StreamEncryptorState::Error) {
+            return Poll::Ready(Err(io::Error::other(
+                "streaming attachment: encryptor in error state",
+            )));
+        }
+
+        // Shut down the inner writer.
+        match Pin::new(&mut this.inner).poll_shutdown(cx) {
+            Poll::Pending => Poll::Pending,
+            Poll::Ready(Ok(())) => {
+                this.state = StreamEncryptorState::Done;
+                Poll::Ready(Ok(()))
+            }
+            Poll::Ready(Err(e)) => {
+                this.state = StreamEncryptorState::Error;
+                Poll::Ready(Err(e))
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        pin::Pin,
+        sync::{Arc, Mutex},
+    };
+
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+    use super::*;
+    use crate::Aes256CbcHmacKey;
+
+    /// In-memory `AsyncWrite` sink that records all writes into a shared buffer so a test can
+    /// inspect the on-wire bytes after the encryptor is dropped.
+    #[derive(Clone)]
+    struct SharedSink(Arc<Mutex<Vec<u8>>>);
+
+    impl AsyncWrite for SharedSink {
+        fn poll_write(
+            self: Pin<&mut Self>,
+            _cx: &mut Context<'_>,
+            buf: &[u8],
+        ) -> Poll<io::Result<usize>> {
+            self.0
+                .lock()
+                .expect("mutex poisoned")
+                .extend_from_slice(buf);
+            Poll::Ready(Ok(buf.len()))
+        }
+        fn poll_flush(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+            Poll::Ready(Ok(()))
+        }
+        fn poll_shutdown(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+            Poll::Ready(Ok(()))
+        }
+    }
+
+    fn aes_key() -> SymmetricCryptoKey {
+        SymmetricCryptoKey::Aes256CbcHmacKey(Aes256CbcHmacKey {
+            enc_key: Box::pin([0u8; 32].into()),
+            mac_key: Box::pin([1u8; 32].into()),
+        })
+    }
+
+    /// Drive the encryptor to completion against an in-memory sink and return the produced wire.
+    async fn encrypt_via_shared(key: SymmetricCryptoKey, plaintext: &[u8]) -> Vec<u8> {
+        let shared = Arc::new(Mutex::new(Vec::<u8>::new()));
+        let sink = SharedSink(shared.clone());
+        let mut enc = StreamingAttachmentEncryptor::new(key, sink).expect("encryptor construction");
+        enc.write_all(plaintext).await.expect("write_all");
+        enc.shutdown().await.expect("shutdown");
+        shared.lock().expect("mutex poisoned").clone()
+    }
+
+    async fn decrypt_wire(key: SymmetricCryptoKey, wire: &[u8]) -> io::Result<Vec<u8>> {
+        let mut dec = StreamingAttachmentDecryptor::new(key, wire).expect("decryptor construction");
+        let mut out = Vec::new();
+        dec.read_to_end(&mut out).await?;
+        Ok(out)
+    }
+
+    const PLAINTEXT_SHORT: &[u8] =
+        b"streaming attachment cipher: AsyncRead/AsyncWrite roundtrip test plaintext.";
+
+    #[tokio::test]
+    async fn aes_cbc_hmac_roundtrip() {
+        let wire = encrypt_via_shared(aes_key(), PLAINTEXT_SHORT).await;
+        assert_eq!(
+            wire.first().copied(),
+            Some(HeaderDiscriminator::Aes256CbcHmacLegacyStream.into()),
+            "wire should start with the AES-CBC-HMAC discriminator"
+        );
+        let roundtripped = decrypt_wire(aes_key(), &wire).await.expect("decrypt");
+        assert_eq!(roundtripped, PLAINTEXT_SHORT);
+    }
+
+    #[tokio::test]
+    async fn aes_cbc_hmac_roundtrip_1_mib() {
+        // Bigger plaintext crossing many CBC blocks.
+        let plaintext: Vec<u8> = (0..(1024 * 1024)).map(|i| (i % 251) as u8).collect();
+        let wire = encrypt_via_shared(aes_key(), &plaintext).await;
+        let roundtripped = decrypt_wire(aes_key(), &wire).await.expect("decrypt");
+        assert_eq!(roundtripped, plaintext);
+    }
+
+    #[tokio::test]
+    async fn unknown_discriminator_byte_fails() {
+        // Build a wire starting with 0xFF (not a known discriminator).
+        let mut wire = vec![0xFFu8];
+        wire.extend_from_slice(&[0u8; 32]);
+        let err = decrypt_wire(aes_key(), &wire)
+            .await
+            .expect_err("expected error for unknown discriminator");
+        assert_eq!(err.kind(), io::ErrorKind::Other);
+    }
+
+    #[tokio::test]
+    async fn truncated_wire_fails_aes() {
+        let wire = encrypt_via_shared(aes_key(), PLAINTEXT_SHORT).await;
+        let truncated = &wire[..wire.len() - 10];
+        let err = decrypt_wire(aes_key(), truncated)
+            .await
+            .expect_err("expected error for truncated wire");
+        assert_eq!(err.kind(), io::ErrorKind::Other);
+    }
+
+    #[tokio::test]
+    async fn small_chunked_writes_roundtrip() {
+        // Drive the encryptor with 1-byte writes to exercise the discriminator-pending path
+        // and ensure no off-by-one in the buffer drain logic.
+        let plaintext = PLAINTEXT_SHORT;
+
+        let shared = Arc::new(Mutex::new(Vec::<u8>::new()));
+        let sink = SharedSink(shared.clone());
+        let mut enc =
+            StreamingAttachmentEncryptor::new(aes_key(), sink).expect("encryptor construction");
+        for byte in plaintext {
+            enc.write_all(std::slice::from_ref(byte))
+                .await
+                .expect("byte-wise write");
+        }
+        enc.shutdown().await.expect("shutdown");
+        let wire = shared.lock().expect("mutex poisoned").clone();
+
+        // Read it back in small chunks too.
+        let mut dec = StreamingAttachmentDecryptor::new(aes_key(), &wire[..])
+            .expect("decryptor construction");
+        let mut out = Vec::new();
+        let mut tmp = [0u8; 7];
+        loop {
+            let n = dec.read(&mut tmp).await.expect("read");
+            if n == 0 {
+                break;
+            }
+            out.extend_from_slice(&tmp[..n]);
+        }
+        assert_eq!(out, plaintext);
+    }
+
+    #[tokio::test]
+    async fn empty_plaintext_roundtrip_aes() {
+        let wire = encrypt_via_shared(aes_key(), &[]).await;
+        let roundtripped = decrypt_wire(aes_key(), &wire).await.expect("decrypt");
+        assert!(roundtripped.is_empty());
+    }
+}

--- a/crates/bitwarden-crypto/src/stream/streaming_attachment_cipher.rs
+++ b/crates/bitwarden-crypto/src/stream/streaming_attachment_cipher.rs
@@ -545,7 +545,7 @@ mod tests {
         let shared = Arc::new(Mutex::new(Vec::<u8>::new()));
         let sink = SharedSink(shared.clone());
         let mut enc = {
-                let key_store: KeyStore<TestIds> = KeyStore::default();
+            let key_store: KeyStore<TestIds> = KeyStore::default();
             let mut ctx = key_store.context_mut();
             let key_slot = ctx.add_local_symmetric_key(key);
             StreamingAttachmentEncryptor::new(key_slot, ctx, sink).expect("encryptor construction")
@@ -624,7 +624,7 @@ mod tests {
             let key_store: KeyStore<TestIds> = KeyStore::default();
             let mut ctx = key_store.context_mut();
             let key_slot = ctx.add_local_symmetric_key(aes_key());
-                StreamingAttachmentEncryptor::new(key_slot, ctx, sink).expect("encryptor construction")
+            StreamingAttachmentEncryptor::new(key_slot, ctx, sink).expect("encryptor construction")
         };
         for byte in plaintext {
             enc.write_all(std::slice::from_ref(byte))

--- a/crates/bitwarden-crypto/src/stream/streaming_attachment_cipher.rs
+++ b/crates/bitwarden-crypto/src/stream/streaming_attachment_cipher.rs
@@ -286,10 +286,15 @@ pub struct StreamingAttachmentEncryptor<W> {
 impl<W> StreamingAttachmentEncryptor<W> {
     /// Construct an encryptor. The corresponding discriminator byte is queued as the first
     /// wire byte.
-    pub fn new(key: SymmetricCryptoKey, inner: W) -> Result<Self, CryptoError> {
+    pub fn new<Ids: KeySlotIds>(
+        key_slot: Ids::Symmetric,
+        ctx: KeyStoreContext<Ids>,
+        inner: W,
+    ) -> Result<Self, CryptoError> {
+        let key = ctx.get_symmetric_key(key_slot)?;
         let (state, discriminator): (StreamEncryptorState, HeaderDiscriminator) = match &key {
             SymmetricCryptoKey::Aes256CbcHmacKey(_) => {
-                let encryptor = StreamingAes256CbcHmacEncryptor::try_new(&key).map_err(|_| {
+                let encryptor = StreamingAes256CbcHmacEncryptor::try_new(key).map_err(|_| {
                     CryptoError::OperationNotSupported(
                         crate::error::UnsupportedOperationError::EncryptionNotImplementedForKey,
                     )
@@ -539,7 +544,11 @@ mod tests {
     async fn encrypt_via_shared(key: SymmetricCryptoKey, plaintext: &[u8]) -> Vec<u8> {
         let shared = Arc::new(Mutex::new(Vec::<u8>::new()));
         let sink = SharedSink(shared.clone());
-        let mut enc = StreamingAttachmentEncryptor::new(key, sink).expect("encryptor construction");
+        let key_store: KeyStore<TestIds> = KeyStore::default();
+        let mut ctx = key_store.context_mut();
+        let key_slot = ctx.add_local_symmetric_key(key);
+        let mut enc =
+            StreamingAttachmentEncryptor::new(key_slot, ctx, sink).expect("encryptor construction");
         enc.write_all(plaintext).await.expect("write_all");
         enc.shutdown().await.expect("shutdown");
         shared.lock().expect("mutex poisoned").clone()
@@ -548,9 +557,9 @@ mod tests {
     async fn decrypt_wire(key: SymmetricCryptoKey, wire: &[u8]) -> io::Result<Vec<u8>> {
         let key_store: KeyStore<TestIds> = KeyStore::default();
         let mut ctx = key_store.context_mut();
-        let key = ctx.add_local_symmetric_key(key);
+        let key_slot = ctx.add_local_symmetric_key(key);
         let mut dec =
-            StreamingAttachmentDecryptor::new(key, ctx, wire).expect("decryptor construction");
+            StreamingAttachmentDecryptor::new(key_slot, ctx, wire).expect("decryptor construction");
         let mut out = Vec::new();
         dec.read_to_end(&mut out).await?;
         Ok(out)
@@ -609,8 +618,11 @@ mod tests {
 
         let shared = Arc::new(Mutex::new(Vec::<u8>::new()));
         let sink = SharedSink(shared.clone());
+        let key_store: KeyStore<TestIds> = KeyStore::default();
+        let mut ctx = key_store.context_mut();
+        let key_slot = ctx.add_local_symmetric_key(aes_key());
         let mut enc =
-            StreamingAttachmentEncryptor::new(aes_key(), sink).expect("encryptor construction");
+            StreamingAttachmentEncryptor::new(key_slot, ctx, sink).expect("encryptor construction");
         for byte in plaintext {
             enc.write_all(std::slice::from_ref(byte))
                 .await
@@ -622,9 +634,9 @@ mod tests {
         // Read it back in small chunks too.
         let key_store: KeyStore<TestIds> = KeyStore::default();
         let mut ctx = key_store.context_mut();
-        let key = ctx.add_local_symmetric_key(aes_key());
-        let mut dec =
-            StreamingAttachmentDecryptor::new(key, ctx, &wire[..]).expect("decryptor construction");
+        let key_slot = ctx.add_local_symmetric_key(aes_key());
+        let mut dec = StreamingAttachmentDecryptor::new(key_slot, ctx, &wire[..])
+            .expect("decryptor construction");
         let mut out = Vec::new();
         let mut tmp = [0u8; 7];
         loop {

--- a/crates/bitwarden-crypto/src/stream/streaming_attachment_cipher.rs
+++ b/crates/bitwarden-crypto/src/stream/streaming_attachment_cipher.rs
@@ -299,15 +299,19 @@ impl<W> StreamingAttachmentEncryptor<W> {
         key_slot: Ids::Symmetric,
         ctx: KeyStoreContext<Ids>,
         inner: W,
+        // Total plaintext byte length. Needed only by the AES-256-CBC-HMAC legacy scheme, which
+        // must buffer the entire ciphertext in memory and pre-allocates it from this size.
+        plaintext_size: usize,
     ) -> Result<Self, CryptoError> {
         let key = ctx.get_symmetric_key(key_slot)?;
         let (state, discriminator): (StreamEncryptorState, HeaderDiscriminator) = match &key {
             SymmetricCryptoKey::Aes256CbcHmacKey(_) => {
-                let encryptor = StreamingAes256CbcHmacEncryptor::try_new(key).map_err(|_| {
-                    CryptoError::OperationNotSupported(
-                        crate::error::UnsupportedOperationError::EncryptionNotImplementedForKey,
-                    )
-                })?;
+                let encryptor = StreamingAes256CbcHmacEncryptor::try_new(key, plaintext_size)
+                    .map_err(|_| {
+                        CryptoError::OperationNotSupported(
+                            crate::error::UnsupportedOperationError::EncryptionNotImplementedForKey,
+                        )
+                    })?;
                 (
                     StreamEncryptorState::Aes256CbcHmacLegacyStream {
                         encryptor: Box::new(encryptor),
@@ -565,7 +569,8 @@ mod tests {
             let key_store: KeyStore<TestIds> = KeyStore::default();
             let mut ctx = key_store.context_mut();
             let key_slot = ctx.add_local_symmetric_key(key);
-            StreamingAttachmentEncryptor::new(key_slot, ctx, sink).expect("encryptor construction")
+            StreamingAttachmentEncryptor::new(key_slot, ctx, sink, plaintext.len())
+                .expect("encryptor construction")
         };
         enc.write_all(plaintext).await.expect("write_all");
         enc.shutdown().await.expect("shutdown");
@@ -641,7 +646,8 @@ mod tests {
             let key_store: KeyStore<TestIds> = KeyStore::default();
             let mut ctx = key_store.context_mut();
             let key_slot = ctx.add_local_symmetric_key(aes_key());
-            StreamingAttachmentEncryptor::new(key_slot, ctx, sink).expect("encryptor construction")
+            StreamingAttachmentEncryptor::new(key_slot, ctx, sink, plaintext.len())
+                .expect("encryptor construction")
         };
         for byte in plaintext {
             enc.write_all(std::slice::from_ref(byte))

--- a/crates/bitwarden-crypto/src/stream/streaming_attachment_cipher.rs
+++ b/crates/bitwarden-crypto/src/stream/streaming_attachment_cipher.rs
@@ -544,22 +544,24 @@ mod tests {
     async fn encrypt_via_shared(key: SymmetricCryptoKey, plaintext: &[u8]) -> Vec<u8> {
         let shared = Arc::new(Mutex::new(Vec::<u8>::new()));
         let sink = SharedSink(shared.clone());
-        let key_store: KeyStore<TestIds> = KeyStore::default();
-        let mut ctx = key_store.context_mut();
-        let key_slot = ctx.add_local_symmetric_key(key);
-        let mut enc =
-            StreamingAttachmentEncryptor::new(key_slot, ctx, sink).expect("encryptor construction");
+        let mut enc = {
+                let key_store: KeyStore<TestIds> = KeyStore::default();
+            let mut ctx = key_store.context_mut();
+            let key_slot = ctx.add_local_symmetric_key(key);
+            StreamingAttachmentEncryptor::new(key_slot, ctx, sink).expect("encryptor construction")
+        };
         enc.write_all(plaintext).await.expect("write_all");
         enc.shutdown().await.expect("shutdown");
         shared.lock().expect("mutex poisoned").clone()
     }
 
     async fn decrypt_wire(key: SymmetricCryptoKey, wire: &[u8]) -> io::Result<Vec<u8>> {
-        let key_store: KeyStore<TestIds> = KeyStore::default();
-        let mut ctx = key_store.context_mut();
-        let key_slot = ctx.add_local_symmetric_key(key);
-        let mut dec =
-            StreamingAttachmentDecryptor::new(key_slot, ctx, wire).expect("decryptor construction");
+        let mut dec = {
+            let key_store: KeyStore<TestIds> = KeyStore::default();
+            let mut ctx = key_store.context_mut();
+            let key_slot = ctx.add_local_symmetric_key(key);
+            StreamingAttachmentDecryptor::new(key_slot, ctx, wire).expect("decryptor construction")
+        };
         let mut out = Vec::new();
         dec.read_to_end(&mut out).await?;
         Ok(out)
@@ -618,11 +620,12 @@ mod tests {
 
         let shared = Arc::new(Mutex::new(Vec::<u8>::new()));
         let sink = SharedSink(shared.clone());
-        let key_store: KeyStore<TestIds> = KeyStore::default();
-        let mut ctx = key_store.context_mut();
-        let key_slot = ctx.add_local_symmetric_key(aes_key());
-        let mut enc =
-            StreamingAttachmentEncryptor::new(key_slot, ctx, sink).expect("encryptor construction");
+        let mut enc = {
+            let key_store: KeyStore<TestIds> = KeyStore::default();
+            let mut ctx = key_store.context_mut();
+            let key_slot = ctx.add_local_symmetric_key(aes_key());
+                StreamingAttachmentEncryptor::new(key_slot, ctx, sink).expect("encryptor construction")
+        };
         for byte in plaintext {
             enc.write_all(std::slice::from_ref(byte))
                 .await
@@ -632,11 +635,13 @@ mod tests {
         let wire = shared.lock().expect("mutex poisoned").clone();
 
         // Read it back in small chunks too.
-        let key_store: KeyStore<TestIds> = KeyStore::default();
-        let mut ctx = key_store.context_mut();
-        let key_slot = ctx.add_local_symmetric_key(aes_key());
-        let mut dec = StreamingAttachmentDecryptor::new(key_slot, ctx, &wire[..])
-            .expect("decryptor construction");
+        let mut dec = {
+            let key_store: KeyStore<TestIds> = KeyStore::default();
+            let mut ctx = key_store.context_mut();
+            let key_slot = ctx.add_local_symmetric_key(aes_key());
+            StreamingAttachmentDecryptor::new(key_slot, ctx, &wire[..])
+                .expect("decryptor construction")
+        };
         let mut out = Vec::new();
         let mut tmp = [0u8; 7];
         loop {

--- a/crates/bitwarden-crypto/src/stream/streaming_attachment_cipher.rs
+++ b/crates/bitwarden-crypto/src/stream/streaming_attachment_cipher.rs
@@ -21,7 +21,8 @@ use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
 use crate::{
     CryptoError, KeySlotIds, KeyStoreContext, SymmetricCryptoKey,
     stream::{
-        ChunkDecryptionResult, ChunkEncryptionResult, StreamingDecryptor, StreamingEncryptor,
+        ChunkDecryptionResult, ChunkEncryptionResult, StreamDecryptionError, StreamEncryptionError,
+        StreamingDecryptor, StreamingEncryptor,
         aes256_cbc_hmac_legacy_stream::{
             StreamingAes256CbcHmacDecryptor, StreamingAes256CbcHmacEncryptor,
         },
@@ -161,11 +162,9 @@ impl<R> StreamingAttachmentDecryptor<R> {
                         self.state = StreamDecryptorState::Done;
                         Ok(())
                     }
-                    ChunkDecryptionResult::Error => {
+                    ChunkDecryptionResult::Error(e) => {
                         self.state = StreamDecryptorState::Error;
-                        Err(io::Error::other(
-                            "streaming attachment: AES-CBC-HMAC decryption error",
-                        ))
+                        Err(io::Error::other(e))
                     }
                 }
             }
@@ -186,9 +185,12 @@ impl<R> StreamingAttachmentDecryptor<R> {
                         self.state = StreamDecryptorState::Done;
                         Ok(())
                     }
-                    _ => Err(io::Error::other(
-                        "streaming attachment: AES-CBC-HMAC finalize failed (truncated or tampered)",
-                    )),
+                    ChunkDecryptionResult::Error(e) => Err(io::Error::other(e)),
+                    // Anything other than the final chunk at finalize means the wire was truncated.
+                    ChunkDecryptionResult::NeedMoreData
+                    | ChunkDecryptionResult::DecryptedChunk(_) => {
+                        Err(io::Error::other(StreamDecryptionError))
+                    }
                 }
             }
             StreamDecryptorState::Done => {
@@ -258,6 +260,12 @@ impl<R: AsyncRead + Unpin> AsyncRead for StreamingAttachmentDecryptor<R> {
     }
 }
 
+/// `io::Error` is neither `Clone` nor `Copy`, so a stored error cannot be returned by value on a
+/// subsequent poll. Reconstruct an equivalent error (kind + message) to re-report it.
+fn clone_io_error(e: &io::Error) -> io::Error {
+    io::Error::new(e.kind(), e.to_string())
+}
+
 enum StreamEncryptorState {
     Aes256CbcHmacLegacyStream {
         encryptor: Box<StreamingAes256CbcHmacEncryptor>,
@@ -267,7 +275,8 @@ enum StreamEncryptorState {
     Finalized,
     /// All bytes flushed to the inner writer and `inner.poll_shutdown` completed.
     Done,
-    Error,
+    /// An error occurred during encryption.
+    Error(io::Error),
 }
 
 /// AsyncWrite adapter that takes plaintext and writes a streaming-attachment-encrypted
@@ -330,15 +339,16 @@ impl<W: AsyncWrite + Unpin> StreamingAttachmentEncryptor<W> {
             match Pin::new(&mut self.inner).poll_write(cx, to_write) {
                 Poll::Pending => return Poll::Pending,
                 Poll::Ready(Err(e)) => {
-                    self.state = StreamEncryptorState::Error;
+                    self.state = StreamEncryptorState::Error(clone_io_error(&e));
                     return Poll::Ready(Err(e));
                 }
                 Poll::Ready(Ok(0)) => {
-                    self.state = StreamEncryptorState::Error;
-                    return Poll::Ready(Err(io::Error::new(
+                    let e = io::Error::new(
                         io::ErrorKind::WriteZero,
                         "streaming attachment: inner writer accepted 0 bytes",
-                    )));
+                    );
+                    self.state = StreamEncryptorState::Error(clone_io_error(&e));
+                    return Poll::Ready(Err(e));
                 }
                 Poll::Ready(Ok(n)) => {
                     self.pending_head += n;
@@ -359,11 +369,10 @@ impl<W: AsyncWrite + Unpin> AsyncWrite for StreamingAttachmentEncryptor<W> {
     ) -> Poll<io::Result<usize>> {
         let this = self.get_mut();
 
-        if matches!(this.state, StreamEncryptorState::Error) {
-            return Poll::Ready(Err(io::Error::other(
-                "streaming attachment: encryptor in error state",
-            )));
+        if let StreamEncryptorState::Error(e) = &this.state {
+            return Poll::Ready(Err(clone_io_error(e)));
         }
+
         if matches!(
             this.state,
             StreamEncryptorState::Finalized | StreamEncryptorState::Done
@@ -377,10 +386,8 @@ impl<W: AsyncWrite + Unpin> AsyncWrite for StreamingAttachmentEncryptor<W> {
         if this.poll_drain_pending(cx).is_pending() {
             return Poll::Pending;
         }
-        if matches!(this.state, StreamEncryptorState::Error) {
-            return Poll::Ready(Err(io::Error::other(
-                "streaming attachment: encryptor in error state",
-            )));
+        if let StreamEncryptorState::Error(e) = &this.state {
+            return Poll::Ready(Err(clone_io_error(e)));
         }
 
         if buf.is_empty() {
@@ -407,11 +414,10 @@ impl<W: AsyncWrite + Unpin> AsyncWrite for StreamingAttachmentEncryptor<W> {
                 this.state = StreamEncryptorState::Finalized;
                 Poll::Ready(Ok(buf.len()))
             }
-            ChunkEncryptionResult::Error => {
-                this.state = StreamEncryptorState::Error;
-                Poll::Ready(Err(io::Error::other(
-                    "streaming attachment: encryption error",
-                )))
+            ChunkEncryptionResult::Error(e) => {
+                let err = io::Error::other(e);
+                this.state = StreamEncryptorState::Error(clone_io_error(&err));
+                Poll::Ready(Err(err))
             }
         }
     }
@@ -424,6 +430,11 @@ impl<W: AsyncWrite + Unpin> AsyncWrite for StreamingAttachmentEncryptor<W> {
         if this.poll_drain_pending(cx).is_pending() {
             return Poll::Pending;
         }
+
+        if let StreamEncryptorState::Error(e) = &this.state {
+            return Poll::Ready(Err(clone_io_error(e)));
+        }
+
         Pin::new(&mut this.inner).poll_flush(cx)
     }
 
@@ -434,10 +445,8 @@ impl<W: AsyncWrite + Unpin> AsyncWrite for StreamingAttachmentEncryptor<W> {
         if this.poll_drain_pending(cx).is_pending() {
             return Poll::Pending;
         }
-        if matches!(this.state, StreamEncryptorState::Error) {
-            return Poll::Ready(Err(io::Error::other(
-                "streaming attachment: encryptor in error state",
-            )));
+        if let StreamEncryptorState::Error(e) = &this.state {
+            return Poll::Ready(Err(clone_io_error(e)));
         }
 
         // If we haven't finalized yet, drain all output from the encryptor.
@@ -445,7 +454,12 @@ impl<W: AsyncWrite + Unpin> AsyncWrite for StreamingAttachmentEncryptor<W> {
             this.state,
             StreamEncryptorState::Aes256CbcHmacLegacyStream { .. }
         ) {
-            let old = std::mem::replace(&mut this.state, StreamEncryptorState::Error);
+            let old = std::mem::replace(
+                &mut this.state,
+                StreamEncryptorState::Error(io::Error::other(
+                    "streaming attachment: encryptor finalizing",
+                )),
+            );
             let StreamEncryptorState::Aes256CbcHmacLegacyStream { encryptor: mut enc } = old else {
                 unreachable!("matched above");
             };
@@ -458,10 +472,15 @@ impl<W: AsyncWrite + Unpin> AsyncWrite for StreamingAttachmentEncryptor<W> {
                         wire.extend_from_slice(&bytes);
                         break;
                     }
-                    ChunkEncryptionResult::NeedMoreData | ChunkEncryptionResult::Error => {
-                        return Poll::Ready(Err(io::Error::other(
-                            "streaming attachment: AES-CBC-HMAC finalize failed",
-                        )));
+                    ChunkEncryptionResult::Error(e) => {
+                        let err = io::Error::other(e);
+                        this.state = StreamEncryptorState::Error(clone_io_error(&err));
+                        return Poll::Ready(Err(err));
+                    }
+                    ChunkEncryptionResult::NeedMoreData => {
+                        let err = io::Error::other(StreamEncryptionError);
+                        this.state = StreamEncryptorState::Error(clone_io_error(&err));
+                        return Poll::Ready(Err(err));
                     }
                 }
             }
@@ -475,10 +494,8 @@ impl<W: AsyncWrite + Unpin> AsyncWrite for StreamingAttachmentEncryptor<W> {
         if this.poll_drain_pending(cx).is_pending() {
             return Poll::Pending;
         }
-        if matches!(this.state, StreamEncryptorState::Error) {
-            return Poll::Ready(Err(io::Error::other(
-                "streaming attachment: encryptor in error state",
-            )));
+        if let StreamEncryptorState::Error(e) = &this.state {
+            return Poll::Ready(Err(clone_io_error(e)));
         }
 
         // Shut down the inner writer.
@@ -489,7 +506,7 @@ impl<W: AsyncWrite + Unpin> AsyncWrite for StreamingAttachmentEncryptor<W> {
                 Poll::Ready(Ok(()))
             }
             Poll::Ready(Err(e)) => {
-                this.state = StreamEncryptorState::Error;
+                this.state = StreamEncryptorState::Error(clone_io_error(&e));
                 Poll::Ready(Err(e))
             }
         }

--- a/crates/bitwarden-crypto/src/stream/streaming_attachment_cipher.rs
+++ b/crates/bitwarden-crypto/src/stream/streaming_attachment_cipher.rs
@@ -44,7 +44,7 @@ impl TryFrom<u8> for HeaderDiscriminator {
     type Error = UnknownDiscriminator;
 
     fn try_from(value: u8) -> Result<Self, Self::Error> {
-         match value {
+        match value {
             0x02 => Ok(HeaderDiscriminator::Aes256CbcHmacLegacyStream),
             _ => Err(UnknownDiscriminator),
         }


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-38106
Unblocking KM-side work for https://github.com/bitwarden/sdk-internal/pull/1093

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Adds support for streaming encryption and decryption of attachments on the crypto side.

There are a few goals which this PR balances:
- Low memory usage while keeping compatibility to the old attachment format
  - This presented limitations as will be clarified later
- Transparent forward compatibility with future, better encryption schemes
- Safe interface / no leaking of cryptographic implementation for consumers
- A standard interface that is easy to work with, within the ecosystem

The public interfaces for this are just standard `AsyncRead` / `AsyncWrite` implementations, making them simple to use, as they can be plugged into the standard ecosystem, such as tokio, and more importantly reqwest for HTTP requests without much custom code on the callers.

The interface is designed to be scalable to better encryption schemes. I have a local implementation of https://eprint.iacr.org/2015/189.pdf / https://docs.rs/aead/latest/aead/stream/index.html, which has much better properties, and validated that the interface scales to this and hides all cryptographic detail.

# AES256-CBC-HMAC
The AES256-CBC-HMAC implementation supports decryption and encryption of current attachments. Note: The existing format is particularly poorly suited to streamed decryption, because the mac is included as the header, not trailer. This means that we cannot emit any encrypted chunks before we have encrypted the full stream. Because of this, we need to buffer the encrypted chunks.

## Wasm Memory Hacks
Since WASM memory grows linearly, we need to introduce external memory via `Uint8array` that can be de-allocated again. We could implement this to cache to storage if required, but in this implementation this allocates in JS heap instead of expanding the JS memory. This makes it so that this at least does not affect the WASM memory and *can* be deallocated again.

# Future work - STREAM
Locally, I have verified that an implementation based on https://docs.rs/aead/latest/aead/stream/index.html works and is reasonable. The benefits are numerous:
- Emitted chunks are always integrity protected, even without reading the full stream
- Minimal memory usage since no full stream buffering is necessary
- Random access decryption possible
  - I added the traits for this in the PR but without an implementation, just to define the public API here.
- This will be the encryption scheme for the COSE typed keys - AES-GCM, CHACHA20-Poly1305

# Integration Test
Left out from this PR because it's unclear how vault will consume the API. I have a DM open with them.


## 🚨 Breaking Changes

<!-- Does this PR introduce any breaking changes? If so, please describe the impact and migration path for clients.

If you're unsure, the automated TypeScript compatibility check will run when you open/update this PR and provide feedback.

For breaking changes:
1. Describe what changed in the client interface
2. Explain why the change was necessary
3. Provide migration steps for client developers
4. Link to any paired client PRs if needed

Otherwise, you can remove this section. -->
