### PR TITLE
Add support for AccountCryptographicState on auth response

### DIFF
--- a/crates/bitwarden-auth/src/login/api/response/login_error_api_response.rs
+++ b/crates/bitwarden-auth/src/login/api/response/login_error_api_response.rs
@@ -1,4 +1,3 @@
-use bitwarden_core::key_management::MasterPasswordError;
 use serde::Deserialize;
 
 #[derive(Deserialize, PartialEq, Eq, Debug)]
@@ -126,20 +125,8 @@ pub enum LoginErrorApiResponse {
 }
 
 // This is just a utility function so that the ? operator works correctly without manual mapping
-impl From<reqwest::Error> for LoginErrorApiResponse {
-    fn from(value: reqwest::Error) -> Self {
-        Self::UnexpectedError(format!("{value:?}"))
-    }
-}
-
-impl From<reqwest_middleware::Error> for LoginErrorApiResponse {
-    fn from(value: reqwest_middleware::Error) -> Self {
-        Self::UnexpectedError(format!("{value:?}"))
-    }
-}
-
-impl From<MasterPasswordError> for LoginErrorApiResponse {
-    fn from(value: MasterPasswordError) -> Self {
+impl<T: std::error::Error> From<T> for LoginErrorApiResponse {
+    fn from(value: T) -> Self {
         Self::UnexpectedError(format!("{value:?}"))
     }
 }

--- a/crates/bitwarden-auth/src/login/api/response/login_success_api_response.rs
+++ b/crates/bitwarden-auth/src/login/api/response/login_success_api_response.rs
@@ -30,10 +30,7 @@ pub(crate) struct LoginSuccessApiResponse {
     // we add aliases for deserialization flexibility.
     /// The user key wrapped user private key
     /// Deprecated in favor of the `AccountKeys` field but still present for backward
-    /// compatibility. and we can't expose AccountKeys in our LoginSuccessResponse until we get
-    /// a PrivateKeysResponseModel SDK response model from KM with WASM / uniffi support.
-    /// TODO: PM-30222 - clean up the comment about not being able to expose AccountKeys once
-    /// we have a trait to convert PrivateKeysResponseModel to WrappedAccountCryptographicState
+    /// compatibility.
     #[serde(rename = "PrivateKey", alias = "privateKey")]
     pub private_key: Option<String>,
 

--- a/crates/bitwarden-auth/src/login/login_via_password/login_via_password_impl.rs
+++ b/crates/bitwarden-auth/src/login/login_via_password/login_via_password_impl.rs
@@ -38,7 +38,10 @@ impl LoginClient {
 
 #[cfg(test)]
 mod tests {
-    use bitwarden_core::{ClientSettings, DeviceType};
+    use bitwarden_core::{
+        ClientSettings, DeviceType,
+        key_management::account_cryptographic_state::WrappedAccountCryptographicState,
+    };
     use bitwarden_crypto::Kdf;
     use bitwarden_test::start_api_mock;
     use wiremock::{Mock, ResponseTemplate, matchers};
@@ -204,6 +207,17 @@ mod tests {
 
                 // Verify master password policy is present
                 assert!(success_response.master_password_policy.is_some());
+
+                // TEST_PRIVATE_KEY is an AesCbc256_HmacSha256_B64 EncString, so the conversion
+                // produces the V1 variant rather than V2.
+                match &success_response.wrapped_account_crypto_state {
+                    Some(WrappedAccountCryptographicState::V1 { private_key }) => {
+                        assert_eq!(private_key.to_string(), TEST_PRIVATE_KEY);
+                    }
+                    other => panic!(
+                        "Expected Some(WrappedAccountCryptographicState::V1), got: {other:?}"
+                    ),
+                }
             }
         }
     }
@@ -229,6 +243,65 @@ mod tests {
             assert!(result.is_ok(), "Failed for KDF type: {kdf_type:?}");
             let login_response = result.unwrap();
             assert_login_success_response(&login_response);
+        }
+    }
+
+    #[tokio::test]
+    async fn test_login_via_password_success_without_account_keys() {
+        let mut raw_success = make_mock_success_response();
+        raw_success
+            .as_object_mut()
+            .expect("mock response is a JSON object")
+            .remove("AccountKeys");
+
+        let mock = add_standard_login_headers(
+            Mock::given(matchers::method("POST")).and(matchers::path("identity/connect/token")),
+        )
+        .respond_with(ResponseTemplate::new(200).set_body_json(raw_success));
+
+        let (mock_server, _api_config) = start_api_mock(vec![mock]).await;
+        let login_client = make_login_client(&mock_server);
+
+        let request = make_password_login_request(TestKdfType::Pbkdf2);
+        let result = login_client.login_via_password(request).await;
+
+        assert!(result.is_ok());
+        let LoginResponse::Authenticated(success_response) = result.unwrap();
+        assert!(success_response.wrapped_account_crypto_state.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_login_via_password_malformed_account_keys() {
+        let mut raw_success = make_mock_success_response();
+        raw_success["AccountKeys"] = serde_json::json!({
+            "publicKeyEncryptionKeyPair": {
+                "wrappedPrivateKey": "not-a-valid-encstring",
+                "publicKey": TEST_PUBLIC_KEY,
+                "Object": "publicKeyEncryptionKeyPair"
+            },
+            "Object": "privateKeys"
+        });
+
+        let mock = add_standard_login_headers(
+            Mock::given(matchers::method("POST")).and(matchers::path("identity/connect/token")),
+        )
+        .respond_with(ResponseTemplate::new(200).set_body_json(raw_success));
+
+        let (mock_server, _api_config) = start_api_mock(vec![mock]).await;
+        let login_client = make_login_client(&mock_server);
+
+        let request = make_password_login_request(TestKdfType::Pbkdf2);
+        let result = login_client.login_via_password(request).await;
+
+        assert!(result.is_err());
+        match result.unwrap_err() {
+            PasswordLoginError::Unknown(msg) => {
+                assert!(
+                    msg.contains("AccountKeys"),
+                    "Expected error message to reference AccountKeys, got: {msg}"
+                );
+            }
+            other => panic!("Expected Unknown error, got: {other:?}"),
         }
     }
 

--- a/crates/bitwarden-auth/src/login/models/login_success_response.rs
+++ b/crates/bitwarden-auth/src/login/models/login_success_response.rs
@@ -1,7 +1,17 @@
 use std::fmt::Debug;
 
-use bitwarden_core::{key_management::MasterPasswordError, require};
+use bitwarden_core::{
+    MissingFieldError,
+    key_management::{
+        MasterPasswordError,
+        account_cryptographic_state::{
+            AccountKeysResponseParseError, WrappedAccountCryptographicState,
+        },
+    },
+    require,
+};
 use bitwarden_policies::MasterPasswordPolicyResponse;
+use thiserror::Error;
 
 use crate::login::{api::response::LoginSuccessApiResponse, models::UserDecryptionOptionsResponse};
 
@@ -62,14 +72,13 @@ pub struct LoginSuccessResponse {
     /// If the user is subject to an organization master password policy,
     /// this field contains the requirements of that policy.
     pub master_password_policy: Option<MasterPasswordPolicyResponse>,
-    // TODO: PM-30222 we can expose this once we have a trait to convert PrivateKeysResponseModel
-    // to WrappedAccountCryptographicState
-    // The user's account cryptographic keys (wrapped with the user key).
-    // pub wrapped_account_crypto_state: Option<WrappedAccountCryptographicState>,
+
+    /// The user's account cryptographic keys (wrapped with the user key).
+    pub wrapped_account_crypto_state: Option<WrappedAccountCryptographicState>,
 }
 
 impl TryFrom<LoginSuccessApiResponse> for LoginSuccessResponse {
-    type Error = MasterPasswordError;
+    type Error = LoginResponseError;
     fn try_from(response: LoginSuccessApiResponse) -> Result<Self, Self::Error> {
         // We want to convert the expires_in from seconds to a millisecond timestamp to have a
         // concrete time the token will expire. This makes it easier to build logic around a
@@ -92,9 +101,29 @@ impl TryFrom<LoginSuccessApiResponse> for LoginSuccessResponse {
             // User decryption options are required on successful login responses
             user_decryption_options: require!(response.user_decryption_options).try_into()?,
             master_password_policy: response.master_password_policy.map(|policy| policy.into()),
-            // TODO: PM-30222 - we can expose this once we have a trait to convert
-            // PrivateKeysResponseModel to WrappedAccountCryptographicState
-            // wrapped_account_crypto_state: response.account_keys.map(|keys| keys.into()),
+            wrapped_account_crypto_state: response
+                .account_keys
+                .as_ref()
+                .map(TryInto::try_into)
+                .transpose()?,
         })
+    }
+}
+
+/// Error that can occur during login and response parsing.
+#[derive(Debug, Error)]
+pub enum LoginResponseError {
+    /// Error from master password related operations.
+    #[error(transparent)]
+    MasterPassword(#[from] MasterPasswordError),
+
+    /// Error parsing account cryptographic state from API response.
+    #[error("Failed to parse account keys: {0}")]
+    AccountKeys(#[from] AccountKeysResponseParseError),
+}
+
+impl From<MissingFieldError> for LoginResponseError {
+    fn from(value: MissingFieldError) -> Self {
+        LoginResponseError::MasterPassword(value.into())
     }
 }


### PR DESCRIPTION
## 📔 Objective

Expose `wrapped_account_crypto_state: Option<WrappedAccountCryptographicState>` on `LoginSuccessResponse`, now that https://bitwarden.atlassian.net/browse/PM-30222 is complete.

Supporting changes:
- New `LoginResponseError` enum composing `MasterPasswordError` and `AccountKeysResponseParseError`, used as the `TryFrom<LoginSuccessApiResponse>::Error`. We could have probably used `LoginErrorApiResponse` directly here, but I decided to keep the API specific error and the model parsing error separate. 
- `LoginErrorApiResponse` collapses its three explicit `From` impls (`reqwest::Error`, `reqwest_middleware::Error`, `MasterPasswordError`) into a single blanket `impl<T: std::error::Error>` to also support the new `LoginResponseError`.
