### PR TITLE
[PM-37616] use Configuration::new() in key-connector tests

### DIFF
--- a/crates/bitwarden-api-key-connector/src/apis/user_keys_api.rs
+++ b/crates/bitwarden-api-key-connector/src/apis/user_keys_api.rs
@@ -106,11 +106,7 @@ mod tests {
     async fn setup_mock_server_with_auth() -> (MockServer, Configuration) {
         let server = MockServer::start().await;
 
-        let configuration = Configuration {
-            base_path: format!("http://{}", server.address()),
-            client: reqwest::Client::new().into(),
-        };
-
+        let configuration = Configuration::new(format!("http://{}", server.address()));
         (server, configuration)
     }
 


### PR DESCRIPTION
## 🎟️ Tracking

[PM-37616](https://bitwarden.atlassian.net/browse/PM-37616)

## 📔 Objective

Replaced the hand-constructed `Configuration { client: reqwest::Client::new().into(), ... }` with `Configuration::new()` in `bitwarden-api-key-connector`, which uses `new_http_client()` under the hood. This will ensure that all the tests in the SDK instantiate the HTTP client with the same TLS stack, and it will simplify upgrades to `reqwest` that require changes during client initialization, like #1091.

[PM-37616]: https://bitwarden.atlassian.net/browse/PM-37616?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ