### PR TITLE
fix: stop bitwarden-api-base Error from shadowing Swift.Error in UniFFI bindings

### DIFF
--- a/crates/bitwarden-api-base/src/error.rs
+++ b/crates/bitwarden-api-base/src/error.rs
@@ -16,8 +16,12 @@ pub struct ResponseContent {
 }
 
 /// Errors that can occur during API operations.
+///
+/// This type is intentionally not exposed over UniFFI. It is always wrapped into
+/// `bitwarden_core::ApiError` before crossing the FFI boundary, and that type carries the
+/// `uniffi::Error` derive. Deriving `uniffi::Error` here as well would export a second error type
+/// named `Error`, which collides with the `Swift.Error` protocol in the generated Swift bindings.
 #[derive(Debug)]
-#[cfg_attr(feature = "uniffi", derive(uniffi::Error), uniffi(flat_error))]
 pub enum Error<T = ()> {
     /// Error from the reqwest HTTP client.
     Reqwest(reqwest::Error),


### PR DESCRIPTION
## 🎟️ Tracking

Follow-up to #1049, which added `derive(uniffi::Error)` to `bitwarden_api_base::Error` in preparation for the API error merge (#1050). That derive broke the iOS build: UniFFI exported the type to Swift as a bare `Error`, shadowing the `Swift.Error` protocol. The clients team worked around it with `typealias Error = Swift.Error`.

## 📔 Objective

Remove the premature `derive(uniffi::Error)` from `bitwarden_api_base::Error` so it is no longer exported across the FFI boundary.

This type is never returned by a UniFFI-exported function — every API call funnels through `bitwarden_core::ApiError` (which carries its own `uniffi::Error` derive and is the type mobile actually consumes). The derive added in #1049 only pulled a dead, collision-causing `Error` type into the generated bindings.

Verified against the actual generated Swift bindings (host `uniffi-bindgen`):
- **Before:** `BitwardenApiBase.swift` declares `public enum Error: Swift.Error, ...` — the collision.
- **After:** no UniFFI type named `Error` in any module; `BitwardenCore.swift` still declares `public enum ApiError: Swift.Error, ...`, and `ResponseContent` is still exported.

This restores the exact pre-#1049 Swift surface. It is a single-crate change with no impact on the `apis::Error<T>` references throughout the feature crates, so it can land ahead of the heavier #1050.

Note for #1050: when it makes `bitwarden_api_base::Error` the unified API error, it should keep the Rust name and add `uniffi(flat_error, name = "ApiError")` to the derive rather than renaming the Rust type — UniFFI honors a `name = "..."` override on the foreign type, avoiding a workspace-wide rename of `apis::Error<T>`.

## 🚨 Breaking Changes

Removes the (broken, unusable) `Error` type from the generated Swift/Kotlin bindings. Clients that added `typealias Error = Swift.Error` to work around #1049 can now remove it. No functional API change — `ApiError` remains the API error type as before #1049.