### PR TITLE
[PM-37919] Compile bitwarden-ssh with ECDSA flag

### DIFF
--- a/crates/bitwarden-ssh/Cargo.toml
+++ b/crates/bitwarden-ssh/Cargo.toml
@@ -16,8 +16,7 @@ license-file.workspace = true
 keywords.workspace = true
 
 [features]
-ecdsa-keys = [
-] # Allow ECDSA key generation and import at runtime (disabled by default, since SSH Agent does not support ECDSA keys yet)
+ecdsa-keys = [] # ECDSA key generation and import
 wasm = [
     "bitwarden-error/wasm",
     "dep:tsify",

--- a/crates/bitwarden-uniffi/Cargo.toml
+++ b/crates/bitwarden-uniffi/Cargo.toml
@@ -37,7 +37,7 @@ bitwarden-pm = { workspace = true, features = ["uniffi"] }
 bitwarden-policies = { workspace = true, features = ["uniffi"] }
 bitwarden-send = { workspace = true, features = ["uniffi"] }
 bitwarden-server-communication-config = { workspace = true, features = ["uniffi"] }
-bitwarden-ssh = { workspace = true, features = ["uniffi"] }
+bitwarden-ssh = { workspace = true, features = ["uniffi", "ecdsa-keys"] }
 bitwarden-state = { workspace = true, features = ["uniffi"] }
 bitwarden-uniffi-error = { workspace = true }
 bitwarden-user-crypto-management = { workspace = true, features = ["uniffi"] }

--- a/crates/bitwarden-wasm-internal/Cargo.toml
+++ b/crates/bitwarden-wasm-internal/Cargo.toml
@@ -48,7 +48,7 @@ bitwarden-pm = { workspace = true, features = ["wasm"] }
 bitwarden-policies = { workspace = true, features = ["wasm"] }
 bitwarden-server-communication-config = { workspace = true, features = ["wasm"] }
 bitwarden-shared-unlock = { workspace = true, features = ["wasm"] }
-bitwarden-ssh = { workspace = true, features = ["wasm"] }
+bitwarden-ssh = { workspace = true, features = ["wasm", "ecdsa-keys"] }
 bitwarden-state = { workspace = true, features = ["wasm"] }
 bitwarden-threading = { workspace = true }
 bitwarden-user-crypto-management = { workspace = true, features = ["wasm"] }


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-37919

## 📔 Objective

`clients` currently has:
- support in the SSH Agent v2 for ECDSA keys
- logic that prevents the import of ECDSA keys (at the vault level) unless ECDSA feature flag is enabled.

With especially the second item, it's now safe to enable ECDSA support in bitwarden-ssh.

## Testing done

Used a local build of the SDK to integrate into the Desktop client.

(see ticket for recordings)

With the FF turned off:
- attempt to import an ecdsa key of all curve types → it should fail with Toast message that the key type is unsupported


With the FF turned on:
- attempt to import an ecdsa key of all curve types → it should succeed
- use an imported ECDSA key in the vault to perform
    - list keys (ssh -L) operations
    - sign request (ssh -T github , or to another host e.g. docker)
    - agent forwarding
