### PR TITLE
Add field-level decryption errors to cipher with GracefulDecrypt (POC)

### DIFF
--- a/crates/bitwarden-exporters/src/lib.rs
+++ b/crates/bitwarden-exporters/src/lib.rs
@@ -295,6 +295,7 @@ impl From<ImportingCipher> for CipherView {
             deleted_date: None,
             revision_date: value.revision_date,
             archived_date: None,
+            decryption_failures: None,
         }
     }
 }

--- a/crates/bitwarden-exporters/src/models.rs
+++ b/crates/bitwarden-exporters/src/models.rs
@@ -313,6 +313,7 @@ mod tests {
             deleted_date: None,
             revision_date: "2024-01-30T17:55:36.150Z".parse().unwrap(),
             archived_date: None,
+            decryption_failures: None,
         };
 
         let login = from_login(&view, &key_store).unwrap();
@@ -369,6 +370,7 @@ mod tests {
             deleted_date: None,
             revision_date: "2024-01-30T17:55:36.150Z".parse().unwrap(),
             archived_date: None,
+            decryption_failures: None,
         };
         let encrypted = key_store.encrypt(cipher_view).unwrap();
 

--- a/crates/bitwarden-fido/src/authenticator.rs
+++ b/crates/bitwarden-fido/src/authenticator.rs
@@ -849,6 +849,7 @@ mod tests {
             deleted_date: None,
             revision_date: "2024-01-30T17:55:36.150Z".parse().unwrap(),
             archived_date: None,
+            decryption_failures: None,
         }
     }
 

--- a/crates/bitwarden-uniffi/src/vault/ciphers.rs
+++ b/crates/bitwarden-uniffi/src/vault/ciphers.rs
@@ -39,6 +39,23 @@ impl CiphersClient {
         Ok(self.0.decrypt_list_with_failures(ciphers).await)
     }
 
+    /// Decrypt a single cipher gracefully — per-field decryption errors are collected
+    /// into `CipherView::decryption_failures` instead of being silently nulled or
+    /// propagated.
+    pub async fn decrypt_graceful(&self, cipher: Cipher) -> Result<CipherView> {
+        Ok(self.0.decrypt_graceful(cipher).await?)
+    }
+
+    /// List-view variant of `decrypt_graceful`. Each successful entry carries its own
+    /// `decryption_failures`; ciphers whose `key` failed to decrypt are returned in
+    /// `failures`.
+    pub async fn decrypt_list_graceful(
+        &self,
+        ciphers: Vec<Cipher>,
+    ) -> Result<DecryptCipherListResult> {
+        Ok(self.0.decrypt_list_graceful(ciphers).await)
+    }
+
     pub fn decrypt_fido2_credentials(
         &self,
         cipher_view: CipherView,

--- a/crates/bitwarden-user-crypto-management/src/key_rotation/data.rs
+++ b/crates/bitwarden-user-crypto-management/src/key_rotation/data.rs
@@ -332,6 +332,7 @@ mod tests {
             archived_date: None,
             edit: false,
             password_history: None,
+            decryption_failures: None,
         };
         let encrypted_cipher = cipher.encrypt_composite(&mut ctx, user_key_old).unwrap();
 

--- a/crates/bitwarden-vault/src/cipher/attachment.rs
+++ b/crates/bitwarden-vault/src/cipher/attachment.rs
@@ -9,7 +9,7 @@ use serde::{Deserialize, Serialize};
 use tsify::Tsify;
 
 use super::Cipher;
-use crate::VaultParseError;
+use crate::{VaultParseError, cipher::cipher::CipherDecryptionFailure};
 
 #[allow(missing_docs)]
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -290,6 +290,48 @@ pub(crate) fn decrypt_attachments_with_failures(
             Ok(decrypted) => successes.push(decrypted),
             Err(e) => {
                 tracing::warn!(attachment_id = ?attachment.id, error = %e, "Failed to decrypt attachment");
+                failures.push(AttachmentView {
+                    id: attachment.id.clone(),
+                    url: attachment.url.clone(),
+                    size: attachment.size.clone(),
+                    size_name: attachment.size_name.clone(),
+                    file_name: None,
+                    key: attachment.key.clone(),
+                    #[cfg(feature = "wasm")]
+                    decrypted_key: None,
+                });
+            }
+        }
+    }
+
+    (successes, failures)
+}
+
+/// Graceful variant of [`decrypt_attachments_with_failures`]. Behaves identically for
+/// successes and the legacy `attachment_decryption_failures` field, but also appends a
+/// [`CipherDecryptionFailure`] entry (with `path = "attachments[i].fileName"`) into
+/// `decryption_failures` for every attachment whose decrypt fails — so clients reading the
+/// unified `CipherView::decryption_failures` see attachment failures alongside everything
+/// else.
+pub(crate) fn decrypt_attachments_with_failures_graceful(
+    attachments: &[Attachment],
+    ctx: &mut KeyStoreContext<KeySlotIds>,
+    key: SymmetricKeySlotId,
+    path_prefix: &str,
+    decryption_failures: &mut Vec<CipherDecryptionFailure>,
+) -> (Vec<AttachmentView>, Vec<AttachmentView>) {
+    let mut successes = Vec::new();
+    let mut failures = Vec::new();
+
+    for (idx, attachment) in attachments.iter().enumerate() {
+        match attachment.decrypt(ctx, key) {
+            Ok(decrypted) => successes.push(decrypted),
+            Err(e) => {
+                tracing::warn!(attachment_id = ?attachment.id, error = %e, "Failed to decrypt attachment");
+                decryption_failures.push(CipherDecryptionFailure::new(
+                    format!("{path_prefix}[{idx}].fileName"),
+                    &e,
+                ));
                 failures.push(AttachmentView {
                     id: attachment.id.clone(),
                     url: attachment.url.clone(),

--- a/crates/bitwarden-vault/src/cipher/bank_account.rs
+++ b/crates/bitwarden-vault/src/cipher/bank_account.rs
@@ -8,7 +8,7 @@ use serde::{Deserialize, Serialize};
 #[cfg(feature = "wasm")]
 use tsify::Tsify;
 
-use super::cipher::CipherKind;
+use super::cipher::{CipherDecryptionFailure, CipherKind, try_decrypt_field};
 use crate::{Cipher, VaultParseError, cipher::cipher::CopyableCipherFields};
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -85,6 +85,42 @@ impl Decryptable<KeySlotIds, SymmetricKeySlotId, BankAccountView> for BankAccoun
             iban: self.iban.decrypt(ctx, key).ok().flatten(),
             bank_contact_phone: self.bank_contact_phone.decrypt(ctx, key).ok().flatten(),
         })
+    }
+}
+
+impl BankAccount {
+    /// Graceful decrypt into a [`BankAccountView`], collecting per-field failures into `failures`.
+    pub(crate) fn decrypt_graceful_view(
+        &self,
+        ctx: &mut KeyStoreContext<KeySlotIds>,
+        key: SymmetricKeySlotId,
+        path_prefix: &str,
+        failures: &mut Vec<CipherDecryptionFailure>,
+    ) -> BankAccountView {
+        macro_rules! tf {
+            ($field:ident, $camel:literal) => {
+                try_decrypt_field(
+                    &self.$field,
+                    ctx,
+                    key,
+                    &format!("{path_prefix}.{}", $camel),
+                    failures,
+                )
+                .flatten()
+            };
+        }
+        BankAccountView {
+            bank_name: tf!(bank_name, "bankName"),
+            name_on_account: tf!(name_on_account, "nameOnAccount"),
+            account_type: tf!(account_type, "accountType"),
+            account_number: tf!(account_number, "accountNumber"),
+            routing_number: tf!(routing_number, "routingNumber"),
+            branch_number: tf!(branch_number, "branchNumber"),
+            pin: tf!(pin, "pin"),
+            swift_code: tf!(swift_code, "swiftCode"),
+            iban: tf!(iban, "iban"),
+            bank_contact_phone: tf!(bank_contact_phone, "bankContactPhone"),
+        }
     }
 }
 

--- a/crates/bitwarden-vault/src/cipher/blob/conversions/mod.rs
+++ b/crates/bitwarden-vault/src/cipher/blob/conversions/mod.rs
@@ -299,6 +299,7 @@ pub(crate) mod test_support {
             deleted_date: None,
             revision_date: Utc.with_ymd_and_hms(2024, 1, 1, 0, 0, 0).unwrap(),
             archived_date: None,
+            decryption_failures: None,
         }
     }
 }

--- a/crates/bitwarden-vault/src/cipher/blob/encryption.rs
+++ b/crates/bitwarden-vault/src/cipher/blob/encryption.rs
@@ -191,6 +191,7 @@ pub(crate) fn decrypt_blob_cipher(
         passport: None,
         fields: None,
         password_history: None,
+        decryption_failures: None,
     };
 
     blob.apply_to_cipher_view(&mut view, ctx, cipher_key)?;

--- a/crates/bitwarden-vault/src/cipher/card.rs
+++ b/crates/bitwarden-vault/src/cipher/card.rs
@@ -8,7 +8,7 @@ use serde::{Deserialize, Serialize};
 #[cfg(feature = "wasm")]
 use tsify::Tsify;
 
-use super::cipher::{CipherKind, StrictDecrypt};
+use super::cipher::{CipherDecryptionFailure, CipherKind, StrictDecrypt, try_decrypt_field};
 use crate::{Cipher, VaultParseError, cipher::cipher::CopyableCipherFields};
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -138,6 +138,88 @@ impl Decryptable<KeySlotIds, SymmetricKeySlotId, CardView> for StrictDecrypt<&Ca
             brand: self.0.brand.decrypt(ctx, key)?,
             number: self.0.number.decrypt(ctx, key)?,
         })
+    }
+}
+
+impl Card {
+    /// Graceful decrypt into a [`CardView`], collecting per-field failures into `failures`.
+    pub(crate) fn decrypt_graceful_view(
+        &self,
+        ctx: &mut KeyStoreContext<KeySlotIds>,
+        key: SymmetricKeySlotId,
+        path_prefix: &str,
+        failures: &mut Vec<CipherDecryptionFailure>,
+    ) -> CardView {
+        CardView {
+            cardholder_name: try_decrypt_field(
+                &self.cardholder_name,
+                ctx,
+                key,
+                &format!("{path_prefix}.cardholderName"),
+                failures,
+            )
+            .flatten(),
+            exp_month: try_decrypt_field(
+                &self.exp_month,
+                ctx,
+                key,
+                &format!("{path_prefix}.expMonth"),
+                failures,
+            )
+            .flatten(),
+            exp_year: try_decrypt_field(
+                &self.exp_year,
+                ctx,
+                key,
+                &format!("{path_prefix}.expYear"),
+                failures,
+            )
+            .flatten(),
+            code: try_decrypt_field(
+                &self.code,
+                ctx,
+                key,
+                &format!("{path_prefix}.code"),
+                failures,
+            )
+            .flatten(),
+            brand: try_decrypt_field(
+                &self.brand,
+                ctx,
+                key,
+                &format!("{path_prefix}.brand"),
+                failures,
+            )
+            .flatten(),
+            number: try_decrypt_field(
+                &self.number,
+                ctx,
+                key,
+                &format!("{path_prefix}.number"),
+                failures,
+            )
+            .flatten(),
+        }
+    }
+
+    /// Graceful decrypt into a [`CardListView`].
+    pub(crate) fn decrypt_graceful_list_view(
+        &self,
+        ctx: &mut KeyStoreContext<KeySlotIds>,
+        key: SymmetricKeySlotId,
+        path_prefix: &str,
+        failures: &mut Vec<CipherDecryptionFailure>,
+    ) -> CardListView {
+        CardListView {
+            brand: try_decrypt_field(
+                &self.brand,
+                ctx,
+                key,
+                &format!("{path_prefix}.brand"),
+                failures,
+            )
+            .flatten(),
+        }
     }
 }
 

--- a/crates/bitwarden-vault/src/cipher/cipher.rs
+++ b/crates/bitwarden-vault/src/cipher/cipher.rs
@@ -460,6 +460,13 @@ pub struct CipherView {
     pub deleted_date: Option<DateTime<Utc>>,
     pub revision_date: DateTime<Utc>,
     pub archived_date: Option<DateTime<Utc>>,
+    /// Per-field decryption failures collected by the graceful decrypt path.
+    /// Only populated by `CiphersClient::decrypt_graceful` and friends; the lenient and
+    /// strict decrypt paths always leave this as `None`. Callers that re-encrypt and save
+    /// a `CipherView` with non-empty `decryption_failures` will overwrite the original
+    /// ciphertext of the affected fields — clients must handle this before mutating.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub decryption_failures: Option<Vec<CipherDecryptionFailure>>,
 }
 
 #[allow(missing_docs)]
@@ -563,6 +570,43 @@ pub struct CipherListView {
     /// Decrypted attachment filenames for search indexing.
     #[cfg(feature = "wasm")]
     pub attachment_names: Option<Vec<String>>,
+    /// Per-field decryption failures collected by the graceful decrypt path.
+    /// Only populated by `CiphersClient::decrypt_list_graceful`; the lenient and strict
+    /// decrypt paths always leave this as `None`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub decryption_failures: Option<Vec<CipherDecryptionFailure>>,
+}
+
+/// Identifies a single field that failed to decrypt within a cipher, along with the
+/// `CryptoError` (flattened to variant + message) returned by `Decryptable::decrypt`
+/// for that field. Populated by `GracefulDecrypt` via the `*_graceful` methods on
+/// `CiphersClient`; never populated by the lenient or strict decrypt paths.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+#[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
+#[cfg_attr(feature = "wasm", derive(Tsify), tsify(into_wasm_abi, from_wasm_abi))]
+pub struct CipherDecryptionFailure {
+    /// Dotted path to the failed field, in camelCase to match the wire format. Examples:
+    /// `"name"`, `"login.password"`, `"login.uris[0].uri"`, `"fields[2].value"`,
+    /// `"attachments[0].fileName"`.
+    pub path: String,
+    /// The `CryptoError` variant name (e.g. `"Decrypt"`, `"KeyDecrypt"`, `"InvalidKey"`).
+    /// Sourced from `bitwarden_error::flat_error::FlatError::error_variant()`.
+    pub error_variant: String,
+    /// The error's `Display` rendering. `CryptoError` variants use fixed `#[error("...")]`
+    /// templates that never interpolate key material, ciphertext, or plaintext.
+    pub error_message: String,
+}
+
+impl CipherDecryptionFailure {
+    pub(crate) fn new(path: impl Into<String>, error: &CryptoError) -> Self {
+        use bitwarden_error::flat_error::FlatError;
+        CipherDecryptionFailure {
+            path: path.into(),
+            error_variant: error.error_variant().to_string(),
+            error_message: error.to_string(),
+        }
+    }
 }
 
 /// Represents the result of decrypting a list of ciphers.
@@ -744,6 +788,7 @@ impl Decryptable<KeySlotIds, SymmetricKeySlotId, CipherView> for Cipher {
             deleted_date: self.deleted_date,
             revision_date: self.revision_date,
             archived_date: self.archived_date,
+            decryption_failures: None,
         };
 
         // For compatibility we only remove URLs with invalid checksums if the cipher has a key
@@ -1115,6 +1160,7 @@ impl Decryptable<KeySlotIds, SymmetricKeySlotId, CipherListView> for Cipher {
                     .filter_map(|a| a.file_name.decrypt(ctx, ciphers_key).ok().flatten())
                     .collect()
             }),
+            decryption_failures: None,
         })
     }
 }
@@ -1155,6 +1201,39 @@ impl IdentifyKey<SymmetricKeySlotId> for CipherListView {
 /// TODO [PM-34531]: Remove StrictDecrypt and `PM-34500-strict_cipher_decryption` feature flag
 /// after feature has fully rolled out.
 pub(crate) struct StrictDecrypt<T>(pub(crate) T);
+
+/// Generic wrapper that uses graceful decryption: field decryption errors are collected
+/// into [`CipherView::decryption_failures`] (or [`CipherListView::decryption_failures`])
+/// rather than nulled silently (lenient) or propagated (strict).
+///
+/// Selected at the call site by the `*_graceful` methods on [`crate::CiphersClient`]; not
+/// gated behind any feature flag.
+pub(crate) struct GracefulDecrypt<T>(pub(crate) T);
+
+/// Decrypt a single field, collecting any error into `failures` and returning `None`.
+///
+/// Used by the graceful decrypt path so that one corrupt field doesn't abort the whole
+/// cipher decrypt. The `path` argument identifies the field for the failure record using
+/// the dotted-camelCase convention documented on [`CipherDecryptionFailure::path`].
+pub(crate) fn try_decrypt_field<E, T>(
+    enc: &E,
+    ctx: &mut KeyStoreContext<KeySlotIds>,
+    key: SymmetricKeySlotId,
+    path: &str,
+    failures: &mut Vec<CipherDecryptionFailure>,
+) -> Option<T>
+where
+    E: Decryptable<KeySlotIds, SymmetricKeySlotId, T>,
+{
+    match enc.decrypt(ctx, key) {
+        Ok(v) => Some(v),
+        Err(e) => {
+            tracing::warn!(field_path = %path, error = %e, "graceful decrypt: field failed");
+            failures.push(CipherDecryptionFailure::new(path, &e));
+            None
+        }
+    }
+}
 
 impl IdentifyKey<SymmetricKeySlotId> for StrictDecrypt<Cipher> {
     fn key_identifier(&self) -> SymmetricKeySlotId {
@@ -1236,6 +1315,7 @@ impl Decryptable<KeySlotIds, SymmetricKeySlotId, CipherView> for StrictDecrypt<C
             deleted_date: self.0.deleted_date,
             revision_date: self.0.revision_date,
             archived_date: self.0.archived_date,
+            decryption_failures: None,
         };
 
         // For compatibility we only remove URLs with invalid checksums if the cipher has a key
@@ -1345,6 +1425,283 @@ impl Decryptable<KeySlotIds, SymmetricKeySlotId, CipherListView> for StrictDecry
                 })
                 .transpose()?
                 .map(|names| names.into_iter().flatten().collect()),
+            decryption_failures: None,
+        })
+    }
+}
+
+impl IdentifyKey<SymmetricKeySlotId> for GracefulDecrypt<Cipher> {
+    fn key_identifier(&self) -> SymmetricKeySlotId {
+        self.0.key_identifier()
+    }
+}
+
+impl Decryptable<KeySlotIds, SymmetricKeySlotId, CipherView> for GracefulDecrypt<Cipher> {
+    #[instrument(err, skip_all, fields(cipher_id = ?self.0.id, org_id = ?self.0.organization_id, kind = ?self.0.r#type))]
+    fn decrypt(
+        &self,
+        ctx: &mut KeyStoreContext<KeySlotIds>,
+        key: SymmetricKeySlotId,
+    ) -> Result<CipherView, CryptoError> {
+        let ciphers_key = Cipher::decrypt_cipher_key(ctx, key, &self.0.key)?;
+
+        let mut failures: Vec<CipherDecryptionFailure> = Vec::new();
+
+        let (attachments, attachment_decryption_failures) =
+            attachment::decrypt_attachments_with_failures_graceful(
+                self.0.attachments.as_deref().unwrap_or_default(),
+                ctx,
+                ciphers_key,
+                "attachments",
+                &mut failures,
+            );
+
+        let login = self
+            .0
+            .login
+            .as_ref()
+            .map(|l| l.decrypt_graceful_view(ctx, ciphers_key, "login", &mut failures));
+        let identity = self
+            .0
+            .identity
+            .as_ref()
+            .map(|i| i.decrypt_graceful_view(ctx, ciphers_key, "identity", &mut failures));
+        let card = self
+            .0
+            .card
+            .as_ref()
+            .map(|c| c.decrypt_graceful_view(ctx, ciphers_key, "card", &mut failures));
+        let ssh_key = self
+            .0
+            .ssh_key
+            .as_ref()
+            .map(|s| s.decrypt_graceful_view(ctx, ciphers_key, "sshKey", &mut failures));
+        let bank_account = self
+            .0
+            .bank_account
+            .as_ref()
+            .map(|b| b.decrypt_graceful_view(ctx, ciphers_key, "bankAccount", &mut failures));
+        let drivers_license =
+            self.0.drivers_license.as_ref().map(|d| {
+                d.decrypt_graceful_view(ctx, ciphers_key, "driversLicense", &mut failures)
+            });
+        let passport = self
+            .0
+            .passport
+            .as_ref()
+            .map(|p| p.decrypt_graceful_view(ctx, ciphers_key, "passport", &mut failures));
+
+        let fields = self.0.fields.as_ref().map(|fields| {
+            fields
+                .iter()
+                .enumerate()
+                .map(|(idx, f)| {
+                    f.decrypt_graceful_view(
+                        ctx,
+                        ciphers_key,
+                        &format!("fields[{idx}]"),
+                        &mut failures,
+                    )
+                })
+                .collect()
+        });
+
+        let password_history = self.0.password_history.as_ref().map(|history| {
+            history
+                .iter()
+                .enumerate()
+                .map(|(idx, h)| {
+                    h.decrypt_graceful_view(
+                        ctx,
+                        ciphers_key,
+                        &format!("passwordHistory[{idx}]"),
+                        &mut failures,
+                    )
+                })
+                .collect()
+        });
+
+        let mut cipher = CipherView {
+            id: self.0.id,
+            organization_id: self.0.organization_id,
+            folder_id: self.0.folder_id,
+            collection_ids: self.0.collection_ids.clone(),
+            key: self.0.key.clone(),
+            name: try_decrypt_field(&self.0.name, ctx, ciphers_key, "name", &mut failures)
+                .unwrap_or_default(),
+            notes: try_decrypt_field(&self.0.notes, ctx, ciphers_key, "notes", &mut failures)
+                .flatten(),
+            r#type: self.0.r#type,
+            login,
+            identity,
+            card,
+            secure_note: self.0.secure_note.decrypt(ctx, ciphers_key).ok().flatten(),
+            ssh_key,
+            bank_account,
+            drivers_license,
+            passport,
+            favorite: self.0.favorite,
+            reprompt: self.0.reprompt,
+            organization_use_totp: self.0.organization_use_totp,
+            edit: self.0.edit,
+            permissions: self.0.permissions,
+            view_password: self.0.view_password,
+            local_data: self.0.local_data.decrypt(ctx, ciphers_key).ok().flatten(),
+            attachments: Some(attachments),
+            attachment_decryption_failures: Some(attachment_decryption_failures),
+            fields,
+            password_history,
+            creation_date: self.0.creation_date,
+            deleted_date: self.0.deleted_date,
+            revision_date: self.0.revision_date,
+            archived_date: self.0.archived_date,
+            decryption_failures: if failures.is_empty() {
+                None
+            } else {
+                Some(failures)
+            },
+        };
+
+        // For compatibility we only remove URLs with invalid checksums if the cipher has a key
+        // or the user is on Crypto V2
+        if cipher.key.is_some()
+            || ctx.get_security_state_version() >= MINIMUM_ENFORCE_ICON_URI_HASH_VERSION
+        {
+            cipher.remove_invalid_checksums();
+        }
+
+        Ok(cipher)
+    }
+}
+
+impl Decryptable<KeySlotIds, SymmetricKeySlotId, CipherListView> for GracefulDecrypt<Cipher> {
+    fn decrypt(
+        &self,
+        ctx: &mut KeyStoreContext<KeySlotIds>,
+        key: SymmetricKeySlotId,
+    ) -> Result<CipherListView, CryptoError> {
+        let ciphers_key = Cipher::decrypt_cipher_key(ctx, key, &self.0.key)?;
+
+        let mut failures: Vec<CipherDecryptionFailure> = Vec::new();
+
+        let name = try_decrypt_field(&self.0.name, ctx, ciphers_key, "name", &mut failures)
+            .unwrap_or_default();
+        let subtitle = match self.0.decrypt_subtitle(ctx, ciphers_key) {
+            Ok(s) => s,
+            Err(e) => {
+                tracing::warn!(error = %e, "graceful decrypt: subtitle failed");
+                failures.push(CipherDecryptionFailure::new("subtitle", &e));
+                String::new()
+            }
+        };
+
+        let r#type = match self.0.r#type {
+            CipherType::Login => match self.0.login.as_ref() {
+                Some(login) => CipherListViewType::Login(login.decrypt_graceful_list_view(
+                    ctx,
+                    ciphers_key,
+                    "login",
+                    &mut failures,
+                )),
+                None => return Err(CryptoError::MissingField("login")),
+            },
+            CipherType::SecureNote => CipherListViewType::SecureNote,
+            CipherType::Card => match self.0.card.as_ref() {
+                Some(card) => CipherListViewType::Card(card.decrypt_graceful_list_view(
+                    ctx,
+                    ciphers_key,
+                    "card",
+                    &mut failures,
+                )),
+                None => return Err(CryptoError::MissingField("card")),
+            },
+            CipherType::Identity => CipherListViewType::Identity,
+            CipherType::SshKey => CipherListViewType::SshKey,
+            CipherType::BankAccount => CipherListViewType::BankAccount,
+            CipherType::Passport => CipherListViewType::Passport,
+            CipherType::DriversLicense => CipherListViewType::DriversLicense,
+        };
+
+        #[cfg(feature = "wasm")]
+        let notes_value =
+            try_decrypt_field(&self.0.notes, ctx, ciphers_key, "notes", &mut failures).flatten();
+        #[cfg(feature = "wasm")]
+        let fields_value = self.0.fields.as_ref().map(|fields| {
+            fields
+                .iter()
+                .enumerate()
+                .map(|(idx, f)| {
+                    field::FieldListView::from(f.decrypt_graceful_view(
+                        ctx,
+                        ciphers_key,
+                        &format!("fields[{idx}]"),
+                        &mut failures,
+                    ))
+                })
+                .collect()
+        });
+        #[cfg(feature = "wasm")]
+        let attachment_names_value = self.0.attachments.as_ref().map(|attachments| {
+            attachments
+                .iter()
+                .enumerate()
+                .filter_map(|(idx, a)| {
+                    try_decrypt_field(
+                        &a.file_name,
+                        ctx,
+                        ciphers_key,
+                        &format!("attachments[{idx}].fileName"),
+                        &mut failures,
+                    )
+                    .flatten()
+                })
+                .collect()
+        });
+
+        Ok(CipherListView {
+            id: self.0.id,
+            organization_id: self.0.organization_id,
+            folder_id: self.0.folder_id,
+            collection_ids: self.0.collection_ids.clone(),
+            key: self.0.key.clone(),
+            name,
+            subtitle,
+            r#type,
+            favorite: self.0.favorite,
+            reprompt: self.0.reprompt,
+            organization_use_totp: self.0.organization_use_totp,
+            edit: self.0.edit,
+            permissions: self.0.permissions,
+            view_password: self.0.view_password,
+            attachments: self
+                .0
+                .attachments
+                .as_ref()
+                .map(|a| a.len() as u32)
+                .unwrap_or(0),
+            has_old_attachments: self
+                .0
+                .attachments
+                .as_ref()
+                .map(|a| a.iter().any(|att| att.key.is_none()))
+                .unwrap_or(false),
+            creation_date: self.0.creation_date,
+            deleted_date: self.0.deleted_date,
+            revision_date: self.0.revision_date,
+            copyable_fields: self.0.get_copyable_fields(),
+            local_data: self.0.local_data.decrypt(ctx, ciphers_key).ok().flatten(),
+            archived_date: self.0.archived_date,
+            #[cfg(feature = "wasm")]
+            notes: notes_value,
+            #[cfg(feature = "wasm")]
+            fields: fields_value,
+            #[cfg(feature = "wasm")]
+            attachment_names: attachment_names_value,
+            decryption_failures: if failures.is_empty() {
+                None
+            } else {
+                Some(failures)
+            },
         })
     }
 }
@@ -1726,6 +2083,7 @@ mod tests {
             deleted_date: None,
             revision_date: "2024-01-30T17:55:36.150Z".parse().unwrap(),
             archived_date: None,
+            decryption_failures: None,
         }
     }
 
@@ -1850,6 +2208,7 @@ mod tests {
                 fields: None,
                 #[cfg(feature = "wasm")]
                 attachment_names: None,
+                decryption_failures: None,
             }
         )
     }
@@ -3099,5 +3458,217 @@ mod tests {
             cipher.view_password,
             "view_password should default to true for CipherMiniDetailsResponseModel"
         );
+    }
+
+    // ---- Graceful decrypt tests ----
+
+    #[test]
+    fn test_graceful_decrypt_single_field_failure() {
+        let key_store =
+            create_test_crypto_with_user_key(SymmetricCryptoKey::make_aes256_cbc_hmac_key());
+
+        // Encrypt a valid cipher, then swap login.password with an EncString from a
+        // different key.
+        let cipher = key_store.encrypt(generate_cipher()).unwrap();
+        let cipher = Cipher {
+            login: Some(Login {
+                password: Some(TEST_CIPHER_NAME.parse().unwrap()),
+                ..cipher.login.unwrap()
+            }),
+            ..cipher
+        };
+
+        let view: CipherView = key_store.decrypt(&GracefulDecrypt(cipher)).unwrap();
+
+        // The other fields decrypted successfully — name and login.username are intact.
+        assert_eq!(view.name, "My test login");
+        assert!(view.login.is_some());
+        let login = view.login.as_ref().unwrap();
+        assert_eq!(login.username.as_deref(), Some("test_username"));
+        // The corrupted field decrypted to None.
+        assert!(login.password.is_none());
+
+        // A single failure entry at the expected path.
+        let failures = view.decryption_failures.expect("expected failures");
+        assert_eq!(failures.len(), 1);
+        assert_eq!(failures[0].path, "login.password");
+        assert!(!failures[0].error_variant.is_empty());
+        assert!(!failures[0].error_message.is_empty());
+    }
+
+    #[test]
+    fn test_graceful_decrypt_multi_field_failure() {
+        let key_store =
+            create_test_crypto_with_user_key(SymmetricCryptoKey::make_aes256_cbc_hmac_key());
+
+        let cipher = key_store.encrypt(generate_cipher()).unwrap();
+        // Corrupt both top-level name and login.password.
+        let cipher = Cipher {
+            name: TEST_CIPHER_NAME.parse().unwrap(),
+            login: Some(Login {
+                password: Some(TEST_CIPHER_NAME.parse().unwrap()),
+                ..cipher.login.unwrap()
+            }),
+            ..cipher
+        };
+
+        let view: CipherView = key_store.decrypt(&GracefulDecrypt(cipher)).unwrap();
+
+        // Name failed → empty string; login.password failed → None.
+        assert_eq!(view.name, "");
+        assert!(view.login.as_ref().unwrap().password.is_none());
+
+        let failures = view.decryption_failures.expect("expected failures");
+        let paths: Vec<&str> = failures.iter().map(|f| f.path.as_str()).collect();
+        assert!(paths.contains(&"name"));
+        assert!(paths.contains(&"login.password"));
+    }
+
+    #[test]
+    fn test_graceful_decrypt_attachment_failure_populates_both_fields() {
+        let user_key: SymmetricCryptoKey = "w2LO+nwV4oxwswVYCxlOfRUseXfvU03VzvKQHrqeklPgiMZrspUe6sOBToCnDn9Ay0tuCBn8ykVVRb7PWhub2Q==".to_string().try_into().unwrap();
+        let key_store = create_test_crypto_with_user_key(user_key);
+
+        let mut ctx = key_store.context();
+        let valid = "valid_file.txt"
+            .encrypt(&mut ctx, SymmetricKeySlotId::User)
+            .unwrap();
+        let wrong_key: SymmetricCryptoKey = "QUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQQ==".to_string().try_into().unwrap();
+        let wrong_key_store = create_test_crypto_with_user_key(wrong_key);
+        let mut wrong_ctx = wrong_key_store.context();
+        let corrupted = "corrupted_file.txt"
+            .encrypt(&mut wrong_ctx, SymmetricKeySlotId::User)
+            .unwrap();
+        drop(ctx);
+
+        let mut cipher = key_store.encrypt(generate_cipher()).unwrap();
+        cipher.attachments = Some(vec![
+            attachment::Attachment {
+                id: Some("valid-attachment".to_string()),
+                url: Some("https://example.com/valid".to_string()),
+                size: Some("100".to_string()),
+                size_name: Some("100 Bytes".to_string()),
+                file_name: Some(valid),
+                key: None,
+            },
+            attachment::Attachment {
+                id: Some("corrupted-attachment".to_string()),
+                url: Some("https://example.com/corrupted".to_string()),
+                size: Some("200".to_string()),
+                size_name: Some("200 Bytes".to_string()),
+                file_name: Some(corrupted),
+                key: None,
+            },
+        ]);
+
+        let view: CipherView = key_store.decrypt(&GracefulDecrypt(cipher)).unwrap();
+
+        // Legacy attachment_decryption_failures contains the failed attachment.
+        let legacy_failures = view
+            .attachment_decryption_failures
+            .as_ref()
+            .expect("legacy attachment failures populated");
+        assert_eq!(legacy_failures.len(), 1);
+        assert_eq!(
+            legacy_failures[0].id.as_deref(),
+            Some("corrupted-attachment")
+        );
+
+        // New unified decryption_failures contains the same failure at the dotted path.
+        let failures = view.decryption_failures.expect("expected failures");
+        let paths: Vec<&str> = failures.iter().map(|f| f.path.as_str()).collect();
+        assert!(
+            paths.contains(&"attachments[1].fileName"),
+            "expected attachments[1].fileName in {paths:?}"
+        );
+    }
+
+    #[test]
+    fn test_graceful_decrypt_list_view_failure() {
+        let key_store =
+            create_test_crypto_with_user_key(SymmetricCryptoKey::make_aes256_cbc_hmac_key());
+
+        // For a Login-type cipher, subtitle is derived from login.username — corrupt
+        // username so subtitle decryption also fails.
+        let cipher = key_store.encrypt(generate_cipher()).unwrap();
+        let cipher = Cipher {
+            login: Some(Login {
+                username: Some(TEST_CIPHER_NAME.parse().unwrap()),
+                ..cipher.login.unwrap()
+            }),
+            ..cipher
+        };
+
+        let view: CipherListView = key_store.decrypt(&GracefulDecrypt(cipher)).unwrap();
+
+        // Name still decrypted; subtitle is empty because the source field failed.
+        assert_eq!(view.name, "My test login");
+        assert_eq!(view.subtitle, "");
+
+        let failures = view.decryption_failures.expect("expected failures");
+        let paths: Vec<&str> = failures.iter().map(|f| f.path.as_str()).collect();
+        assert!(
+            paths.contains(&"subtitle"),
+            "expected subtitle failure in {paths:?}"
+        );
+    }
+
+    #[test]
+    fn test_graceful_decrypt_cipher_key_failure_is_catastrophic() {
+        let key_store =
+            create_test_crypto_with_user_key(SymmetricCryptoKey::make_aes256_cbc_hmac_key());
+
+        let cipher = key_store.encrypt(generate_cipher()).unwrap();
+        // Replace the cipher's own key with garbage encrypted under a different key —
+        // the cipher-key decrypt fails, no field can be recovered.
+        let cipher = Cipher {
+            key: Some(TEST_CIPHER_NAME.parse().unwrap()),
+            ..cipher
+        };
+
+        let result: Result<CipherView, _> = key_store.decrypt(&GracefulDecrypt(cipher));
+        assert!(
+            result.is_err(),
+            "Graceful decrypt should still propagate cipher-key failures"
+        );
+    }
+
+    #[test]
+    fn test_graceful_decrypt_no_failure_yields_none() {
+        let key_store =
+            create_test_crypto_with_user_key(SymmetricCryptoKey::make_aes256_cbc_hmac_key());
+
+        let cipher = key_store.encrypt(generate_cipher()).unwrap();
+        let view: CipherView = key_store.decrypt(&GracefulDecrypt(cipher)).unwrap();
+
+        assert!(
+            view.decryption_failures.is_none(),
+            "decryption_failures should be None when nothing failed (not Some(vec![]))"
+        );
+    }
+
+    #[test]
+    fn test_existing_lenient_and_strict_paths_leave_decryption_failures_none() {
+        let key_store =
+            create_test_crypto_with_user_key(SymmetricCryptoKey::make_aes256_cbc_hmac_key());
+
+        // A cipher with a corrupted name — lenient swallows, strict aborts.
+        let cipher = key_store.encrypt(generate_cipher()).unwrap();
+        let cipher = Cipher {
+            name: TEST_CIPHER_NAME.parse().unwrap(),
+            ..cipher
+        };
+
+        // Lenient path returns Ok but with empty name and decryption_failures None.
+        let lenient_view: CipherView = key_store.decrypt(&cipher).unwrap();
+        assert_eq!(lenient_view.name, "");
+        assert!(
+            lenient_view.decryption_failures.is_none(),
+            "lenient path must never populate decryption_failures"
+        );
+
+        // Strict path errors out as before — unchanged behavior.
+        let strict_result: Result<CipherView, _> = key_store.decrypt(&StrictDecrypt(cipher));
+        assert!(strict_result.is_err());
     }
 }

--- a/crates/bitwarden-vault/src/cipher/cipher_client/admin/edit.rs
+++ b/crates/bitwarden-vault/src/cipher/cipher_client/admin/edit.rs
@@ -229,6 +229,7 @@ mod tests {
             deleted_date: None,
             revision_date: "2025-01-01T00:00:00Z".parse().unwrap(),
             archived_date: None,
+            decryption_failures: None,
         }
     }
 

--- a/crates/bitwarden-vault/src/cipher/cipher_client/create.rs
+++ b/crates/bitwarden-vault/src/cipher/cipher_client/create.rs
@@ -106,6 +106,7 @@ pub(crate) fn convert_request_to_cipher_view(r: CipherCreateRequest) -> CipherVi
         deleted_date: None,
         revision_date: now,
         archived_date: r.archived_date,
+        decryption_failures: None,
     }
 }
 

--- a/crates/bitwarden-vault/src/cipher/cipher_client/edit.rs
+++ b/crates/bitwarden-vault/src/cipher/cipher_client/edit.rs
@@ -162,6 +162,7 @@ pub(crate) fn convert_request_to_cipher_view(r: CipherEditRequest) -> CipherView
         deleted_date: None,
         revision_date: r.revision_date,
         archived_date: r.archived_date,
+        decryption_failures: None,
     }
 }
 
@@ -398,6 +399,7 @@ mod tests {
             deleted_date: None,
             revision_date: "2025-01-01T00:00:00Z".parse().unwrap(),
             archived_date: None,
+            decryption_failures: None,
         }
     }
 

--- a/crates/bitwarden-vault/src/cipher/cipher_client/mod.rs
+++ b/crates/bitwarden-vault/src/cipher/cipher_client/mod.rs
@@ -17,7 +17,7 @@ use wasm_bindgen::prelude::*;
 use super::EncryptionContext;
 use crate::{
     Cipher, CipherError, CipherListView, CipherView, DecryptError, EncryptError,
-    cipher::cipher::{DecryptCipherListResult, StrictDecrypt},
+    cipher::cipher::{DecryptCipherListResult, GracefulDecrypt, StrictDecrypt},
     cipher_client::admin::CipherAdminClient,
 };
 #[cfg(feature = "wasm")]
@@ -271,6 +271,54 @@ impl CiphersClient {
         }
     }
 
+    /// Decrypt a single cipher gracefully — fields that fail to decrypt do not abort the
+    /// operation, and their failures are collected in [`CipherView::decryption_failures`].
+    /// Returns `Err` only when the cipher's own key fails to decrypt (no field can be
+    /// recovered in that case).
+    ///
+    /// This is opt-in: existing `decrypt` / `decrypt_list` / `decrypt_list_with_failures`
+    /// are unchanged. Callers must be aware that re-encrypting and saving a `CipherView`
+    /// with non-empty `decryption_failures` will overwrite the original ciphertext of the
+    /// affected fields.
+    // `async` kept for API symmetry with `decrypt` / `decrypt_list` and to give us room
+    // to read client flags or state in the future without a breaking change.
+    #[allow(clippy::unused_async)]
+    pub async fn decrypt_graceful(&self, cipher: Cipher) -> Result<CipherView, DecryptError> {
+        let key_store = self.client.internal.get_key_store();
+        Ok(key_store.decrypt(&GracefulDecrypt(cipher))?)
+    }
+
+    /// List-view variant of [`Self::decrypt_graceful`]. Per-cipher catastrophic failures
+    /// (cipher-key decrypt errors) are partitioned via the existing
+    /// [`DecryptCipherListResult`] machinery; each successful entry carries its own
+    /// [`CipherListView::decryption_failures`] populated.
+    #[allow(clippy::unused_async)]
+    pub async fn decrypt_list_graceful(&self, ciphers: Vec<Cipher>) -> DecryptCipherListResult {
+        let key_store = self.client.internal.get_key_store();
+        let graceful: Vec<GracefulDecrypt<Cipher>> =
+            ciphers.into_iter().map(GracefulDecrypt).collect();
+        let (successes, failures) = key_store.decrypt_list_with_failures(&graceful);
+        DecryptCipherListResult {
+            successes,
+            failures: failures.into_iter().map(|f| f.0.clone()).collect(),
+        }
+    }
+
+    /// Full-view variant of [`Self::decrypt_list_graceful`] — returns `CipherView`s
+    /// (each with its own `decryption_failures`) rather than the lighter `CipherListView`.
+    #[cfg(feature = "wasm")]
+    #[allow(clippy::unused_async)]
+    pub async fn decrypt_list_full_graceful(&self, ciphers: Vec<Cipher>) -> DecryptCipherResult {
+        let key_store = self.client.internal.get_key_store();
+        let graceful: Vec<GracefulDecrypt<Cipher>> =
+            ciphers.into_iter().map(GracefulDecrypt).collect();
+        let (successes, failures) = key_store.decrypt_list_with_failures(&graceful);
+        DecryptCipherResult {
+            successes,
+            failures: failures.into_iter().map(|f| f.0.clone()).collect(),
+        }
+    }
+
     #[allow(missing_docs)]
     pub fn decrypt_fido2_credentials(
         &self,
@@ -436,6 +484,7 @@ mod tests {
             deleted_date: None,
             revision_date: "2024-01-30T17:55:36.150Z".parse().unwrap(),
             archived_date: None,
+            decryption_failures: None,
         }
     }
 

--- a/crates/bitwarden-vault/src/cipher/cipher_client/share_cipher.rs
+++ b/crates/bitwarden-vault/src/cipher/cipher_client/share_cipher.rs
@@ -360,6 +360,7 @@ mod tests {
             deleted_date: None,
             revision_date: "2024-01-30T17:55:36.150Z".parse().unwrap(),
             archived_date: None,
+            decryption_failures: None,
         }
     }
 

--- a/crates/bitwarden-vault/src/cipher/drivers_license.rs
+++ b/crates/bitwarden-vault/src/cipher/drivers_license.rs
@@ -8,7 +8,7 @@ use serde::{Deserialize, Serialize};
 #[cfg(feature = "wasm")]
 use tsify::Tsify;
 
-use super::cipher::CipherKind;
+use super::cipher::{CipherDecryptionFailure, CipherKind, try_decrypt_field};
 use crate::{Cipher, VaultParseError, cipher::cipher::CopyableCipherFields};
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -89,6 +89,44 @@ impl Decryptable<KeySlotIds, SymmetricKeySlotId, DriversLicenseView> for Drivers
             issuing_authority: self.issuing_authority.decrypt(ctx, key).ok().flatten(),
             license_class: self.license_class.decrypt(ctx, key).ok().flatten(),
         })
+    }
+}
+
+impl DriversLicense {
+    /// Graceful decrypt into a [`DriversLicenseView`], collecting per-field failures into
+    /// `failures`.
+    pub(crate) fn decrypt_graceful_view(
+        &self,
+        ctx: &mut KeyStoreContext<KeySlotIds>,
+        key: SymmetricKeySlotId,
+        path_prefix: &str,
+        failures: &mut Vec<CipherDecryptionFailure>,
+    ) -> DriversLicenseView {
+        macro_rules! tf {
+            ($field:ident, $camel:literal) => {
+                try_decrypt_field(
+                    &self.$field,
+                    ctx,
+                    key,
+                    &format!("{path_prefix}.{}", $camel),
+                    failures,
+                )
+                .flatten()
+            };
+        }
+        DriversLicenseView {
+            first_name: tf!(first_name, "firstName"),
+            middle_name: tf!(middle_name, "middleName"),
+            last_name: tf!(last_name, "lastName"),
+            date_of_birth: tf!(date_of_birth, "dateOfBirth"),
+            license_number: tf!(license_number, "licenseNumber"),
+            issuing_country: tf!(issuing_country, "issuingCountry"),
+            issuing_state: tf!(issuing_state, "issuingState"),
+            issue_date: tf!(issue_date, "issueDate"),
+            expiration_date: tf!(expiration_date, "expirationDate"),
+            issuing_authority: tf!(issuing_authority, "issuingAuthority"),
+            license_class: tf!(license_class, "licenseClass"),
+        }
     }
 }
 

--- a/crates/bitwarden-vault/src/cipher/field.rs
+++ b/crates/bitwarden-vault/src/cipher/field.rs
@@ -17,7 +17,10 @@ use tsify::Tsify;
 #[cfg(feature = "wasm")]
 use wasm_bindgen::prelude::wasm_bindgen;
 
-use super::{cipher::StrictDecrypt, linked_id::LinkedIdType};
+use super::{
+    cipher::{CipherDecryptionFailure, StrictDecrypt, try_decrypt_field},
+    linked_id::LinkedIdType,
+};
 use crate::{PasswordHistoryView, VaultParseError};
 
 /// Represents the type of a [FieldView].
@@ -186,6 +189,39 @@ impl Decryptable<KeySlotIds, SymmetricKeySlotId, FieldView> for StrictDecrypt<&F
             r#type: self.0.r#type,
             linked_id: self.0.linked_id,
         })
+    }
+}
+
+impl Field {
+    /// Graceful decrypt into a [`FieldView`], collecting per-field failures into `failures`.
+    /// `path_prefix` is typically `"fields[i]"` (the array index slot the caller is filling).
+    pub(crate) fn decrypt_graceful_view(
+        &self,
+        ctx: &mut KeyStoreContext<KeySlotIds>,
+        key: SymmetricKeySlotId,
+        path_prefix: &str,
+        failures: &mut Vec<CipherDecryptionFailure>,
+    ) -> FieldView {
+        FieldView {
+            name: try_decrypt_field(
+                &self.name,
+                ctx,
+                key,
+                &format!("{path_prefix}.name"),
+                failures,
+            )
+            .flatten(),
+            value: try_decrypt_field(
+                &self.value,
+                ctx,
+                key,
+                &format!("{path_prefix}.value"),
+                failures,
+            )
+            .flatten(),
+            r#type: self.r#type,
+            linked_id: self.linked_id,
+        }
     }
 }
 

--- a/crates/bitwarden-vault/src/cipher/identity.rs
+++ b/crates/bitwarden-vault/src/cipher/identity.rs
@@ -8,7 +8,7 @@ use serde::{Deserialize, Serialize};
 #[cfg(feature = "wasm")]
 use tsify::Tsify;
 
-use super::cipher::{CipherKind, StrictDecrypt};
+use super::cipher::{CipherDecryptionFailure, CipherKind, StrictDecrypt, try_decrypt_field};
 use crate::{Cipher, VaultParseError, cipher::cipher::CopyableCipherFields};
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -146,6 +146,52 @@ impl Decryptable<KeySlotIds, SymmetricKeySlotId, IdentityView> for StrictDecrypt
             passport_number: self.0.passport_number.decrypt(ctx, key)?,
             license_number: self.0.license_number.decrypt(ctx, key)?,
         })
+    }
+}
+
+impl Identity {
+    /// Graceful decrypt into an [`IdentityView`], collecting per-field failures into `failures`.
+    pub(crate) fn decrypt_graceful_view(
+        &self,
+        ctx: &mut KeyStoreContext<KeySlotIds>,
+        key: SymmetricKeySlotId,
+        path_prefix: &str,
+        failures: &mut Vec<CipherDecryptionFailure>,
+    ) -> IdentityView {
+        // Local macro to keep the 18-field expansion readable. `$camel` is the
+        // dotted-camelCase path component we publish to clients.
+        macro_rules! tf {
+            ($field:ident, $camel:literal) => {
+                try_decrypt_field(
+                    &self.$field,
+                    ctx,
+                    key,
+                    &format!("{path_prefix}.{}", $camel),
+                    failures,
+                )
+                .flatten()
+            };
+        }
+        IdentityView {
+            title: tf!(title, "title"),
+            first_name: tf!(first_name, "firstName"),
+            middle_name: tf!(middle_name, "middleName"),
+            last_name: tf!(last_name, "lastName"),
+            address1: tf!(address1, "address1"),
+            address2: tf!(address2, "address2"),
+            address3: tf!(address3, "address3"),
+            city: tf!(city, "city"),
+            state: tf!(state, "state"),
+            postal_code: tf!(postal_code, "postalCode"),
+            country: tf!(country, "country"),
+            company: tf!(company, "company"),
+            email: tf!(email, "email"),
+            phone: tf!(phone, "phone"),
+            ssn: tf!(ssn, "ssn"),
+            username: tf!(username, "username"),
+            passport_number: tf!(passport_number, "passportNumber"),
+            license_number: tf!(license_number, "licenseNumber"),
+        }
     }
 }
 

--- a/crates/bitwarden-vault/src/cipher/login.rs
+++ b/crates/bitwarden-vault/src/cipher/login.rs
@@ -17,7 +17,7 @@ use tsify::Tsify;
 #[cfg(feature = "wasm")]
 use wasm_bindgen::prelude::wasm_bindgen;
 
-use super::cipher::{CipherKind, StrictDecrypt};
+use super::cipher::{CipherDecryptionFailure, CipherKind, StrictDecrypt, try_decrypt_field};
 use crate::{Cipher, PasswordHistoryView, VaultParseError, cipher::cipher::CopyableCipherFields};
 
 #[allow(missing_docs)]
@@ -486,6 +486,142 @@ impl Decryptable<KeySlotIds, SymmetricKeySlotId, LoginView> for StrictDecrypt<&L
             autofill_on_page_load: self.0.autofill_on_page_load,
             fido2_credentials: self.0.fido2_credentials.clone(),
         })
+    }
+}
+
+impl Login {
+    /// Graceful decrypt into a [`LoginView`], collecting per-field failures into `failures`.
+    pub(crate) fn decrypt_graceful_view(
+        &self,
+        ctx: &mut KeyStoreContext<KeySlotIds>,
+        key: SymmetricKeySlotId,
+        path_prefix: &str,
+        failures: &mut Vec<CipherDecryptionFailure>,
+    ) -> LoginView {
+        let uris = self.uris.as_ref().map(|uris| {
+            uris.iter()
+                .enumerate()
+                .map(|(idx, uri)| LoginUriView {
+                    uri: try_decrypt_field(
+                        &uri.uri,
+                        ctx,
+                        key,
+                        &format!("{path_prefix}.uris[{idx}].uri"),
+                        failures,
+                    )
+                    .flatten(),
+                    r#match: uri.r#match,
+                    uri_checksum: try_decrypt_field(
+                        &uri.uri_checksum,
+                        ctx,
+                        key,
+                        &format!("{path_prefix}.uris[{idx}].uriChecksum"),
+                        failures,
+                    )
+                    .flatten(),
+                })
+                .collect()
+        });
+
+        LoginView {
+            username: try_decrypt_field(
+                &self.username,
+                ctx,
+                key,
+                &format!("{path_prefix}.username"),
+                failures,
+            )
+            .flatten(),
+            password: try_decrypt_field(
+                &self.password,
+                ctx,
+                key,
+                &format!("{path_prefix}.password"),
+                failures,
+            )
+            .flatten(),
+            password_revision_date: self.password_revision_date,
+            uris,
+            totp: try_decrypt_field(
+                &self.totp,
+                ctx,
+                key,
+                &format!("{path_prefix}.totp"),
+                failures,
+            )
+            .flatten(),
+            autofill_on_page_load: self.autofill_on_page_load,
+            fido2_credentials: self.fido2_credentials.clone(),
+        }
+    }
+
+    /// Graceful decrypt into a [`LoginListView`]. Mirrors `StrictDecrypt<&Login>` for the
+    /// list-view variant; only the small subset of fields needed for the list is collected,
+    /// and any failures are added to `failures`.
+    pub(crate) fn decrypt_graceful_list_view(
+        &self,
+        ctx: &mut KeyStoreContext<KeySlotIds>,
+        key: SymmetricKeySlotId,
+        path_prefix: &str,
+        failures: &mut Vec<CipherDecryptionFailure>,
+    ) -> LoginListView {
+        let uris = self.uris.as_ref().map(|uris| {
+            uris.iter()
+                .enumerate()
+                .map(|(idx, uri)| LoginUriView {
+                    uri: try_decrypt_field(
+                        &uri.uri,
+                        ctx,
+                        key,
+                        &format!("{path_prefix}.uris[{idx}].uri"),
+                        failures,
+                    )
+                    .flatten(),
+                    r#match: uri.r#match,
+                    uri_checksum: try_decrypt_field(
+                        &uri.uri_checksum,
+                        ctx,
+                        key,
+                        &format!("{path_prefix}.uris[{idx}].uriChecksum"),
+                        failures,
+                    )
+                    .flatten(),
+                })
+                .collect()
+        });
+
+        let fido2_credentials = self.fido2_credentials.as_ref().map(|creds| {
+            // Fido2Credential decryption is all-or-nothing per credential; if any field
+            // fails we surface a single failure for the credential and drop it from the
+            // list rather than emitting per-sub-field paths (Fido2CredentialListView is
+            // already a tightly-coupled aggregate).
+            let mut out = Vec::with_capacity(creds.len());
+            for (idx, cred) in creds.iter().enumerate() {
+                match cred.decrypt(ctx, key) {
+                    Ok(decrypted) => out.push(decrypted),
+                    Err(e) => failures.push(CipherDecryptionFailure::new(
+                        format!("{path_prefix}.fido2Credentials[{idx}]"),
+                        &e,
+                    )),
+                }
+            }
+            out
+        });
+
+        LoginListView {
+            fido2_credentials,
+            has_fido2: self.fido2_credentials.is_some(),
+            username: try_decrypt_field(
+                &self.username,
+                ctx,
+                key,
+                &format!("{path_prefix}.username"),
+                failures,
+            )
+            .flatten(),
+            totp: self.totp.clone(),
+            uris,
+        }
     }
 }
 

--- a/crates/bitwarden-vault/src/cipher/passport.rs
+++ b/crates/bitwarden-vault/src/cipher/passport.rs
@@ -8,7 +8,7 @@ use serde::{Deserialize, Serialize};
 #[cfg(feature = "wasm")]
 use tsify::Tsify;
 
-use super::cipher::CipherKind;
+use super::cipher::{CipherDecryptionFailure, CipherKind, try_decrypt_field};
 use crate::{Cipher, VaultParseError, cipher::cipher::CopyableCipherFields};
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -103,6 +103,48 @@ impl Decryptable<KeySlotIds, SymmetricKeySlotId, PassportView> for Passport {
             issue_date: self.issue_date.decrypt(ctx, key).ok().flatten(),
             expiration_date: self.expiration_date.decrypt(ctx, key).ok().flatten(),
         })
+    }
+}
+
+impl Passport {
+    /// Graceful decrypt into a [`PassportView`], collecting per-field failures into `failures`.
+    pub(crate) fn decrypt_graceful_view(
+        &self,
+        ctx: &mut KeyStoreContext<KeySlotIds>,
+        key: SymmetricKeySlotId,
+        path_prefix: &str,
+        failures: &mut Vec<CipherDecryptionFailure>,
+    ) -> PassportView {
+        macro_rules! tf {
+            ($field:ident, $camel:literal) => {
+                try_decrypt_field(
+                    &self.$field,
+                    ctx,
+                    key,
+                    &format!("{path_prefix}.{}", $camel),
+                    failures,
+                )
+                .flatten()
+            };
+        }
+        PassportView {
+            surname: tf!(surname, "surname"),
+            given_name: tf!(given_name, "givenName"),
+            date_of_birth: tf!(date_of_birth, "dateOfBirth"),
+            sex: tf!(sex, "sex"),
+            birth_place: tf!(birth_place, "birthPlace"),
+            nationality: tf!(nationality, "nationality"),
+            issuing_country: tf!(issuing_country, "issuingCountry"),
+            passport_number: tf!(passport_number, "passportNumber"),
+            passport_type: tf!(passport_type, "passportType"),
+            national_identification_number: tf!(
+                national_identification_number,
+                "nationalIdentificationNumber"
+            ),
+            issuing_authority: tf!(issuing_authority, "issuingAuthority"),
+            issue_date: tf!(issue_date, "issueDate"),
+            expiration_date: tf!(expiration_date, "expirationDate"),
+        }
     }
 }
 

--- a/crates/bitwarden-vault/src/cipher/ssh_key.rs
+++ b/crates/bitwarden-vault/src/cipher/ssh_key.rs
@@ -11,7 +11,7 @@ use serde::{Deserialize, Serialize};
 #[cfg(feature = "wasm")]
 use tsify::Tsify;
 
-use super::cipher::CipherKind;
+use super::cipher::{CipherDecryptionFailure, CipherKind, try_decrypt_field};
 use crate::{Cipher, VaultParseError, cipher::cipher::CopyableCipherFields};
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -66,6 +66,45 @@ impl Decryptable<KeySlotIds, SymmetricKeySlotId, SshKeyView> for SshKey {
             public_key: self.public_key.decrypt(ctx, key)?,
             fingerprint: self.fingerprint.decrypt(ctx, key)?,
         })
+    }
+}
+
+impl SshKey {
+    /// Graceful decrypt into an [`SshKeyView`]. Fields that fail to decrypt become empty
+    /// strings; failures are pushed into `failures`.
+    pub(crate) fn decrypt_graceful_view(
+        &self,
+        ctx: &mut KeyStoreContext<KeySlotIds>,
+        key: SymmetricKeySlotId,
+        path_prefix: &str,
+        failures: &mut Vec<CipherDecryptionFailure>,
+    ) -> SshKeyView {
+        SshKeyView {
+            private_key: try_decrypt_field(
+                &self.private_key,
+                ctx,
+                key,
+                &format!("{path_prefix}.privateKey"),
+                failures,
+            )
+            .unwrap_or_default(),
+            public_key: try_decrypt_field(
+                &self.public_key,
+                ctx,
+                key,
+                &format!("{path_prefix}.publicKey"),
+                failures,
+            )
+            .unwrap_or_default(),
+            fingerprint: try_decrypt_field(
+                &self.fingerprint,
+                ctx,
+                key,
+                &format!("{path_prefix}.fingerprint"),
+                failures,
+            )
+            .unwrap_or_default(),
+        }
     }
 }
 

--- a/crates/bitwarden-vault/src/password_history.rs
+++ b/crates/bitwarden-vault/src/password_history.rs
@@ -9,7 +9,10 @@ use serde::{Deserialize, Serialize};
 #[cfg(feature = "wasm")]
 use tsify::Tsify;
 
-use crate::VaultParseError;
+use crate::{
+    VaultParseError,
+    cipher::cipher::{CipherDecryptionFailure, try_decrypt_field},
+};
 
 /// Maximum number of password history entries to retain
 pub(crate) const MAX_PASSWORD_HISTORY_ENTRIES: usize = 5;
@@ -68,6 +71,30 @@ impl Decryptable<KeySlotIds, SymmetricKeySlotId, PasswordHistoryView> for Passwo
             password: self.password.decrypt(ctx, key).ok().unwrap_or_default(),
             last_used_date: self.last_used_date,
         })
+    }
+}
+
+impl PasswordHistory {
+    /// Graceful decrypt into a [`PasswordHistoryView`]. On failure the password becomes an
+    /// empty string and a failure entry is added at `{path_prefix}.password`.
+    pub(crate) fn decrypt_graceful_view(
+        &self,
+        ctx: &mut KeyStoreContext<KeySlotIds>,
+        key: SymmetricKeySlotId,
+        path_prefix: &str,
+        failures: &mut Vec<CipherDecryptionFailure>,
+    ) -> PasswordHistoryView {
+        PasswordHistoryView {
+            password: try_decrypt_field(
+                &self.password,
+                ctx,
+                key,
+                &format!("{path_prefix}.password"),
+                failures,
+            )
+            .unwrap_or_default(),
+            last_used_date: self.last_used_date,
+        }
     }
 }
 

--- a/crates/bitwarden-vault/src/totp.rs
+++ b/crates/bitwarden-vault/src/totp.rs
@@ -765,6 +765,7 @@ mod tests {
             fields: None,
             #[cfg(feature = "wasm")]
             attachment_names: None,
+            decryption_failures: None,
         };
 
         let key = SymmetricCryptoKey::try_from("w2LO+nwV4oxwswVYCxlOfRUseXfvU03VzvKQHrqeklPgiMZrspUe6sOBToCnDn9Ay0tuCBn8ykVVRb7PWhub2Q==".to_string()).unwrap();


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-38296

## 📔 Objective

This is a proof of concept for reporting back on field-level decryption errors. It introduces a new "GracefulDecrypt" to populate a. (newly added) `decryption_failures` field with the specific fields that failed to decrypt. Expected to be used for diagnostic reasons only.
