### PR TITLE
[PM-38851] crypto cipher suite

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -721,6 +721,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "bitwarden-crypto-cipher-suite"
+version = "3.0.0"
+dependencies = [
+ "bitwarden-core",
+ "bitwarden-crypto",
+ "tsify",
+ "uniffi",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "bitwarden-encoding"
 version = "3.0.0"
 dependencies = [
@@ -986,6 +997,7 @@ dependencies = [
  "bitwarden-commercial-vault",
  "bitwarden-core",
  "bitwarden-crypto",
+ "bitwarden-crypto-cipher-suite",
  "bitwarden-exporters",
  "bitwarden-fido",
  "bitwarden-generators",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ bitwarden-commercial-vault = { path = "bitwarden_license/bitwarden-commercial-va
 bitwarden-core = { path = "crates/bitwarden-core", version = "=3.0.0" }
 bitwarden-core-macro = { path = "crates/bitwarden-core-macro", version = "=3.0.0" }
 bitwarden-crypto = { path = "crates/bitwarden-crypto", version = "=3.0.0" }
+bitwarden-crypto-cipher-suite = { path = "crates/bitwarden-crypto-cipher-suite", version = "=3.0.0" }
 bitwarden-encoding = { path = "crates/bitwarden-encoding", version = "=3.0.0" }
 bitwarden-error = { path = "crates/bitwarden-error", version = "=3.0.0" }
 bitwarden-error-macro = { path = "crates/bitwarden-error-macro", version = "=3.0.0" }

--- a/crates/bitwarden-core/src/client/builder.rs
+++ b/crates/bitwarden-core/src/client/builder.rs
@@ -3,7 +3,7 @@ use std::sync::RwLock;
 use std::sync::{Arc, OnceLock};
 
 use bitwarden_api_base::new_http_client_builder;
-use bitwarden_crypto::KeyStore;
+use bitwarden_crypto::{CipherSuite, KeyStore};
 use bitwarden_state::registry::StateRegistry;
 use reqwest::header::{self, HeaderValue};
 
@@ -132,7 +132,7 @@ impl ClientBuilder {
             client: bw_http_client,
         };
 
-        Client {
+        let client = Client {
             internal: Arc::new(InternalClient {
                 user_id: OnceLock::new(),
                 token_handler: self.token_handler,
@@ -145,7 +145,18 @@ impl ClientBuilder {
                 state_bridge: StateBridge::new(),
                 state_registry,
             }),
-        }
+        };
+
+        // Configure the key store's cipher suite from the client's environment, so all crypto
+        // operations (e.g. the KDF for a new account) pick compliant algorithms.
+        // TODO: gov_mode() is a placeholder that always returns false until PM-38266 lands; once it
+        // does, this automatically resolves to the FIPS suite in gov environments.
+        client
+            .internal
+            .get_key_store()
+            .set_cipher_suite(CipherSuite::from_gov_mode(client.gov_mode()));
+
+        client
     }
 }
 

--- a/crates/bitwarden-core/src/client/builder.rs
+++ b/crates/bitwarden-core/src/client/builder.rs
@@ -149,8 +149,6 @@ impl ClientBuilder {
 
         // Configure the key store's cipher suite from the client's environment, so all crypto
         // operations (e.g. the KDF for a new account) pick compliant algorithms.
-        // TODO: gov_mode() is a placeholder that always returns false until PM-38266 lands; once it
-        // does, this automatically resolves to the FIPS suite in gov environments.
         client
             .internal
             .get_key_store()

--- a/crates/bitwarden-core/src/client/client.rs
+++ b/crates/bitwarden-core/src/client/client.rs
@@ -49,4 +49,12 @@ impl Client {
     pub fn builder() -> ClientBuilder {
         ClientBuilder::new()
     }
+
+    /// Whether the client is in Gov Mode (FedRAMP).
+    ///
+    /// TODO: Placeholder that always returns `false` until the real implementation lands in
+    /// <https://bitwarden.atlassian.net/browse/PM-38266>.
+    pub fn gov_mode(&self) -> bool {
+        false
+    }
 }

--- a/crates/bitwarden-core/src/key_management/crypto.rs
+++ b/crates/bitwarden-core/src/key_management/crypto.rs
@@ -1186,7 +1186,7 @@ pub(crate) fn make_user_jit_master_password_registration(
     let (user_key_id, wrapped_state) = WrappedAccountCryptographicState::make(&mut ctx)
         .map_err(MakeKeysError::AccountCryptographyInitialization)?;
 
-    let kdf = Kdf::default_argon2();
+    let kdf = ctx.cipher_suite().default_kdf_for_new_account();
 
     #[expect(deprecated)]
     let user_key = ctx.dangerous_get_symmetric_key(user_key_id)?.to_owned();
@@ -1245,7 +1245,7 @@ pub(crate) fn make_user_password_registration(
     let (user_key_id, wrapped_state) = WrappedAccountCryptographicState::make(&mut ctx)
         .map_err(MakeKeysError::AccountCryptographyInitialization)?;
 
-    let kdf = Kdf::default_argon2();
+    let kdf = ctx.cipher_suite().default_kdf_for_new_account();
 
     #[expect(deprecated)]
     let user_key = ctx.dangerous_get_symmetric_key(user_key_id)?.to_owned();

--- a/crates/bitwarden-crypto-cipher-suite/Cargo.toml
+++ b/crates/bitwarden-crypto-cipher-suite/Cargo.toml
@@ -1,0 +1,35 @@
+[package]
+name = "bitwarden-crypto-cipher-suite"
+description = """
+Internal crate for the bitwarden crate. Do not use.
+"""
+
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+readme.workspace = true
+homepage.workspace = true
+repository.workspace = true
+license-file.workspace = true
+keywords.workspace = true
+
+[features]
+default = []
+uniffi = ["bitwarden-core/uniffi", "bitwarden-crypto/uniffi", "dep:uniffi"]
+wasm = [
+    "bitwarden-core/wasm",
+    "bitwarden-crypto/wasm",
+    "dep:tsify",
+    "dep:wasm-bindgen",
+]
+
+[dependencies]
+bitwarden-core = { workspace = true }
+bitwarden-crypto = { workspace = true }
+tsify = { workspace = true, optional = true }
+uniffi = { workspace = true, optional = true }
+wasm-bindgen = { workspace = true, optional = true }
+
+[lints]
+workspace = true

--- a/crates/bitwarden-crypto-cipher-suite/README.md
+++ b/crates/bitwarden-crypto-cipher-suite/README.md
@@ -1,0 +1,6 @@
+# bitwarden-crypto-cipher-suite
+
+Decides which cryptographic algorithms are allowed for the current user/environment.
+
+Gov Mode (FedRAMP) deployments must use the FIPS-approved PBKDF2 for a new account's KDF, while
+everyone else uses the modern Argon2id default.

--- a/crates/bitwarden-crypto-cipher-suite/src/cipher_suite_client.rs
+++ b/crates/bitwarden-crypto-cipher-suite/src/cipher_suite_client.rs
@@ -1,0 +1,100 @@
+use bitwarden_core::{Client, FromClient, key_management::KeySlotIds};
+use bitwarden_crypto::{Kdf, KeyStore};
+#[cfg(feature = "wasm")]
+use wasm_bindgen::prelude::wasm_bindgen;
+
+/// Tells you which cryptographic algorithms to use for the current account and environment.
+///
+/// Some environments are restricted in which algorithms they may use — for example, government
+/// (FedRAMP) deployments must use FIPS-approved algorithms. Ask this client which algorithm to use
+/// instead of picking one yourself, so the choice stays correct as those rules change.
+#[cfg_attr(feature = "wasm", wasm_bindgen)]
+#[derive(FromClient)]
+pub struct CryptoCipherSuiteClient {
+    pub(crate) key_store: KeyStore<KeySlotIds>,
+}
+
+#[cfg_attr(feature = "wasm", wasm_bindgen)]
+impl CryptoCipherSuiteClient {
+    /// Returns the KDF a new account should use in the current environment.
+    ///
+    /// In a FIPS (gov) environment the FIPS-approved PBKDF2 is used; otherwise the modern Argon2id
+    /// default.
+    pub fn default_kdf_for_new_account(&self) -> Kdf {
+        self.key_store
+            .context()
+            .cipher_suite()
+            .default_kdf_for_new_account()
+    }
+
+    /// Returns whether the given KDF is allowed in the current environment.
+    ///
+    /// Intended for surfaces that let a user pick a KDF (e.g. the Change KDF settings screen): the
+    /// caller can validate or filter the options it offers. In a FIPS (gov) environment only PBKDF2
+    /// is allowed; otherwise every supported KDF is allowed.
+    pub fn is_kdf_compliant(&self, kdf: Kdf) -> bool {
+        self.key_store
+            .context()
+            .cipher_suite()
+            .is_kdf_compliant(&kdf)
+    }
+}
+
+/// Extension trait that exposes [`CryptoCipherSuiteClient`] on [`Client`].
+pub trait CryptoCipherSuiteClientExt {
+    /// Returns a [`CryptoCipherSuiteClient`] for the current environment.
+    fn crypto_cipher_suite(&self) -> CryptoCipherSuiteClient;
+}
+
+impl CryptoCipherSuiteClientExt for Client {
+    fn crypto_cipher_suite(&self) -> CryptoCipherSuiteClient {
+        CryptoCipherSuiteClient::from_client(self)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use bitwarden_core::{Client, ClientSettings};
+    use bitwarden_crypto::CipherSuite;
+
+    use super::*;
+
+    fn client_with_suite(cipher_suite: CipherSuite) -> Client {
+        let client = Client::new(Some(ClientSettings::default()));
+        client
+            .internal
+            .get_key_store()
+            .set_cipher_suite(cipher_suite);
+        client
+    }
+
+    #[test]
+    fn default_kdf_for_new_account_is_argon2_under_standard() {
+        let kdf = client_with_suite(CipherSuite::Standard)
+            .crypto_cipher_suite()
+            .default_kdf_for_new_account();
+        assert!(matches!(kdf, Kdf::Argon2id { .. }));
+    }
+
+    #[test]
+    fn default_kdf_for_new_account_is_pbkdf2_under_fips() {
+        let kdf = client_with_suite(CipherSuite::Fips)
+            .crypto_cipher_suite()
+            .default_kdf_for_new_account();
+        assert!(matches!(kdf, Kdf::PBKDF2 { .. }));
+    }
+
+    #[test]
+    fn every_kdf_is_compliant_under_standard() {
+        let client = client_with_suite(CipherSuite::Standard).crypto_cipher_suite();
+        assert!(client.is_kdf_compliant(Kdf::default_argon2()));
+        assert!(client.is_kdf_compliant(Kdf::default_pbkdf2()));
+    }
+
+    #[test]
+    fn only_pbkdf2_is_compliant_under_fips() {
+        let client = client_with_suite(CipherSuite::Fips).crypto_cipher_suite();
+        assert!(client.is_kdf_compliant(Kdf::default_pbkdf2()));
+        assert!(!client.is_kdf_compliant(Kdf::default_argon2()));
+    }
+}

--- a/crates/bitwarden-crypto-cipher-suite/src/lib.rs
+++ b/crates/bitwarden-crypto-cipher-suite/src/lib.rs
@@ -1,0 +1,4 @@
+#![doc = include_str!("../README.md")]
+
+mod cipher_suite_client;
+pub use cipher_suite_client::{CryptoCipherSuiteClient, CryptoCipherSuiteClientExt};

--- a/crates/bitwarden-crypto/src/lib.rs
+++ b/crates/bitwarden-crypto/src/lib.rs
@@ -35,7 +35,7 @@ pub use wordlist::EFF_LONG_WORD_LIST;
 mod store;
 #[expect(deprecated)]
 pub use store::{
-    KeyStore, KeyStoreContext, RotatedUserKeys, dangerous_get_v2_rotated_account_keys,
+    CipherSuite, KeyStore, KeyStoreContext, RotatedUserKeys, dangerous_get_v2_rotated_account_keys,
 };
 mod cose;
 pub(crate) use cose::CONTENT_TYPE_PADDED_CBOR;

--- a/crates/bitwarden-crypto/src/store/cipher_suite.rs
+++ b/crates/bitwarden-crypto/src/store/cipher_suite.rs
@@ -1,0 +1,95 @@
+use crate::Kdf;
+
+/// The set of cryptographic algorithms a [`super::KeyStore`] is allowed to use, determined by the
+/// environment it operates in.
+///
+/// It is set once when the store is constructed (see [`super::KeyStore::set_cipher_suite`]) and
+/// read through [`super::KeyStoreContext`] by operations that must pick a compliant algorithm, such
+/// as the KDF for a new account.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum CipherSuite {
+    /// The default suite, using the modern recommended algorithms (e.g. Argon2id).
+    #[default]
+    Standard,
+    /// The FIPS-compliant suite required in government (FedRAMP) environments, restricted to
+    /// FIPS-approved algorithms (e.g. PBKDF2).
+    Fips,
+}
+
+impl CipherSuite {
+    /// Returns the [`CipherSuite`] for the current environment, given whether the client is in
+    /// Gov Mode (FedRAMP).
+    pub fn from_gov_mode(gov_mode: bool) -> Self {
+        if gov_mode {
+            CipherSuite::Fips
+        } else {
+            CipherSuite::Standard
+        }
+    }
+
+    /// Returns the KDF a new account should use under this suite.
+    ///
+    /// [`CipherSuite::Fips`] uses the FIPS-approved PBKDF2; [`CipherSuite::Standard`] uses the
+    /// modern Argon2id default.
+    pub fn default_kdf_for_new_account(self) -> Kdf {
+        match self {
+            CipherSuite::Standard => Kdf::default_argon2(),
+            CipherSuite::Fips => Kdf::default_pbkdf2(),
+        }
+    }
+
+    /// Returns whether the given KDF is allowed under this suite.
+    ///
+    /// Under [`CipherSuite::Fips`] only PBKDF2 is FIPS-approved; under [`CipherSuite::Standard`]
+    /// every supported KDF is allowed.
+    pub fn is_kdf_compliant(self, kdf: &Kdf) -> bool {
+        match self {
+            CipherSuite::Standard => true,
+            CipherSuite::Fips => matches!(kdf, Kdf::PBKDF2 { .. }),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_is_standard() {
+        assert_eq!(CipherSuite::default(), CipherSuite::Standard);
+    }
+
+    #[test]
+    fn from_gov_mode_maps_to_suite() {
+        assert_eq!(CipherSuite::from_gov_mode(false), CipherSuite::Standard);
+        assert_eq!(CipherSuite::from_gov_mode(true), CipherSuite::Fips);
+    }
+
+    #[test]
+    fn standard_uses_argon2_for_new_account() {
+        assert!(matches!(
+            CipherSuite::Standard.default_kdf_for_new_account(),
+            Kdf::Argon2id { .. }
+        ));
+    }
+
+    #[test]
+    fn fips_uses_pbkdf2_for_new_account() {
+        assert!(matches!(
+            CipherSuite::Fips.default_kdf_for_new_account(),
+            Kdf::PBKDF2 { .. }
+        ));
+    }
+
+    #[test]
+    fn standard_allows_any_kdf() {
+        assert!(CipherSuite::Standard.is_kdf_compliant(&Kdf::default_argon2()));
+        assert!(CipherSuite::Standard.is_kdf_compliant(&Kdf::default_pbkdf2()));
+    }
+
+    #[test]
+    fn fips_allows_only_pbkdf2() {
+        assert!(CipherSuite::Fips.is_kdf_compliant(&Kdf::default_pbkdf2()));
+        assert!(!CipherSuite::Fips.is_kdf_compliant(&Kdf::default_argon2()));
+    }
+}

--- a/crates/bitwarden-crypto/src/store/context.rs
+++ b/crates/bitwarden-crypto/src/store/context.rs
@@ -7,7 +7,7 @@ use coset::iana::KeyOperation;
 use serde::Serialize;
 use zeroize::Zeroizing;
 
-use super::KeyStoreInner;
+use super::{CipherSuite, KeyStoreInner};
 use crate::{
     BitwardenLegacyKeyBytes, ContentFormat, CoseEncrypt0Bytes, CoseKeyBytes, CoseSerializable,
     CryptoError, EncString, KeyDecryptable, KeyEncryptable, KeyId, KeySlotId, KeySlotIds, LocalId,
@@ -85,6 +85,8 @@ pub struct KeyStoreContext<'a, Ids: KeySlotIds> {
 
     pub(super) security_state_version: u64,
 
+    pub(super) cipher_suite: CipherSuite,
+
     // Make sure the context is !Send & !Sync
     pub(super) _phantom: std::marker::PhantomData<(Cell<()>, RwLockReadGuard<'static, ()>)>,
 }
@@ -143,6 +145,12 @@ impl<Ids: KeySlotIds> KeyStoreContext<'_, Ids> {
     /// safely.
     pub fn get_security_state_version(&self) -> u64 {
         self.security_state_version
+    }
+
+    /// Returns the [CipherSuite] this context operates under, which determines the algorithms
+    /// operations are allowed to use in the current environment.
+    pub fn cipher_suite(&self) -> CipherSuite {
+        self.cipher_suite
     }
 
     /// Remove all symmetric keys from the context for which the predicate returns false

--- a/crates/bitwarden-crypto/src/store/mod.rs
+++ b/crates/bitwarden-crypto/src/store/mod.rs
@@ -29,9 +29,11 @@ use rayon::{iter::Either, prelude::*};
 use crate::{CompositeEncryptable, Decryptable, IdentifyKey, KeySlotId, KeySlotIds};
 
 mod backend;
+mod cipher_suite;
 mod context;
 
 use backend::{StoreBackend, create_store};
+pub use cipher_suite::CipherSuite;
 use context::GlobalKeys;
 pub use context::KeyStoreContext;
 
@@ -122,6 +124,7 @@ struct KeyStoreInner<Ids: KeySlotIds> {
     private_keys: Box<dyn StoreBackend<Ids::Private>>,
     signing_keys: Box<dyn StoreBackend<Ids::Signing>>,
     security_state_version: u64,
+    cipher_suite: CipherSuite,
 }
 
 /// Create a new key store with the best available implementation for the current platform.
@@ -133,6 +136,7 @@ impl<Ids: KeySlotIds> Default for KeyStore<Ids> {
                 private_keys: create_store(),
                 signing_keys: create_store(),
                 security_state_version: 1,
+                cipher_suite: CipherSuite::default(),
             })),
         }
     }
@@ -152,6 +156,14 @@ impl<Ids: KeySlotIds> KeyStore<Ids> {
     pub fn set_security_state_version(&self, version: u64) {
         let mut data = self.inner.write().expect("RwLock is poisoned");
         data.security_state_version = version;
+    }
+
+    /// Sets the [CipherSuite] for this store, which determines the algorithms operations are
+    /// allowed to use (e.g. the KDF for a new account). This should be set once when the store
+    /// is constructed, based on the client's environment.
+    pub fn set_cipher_suite(&self, cipher_suite: CipherSuite) {
+        let mut data = self.inner.write().expect("RwLock is poisoned");
+        data.cipher_suite = cipher_suite;
     }
 
     /// Initiate an encryption/decryption context. This context will have read only access to the
@@ -187,12 +199,14 @@ impl<Ids: KeySlotIds> KeyStore<Ids> {
     pub fn context(&'_ self) -> KeyStoreContext<'_, Ids> {
         let data = self.inner.read().expect("RwLock is poisoned");
         let security_state_version = data.security_state_version;
+        let cipher_suite = data.cipher_suite;
         KeyStoreContext {
             global_keys: GlobalKeys::ReadOnly(data),
             local_symmetric_keys: create_store(),
             local_private_keys: create_store(),
             local_signing_keys: create_store(),
             security_state_version,
+            cipher_suite,
             _phantom: std::marker::PhantomData,
         }
     }
@@ -220,12 +234,14 @@ impl<Ids: KeySlotIds> KeyStore<Ids> {
     pub fn context_mut(&'_ self) -> KeyStoreContext<'_, Ids> {
         let inner = self.inner.write().expect("RwLock is poisoned");
         let security_state_version = inner.security_state_version;
+        let cipher_suite = inner.cipher_suite;
         KeyStoreContext {
             global_keys: GlobalKeys::ReadWrite(inner),
             local_symmetric_keys: create_store(),
             local_private_keys: create_store(),
             local_signing_keys: create_store(),
             security_state_version,
+            cipher_suite,
             _phantom: std::marker::PhantomData,
         }
     }

--- a/crates/bitwarden-pm/Cargo.toml
+++ b/crates/bitwarden-pm/Cargo.toml
@@ -19,6 +19,7 @@ cli = ["bitwarden-unlock/cli"]
 no-memory-hardening = ["bitwarden-core/no-memory-hardening"]
 uniffi = [
     "bitwarden-core/uniffi",
+    "bitwarden-crypto-cipher-suite/uniffi",
     "bitwarden-exporters/uniffi",
     "bitwarden-fido/uniffi",
     "bitwarden-generators/uniffi",
@@ -33,6 +34,7 @@ wasm = [
     "bitwarden-auth/wasm",
     "bitwarden-commercial-vault/wasm",
     "bitwarden-core/wasm",
+    "bitwarden-crypto-cipher-suite/wasm",
     "bitwarden-exporters/wasm",
     "bitwarden-generators/wasm",
     "bitwarden-importers/wasm",
@@ -54,6 +56,7 @@ bitwarden-auth = { workspace = true }
 bitwarden-commercial-vault = { workspace = true, optional = true }
 bitwarden-core = { workspace = true, features = ["internal"] }
 bitwarden-crypto = { workspace = true }
+bitwarden-crypto-cipher-suite = { workspace = true }
 bitwarden-exporters = { workspace = true }
 bitwarden-fido = { workspace = true }
 bitwarden-generators = { workspace = true }

--- a/crates/bitwarden-pm/src/lib.rs
+++ b/crates/bitwarden-pm/src/lib.rs
@@ -10,6 +10,7 @@ use bitwarden_core::{
     FromClient,
     auth::{ClientManagedTokenHandler, ClientManagedTokens},
 };
+use bitwarden_crypto_cipher_suite::CryptoCipherSuiteClientExt as _;
 use bitwarden_exporters::ExporterClientExt as _;
 use bitwarden_generators::GeneratorClientsExt as _;
 use bitwarden_importers::ImporterClientExt as _;
@@ -28,6 +29,7 @@ uniffi::setup_scaffolding!();
 pub mod clients {
     pub use bitwarden_auth::AuthClient;
     pub use bitwarden_core::key_management::CryptoClient;
+    pub use bitwarden_crypto_cipher_suite::CryptoCipherSuiteClient;
     pub use bitwarden_exporters::ExporterClient;
     pub use bitwarden_generators::GeneratorClient;
     pub use bitwarden_importers::ImporterClient;
@@ -111,6 +113,11 @@ impl PasswordManagerClient {
     /// Crypto operations
     pub fn crypto(&self) -> bitwarden_core::key_management::CryptoClient {
         self.0.crypto()
+    }
+
+    /// Crypto cipher suite operations
+    pub fn crypto_cipher_suite(&self) -> bitwarden_crypto_cipher_suite::CryptoCipherSuiteClient {
+        self.0.crypto_cipher_suite()
     }
 
     /// Feature flag operations

--- a/crates/bitwarden-wasm-internal/src/client.rs
+++ b/crates/bitwarden-wasm-internal/src/client.rs
@@ -127,6 +127,11 @@ impl PasswordManagerClient {
     pub fn invite_link(&self) -> InviteLinkClient {
         self.0.invite_link()
     }
+
+    /// Crypto cipher suite operations.
+    pub fn crypto_cipher_suite(&self) -> CryptoCipherSuiteClient {
+        self.0.crypto_cipher_suite()
+    }
 }
 
 #[bitwarden_error(basic)]


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-38851

## 📔 Objective

Crypto cipher suite api and client, to help choose the correct cipher suites and algorithms when in Gov mode (FedRAMP environment).
Currently only supports KDF.
Crypto crate SAFE primitives outside of scope for this PR.
Mocks the `gov_mode` implementation to always return false - will be fixed by #1147. Note to Platform: This PR can be merged independently, since all environments as of today are in non-gov mode, hence have zero impact with this PR.

## 🚨 Breaking Changes

<!-- Does this PR introduce any breaking changes? If so, please describe the impact and migration path for clients.

If you're unsure, the automated TypeScript compatibility check will run when you open/update this PR and provide feedback.

For breaking changes:
1. Describe what changed in the client interface
2. Explain why the change was necessary
3. Provide migration steps for client developers
4. Link to any paired client PRs if needed

Otherwise, you can remove this section. -->
