### PR TITLE
[PM-33408] Add policy override for OrganizationUserNotification policy

### DIFF
--- a/crates/bitwarden-policies/src/policy_client.rs
+++ b/crates/bitwarden-policies/src/policy_client.rs
@@ -18,6 +18,7 @@ fn build_policy_registry() -> PolicyRegistry {
         .register(RemoveUnlockWithPinPolicy)
         .register(RestrictedItemTypesPolicy)
         .register(AutomaticUserConfirmationPolicy)
+        .register(OrganizationUserNotificationPolicy)
         .build()
 }
 

--- a/crates/bitwarden-policies/src/policy_overrides.rs
+++ b/crates/bitwarden-policies/src/policy_overrides.rs
@@ -109,6 +109,21 @@ impl Policy for AutomaticUserConfirmationPolicy {
     }
 }
 
+/// Organization User Notification policy.
+///
+/// Applies to **everyone**, including Owners and Admins.
+pub struct OrganizationUserNotificationPolicy;
+
+impl Policy for OrganizationUserNotificationPolicy {
+    fn policy_type(&self) -> PolicyType {
+        PolicyType::OrganizationUserNotification
+    }
+
+    fn exempt_roles(&self) -> &[OrganizationUserType] {
+        &[]
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use bitwarden_organizations::{OrganizationUserStatusType, OrganizationUserType};
@@ -247,6 +262,40 @@ mod tests {
         let orgs = [org(org_id, OrganizationUserType::Owner)];
         assert_eq!(
             AutomaticUserConfirmationPolicy
+                .filter(&policies, &orgs)
+                .len(),
+            1
+        );
+    }
+
+    // --- OrganizationUserNotificationPolicy ---
+
+    #[test]
+    fn organization_user_notification_applies_to_owner() {
+        let org_id = Uuid::new_v4();
+        let policies = [policy_view(
+            org_id,
+            PolicyType::OrganizationUserNotification,
+        )];
+        let orgs = [org(org_id, OrganizationUserType::Owner)];
+        assert_eq!(
+            OrganizationUserNotificationPolicy
+                .filter(&policies, &orgs)
+                .len(),
+            1
+        );
+    }
+
+    #[test]
+    fn organization_user_notification_applies_to_admin() {
+        let org_id = Uuid::new_v4();
+        let policies = [policy_view(
+            org_id,
+            PolicyType::OrganizationUserNotification,
+        )];
+        let orgs = [org(org_id, OrganizationUserType::Admin)];
+        assert_eq!(
+            OrganizationUserNotificationPolicy
                 .filter(&policies, &orgs)
                 .len(),
             1


### PR DESCRIPTION
## 🎟️ Tracking

[Jira](https://bitwarden.atlassian.net/browse/PM-33408)

## 📔 Objective

Adds override to the OrganizationUserNotification policy to disallow exemption for owner/admin level users

## 🚨 Breaking Changes

<!-- Does this PR introduce any breaking changes? If so, please describe the impact and migration path for clients.

If you're unsure, the automated TypeScript compatibility check will run when you open/update this PR and provide feedback.

For breaking changes:
1. Describe what changed in the client interface
2. Explain why the change was necessary
3. Provide migration steps for client developers
4. Link to any paired client PRs if needed

Otherwise, you can remove this section. -->
