### PR TITLE
[PM-39294] Gate shared unlock handshakes on transport reachability

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -918,6 +918,7 @@ dependencies = [
  "uuid",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "web-time",
  "zeroize",
 ]
 
@@ -2207,8 +2208,7 @@ dependencies = [
 [[package]]
 name = "crypto-bigint"
 version = "0.7.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a52aa3fcda4e6302a9f48734f234d35d4721b96f8fe07d073f07ce9df4f0271"
+source = "git+https://github.com/RustCrypto/crypto-bigint?tag=v0.7.5#2b54d248cce00457e3afb5650d9b14632ef4a116"
 dependencies = [
  "cpubits",
  "ctutils",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -100,7 +100,7 @@ reqwest-middleware = { version = "0.5.1", features = [
     "form",
     "query",
 ] }
-rsa = "0.10.0-rc.17"
+rsa = "0.10.0-rc.18"
 rustls = { version = "0.23.27", default-features = false, features = [
     "std",
     "tls12",
@@ -202,3 +202,9 @@ opt-level = 3
 # Stripping the binary reduces the size by ~30%, but the stacktraces won't be usable anymore.
 # This is fine as long as we don't have any unhandled panics, but let's keep it disabled for now
 # strip = true
+
+# The crates.io 0.7.x releases of crypto-bigint were yanked after 0.7.5 shipped a bugfix, so
+# stale registry indexes can fail to resolve `crypto-bigint = "^0.7"` (required by rsa). Override
+# to the published 0.7.5 from git to keep the build resolving regardless of index state.
+[patch.crates-io]
+crypto-bigint = { git = "https://github.com/RustCrypto/crypto-bigint", tag = "v0.7.5" }

--- a/crates/bitwarden-ipc/Cargo.toml
+++ b/crates/bitwarden-ipc/Cargo.toml
@@ -43,6 +43,7 @@ tsify = { workspace = true, optional = true }
 uuid = { workspace = true }
 wasm-bindgen = { workspace = true, optional = true }
 wasm-bindgen-futures = { workspace = true, optional = true }
+web-time = "1.1.0"
 zeroize = { workspace = true, features = ["zeroize_derive"] }
 
 [lints]

--- a/crates/bitwarden-ipc/src/crypto_provider/noise/crypto_provider.rs
+++ b/crates/bitwarden-ipc/src/crypto_provider/noise/crypto_provider.rs
@@ -105,6 +105,12 @@ impl NoiseCryptoProvider {
                     continue;
                 }
 
+                // Plaintext reachability ping/pong travels over the raw transport and must NOT be
+                // parsed as a Noise frame; skip it so it doesn't abort an in-flight handshake.
+                if is_reachability_topic(incoming.topic.as_deref()) {
+                    continue;
+                }
+
                 // Malformed messages will cancel the handshake
                 let Ok(response_frame) = Frame::from_cbor(&incoming.payload) else {
                     return Err(NoiseCryptoProviderError::HandshakeProtocol);
@@ -403,7 +409,7 @@ impl Frame {
 
 #[cfg(test)]
 mod tests {
-    use std::collections::HashMap;
+    use std::{collections::HashMap, time::Duration};
 
     use crate::{
         IpcClientImpl,
@@ -418,15 +424,36 @@ mod tests {
     async fn ping_pong() {
         let (provider_1, provider_2) = TestTwoWayCommunicationBackend::new();
 
+        // Both clients ping each other so their reachability trackers see liveness; in this test
+        // backend every message appears to originate from `DesktopMain`.
         let session_map_1 = InMemorySessionRepository::new(HashMap::new());
-        let client_1 = IpcClientImpl::new(NoiseCryptoProvider, provider_1, session_map_1);
+        let client_1 = IpcClientImpl::new_with_reachability(
+            NoiseCryptoProvider,
+            provider_1,
+            session_map_1,
+            vec![Endpoint::DesktopMain],
+        );
         let _ = client_1.start(None).await;
         let mut recv_1 = client_1.subscribe(None).await.unwrap();
 
         let session_map_2 = InMemorySessionRepository::new(HashMap::new());
-        let client_2 = IpcClientImpl::new(NoiseCryptoProvider, provider_2, session_map_2);
+        let client_2 = IpcClientImpl::new_with_reachability(
+            NoiseCryptoProvider,
+            provider_2,
+            session_map_2,
+            vec![Endpoint::DesktopMain],
+        );
         let _ = client_2.start(None).await;
         let mut recv_2 = client_2.subscribe(None).await.unwrap();
+
+        // `send` drops messages to a destination that is not yet reachable, so wait for the ping
+        // schedulers to establish reachability before exchanging traffic. Otherwise the first send
+        // would be silently dropped and the receivers would block forever.
+        for client in [&client_1, &client_2] {
+            while !client.is_reachable(Endpoint::DesktopMain).await {
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        }
 
         let handle_1 = tokio::spawn(async move {
             let mut val: u8 = 0;

--- a/crates/bitwarden-ipc/src/crypto_provider/noise/crypto_provider.rs
+++ b/crates/bitwarden-ipc/src/crypto_provider/noise/crypto_provider.rs
@@ -5,6 +5,7 @@ use serde::{Deserialize, Serialize};
 use tracing::{error, info, warn};
 
 use crate::{
+    ReachabilityTracker,
     crypto_provider::noise::{
         handshake::{
             CipherSuite, HandshakeFinishMessage, HandshakeInitiator, HandshakeResponder,
@@ -14,6 +15,7 @@ use crate::{
     },
     error::IpcErrorKind,
     message::{IncomingMessage, OutgoingMessage},
+    reachability::is_reachability_topic,
     traits::{
         CommunicationBackend, CommunicationBackendReceiver, CryptoProvider, SessionRepository,
     },
@@ -173,6 +175,7 @@ where
         &self,
         communication: &Com,
         sessions: &Ses,
+        reachability: &ReachabilityTracker,
         message: OutgoingMessage,
     ) -> Result<(), Self::SendError> {
         // Send operations *MUST* be serialized, otherwise nonce re-use may happen since
@@ -187,7 +190,19 @@ where
             .await
             .expect("Get session should not fail");
 
+        let reachable = reachability.is_reachable(&destination);
+
         let mut should_handshake = crypto_state.is_none();
+
+        // Not reachable, drop the message
+        if !reachable {
+            info!(
+                "Destination {:?} is not reachable; dropping message without attempting handshake",
+                destination
+            );
+            return Ok(());
+        }
+
         if let Some(state) = crypto_state.as_ref()
             && state.state.should_rehandshake(REHANDSHAKE_INTERVAL_SECS)
         {
@@ -260,6 +275,12 @@ where
                     fatal: e.is_fatal(),
                 }
             })?;
+
+            // Plaintext reachability ping/pong travels over the raw transport and must NOT be
+            // decoded as a Noise frame. Pass it straight through; the IPC client handles it.
+            if is_reachability_topic(message.topic.as_deref()) {
+                return Ok(message);
+            }
 
             // Ensure session exists
             let source_endpoint: crate::endpoint::Endpoint = message.source.clone().into();
@@ -382,7 +403,7 @@ impl Frame {
 
 #[cfg(test)]
 mod tests {
-    use std::collections::HashMap;
+    use std::{collections::HashMap, time::Duration};
 
     use crate::{
         IpcClientImpl,
@@ -390,7 +411,10 @@ mod tests {
         endpoint::Endpoint,
         ipc_client_trait::IpcClient,
         message::OutgoingMessage,
-        traits::{InMemorySessionRepository, TestTwoWayCommunicationBackend},
+        reachability::is_reachability_topic,
+        traits::{
+            InMemorySessionRepository, TestCommunicationBackend, TestTwoWayCommunicationBackend,
+        },
     };
 
     #[tokio::test]

--- a/crates/bitwarden-ipc/src/crypto_provider/noise/crypto_provider.rs
+++ b/crates/bitwarden-ipc/src/crypto_provider/noise/crypto_provider.rs
@@ -403,7 +403,7 @@ impl Frame {
 
 #[cfg(test)]
 mod tests {
-    use std::{collections::HashMap, time::Duration};
+    use std::collections::HashMap;
 
     use crate::{
         IpcClientImpl,
@@ -411,10 +411,7 @@ mod tests {
         endpoint::Endpoint,
         ipc_client_trait::IpcClient,
         message::OutgoingMessage,
-        reachability::is_reachability_topic,
-        traits::{
-            InMemorySessionRepository, TestCommunicationBackend, TestTwoWayCommunicationBackend,
-        },
+        traits::{InMemorySessionRepository, TestTwoWayCommunicationBackend},
     };
 
     #[tokio::test]

--- a/crates/bitwarden-ipc/src/ipc_client.rs
+++ b/crates/bitwarden-ipc/src/ipc_client.rs
@@ -6,22 +6,17 @@ use thiserror::Error;
 use tokio::select;
 
 use crate::{
-    constants::CHANNEL_BUFFER_CAPACITY,
-    error::{
+    Endpoint, constants::CHANNEL_BUFFER_CAPACITY, error::{
         AlreadyRunningError, IpcErrorKind, ReceiveError, SendError, SubscribeError,
         TypedReceiveError,
-    },
-    message::{
+    }, message::{
         IncomingMessage, OutgoingMessage, PayloadTypeName, TypedIncomingMessage,
         TypedOutgoingMessage,
-    },
-    rpc::{
+    }, reachability::{ReachabilityTracker, is_reachability_topic}, rpc::{
         exec::{handler::ErasedRpcHandler, handler_registry::RpcHandlerRegistry},
         request_message::{RPC_REQUEST_PAYLOAD_TYPE_NAME, RpcRequestPayload},
         response_message::OutgoingRpcResponseMessage,
-    },
-    serde_utils,
-    traits::{CommunicationBackend, CryptoProvider, SessionRepository},
+    }, serde_utils, traits::{CommunicationBackend, CryptoProvider, SessionRepository},
 };
 
 /// A subscription to receive messages over IPC.
@@ -52,6 +47,7 @@ where
     crypto: Crypto,
     communication: Com,
     sessions: Ses,
+    reachability: ReachabilityTracker,
 
     handlers: RpcHandlerRegistry,
     incoming: Mutex<Option<tokio::sync::broadcast::Receiver<IncomingMessage>>>,
@@ -92,13 +88,30 @@ where
     Ses: SessionRepository<Crypto::Session>,
 {
     /// Create a new IPC client with the provided crypto provider, communication backend, and
-    /// session repository.
+    /// session repository. The client does not actively ping any peers; a destination is only
+    /// reported reachable once inbound traffic has been observed from it within the active window.
     pub fn new(crypto: Crypto, communication: Com, sessions: Ses) -> Self {
+        Self::new_with_reachability(crypto, communication, sessions, Vec::new())
+    }
+
+    /// Create a new IPC client that actively pings the given leader endpoints.
+    ///
+    /// `ping_targets` are the leader endpoints this client follows: the SDK runs an adaptive ping
+    /// scheduler for each (emitting plaintext reachability pings as ordinary [`OutgoingMessage`]s
+    /// over the communication backend, bypassing the crypto channel). An endpoint's reachability
+    /// is then derived from inbound traffic (see [`ReachabilityTracker`]).
+    pub fn new_with_reachability(
+        crypto: Crypto,
+        communication: Com,
+        sessions: Ses,
+        ping_targets: Vec<Endpoint>,
+    ) -> Self {
         Self {
             inner: Arc::new(IpcClientInner {
                 crypto,
                 communication,
                 sessions,
+                reachability: ReachabilityTracker::new(ping_targets),
 
                 handlers: RpcHandlerRegistry::new(),
                 incoming: Mutex::new(None),
@@ -130,6 +143,10 @@ where
             .expect("Failed to lock cancellation token mutex")
             .replace(cancellation_token.clone());
 
+        // Cloned before `cancellation_token` is moved into the receive loop, so the ping
+        // scheduler(s) below share the same lifecycle.
+        let scheduler_token = cancellation_token.clone();
+
         let com_receiver = self.inner.communication.subscribe().await;
         let (client_tx, client_rx) = tokio::sync::broadcast::channel(CHANNEL_BUFFER_CAPACITY);
 
@@ -150,10 +167,15 @@ where
                     }
                     received = inner.crypto.receive(&com_receiver, &inner.communication, &inner.sessions) => {
                         match received {
+                            Ok(message) if is_reachability_topic(message.topic.as_deref()) => {
+                                handle_reachability(&inner, message).await;
+                            }
                             Ok(message) if message.topic == Some(rpc_topic) => {
+                                inner.reachability.record(&message.source.to_endpoint());
                                 handle_rpc_request(&inner, message)
                             }
                             Ok(message) => {
+                                inner.reachability.record(&message.source.to_endpoint());
                                 if client_tx.send(message).is_err() {
                                     tracing::error!("Failed to save incoming message");
                                     break;
@@ -180,6 +202,36 @@ where
         #[cfg(target_arch = "wasm32")]
         wasm_bindgen_futures::spawn_local(future);
 
+        // Spawn one reachability ping scheduler per configured leader endpoint
+        for target in self.inner.reachability.ping_targets().to_vec() {
+            let inner = self.inner.clone();
+            let scheduler_token = scheduler_token.clone();
+            let ping_future = async move {
+                loop {
+                    let _ = inner
+                        .communication
+                        .send(OutgoingMessage {
+                            payload: Vec::new(),
+                            destination: target.clone(),
+                            topic: Some(crate::reachability::REACHABILITY_PING_TOPIC.to_owned()),
+                        })
+                        .await;
+                    let interval = inner.reachability.interval_for(&target);
+                    select! {
+                        _ = scheduler_token.cancelled() => break,
+                        _ = bitwarden_threading::time::sleep(interval) => {}
+                        _ = inner.reachability.rearmed() => {}
+                    }
+                }
+            };
+
+            #[cfg(not(target_arch = "wasm32"))]
+            tokio::spawn(ping_future);
+
+            #[cfg(target_arch = "wasm32")]
+            wasm_bindgen_futures::spawn_local(ping_future);
+        }
+
         Ok(())
     }
 
@@ -205,7 +257,12 @@ where
         let result = self
             .inner
             .crypto
-            .send(&self.inner.communication, &self.inner.sessions, message)
+            .send(
+                &self.inner.communication,
+                &self.inner.sessions,
+                &self.inner.reachability,
+                message,
+            )
             .await;
 
         if let Err(ref error) = result {
@@ -240,6 +297,14 @@ where
         })
     }
 
+    async fn is_reachable(&self, destination: Endpoint) -> bool {
+        self.inner.reachability.is_reachable(&destination)
+    }
+
+    fn invalidate_reachability(&self, endpoint: Endpoint) {
+        self.inner.reachability.invalidate(&endpoint);
+    }
+
     async fn register_rpc_handler_erased(&self, name: &str, handler: Box<dyn ErasedRpcHandler>) {
         self.inner
             .handlers
@@ -261,6 +326,29 @@ where
 
     if let Some(cancellation_token) = cancellation_token.take() {
         cancellation_token.cancel();
+    }
+}
+
+async fn handle_reachability<Crypto, Com, Ses>(
+    inner: &Arc<IpcClientInner<Crypto, Com, Ses>>,
+    message: IncomingMessage,
+) where
+    Crypto: CryptoProvider<Com, Ses>,
+    Com: CommunicationBackend,
+    Ses: SessionRepository<Crypto::Session>,
+{
+    let source = message.source.to_endpoint();
+    inner.reachability.record(&source);
+
+    if message.topic.as_deref() == Some(crate::reachability::REACHABILITY_PING_TOPIC) {
+        let _ = inner
+            .communication
+            .send(OutgoingMessage {
+                payload: Vec::new(),
+                destination: source,
+                topic: Some(crate::reachability::REACHABILITY_PONG_TOPIC.to_owned()),
+            })
+            .await;
     }
 }
 
@@ -315,7 +403,12 @@ fn handle_rpc_request<Crypto, Com, Ses>(
                 // since we're inside the background task and don't have a trait object.
                 let result = inner
                     .crypto
-                    .send(&inner.communication, &inner.sessions, outgoing_message)
+                    .send(
+                        &inner.communication,
+                        &inner.sessions,
+                        &inner.reachability,
+                        outgoing_message,
+                    )
                     .await;
                 if result.is_err() {
                     tracing::error!("Failed to send response message");
@@ -461,6 +554,7 @@ mod tests {
             &self,
             _communication: &TestCommunicationBackend,
             _sessions: &TestSessionRepository,
+            _reachability: &ReachabilityTracker,
             _message: OutgoingMessage,
         ) -> Result<(), Self::SendError> {
             match &self.send_result {
@@ -815,6 +909,69 @@ mod tests {
         let is_running = client.is_running();
 
         assert!(!is_running);
+    }
+
+    #[tokio::test]
+    async fn scheduler_emits_reachability_ping_to_target() {
+        let target = Endpoint::BrowserBackground { id: HostId::Own };
+        let communication_provider = TestCommunicationBackend::new();
+        let session_map = InMemorySessionRepository::new(HashMap::new());
+        let client = IpcClientImpl::new_with_reachability(
+            NoEncryptionCryptoProvider,
+            communication_provider.clone(),
+            session_map,
+            vec![target.clone()],
+        );
+        client.start(None).await.unwrap();
+
+        // Give the scheduler a moment to emit its first ping.
+        tokio::time::sleep(Duration::from_millis(50)).await;
+
+        let outgoing = communication_provider.outgoing().await;
+        assert!(
+            outgoing.iter().any(|m| m.destination == target
+                && m.topic.as_deref() == Some(crate::reachability::REACHABILITY_PING_TOPIC)),
+            "scheduler should emit a reachability ping to the configured target"
+        );
+    }
+
+    #[tokio::test]
+    async fn replies_with_pong_to_incoming_ping() {
+        let communication_provider = TestCommunicationBackend::new();
+        let session_map = InMemorySessionRepository::new(HashMap::new());
+        // No ping targets: the client only responds, so the sole outgoing message is the pong.
+        let client = IpcClientImpl::new(
+            NoEncryptionCryptoProvider,
+            communication_provider.clone(),
+            session_map,
+        );
+        client.start(None).await.unwrap();
+
+        // Inject a plaintext reachability ping from a web tab.
+        communication_provider.push_incoming(IncomingMessage {
+            payload: vec![],
+            destination: Endpoint::BrowserBackground { id: HostId::Own },
+            source: Source::Web {
+                tab_id: 7,
+                document_id: "doc-1".to_string(),
+                origin: "https://example.com".to_string(),
+            },
+            topic: Some(crate::reachability::REACHABILITY_PING_TOPIC.to_owned()),
+        });
+
+        tokio::time::sleep(Duration::from_millis(50)).await;
+
+        let outgoing = communication_provider.outgoing().await;
+        assert!(
+            outgoing.iter().any(|m| m.topic.as_deref()
+                == Some(crate::reachability::REACHABILITY_PONG_TOPIC)
+                && m.destination
+                    == Endpoint::Web {
+                        tab_id: 7,
+                        document_id: "doc-1".to_string(),
+                    }),
+            "a ping should be answered with a pong addressed back to the sender"
+        );
     }
 
     #[tokio::test]

--- a/crates/bitwarden-ipc/src/ipc_client.rs
+++ b/crates/bitwarden-ipc/src/ipc_client.rs
@@ -6,17 +6,24 @@ use thiserror::Error;
 use tokio::select;
 
 use crate::{
-    Endpoint, constants::CHANNEL_BUFFER_CAPACITY, error::{
+    Endpoint,
+    constants::CHANNEL_BUFFER_CAPACITY,
+    error::{
         AlreadyRunningError, IpcErrorKind, ReceiveError, SendError, SubscribeError,
         TypedReceiveError,
-    }, message::{
+    },
+    message::{
         IncomingMessage, OutgoingMessage, PayloadTypeName, TypedIncomingMessage,
         TypedOutgoingMessage,
-    }, reachability::{ReachabilityTracker, is_reachability_topic}, rpc::{
+    },
+    reachability::{ReachabilityTracker, is_reachability_topic},
+    rpc::{
         exec::{handler::ErasedRpcHandler, handler_registry::RpcHandlerRegistry},
         request_message::{RPC_REQUEST_PAYLOAD_TYPE_NAME, RpcRequestPayload},
         response_message::OutgoingRpcResponseMessage,
-    }, serde_utils, traits::{CommunicationBackend, CryptoProvider, SessionRepository},
+    },
+    serde_utils,
+    traits::{CommunicationBackend, CryptoProvider, SessionRepository},
 };
 
 /// A subscription to receive messages over IPC.

--- a/crates/bitwarden-ipc/src/ipc_client_trait.rs
+++ b/crates/bitwarden-ipc/src/ipc_client_trait.rs
@@ -48,7 +48,7 @@ pub trait IpcClient: Send + Sync {
     #[doc(hidden)]
     async fn register_rpc_handler_erased(&self, name: &str, handler: Box<dyn ErasedRpcHandler>);
 
-    /// Whether `destination` is reachable
+    /// Whether `destination` is reachable.
     async fn is_reachable(&self, destination: Endpoint) -> bool;
 
     /// Immediately mark `endpoint` as unreachable (e.g. on a transport disconnect)

--- a/crates/bitwarden-ipc/src/ipc_client_trait.rs
+++ b/crates/bitwarden-ipc/src/ipc_client_trait.rs
@@ -1,6 +1,7 @@
 use bitwarden_threading::cancellation_token::CancellationToken;
 
 use crate::{
+    endpoint::Endpoint,
     error::{AlreadyRunningError, SendError, SubscribeError},
     ipc_client::IpcClientSubscription,
     message::OutgoingMessage,
@@ -46,4 +47,10 @@ pub trait IpcClient: Send + Sync {
     /// instead.
     #[doc(hidden)]
     async fn register_rpc_handler_erased(&self, name: &str, handler: Box<dyn ErasedRpcHandler>);
+
+    /// Whether `destination` is reachable
+    async fn is_reachable(&self, destination: Endpoint) -> bool;
+
+    /// Immediately mark `endpoint` as unreachable (e.g. on a transport disconnect)
+    fn invalidate_reachability(&self, endpoint: Endpoint);
 }

--- a/crates/bitwarden-ipc/src/lib.rs
+++ b/crates/bitwarden-ipc/src/lib.rs
@@ -9,6 +9,7 @@ mod ipc_client;
 mod ipc_client_ext;
 mod ipc_client_trait;
 mod message;
+mod reachability;
 mod rpc;
 mod serde_utils;
 mod traits;
@@ -27,6 +28,7 @@ pub use ipc_client_trait::IpcClient;
 pub use message::{
     IncomingMessage, OutgoingMessage, PayloadTypeName, TypedIncomingMessage, TypedOutgoingMessage,
 };
+pub use reachability::ReachabilityTracker;
 #[doc(hidden)]
 pub use rpc::exec::handler::ErasedRpcHandler;
 pub use rpc::{exec::handler::RpcHandler, request::RpcRequest};

--- a/crates/bitwarden-ipc/src/reachability.rs
+++ b/crates/bitwarden-ipc/src/reachability.rs
@@ -1,0 +1,273 @@
+//! A reachability tracker to keep track of which endponits ar reachable.
+//!
+//! Followers continuously send a lightweight plaintext ping to their leader; the leader replies
+//! with a pong. These messages travel over the raw transport and are deliberately NOT routed
+//! through the SDK crypto channel — they exist only to measure liveness. The
+//! [`ReachabilityTracker`] records the timestamp of the last message seen from each
+//! peer and derives activity from it; an endpoint is considered reachable/active when that
+//! timestamp is within [`ACTIVE_WINDOW`].
+
+use std::{collections::HashMap, sync::Mutex, time::Duration};
+
+use tokio::sync::Notify;
+use web_time::Instant;
+
+use crate::endpoint::Endpoint;
+
+/// Topic marking a plaintext reachability ping.
+pub(crate) const REACHABILITY_PING_TOPIC: &str = "$bitwarden_reachability_ping";
+/// Topic marking a plaintext reachability pong (the reply to a ping).
+pub(crate) const REACHABILITY_PONG_TOPIC: &str = "$bitwarden_reachability_pong";
+
+/// Whether `topic` marks a plaintext reachability ping/pong that must bypass the crypto channel.
+pub(crate) fn is_reachability_topic(topic: Option<&str>) -> bool {
+    matches!(
+        topic,
+        Some(REACHABILITY_PING_TOPIC) | Some(REACHABILITY_PONG_TOPIC)
+    )
+}
+
+/// An endpoint is "active"/reachable when the last message from it was within this window.
+pub(crate) const ACTIVE_WINDOW: Duration = Duration::from_secs(5);
+/// Ping cadence while the peer is active. Must be `< ACTIVE_WINDOW` to sustain activity.
+pub(crate) const ACTIVE_PING_INTERVAL: Duration = Duration::from_secs(2);
+/// Back-off ping cadence while the peer is inactive (e.g. not installed / not running).
+pub(crate) const INACTIVE_PING_INTERVAL: Duration = Duration::from_secs(10);
+
+/// Tracks the timestamp of the last message seen from each endpoint and derives activity
+/// status from it.
+pub struct ReachabilityTracker {
+    last_message: Mutex<HashMap<Endpoint, Instant>>,
+    active_state: Mutex<HashMap<Endpoint, bool>>,
+    /// Concrete leader endpoints this client actively pings.
+    ping_targets: Vec<Endpoint>,
+    /// Woken on a stale->active transition so the ping scheduler retightens its cadence.
+    rearm: Notify,
+    /// Injectable clock, so tests can advance time deterministically.
+    now: Box<dyn Fn() -> Instant + Send + Sync>,
+}
+
+impl ReachabilityTracker {
+    /// Create a tracker that pings the given leader endpoints.
+    pub(crate) fn new(ping_targets: Vec<Endpoint>) -> Self {
+        Self::with_clock(ping_targets, Box::new(Instant::now))
+    }
+
+    /// Create a tracker with an injectable clock (used by tests).
+    pub(crate) fn with_clock(
+        ping_targets: Vec<Endpoint>,
+        now: Box<dyn Fn() -> Instant + Send + Sync>,
+    ) -> Self {
+        Self {
+            last_message: Mutex::new(HashMap::new()),
+            active_state: Mutex::new(HashMap::new()),
+            ping_targets,
+            rearm: Notify::new(),
+            now,
+        }
+    }
+
+    /// Record that a message was just received from `endpoint`.
+    pub(crate) fn record(&self, endpoint: &Endpoint) {
+        self.last_message
+            .lock()
+            .expect("reachability last_message mutex poisoned")
+            .insert(endpoint.clone(), (self.now)());
+        self.emit_if_changed(endpoint, true);
+    }
+
+    /// Immediately mark `endpoint` as stale, as if no message was ever received from it.
+    pub(crate) fn invalidate(&self, endpoint: &Endpoint) {
+        self.last_message
+            .lock()
+            .expect("reachability last_message mutex poisoned")
+            .remove(endpoint);
+        self.emit_if_changed(endpoint, false);
+    }
+
+    /// Returns whether a destination is reachable
+    pub fn is_reachable(&self, endpoint: &Endpoint) -> bool {
+        let last = self
+            .last_message
+            .lock()
+            .expect("reachability last_message mutex poisoned")
+            .get(endpoint)
+            .copied();
+        match last {
+            Some(last) => (self.now)().saturating_duration_since(last) < ACTIVE_WINDOW,
+            None => false,
+        }
+    }
+
+    /// Adaptive ping cadence for `endpoint`: faster while active, backed off while inactive.
+    /// Polling this is also where staleness transitions surface (the ping scheduler calls it
+    /// every cycle).
+    pub(crate) fn interval_for(&self, endpoint: &Endpoint) -> Duration {
+        let active = self.is_reachable(endpoint);
+        self.emit_if_changed(endpoint, active);
+        if active {
+            ACTIVE_PING_INTERVAL
+        } else {
+            INACTIVE_PING_INTERVAL
+        }
+    }
+
+    /// The leader endpoints this client should actively ping.
+    pub(crate) fn ping_targets(&self) -> &[Endpoint] {
+        &self.ping_targets
+    }
+
+    /// Resolves the next time a stale->active transition retightens the ping cadence.
+    pub(crate) async fn rearmed(&self) {
+        self.rearm.notified().await;
+    }
+
+    fn emit_if_changed(&self, endpoint: &Endpoint, active: bool) {
+        let changed = {
+            let mut states = self
+                .active_state
+                .lock()
+                .expect("reachability active_state mutex poisoned");
+            let previous = states.get(endpoint).copied().unwrap_or(false);
+            if previous != active {
+                states.insert(endpoint.clone(), active);
+                true
+            } else {
+                false
+            }
+        };
+
+        if changed {
+            if active {
+                tracing::debug!(?endpoint, "IPC endpoint became reachable");
+                // Wake the ping scheduler so it reschedules at the (now active) cadence.
+                self.rearm.notify_one();
+            } else {
+                tracing::warn!(?endpoint, "IPC endpoint became unreachable");
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{
+        Arc,
+        atomic::{AtomicU64, Ordering},
+    };
+
+    use super::*;
+    use crate::endpoint::HostId;
+
+    /// A controllable clock: `now()` returns a base instant plus the accumulated advance.
+    #[derive(Clone)]
+    struct MockClock {
+        base: Instant,
+        advance_ms: Arc<AtomicU64>,
+    }
+
+    impl MockClock {
+        fn new() -> Self {
+            Self {
+                base: Instant::now(),
+                advance_ms: Arc::new(AtomicU64::new(0)),
+            }
+        }
+
+        fn advance(&self, by: Duration) {
+            self.advance_ms
+                .fetch_add(by.as_millis() as u64, Ordering::SeqCst);
+        }
+
+        fn clock(&self) -> Box<dyn Fn() -> Instant + Send + Sync> {
+            let base = self.base;
+            let advance_ms = self.advance_ms.clone();
+            Box::new(move || base + Duration::from_millis(advance_ms.load(Ordering::SeqCst)))
+        }
+    }
+
+    fn tracker(targets: Vec<Endpoint>) -> (ReachabilityTracker, MockClock) {
+        let clock = MockClock::new();
+        let tracker = ReachabilityTracker::with_clock(targets, clock.clock());
+        (tracker, clock)
+    }
+
+    const EXTENSION: Endpoint = Endpoint::BrowserBackground { id: HostId::Own };
+
+    #[test]
+    fn inactive_until_first_message() {
+        let (tracker, _clock) = tracker(vec![EXTENSION]);
+        assert!(!tracker.is_reachable(&EXTENSION));
+    }
+
+    #[test]
+    fn active_immediately_after_record() {
+        let (tracker, _clock) = tracker(vec![EXTENSION]);
+        tracker.record(&EXTENSION);
+        assert!(tracker.is_reachable(&EXTENSION));
+    }
+
+    #[test]
+    fn stays_active_within_window_then_goes_stale() {
+        let (tracker, clock) = tracker(vec![EXTENSION]);
+        tracker.record(&EXTENSION);
+        clock.advance(ACTIVE_WINDOW - Duration::from_millis(1));
+        assert!(tracker.is_reachable(&EXTENSION));
+        clock.advance(Duration::from_millis(1));
+        assert!(!tracker.is_reachable(&EXTENSION));
+    }
+
+    #[test]
+    fn adaptive_cadence_follows_activity() {
+        let (tracker, clock) = tracker(vec![EXTENSION]);
+        assert_eq!(tracker.interval_for(&EXTENSION), INACTIVE_PING_INTERVAL);
+        tracker.record(&EXTENSION);
+        assert_eq!(tracker.interval_for(&EXTENSION), ACTIVE_PING_INTERVAL);
+        clock.advance(ACTIVE_WINDOW);
+        assert_eq!(tracker.interval_for(&EXTENSION), INACTIVE_PING_INTERVAL);
+    }
+
+    #[test]
+    fn endpoints_tracked_independently() {
+        let (tracker, _clock) = tracker(vec![Endpoint::DesktopRenderer]);
+        tracker.record(&Endpoint::DesktopMain);
+        // Each endpoint is keyed individually; recording the main process does not make the
+        // renderer reachable.
+        assert!(tracker.is_reachable(&Endpoint::DesktopMain));
+        assert!(!tracker.is_reachable(&Endpoint::DesktopRenderer));
+    }
+
+    #[test]
+    fn web_tabs_tracked_independently() {
+        let tab1 = Endpoint::Web {
+            tab_id: 1,
+            document_id: "a".to_owned(),
+        };
+        let tab2 = Endpoint::Web {
+            tab_id: 2,
+            document_id: "b".to_owned(),
+        };
+        let (tracker, _clock) = tracker(vec![]);
+        tracker.record(&tab1);
+        assert!(tracker.is_reachable(&tab1));
+        assert!(!tracker.is_reachable(&tab2));
+    }
+
+    #[test]
+    fn invalidate_marks_stale_immediately() {
+        let (tracker, _clock) = tracker(vec![EXTENSION]);
+        tracker.record(&EXTENSION);
+        assert!(tracker.is_reachable(&EXTENSION));
+        tracker.invalidate(&EXTENSION);
+        assert!(!tracker.is_reachable(&EXTENSION));
+    }
+
+    #[tokio::test]
+    async fn record_rearms_scheduler_on_activation() {
+        let (tracker, _clock) = tracker(vec![EXTENSION]);
+        // A stale->active transition must wake a waiter.
+        tracker.record(&EXTENSION);
+        // notify_one stored a permit, so rearmed() resolves immediately.
+        tracker.rearmed().await;
+    }
+}

--- a/crates/bitwarden-ipc/src/reachability.rs
+++ b/crates/bitwarden-ipc/src/reachability.rs
@@ -85,8 +85,18 @@ impl ReachabilityTracker {
         self.emit_if_changed(endpoint, false);
     }
 
-    /// Returns whether a destination is reachable
+    /// Returns whether a destination is reachable.
     pub fn is_reachable(&self, endpoint: &Endpoint) -> bool {
+        if self.ping_targets.contains(endpoint) {
+            self.is_active(endpoint)
+        } else {
+            true
+        }
+    }
+
+    /// Raw liveness for `endpoint`: whether the last message seen from it was within
+    /// [`ACTIVE_WINDOW`]. This is the signal a monitored ping target's reachability derives from.
+    fn is_active(&self, endpoint: &Endpoint) -> bool {
         let last = self
             .last_message
             .lock()
@@ -103,7 +113,7 @@ impl ReachabilityTracker {
     /// Polling this is also where staleness transitions surface (the ping scheduler calls it
     /// every cycle).
     pub(crate) fn interval_for(&self, endpoint: &Endpoint) -> Duration {
-        let active = self.is_reachable(endpoint);
+        let active = self.is_active(endpoint);
         self.emit_if_changed(endpoint, active);
         if active {
             ACTIVE_PING_INTERVAL
@@ -232,9 +242,10 @@ mod tests {
         let (tracker, _clock) = tracker(vec![Endpoint::DesktopRenderer]);
         tracker.record(&Endpoint::DesktopMain);
         // Each endpoint is keyed individually; recording the main process does not make the
-        // renderer reachable.
-        assert!(tracker.is_reachable(&Endpoint::DesktopMain));
-        assert!(!tracker.is_reachable(&Endpoint::DesktopRenderer));
+        // renderer active. (Checked via raw liveness, since reachability is permissive for
+        // unmonitored endpoints.)
+        assert!(tracker.is_active(&Endpoint::DesktopMain));
+        assert!(!tracker.is_active(&Endpoint::DesktopRenderer));
     }
 
     #[test]
@@ -249,8 +260,17 @@ mod tests {
         };
         let (tracker, _clock) = tracker(vec![]);
         tracker.record(&tab1);
-        assert!(tracker.is_reachable(&tab1));
-        assert!(!tracker.is_reachable(&tab2));
+        assert!(tracker.is_active(&tab1));
+        assert!(!tracker.is_active(&tab2));
+    }
+
+    #[test]
+    fn unmonitored_endpoints_are_always_reachable() {
+        // An endpoint that is not a ping target has no liveness signal, so it is treated as
+        // reachable even before (and without) any message being observed from it.
+        let (tracker, _clock) = tracker(vec![Endpoint::DesktopRenderer]);
+        assert!(tracker.is_reachable(&Endpoint::DesktopMain));
+        assert!(!tracker.is_reachable(&Endpoint::DesktopRenderer));
     }
 
     #[test]

--- a/crates/bitwarden-ipc/src/traits/crypto_provider.rs
+++ b/crates/bitwarden-ipc/src/traits/crypto_provider.rs
@@ -6,6 +6,7 @@ use super::{CommunicationBackend, SessionRepository};
 use crate::{
     error::IpcErrorKind,
     message::{IncomingMessage, OutgoingMessage},
+    reachability::ReachabilityTracker,
 };
 
 pub trait CryptoProvider<Com, Ses>: Send + Sync + 'static
@@ -33,6 +34,7 @@ where
         &self,
         communication: &Com,
         sessions: &Ses,
+        reachability: &ReachabilityTracker,
         message: OutgoingMessage,
     ) -> impl std::future::Future<Output = Result<(), Self::SendError>> + Send + Sync;
 
@@ -75,6 +77,7 @@ where
         &self,
         communication: &Com,
         _sessions: &Ses,
+        _reachability: &ReachabilityTracker,
         message: OutgoingMessage,
     ) -> Result<(), Self::SendError> {
         communication.send(message).await

--- a/crates/bitwarden-ipc/src/wasm/ipc_client.rs
+++ b/crates/bitwarden-ipc/src/wasm/ipc_client.rs
@@ -1,12 +1,15 @@
 use std::{collections::HashMap, sync::Arc};
 
 use bitwarden_threading::cancellation_token::wasm::{AbortSignal, AbortSignalExt};
+use serde::{Deserialize, Serialize};
+use tsify::Tsify;
 use wasm_bindgen::prelude::*;
 
 use super::communication_backend::JsCommunicationBackend;
 use crate::{
     IpcClientImpl,
     crypto_provider::noise::crypto_provider::NoiseCryptoProvider,
+    endpoint::Endpoint,
     error::{AlreadyRunningError, ReceiveError, SubscribeError},
     ipc_client::IpcClientSubscription,
     ipc_client_trait::IpcClient,
@@ -17,6 +20,16 @@ use crate::{
         generic_session_repository::GenericSessionRepository,
     },
 };
+
+/// Reachability configuration for an `IpcClient`.
+#[derive(Tsify, Serialize, Deserialize)]
+#[tsify(from_wasm_abi)]
+#[serde(rename_all = "camelCase")]
+pub struct ReachabilityConfig {
+    /// The leader endpoints this client follows. The SDK runs an adaptive reachability ping
+    /// for each of the targets, to determine at runtime whether they are reachable continuously.
+    pub ping_targets: Vec<Endpoint>,
+}
 
 /// JavaScript wrapper around the IPC client. For more information, see the
 /// [`IpcClient`] trait documentation.
@@ -62,14 +75,16 @@ impl JsIpcClient {
     #[wasm_bindgen(js_name = newWithSdkInMemorySessions)]
     pub fn new_with_sdk_in_memory_sessions(
         communication_provider: &JsCommunicationBackend,
+        reachability: ReachabilityConfig,
     ) -> JsIpcClient {
         JsIpcClient {
-            client: Arc::new(IpcClientImpl::new(
+            client: Arc::new(IpcClientImpl::new_with_reachability(
                 NoiseCryptoProvider,
                 communication_provider.clone(),
                 GenericSessionRepository::InMemory(Arc::new(InMemorySessionRepository::new(
                     HashMap::new(),
                 ))),
+                reachability.ping_targets,
             )),
         }
     }
@@ -81,14 +96,16 @@ impl JsIpcClient {
     pub fn new_with_client_managed_sessions(
         communication_provider: &JsCommunicationBackend,
         session_repository: RawJsSessionRepository,
+        reachability: ReachabilityConfig,
     ) -> JsIpcClient {
         JsIpcClient {
-            client: Arc::new(IpcClientImpl::new(
+            client: Arc::new(IpcClientImpl::new_with_reachability(
                 NoiseCryptoProvider,
                 communication_provider.clone(),
                 GenericSessionRepository::JsSessionRepository(Arc::new(JsSessionRepository::new(
                     session_repository,
                 ))),
+                reachability.ping_targets,
             )),
         }
     }
@@ -125,5 +142,21 @@ impl JsIpcClient {
     pub async fn subscribe(&self) -> Result<JsIpcClientSubscription, SubscribeError> {
         let subscription = self.client.subscribe(None).await?;
         Ok(JsIpcClientSubscription { subscription })
+    }
+
+    /// Whether `endpoint` is currently reachable, per the client's reachability tracker: an
+    /// endpoint is reachable when inbound traffic was seen from it within the active window.
+    #[wasm_only]
+    #[wasm_bindgen(js_name = isReachable)]
+    pub async fn is_reachable(&self, endpoint: Endpoint) -> bool {
+        self.client.is_reachable(endpoint).await
+    }
+
+    /// Immediately mark `endpoint` as unreachable (e.g. on a known transport disconnect), without
+    /// waiting for the active window to elapse.
+    #[wasm_only]
+    #[wasm_bindgen(js_name = invalidateReachability)]
+    pub fn invalidate_reachability(&self, endpoint: Endpoint) {
+        self.client.invalidate_reachability(endpoint);
     }
 }

--- a/crates/bitwarden-shared-unlock/src/follower.rs
+++ b/crates/bitwarden-shared-unlock/src/follower.rs
@@ -44,9 +44,11 @@ impl<L: SharedUnlockDriver + Send + Sync + 'static> Follower<L> {
             return;
         };
 
-        // Do not start sessions when the leader is unreachable. This avoids triggering Noise
-        // handshakes (and the resulting reconnect churn) against an absent leader. Reachability is
-        // a transport-level signal that does not go through the crypto channel.
+        // Do not start sessions when the leader is a monitored ping target that has gone stale.
+        // This avoids triggering Noise handshakes (and the resulting reconnect churn) against an
+        // absent leader. A leader we don't actively monitor is always treated as reachable, so we
+        // still establish the session (see `IpcClient::is_reachable`). Reachability is a
+        // transport-level signal that does not go through the crypto channel.
         if !self.0.ipc_client.is_reachable(leader.clone()).await {
             tracing::debug!("Leader not reachable; not starting shared unlock sessions");
             return;
@@ -128,8 +130,10 @@ impl<L: SharedUnlockDriver + Send + Sync + 'static> Follower<L> {
                     }
                     _ = bitwarden_threading::time::sleep(crate::HEARTBEAT_INTERVAL) => {
                         if let Some(leader) = follower.0.driver.discover_leader().await {
-                            // Skip the heartbeat when the leader is unreachable, so we don't trigger
-                            // a Noise handshake against an absent leader every interval.
+                            // Skip the heartbeat when the leader is a monitored ping target that has
+                            // gone stale, so we don't trigger a Noise handshake against an absent
+                            // leader every interval. An unmonitored leader is always treated as
+                            // reachable (see `IpcClient::is_reachable`).
                             if !follower.0.ipc_client.is_reachable(leader.clone()).await {
                                 continue;
                             }

--- a/crates/bitwarden-shared-unlock/src/follower.rs
+++ b/crates/bitwarden-shared-unlock/src/follower.rs
@@ -40,13 +40,19 @@ impl<L: SharedUnlockDriver + Send + Sync + 'static> Follower<L> {
     }
 
     pub(crate) async fn start_sessions(&self) {
+        let Some(leader) = self.0.driver.discover_leader().await else {
+            return;
+        };
+
+        // Do not start sessions when the leader is unreachable. This avoids triggering Noise
+        // handshakes (and the resulting reconnect churn) against an absent leader. Reachability is
+        // a transport-level signal that does not go through the crypto channel.
+        if !self.0.ipc_client.is_reachable(leader.clone()).await {
+            tracing::debug!("Leader not reachable; not starting shared unlock sessions");
+            return;
+        }
+
         let users: Vec<bitwarden_core::UserId> = self.0.driver.list_users().await;
-        let leader = self
-            .0
-            .driver
-            .discover_leader()
-            .await
-            .expect("leader discovery should return a leader");
 
         if !users.is_empty() {
             tracing::info!("Starting shared unlock sessions for users: {:?}", users);
@@ -122,6 +128,11 @@ impl<L: SharedUnlockDriver + Send + Sync + 'static> Follower<L> {
                     }
                     _ = bitwarden_threading::time::sleep(crate::HEARTBEAT_INTERVAL) => {
                         if let Some(leader) = follower.0.driver.discover_leader().await {
+                            // Skip the heartbeat when the leader is unreachable, so we don't trigger
+                            // a Noise handshake against an absent leader every interval.
+                            if !follower.0.ipc_client.is_reachable(leader.clone()).await {
+                                continue;
+                            }
                             // For all users that are logged in, send a heartbeat message to the leader.
                             for user_id in follower.0.driver.list_users().await {
                                 let message = FollowerMessage::HeartBeat { user_id };

--- a/crates/bitwarden-shared-unlock/src/lib.rs
+++ b/crates/bitwarden-shared-unlock/src/lib.rs
@@ -172,7 +172,7 @@ pub enum DeviceEvent {
         /// User whose vault was manually unlocked.
         user_id: UserId,
         /// Raw user key bytes used to unlock the vault.
-        #[tsify(type = "SymmetricKey")]
+        #[cfg_attr(feature = "wasm", tsify(type = "SymmetricKey"))]
         user_key: SymmetricCryptoKey,
     },
 }

--- a/crates/bitwarden-shared-unlock/src/tests.rs
+++ b/crates/bitwarden-shared-unlock/src/tests.rs
@@ -262,7 +262,10 @@ async fn unreachable_aware_follower(
 /// Drives the IPC client's reachability tracker to report the leader as reachable by starting its
 /// receive loop and delivering an inbound message from the leader, mirroring real transport traffic
 /// (reachability is derived from observed inbound messages, not set directly).
-async fn mark_leader_reachable(ipc_client: &Arc<dyn IpcClient>, backend: &TestCommunicationBackend) {
+async fn mark_leader_reachable(
+    ipc_client: &Arc<dyn IpcClient>,
+    backend: &TestCommunicationBackend,
+) {
     ipc_client
         .start(None)
         .await
@@ -276,8 +279,8 @@ async fn mark_leader_reachable(ipc_client: &Arc<dyn IpcClient>, backend: &TestCo
     wait_until_reachable(ipc_client, LEADER_ENDPOINT).await;
 }
 
-/// Polls the IPC client until `endpoint` is reported reachable, yielding so the spawned receive loop
-/// can process the injected message.
+/// Polls the IPC client until `endpoint` is reported reachable, yielding so the spawned receive
+/// loop can process the injected message.
 async fn wait_until_reachable(ipc_client: &Arc<dyn IpcClient>, endpoint: Endpoint) {
     for _ in 0..1000 {
         if ipc_client.is_reachable(endpoint.clone()).await {

--- a/crates/bitwarden-shared-unlock/src/tests.rs
+++ b/crates/bitwarden-shared-unlock/src/tests.rs
@@ -159,6 +159,9 @@ impl Harness {
             InMemorySessionRepository::new(HashMap::new()),
         ));
 
+        // The leader must look reachable or the follower skips starting sessions.
+        mark_leader_reachable(&ipc_client, &follower_ipc_backend).await;
+
         let follower = Follower::create(follower_lock.clone(), ipc_client);
         follower.start_sessions().await;
 
@@ -235,24 +238,54 @@ impl Harness {
 
 /// Builds a follower whose IPC backend reports the given reachability, plus the backend so the test
 /// can inspect outgoing messages.
-fn unreachable_aware_follower(
+async fn unreachable_aware_follower(
     follower_states: HashMap<UserId, LockState>,
     reachable: bool,
 ) -> (Follower<MockDriver>, TestCommunicationBackend) {
     let follower_lock = MockDriver::new(follower_states);
     let backend = TestCommunicationBackend::new();
-    // Gate the leader endpoint so reachability is enforced, then drive it via the tracker: a
-    // recorded liveness signal makes it reachable; leaving it unrecorded keeps it unreachable.
+    // Reachability is derived from inbound traffic, so an endpoint stays unreachable until a
+    // message is observed from it. No ping targets are configured, keeping the ping scheduler from
+    // emitting liveness pings that would otherwise show up in `drain_outgoing`.
     let ipc_client: Arc<dyn IpcClient> = Arc::new(TestIpcClient::new_with_reachability(
         NoEncryptionCryptoProvider,
         backend.clone(),
         InMemorySessionRepository::new(HashMap::new()),
-        vec![LEADER_ENDPOINT],
+        Vec::new(),
     ));
     if reachable {
-        ipc_client.record_reachability(LEADER_ENDPOINT);
+        mark_leader_reachable(&ipc_client, &backend).await;
     }
     (Follower::create(follower_lock, ipc_client), backend)
+}
+
+/// Drives the IPC client's reachability tracker to report the leader as reachable by starting its
+/// receive loop and delivering an inbound message from the leader, mirroring real transport traffic
+/// (reachability is derived from observed inbound messages, not set directly).
+async fn mark_leader_reachable(ipc_client: &Arc<dyn IpcClient>, backend: &TestCommunicationBackend) {
+    ipc_client
+        .start(None)
+        .await
+        .expect("IPC client should start");
+    backend.push_incoming(IncomingMessage {
+        payload: Vec::new(),
+        destination: Endpoint::DesktopRenderer,
+        source: Source::DesktopMain,
+        topic: None,
+    });
+    wait_until_reachable(ipc_client, LEADER_ENDPOINT).await;
+}
+
+/// Polls the IPC client until `endpoint` is reported reachable, yielding so the spawned receive loop
+/// can process the injected message.
+async fn wait_until_reachable(ipc_client: &Arc<dyn IpcClient>, endpoint: Endpoint) {
+    for _ in 0..1000 {
+        if ipc_client.is_reachable(endpoint.clone()).await {
+            return;
+        }
+        tokio::task::yield_now().await;
+    }
+    panic!("leader did not become reachable");
 }
 
 #[tokio::test]
@@ -263,7 +296,7 @@ async fn test_follower_skips_start_sessions_when_leader_unreachable() {
             user_key: test_user_key(),
         },
     )]);
-    let (follower, backend) = unreachable_aware_follower(follower_states, false);
+    let (follower, backend) = unreachable_aware_follower(follower_states, false).await;
 
     follower.start_sessions().await;
 
@@ -281,7 +314,7 @@ async fn test_follower_starts_sessions_when_leader_reachable() {
             user_key: test_user_key(),
         },
     )]);
-    let (follower, backend) = unreachable_aware_follower(follower_states, true);
+    let (follower, backend) = unreachable_aware_follower(follower_states, true).await;
 
     follower.start_sessions().await;
 

--- a/crates/bitwarden-shared-unlock/src/tests.rs
+++ b/crates/bitwarden-shared-unlock/src/tests.rs
@@ -12,7 +12,7 @@ use bitwarden_crypto::SymmetricCryptoKey;
 use bitwarden_encoding::B64;
 use bitwarden_ipc::{
     Endpoint, HostId, InMemorySessionRepository, IncomingMessage, IpcClient,
-    NoEncryptionCryptoProvider, Source, TestCommunicationBackend, TestIpcClient,
+    NoEncryptionCryptoProvider, PayloadTypeName, Source, TestCommunicationBackend, TestIpcClient,
     TypedIncomingMessage,
 };
 
@@ -236,27 +236,35 @@ impl Harness {
 
 // --- Tests ---
 
-/// Builds a follower whose IPC backend reports the given reachability, plus the backend so the test
-/// can inspect outgoing messages.
-async fn unreachable_aware_follower(
+/// Builds a follower that actively monitors (pings) `LEADER_ENDPOINT`, plus the backend so the test
+/// can inspect outgoing messages. Reachability gating only applies to monitored ping targets, so
+/// the leader must be one for the unreachable case to be exercised. When `reachable` is set, the
+/// leader is driven to look reachable via an injected inbound message.
+async fn monitoring_follower(
     follower_states: HashMap<UserId, LockState>,
     reachable: bool,
 ) -> (Follower<MockDriver>, TestCommunicationBackend) {
     let follower_lock = MockDriver::new(follower_states);
     let backend = TestCommunicationBackend::new();
-    // Reachability is derived from inbound traffic, so an endpoint stays unreachable until a
-    // message is observed from it. No ping targets are configured, keeping the ping scheduler from
-    // emitting liveness pings that would otherwise show up in `drain_outgoing`.
     let ipc_client: Arc<dyn IpcClient> = Arc::new(TestIpcClient::new_with_reachability(
         NoEncryptionCryptoProvider,
         backend.clone(),
         InMemorySessionRepository::new(HashMap::new()),
-        Vec::new(),
+        vec![LEADER_ENDPOINT],
     ));
     if reachable {
         mark_leader_reachable(&ipc_client, &backend).await;
     }
     (Follower::create(follower_lock, ipc_client), backend)
+}
+
+/// Counts the `StartSession` (follower-to-leader typed) messages among `outgoing`, ignoring the
+/// plaintext reachability pings the scheduler emits to monitored targets.
+fn count_start_sessions(outgoing: &[bitwarden_ipc::OutgoingMessage]) -> usize {
+    outgoing
+        .iter()
+        .filter(|m| m.topic.as_deref() == Some(FollowerMessage::PAYLOAD_TYPE_NAME))
+        .count()
 }
 
 /// Drives the IPC client's reachability tracker to report the leader as reachable by starting its
@@ -299,13 +307,14 @@ async fn test_follower_skips_start_sessions_when_leader_unreachable() {
             user_key: test_user_key(),
         },
     )]);
-    let (follower, backend) = unreachable_aware_follower(follower_states, false).await;
+    let (follower, backend) = monitoring_follower(follower_states, false).await;
 
     follower.start_sessions().await;
 
-    assert!(
-        backend.drain_outgoing().await.is_empty(),
-        "no StartSession should be sent while the leader is unreachable"
+    assert_eq!(
+        count_start_sessions(&backend.drain_outgoing().await),
+        0,
+        "no StartSession should be sent while the monitored leader is unreachable"
     );
 }
 
@@ -317,12 +326,12 @@ async fn test_follower_starts_sessions_when_leader_reachable() {
             user_key: test_user_key(),
         },
     )]);
-    let (follower, backend) = unreachable_aware_follower(follower_states, true).await;
+    let (follower, backend) = monitoring_follower(follower_states, true).await;
 
     follower.start_sessions().await;
 
     assert_eq!(
-        backend.drain_outgoing().await.len(),
+        count_start_sessions(&backend.drain_outgoing().await),
         1,
         "a StartSession should be sent to a reachable leader"
     );

--- a/crates/bitwarden-shared-unlock/src/tests.rs
+++ b/crates/bitwarden-shared-unlock/src/tests.rs
@@ -233,6 +233,65 @@ impl Harness {
 
 // --- Tests ---
 
+/// Builds a follower whose IPC backend reports the given reachability, plus the backend so the test
+/// can inspect outgoing messages.
+fn unreachable_aware_follower(
+    follower_states: HashMap<UserId, LockState>,
+    reachable: bool,
+) -> (Follower<MockDriver>, TestCommunicationBackend) {
+    let follower_lock = MockDriver::new(follower_states);
+    let backend = TestCommunicationBackend::new();
+    // Gate the leader endpoint so reachability is enforced, then drive it via the tracker: a
+    // recorded liveness signal makes it reachable; leaving it unrecorded keeps it unreachable.
+    let ipc_client: Arc<dyn IpcClient> = Arc::new(TestIpcClient::new_with_reachability(
+        NoEncryptionCryptoProvider,
+        backend.clone(),
+        InMemorySessionRepository::new(HashMap::new()),
+        vec![LEADER_ENDPOINT],
+    ));
+    if reachable {
+        ipc_client.record_reachability(LEADER_ENDPOINT);
+    }
+    (Follower::create(follower_lock, ipc_client), backend)
+}
+
+#[tokio::test]
+async fn test_follower_skips_start_sessions_when_leader_unreachable() {
+    let follower_states = HashMap::from([(
+        user_a(),
+        LockState::Unlocked {
+            user_key: test_user_key(),
+        },
+    )]);
+    let (follower, backend) = unreachable_aware_follower(follower_states, false);
+
+    follower.start_sessions().await;
+
+    assert!(
+        backend.drain_outgoing().await.is_empty(),
+        "no StartSession should be sent while the leader is unreachable"
+    );
+}
+
+#[tokio::test]
+async fn test_follower_starts_sessions_when_leader_reachable() {
+    let follower_states = HashMap::from([(
+        user_a(),
+        LockState::Unlocked {
+            user_key: test_user_key(),
+        },
+    )]);
+    let (follower, backend) = unreachable_aware_follower(follower_states, true);
+
+    follower.start_sessions().await;
+
+    assert_eq!(
+        backend.drain_outgoing().await.len(),
+        1,
+        "a StartSession should be sent to a reachable leader"
+    );
+}
+
 #[tokio::test]
 async fn test_follower_startup_locked() {
     let user = user_a();

--- a/crates/bitwarden-wasm-internal/integration-tests/tests/reachability-ipc.test.ts
+++ b/crates/bitwarden-wasm-internal/integration-tests/tests/reachability-ipc.test.ts
@@ -1,0 +1,159 @@
+import {
+  Endpoint,
+  IncomingMessage,
+  IpcClient,
+  IpcCommunicationBackend,
+  IpcCommunicationBackendSender,
+  OutgoingMessage,
+  Source,
+  init_sdk,
+} from "@bitwarden/sdk-internal";
+
+import { sleep } from "./utils";
+
+const REACHABILITY_PING_TOPIC = "$bitwarden_reachability_ping";
+const REACHABILITY_PONG_TOPIC = "$bitwarden_reachability_pong";
+
+/**
+ * Wires two IPC clients over a paired in-memory transport, capturing every outgoing message from
+ * each side so tests can assert on the reachability ping/pong that the SDK drives itself.
+ */
+function setupCapturingPair(
+  followerSource: Source = "DesktopMain",
+  leaderSource: Source = "DesktopRenderer",
+) {
+  const followerOutgoing: OutgoingMessage[] = [];
+  const leaderOutgoing: OutgoingMessage[] = [];
+
+  let receiveOnLeader: (m: IncomingMessage) => void;
+  let receiveOnFollower: (m: IncomingMessage) => void;
+
+  const followerSender: IpcCommunicationBackendSender = {
+    send: async (outgoing: OutgoingMessage) => {
+      followerOutgoing.push(outgoing);
+      receiveOnLeader(
+        new IncomingMessage(outgoing.payload, outgoing.destination, followerSource, outgoing.topic),
+      );
+    },
+  };
+  const leaderSender: IpcCommunicationBackendSender = {
+    send: async (outgoing: OutgoingMessage) => {
+      leaderOutgoing.push(outgoing);
+      receiveOnFollower(
+        new IncomingMessage(outgoing.payload, outgoing.destination, leaderSource, outgoing.topic),
+      );
+    },
+  };
+
+  const followerBackend = new IpcCommunicationBackend(followerSender);
+  const leaderBackend = new IpcCommunicationBackend(leaderSender);
+  receiveOnFollower = (m) => followerBackend.receive(m);
+  receiveOnLeader = (m) => leaderBackend.receive(m);
+
+  return { followerBackend, leaderBackend, followerOutgoing, leaderOutgoing, leaderSource };
+}
+
+async function waitForReachable(client: IpcClient, endpoint: Endpoint): Promise<boolean> {
+  for (let i = 0; i < 50; i++) {
+    if (await client.isReachable(endpoint)) {
+      return true;
+    }
+    await sleep(20);
+  }
+  return false;
+}
+
+describe("reachability ipc", () => {
+  it("pings the configured leader, which answers with a pong, marking it reachable", async () => {
+    init_sdk();
+
+    const { followerBackend, leaderBackend, followerOutgoing, leaderOutgoing, leaderSource } =
+      setupCapturingPair();
+    // The follower records the leader by the source stamped on inbound frames.
+    const leaderEndpoint = leaderSource as Endpoint;
+
+    // The follower pings (and therefore gates) the leader; the leader is a passive responder.
+    const follower = IpcClient.newWithSdkInMemorySessions(followerBackend, {
+      pingTargets: [leaderEndpoint],
+    });
+    const leader = IpcClient.newWithSdkInMemorySessions(leaderBackend, { pingTargets: [] });
+
+    // Gated and never seen: the leader starts out unreachable.
+    expect(await follower.isReachable(leaderEndpoint)).toBe(false);
+
+    // Start the responder first so it is subscribed before the follower emits its first ping.
+    await leader.start();
+    await follower.start();
+
+    // The SDK-driven ping/pong round trip should make the leader reachable.
+    expect(await waitForReachable(follower, leaderEndpoint)).toBe(true);
+
+    // ...and that round trip is visible on the wire: a ping from the follower, a pong from the leader.
+    expect(
+      followerOutgoing.some(
+        (m) => m.topic === REACHABILITY_PING_TOPIC && m.destination === leaderEndpoint,
+      ),
+    ).toBe(true);
+    expect(leaderOutgoing.some((m) => m.topic === REACHABILITY_PONG_TOPIC)).toBe(true);
+  });
+
+  it("answers an inbound ping with a pong even when it pings no one itself", async () => {
+    init_sdk();
+
+    const { followerBackend, leaderBackend, leaderOutgoing, leaderSource } = setupCapturingPair();
+    const leaderEndpoint = leaderSource as Endpoint;
+
+    const follower = IpcClient.newWithSdkInMemorySessions(followerBackend, {
+      pingTargets: [leaderEndpoint],
+    });
+    // Passive responder: no ping targets, but the SDK still answers inbound pings.
+    const responder = IpcClient.newWithSdkInMemorySessions(leaderBackend, { pingTargets: [] });
+
+    await responder.start();
+    await follower.start();
+
+    await waitForReachable(follower, leaderEndpoint);
+
+    expect(leaderOutgoing.some((m) => m.topic === REACHABILITY_PONG_TOPIC)).toBe(true);
+  });
+
+  it("keeps a gated leader unreachable when nothing answers its pings", async () => {
+    init_sdk();
+
+    const leaderEndpoint: Endpoint = "DesktopRenderer";
+    // A backend whose sends go nowhere: pings are emitted but never answered.
+    const followerBackend = new IpcCommunicationBackend({
+      send: async () => {},
+    });
+    const follower = IpcClient.newWithSdkInMemorySessions(followerBackend, {
+      pingTargets: [leaderEndpoint],
+    });
+
+    await follower.start();
+    // Give the scheduler time to emit unanswered pings.
+    await sleep(100);
+
+    expect(await follower.isReachable(leaderEndpoint)).toBe(false);
+  });
+
+  it("marks a leader unreachable after invalidateReachability", async () => {
+    init_sdk();
+
+    const { followerBackend, leaderBackend, leaderSource } = setupCapturingPair();
+    const leaderEndpoint = leaderSource as Endpoint;
+
+    const follower = IpcClient.newWithSdkInMemorySessions(followerBackend, {
+      pingTargets: [leaderEndpoint],
+    });
+    const leader = IpcClient.newWithSdkInMemorySessions(leaderBackend, { pingTargets: [] });
+
+    await leader.start();
+    await follower.start();
+
+    expect(await waitForReachable(follower, leaderEndpoint)).toBe(true);
+
+    // A known transport disconnect can be surfaced immediately rather than waiting for the window.
+    follower.invalidateReachability(leaderEndpoint);
+    expect(await follower.isReachable(leaderEndpoint)).toBe(false);
+  });
+});

--- a/crates/bitwarden-wasm-internal/integration-tests/tests/unlock/biometrics-ipc.test.ts
+++ b/crates/bitwarden-wasm-internal/integration-tests/tests/unlock/biometrics-ipc.test.ts
@@ -18,8 +18,8 @@ async function setupClientPair(driver = makeMockBiometricsDriver()) {
   init_sdk();
 
   const [requesterBackend, responderBackend] = makeMockTransportPair();
-  const requester = IpcClient.newWithSdkInMemorySessions(requesterBackend);
-  const responder = IpcClient.newWithSdkInMemorySessions(responderBackend);
+  const requester = IpcClient.newWithSdkInMemorySessions(requesterBackend, { pingTargets: [] });
+  const responder = IpcClient.newWithSdkInMemorySessions(responderBackend, { pingTargets: [] });
 
   await requester.start();
   await responder.start();

--- a/crates/bitwarden-wasm-internal/integration-tests/tests/unlock/shared-unlock-failures.test.ts
+++ b/crates/bitwarden-wasm-internal/integration-tests/tests/unlock/shared-unlock-failures.test.ts
@@ -1,0 +1,146 @@
+import { Endpoint, UserId } from "@bitwarden/sdk-internal";
+import { sleep, setupSharedUnlockPair, setupSharedUnlockHub, testSymmetricKey } from "../utils";
+
+const USER_A = "00000000-0000-0000-0000-000000000001" as unknown as UserId;
+const USER_KEY = testSymmetricKey(0x11);
+const USER_A_LOCKED_STATE = new Map([[USER_A, undefined]]);
+const USER_A_UNLOCKED_STATE = new Map([[USER_A, USER_KEY]]);
+const UNLOCK_EVENT = { ManualUnlock: { user_id: USER_A, user_key: USER_KEY } };
+const LOCK_EVENT = { ManualLock: { user_id: USER_A } };
+
+/** Polls `predicate` until it is true or the timeout elapses. */
+async function waitFor(predicate: () => boolean, timeoutMs: number): Promise<boolean> {
+  const step = 20;
+  for (let elapsed = 0; elapsed < timeoutMs; elapsed += step) {
+    if (predicate()) {
+      return true;
+    }
+    await sleep(step);
+  }
+  return predicate();
+}
+
+/** Polls an async `predicate` until it resolves true or the timeout elapses. */
+async function waitForAsync(
+  predicate: () => Promise<boolean>,
+  timeoutMs: number,
+): Promise<boolean> {
+  const step = 20;
+  for (let elapsed = 0; elapsed < timeoutMs; elapsed += step) {
+    if (await predicate()) {
+      return true;
+    }
+    await sleep(step);
+  }
+  return predicate();
+}
+
+// These tests exercise partial-connectivity failure modes: a follower that is still in the leader's
+// session map but temporarily cannot receive messages. The recovery mechanism under test is the
+// authoritative `LockStateUpdate` the leader piggybacks on every heartbeat response — the only
+// desync-repair path, since sends are fire-and-forget.
+//
+// NOTE: `handle_device_event` only *broadcasts*; it does not mutate the caller's own driver (in a
+// real client the app already changed its own lock state and is merely notifying peers). The
+// per-heartbeat authoritative update reads the leader driver's state, so each test first drives the
+// leader's mock driver to the state it is about to announce — otherwise the heartbeat would revert
+// the followers right back.
+describe("shared unlock failure cases", () => {
+  it("re-locks a follower that missed the leader's Lock broadcast while its downlink was down", async () => {
+    const pair = await setupSharedUnlockPair({
+      leader: { initialStates: USER_A_UNLOCKED_STATE },
+      follower: { initialStates: USER_A_UNLOCKED_STATE },
+    });
+    await sleep(50);
+    expect(pair.followerDriver.getUserKey(USER_A)).toBe(USER_KEY);
+
+    // The leader->follower downlink dies: the follower can no longer receive broadcasts or
+    // heartbeat responses, but its own heartbeats still reach the leader.
+    pair._internal.router.setLinkUp("secondToFirst", false);
+
+    // The leader locks. The broadcast `LockStateUpdate{Locked}` is dropped on the dead downlink.
+    await pair.leaderDriver.driver.lock_user(USER_A);
+    await pair.leader.handle_device_event(LOCK_EVENT);
+    await sleep(200);
+    expect(pair.followerDriver.getUserKey(USER_A)).toBe(USER_KEY); // missed the lock, still unlocked
+
+    // Restore the downlink. The next heartbeat carries the authoritative locked state and the
+    // follower re-locks.
+    pair._internal.router.setLinkUp("secondToFirst", true);
+    expect(await waitFor(() => pair.followerDriver.getUserKey(USER_A) === undefined, 6000)).toBe(
+      true,
+    );
+
+    pair.leaderAbort.abort();
+    pair.followerAbort.abort();
+  }, 15000);
+
+  it("stops talking to an unreachable leader and resyncs once it returns", async () => {
+    // The follower discovers `DesktopRenderer` as its leader, so gate (and ping) that endpoint.
+    const leaderEndpoint: Endpoint = "DesktopRenderer";
+    const pair = await setupSharedUnlockPair({
+      leader: { initialStates: USER_A_UNLOCKED_STATE },
+      follower: { initialStates: USER_A_UNLOCKED_STATE, pingTargets: [leaderEndpoint] },
+    });
+    const { followerIpc, router } = pair._internal;
+
+    // A gated leader is unreachable until the ping/pong round trip lands.
+    expect(await waitForAsync(() => followerIpc.isReachable(leaderEndpoint), 6000)).toBe(true);
+    await sleep(50);
+    expect(pair.followerDriver.getUserKey(USER_A)).toBe(USER_KEY);
+
+    // Cut the downlink (no more pongs) and surface the disconnect immediately rather than waiting
+    // out the activity window.
+    router.setLinkUp("secondToFirst", false);
+    followerIpc.invalidateReachability(leaderEndpoint);
+    expect(await followerIpc.isReachable(leaderEndpoint)).toBe(false);
+
+    // The leader locks while the follower is unreachable; nothing reaches the follower, and the
+    // follower suppresses its own heartbeats against the absent leader.
+    await pair.leaderDriver.driver.lock_user(USER_A);
+    await pair.leader.handle_device_event(LOCK_EVENT);
+    await sleep(200);
+    expect(pair.followerDriver.getUserKey(USER_A)).toBe(USER_KEY);
+
+    // Heal the downlink: pings are answered again → reachable → heartbeats resume → the
+    // authoritative locked state is applied.
+    router.setLinkUp("secondToFirst", true);
+    expect(await waitForAsync(() => followerIpc.isReachable(leaderEndpoint), 12000)).toBe(true);
+    expect(await waitFor(() => pair.followerDriver.getUserKey(USER_A) === undefined, 6000)).toBe(
+      true,
+    );
+
+    pair.leaderAbort.abort();
+    pair.followerAbort.abort();
+  }, 25000);
+
+  it("fans a state change out to every follower and resyncs one whose downlink was down", async () => {
+    const hub = await setupSharedUnlockHub({
+      leader: { initialStates: USER_A_LOCKED_STATE },
+      followers: [{ initialStates: USER_A_LOCKED_STATE }, { initialStates: USER_A_LOCKED_STATE }],
+    });
+    const [followerA, followerB] = hub.followers;
+    await sleep(100); // let both followers' StartSession register on the leader
+
+    // Unlock fans out to both followers.
+    await hub.leaderDriver.driver.unlock_user(USER_A, USER_KEY);
+    await hub.leader.handle_device_event(UNLOCK_EVENT);
+    expect(await waitFor(() => followerA.driver.getUserKey(USER_A) === USER_KEY, 4000)).toBe(true);
+    expect(await waitFor(() => followerB.driver.getUserKey(USER_A) === USER_KEY, 4000)).toBe(true);
+
+    // Drop follower B's downlink, then lock. A locks from the broadcast; B never receives it.
+    hub.hub.setDownlinkUp(1, false);
+    await hub.leaderDriver.driver.lock_user(USER_A);
+    await hub.leader.handle_device_event(LOCK_EVENT);
+    expect(await waitFor(() => followerA.driver.getUserKey(USER_A) === undefined, 4000)).toBe(true);
+    await sleep(200);
+    expect(followerB.driver.getUserKey(USER_A)).toBe(USER_KEY); // B missed the lock, still unlocked
+
+    // Heal B's downlink: its heartbeat pulls the authoritative locked state.
+    hub.hub.setDownlinkUp(1, true);
+    expect(await waitFor(() => followerB.driver.getUserKey(USER_A) === undefined, 6000)).toBe(true);
+
+    hub.leaderAbort.abort();
+    hub.followers.forEach((f) => f.abort.abort());
+  }, 15000);
+});

--- a/crates/bitwarden-wasm-internal/integration-tests/tests/utils.ts
+++ b/crates/bitwarden-wasm-internal/integration-tests/tests/utils.ts
@@ -16,6 +16,7 @@ import {
   IncomingMessage,
   OutgoingMessage,
   Source,
+  Endpoint,
   BiometricsUnlock,
   BiometricsStatus,
   SharedUnlockDriver,
@@ -216,6 +217,13 @@ export async function makeOrgInitializedClient(
 export interface MockTransportRouter {
   setFirstReceiver(receive: (m: IncomingMessage) => void): void;
   setSecondReceiver(receive: (m: IncomingMessage) => void): void;
+  /**
+   * Brings a directional link up or down. While a link is down, every message
+   * sent in that direction is silently dropped, modelling a dead transport
+   * (the SDK's `send` is already fire-and-forget). `firstToSecond` is the
+   * follower→leader uplink; `secondToFirst` is the leader→follower downlink.
+   */
+  setLinkUp(direction: "firstToSecond" | "secondToFirst", up: boolean): void;
   firstSource: Source;
   secondSource: Source;
 }
@@ -232,9 +240,12 @@ export function makeMockTransportPair(
 ): [IpcCommunicationBackend, IpcCommunicationBackend, MockTransportRouter] {
   let receiveOnFirst: (m: IncomingMessage) => void;
   let receiveOnSecond: (m: IncomingMessage) => void;
+  let firstToSecondUp = true;
+  let secondToFirstUp = true;
 
   const firstSender: IpcCommunicationBackendSender = {
     send: async (outgoing: OutgoingMessage) => {
+      if (!firstToSecondUp) return;
       receiveOnSecond(
         new IncomingMessage(outgoing.payload, outgoing.destination, firstSource, outgoing.topic),
       );
@@ -242,6 +253,7 @@ export function makeMockTransportPair(
   };
   const secondSender: IpcCommunicationBackendSender = {
     send: async (outgoing: OutgoingMessage) => {
+      if (!secondToFirstUp) return;
       receiveOnFirst(
         new IncomingMessage(outgoing.payload, outgoing.destination, secondSource, outgoing.topic),
       );
@@ -259,6 +271,13 @@ export function makeMockTransportPair(
     },
     setSecondReceiver: (fn) => {
       receiveOnSecond = fn;
+    },
+    setLinkUp: (direction, up) => {
+      if (direction === "firstToSecond") {
+        firstToSecondUp = up;
+      } else {
+        secondToFirstUp = up;
+      }
     },
     firstSource,
     secondSource,
@@ -378,14 +397,26 @@ export interface SharedUnlockPair {
     router: MockTransportRouter;
     leaderBackend: IpcCommunicationBackend;
     followerBackend: IpcCommunicationBackend;
+    leaderIpc: IpcClient;
+    followerIpc: IpcClient;
     followerSource: Source;
     leaderSource: Source;
   };
 }
 
+/**
+ * Driver options plus optional reachability ping targets for that side. When
+ * `pingTargets` is set, that client gates (and actively pings) the listed
+ * endpoints; when omitted it stays permissively reachable, preserving the
+ * default used by the happy-path shared-unlock tests.
+ */
+export type SharedUnlockSideOptions = MockSharedUnlockDriverOptions & {
+  pingTargets?: Endpoint[];
+};
+
 export async function setupSharedUnlockPair(options: {
-  leader: MockSharedUnlockDriverOptions;
-  follower: MockSharedUnlockDriverOptions;
+  leader: SharedUnlockSideOptions;
+  follower: SharedUnlockSideOptions;
 }): Promise<SharedUnlockPair> {
   init_sdk();
 
@@ -398,8 +429,14 @@ export async function setupSharedUnlockPair(options: {
     leaderSource,
   );
 
-  const leaderIpc = IpcClient.newWithSdkInMemorySessions(leaderBackend);
-  const followerIpc = IpcClient.newWithSdkInMemorySessions(followerBackend);
+  // By default neither side pings and every destination stays permissively reachable (reachability
+  // gating is covered by reachability-ipc.test). A side can opt into gating via `pingTargets`.
+  const leaderIpc = IpcClient.newWithSdkInMemorySessions(leaderBackend, {
+    pingTargets: options.leader.pingTargets ?? [],
+  });
+  const followerIpc = IpcClient.newWithSdkInMemorySessions(followerBackend, {
+    pingTargets: options.follower.pingTargets ?? [],
+  });
 
   await leaderIpc.start();
   await followerIpc.start();
@@ -428,6 +465,8 @@ export async function setupSharedUnlockPair(options: {
       router,
       leaderBackend,
       followerBackend,
+      leaderIpc,
+      followerIpc,
       followerSource,
       leaderSource,
     },
@@ -460,7 +499,9 @@ export async function reloadFollower(
 
   router.setFirstReceiver((m) => newFollowerBackend.receive(m));
 
-  const newFollowerIpc = IpcClient.newWithSdkInMemorySessions(newFollowerBackend);
+  const newFollowerIpc = IpcClient.newWithSdkInMemorySessions(newFollowerBackend, {
+    pingTargets: [],
+  });
   await newFollowerIpc.start();
 
   const newFollowerDriver = makeMockSharedUnlockDriver(options.follower);
@@ -507,7 +548,7 @@ export async function reloadLeader(
 
   router.setSecondReceiver((m) => newLeaderBackend.receive(m));
 
-  const newLeaderIpc = IpcClient.newWithSdkInMemorySessions(newLeaderBackend);
+  const newLeaderIpc = IpcClient.newWithSdkInMemorySessions(newLeaderBackend, { pingTargets: [] });
   await newLeaderIpc.start();
 
   const newLeaderDriver = makeMockSharedUnlockDriver(options.leader);
@@ -526,4 +567,132 @@ export async function reloadLeader(
       leaderBackend: newLeaderBackend,
     },
   };
+}
+
+/** Stable comparison key for an `Endpoint`/`Source` (which share their wire shape here). */
+function endpointKey(endpoint: Endpoint | Source): string {
+  return typeof endpoint === "string" ? endpoint : JSON.stringify(endpoint);
+}
+
+/**
+ * Hub for one leader and N followers over in-memory transports. Followers send
+ * only to the leader; the leader addresses each follower by the `Source` that
+ * follower stamps on its own frames (which is how the leader's session map keys
+ * them). Each follower's downlink (leader→follower) can be brought down to model
+ * that follower being unreachable while the others stay connected.
+ */
+export interface MockTransportHub {
+  leaderBackend: IpcCommunicationBackend;
+  followerBackends: IpcCommunicationBackend[];
+  /** Bring the leader→follower[index] downlink up or down. */
+  setDownlinkUp(index: number, up: boolean): void;
+}
+
+export function makeMockTransportHub(
+  leaderSource: Source,
+  followerSources: Source[],
+): MockTransportHub {
+  const downlinkUp = followerSources.map(() => true);
+  const followerReceives: ((m: IncomingMessage) => void)[] = [];
+  let receiveOnLeader: (m: IncomingMessage) => void;
+
+  // Leader → followers: route by destination to the follower whose endpoint matches.
+  const leaderSender: IpcCommunicationBackendSender = {
+    send: async (outgoing: OutgoingMessage) => {
+      const index = followerSources.findIndex(
+        (source) => endpointKey(source) === endpointKey(outgoing.destination),
+      );
+      if (index === -1 || !downlinkUp[index]) return;
+      followerReceives[index](
+        new IncomingMessage(outgoing.payload, outgoing.destination, leaderSource, outgoing.topic),
+      );
+    },
+  };
+  const leaderBackend = new IpcCommunicationBackend(leaderSender);
+  receiveOnLeader = (m) => leaderBackend.receive(m);
+
+  const followerBackends = followerSources.map((source, index) => {
+    const followerSender: IpcCommunicationBackendSender = {
+      send: async (outgoing: OutgoingMessage) => {
+        // Followers only ever address the leader.
+        receiveOnLeader(
+          new IncomingMessage(outgoing.payload, outgoing.destination, source, outgoing.topic),
+        );
+      },
+    };
+    const backend = new IpcCommunicationBackend(followerSender);
+    followerReceives[index] = (m) => backend.receive(m);
+    return backend;
+  });
+
+  return {
+    leaderBackend,
+    followerBackends,
+    setDownlinkUp: (index, up) => {
+      downlinkUp[index] = up;
+    },
+  };
+}
+
+/** A single follower attached to a {@link SharedUnlockHub}. */
+export interface SharedUnlockHubFollower {
+  follower: SharedUnlockFollower;
+  driver: MockSharedUnlockDriverHandle;
+  abort: AbortController;
+  ipc: IpcClient;
+}
+
+/** One leader fanning out to multiple followers, for broadcast/partition tests. */
+export interface SharedUnlockHub {
+  leader: SharedUnlockLeader;
+  leaderDriver: MockSharedUnlockDriverHandle;
+  leaderAbort: AbortController;
+  followers: SharedUnlockHubFollower[];
+  hub: MockTransportHub;
+}
+
+/**
+ * Wires one `SharedUnlockLeader` to up to two `SharedUnlockFollower`s over a
+ * {@link makeMockTransportHub}. Followers default to the `"browser"` client
+ * name, which discovers `DesktopRenderer` as its leader, so the leader stamps
+ * `DesktopRenderer`. Each follower stamps a distinct non-Web source so the
+ * leader tracks them as separate endpoints and the web origin check is skipped.
+ */
+export async function setupSharedUnlockHub(options: {
+  leader: MockSharedUnlockDriverOptions;
+  followers: MockSharedUnlockDriverOptions[];
+}): Promise<SharedUnlockHub> {
+  init_sdk();
+
+  const leaderSource: Source = "DesktopRenderer";
+  const allFollowerSources: Source[] = ["DesktopMain", { BrowserBackground: { id: "Own" } }];
+  if (options.followers.length > allFollowerSources.length) {
+    throw new Error(`setupSharedUnlockHub supports at most ${allFollowerSources.length} followers`);
+  }
+  const followerSources = allFollowerSources.slice(0, options.followers.length);
+
+  const hub = makeMockTransportHub(leaderSource, followerSources);
+
+  // Start the leader first so it has subscribed before followers send their initial sessions.
+  const leaderIpc = IpcClient.newWithSdkInMemorySessions(hub.leaderBackend, { pingTargets: [] });
+  await leaderIpc.start();
+  const leaderDriver = makeMockSharedUnlockDriver(options.leader);
+  const leader = SharedUnlockLeader.try_new(leaderIpc, leaderDriver.driver);
+  const leaderAbort = new AbortController();
+  await leader.start(leaderAbort);
+
+  const followers: SharedUnlockHubFollower[] = [];
+  for (let index = 0; index < options.followers.length; index++) {
+    const ipc = IpcClient.newWithSdkInMemorySessions(hub.followerBackends[index], {
+      pingTargets: [],
+    });
+    await ipc.start();
+    const driver = makeMockSharedUnlockDriver(options.followers[index]);
+    const follower = SharedUnlockFollower.try_new(ipc, driver.driver);
+    const abort = new AbortController();
+    await follower.start(abort);
+    followers.push({ follower, driver, abort, ipc });
+  }
+
+  return { leader, leaderDriver, leaderAbort, followers, hub };
 }


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-39294
https://github.com/bitwarden/clients/pull/21450

## 📔 Objective

Stops shared-unlock error spam in the browser extension caused by repeated Noise handshakes against an absent leader.
Note: this requires  the client side change too.

## 🚨 Breaking Changes

