### PR TITLE
[PM-39258] Switch bitwarden-ipc to use P-256 curve by default

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -688,7 +688,7 @@ dependencies = [
  "criterion",
  "ed25519-dalek",
  "hex",
- "hkdf",
+ "hkdf 0.13.0",
  "hmac 0.13.0",
  "hybrid-array",
  "js-sys",
@@ -2680,6 +2680,7 @@ dependencies = [
  "ff 0.13.1",
  "generic-array",
  "group 0.13.0",
+ "hkdf 0.12.4",
  "pem-rfc7468 0.7.0",
  "pkcs8 0.10.2",
  "rand_core 0.6.4",
@@ -3277,6 +3278,15 @@ name = "hex-literal"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e712f64ec3850b98572bffac52e2c6f282b29fe6c5fa6d42334b30be438d95c1"
+
+[[package]]
+name = "hkdf"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
+dependencies = [
+ "hmac 0.12.1",
+]
 
 [[package]]
 name = "hkdf"
@@ -5818,6 +5828,7 @@ dependencies = [
  "chacha20poly1305 0.10.1",
  "curve25519-dalek 4.1.3",
  "getrandom 0.3.4",
+ "p256 0.13.2",
  "rustc_version",
  "sha2 0.10.9",
  "subtle",

--- a/crates/bitwarden-ipc/Cargo.toml
+++ b/crates/bitwarden-ipc/Cargo.toml
@@ -35,6 +35,7 @@ snow = { version = "0.10.0", default-features = false, features = [
     "default-resolver",
     "default-resolver-crypto",
     "risky-raw-split",
+    "use-p256",
 ] }
 thiserror = { workspace = true }
 tokio = { features = ["sync", "time", "rt"], workspace = true }

--- a/crates/bitwarden-ipc/src/crypto_provider/noise/handshake.rs
+++ b/crates/bitwarden-ipc/src/crypto_provider/noise/handshake.rs
@@ -25,8 +25,10 @@ pub(crate) enum CipherSuite {
     #[allow(non_camel_case_types)]
     Noise_NN_25519_ChaChaPoly_BLAKE2s,
     #[allow(non_camel_case_types)]
-    #[default]
     Noise_NN_25519_AESGCM_SHA256,
+    #[allow(non_camel_case_types)]
+    #[default]
+    Noise_NN_P256_AESGCM_SHA256,
 }
 
 impl CipherSuite {
@@ -35,6 +37,7 @@ impl CipherSuite {
         match self {
             Self::Noise_NN_25519_ChaChaPoly_BLAKE2s => TransportCipher::ChaCha20Poly1305,
             Self::Noise_NN_25519_AESGCM_SHA256 => TransportCipher::Aes256Gcm,
+            Self::Noise_NN_P256_AESGCM_SHA256 => TransportCipher::Aes256Gcm,
         }
     }
 }
@@ -47,6 +50,9 @@ impl Display for CipherSuite {
             }
             Self::Noise_NN_25519_AESGCM_SHA256 => {
                 write!(f, "Noise_NN_25519_AESGCM_SHA256")
+            }
+            Self::Noise_NN_P256_AESGCM_SHA256 => {
+                write!(f, "Noise_NN_P256_AESGCM_SHA256")
             }
         }
     }
@@ -188,10 +194,9 @@ mod tests {
     use super::*;
     use crate::crypto_provider::noise::transport_state::assert_matching_pair;
 
-    #[test]
-    fn test_handshake() {
-        let mut initiator = HandshakeInitiator::new(&CipherSuite::default());
-        let mut responder = HandshakeResponder::new(&CipherSuite::default());
+    fn run_handshake(ciphersuite: &CipherSuite) {
+        let mut initiator = HandshakeInitiator::new(ciphersuite);
+        let mut responder = HandshakeResponder::new(ciphersuite);
 
         let init_message = initiator.write_start_message().unwrap();
         responder.read_start_message(&init_message).unwrap();
@@ -201,5 +206,16 @@ mod tests {
         let initiator_transport_state = (&mut initiator).into();
         let responder_transport_state = (&mut responder).into();
         assert_matching_pair(&initiator_transport_state, &responder_transport_state);
+    }
+
+    #[test]
+    fn test_handshake() {
+        for ciphersuite in [
+            CipherSuite::Noise_NN_25519_ChaChaPoly_BLAKE2s,
+            CipherSuite::Noise_NN_25519_AESGCM_SHA256,
+            CipherSuite::Noise_NN_P256_AESGCM_SHA256,
+        ] {
+            run_handshake(&ciphersuite);
+        }
     }
 }


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-39258

## 📔 Objective

Switch `bitwarden-ipc` crate to use FIPS compliant cipher suite by default.
Adds new (default) `Noise_NN_P256_AESGCM_SHA256` cipher suite (handshake using P-256 curve, transport using AES-GCM cipher and SHA-256 for hash).

❓ Do we want to remove other cipher suites (or at least leave one for non-gov environment, likely ChaChaPoly) ?

## 🚨 Breaking Changes

None expected.
Note: While older client won't be able to communicate with new client with this change though ipc, the only use of this implementation is shared unlock, which is not enabled in prod. Older clients will eventually catch up (upgrade) to new version that will have this SDK, hence become compatible again.
