### PR TITLE
[PM-37616] use new_http_client() in auth tests

### DIFF
--- a/crates/bitwarden-auth/src/token_management/middleware.rs
+++ b/crates/bitwarden-auth/src/token_management/middleware.rs
@@ -137,7 +137,7 @@ mod tests {
         sync::{Arc, Mutex},
     };
 
-    use bitwarden_api_api::apis::AuthRequired;
+    use bitwarden_api_api::{apis::AuthRequired, new_http_client};
     use reqwest_middleware::{ClientBuilder, ClientWithMiddleware};
     use wiremock::MockServer;
 
@@ -190,7 +190,8 @@ mod tests {
         let ext = MockMiddleware {
             state: state.clone(),
         };
-        let client = ClientBuilder::new(reqwest::Client::new())
+
+        let client = ClientBuilder::new(new_http_client())
             .with_arc(Arc::new(MiddlewareWrapper::new(ext)))
             .build();
         (client, state)

--- a/crates/bitwarden-auth/src/token_management/test_utils.rs
+++ b/crates/bitwarden-auth/src/token_management/test_utils.rs
@@ -1,6 +1,6 @@
 use std::time::Duration;
 
-use bitwarden_api_api::apis::AuthRequired;
+use bitwarden_api_api::{apis::AuthRequired, new_http_client};
 use bitwarden_core::{auth::TokenHandler, key_management::KeySlotIds};
 use bitwarden_crypto::KeyStore;
 use bitwarden_state::registry::StateRegistry;
@@ -109,7 +109,7 @@ pub fn build_client<H: TokenHandler>(
         bitwarden_api_api::Configuration::new(identity_server.uri()),
         KeyStore::<KeySlotIds>::default(),
     );
-    reqwest_middleware::ClientBuilder::new(reqwest::Client::new())
+    reqwest_middleware::ClientBuilder::new(new_http_client())
         .with_arc(middleware)
         .build()
 }


### PR DESCRIPTION
## 🎟️ Tracking

[PM-37616](https://bitwarden.atlassian.net/browse/PM-37616)

## 📔 Objective

Replaced use of `reqwest::Client::new()` by `new_http_client()` in `bitwarden-auth`. This will ensure that all the tests in the SDK instantiate the HTTP client with the same TLS stack, and it will simplify upgrades to `reqwest` that require changes during client initialization, like #1091.

[PM-37616]: https://bitwarden.atlassian.net/browse/PM-37616?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ