### PR TITLE
chore: add fedramp-gov-region feature flag

### DIFF
--- a/crates/bitwarden-core/src/client/flags.rs
+++ b/crates/bitwarden-core/src/client/flags.rs
@@ -16,6 +16,10 @@ pub struct Flags {
     /// Enable strict cipher field decryption (propagates errors instead of nulling fields).
     #[serde(alias = "pm-34500-strict-cipher-decryption")]
     pub strict_cipher_decryption: bool,
+
+    /// Enable FedRAMP government region behavior.
+    #[serde(alias = "fedrampGovRegion")]
+    pub fedramp_gov_region: bool,
 }
 
 impl Flags {


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-38177
https://github.com/bitwarden/server/pull/7726
https://github.com/bitwarden/clients/pull/20880

## 📔 Objective

Add the fedramp-gov-region feature flag to the SDK so we can use it to support `GovMode`.