### PR TITLE
[PM-39476] Add Staged OrganizationUserStatusType

### DIFF
--- a/crates/bitwarden-organizations/src/lib.rs
+++ b/crates/bitwarden-organizations/src/lib.rs
@@ -28,6 +28,8 @@ pub enum OrganizationUserStatusType {
     Accepted = 1,
     /// The user has been confirmed by an admin and has full access.
     Confirmed = 2,
+    /// The user has been staged for provisioning but has not yet been invited.
+    Staged = 3,
 }
 
 /// The role of a user within an organization.


### PR DESCRIPTION
## 🎟️ Tracking
[PM-39476](https://bitwarden.atlassian.net/browse/PM-39476)

## 📔 Objective
Mimicking the changes that were added in [PM-37953](https://bitwarden.atlassian.net/browse/PM-37953), we are introducing a new OrganizationUserStatusType


[PM-39476]: https://bitwarden.atlassian.net/browse/PM-39476?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PM-37953]: https://bitwarden.atlassian.net/browse/PM-37953?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ