### PR TITLE
[PM-29567] Pin binary cargo tools via cargo-run-bin

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -5,14 +5,24 @@
   enabledManagers: ["cargo", "dockerfile", "github-actions", "npm", "nuget", "custom.regex"],
   regexManagers: [
     {
+      // Pinned binary cargo tools declared in [workspace.metadata.bin].
+      // Matches only crates.io-sourced entries (git-pinned tools have `git =`
+      // immediately after the version field, so they are skipped here and
+      // remain manually managed).
+      fileMatch: ["^Cargo\\.toml$"],
+      matchStrings: [
+        '(?<depName>[a-z][a-z0-9_-]*)\\s*=\\s*\\{\\s*version\\s*=\\s*"=?(?<currentValue>\\d+\\.\\d+\\.\\d+)"\\s*,\\s*locked\\s*=\\s*true',
+      ],
+      datasourceTemplate: "crate",
+      versioningTemplate: "cargo",
+    },
+    {
+      // Bootstrap pin for cargo-run-bin in CI workflows.
       fileMatch: ["^\\.github/workflows/.*\\.ya?ml$"],
       matchStrings: [
-        "cargo install (?<depName>cargo-dylint) (?:[\\w-]+ )?--version (?<currentValue>\\d+\\.\\d+\\.\\d+) --locked",
-        "cargo install (?<depName>dylint-link) (?:[\\w-]+ )?--version (?<currentValue>\\d+\\.\\d+\\.\\d+) --locked",
-        "cargo install (?<depName>cargo-sort) --version (?<currentValue>\\d+\\.\\d+\\.\\d+) --locked",
-        "cargo install (?<depName>cargo-udeps) --version (?<currentValue>\\d+\\.\\d+\\.\\d+) --locked",
+        "cargo install (?<depName>cargo-run-bin) --locked --version (?<currentValue>\\d+\\.\\d+\\.\\d+)",
       ],
-      datasourceTemplate: "cargo",
+      datasourceTemplate: "crate",
       versioningTemplate: "cargo",
     },
   ],

--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -47,13 +47,13 @@ jobs:
         with:
           key: ${{ matrix.settings.target }}-cargo
 
-      - name: Install Cross
-        run: cargo install cross --locked --git https://github.com/cross-rs/cross.git --rev 185398b1b885820515a212de720a306b08e2c8c9
+      - name: Install cargo-run-bin
+        run: cargo install cargo-run-bin --locked --version 1.7.4
 
       - name: Build
         env:
           TARGET: ${{ matrix.settings.target }}
-        run: cross build -p bitwarden-uniffi --release --target=${{ matrix.settings.target }}
+        run: cargo bin cross build -p bitwarden-uniffi --release --target=${{ matrix.settings.target }}
 
       - name: Upload artifact
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0

--- a/.github/workflows/build-rust-crates.yml
+++ b/.github/workflows/build-rust-crates.yml
@@ -73,8 +73,8 @@ jobs:
       - name: Cache cargo registry
         uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2.8.2
 
-      - name: Install cargo-release
-        run: cargo install cargo-release --version 0.25.20 --locked
+      - name: Install cargo-run-bin
+        run: cargo install cargo-run-bin --locked --version 1.7.4
 
       - name: Cargo release dry run
-        run: cargo-release release publish --no-publish -p bitwarden-api-api -p bitwarden-api-identity -p bitwarden
+        run: cargo bin cargo-release release publish --no-publish -p bitwarden-api-api -p bitwarden-api-identity -p bitwarden

--- a/.github/workflows/check-powerset.yml
+++ b/.github/workflows/check-powerset.yml
@@ -37,10 +37,10 @@ jobs:
       - name: Cache cargo registry
         uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2.8.2
 
-      - name: Install cargo-hack
-        run: cargo install cargo-hack --version 0.6.33 --locked
+      - name: Install cargo-run-bin
+        run: cargo install cargo-run-bin --locked --version 1.7.4
 
       - name: Build
-        run: cargo hack check --workspace --feature-powerset --no-dev-deps
+        run: cargo bin cargo-hack check --workspace --feature-powerset --no-dev-deps
         env:
           RUSTFLAGS: "-D warnings"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -103,9 +103,11 @@ jobs:
 
       - name: Run clippy with SARIF output
         if: matrix.check == 'clippy'
-        env:
-          RUSTFLAGS: "-D warnings"
-        run: cargo clippy --all-features --all-targets --message-format=json |
+        # Pass `-D warnings` to clippy directly rather than via RUSTFLAGS so the
+        # deny level applies only to the linted crates, not to the from-source
+        # builds of clippy-sarif/sarif-fmt that `cargo bin` triggers in this step
+        # (some of their transitive deps emit warnings we don't control).
+        run: cargo clippy --all-features --all-targets --message-format=json -- -D warnings |
           cargo bin clippy-sarif | tee clippy_result.sarif | cargo bin sarif-fmt
 
       - name: Upload clippy results to GitHub

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -97,6 +97,20 @@ jobs:
         if: matrix.needs_rust
         uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2.8.2
 
+      # Cache cargo-run-bin's built tools (.bin) separately from rust-cache. The
+      # tools depend only on their pinned versions (Cargo.toml) and the toolchain,
+      # not on Cargo.lock, so this key avoids rust-cache's lockfile rotation. Keyed
+      # per check so each one caches only the tools it builds, with no contention
+      # (rust-cache keys all matrix checks under one shared job-based key).
+      - name: Cache cargo-run-bin tools
+        if: matrix.needs_rust
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: .bin
+          key: cargo-bin-${{ runner.os }}-${{ matrix.check }}-${{ hashFiles('Cargo.toml', 'rust-toolchain.toml') }}
+          restore-keys: |
+            cargo-bin-${{ runner.os }}-${{ matrix.check }}-
+
       - name: Install cargo-run-bin
         if: matrix.needs_rust
         run: cargo install cargo-run-bin --locked --version 1.7.4

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -42,14 +42,11 @@ jobs:
             needs_rust: true
           - check: sort
             needs_rust: true
-            install: cargo install cargo-sort --version 2.0.2 --locked
           - check: udeps
             needs_rust: true
             needs_rust_nightly: true
-            install: cargo install cargo-udeps --version 0.1.57 --locked
           - check: dylint
             needs_rust: true
-            install: cargo install cargo-dylint dylint-link --version 5.0.0 --locked
           - check: doc
             needs_rust: true
           - check: prettier
@@ -100,20 +97,16 @@ jobs:
         if: matrix.needs_rust
         uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2.8.2
 
-      - name: Install per-check cargo tool
-        if: matrix.install
-        run: ${{ matrix.install }}
-
-      - name: Install clippy-sarif and sarif-fmt
-        if: matrix.check == 'clippy'
-        run: cargo install clippy-sarif sarif-fmt --locked --git https://github.com/psastras/sarif-rs.git --rev 11c33a53f6ffeaed736856b86fb6b7b09fabdfd8
+      - name: Install cargo-run-bin
+        if: matrix.needs_rust
+        run: cargo install cargo-run-bin --locked --version 1.7.4
 
       - name: Run clippy with SARIF output
         if: matrix.check == 'clippy'
         env:
           RUSTFLAGS: "-D warnings"
         run: cargo clippy --all-features --all-targets --message-format=json |
-          clippy-sarif | tee clippy_result.sarif | sarif-fmt
+          cargo bin clippy-sarif | tee clippy_result.sarif | cargo bin sarif-fmt
 
       - name: Upload clippy results to GitHub
         if: matrix.check == 'clippy'

--- a/.github/workflows/rust-test.yml
+++ b/.github/workflows/rust-test.yml
@@ -105,11 +105,11 @@ jobs:
       - name: Cache cargo registry
         uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2.8.2
 
-      - name: Install cargo-llvm-cov
-        run: cargo install cargo-llvm-cov --version 0.5.38 --locked
+      - name: Install cargo-run-bin
+        run: cargo install cargo-run-bin --locked --version 1.7.4
 
       - name: Generate coverage
-        run: cargo llvm-cov --all-features --lcov --output-path lcov.info --ignore-filename-regex "crates/bitwarden-api-"
+        run: cargo bin cargo-llvm-cov --all-features --lcov --output-path lcov.info --ignore-filename-regex "crates/bitwarden-api-"
 
       - name: Upload to codecov.io
         uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -35,8 +35,8 @@ jobs:
       - name: Cache cargo registry
         uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2.8.2
 
-      - name: Install cargo-release
-        run: cargo install cargo-edit --locked
+      - name: Install cargo-run-bin
+        run: cargo install cargo-run-bin --locked --version 1.7.4
 
       - name: Log in to Azure
         uses: bitwarden/gh-actions/azure-login@main
@@ -95,14 +95,14 @@ jobs:
         if: ${{ inputs.project == 'bitwarden-core' }}
         env:
           VERSION_NUMBER: ${{ inputs.version_number }}
-        run: cargo set-version -p bitwarden-core "$VERSION_NUMBER"
+        run: cargo bin cargo-set-version -p bitwarden-core "$VERSION_NUMBER"
 
       ### bitwarden-sm
       - name: Bump bitwarden-sm crate Version
         if: ${{ inputs.project == 'bitwarden-sm' }}
         env:
           VERSION_NUMBER: ${{ inputs.version_number }}
-        run: cargo set-version -p bitwarden-sm "$VERSION_NUMBER"
+        run: cargo bin cargo-set-version -p bitwarden-sm "$VERSION_NUMBER"
 
       ############################
       # VERSION BUMP SECTION END #

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 /target
+# cargo-run-bin per-tool build cache
+/.bin
 .DS_Store
 .pytest_cache
 .vscode/c_cpp_properties.json

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -143,6 +143,22 @@ unexpected_cfgs = { level = "warn", check-cfg = [
 [workspace.metadata.dylint]
 libraries = [{ path = "support/lints" }]
 
+# Pinned binary cargo tools used by CI and `scripts/lint.sh`.
+# Install the runner once with `cargo install cargo-run-bin --locked`, then
+# invoke any tool via `cargo bin <tool> <args>`. See README for details.
+[workspace.metadata.bin]
+cargo-sort = { version = "2.0.2", locked = true }
+cargo-udeps = { version = "0.1.57", locked = true }
+cargo-hack = { version = "0.6.33", locked = true }
+cargo-llvm-cov = { version = "0.5.38", locked = true }
+cargo-release = { version = "0.25.20", locked = true }
+cargo-edit = { version = "0.13.6", locked = true, bins = ["cargo-set-version"] }
+cargo-dylint = { version = "5.0.0", locked = true }
+dylint-link = { version = "5.0.0", locked = true }
+cross = { version = "0.2.5", git = "https://github.com/cross-rs/cross.git", rev = "185398b1b885820515a212de720a306b08e2c8c9", locked = true }
+clippy-sarif = { version = "0.4.2", git = "https://github.com/psastras/sarif-rs.git", rev = "11c33a53f6ffeaed736856b86fb6b7b09fabdfd8", locked = true }
+sarif-fmt = { version = "0.4.2", git = "https://github.com/psastras/sarif-rs.git", rev = "11c33a53f6ffeaed736856b86fb6b7b09fabdfd8", locked = true }
+
 # Turn on a small amount of optimisation in development mode. This might interfere when trying to use a debugger
 # if the compiler decides to optimize some code away, if that's the case, it can be set to 0 or commented out
 [profile.dev]

--- a/README.md
+++ b/README.md
@@ -454,8 +454,17 @@ The command is implemented in [scripts/lint.sh](./scripts/lint.sh) and mirrors
 
 ### Installation
 
-The tools each check needs (and pinned versions) are installed in the lint workflow above. The
-underlying tools are:
+Binary cargo tools (cargo-sort, cargo-udeps, cargo-dylint, etc.) are pinned in the root `Cargo.toml`
+under `[workspace.metadata.bin]` and installed lazily by
+[`cargo-run-bin`](https://crates.io/crates/cargo-run-bin), so dev and CI versions stay in sync.
+Bootstrap once:
+
+```bash
+cargo install cargo-run-bin --locked
+```
+
+After that, `npm run lint` (or `scripts/lint.sh` directly) handles installation of any missing tool
+on first invocation. The underlying tools are:
 
 - Nightly [cargo fmt](https://github.com/rust-lang/rustfmt) and
   [cargo udeps](https://github.com/est31/cargo-udeps)
@@ -464,7 +473,7 @@ underlying tools are:
 - [cargo sort](https://github.com/DevinR528/cargo-sort)
 - [prettier](https://github.com/prettier/prettier)
 
-If a tool is missing locally, `npm run lint` will tell you which one and how to install it.
+If `cargo-run-bin` itself is missing locally, `npm run lint` will tell you how to install it.
 
 ## Documentation
 

--- a/crates/bitwarden-uniffi/kotlin/README.md
+++ b/crates/bitwarden-uniffi/kotlin/README.md
@@ -3,10 +3,11 @@
 Android builds needs vendored OpenSSL to function correctly. The easiest way to build this is by
 using [cross](https://github.com/cross-rs/cross).
 
-Note that the latest published version is very old, so we need to use a newer Git commit instead.
+The pinned `cross` revision lives in the root `Cargo.toml` under `[workspace.metadata.bin]`. Install
+the bootstrap once and invoke `cross` via `cargo bin`:
 
 ```bash
-cargo install cross --locked --git https://github.com/cross-rs/cross.git --rev 185398b1b885820515a212de720a306b08e2c8c9
+cargo install cargo-run-bin --locked
 ```
 
 ## Development
@@ -26,16 +27,16 @@ Depending on which CPU architecture you will need to specify different targets. 
 ```bash
 mkdir -p ./sdk/src/main/jniLibs/{arm64-v8a,armeabi-v7a,x86_64,x86}
 
-cross build -p bitwarden-uniffi --release --target=aarch64-linux-android
+cargo bin cross build -p bitwarden-uniffi --release --target=aarch64-linux-android
 mv ../../../target/aarch64-linux-android/release/libbitwarden_uniffi.so ./sdk/src/main/jniLibs/arm64-v8a/libbitwarden_uniffi.so
 
-cross build -p bitwarden-uniffi --release --target=armv7-linux-androideabi
+cargo bin cross build -p bitwarden-uniffi --release --target=armv7-linux-androideabi
 mv ../../../target/armv7-linux-androideabi/release/libbitwarden_uniffi.so ./sdk/src/main/jniLibs/armeabi-v7a/libbitwarden_uniffi.so
 
-cross build -p bitwarden-uniffi --release --target=x86_64-linux-android
+cargo bin cross build -p bitwarden-uniffi --release --target=x86_64-linux-android
 mv ../../../target/x86_64-linux-android/release/libbitwarden_uniffi.so ./sdk/src/main/jniLibs/x86_64/libbitwarden_uniffi.so
 
-cross build -p bitwarden-uniffi --release --target=i686-linux-android
+cargo bin cross build -p bitwarden-uniffi --release --target=i686-linux-android
 mv ../../../target/i686-linux-android/release/libbitwarden_uniffi.so ./sdk/src/main/jniLibs/x86/libbitwarden_uniffi.so
 ```
 

--- a/crates/bitwarden-uniffi/kotlin/publish-local.sh
+++ b/crates/bitwarden-uniffi/kotlin/publish-local.sh
@@ -8,20 +8,20 @@ SDK_REPO_ROOT="$(git rev-parse --show-toplevel)"
 mkdir -p ./sdk/src/main/jniLibs/{arm64-v8a,armeabi-v7a,x86_64,x86}
 
 # Build arm64 for emulator
-cross build -p bitwarden-uniffi --release --target=aarch64-linux-android
+cargo bin cross build -p bitwarden-uniffi --release --target=aarch64-linux-android
 mv $SDK_REPO_ROOT/target/aarch64-linux-android/release/libbitwarden_uniffi.so ./sdk/src/main/jniLibs/arm64-v8a/libbitwarden_uniffi.so
 
 # Build other archs
 if [ "$1" = "all" ]; then
     echo "Building for all architectures"
     
-    cross build -p bitwarden-uniffi --release --target=armv7-linux-androideabi
+    cargo bin cross build -p bitwarden-uniffi --release --target=armv7-linux-androideabi
     mv $SDK_REPO_ROOT/target/armv7-linux-androideabi/release/libbitwarden_uniffi.so ./sdk/src/main/jniLibs/armeabi-v7a/libbitwarden_uniffi.so
 
-    cross build -p bitwarden-uniffi --release --target=x86_64-linux-android
+    cargo bin cross build -p bitwarden-uniffi --release --target=x86_64-linux-android
     mv $SDK_REPO_ROOT/target/x86_64-linux-android/release/libbitwarden_uniffi.so ./sdk/src/main/jniLibs/x86_64/libbitwarden_uniffi.so
 
-    cross build -p bitwarden-uniffi --release --target=i686-linux-android
+    cargo bin cross build -p bitwarden-uniffi --release --target=i686-linux-android
     mv $SDK_REPO_ROOT/target/i686-linux-android/release/libbitwarden_uniffi.so ./sdk/src/main/jniLibs/x86/libbitwarden_uniffi.so
 fi
 

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -59,11 +59,11 @@ should_run() {
   [[ -z "$ONLY" || "$ONLY" == "$1" ]]
 }
 
-require_tool() {
-  local tool="$1" install_hint="$2"
-  if ! command -v "$tool" >/dev/null 2>&1; then
-    echo "Required tool not found on PATH: $tool" >&2
-    echo "Install with: $install_hint" >&2
+require_cargo_bin() {
+  if ! command -v cargo-bin >/dev/null 2>&1; then
+    echo "Required tool not found on PATH: cargo-bin" >&2
+    echo "Install with: cargo install cargo-run-bin --locked" >&2
+    echo "(Binary tool versions are pinned in Cargo.toml under [workspace.metadata.bin].)" >&2
     exit 1
   fi
 }
@@ -85,22 +85,22 @@ run_clippy() {
 }
 
 run_sort() {
-  require_tool cargo-sort "cargo install cargo-sort --locked"
+  require_cargo_bin
   if (( FIX )); then
-    cargo sort --workspace --grouped
+    cargo bin cargo-sort --workspace --grouped
   else
-    cargo sort --workspace --grouped --check
+    cargo bin cargo-sort --workspace --grouped --check
   fi
 }
 
 run_udeps() {
-  require_tool cargo-udeps "cargo install cargo-udeps --locked"
-  cargo "+$RUST_NIGHTLY_TOOLCHAIN" udeps --workspace --all-features
+  require_cargo_bin
+  cargo "+$RUST_NIGHTLY_TOOLCHAIN" bin cargo-udeps --workspace --all-features
 }
 
 run_dylint() {
-  require_tool cargo-dylint "cargo install cargo-dylint dylint-link --locked"
-  cargo dylint --all -- --all-features --all-targets
+  require_cargo_bin
+  cargo bin cargo-dylint --all -- --all-features --all-targets
 }
 
 run_doc() {

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -100,7 +100,32 @@ run_udeps() {
 
 run_dylint() {
   require_cargo_bin
-  cargo bin cargo-dylint --all -- --all-features --all-targets
+  # cargo-dylint invokes `dylint-link` as rustc's linker, found by name on PATH.
+  # Running cargo-dylint through `cargo bin` doesn't work: cargo-run-bin prepends
+  # a shim directory to PATH whose dylint-link shim re-runs `cargo bin
+  # dylint-link`, which fails from the directories rustc links in (support/lints
+  # and each dependency's source dir, none of which declare
+  # [workspace.metadata.bin]). So build the tools and invoke cargo-dylint
+  # directly with the real dylint-link binary on PATH, using an absolute path so
+  # it resolves no matter which directory cargo-dylint links from.
+  #
+  # Build only the two tools dylint needs rather than `cargo bin --install`,
+  # which builds every pinned tool (including some that don't compile on this
+  # toolchain, e.g. cross). `cargo bin` builds a tool on first use; the throwaway
+  # invocations below just trigger those builds (dylint-link has no safe no-op
+  # invocation, so its run is allowed to fail; the builds are verified by the
+  # `find`s that follow).
+  cargo bin cargo-dylint --help >/dev/null
+  cargo bin dylint-link --help >/dev/null 2>&1 || true
+
+  local cargo_dylint dylint_link
+  cargo_dylint="$(find "$REPO_ROOT/.bin" -type f -name cargo-dylint -not -path '*/.shims/*' -print -quit)"
+  dylint_link="$(find "$REPO_ROOT/.bin" -type f -name dylint-link -not -path '*/.shims/*' -print -quit)"
+  if [[ -z "$cargo_dylint" || -z "$dylint_link" ]]; then
+    echo "Could not find cargo-dylint/dylint-link under .bin (build failed?)" >&2
+    exit 1
+  fi
+  PATH="$(dirname "$dylint_link"):$PATH" "$cargo_dylint" dylint --all -- --all-features --all-targets
 }
 
 run_doc() {


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-29567

## 📔 Objective

Add a [workspace.metadata.bin] block to the root Cargo.toml listing every binary cargo tool used by CI and scripts/lint.sh. CI and developers bootstrap cargo-run-bin once and invoke any tool via `cargo bin <tool>`, so dev versions stay in sync with CI.

scripts/lint.sh switches from PATH lookups (with manual install hints) to `cargo bin <tool>` invocations; the lint matrix drops its per-check install steps in favor of one shared cargo-run-bin install. The other workflows (check-powerset, build-rust-crates, build-android, version-bump, rust-test) get the same treatment.

Renovate's regex managers now target the manifest plus the cargo-run-bin bootstrap pin, replacing the four per-tool workflow regex managers.

### Follow-up fixes to get the lint matrix green

Moving the tools under cargo-run-bin surfaced two lint failures and one efficiency gap, fixed here:

- **clippy**: the clippy step set `RUSTFLAGS: -D warnings` for the whole step, which leaked into the from-source builds of `clippy-sarif`/`sarif-fmt` that `cargo bin` triggers in that step — a warning in their transitive dependency `serde-sarif` then became a hard error. `-D warnings` is now passed on the clippy command line instead, so the deny level applies only to the linted crates.

- **dylint**: `cargo-dylint` invokes `dylint-link` as rustc's linker, found by name on PATH. Run through `cargo bin`, cargo-run-bin prepends a shim directory whose `dylint-link` shim re-runs `cargo bin dylint-link`, which fails from the directories rustc links in (support/lints and each dependency's source dir, none of which declare `[workspace.metadata.bin]`). The dylint check now invokes the `cargo-dylint` binary directly with the real `dylint-link` on an absolute PATH, bypassing the shims. It builds only the two tools dylint needs rather than `cargo bin --install`, which also tries to build `cross` (which doesn't compile on the pinned toolchain).

- **caching**: cargo-run-bin builds its tools into `.bin`, which wasn't cached, so every lint check rebuilt its tools from source each run. A dedicated `actions/cache` step now caches `.bin` per check, keyed on `Cargo.toml` + `rust-toolchain.toml` (the tools depend on their pinned versions and the toolchain, not on `Cargo.lock`) with restore-keys for graceful fallback when a version is bumped.

## 🚨 Breaking Changes

None.
