### PR TITLE
Kotlin/Swift local date

### DIFF
--- a/crates/bitwarden-core/src/uniffi_support.rs
+++ b/crates/bitwarden-core/src/uniffi_support.rs
@@ -21,6 +21,13 @@ uniffi::custom_type!(Uuid, String, {
     lower: |obj| obj.to_string(),
 });
 
+type NaiveDate = chrono::NaiveDate;
+uniffi::custom_type!(NaiveDate, String, {
+    remote,
+    try_lift: |val| convert_result(NaiveDate::from_str(&val)),
+    lower: |obj| obj.to_string(),
+});
+
 // Uniffi doesn't emit unused types, this is a dummy record to ensure that the custom type
 // converters are emitted
 #[allow(dead_code)]
@@ -28,6 +35,7 @@ uniffi::custom_type!(Uuid, String, {
 struct UniffiConverterDummyRecord {
     uuid: Uuid,
     date: DateTime,
+    naive_date: NaiveDate,
 }
 
 uniffi::custom_type!(SignedSecurityState, String, {

--- a/crates/bitwarden-core/uniffi.toml
+++ b/crates/bitwarden-core/uniffi.toml
@@ -5,6 +5,12 @@ android = true
 # Temporary workaround for https://github.com/mozilla/uniffi-rs/issues/2740
 omit_checksums = true
 
+[bindings.kotlin.custom_types.NaiveDate]
+type_name = "LocalDate"
+imports = ["java.time.LocalDate"]
+into_custom = "LocalDate.parse({})"
+from_custom = "{}.toString()"
+
 [bindings.swift]
 ffi_module_name = "BitwardenCoreFFI"
 module_name = "BitwardenCore"

--- a/crates/bitwarden-core/uniffi.toml
+++ b/crates/bitwarden-core/uniffi.toml
@@ -16,3 +16,9 @@ ffi_module_name = "BitwardenCoreFFI"
 module_name = "BitwardenCore"
 generate_immutable_records = true
 generate_codable_conformance = true
+
+[bindings.swift.custom_types.NaiveDate]
+type_name = "Date"
+imports = ["Foundation", "BitwardenSdkSupport"]
+into_custom = "try NaiveDateFormatter.date(from: {})"
+from_custom = "NaiveDateFormatter.string(from: {})"

--- a/crates/bitwarden-uniffi/src/uniffi_support.rs
+++ b/crates/bitwarden-uniffi/src/uniffi_support.rs
@@ -5,6 +5,9 @@ use uuid::Uuid;
 type DateTime = chrono::DateTime<chrono::Utc>;
 uniffi::use_remote_type!(bitwarden_core::DateTime);
 
+type NaiveDate = chrono::NaiveDate;
+uniffi::use_remote_type!(bitwarden_core::NaiveDate);
+
 uniffi::use_remote_type!(bitwarden_core::Uuid);
 
 uniffi::use_remote_type!(bitwarden_crypto::safe::PasswordProtectedKeyEnvelope);

--- a/crates/bitwarden-uniffi/swift/Package.swift
+++ b/crates/bitwarden-uniffi/swift/Package.swift
@@ -23,8 +23,9 @@ let package = Package(
         // Targets can depend on other targets in this package, and on products in packages this package depends on.
         .target(
             name: "BitwardenSdk",
-            dependencies: ["BitwardenFFI"],
+            dependencies: ["BitwardenFFI", "BitwardenSdkSupport"],
             swiftSettings: [.unsafeFlags(["-suppress-warnings"])]),
+        .target(name: "BitwardenSdkSupport"),
         .testTarget(
             name: "BitwardenSdkTests",
             dependencies: ["BitwardenSdk"]),

--- a/crates/bitwarden-uniffi/swift/Sources/BitwardenSdkSupport/NaiveDateFormatter.swift
+++ b/crates/bitwarden-uniffi/swift/Sources/BitwardenSdkSupport/NaiveDateFormatter.swift
@@ -1,0 +1,28 @@
+// Hand-written support code for the generated bindings in `BitwardenSdk`. Referenced from the
+// `NaiveDate` custom type conversion configured in `bitwarden-core/uniffi.toml`.
+
+import Foundation
+
+public struct InvalidNaiveDateError: Error {}
+
+public enum NaiveDateFormatter {
+    private static let formatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = TimeZone(identifier: "UTC")
+        formatter.dateFormat = "yyyy-MM-dd"
+        formatter.isLenient = false
+        return formatter
+    }()
+
+    public static func date(from string: String) throws -> Date {
+        guard let date = formatter.date(from: string) else {
+            throw InvalidNaiveDateError()
+        }
+        return date
+    }
+
+    public static func string(from date: Date) -> String {
+        formatter.string(from: date)
+    }
+}

--- a/crates/bitwarden-vault/src/cipher/blob/conversions/drivers_license.rs
+++ b/crates/bitwarden-vault/src/cipher/blob/conversions/drivers_license.rs
@@ -1,22 +1,40 @@
 use super::{DriversLicenseDataV1, DriversLicenseView};
 
-impl_bidirectional_from!(
-    DriversLicenseView,
-    DriversLicenseDataV1,
-    [
-        first_name,
-        middle_name,
-        last_name,
-        date_of_birth,
-        license_number,
-        issuing_country,
-        issuing_state,
-        issue_date,
-        expiration_date,
-        issuing_authority,
-        license_class,
-    ]
-);
+impl From<&DriversLicenseView> for DriversLicenseDataV1 {
+    fn from(src: &DriversLicenseView) -> Self {
+        Self {
+            first_name: src.first_name.clone(),
+            middle_name: src.middle_name.clone(),
+            last_name: src.last_name.clone(),
+            date_of_birth: src.date_of_birth.map(|d| d.to_string()),
+            license_number: src.license_number.clone(),
+            issuing_country: src.issuing_country.clone(),
+            issuing_state: src.issuing_state.clone(),
+            issue_date: src.issue_date.map(|d| d.to_string()),
+            expiration_date: src.expiration_date.map(|d| d.to_string()),
+            issuing_authority: src.issuing_authority.clone(),
+            license_class: src.license_class.clone(),
+        }
+    }
+}
+
+impl From<&DriversLicenseDataV1> for DriversLicenseView {
+    fn from(src: &DriversLicenseDataV1) -> Self {
+        Self {
+            first_name: src.first_name.clone(),
+            middle_name: src.middle_name.clone(),
+            last_name: src.last_name.clone(),
+            date_of_birth: src.date_of_birth.as_deref().and_then(|s| s.parse().ok()),
+            license_number: src.license_number.clone(),
+            issuing_country: src.issuing_country.clone(),
+            issuing_state: src.issuing_state.clone(),
+            issue_date: src.issue_date.as_deref().and_then(|s| s.parse().ok()),
+            expiration_date: src.expiration_date.as_deref().and_then(|s| s.parse().ok()),
+            issuing_authority: src.issuing_authority.clone(),
+            license_class: src.license_class.clone(),
+        }
+    }
+}
 
 #[cfg(test)]
 mod tests {
@@ -36,12 +54,12 @@ mod tests {
                 first_name: Some("John".to_string()),
                 middle_name: Some("Michael".to_string()),
                 last_name: Some("Doe".to_string()),
-                date_of_birth: Some("1985-06-15".to_string()),
+                date_of_birth: chrono::NaiveDate::from_ymd_opt(1985, 6, 15),
                 license_number: Some("DL-987654".to_string()),
                 issuing_country: Some("US".to_string()),
                 issuing_state: Some("NY".to_string()),
-                issue_date: Some("2020-01-01".to_string()),
-                expiration_date: Some("2028-01-01".to_string()),
+                issue_date: chrono::NaiveDate::from_ymd_opt(2020, 1, 1),
+                expiration_date: chrono::NaiveDate::from_ymd_opt(2028, 1, 1),
                 issuing_authority: Some("NY DMV".to_string()),
                 license_class: Some("D".to_string()),
             }),

--- a/crates/bitwarden-vault/src/cipher/blob/conversions/passport.rs
+++ b/crates/bitwarden-vault/src/cipher/blob/conversions/passport.rs
@@ -1,24 +1,44 @@
 use super::{PassportDataV1, PassportView};
 
-impl_bidirectional_from!(
-    PassportView,
-    PassportDataV1,
-    [
-        surname,
-        given_name,
-        date_of_birth,
-        sex,
-        birth_place,
-        nationality,
-        issuing_country,
-        passport_number,
-        passport_type,
-        national_identification_number,
-        issuing_authority,
-        issue_date,
-        expiration_date,
-    ]
-);
+impl From<&PassportView> for PassportDataV1 {
+    fn from(src: &PassportView) -> Self {
+        Self {
+            surname: src.surname.clone(),
+            given_name: src.given_name.clone(),
+            date_of_birth: src.date_of_birth.map(|d| d.to_string()),
+            sex: src.sex.clone(),
+            birth_place: src.birth_place.clone(),
+            nationality: src.nationality.clone(),
+            issuing_country: src.issuing_country.clone(),
+            passport_number: src.passport_number.clone(),
+            passport_type: src.passport_type.clone(),
+            national_identification_number: src.national_identification_number.clone(),
+            issuing_authority: src.issuing_authority.clone(),
+            issue_date: src.issue_date.map(|d| d.to_string()),
+            expiration_date: src.expiration_date.map(|d| d.to_string()),
+        }
+    }
+}
+
+impl From<&PassportDataV1> for PassportView {
+    fn from(src: &PassportDataV1) -> Self {
+        Self {
+            surname: src.surname.clone(),
+            given_name: src.given_name.clone(),
+            date_of_birth: src.date_of_birth.as_deref().and_then(|s| s.parse().ok()),
+            sex: src.sex.clone(),
+            birth_place: src.birth_place.clone(),
+            nationality: src.nationality.clone(),
+            issuing_country: src.issuing_country.clone(),
+            passport_number: src.passport_number.clone(),
+            passport_type: src.passport_type.clone(),
+            national_identification_number: src.national_identification_number.clone(),
+            issuing_authority: src.issuing_authority.clone(),
+            issue_date: src.issue_date.as_deref().and_then(|s| s.parse().ok()),
+            expiration_date: src.expiration_date.as_deref().and_then(|s| s.parse().ok()),
+        }
+    }
+}
 
 #[cfg(test)]
 mod tests {
@@ -37,7 +57,7 @@ mod tests {
             passport: Some(PassportView {
                 surname: Some("Doe".to_string()),
                 given_name: Some("Jane".to_string()),
-                date_of_birth: Some("1990-01-01".to_string()),
+                date_of_birth: chrono::NaiveDate::from_ymd_opt(1990, 1, 1),
                 sex: Some("F".to_string()),
                 birth_place: Some("New York".to_string()),
                 nationality: Some("American".to_string()),
@@ -46,8 +66,8 @@ mod tests {
                 passport_type: Some("P".to_string()),
                 national_identification_number: Some("123-45-6789".to_string()),
                 issuing_authority: Some("US State Department".to_string()),
-                issue_date: Some("2020-01-01".to_string()),
-                expiration_date: Some("2030-01-01".to_string()),
+                issue_date: chrono::NaiveDate::from_ymd_opt(2020, 1, 1),
+                expiration_date: chrono::NaiveDate::from_ymd_opt(2030, 1, 1),
             }),
             ..create_shell_cipher_view(CipherType::Passport)
         };

--- a/crates/bitwarden-vault/src/cipher/cipher.rs
+++ b/crates/bitwarden-vault/src/cipher/cipher.rs
@@ -3488,7 +3488,7 @@ mod tests {
         let passport = passport::PassportView {
             given_name: Some("Jane".to_string()),
             surname: Some("Doe".to_string()),
-            date_of_birth: Some("1990-01-01".to_string()),
+            date_of_birth: chrono::NaiveDate::from_ymd_opt(1990, 1, 1),
             sex: Some("F".to_string()),
             birth_place: Some("New York".to_string()),
             nationality: Some("American".to_string()),
@@ -3497,8 +3497,8 @@ mod tests {
             passport_type: Some("P".to_string()),
             national_identification_number: Some("123-45-6789".to_string()),
             issuing_authority: Some("US State Department".to_string()),
-            issue_date: Some("2020-01-01".to_string()),
-            expiration_date: Some("2030-01-01".to_string()),
+            issue_date: chrono::NaiveDate::from_ymd_opt(2020, 1, 1),
+            expiration_date: chrono::NaiveDate::from_ymd_opt(2030, 1, 1),
         };
 
         let cipher_view = CipherView {
@@ -3526,12 +3526,12 @@ mod tests {
             first_name: Some("John".to_string()),
             middle_name: Some("Michael".to_string()),
             last_name: Some("Doe".to_string()),
-            date_of_birth: Some("1985-06-15".to_string()),
+            date_of_birth: chrono::NaiveDate::from_ymd_opt(1985, 6, 15),
             license_number: Some("DL-987654".to_string()),
             issuing_country: Some("US".to_string()),
             issuing_state: Some("NY".to_string()),
-            issue_date: Some("2020-01-01".to_string()),
-            expiration_date: Some("2028-01-01".to_string()),
+            issue_date: chrono::NaiveDate::from_ymd_opt(2020, 1, 1),
+            expiration_date: chrono::NaiveDate::from_ymd_opt(2028, 1, 1),
             issuing_authority: Some("NY DMV".to_string()),
             license_class: Some("D".to_string()),
         };
@@ -3958,12 +3958,12 @@ mod tests {
                             first_name: Some("Jane".to_string()),
                             middle_name: Some("Q".to_string()),
                             last_name: Some("Doe".to_string()),
-                            date_of_birth: Some("1990-01-01".to_string()),
+                            date_of_birth: chrono::NaiveDate::from_ymd_opt(1990, 1, 1),
                             license_number: Some("D1234567".to_string()),
                             issuing_country: Some("US".to_string()),
                             issuing_state: Some("CA".to_string()),
-                            issue_date: Some("2020-01-01".to_string()),
-                            expiration_date: Some("2030-01-01".to_string()),
+                            issue_date: chrono::NaiveDate::from_ymd_opt(2020, 1, 1),
+                            expiration_date: chrono::NaiveDate::from_ymd_opt(2030, 1, 1),
                             issuing_authority: Some("DMV".to_string()),
                             license_class: Some("C".to_string()),
                         });
@@ -3975,7 +3975,7 @@ mod tests {
                         v.passport = Some(PassportView {
                             surname: Some("Doe".to_string()),
                             given_name: Some("Jane".to_string()),
-                            date_of_birth: Some("1990-01-01".to_string()),
+                            date_of_birth: chrono::NaiveDate::from_ymd_opt(1990, 1, 1),
                             sex: Some("F".to_string()),
                             birth_place: Some("Anytown".to_string()),
                             nationality: Some("US".to_string()),
@@ -3984,8 +3984,8 @@ mod tests {
                             passport_type: Some("P".to_string()),
                             national_identification_number: Some("000-00-0000".to_string()),
                             issuing_authority: Some("State Dept".to_string()),
-                            issue_date: Some("2020-01-01".to_string()),
-                            expiration_date: Some("2030-01-01".to_string()),
+                            issue_date: chrono::NaiveDate::from_ymd_opt(2020, 1, 1),
+                            expiration_date: chrono::NaiveDate::from_ymd_opt(2030, 1, 1),
                         });
                     }),
                 ),

--- a/crates/bitwarden-vault/src/cipher/drivers_license.rs
+++ b/crates/bitwarden-vault/src/cipher/drivers_license.rs
@@ -4,6 +4,7 @@ use bitwarden_crypto::{
     CompositeEncryptable, CryptoError, Decryptable, EncString, KeyStoreContext,
     PrimitiveEncryptable,
 };
+use chrono::NaiveDate;
 use serde::{Deserialize, Serialize};
 #[cfg(feature = "wasm")]
 use tsify::Tsify;
@@ -38,12 +39,12 @@ pub struct DriversLicenseView {
     pub first_name: Option<String>,
     pub middle_name: Option<String>,
     pub last_name: Option<String>,
-    pub date_of_birth: Option<String>,
+    pub date_of_birth: Option<NaiveDate>,
     pub license_number: Option<String>,
     pub issuing_country: Option<String>,
     pub issuing_state: Option<String>,
-    pub issue_date: Option<String>,
-    pub expiration_date: Option<String>,
+    pub issue_date: Option<NaiveDate>,
+    pub expiration_date: Option<NaiveDate>,
     pub issuing_authority: Option<String>,
     pub license_class: Option<String>,
 }
@@ -58,12 +59,18 @@ impl CompositeEncryptable<KeySlotIds, SymmetricKeySlotId, DriversLicense> for Dr
             first_name: self.first_name.encrypt(ctx, key)?,
             middle_name: self.middle_name.encrypt(ctx, key)?,
             last_name: self.last_name.encrypt(ctx, key)?,
-            date_of_birth: self.date_of_birth.encrypt(ctx, key)?,
+            date_of_birth: self
+                .date_of_birth
+                .map(|d| d.to_string())
+                .encrypt(ctx, key)?,
             license_number: self.license_number.encrypt(ctx, key)?,
             issuing_country: self.issuing_country.encrypt(ctx, key)?,
             issuing_state: self.issuing_state.encrypt(ctx, key)?,
-            issue_date: self.issue_date.encrypt(ctx, key)?,
-            expiration_date: self.expiration_date.encrypt(ctx, key)?,
+            issue_date: self.issue_date.map(|d| d.to_string()).encrypt(ctx, key)?,
+            expiration_date: self
+                .expiration_date
+                .map(|d| d.to_string())
+                .encrypt(ctx, key)?,
             issuing_authority: self.issuing_authority.encrypt(ctx, key)?,
             license_class: self.license_class.encrypt(ctx, key)?,
         })
@@ -80,12 +87,27 @@ impl Decryptable<KeySlotIds, SymmetricKeySlotId, DriversLicenseView> for Drivers
             first_name: self.first_name.decrypt(ctx, key).ok().flatten(),
             middle_name: self.middle_name.decrypt(ctx, key).ok().flatten(),
             last_name: self.last_name.decrypt(ctx, key).ok().flatten(),
-            date_of_birth: self.date_of_birth.decrypt(ctx, key).ok().flatten(),
+            date_of_birth: self
+                .date_of_birth
+                .decrypt(ctx, key)
+                .ok()
+                .flatten()
+                .and_then(|s: String| s.parse().ok()),
             license_number: self.license_number.decrypt(ctx, key).ok().flatten(),
             issuing_country: self.issuing_country.decrypt(ctx, key).ok().flatten(),
             issuing_state: self.issuing_state.decrypt(ctx, key).ok().flatten(),
-            issue_date: self.issue_date.decrypt(ctx, key).ok().flatten(),
-            expiration_date: self.expiration_date.decrypt(ctx, key).ok().flatten(),
+            issue_date: self
+                .issue_date
+                .decrypt(ctx, key)
+                .ok()
+                .flatten()
+                .and_then(|s: String| s.parse().ok()),
+            expiration_date: self
+                .expiration_date
+                .decrypt(ctx, key)
+                .ok()
+                .flatten()
+                .and_then(|s: String| s.parse().ok()),
             issuing_authority: self.issuing_authority.decrypt(ctx, key).ok().flatten(),
             license_class: self.license_class.decrypt(ctx, key).ok().flatten(),
         })
@@ -200,12 +222,12 @@ mod tests {
             first_name: Some("John".to_string()),
             middle_name: Some("Michael".to_string()),
             last_name: Some("Doe".to_string()),
-            date_of_birth: Some("1985-06-15".to_string()),
+            date_of_birth: NaiveDate::from_ymd_opt(1985, 6, 15),
             license_number: Some("DL-987654".to_string()),
             issuing_country: Some("US".to_string()),
             issuing_state: Some("NY".to_string()),
-            issue_date: Some("2020-01-01".to_string()),
-            expiration_date: Some("2028-01-01".to_string()),
+            issue_date: NaiveDate::from_ymd_opt(2020, 1, 1),
+            expiration_date: NaiveDate::from_ymd_opt(2028, 1, 1),
             issuing_authority: Some("NY DMV".to_string()),
             license_class: Some("D".to_string()),
         }

--- a/crates/bitwarden-vault/src/cipher/passport.rs
+++ b/crates/bitwarden-vault/src/cipher/passport.rs
@@ -4,6 +4,7 @@ use bitwarden_crypto::{
     CompositeEncryptable, CryptoError, Decryptable, EncString, KeyStoreContext,
     PrimitiveEncryptable,
 };
+use chrono::NaiveDate;
 use serde::{Deserialize, Serialize};
 #[cfg(feature = "wasm")]
 use tsify::Tsify;
@@ -39,7 +40,7 @@ pub struct Passport {
 pub struct PassportView {
     pub surname: Option<String>,
     pub given_name: Option<String>,
-    pub date_of_birth: Option<String>,
+    pub date_of_birth: Option<NaiveDate>,
     pub sex: Option<String>,
     pub birth_place: Option<String>,
     pub nationality: Option<String>,
@@ -48,8 +49,8 @@ pub struct PassportView {
     pub passport_type: Option<String>,
     pub national_identification_number: Option<String>,
     pub issuing_authority: Option<String>,
-    pub issue_date: Option<String>,
-    pub expiration_date: Option<String>,
+    pub issue_date: Option<NaiveDate>,
+    pub expiration_date: Option<NaiveDate>,
 }
 
 impl CompositeEncryptable<KeySlotIds, SymmetricKeySlotId, Passport> for PassportView {
@@ -61,7 +62,10 @@ impl CompositeEncryptable<KeySlotIds, SymmetricKeySlotId, Passport> for Passport
         Ok(Passport {
             surname: self.surname.encrypt(ctx, key)?,
             given_name: self.given_name.encrypt(ctx, key)?,
-            date_of_birth: self.date_of_birth.encrypt(ctx, key)?,
+            date_of_birth: self
+                .date_of_birth
+                .map(|d| d.to_string())
+                .encrypt(ctx, key)?,
             sex: self.sex.encrypt(ctx, key)?,
             birth_place: self.birth_place.encrypt(ctx, key)?,
             nationality: self.nationality.encrypt(ctx, key)?,
@@ -72,8 +76,11 @@ impl CompositeEncryptable<KeySlotIds, SymmetricKeySlotId, Passport> for Passport
                 .national_identification_number
                 .encrypt(ctx, key)?,
             issuing_authority: self.issuing_authority.encrypt(ctx, key)?,
-            issue_date: self.issue_date.encrypt(ctx, key)?,
-            expiration_date: self.expiration_date.encrypt(ctx, key)?,
+            issue_date: self.issue_date.map(|d| d.to_string()).encrypt(ctx, key)?,
+            expiration_date: self
+                .expiration_date
+                .map(|d| d.to_string())
+                .encrypt(ctx, key)?,
         })
     }
 }
@@ -87,7 +94,12 @@ impl Decryptable<KeySlotIds, SymmetricKeySlotId, PassportView> for Passport {
         Ok(PassportView {
             surname: self.surname.decrypt(ctx, key).ok().flatten(),
             given_name: self.given_name.decrypt(ctx, key).ok().flatten(),
-            date_of_birth: self.date_of_birth.decrypt(ctx, key).ok().flatten(),
+            date_of_birth: self
+                .date_of_birth
+                .decrypt(ctx, key)
+                .ok()
+                .flatten()
+                .and_then(|s: String| s.parse().ok()),
             sex: self.sex.decrypt(ctx, key).ok().flatten(),
             birth_place: self.birth_place.decrypt(ctx, key).ok().flatten(),
             nationality: self.nationality.decrypt(ctx, key).ok().flatten(),
@@ -100,8 +112,18 @@ impl Decryptable<KeySlotIds, SymmetricKeySlotId, PassportView> for Passport {
                 .ok()
                 .flatten(),
             issuing_authority: self.issuing_authority.decrypt(ctx, key).ok().flatten(),
-            issue_date: self.issue_date.decrypt(ctx, key).ok().flatten(),
-            expiration_date: self.expiration_date.decrypt(ctx, key).ok().flatten(),
+            issue_date: self
+                .issue_date
+                .decrypt(ctx, key)
+                .ok()
+                .flatten()
+                .and_then(|s: String| s.parse().ok()),
+            expiration_date: self
+                .expiration_date
+                .decrypt(ctx, key)
+                .ok()
+                .flatten()
+                .and_then(|s: String| s.parse().ok()),
         })
     }
 }
@@ -221,7 +243,7 @@ mod tests {
         PassportView {
             surname: Some("Doe".to_string()),
             given_name: Some("Jane".to_string()),
-            date_of_birth: Some("1990-01-01".to_string()),
+            date_of_birth: NaiveDate::from_ymd_opt(1990, 1, 1),
             sex: Some("F".to_string()),
             birth_place: Some("New York".to_string()),
             nationality: Some("American".to_string()),
@@ -230,8 +252,8 @@ mod tests {
             passport_type: Some("P".to_string()),
             national_identification_number: Some("123-45-6789".to_string()),
             issuing_authority: Some("US State Department".to_string()),
-            issue_date: Some("2020-01-01".to_string()),
-            expiration_date: Some("2030-01-01".to_string()),
+            issue_date: NaiveDate::from_ymd_opt(2020, 1, 1),
+            expiration_date: NaiveDate::from_ymd_opt(2030, 1, 1),
         }
     }
 

--- a/crates/bitwarden-vault/src/uniffi_support.rs
+++ b/crates/bitwarden-vault/src/uniffi_support.rs
@@ -2,4 +2,6 @@ use uuid::Uuid;
 
 type DateTime = chrono::DateTime<chrono::Utc>;
 uniffi::use_remote_type!(bitwarden_core::DateTime);
+type NaiveDate = chrono::NaiveDate;
+uniffi::use_remote_type!(bitwarden_core::NaiveDate);
 uniffi::use_remote_type!(bitwarden_core::Uuid);

--- a/crates/bitwarden-wasm-internal/src/custom_types.rs
+++ b/crates/bitwarden-wasm-internal/src/custom_types.rs
@@ -19,6 +19,11 @@ export type Uuid = unknown;
 export type DateTime<T = unknown> = string;
 
 /**
+ * ISO 8601 compliant date string (yyyy-mm-dd).
+ */
+export type NaiveDate = string;
+
+/**
  * UTC date-time string. Not used in JavaScript.
  */
 export type Utc = unknown;


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-38604

## 📔 Objective

This is my first SDK PR and Claude helped me manage a lot of the heavy lifting, please let me know if I am properly honoring the best practices.

This PR updates the date values in the SDK for some of the new cipher types to utilize the Rust `NaiveDate` and translate it to a Java `LocalDate`.

## 🚨 Breaking Changes

This will create a breaking change for the Kotlin output of the SDK where previously certain date Strings will now be converted to the type-safe `LocalDate` class. This is required to enforce a consistent date format that can be parsed an utilized properly across the platforms.
<!-- Does this PR introduce any breaking changes? If so, please describe the impact and migration path for clients.

If you're unsure, the automated TypeScript compatibility check will run when you open/update this PR and provide feedback.

For breaking changes:
1. Describe what changed in the client interface
2. Explain why the change was necessary
3. Provide migration steps for client developers
4. Link to any paired client PRs if needed

Otherwise, you can remove this section. -->
