### PR TITLE
chore(bitwarden-crypto): bump hybrid-array to 0.4.12

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -99,7 +99,7 @@ reqwest-middleware = { version = "0.5.1", features = [
     "form",
     "query",
 ] }
-rsa = "0.10.0-rc.17"
+rsa = "=0.10.0-rc.17"
 rustls = { version = "0.23.27", default-features = false, features = [
     "std",
     "tls12",


### PR DESCRIPTION

## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective

cargo update in the direct-maximum-versions CI job was
auto-selecting rsa 0.10.0-rc.18, which chains through
crypto-bigint 0.7.5 -> hybrid-array ^0.4.12 -> typenum
^1.20, creating cascading dependency conflicts across the
workspace. Pinning rsa exactly to rc.17 with the = prefix
stops the cascade at the source and stabilizes CI.


## 🚨 Breaking Changes

<!-- Does this PR introduce any breaking changes? If so, please describe the impact and migration path for clients.

If you're unsure, the automated TypeScript compatibility check will run when you open/update this PR and provide feedback.

For breaking changes:
1. Describe what changed in the client interface
2. Explain why the change was necessary
3. Provide migration steps for client developers
4. Link to any paired client PRs if needed

Otherwise, you can remove this section. -->
