### PR TITLE
[BEEEP] [PM-38310] Introduce Sensitive Value Wrapper

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -102,11 +102,6 @@ Monorepo crates organized in **four architectural layers**:
 ### Security Requirements
 
 - **Never log** keys, passwords, or vault data in logs or error paths
-  - Consider newtype wrappers, such as the ones exposed in the `bitwarden-sensitive-value` crate.
-    Calling `.expose()` on them is allowed when passing to external libraries that do not support
-    this type.
-  - The `SymmetricCryptoKey`, `PrivateKey` and `SigningKey` types have a protected logging
-    implementation that makes them safe to log.
 - **Redact sensitive data** in all error messages
 - **Unsafe blocks** require comments explaining safety and invariants
 - **Encryption/decryption changes** must maintain backward compatibility (existing encrypted data

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -102,6 +102,11 @@ Monorepo crates organized in **four architectural layers**:
 ### Security Requirements
 
 - **Never log** keys, passwords, or vault data in logs or error paths
+  - Consider newtype wrappers, such as the ones exposed in the `bitwarden-sensitive-value` crate.
+    Calling `.expose()` on them is allowed when passing to external libraries that do not support
+    this type.
+  - The `SymmetricCryptoKey`, `PrivateKey` and `SigningKey` types have a protected logging
+    implementation that makes them safe to log.
 - **Redact sensitive data** in all error messages
 - **Unsafe blocks** require comments explaining safety and invariants
 - **Encryption/decryption changes** must maintain backward compatibility (existing encrypted data

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -43,6 +43,7 @@ crates/bitwarden-generators/** @bitwarden/team-tools-dev @bitwarden/team-platfor
 crates/bitwarden-organization-crypto/** @bitwarden/team-key-management-dev
 crates/bitwarden-organizations/** @bitwarden/team-admin-console-dev
 crates/bitwarden-policies/** @bitwarden/team-admin-console-dev
+crates/bitwarden-sensitive-value/** @bitwarden/team-key-management-dev
 crates/bitwarden-send/** @bitwarden/team-tools-dev @bitwarden/team-platform-dev
 crates/bitwarden-shared-unlock/** @bitwarden/team-key-management-dev
 crates/bitwarden-state-bridge-macro/** @bitwarden/team-key-management-dev

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -999,6 +999,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "bitwarden-sensitive-value"
+version = "3.0.0"
+dependencies = [
+ "serde",
+ "serde_json",
+ "uniffi",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "bitwarden-server-communication-config"
 version = "3.0.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,7 @@ bitwarden-organizations = { path = "crates/bitwarden-organizations", version = "
 bitwarden-pm = { path = "crates/bitwarden-pm", version = "=3.0.0" }
 bitwarden-policies = { path = "crates/bitwarden-policies", version = "=3.0.0" }
 bitwarden-send = { path = "crates/bitwarden-send", version = "=3.0.0" }
+bitwarden-sensitive-value = { path = "crates/bitwarden-sensitive-value", version = "=3.0.0" }
 bitwarden-server-communication-config = { path = "crates/bitwarden-server-communication-config", version = "=3.0.0" }
 bitwarden-shared-unlock = { path = "crates/bitwarden-shared-unlock", version = "=3.0.0" }
 bitwarden-ssh = { path = "crates/bitwarden-ssh", version = "=3.0.0" }

--- a/crates/bitwarden-sensitive-value/Cargo.toml
+++ b/crates/bitwarden-sensitive-value/Cargo.toml
@@ -1,0 +1,34 @@
+[package]
+name = "bitwarden-sensitive-value"
+description = """
+Internal crate for the bitwarden crate. Do not use.
+"""
+
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+readme.workspace = true
+homepage.workspace = true
+repository.workspace = true
+license-file.workspace = true
+keywords.workspace = true
+
+[features]
+default = []
+# WARNING: This feature is for debugging purposes only and should never be enabled in production.
+# It disables redaction of secret values in `Debug`/`Display` output.
+dangerous-crypto-debug = []
+uniffi = ["dep:uniffi"]
+wasm = ["dep:wasm-bindgen"]
+
+[dependencies]
+serde = { workspace = true }
+uniffi = { workspace = true, optional = true }
+wasm-bindgen = { workspace = true, optional = true }
+
+[dev-dependencies]
+serde_json = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/bitwarden-sensitive-value/README.md
+++ b/crates/bitwarden-sensitive-value/README.md
@@ -1,7 +1,7 @@
 # Bitwarden Sensitive Value
 
-Provides the `Sensitive<T>`, `SensitiveString` wrapper types and aliases (`MasterPassword`,
-`Pin`) used to mark values as secret and prevent accidental logging.
+Provides the `Sensitive<T>`, `SensitiveString` wrapper types and aliases (`MasterPassword`, `Pin`)
+used to mark values as secret and prevent accidental logging.
 
 ## NOT A PUBLIC API
 

--- a/crates/bitwarden-sensitive-value/README.md
+++ b/crates/bitwarden-sensitive-value/README.md
@@ -1,0 +1,9 @@
+# Bitwarden Sensitive Value
+
+Provides the `Sensitive<T>`, `SensitiveString` wrapper types and aliases (`MasterPassword`,
+`Pin`) used to mark values as secret and prevent accidental logging.
+
+## NOT A PUBLIC API
+
+Please note that this is currently NOT public API and other teams should not currently rely on this
+as there are no stability guarantees. There is currently no support for external usages!

--- a/crates/bitwarden-sensitive-value/examples/custom_sensitive_type.rs
+++ b/crates/bitwarden-sensitive-value/examples/custom_sensitive_type.rs
@@ -1,0 +1,65 @@
+//! Demonstrates defining a custom, domain-named sensitive newtype around an integer. This is the
+//! same pattern [`SensitiveString`] uses internally: a tuple struct wrapping [`Sensitive<T>`] with
+//! [`ExposeSensitive`], `From`, and delegated `Debug`/`Display` impls so redaction is inherited.
+
+use core::fmt;
+
+use bitwarden_sensitive_value::{ExposeSensitive, Sensitive};
+
+/// A custom sensitive wrapper around an account identifier. Naming the type makes intent clear at
+/// call sites while keeping the value out of logs.
+pub struct SensitiveAccountId(Sensitive<u64>);
+
+impl From<u64> for SensitiveAccountId {
+    fn from(value: u64) -> Self {
+        Self(Sensitive::from(value))
+    }
+}
+
+impl ExposeSensitive for SensitiveAccountId {
+    type Exposed = u64;
+
+    fn expose(&self) -> &Self::Exposed {
+        self.0.expose()
+    }
+
+    fn expose_owned(self) -> Self::Exposed {
+        self.0.expose_owned()
+    }
+}
+
+// Delegating to the inner `Sensitive` means redaction is inherited for free.
+impl fmt::Debug for SensitiveAccountId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+impl fmt::Display for SensitiveAccountId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+fn main() {
+    let account_id = SensitiveAccountId::from(1_234_567_890_u64);
+
+    // `Debug` and `Display` are redacted, so the id is safe to log accidentally.
+    #[cfg(not(feature = "dangerous-crypto-debug"))]
+    assert_eq!(format!("{account_id:?}"), "[REDACTED]");
+    #[cfg(not(feature = "dangerous-crypto-debug"))]
+    assert_eq!(format!("{account_id}"), "[REDACTED]");
+
+    // EXPOSE: We borrow the raw id only to hand it to a lookup helper that does not log it. This is
+    // the boundary where the secret is intentionally used.
+    lookup_account(*account_id.expose());
+
+    // EXPOSE: Consume the wrapper to recover the underlying integer for the final assertion.
+    let raw = account_id.expose_owned();
+    assert_eq!(raw, 1_234_567_890);
+}
+
+fn lookup_account(id: u64) {
+    // Pretend to look up the account by id.
+    assert_eq!(id, 1_234_567_890);
+}

--- a/crates/bitwarden-sensitive-value/examples/wrap_byte_slice.rs
+++ b/crates/bitwarden-sensitive-value/examples/wrap_byte_slice.rs
@@ -1,0 +1,28 @@
+//! Demonstrates wrapping a borrowed `&[u8]` with [`SensitiveSlice`] for a zero-copy view of secret
+//! bytes. Wrapping a reference borrows the underlying buffer instead of cloning it — useful when
+//! the bytes already live in another owned buffer (e.g. a parsed message or a key store entry) and
+//! you only need a non-logging handle to them.
+
+use bitwarden_sensitive_value::{ExposeSensitive, SensitiveSlice};
+
+fn main() {
+    // Pretend this buffer came from somewhere we don't want to copy out of — a network frame,
+    // a memory-mapped file, a decrypted scratch buffer, etc.
+    let key_material: [u8; 32] = [0x42; 32];
+
+    // Wrap a borrow. This is a zero-copy operation with redacted `Debug`/`Display`.
+    let secret: SensitiveSlice<'_> = SensitiveSlice::from(key_material.as_slice());
+    #[cfg(not(feature = "dangerous-crypto-debug"))]
+    assert_eq!(format!("{secret:?}"), "[REDACTED]");
+
+    // The borrow is tied to `key_material`'s lifetime — the wrapper does not extend it.
+    derive_subkey(secret.expose());
+
+    // The owner still has the underlying buffer and can wrap it again as needed.
+    assert_eq!(key_material.len(), 32);
+}
+
+fn derive_subkey(secret: &[u8]) {
+    assert_eq!(secret.len(), 32);
+    assert!(secret.iter().all(|&b| b == 0x42));
+}

--- a/crates/bitwarden-sensitive-value/examples/wrap_secret.rs
+++ b/crates/bitwarden-sensitive-value/examples/wrap_secret.rs
@@ -1,0 +1,34 @@
+//! Demonstrates wrapping secret values with [`Sensitive`] and [`SensitiveString`] so that
+//! `Debug` and `Display` output is redacted by default.
+
+use bitwarden_sensitive_value::{ExposeSensitive, MasterPassword, Sensitive};
+
+fn main() {
+    // `SensitiveString` is the FFI-friendly wrapper used for passwords, PINs, and similar
+    // string-shaped secrets. `MasterPassword` and `Pin` are type aliases for it.
+    let password: MasterPassword = MasterPassword::from("hunter2");
+
+    // `Debug` and `Display` are redacted, so the secret is safe to log accidentally.
+    #[cfg(not(feature = "dangerous-crypto-debug"))]
+    assert_eq!(format!("{password:?}"), "[REDACTED]");
+    #[cfg(not(feature = "dangerous-crypto-debug"))]
+    assert_eq!(format!("{password}"), "[REDACTED]");
+
+    // Explicitly borrow the secret when you need to use it.
+    authenticate(password.expose());
+
+    // The generic `Sensitive<T>` works for any type, not just strings. Here we wrap a
+    // numeric token to prevent it from leaking into logs.
+    let token: Sensitive<u64> = Sensitive::from(0xDEAD_BEEF_u64);
+    #[cfg(not(feature = "dangerous-crypto-debug"))]
+    assert_eq!(format!("{token:?}"), "[REDACTED]");
+
+    // `into_inner` consumes the wrapper and returns the underlying value.
+    let raw = token.expose_owned();
+    assert_eq!(raw, 0xDEAD_BEEF);
+}
+
+fn authenticate(password: &str) {
+    // Pretend to verify the password against a stored hash.
+    assert_eq!(password, "hunter2");
+}

--- a/crates/bitwarden-sensitive-value/examples/wrap_secret.rs
+++ b/crates/bitwarden-sensitive-value/examples/wrap_secret.rs
@@ -23,7 +23,7 @@ fn main() {
     #[cfg(not(feature = "dangerous-crypto-debug"))]
     assert_eq!(format!("{token:?}"), "[REDACTED]");
 
-    // `into_inner` consumes the wrapper and returns the underlying value.
+    // `expose_owned` consumes the wrapper and returns the underlying value.
     let raw = token.expose_owned();
     assert_eq!(raw, 0xDEAD_BEEF);
 }

--- a/crates/bitwarden-sensitive-value/src/lib.rs
+++ b/crates/bitwarden-sensitive-value/src/lib.rs
@@ -1,0 +1,14 @@
+#![doc = include_str!("../README.md")]
+
+#[cfg(feature = "uniffi")]
+uniffi::setup_scaffolding!();
+
+mod sensitive;
+mod sensitive_slice;
+mod sensitive_string;
+mod types;
+
+pub use sensitive::{ExposeSensitive, Sensitive};
+pub use sensitive_slice::SensitiveSlice;
+pub use sensitive_string::SensitiveString;
+pub use types::*;

--- a/crates/bitwarden-sensitive-value/src/sensitive.rs
+++ b/crates/bitwarden-sensitive-value/src/sensitive.rs
@@ -1,0 +1,139 @@
+/// A wrapper type that marks the inner value as secret. This is used to prevent accidental logging
+/// of secrets by overriding the `Debug` and `Display` implementations to redact the value. This
+/// redaction can be bypassed by enabling the `dangerous-crypto-debug` feature.
+pub struct Sensitive<T>(pub(crate) T);
+
+/// A trait for types that can expose their inner secret value. This is implemented for
+/// `Sensitive<T>` and can be implemented for other wrapper types as needed. The `expose` and
+/// `expose_owned` methods are intentionally explicit and require justification in comments to
+/// prevent accidental misuse.
+pub trait ExposeSensitive {
+    /// The type of the inner value that is being wrapped. This is used to define the return type of
+    /// the `expose` and `expose_owned` methods.
+    type Exposed;
+
+    /// Explicitly borrow the secret value. This exposes the secret to logging. This should be used
+    /// exactly only when interacting with APIs we do not control. Each usage of `expose` MUST have
+    /// a comment justifying why it is necessary and acknowledging that the appropriate checks have
+    /// been performed.
+    fn expose(&self) -> &Self::Exposed;
+
+    /// Consume the wrapper and return the inner value. This exposes the secret to logging. This
+    /// should be used exactly only when interacting with APIs we do not control. Each usage of
+    /// `expose` MUST have a comment justifying why it is necessary and acknowledging that the
+    /// appropriate checks have been performed.
+    fn expose_owned(self) -> Self::Exposed;
+}
+
+impl<T> ExposeSensitive for Sensitive<T> {
+    type Exposed = T;
+
+    /// Explicitly borrow the wrapped value. This exposes the secret to logging. This should
+    /// be used exactly only when interacting with APIs we do not control. Each usage of expose
+    /// MUST have a comment justifying why it is necessary and acknowledging that the appropriate
+    /// checks have been performed.
+    /// ```
+    /// use bitwarden_sensitive_value::{ExposeSensitive, Sensitive};
+    /// # fn pbkdf2(_password: &[u8], _salt: &[u8], _rounds: u32) -> [u8; 32] { [0u8; 32] }
+    /// fn hash_password(password: &Sensitive<String>) -> [u8; 32] {
+    ///    // EXPOSE: We need to pass the password to pbkdf2, because `pbkdf2` does not support the
+    ///    // sensitive type and is an external crate. It is safe to do so because the library does
+    ///    // not log data.
+    ///    let exposed = password.expose();
+    ///    pbkdf2(exposed.as_bytes(), b"salt", 100_000)
+    /// }
+    /// ```
+    fn expose(&self) -> &T {
+        &self.0
+    }
+
+    /// Consume the wrapper and return the inner value. This exposes the secret to logging.
+    fn expose_owned(self) -> T {
+        self.0
+    }
+}
+
+impl<T> PartialEq for Sensitive<T>
+where
+    T: PartialEq,
+{
+    fn eq(&self, other: &Self) -> bool {
+        self.0.eq(&other.0)
+    }
+}
+
+impl<T> Clone for Sensitive<T>
+where
+    T: Clone,
+{
+    fn clone(&self) -> Self {
+        Self(self.0.clone())
+    }
+}
+
+impl<T> From<T> for Sensitive<T> {
+    fn from(value: T) -> Self {
+        Self(value)
+    }
+}
+
+impl<T: serde::Serialize> serde::Serialize for Sensitive<T> {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        self.0.serialize(serializer)
+    }
+}
+
+impl<'de, T: serde::Deserialize<'de>> serde::Deserialize<'de> for Sensitive<T> {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        Ok(Self(T::deserialize(deserializer)?))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn from_wraps_value_and_expose_returns_it() {
+        let sensitive = Sensitive::from(42u32);
+        assert_eq!(sensitive.expose(), &42);
+        assert_eq!(sensitive.expose_owned(), 42);
+    }
+
+    #[test]
+    fn from_str_creates_sensitive_string() {
+        let sensitive: Sensitive<String> = Sensitive::from("secret");
+        assert_eq!(sensitive.expose(), "secret");
+    }
+
+    #[test]
+    fn partial_eq_compares_inner_values() {
+        assert_eq!(Sensitive::from(1u32), Sensitive::from(1u32));
+        assert_ne!(Sensitive::from(1u32), Sensitive::from(2u32));
+    }
+
+    #[cfg(not(feature = "dangerous-crypto-debug"))]
+    #[test]
+    fn debug_is_redacted() {
+        let sensitive = Sensitive::from("secret".to_string());
+        assert_eq!(format!("{sensitive:?}"), "[REDACTED]");
+    }
+
+    #[cfg(not(feature = "dangerous-crypto-debug"))]
+    #[test]
+    fn display_is_redacted() {
+        let sensitive = Sensitive::from("secret".to_string());
+        assert_eq!(format!("{sensitive}"), "[REDACTED]");
+    }
+
+    #[test]
+    fn serde_json_round_trips_transparently() {
+        let sensitive = Sensitive::from("secret".to_string());
+
+        let serialized = serde_json::to_string(&sensitive).unwrap();
+        assert_eq!(serialized, "\"secret\"");
+
+        let deserialized: Sensitive<String> = serde_json::from_str(&serialized).unwrap();
+        assert_eq!(deserialized, sensitive);
+    }
+}

--- a/crates/bitwarden-sensitive-value/src/sensitive_slice.rs
+++ b/crates/bitwarden-sensitive-value/src/sensitive_slice.rs
@@ -1,0 +1,66 @@
+use crate::Sensitive;
+
+/// A zero-copy view over a borrowed slice of secret bytes. Wrapping a `&[u8]` borrows the
+/// underlying buffer instead of cloning it, so the wrapper is bound by the borrow's lifetime
+/// `'a` and cannot outlive the data it points at. `Debug`/`Display` are redacted via the inner
+/// [`Sensitive`].
+///
+/// For owned secret bytes (e.g. when deserializing, where borrowing is not possible) use
+/// `Sensitive<Vec<u8>>` instead.
+pub type SensitiveSlice<'a> = Sensitive<&'a [u8]>;
+
+impl<'a, const N: usize> From<&'a [u8; N]> for SensitiveSlice<'a> {
+    fn from(value: &'a [u8; N]) -> Self {
+        Sensitive::from(value.as_slice())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ExposeSensitive;
+
+    #[test]
+    fn from_borrows_and_expose_returns_slice() {
+        let key_material = [0x42u8; 32];
+        let secret: SensitiveSlice<'_> = Sensitive::from(key_material.as_slice());
+
+        assert_eq!(*secret.expose(), key_material.as_slice());
+        assert_eq!(secret.expose_owned(), key_material.as_slice());
+        // The owner still holds the buffer; wrapping only borrowed it.
+        assert_eq!(key_material.len(), 32);
+    }
+
+    #[test]
+    fn partial_eq_compares_borrowed_bytes() {
+        let a = [1u8, 2, 3];
+        let b = [1u8, 2, 3];
+        let c = [9u8, 9, 9];
+
+        assert_eq!(Sensitive::from(a.as_slice()), Sensitive::from(b.as_slice()));
+        assert_ne!(Sensitive::from(a.as_slice()), Sensitive::from(c.as_slice()));
+    }
+
+    #[test]
+    fn from_array_ref_borrows_without_as_slice() {
+        let key_material = [0x42u8; 13];
+        let secret: SensitiveSlice<'_> = (&key_material).into();
+        assert_eq!(secret.expose_owned(), key_material.as_slice());
+    }
+
+    #[cfg(not(feature = "dangerous-crypto-debug"))]
+    #[test]
+    fn debug_is_redacted() {
+        let secret: SensitiveSlice<'_> = Sensitive::from([0x42u8; 4].as_slice());
+        assert_eq!(format!("{secret:?}"), "[REDACTED]");
+    }
+
+    #[test]
+    fn serde_json_serializes_as_byte_array() {
+        let bytes = [1u8, 2, 3];
+        let secret: SensitiveSlice<'_> = Sensitive::from(bytes.as_slice());
+
+        let serialized = serde_json::to_string(&secret).unwrap();
+        assert_eq!(serialized, "[1,2,3]");
+    }
+}

--- a/crates/bitwarden-sensitive-value/src/sensitive_string.rs
+++ b/crates/bitwarden-sensitive-value/src/sensitive_string.rs
@@ -1,0 +1,243 @@
+use core::fmt;
+
+use crate::{Sensitive, SensitiveSlice, sensitive::ExposeSensitive};
+
+/// FFI-friendly concrete wrapper around a sensitive `String`. This is the type exposed across the
+/// UniFFI / WASM boundary; bindings see it as an opaque tagged string. `Debug` and `Display`
+/// delegate to the inner [`Sensitive`], so output is redacted unless `dangerous-crypto-debug`
+/// is enabled.
+pub struct SensitiveString(Sensitive<String>);
+
+impl From<&str> for Sensitive<String> {
+    fn from(value: &str) -> Self {
+        Self(value.to_string())
+    }
+}
+
+impl SensitiveString {
+    /// Borrow the secret as a zero-copy [`SensitiveSlice`] over its UTF-8 bytes. The returned
+    /// slice borrows from this value and stays wrapped, so the bytes are never exposed and the
+    /// borrow cannot outlive `self`.
+    pub fn as_bytes(&self) -> SensitiveSlice<'_> {
+        // EXPOSE: We borrow the inner string only to immediately re-wrap its bytes in another
+        // `Sensitive`, so the secret is never actually exposed to logging.
+        Sensitive::from(self.0.expose().as_bytes())
+    }
+}
+
+impl<T: fmt::Debug> fmt::Debug for Sensitive<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        #[cfg(feature = "dangerous-crypto-debug")]
+        {
+            self.0.fmt(f)
+        }
+        #[cfg(not(feature = "dangerous-crypto-debug"))]
+        {
+            f.write_str("[REDACTED]")
+        }
+    }
+}
+
+impl<T: fmt::Display> fmt::Display for Sensitive<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        #[cfg(feature = "dangerous-crypto-debug")]
+        {
+            self.0.fmt(f)
+        }
+        #[cfg(not(feature = "dangerous-crypto-debug"))]
+        {
+            f.write_str("[REDACTED]")
+        }
+    }
+}
+
+impl ExposeSensitive for SensitiveString {
+    type Exposed = String;
+
+    fn expose(&self) -> &Self::Exposed {
+        self.0.expose()
+    }
+
+    fn expose_owned(self) -> Self::Exposed {
+        self.0.expose_owned()
+    }
+}
+
+impl From<&str> for SensitiveString {
+    fn from(value: &str) -> Self {
+        Self(Sensitive::from(value.to_string()))
+    }
+}
+
+impl From<String> for SensitiveString {
+    fn from(value: String) -> Self {
+        Self(Sensitive::from(value))
+    }
+}
+
+impl PartialEq for SensitiveString {
+    fn eq(&self, other: &Self) -> bool {
+        self.0.eq(&other.0)
+    }
+}
+
+impl serde::Serialize for SensitiveString {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        self.0.serialize(serializer)
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for SensitiveString {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        Ok(Self(Sensitive::<String>::deserialize(deserializer)?))
+    }
+}
+
+impl fmt::Debug for SensitiveString {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+impl fmt::Display for SensitiveString {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+#[cfg(feature = "uniffi")]
+uniffi::custom_type!(SensitiveString, String, {
+    try_lift: |val| Ok(SensitiveString::from(val)),
+    lower: |obj| obj.expose().to_string(),
+});
+
+#[cfg(feature = "wasm")]
+const _: () = {
+    use wasm_bindgen::{
+        JsValue,
+        convert::{FromWasmAbi, IntoWasmAbi, OptionFromWasmAbi, OptionIntoWasmAbi},
+        describe::WasmDescribe,
+        prelude::wasm_bindgen,
+    };
+
+    #[wasm_bindgen(typescript_custom_section)]
+    const TS_CUSTOM_TYPES: &'static str = r#"
+export type SensitiveString = Tagged<string, "SensitiveString">;
+"#;
+
+    impl WasmDescribe for SensitiveString {
+        fn describe() {
+            <String as WasmDescribe>::describe();
+        }
+    }
+
+    impl FromWasmAbi for SensitiveString {
+        type Abi = <String as FromWasmAbi>::Abi;
+
+        unsafe fn from_abi(abi: Self::Abi) -> Self {
+            let string = unsafe { String::from_abi(abi) };
+            SensitiveString::from(string)
+        }
+    }
+
+    impl OptionFromWasmAbi for SensitiveString {
+        fn is_none(abi: &Self::Abi) -> bool {
+            <String as OptionFromWasmAbi>::is_none(abi)
+        }
+    }
+
+    impl IntoWasmAbi for SensitiveString {
+        type Abi = <String as IntoWasmAbi>::Abi;
+
+        fn into_abi(self) -> Self::Abi {
+            self.expose_owned().into_abi()
+        }
+    }
+
+    impl OptionIntoWasmAbi for SensitiveString {
+        fn none() -> Self::Abi {
+            <String as OptionIntoWasmAbi>::none()
+        }
+    }
+
+    impl From<SensitiveString> for JsValue {
+        fn from(value: SensitiveString) -> Self {
+            JsValue::from(value.expose_owned())
+        }
+    }
+
+    impl TryFrom<JsValue> for SensitiveString {
+        type Error = &'static str;
+
+        fn try_from(value: JsValue) -> Result<Self, Self::Error> {
+            value
+                .as_string()
+                .map(SensitiveString::from)
+                .ok_or("SensitiveString JsValue is not a string")
+        }
+    }
+};
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn from_str_and_from_string_are_equivalent() {
+        assert_eq!(
+            SensitiveString::from("secret"),
+            SensitiveString::from("secret".to_string())
+        );
+    }
+
+    #[test]
+    fn partial_eq_compares_inner_values() {
+        assert_eq!(
+            SensitiveString::from("secret"),
+            SensitiveString::from("secret")
+        );
+        assert_ne!(
+            SensitiveString::from("secret"),
+            SensitiveString::from("other")
+        );
+    }
+
+    #[test]
+    fn expose_returns_inner_string() {
+        let sensitive = SensitiveString::from("secret");
+        assert_eq!(sensitive.expose(), "secret");
+        assert_eq!(sensitive.expose_owned(), "secret");
+    }
+
+    #[test]
+    fn as_bytes_borrows_utf8_bytes() {
+        let sensitive = SensitiveString::from("secret");
+        let bytes = sensitive.as_bytes();
+        assert_eq!(bytes.expose_owned(), b"secret");
+    }
+
+    #[cfg(not(feature = "dangerous-crypto-debug"))]
+    #[test]
+    fn debug_is_redacted() {
+        let sensitive = SensitiveString::from("secret");
+        assert_eq!(format!("{sensitive:?}"), "[REDACTED]");
+    }
+
+    #[cfg(not(feature = "dangerous-crypto-debug"))]
+    #[test]
+    fn display_is_redacted() {
+        let sensitive = SensitiveString::from("secret");
+        assert_eq!(format!("{sensitive}"), "[REDACTED]");
+    }
+
+    #[test]
+    fn serde_json_round_trips_transparently() {
+        let sensitive = SensitiveString::from("secret");
+
+        let serialized = serde_json::to_string(&sensitive).unwrap();
+        assert_eq!(serialized, "\"secret\"");
+
+        let deserialized: SensitiveString = serde_json::from_str(&serialized).unwrap();
+        assert_eq!(deserialized, sensitive);
+    }
+}

--- a/crates/bitwarden-sensitive-value/src/types.rs
+++ b/crates/bitwarden-sensitive-value/src/types.rs
@@ -1,0 +1,20 @@
+use crate::SensitiveString;
+
+// A list of secret value type aliases
+/// A master password. Wrapped to prevent accidental logging.
+pub type MasterPassword = SensitiveString;
+/// A PIN. Wrapped to prevent accidental logging.
+pub type Pin = SensitiveString;
+
+// Tsify/wasm-bindgen emit the type alias name verbatim when these are used as fields, so we must
+// declare matching TypeScript types. They are structurally identical to `SensitiveString`.
+#[cfg(feature = "wasm")]
+const _: () = {
+    use wasm_bindgen::prelude::wasm_bindgen;
+
+    #[wasm_bindgen(typescript_custom_section)]
+    const TS_CUSTOM_TYPES: &'static str = r#"
+export type MasterPassword = SensitiveString;
+export type Pin = SensitiveString;
+"#;
+};


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-38310

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
Introduce a new crate - `bitwarden-sensitive-value` which adds a generic type, Sensitive, along with a concrete type. These can be passed along the FFI layer.

This prevents developers form accidentally logging secrets. To prevent secret logging, you can wrap your type with the `Sensitive` wrapper. Exposing secrets out of the sensitive wrapper must be done explicitly, making it clear when a secret is exposed.

Follow-up PR's will propagate these changes throughout all features, which use passwords or pins.

## 🚨 Breaking Changes

<!-- Does this PR introduce any breaking changes? If so, please describe the impact and migration path for clients.

If you're unsure, the automated TypeScript compatibility check will run when you open/update this PR and provide feedback.

For breaking changes:
1. Describe what changed in the client interface
2. Explain why the change was necessary
3. Provide migration steps for client developers
4. Link to any paired client PRs if needed

Otherwise, you can remove this section. -->
