### PR TITLE
Remove long argument for output

### DIFF
--- a/crates/bw/src/command/mod.rs
+++ b/crates/bw/src/command/mod.rs
@@ -17,6 +17,7 @@ use crate::{
     auth::LoginArgs,
     key_management::{LockArgs, UnlockArgs},
     platform::{CompletionArgs, ConfigCommand, EncodeArgs, ServeArgs, StatusArgs, SyncArgs},
+    render::Output,
     tools::{ExportArgs, GenerateArgs, ImportArgs, ReceiveArgs, SendArgs},
     vault::RestoreArgs,
 };
@@ -42,9 +43,9 @@ pub struct Cli {
     #[command(subcommand)]
     pub command: Option<Commands>,
 
-    // Disabled since it collides with other flags.
-    // #[arg(short = 'o', long, global = true, value_enum, default_value_t = Output::JSON)]
-    // pub output: Output,
+    #[arg(short = 'o', global = true, value_enum, default_value_t = Output::JSON)]
+    pub output: Output,
+
     /// Color
     #[arg(short = 'c', long, global = true, value_enum, default_value_t = Color::Auto)]
     pub color: Color,

--- a/crates/bw/src/command/mod.rs
+++ b/crates/bw/src/command/mod.rs
@@ -17,7 +17,6 @@ use crate::{
     auth::LoginArgs,
     key_management::{LockArgs, UnlockArgs},
     platform::{CompletionArgs, ConfigCommand, EncodeArgs, ServeArgs, StatusArgs, SyncArgs},
-    render::Output,
     tools::{ExportArgs, GenerateArgs, ImportArgs, ReceiveArgs, SendArgs},
     vault::RestoreArgs,
 };
@@ -43,9 +42,10 @@ pub struct Cli {
     #[command(subcommand)]
     pub command: Option<Commands>,
 
-    #[arg(short = 'o', long, global = true, value_enum, default_value_t = Output::JSON)]
-    pub output: Output,
-
+    // Disabled since it collides with other flags.
+    // #[arg(short = 'o', long, global = true, value_enum, default_value_t = Output::JSON)]
+    // pub output: Output,
+    /// Color
     #[arg(short = 'c', long, global = true, value_enum, default_value_t = Color::Auto)]
     pub color: Color,
 

--- a/crates/bw/src/render.rs
+++ b/crates/bw/src/render.rs
@@ -45,7 +45,7 @@ pub struct RenderConfig {
 impl RenderConfig {
     pub fn new(cli: &Cli) -> Self {
         Self {
-            output: cli.output,
+            output: Output::JSON,
             color: cli.color,
             clean_exit: cli.clean_exit,
             quiet: cli.quiet,


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Tools need the `output` arg for deciding files. I suggest they name this more appropriately and deprecate the existing `output` so we can use this in the future.

## 🚨 Breaking Changes

<!-- Does this PR introduce any breaking changes? If so, please describe the impact and migration path for clients.

If you're unsure, the automated TypeScript compatibility check will run when you open/update this PR and provide feedback.

For breaking changes:
1. Describe what changed in the client interface
2. Explain why the change was necessary
3. Provide migration steps for client developers
4. Link to any paired client PRs if needed

Otherwise, you can remove this section. -->
