### PR TITLE
[PM-39051] feat: classify IPC errors as fatal vs recoverable

### DIFF
--- a/crates/bitwarden-ipc/src/crypto_provider/noise/crypto_provider.rs
+++ b/crates/bitwarden-ipc/src/crypto_provider/noise/crypto_provider.rs
@@ -12,6 +12,7 @@ use crate::{
         },
         transport_state::{PersistentTransportState, TransportFrame},
     },
+    error::IpcErrorKind,
     message::{IncomingMessage, OutgoingMessage},
     traits::{
         CommunicationBackend, CommunicationBackendReceiver, CryptoProvider, SessionRepository,
@@ -26,12 +27,31 @@ pub enum NoiseCryptoProviderError {
     HandshakeProtocol,
     /// A timeout waiting for a message
     Timeout,
-    /// Could not send via the underlying transport
-    TransportSend,
-    /// Could not receive via the underlying transport
-    TransportReceive,
+    /// Could not send via the underlying transport. `fatal` is derived from the underlying
+    /// backend error's [`IpcErrorKind`] classification.
+    TransportSend { fatal: bool },
+    /// Could not receive via the underlying transport. `fatal` is derived from the underlying
+    /// backend error's [`IpcErrorKind`] classification.
+    TransportReceive { fatal: bool },
     /// A cryptographic error. In most cases, such messages are just dropped.
     DecryptionFailure,
+}
+
+impl IpcErrorKind for NoiseCryptoProviderError {
+    fn is_fatal(&self) -> bool {
+        match self {
+            // A bad/missing handshake frame from one peer does not affect the shared client; the
+            // peer can retry the handshake.
+            NoiseCryptoProviderError::HandshakeProtocol => false,
+            // The handshake is retryable on a subsequent send.
+            NoiseCryptoProviderError::Timeout => false,
+            // A decryption failure only affects the offending message, which is dropped.
+            NoiseCryptoProviderError::DecryptionFailure => false,
+            // Defer to the underlying backend's classification, captured at construction.
+            NoiseCryptoProviderError::TransportSend { fatal } => *fatal,
+            NoiseCryptoProviderError::TransportReceive { fatal } => *fatal,
+        }
+    }
 }
 
 // Serialize send operations to prevent concurrent reads of the same persisted
@@ -65,15 +85,18 @@ impl NoiseCryptoProvider {
                 topic: None,
             })
             .await
-            .map_err(|_| NoiseCryptoProviderError::TransportSend)?;
+            .map_err(|e| NoiseCryptoProviderError::TransportSend {
+                fatal: e.is_fatal(),
+            })?;
 
         // Wait for the handshake response (with timeout)
         timeout(Duration::from_secs(HANDSHAKE_TIMEOUT_SECS), async {
             loop {
-                let incoming = receiver
-                    .receive()
-                    .await
-                    .map_err(|_| NoiseCryptoProviderError::TransportReceive)?;
+                let incoming = receiver.receive().await.map_err(|e| {
+                    NoiseCryptoProviderError::TransportReceive {
+                        fatal: e.is_fatal(),
+                    }
+                })?;
 
                 // For concurrent handshakes, ignore messages
                 if incoming.source.to_endpoint() != destination {
@@ -213,7 +236,9 @@ where
                 topic: message.topic,
             })
             .await
-            .map_err(|_| NoiseCryptoProviderError::TransportSend)?;
+            .map_err(|e| NoiseCryptoProviderError::TransportSend {
+                fatal: e.is_fatal(),
+            })?;
 
         sessions
             .save(destination, crypto_state)
@@ -230,10 +255,11 @@ where
         sessions: &Ses,
     ) -> Result<IncomingMessage, Self::ReceiveError> {
         loop {
-            let message = receiver
-                .receive()
-                .await
-                .map_err(|_| NoiseCryptoProviderError::TransportReceive)?;
+            let message = receiver.receive().await.map_err(|e| {
+                NoiseCryptoProviderError::TransportReceive {
+                    fatal: e.is_fatal(),
+                }
+            })?;
 
             // Ensure session exists
             let source_endpoint: crate::endpoint::Endpoint = message.source.clone().into();
@@ -261,7 +287,9 @@ where
                             topic: None,
                         })
                         .await
-                        .map_err(|_| NoiseCryptoProviderError::TransportSend)?;
+                        .map_err(|e| NoiseCryptoProviderError::TransportSend {
+                            fatal: e.is_fatal(),
+                        })?;
 
                     let crypto_state = NoiseCryptoProviderState {
                         state: (&mut responder).into(),
@@ -287,7 +315,9 @@ where
                                 topic: None,
                             })
                             .await
-                            .map_err(|_| NoiseCryptoProviderError::TransportSend)?;
+                            .map_err(|e| NoiseCryptoProviderError::TransportSend {
+                                fatal: e.is_fatal(),
+                            })?;
                         continue;
                     };
 

--- a/crates/bitwarden-ipc/src/error.rs
+++ b/crates/bitwarden-ipc/src/error.rs
@@ -32,17 +32,6 @@ impl IpcErrorKind for std::convert::Infallible {
     }
 }
 
-impl IpcErrorKind for String {
-    fn is_fatal(&self) -> bool {
-        // String errors carry no structured recoverability information. The IPC backends that use
-        // them (e.g. the WASM communication backend) have no genuinely non-recoverable send or
-        // receive errors today, so treat them as recoverable to keep the shared client alive. If a
-        // backend ever needs to signal a fatal error, it should use a structured error type that
-        // implements [`IpcErrorKind`] with a real fatal/recoverable distinction instead.
-        false
-    }
-}
-
 #[cfg(any(test, feature = "test-support"))]
 impl IpcErrorKind for () {
     fn is_fatal(&self) -> bool {

--- a/crates/bitwarden-ipc/src/error.rs
+++ b/crates/bitwarden-ipc/src/error.rs
@@ -3,6 +3,53 @@ use thiserror::Error;
 
 use crate::rpc::error::RpcError;
 
+/// Classifies an IPC error as either fatal or recoverable.
+///
+/// The IPC client runs a single long-lived processing loop that is shared across every peer and
+/// every message. Historically *any* transport or crypto error tore that loop down, which meant a
+/// single transient failure (a handshake timeout, a peer disconnecting mid-send, a malformed
+/// frame) permanently disabled the shared client and it never recovered.
+///
+/// This trait lets each layer classify its own errors so the client can distinguish the two cases:
+/// - **Fatal** (`is_fatal() == true`): the client can no longer make progress, so the processing
+///   loop should stop.
+/// - **Recoverable** (`is_fatal() == false`): only the current operation failed, so the client
+///   should stay running and continue processing other messages.
+///
+/// Implementations should classify errors at construction, where the most context is available,
+/// and default ambiguous cases to recoverable. Failing open keeps the shared client alive, which
+/// is almost always the safer choice.
+pub trait IpcErrorKind {
+    /// Returns `true` if the error is fatal and the IPC client should stop processing messages, or
+    /// `false` if the error is recoverable and the client should keep running.
+    fn is_fatal(&self) -> bool;
+}
+
+impl IpcErrorKind for std::convert::Infallible {
+    fn is_fatal(&self) -> bool {
+        // `Infallible` can never be constructed, so this is unreachable.
+        match *self {}
+    }
+}
+
+impl IpcErrorKind for String {
+    fn is_fatal(&self) -> bool {
+        // String errors carry no structured recoverability information. The IPC backends that use
+        // them (e.g. the WASM communication backend) have no genuinely non-recoverable send or
+        // receive errors today, so treat them as recoverable to keep the shared client alive. If a
+        // backend ever needs to signal a fatal error, it should use a structured error type that
+        // implements [`IpcErrorKind`] with a real fatal/recoverable distinction instead.
+        false
+    }
+}
+
+#[cfg(any(test, feature = "test-support"))]
+impl IpcErrorKind for () {
+    fn is_fatal(&self) -> bool {
+        false
+    }
+}
+
 /// Error returned by [`IpcClient::start`](crate::IpcClient::start). Indicates that the IPC client
 /// is already running.
 #[derive(Debug, Error, Clone, PartialEq, Eq)]

--- a/crates/bitwarden-ipc/src/ipc_client.rs
+++ b/crates/bitwarden-ipc/src/ipc_client.rs
@@ -7,7 +7,10 @@ use tokio::select;
 
 use crate::{
     constants::CHANNEL_BUFFER_CAPACITY,
-    error::{AlreadyRunningError, ReceiveError, SendError, SubscribeError, TypedReceiveError},
+    error::{
+        AlreadyRunningError, IpcErrorKind, ReceiveError, SendError, SubscribeError,
+        TypedReceiveError,
+    },
     message::{
         IncomingMessage, OutgoingMessage, PayloadTypeName, TypedIncomingMessage,
         TypedOutgoingMessage,
@@ -156,9 +159,12 @@ where
                                     break;
                                 };
                             }
-                            Err(error) => {
-                                tracing::error!(?error, "Error receiving message");
+                            Err(error) if error.is_fatal() => {
+                                tracing::error!(?error, "Fatal error receiving message, stopping IPC client");
                                 break;
+                            }
+                            Err(error) => {
+                                tracing::warn!(?error, "Recoverable error receiving message, continuing");
                             }
                         }
                     }
@@ -203,8 +209,15 @@ where
             .await;
 
         if let Err(ref error) = result {
-            tracing::error!(?error, "Error sending message");
-            stop_inner(&self.inner);
+            if error.is_fatal() {
+                tracing::error!(?error, "Fatal error sending message, stopping IPC client");
+                stop_inner(&self.inner);
+            } else {
+                tracing::warn!(
+                    ?error,
+                    "Recoverable error sending message, IPC client will continue running"
+                );
+            }
         }
 
         result.map_err(|e| SendError(format!("{e:?}")))
@@ -388,18 +401,35 @@ mod tests {
         traits::{InMemorySessionRepository, NoEncryptionCryptoProvider, TestCommunicationBackend},
     };
 
+    /// Error type for [`TestCryptoProvider`] that carries an explicit fatal/recoverable
+    /// classification so tests can exercise both control-flow paths.
+    #[derive(Debug, Clone)]
+    struct TestCryptoError {
+        // Read only through the derived `Debug` impl (the outer `SendError` wraps it via
+        // `{e:?}`), which dead-code analysis does not count as a use.
+        #[allow(dead_code)]
+        message: String,
+        fatal: bool,
+    }
+
+    impl IpcErrorKind for TestCryptoError {
+        fn is_fatal(&self) -> bool {
+            self.fatal
+        }
+    }
+
     struct TestCryptoProvider {
         /// Simulate a send result. Set to `None` wait indefinitely
-        send_result: Option<Result<(), String>>,
+        send_result: Option<Result<(), TestCryptoError>>,
         /// Simulate a receive result. Set to `None` wait indefinitely
-        receive_result: Option<Result<IncomingMessage, String>>,
+        receive_result: Option<Result<IncomingMessage, TestCryptoError>>,
     }
 
     type TestSessionRepository = InMemorySessionRepository<String>;
     impl CryptoProvider<TestCommunicationBackend, TestSessionRepository> for TestCryptoProvider {
         type Session = String;
-        type SendError = String;
-        type ReceiveError = String;
+        type SendError = TestCryptoError;
+        type ReceiveError = TestCryptoError;
 
         async fn receive(
             &self,
@@ -408,11 +438,21 @@ mod tests {
             _sessions: &TestSessionRepository,
         ) -> Result<IncomingMessage, Self::ReceiveError> {
             match &self.receive_result {
-                Some(result) => result.clone(),
+                Some(result) => {
+                    // Yield (and throttle) so a recoverable error that makes the processing loop
+                    // `continue` doesn't busy-spin and starve the single-threaded test runtime.
+                    // Real backends await their underlying transport here, which has the same
+                    // effect.
+                    sleep(Duration::from_millis(5)).await;
+                    result.clone()
+                }
                 None => {
                     // Simulate waiting for a message but never returning
                     sleep(Duration::from_secs(600)).await;
-                    Err("Simulated timeout".to_string())
+                    Err(TestCryptoError {
+                        message: "Simulated timeout".to_string(),
+                        fatal: true,
+                    })
                 }
             }
         }
@@ -428,7 +468,10 @@ mod tests {
                 None => {
                     // Simulate waiting for a message to be send but never returning
                     sleep(Duration::from_secs(600)).await;
-                    Err("Simulated timeout".to_string())
+                    Err(TestCryptoError {
+                        message: "Simulated timeout".to_string(),
+                        fatal: true,
+                    })
                 }
             }
         }
@@ -442,8 +485,14 @@ mod tests {
             topic: None,
         };
         let crypto_provider = TestCryptoProvider {
-            send_result: Some(Err("Crypto error".to_string())),
-            receive_result: Some(Err("Should not have be called".to_string())),
+            send_result: Some(Err(TestCryptoError {
+                message: "Crypto error".to_string(),
+                fatal: false,
+            })),
+            receive_result: Some(Err(TestCryptoError {
+                message: "Should not have be called".to_string(),
+                fatal: false,
+            })),
         };
         let communication_provider = TestCommunicationBackend::new();
         let session_map = TestSessionRepository::new(HashMap::new());
@@ -642,14 +691,17 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn ipc_client_stops_if_crypto_returns_send_error() {
+    async fn ipc_client_stops_if_crypto_returns_fatal_send_error() {
         let message = OutgoingMessage {
             payload: vec![],
             destination: Endpoint::BrowserBackground { id: HostId::Own },
             topic: None,
         };
         let crypto_provider = TestCryptoProvider {
-            send_result: Some(Err("Crypto error".to_string())),
+            send_result: Some(Err(TestCryptoError {
+                message: "Crypto error".to_string(),
+                fatal: true,
+            })),
             receive_result: None,
         };
         let communication_provider = TestCommunicationBackend::new();
@@ -665,10 +717,44 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn ipc_client_stops_if_crypto_returns_receive_error() {
+    async fn ipc_client_keeps_running_if_crypto_returns_recoverable_send_error() {
+        let message = OutgoingMessage {
+            payload: vec![],
+            destination: Endpoint::BrowserBackground { id: HostId::Own },
+            topic: None,
+        };
+        let crypto_provider = TestCryptoProvider {
+            // A recoverable send error (e.g. a handshake timeout because the peer is down) must
+            // not tear down the shared client.
+            send_result: Some(Err(TestCryptoError {
+                message: "Crypto error".to_string(),
+                fatal: false,
+            })),
+            // Block forever on receive so the loop stays alive while we inspect it.
+            receive_result: None,
+        };
+        let communication_provider = TestCommunicationBackend::new();
+        let session_map = TestSessionRepository::new(HashMap::new());
+        let client = IpcClientImpl::new(crypto_provider, communication_provider, session_map);
+        let _ = client.start(None).await;
+
+        let error = client.send(message).await.unwrap_err();
+        let is_running = client.is_running();
+
+        // The error is still surfaced to the caller...
+        assert!(error.to_string().contains("Crypto error"));
+        // ...but the client keeps running so future sends/requests can succeed.
+        assert!(is_running);
+    }
+
+    #[tokio::test]
+    async fn ipc_client_stops_if_crypto_returns_fatal_receive_error() {
         let crypto_provider = TestCryptoProvider {
             send_result: None,
-            receive_result: Some(Err("Crypto error".to_string())),
+            receive_result: Some(Err(TestCryptoError {
+                message: "Crypto error".to_string(),
+                fatal: true,
+            })),
         };
         let communication_provider = TestCommunicationBackend::new();
         let session_map = TestSessionRepository::new(HashMap::new());
@@ -682,6 +768,30 @@ mod tests {
 
         assert!(!is_running);
         assert!(cancellation_token.is_cancelled());
+    }
+
+    #[tokio::test]
+    async fn ipc_client_keeps_running_if_crypto_returns_recoverable_receive_error() {
+        let crypto_provider = TestCryptoProvider {
+            send_result: None,
+            // A recoverable receive error must not stop the processing loop.
+            receive_result: Some(Err(TestCryptoError {
+                message: "Crypto error".to_string(),
+                fatal: false,
+            })),
+        };
+        let communication_provider = TestCommunicationBackend::new();
+        let session_map = TestSessionRepository::new(HashMap::new());
+        let client = IpcClientImpl::new(crypto_provider, communication_provider, session_map);
+        let cancellation_token = CancellationToken::new();
+        let _ = client.start(Some(cancellation_token.clone())).await;
+
+        // Give the client time to hit the recoverable receive error (repeatedly).
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        let is_running = client.is_running();
+
+        assert!(is_running);
+        assert!(!cancellation_token.is_cancelled());
     }
 
     #[tokio::test]

--- a/crates/bitwarden-ipc/src/ipc_client_trait.rs
+++ b/crates/bitwarden-ipc/src/ipc_client_trait.rs
@@ -26,6 +26,11 @@ pub trait IpcClient: Send + Sync {
     fn is_running(&self) -> bool;
 
     /// Send a message over IPC.
+    ///
+    /// Returning an error means this particular send failed. The client only stops processing
+    /// messages when the underlying error is fatal (see
+    /// [`IpcErrorKind`](crate::IpcErrorKind)); recoverable errors leave the client running, so the
+    /// send can be retried and existing subscriptions remain valid.
     async fn send(&self, message: OutgoingMessage) -> Result<(), SendError>;
 
     /// Subscribe to receive messages, optionally filtered by topic.

--- a/crates/bitwarden-ipc/src/lib.rs
+++ b/crates/bitwarden-ipc/src/lib.rs
@@ -18,7 +18,9 @@ mod traits;
 pub mod wasm;
 
 pub use endpoint::{Endpoint, HostId, Source};
-pub use error::{ReceiveError, RequestError, SendError, SubscribeError, TypedReceiveError};
+pub use error::{
+    IpcErrorKind, ReceiveError, RequestError, SendError, SubscribeError, TypedReceiveError,
+};
 pub use ipc_client::{IpcClientImpl, IpcClientSubscription, IpcClientTypedSubscription};
 pub use ipc_client_ext::IpcClientExt;
 pub use ipc_client_trait::IpcClient;

--- a/crates/bitwarden-ipc/src/traits/communication_backend.rs
+++ b/crates/bitwarden-ipc/src/traits/communication_backend.rs
@@ -1,12 +1,15 @@
 use std::fmt::Debug;
 
-use crate::message::{IncomingMessage, OutgoingMessage};
+use crate::{
+    error::IpcErrorKind,
+    message::{IncomingMessage, OutgoingMessage},
+};
 
 /// This trait defines the interface that will be used to send and receive messages over IPC.
 /// It is up to the platform to implement this trait and any necessary thread synchronization and
 /// broadcasting.
 pub trait CommunicationBackend: Send + Sync + 'static {
-    type SendError: Debug + Send + Sync + 'static;
+    type SendError: Debug + Send + Sync + 'static + IpcErrorKind;
     type Receiver: CommunicationBackendReceiver;
 
     /// Send a message to the destination specified in the message. This function may be called
@@ -39,7 +42,7 @@ pub trait CommunicationBackend: Send + Sync + 'static {
 ///       receive().
 ///     - The receiver buffers messages between calls to receive().
 pub trait CommunicationBackendReceiver: Send + Sync + 'static {
-    type ReceiveError: Debug + Send + Sync + 'static;
+    type ReceiveError: Debug + Send + Sync + 'static + IpcErrorKind;
 
     /// Receive a message. This function will block asynchronously until a message is received.
     ///

--- a/crates/bitwarden-ipc/src/traits/communication_backend.rs
+++ b/crates/bitwarden-ipc/src/traits/communication_backend.rs
@@ -15,8 +15,10 @@ pub trait CommunicationBackend: Send + Sync + 'static {
     /// Send a message to the destination specified in the message. This function may be called
     /// from any thread at any time.
     ///
-    /// An error should only be returned for fatal and unrecoverable errors.
-    /// Returning an error will cause the IPC client to stop processing messages.
+    /// Both recoverable and fatal errors may be returned, classified via
+    /// [`IpcErrorKind::is_fatal()`]. A recoverable error (e.g. a transient transport failure) is
+    /// logged and the IPC client keeps running; a fatal error stops the client from processing any
+    /// further messages. Ambiguous cases should be classified as recoverable.
     ///
     /// The implementation of this trait needs to guarantee that:
     ///     - Multiple concurrent receivers and senders can coexist.
@@ -46,8 +48,10 @@ pub trait CommunicationBackendReceiver: Send + Sync + 'static {
 
     /// Receive a message. This function will block asynchronously until a message is received.
     ///
-    /// An error should only be returned for fatal and unrecoverable errors.
-    /// Returning an error will cause the IPC client to stop processing messages.
+    /// Both recoverable and fatal errors may be returned, classified via
+    /// [`IpcErrorKind::is_fatal()`]. A recoverable error (e.g. the receiver lagging) is logged and
+    /// the IPC client's processing loop continues; a fatal error (e.g. the channel being closed)
+    /// stops the loop. Ambiguous cases should be classified as recoverable.
     ///
     /// Do not call this function from multiple threads at the same time. Use the subscribe function
     /// to create one receiver per thread.

--- a/crates/bitwarden-ipc/src/traits/crypto_provider.rs
+++ b/crates/bitwarden-ipc/src/traits/crypto_provider.rs
@@ -24,9 +24,11 @@ where
     /// session, the function may first send a message to establish a session and then send the
     /// original message. The implementation of this function should handle this logic.
     ///
-    /// An error should only be returned for fatal and unrecoverable errors e.g. if the session
-    /// storage is full or cannot be accessed. Returning an error will cause the IPC client to
-    /// stop processing messages.
+    /// Both recoverable and fatal errors may be returned, classified via
+    /// [`IpcErrorKind::is_fatal()`]. A recoverable error (e.g. a handshake timeout or a transient
+    /// transport failure) is logged and the IPC client keeps running; a fatal error (e.g. the
+    /// session storage being inaccessible) stops the client from processing any further messages.
+    /// Ambiguous cases should be classified as recoverable.
     fn send(
         &self,
         communication: &Com,
@@ -42,9 +44,11 @@ where
     /// re-request the original message. The implementation of this function should handle this
     /// logic.
     ///
-    /// An error should only be returned for fatal and unrecoverable errors e.g. if the session
-    /// storage is full or cannot be accessed. Returning an error will cause the IPC client to
-    /// stop processing messages.
+    /// Both recoverable and fatal errors may be returned, classified via
+    /// [`IpcErrorKind::is_fatal()`]. A recoverable error (e.g. a malformed frame from one peer or a
+    /// transient transport failure) is logged and the IPC client's processing loop continues; a
+    /// fatal error (e.g. the session storage being inaccessible) stops the loop. Ambiguous cases
+    /// should be classified as recoverable.
     fn receive(
         &self,
         receiver: &Com::Receiver,

--- a/crates/bitwarden-ipc/src/traits/crypto_provider.rs
+++ b/crates/bitwarden-ipc/src/traits/crypto_provider.rs
@@ -3,7 +3,10 @@ use std::fmt::Debug;
 #[cfg(any(test, feature = "test-support"))]
 use super::CommunicationBackendReceiver;
 use super::{CommunicationBackend, SessionRepository};
-use crate::message::{IncomingMessage, OutgoingMessage};
+use crate::{
+    error::IpcErrorKind,
+    message::{IncomingMessage, OutgoingMessage},
+};
 
 pub trait CryptoProvider<Com, Ses>: Send + Sync + 'static
 where
@@ -11,8 +14,8 @@ where
     Ses: SessionRepository<Self::Session>,
 {
     type Session: Send + Sync + 'static;
-    type SendError: Debug + Send + Sync + 'static;
-    type ReceiveError: Debug + Send + Sync + 'static;
+    type SendError: Debug + Send + Sync + 'static + IpcErrorKind;
+    type ReceiveError: Debug + Send + Sync + 'static + IpcErrorKind;
 
     /// Send a message.
     ///

--- a/crates/bitwarden-ipc/src/wasm/communication_backend.rs
+++ b/crates/bitwarden-ipc/src/wasm/communication_backend.rs
@@ -35,7 +35,7 @@ pub enum WasmCommunicationError {
     /// An error returned by the JavaScript backend (e.g. a failed send). Recoverable: the IPC
     /// client keeps running so future operations can succeed.
     #[error("{0}")]
-    JsError(String),
+    Js(String),
 
     /// The incoming message receiver fell behind and `0` messages were dropped. Recoverable: the
     /// next receive resumes normally.
@@ -131,8 +131,8 @@ impl CommunicationBackend for JsCommunicationBackend {
                 sender.send(message).await.map_err(|e| format!("{e:?}"))
             })
             .await
-            .map_err(|e| WasmCommunicationError::JsError(e.to_string()))?
-            .map_err(WasmCommunicationError::JsError)
+            .map_err(|e| WasmCommunicationError::Js(e.to_string()))?
+            .map_err(WasmCommunicationError::Js)
     }
 
     async fn subscribe(&self) -> Self::Receiver {

--- a/crates/bitwarden-ipc/src/wasm/communication_backend.rs
+++ b/crates/bitwarden-ipc/src/wasm/communication_backend.rs
@@ -7,6 +7,7 @@ use tokio::sync::RwLock;
 use wasm_bindgen::prelude::*;
 
 use crate::{
+    error::IpcErrorKind,
     message::{IncomingMessage, OutgoingMessage},
     traits::{CommunicationBackend, CommunicationBackendReceiver},
 };
@@ -22,6 +23,36 @@ pub struct DeserializeError(String);
 #[bitwarden_error(basic)]
 #[error("Incoming message channel failed: {0}")]
 pub struct ChannelError(String);
+
+/// Error type for the WASM communication backend's send and receive operations.
+///
+/// Distinguishes recoverable failures (which leave the shared IPC client running) from the fatal
+/// closed-channel state. Without this distinction the client's processing loop would treat a
+/// permanently-closed broadcast channel as recoverable and busy-loop on it, since a closed channel
+/// returns an error immediately and forever without ever awaiting.
+#[derive(Debug, Error)]
+pub enum WasmCommunicationError {
+    /// An error returned by the JavaScript backend (e.g. a failed send). Recoverable: the IPC
+    /// client keeps running so future operations can succeed.
+    #[error("{0}")]
+    JsError(String),
+
+    /// The incoming message receiver fell behind and `0` messages were dropped. Recoverable: the
+    /// next receive resumes normally.
+    #[error("incoming message channel lagged, {0} messages were dropped")]
+    Lagged(u64),
+
+    /// The communication channel was closed because all senders were dropped. This is fatal: the
+    /// IPC client's processing loop stops cleanly instead of busy-looping on the closed channel.
+    #[error("incoming message channel closed")]
+    Closed,
+}
+
+impl IpcErrorKind for WasmCommunicationError {
+    fn is_fatal(&self) -> bool {
+        matches!(self, WasmCommunicationError::Closed)
+    }
+}
 
 #[wasm_bindgen(typescript_custom_section)]
 const TS_CUSTOM_TYPES: &'static str = r#"
@@ -89,18 +120,19 @@ impl JsCommunicationBackend {
 }
 
 impl CommunicationBackend for JsCommunicationBackend {
-    type SendError = String;
+    type SendError = WasmCommunicationError;
     type Receiver = RwLock<tokio::sync::broadcast::Receiver<IncomingMessage>>;
 
     async fn send(&self, message: OutgoingMessage) -> Result<(), Self::SendError> {
-        let result = self
-            .sender
+        // Both the thread-runner failure and the JS-side send failure are treated as recoverable:
+        // a single failed send must not tear down the shared IPC client.
+        self.sender
             .run_in_thread(|sender| async move {
                 sender.send(message).await.map_err(|e| format!("{e:?}"))
             })
-            .await;
-
-        result.map_err(|e| e.to_string())?
+            .await
+            .map_err(|e| WasmCommunicationError::JsError(e.to_string()))?
+            .map_err(WasmCommunicationError::JsError)
     }
 
     async fn subscribe(&self) -> Self::Receiver {
@@ -109,9 +141,67 @@ impl CommunicationBackend for JsCommunicationBackend {
 }
 
 impl CommunicationBackendReceiver for RwLock<tokio::sync::broadcast::Receiver<IncomingMessage>> {
-    type ReceiveError = String;
+    type ReceiveError = WasmCommunicationError;
 
     async fn receive(&self) -> Result<IncomingMessage, Self::ReceiveError> {
-        self.write().await.recv().await.map_err(|e| e.to_string())
+        use tokio::sync::broadcast::error::RecvError;
+
+        self.write().await.recv().await.map_err(|e| match e {
+            // All senders have been dropped; the channel can never produce another message and
+            // `recv()` would return immediately forever. Treat this as fatal so the processing
+            // loop stops instead of busy-looping.
+            RecvError::Closed => WasmCommunicationError::Closed,
+            // The receiver fell behind and missed `skipped` messages. The next `recv()` resumes
+            // normally, so this is recoverable.
+            RecvError::Lagged(skipped) => WasmCommunicationError::Lagged(skipped),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use tokio::sync::{RwLock, broadcast};
+
+    use super::*;
+    use crate::{
+        endpoint::{Endpoint, HostId, Source},
+        error::IpcErrorKind,
+    };
+
+    fn test_message() -> IncomingMessage {
+        IncomingMessage {
+            payload: vec![],
+            source: Source::BrowserBackground { id: HostId::Own },
+            destination: Endpoint::BrowserBackground { id: HostId::Own },
+            topic: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn receive_returns_fatal_closed_when_all_senders_are_dropped() {
+        let (tx, rx) = broadcast::channel::<IncomingMessage>(4);
+        let receiver = RwLock::new(rx);
+
+        // Dropping the only sender closes the channel permanently.
+        drop(tx);
+
+        let error = receiver.receive().await.unwrap_err();
+        assert!(matches!(error, WasmCommunicationError::Closed));
+        assert!(error.is_fatal());
+    }
+
+    #[tokio::test]
+    async fn receive_returns_recoverable_lagged_when_receiver_falls_behind() {
+        let (tx, rx) = broadcast::channel::<IncomingMessage>(1);
+        let receiver = RwLock::new(rx);
+
+        // Overflow the buffer without receiving so the next recv reports lag.
+        for _ in 0..3 {
+            tx.send(test_message()).expect("send should not fail");
+        }
+
+        let error = receiver.receive().await.unwrap_err();
+        assert!(matches!(error, WasmCommunicationError::Lagged(_)));
+        assert!(!error.is_fatal());
     }
 }


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-39051

## 📔 Objective

The IPC client (`bitwarden-ipc`) runs a single long-lived processing loop that is shared across every peer and every message. Previously, *any* transport or crypto error (a handshake timeout, a peer disconnecting mid-send, a malformed frame, a lagged broadcast) tore that loop down via `stop_inner`, permanently disabling the shared `IpcClient` with no path to recovery.

Concretely: the browser extension calls `ipcRequestDiscover("DesktopRenderer")` on a reconnect loop. When the desktop app is down, the Noise handshake times out → `crypto.send` returns an error → `stop_inner` kills the shared client forever. Even after the desktop comes back up, every later `request()` fails at the closed `incoming` channel with "channel closed".

This PR classifies errors as **fatal** vs **recoverable** and only stops the client on fatal errors:

- New `IpcErrorKind` trait with `fn is_fatal(&self) -> bool`, bounded on the associated `SendError`/`ReceiveError` types of `CommunicationBackend`, `CommunicationBackendReceiver`, and `CryptoProvider`.
- Errors are classified at construction (where the most context exists), defaulting ambiguous cases to recoverable (fail-open keeps the shared client alive).
- `NoiseCryptoProviderError`: handshake/timeout/decryption failures → recoverable; `TransportSend`/`TransportReceive` carry a `fatal` flag derived from the underlying backend error's classification.
- `IpcClient::send` only calls `stop_inner` when the error is fatal; otherwise it returns the error and leaves the client running. The receive loop `continue`s on recoverable errors instead of `break`ing.
- The WASM backend uses a structured `WasmCommunicationError` (`JsError` / `Lagged` / `Closed`) instead of a bare `String`. `JsError` (JS-side send failures) and `Lagged` (receiver fell behind) are recoverable; **`Closed` (all senders dropped) is fatal**, so the loop stops cleanly instead of busy-looping on a permanently-closed channel that returns an error immediately and forever. The previously-blanket `impl IpcErrorKind for String` is removed to avoid silently classifying all string errors as recoverable.

**Tests:** recoverable send/receive errors leave the client running while fatal errors still stop it; the WASM receiver maps `Closed` → fatal and `Lagged` → recoverable.

## 🚨 Breaking Changes

Adds a supertrait-style bound (`IpcErrorKind`) to the public `CommunicationBackend`/`CommunicationBackendReceiver`/`CryptoProvider` associated error types. Any **out-of-crate Rust implementor** of those traits would now also need to implement `IpcErrorKind`. All current implementors live inside this repo and are updated here; TypeScript/WASM clients consume the bindings (not Rust trait impls) and are unaffected. The automated TypeScript compatibility check will confirm no client breakage.
