### PR TITLE
[PM-37616] use new_http_client() in vault tests

### DIFF
--- a/crates/bitwarden-vault/src/cipher_risk/hibp.rs
+++ b/crates/bitwarden-vault/src/cipher_risk/hibp.rs
@@ -71,6 +71,8 @@ pub(super) async fn check_password_exposed(
 
 #[cfg(test)]
 mod tests {
+    use bitwarden_api_api::new_http_client;
+
     use super::*;
 
     #[test]
@@ -163,8 +165,7 @@ mod tests {
             .mount(&server)
             .await;
 
-        let result =
-            check_password_exposed(&reqwest::Client::new(), "password", &server.uri()).await;
+        let result = check_password_exposed(&new_http_client(), "password", &server.uri()).await;
 
         assert!(result.is_err());
         assert!(matches!(result.unwrap_err(), CipherRiskError::Reqwest(_)));


### PR DESCRIPTION
## 🎟️ Tracking

[PM-37616](https://bitwarden.atlassian.net/browse/PM-37616)

## 📔 Objective

Replaced use of `reqwest::Client::new()` by `new_http_client()` in `bitwarden-vault`. This will ensure that all the tests in the SDK instantiate the HTTP client with the same TLS stack, and it will simplify upgrades to `reqwest` that require changes during client initialization, like #1091.

[PM-37616]: https://bitwarden.atlassian.net/browse/PM-37616?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ