### PR TITLE
[PM-37616] use new_http_client() in generators tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -824,6 +824,7 @@ dependencies = [
 name = "bitwarden-generators"
 version = "3.0.0"
 dependencies = [
+ "bitwarden-api-base",
  "bitwarden-core",
  "bitwarden-crypto",
  "bitwarden-error",

--- a/crates/bitwarden-generators/Cargo.toml
+++ b/crates/bitwarden-generators/Cargo.toml
@@ -37,6 +37,7 @@ uniffi = { workspace = true, optional = true }
 wasm-bindgen = { workspace = true, optional = true }
 
 [dev-dependencies]
+bitwarden-api-base = { workspace = true }
 rand_chacha = { workspace = true }
 tokio = { workspace = true, features = ["rt"] }
 wiremock = { workspace = true }

--- a/crates/bitwarden-generators/src/username_forwarders/addyio.rs
+++ b/crates/bitwarden-generators/src/username_forwarders/addyio.rs
@@ -51,6 +51,7 @@ pub(crate) async fn generate(
 
 #[cfg(test)]
 mod tests {
+    use bitwarden_api_base::new_http_client;
     use serde_json::json;
 
     use crate::username::UsernameError;
@@ -116,7 +117,7 @@ mod tests {
             .await;
 
         let address = super::generate(
-            &reqwest::Client::new(),
+            &new_http_client(),
             "MY_TOKEN".into(),
             "myemail.com".into(),
             format!("http://{}", server.address()),
@@ -126,7 +127,7 @@ mod tests {
         .unwrap();
 
         let fake_token_error = super::generate(
-            &reqwest::Client::new(),
+            &new_http_client(),
             "MY_FAKE_TOKEN".into(),
             "myemail.com".into(),
             format!("http://{}", server.address()),
@@ -141,7 +142,7 @@ mod tests {
         );
 
         let fake_domain_error = super::generate(
-            &reqwest::Client::new(),
+            &new_http_client(),
             "MY_TOKEN".into(),
             "gmail.com".into(),
             format!("http://{}", server.address()),

--- a/crates/bitwarden-generators/src/username_forwarders/duckduckgo.rs
+++ b/crates/bitwarden-generators/src/username_forwarders/duckduckgo.rs
@@ -39,6 +39,7 @@ async fn generate_with_api_url(
 
 #[cfg(test)]
 mod tests {
+    use bitwarden_api_base::new_http_client;
     use serde_json::json;
 
     use crate::username::UsernameError;
@@ -74,7 +75,7 @@ mod tests {
             .await;
 
         let address = super::generate_with_api_url(
-            &reqwest::Client::new(),
+            &new_http_client(),
             "MY_TOKEN".into(),
             format!("http://{}", server.address()),
         )
@@ -83,7 +84,7 @@ mod tests {
         assert_eq!(address, "bw7prt@duck.com");
 
         let fake_token_error = super::generate_with_api_url(
-            &reqwest::Client::new(),
+            &new_http_client(),
             "MY_FAKE_TOKEN".into(),
             format!("http://{}", server.address()),
         )

--- a/crates/bitwarden-generators/src/username_forwarders/fastmail.rs
+++ b/crates/bitwarden-generators/src/username_forwarders/fastmail.rs
@@ -124,6 +124,7 @@ async fn get_account_id(
 
 #[cfg(test)]
 mod tests {
+    use bitwarden_api_base::new_http_client;
     use serde_json::json;
 
     use crate::username::UsernameError;
@@ -178,7 +179,7 @@ mod tests {
             .await;
 
         let address = super::generate_with_api_url(
-            &reqwest::Client::new(),
+            &new_http_client(),
             "MY_TOKEN".into(),
             Some("example.com".into()),
             format!("http://{}", server.address()),
@@ -188,7 +189,7 @@ mod tests {
         assert_eq!(address, "9f823dq23d123ds@mydomain.com");
 
         let fake_token_error = super::generate_with_api_url(
-            &reqwest::Client::new(),
+            &new_http_client(),
             "MY_FAKE_TOKEN".into(),
             Some("example.com".into()),
             format!("http://{}", server.address()),

--- a/crates/bitwarden-generators/src/username_forwarders/firefox.rs
+++ b/crates/bitwarden-generators/src/username_forwarders/firefox.rs
@@ -58,6 +58,7 @@ async fn generate_with_api_url(
 
 #[cfg(test)]
 mod tests {
+    use bitwarden_api_base::new_http_client;
     use serde_json::json;
 
     use crate::username::UsernameError;
@@ -87,7 +88,7 @@ mod tests {
             .await;
 
         let address = super::generate_with_api_url(
-            &reqwest::Client::new(),
+            &new_http_client(),
             "MY_TOKEN".into(),
             Some("example.com".into()),
             format!("http://{}", server.address()),
@@ -123,7 +124,7 @@ mod tests {
             .await;
 
         let address = super::generate_with_api_url(
-            &reqwest::Client::new(),
+            &new_http_client(),
             "MY_OTHER_TOKEN".into(),
             None,
             format!("http://{}", server.address()),
@@ -158,7 +159,7 @@ mod tests {
             .await;
 
         let error = super::generate_with_api_url(
-            &reqwest::Client::new(),
+            &new_http_client(),
             "MY_FAKE_TOKEN".into(),
             Some("example.com".into()),
             format!("http://{}", server.address()),

--- a/crates/bitwarden-generators/src/username_forwarders/forwardemail.rs
+++ b/crates/bitwarden-generators/src/username_forwarders/forwardemail.rs
@@ -86,6 +86,7 @@ async fn generate_with_api_url(
 
 #[cfg(test)]
 mod tests {
+    use bitwarden_api_base::new_http_client;
     use serde_json::json;
 
     use crate::username::UsernameError;
@@ -164,7 +165,7 @@ mod tests {
             .await;
 
         let address = super::generate_with_api_url(
-            &reqwest::Client::new(),
+            &new_http_client(),
             "MY_TOKEN".into(),
             "mydomain.com".into(),
             Some("example.com".into()),
@@ -175,7 +176,7 @@ mod tests {
         assert_eq!(address, "wertg8ad@mydomain.com");
 
         let invalid_token_error = super::generate_with_api_url(
-            &reqwest::Client::new(),
+            &new_http_client(),
             "MY_FAKE_TOKEN".into(),
             "mydomain.com".into(),
             Some("example.com".into()),
@@ -190,7 +191,7 @@ mod tests {
         );
 
         let free_token_error = super::generate_with_api_url(
-            &reqwest::Client::new(),
+            &new_http_client(),
             "MY_FREE_TOKEN".into(),
             "mydomain.com".into(),
             Some("example.com".into()),

--- a/crates/bitwarden-generators/src/username_forwarders/simplelogin.rs
+++ b/crates/bitwarden-generators/src/username_forwarders/simplelogin.rs
@@ -55,6 +55,7 @@ async fn generate_with_api_url(
 
 #[cfg(test)]
 mod tests {
+    use bitwarden_api_base::new_http_client;
     use serde_json::json;
 
     use crate::username::UsernameError;
@@ -98,7 +99,7 @@ mod tests {
             .await;
 
         let address = super::generate_with_api_url(
-            &reqwest::Client::new(),
+            &new_http_client(),
             "MY_TOKEN".into(),
             format!("http://{}", server.address()),
             Some("example.com".into()),
@@ -108,7 +109,7 @@ mod tests {
         assert_eq!(address, "simplelogin.yut3g8@aleeas.com");
 
         let fake_token_error = super::generate_with_api_url(
-            &reqwest::Client::new(),
+            &new_http_client(),
             "MY_FAKE_TOKEN".into(),
             format!("http://{}", server.address()),
             Some("example.com".into()),


### PR DESCRIPTION
## 🎟️ Tracking

[PM-37616](https://bitwarden.atlassian.net/browse/PM-37616)

## 📔 Objective

Replaced use of `reqwest::Client::new()` by `new_http_client()` in `bitwarden-generators`. This will ensure that all the tests in the SDK instantiate the HTTP client with the same TLS stack, and it will simplify upgrades to `reqwest` that require changes during client initialization, like #1091.

[PM-37616]: https://bitwarden.atlassian.net/browse/PM-37616?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ