### PR TITLE
Add Key Management as co-owners of testvector skill

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -30,6 +30,7 @@ crates/bitwarden-api-key-connector/src/** @bitwarden/team-key-management-dev
 
 # Claude related files
 .claude/ @bitwarden/team-ai-sme
+.claude/skills/create-testvectors/ @bitwarden/team-ai-sme @bitwarden/team-key-management-dev
 .github/workflows/respond.yml @bitwarden/team-ai-sme
 .github/workflows/review-code.yml @bitwarden/team-ai-sme
 


### PR DESCRIPTION
## 🎟️ Tracking

n/a

## 📔 Objective

Add `team-key-management-dev` as co-owners of the `create-testvectors` Claude skill in CODEOWNERS, alongside `team-ai-sme`.
