### PR TITLE
fix(deps): raise hybrid-array and typenum floors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3338,9 +3338,9 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hybrid-array"
-version = "0.4.10"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3944cf8cf766b40e2a1a333ee5e9b563f854d5fa49d6a8ca2764e97c6eddb214"
+checksum = "9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da"
 dependencies = [
  "ctutils",
  "serde",
@@ -6586,9 +6586,9 @@ checksum = "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
 
 [[package]]
 name = "typenum"
-version = "1.19.0"
+version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "unicase"

--- a/crates/bitwarden-crypto/Cargo.toml
+++ b/crates/bitwarden-crypto/Cargo.toml
@@ -49,7 +49,7 @@ ed25519-dalek = { workspace = true, features = ["rand_core", "zeroize"] }
 hex = { version = ">=0.4.0, <0.5" }
 hkdf = "0.13.0"
 hmac = { workspace = true, features = ["zeroize"] }
-hybrid-array = { version = "0.4.10", features = ["alloc", "serde", "zeroize"] }
+hybrid-array = { version = ">=0.4.12, <0.5.0", features = ["alloc", "serde", "zeroize"] }
 js-sys = { workspace = true, optional = true }
 ml-dsa = { version = "0.1.0-rc.8", features = ["zeroize"] }
 num-bigint = ">=0.4, <0.5"
@@ -69,7 +69,7 @@ thiserror = { workspace = true }
 tokio = { workspace = true, features = ["io-util"] }
 tracing = { workspace = true }
 tsify = { workspace = true, optional = true }
-typenum = ">=1.18.0, <1.20.0"
+typenum = ">=1.20.0, <1.21.0"
 uniffi = { workspace = true, optional = true }
 uuid = { workspace = true }
 wasm-bindgen = { workspace = true, optional = true }


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective

The direct-maximum-versions CI check runs cargo update to test that all dependencies can resolve to their latest compatible versions. crypto-bigint 0.7.0-0.7.4 are all YANKED upstream, so cargo update resolves to 0.7.5. That version requires hybrid-array ^0.4.12 and typenum ^1.20, which bitwarden-crypto's existing floors excluded, producing a resolver conflict that blocked all PRs.

Raise the two floors to admit what crypto-bigint 0.7.5 and rsa 0.10.0-rc.18 require. The committed Cargo.lock intentionally holds crypto-bigint at 0.7.3 (a locked-yanked version that still builds) so that local and Aikido-restricted dev environments do not pull anything newer than 7 days old. Only the no-Aikido CI runner resolves to 0.7.5 via its own cargo update.

Verified locally: cargo check --all-features -D warnings passes. Both newly-pulled versions (hybrid-array 0.4.12 @ 2026-05-09, typenum 1.20.1 @ 2026-05-29) are >7 days old.

## 🚨 Breaking Changes

<!-- Does this PR introduce any breaking changes? If so, please describe the impact and migration path for clients.

If you're unsure, the automated TypeScript compatibility check will run when you open/update this PR and provide feedback.

For breaking changes:
1. Describe what changed in the client interface
2. Explain why the change was necessary
3. Provide migration steps for client developers
4. Link to any paired client PRs if needed

Otherwise, you can remove this section. -->
