### PR TITLE
[PM-35105] Extract shared key-envelope helpers in bitwarden-crypto

### DIFF
--- a/crates/bitwarden-crypto/src/safe/helpers.rs
+++ b/crates/bitwarden-crypto/src/safe/helpers.rs
@@ -2,13 +2,9 @@ use std::fmt::DebugStruct;
 
 use ciborium::Value;
 
-use crate::{
-    KEY_ID_SIZE,
-    cose::{
-        CONTAINED_KEY_ID, ContentNamespace, SAFE_CONTENT_NAMESPACE, SAFE_OBJECT_NAMESPACE,
-        SafeObjectNamespace, extract_bytes, extract_integer,
-    },
-    keys::KeyId,
+use crate::cose::{
+    ContentNamespace, SAFE_CONTENT_NAMESPACE, SAFE_OBJECT_NAMESPACE, SafeObjectNamespace,
+    extract_integer,
 };
 
 #[derive(Debug)]
@@ -51,7 +47,7 @@ pub(super) fn debug_fmt<C: ContentNamespace>(
     }
 }
 
-fn set_header_value(header: &mut coset::Header, label: i64, value: Value) {
+pub(super) fn set_header_value(header: &mut coset::Header, label: i64, value: Value) {
     if let Some((_, existing_value)) =
         header
             .rest
@@ -110,18 +106,6 @@ pub(super) fn validate_safe_namespaces<T: ContentNamespace>(
         // If the namespace is present but invalid (e.g., not an integer or out of range), return an
         // error.
         Err(ExtractionError::InvalidNamespace) => Err(ExtractionError::InvalidNamespace),
-    }
-}
-
-/// Extract the contained key ID from a COSE header, if present.
-pub(super) fn extract_contained_key_id(header: &coset::Header) -> Result<Option<KeyId>, ()> {
-    let key_id_bytes = extract_bytes(header, CONTAINED_KEY_ID, "key id");
-
-    if let Ok(bytes) = key_id_bytes {
-        let key_id_array: [u8; KEY_ID_SIZE] = bytes.as_slice().try_into().map_err(|_| ())?;
-        Ok(Some(KeyId::from(key_id_array)))
-    } else {
-        Ok(None)
     }
 }
 

--- a/crates/bitwarden-crypto/src/safe/mod.rs
+++ b/crates/bitwarden-crypto/src/safe/mod.rs
@@ -9,3 +9,97 @@ pub use symmetric_key_envelope::*;
 mod data_envelope;
 pub use data_envelope::*;
 mod helpers;
+
+use ciborium::Value;
+
+use crate::{
+    BitwardenLegacyKeyBytes, ContentFormat, CoseKeyBytes, EncodedSymmetricKey, KEY_ID_SIZE,
+    SymmetricCryptoKey,
+    cose::{CONTAINED_KEY_ID, extract_bytes},
+    keys::KeyId,
+    safe::helpers::set_header_value,
+};
+
+/// Failure modes when decoding the raw key bytes recovered from a key envelope back into a
+/// [`SymmetricCryptoKey`]. See [`decode_sealed_symmetric_key`].
+pub(super) enum DecodeSealedKeyError {
+    /// The protected header did not declare a valid content format.
+    InvalidContentFormat,
+    /// The declared content format is not a supported symmetric key encoding.
+    UnsupportedContentFormat,
+    /// The decoded bytes do not form a valid symmetric key.
+    InvalidKey,
+}
+
+/// Decodes the raw key bytes recovered from a key envelope into a [`SymmetricCryptoKey`], using the
+/// content format declared in the envelope's protected `header`.
+///
+/// Shared by the key envelopes
+/// ([`PasswordProtectedKeyEnvelope`], `SecretProtectedKeyEnvelope`, and [`SymmetricKeyEnvelope`]),
+/// which all store the wrapped key using the same content-format-tagged encoding.
+pub(super) fn decode_sealed_symmetric_key(
+    header: &coset::Header,
+    key_bytes: Vec<u8>,
+) -> Result<SymmetricCryptoKey, DecodeSealedKeyError> {
+    let encoded_key = match ContentFormat::try_from(header)
+        .map_err(|_| DecodeSealedKeyError::InvalidContentFormat)?
+    {
+        ContentFormat::BitwardenLegacyKey => {
+            EncodedSymmetricKey::BitwardenLegacyKey(BitwardenLegacyKeyBytes::from(key_bytes))
+        }
+        ContentFormat::CoseKey => EncodedSymmetricKey::CoseKey(CoseKeyBytes::from(key_bytes)),
+        _ => return Err(DecodeSealedKeyError::UnsupportedContentFormat),
+    };
+    SymmetricCryptoKey::try_from(encoded_key).map_err(|_| DecodeSealedKeyError::InvalidKey)
+}
+
+/// Extract the contained key ID from a COSE header, if present.
+/// Only COSE keys have a key ID; legacy keys do not.
+pub(super) fn extract_key_id(header: &coset::Header) -> Result<Option<KeyId>, ()> {
+    let key_id_bytes = extract_bytes(header, CONTAINED_KEY_ID, "key id");
+
+    if let Ok(bytes) = key_id_bytes {
+        let key_id_array: [u8; KEY_ID_SIZE] = bytes.as_slice().try_into().map_err(|_| ())?;
+        Ok(Some(KeyId::from(key_id_array)))
+    } else {
+        Ok(None)
+    }
+}
+
+/// Set the contained key ID on a COSE header, if present.
+pub(super) fn set_contained_key_id(header: &mut coset::Header, key_id: Option<KeyId>) {
+    if let Some(key_id) = key_id {
+        set_header_value(header, CONTAINED_KEY_ID, Value::from(Vec::from(&key_id)));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn set_contained_key_id_round_trips_through_extract_key_id() {
+        let key_id = KeyId::from([7u8; KEY_ID_SIZE]);
+        let mut header = coset::HeaderBuilder::new().build();
+
+        set_contained_key_id(&mut header, Some(key_id.clone()));
+
+        assert_eq!(extract_key_id(&header), Ok(Some(key_id)));
+    }
+
+    #[test]
+    fn extract_key_id_returns_none_when_absent() {
+        let header = coset::HeaderBuilder::new().build();
+
+        assert_eq!(extract_key_id(&header), Ok(None));
+    }
+
+    #[test]
+    fn set_contained_key_id_with_none_leaves_header_without_key_id() {
+        let mut header = coset::HeaderBuilder::new().build();
+
+        set_contained_key_id(&mut header, None);
+
+        assert_eq!(extract_key_id(&header), Ok(None));
+    }
+}

--- a/crates/bitwarden-crypto/src/safe/password_protected_key_envelope.rs
+++ b/crates/bitwarden-crypto/src/safe/password_protected_key_envelope.rs
@@ -26,16 +26,18 @@ use thiserror::Error;
 use wasm_bindgen::convert::{FromWasmAbi, IntoWasmAbi, OptionFromWasmAbi};
 
 use crate::{
-    BitwardenLegacyKeyBytes, ContentFormat, CoseKeyBytes, EncodedSymmetricKey, KEY_ID_SIZE,
-    KeySlotIds, KeyStoreContext, SymmetricCryptoKey,
+    ContentFormat, EncodedSymmetricKey, KeySlotIds, KeyStoreContext, SymmetricCryptoKey,
     cose::{
         ALG_ARGON2ID13, ARGON2_ITERATIONS, ARGON2_MEMORY, ARGON2_PARALLELISM, ARGON2_SALT,
-        CONTAINED_KEY_ID, ContentNamespace, CoseExtractError, SafeObjectNamespace, extract_bytes,
-        extract_integer,
+        ContentNamespace, CoseExtractError, SafeObjectNamespace, extract_bytes, extract_integer,
         symmetric::{CoseContentEncryptionAlgorithm, decrypt_cose, encrypt_cose},
     },
     keys::KeyId,
-    safe::helpers::{debug_fmt, set_safe_namespaces, validate_safe_namespaces},
+    safe::{
+        DecodeSealedKeyError, decode_sealed_symmetric_key, extract_key_id,
+        helpers::{debug_fmt, set_safe_namespaces, validate_safe_namespaces},
+        set_contained_key_id,
+    },
 };
 
 /// 16 is the RECOMMENDED salt size for all applications:
@@ -116,11 +118,8 @@ impl PasswordProtectedKeyEnvelope {
         };
 
         let protected_header = {
-            let mut hdr = HeaderBuilder::from(content_format);
-            if let Some(key_id) = key_to_seal.key_id() {
-                hdr = hdr.value(CONTAINED_KEY_ID, Value::from(Vec::from(&key_id)));
-            }
-            let mut header = hdr.build();
+            let mut header = HeaderBuilder::from(content_format).build();
+            set_contained_key_id(&mut header, key_to_seal.key_id());
             set_safe_namespaces(
                 &mut header,
                 SafeObjectNamespace::PasswordProtectedKeyEnvelope,
@@ -216,24 +215,21 @@ impl PasswordProtectedKeyEnvelope {
         )
         .map_err(|_| PasswordProtectedKeyEnvelopeError::WrongPassword)?;
 
-        SymmetricCryptoKey::try_from(
-            match ContentFormat::try_from(&self.cose_encrypt.protected.header).map_err(|_| {
-                PasswordProtectedKeyEnvelopeError::Parsing("Invalid content format".to_string())
-            })? {
-                ContentFormat::BitwardenLegacyKey => EncodedSymmetricKey::BitwardenLegacyKey(
-                    BitwardenLegacyKeyBytes::from(key_bytes),
-                ),
-                ContentFormat::CoseKey => {
-                    EncodedSymmetricKey::CoseKey(CoseKeyBytes::from(key_bytes))
+        decode_sealed_symmetric_key(&self.cose_encrypt.protected.header, key_bytes).map_err(|e| {
+            match e {
+                DecodeSealedKeyError::InvalidContentFormat => {
+                    PasswordProtectedKeyEnvelopeError::Parsing("Invalid content format".to_string())
                 }
-                _ => {
-                    return Err(PasswordProtectedKeyEnvelopeError::Parsing(
+                DecodeSealedKeyError::UnsupportedContentFormat => {
+                    PasswordProtectedKeyEnvelopeError::Parsing(
                         "Unknown or unsupported content format".to_string(),
-                    ));
+                    )
                 }
-            },
-        )
-        .map_err(|_| PasswordProtectedKeyEnvelopeError::Parsing("Failed to decode key".to_string()))
+                DecodeSealedKeyError::InvalidKey => {
+                    PasswordProtectedKeyEnvelopeError::Parsing("Failed to decode key".to_string())
+                }
+            }
+        })
     }
 
     /// Re-seals the key with new KDF parameters (updated settings, salt), and a new password
@@ -250,20 +246,8 @@ impl PasswordProtectedKeyEnvelope {
     /// Get the key ID of the contained key, if the key ID is stored on the envelope headers.
     /// Only COSE keys have a key ID, legacy keys do not.
     pub fn contained_key_id(&self) -> Result<Option<KeyId>, PasswordProtectedKeyEnvelopeError> {
-        let key_id_bytes = extract_bytes(
-            &self.cose_encrypt.protected.header,
-            CONTAINED_KEY_ID,
-            "key id",
-        );
-
-        if let Ok(bytes) = key_id_bytes {
-            let key_id_array: [u8; KEY_ID_SIZE] = bytes.as_slice().try_into().map_err(|_| {
-                PasswordProtectedKeyEnvelopeError::Parsing("Invalid key id".to_string())
-            })?;
-            Ok(Some(KeyId::from(key_id_array)))
-        } else {
-            Ok(None)
-        }
+        extract_key_id(&self.cose_encrypt.protected.header)
+            .map_err(|_| PasswordProtectedKeyEnvelopeError::Parsing("Invalid key id".to_string()))
     }
 }
 
@@ -680,9 +664,8 @@ mod tests {
                 &mut ctx,
             )
             .expect("Unsealing should succeed");
-        #[allow(deprecated)]
         let unsealed_key = ctx
-            .dangerous_get_symmetric_key(key)
+            .get_symmetric_key(key)
             .expect("Key should exist in the key store");
         assert_eq!(
             unsealed_key.to_encoded().to_vec(),
@@ -704,9 +687,8 @@ mod tests {
                 &mut ctx,
             )
             .expect("Unsealing should succeed");
-        #[allow(deprecated)]
         let unsealed_key = ctx
-            .dangerous_get_symmetric_key(key)
+            .get_symmetric_key(key)
             .expect("Key should exist in the key store");
         assert_eq!(
             unsealed_key.to_encoded().to_vec(),
@@ -744,14 +726,12 @@ mod tests {
             .unwrap();
 
         // Verify that the unsealed key matches the original key
-        #[allow(deprecated)]
         let unsealed_key = ctx
-            .dangerous_get_symmetric_key(key)
+            .get_symmetric_key(key)
             .expect("Key should exist in the key store");
 
-        #[allow(deprecated)]
         let key_before_sealing = ctx
-            .dangerous_get_symmetric_key(test_key)
+            .get_symmetric_key(test_key)
             .expect("Key should exist in the key store");
 
         assert_eq!(unsealed_key, key_before_sealing);
@@ -787,14 +767,12 @@ mod tests {
             .unwrap();
 
         // Verify that the unsealed key matches the original key
-        #[allow(deprecated)]
         let unsealed_key = ctx
-            .dangerous_get_symmetric_key(key)
+            .get_symmetric_key(key)
             .expect("Key should exist in the key store");
 
-        #[allow(deprecated)]
         let key_before_sealing = ctx
-            .dangerous_get_symmetric_key(test_key)
+            .get_symmetric_key(test_key)
             .expect("Key should exist in the key store");
 
         assert_eq!(unsealed_key, key_before_sealing);
@@ -913,12 +891,7 @@ mod tests {
         let key_store = KeyStore::<TestIds>::default();
         let mut ctx: KeyStoreContext<'_, TestIds> = key_store.context_mut();
         let test_key = ctx.make_symmetric_key(SymmetricKeyAlgorithm::XChaCha20Poly1305);
-        #[allow(deprecated)]
-        let key_id = ctx
-            .dangerous_get_symmetric_key(test_key)
-            .unwrap()
-            .key_id()
-            .unwrap();
+        let key_id = ctx.get_symmetric_key(test_key).unwrap().key_id().unwrap();
 
         let password = "test_password";
 

--- a/crates/bitwarden-crypto/src/safe/symmetric_key_envelope.rs
+++ b/crates/bitwarden-crypto/src/safe/symmetric_key_envelope.rs
@@ -3,7 +3,6 @@
 use std::str::FromStr;
 
 use bitwarden_encoding::{B64, FromStrVisitor};
-use ciborium::Value;
 use coset::{CborSerializable, CoseEncrypt0Builder, HeaderBuilder};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
@@ -11,15 +10,17 @@ use thiserror::Error;
 use wasm_bindgen::convert::FromWasmAbi;
 
 use crate::{
-    BitwardenLegacyKeyBytes, ContentFormat, CoseKeyBytes, EncodedSymmetricKey, KeySlotIds,
-    KeyStoreContext, SymmetricCryptoKey, XChaCha20Poly1305Key,
+    ContentFormat, EncodedSymmetricKey, KeySlotIds, KeyStoreContext, SymmetricCryptoKey,
+    XChaCha20Poly1305Key,
     cose::{
-        CONTAINED_KEY_ID, ContentNamespace, SafeObjectNamespace,
+        ContentNamespace, SafeObjectNamespace,
         symmetric::{CoseContentEncryptionAlgorithm, decrypt_cose0, encrypt_cose0},
     },
     keys::KeyId,
-    safe::helpers::{
-        debug_fmt, extract_contained_key_id, set_safe_namespaces, validate_safe_namespaces,
+    safe::{
+        DecodeSealedKeyError, decode_sealed_symmetric_key, extract_key_id,
+        helpers::{debug_fmt, set_safe_namespaces, validate_safe_namespaces},
+        set_contained_key_id,
     },
 };
 
@@ -86,15 +87,10 @@ impl SymmetricKeyEnvelope {
             EncodedSymmetricKey::CoseKey(key_bytes) => (ContentFormat::CoseKey, key_bytes.to_vec()),
         };
 
-        let mut header_builder = HeaderBuilder::from(content_format);
+        let mut protected_header = HeaderBuilder::from(content_format).build();
 
-        // Only set the contained key ID if the key has one
-        if let Some(key_id) = key_to_seal.key_id() {
-            header_builder =
-                header_builder.value(CONTAINED_KEY_ID, Value::from(Vec::from(&key_id)));
-        }
+        set_contained_key_id(&mut protected_header, key_to_seal.key_id());
 
-        let mut protected_header = header_builder.build();
         set_safe_namespaces(
             &mut protected_header,
             SafeObjectNamespace::SymmetricKeyEnvelope,
@@ -141,12 +137,9 @@ impl SymmetricKeyEnvelope {
         )
         .map_err(|_| SymmetricKeyEnvelopeError::InvalidNamespace)?;
 
-        // Validate the content format
-        let content_format = ContentFormat::try_from(&self.cose_encrypt0.protected.header)
-            .map_err(|_| {
-                SymmetricKeyEnvelopeError::Parsing("Invalid content format".to_string())
-            })?;
-
+        // Decrypt the key bytes. `decrypt_cose0` also validates that the declared
+        // content-encryption algorithm matches the cipher before attempting decryption. The
+        // envelope always declares the algorithm, so no decryption fallback is needed.
         let key_bytes = decrypt_cose0(
             &self.cose_encrypt0,
             None,
@@ -154,26 +147,21 @@ impl SymmetricKeyEnvelope {
         )
         .map_err(|_| SymmetricKeyEnvelopeError::WrongKey)?;
 
-        // Reconstruct the encoded symmetric key from the content format
-        let encoded_key = match content_format {
-            ContentFormat::BitwardenLegacyKey => {
-                EncodedSymmetricKey::BitwardenLegacyKey(BitwardenLegacyKeyBytes::from(key_bytes))
-            }
-            ContentFormat::CoseKey => EncodedSymmetricKey::CoseKey(CoseKeyBytes::from(key_bytes)),
-            _ => {
-                return Err(SymmetricKeyEnvelopeError::WrongKeyType);
-            }
-        };
-
-        let key = SymmetricCryptoKey::try_from(encoded_key)
-            .map_err(|_| SymmetricKeyEnvelopeError::WrongKeyType)?;
+        let key = decode_sealed_symmetric_key(&self.cose_encrypt0.protected.header, key_bytes)
+            .map_err(|e| match e {
+                DecodeSealedKeyError::InvalidContentFormat => {
+                    SymmetricKeyEnvelopeError::Parsing("Invalid content format".to_string())
+                }
+                DecodeSealedKeyError::UnsupportedContentFormat
+                | DecodeSealedKeyError::InvalidKey => SymmetricKeyEnvelopeError::WrongKeyType,
+            })?;
 
         Ok(ctx.add_local_symmetric_key(key))
     }
 
     /// Get the key ID of the contained key.
     pub fn contained_key_id(&self) -> Result<Option<KeyId>, SymmetricKeyEnvelopeError> {
-        extract_contained_key_id(&self.cose_encrypt0.protected.header)
+        extract_key_id(&self.cose_encrypt0.protected.header)
             .map_err(|_| SymmetricKeyEnvelopeError::Parsing("Invalid contained key id".to_string()))
     }
 }


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-35105

## 📔 Objective

Stacked PR **3/4** (on top of #1202).

Factors the duplicated key-decode and contained-key-id logic out of the symmetric-key and password-protected envelopes into shared helpers (`decode_sealed_symmetric_key`, `extract_key_id`, `set_contained_key_id`) on the `safe` module, and exposes `set_header_value` to the module. No behavior change.

Base: `km/hazmat-cose-symmetric` (#1202).