### PR TITLE
[PM-39294] Gate shared unlock handshakes on transport reachability

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -919,7 +919,6 @@ dependencies = [
  "uuid",
  "wasm-bindgen",
  "wasm-bindgen-futures",
- "web-time",
  "zeroize",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2208,8 +2208,7 @@ dependencies = [
 [[package]]
 name = "crypto-bigint"
 version = "0.7.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a52aa3fcda4e6302a9f48734f234d35d4721b96f8fe07d073f07ce9df4f0271"
+source = "git+https://github.com/RustCrypto/crypto-bigint?tag=v0.7.5#2b54d248cce00457e3afb5650d9b14632ef4a116"
 dependencies = [
  "cpubits",
  "ctutils",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -919,6 +919,7 @@ dependencies = [
  "uuid",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "web-time",
  "zeroize",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -100,7 +100,7 @@ reqwest-middleware = { version = "0.5.1", features = [
     "form",
     "query",
 ] }
-rsa = "0.10.0-rc.17"
+rsa = "0.10.0-rc.18"
 rustls = { version = "0.23.27", default-features = false, features = [
     "std",
     "tls12",
@@ -202,3 +202,9 @@ opt-level = 3
 # Stripping the binary reduces the size by ~30%, but the stacktraces won't be usable anymore.
 # This is fine as long as we don't have any unhandled panics, but let's keep it disabled for now
 # strip = true
+
+# The crates.io 0.7.x releases of crypto-bigint were yanked after 0.7.5 shipped a bugfix, so
+# stale registry indexes can fail to resolve `crypto-bigint = "^0.7"` (required by rsa). Override
+# to the published 0.7.5 from git to keep the build resolving regardless of index state.
+[patch.crates-io]
+crypto-bigint = { git = "https://github.com/RustCrypto/crypto-bigint", tag = "v0.7.5" }

--- a/crates/bitwarden-ipc/Cargo.toml
+++ b/crates/bitwarden-ipc/Cargo.toml
@@ -43,6 +43,7 @@ tsify = { workspace = true, optional = true }
 uuid = { workspace = true }
 wasm-bindgen = { workspace = true, optional = true }
 wasm-bindgen-futures = { workspace = true, optional = true }
+web-time = "1.1.0"
 zeroize = { workspace = true, features = ["zeroize_derive"] }
 
 [lints]

--- a/crates/bitwarden-ipc/Cargo.toml
+++ b/crates/bitwarden-ipc/Cargo.toml
@@ -43,7 +43,6 @@ tsify = { workspace = true, optional = true }
 uuid = { workspace = true }
 wasm-bindgen = { workspace = true, optional = true }
 wasm-bindgen-futures = { workspace = true, optional = true }
-web-time = "1.1.0"
 zeroize = { workspace = true, features = ["zeroize_derive"] }
 
 [lints]

--- a/crates/bitwarden-ipc/src/control.rs
+++ b/crates/bitwarden-ipc/src/control.rs
@@ -1,0 +1,32 @@
+//! The IPC control plane: reserved topics for transport-level frames that travel over the raw
+//! transport and deliberately bypass the crypto channel (reachability ping/pong).
+//!
+//! Frames whose topic falls under [`CONTROL_TOPIC_PREFIX`] are peeled off by the
+//! [`ControlSplitter`](crate::control_splitter::ControlSplitter) before the crypto layer ever sees
+//! them, so they can measure liveness without (and without disturbing) a crypto session.
+
+/// Reserved topic namespace for transport control frames that bypass the crypto channel.
+pub(crate) const CONTROL_TOPIC_PREFIX: &str = "$bw.control.";
+/// Topic marking a plaintext reachability ping.
+pub(crate) const CONTROL_PING_TOPIC: &str = "$bw.control.ping";
+/// Topic marking a plaintext reachability pong (the reply to a ping).
+pub(crate) const CONTROL_PONG_TOPIC: &str = "$bw.control.pong";
+
+/// Whether `topic` belongs to the reserved control-topic namespace and must bypass crypto.
+pub(crate) fn is_control_topic(topic: Option<&str>) -> bool {
+    topic.is_some_and(|t| t.starts_with(CONTROL_TOPIC_PREFIX))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn is_control_topic_matches_namespace() {
+        assert!(is_control_topic(Some(CONTROL_PING_TOPIC)));
+        assert!(is_control_topic(Some(CONTROL_PONG_TOPIC)));
+        assert!(is_control_topic(Some("$bw.control.future")));
+        assert!(!is_control_topic(Some("some-rpc-topic")));
+        assert!(!is_control_topic(None));
+    }
+}

--- a/crates/bitwarden-ipc/src/control.rs
+++ b/crates/bitwarden-ipc/src/control.rs
@@ -5,6 +5,11 @@
 //! [`ControlSplitter`](crate::control_splitter::ControlSplitter) before the crypto layer ever sees
 //! them, so they can measure liveness without (and without disturbing) a crypto session.
 
+use crate::{
+    endpoint::{Endpoint, Source},
+    message::OutgoingMessage,
+};
+
 /// Reserved topic namespace for transport control frames that bypass the crypto channel.
 pub(crate) const CONTROL_TOPIC_PREFIX: &str = "$bw.control.";
 /// Topic marking a plaintext reachability ping.
@@ -15,6 +20,50 @@ pub(crate) const CONTROL_PONG_TOPIC: &str = "$bw.control.pong";
 /// Whether `topic` belongs to the reserved control-topic namespace and must bypass crypto.
 pub(crate) fn is_control_topic(topic: Option<&str>) -> bool {
     topic.is_some_and(|t| t.starts_with(CONTROL_TOPIC_PREFIX))
+}
+
+/// A transport control-plane message. These ride the reserved control topics over the raw
+/// transport rather than the crypto channel.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ControlMessage {
+    /// Liveness probe.
+    Ping,
+    /// Reply to a [`ControlMessage::Ping`].
+    Pong,
+}
+
+impl ControlMessage {
+    /// The reserved topic this message rides on.
+    pub(crate) fn topic(self) -> &'static str {
+        match self {
+            ControlMessage::Ping => CONTROL_PING_TOPIC,
+            ControlMessage::Pong => CONTROL_PONG_TOPIC,
+        }
+    }
+
+    /// Parse a control message from a frame's topic, returning `None` for non-control frames.
+    pub(crate) fn from_topic(topic: Option<&str>) -> Option<Self> {
+        match topic {
+            Some(CONTROL_PING_TOPIC) => Some(ControlMessage::Ping),
+            Some(CONTROL_PONG_TOPIC) => Some(ControlMessage::Pong),
+            _ => None,
+        }
+    }
+
+    /// Build the outgoing frame carrying this control message to `destination`.
+    pub(crate) fn to_outgoing(self, destination: Endpoint) -> OutgoingMessage {
+        OutgoingMessage {
+            payload: Vec::new(),
+            destination,
+            topic: Some(self.topic().to_owned()),
+        }
+    }
+}
+
+/// An inbound [`ControlMessage`] together with the peer it came from.
+pub(crate) struct IncomingControlMessage {
+    pub(crate) message: ControlMessage,
+    pub(crate) source: Source,
 }
 
 #[cfg(test)]

--- a/crates/bitwarden-ipc/src/control_splitter.rs
+++ b/crates/bitwarden-ipc/src/control_splitter.rs
@@ -26,7 +26,11 @@ use crate::{
 /// Wraps a communication backend so reachability control frames bypass crypto. The receivers handed
 /// to the crypto layer silently drop control frames; a single dedicated handler task routes them to
 /// the tracker (recording liveness and answering pings).
-pub(crate) struct ControlSplitter<Com> {
+// Public (but hidden) only because it appears in `IpcClientImpl`'s public trait bounds: the client
+// hands this wrapper to the crypto provider so control frames never reach it. It is not part of the
+// supported API and should not be used directly.
+#[doc(hidden)]
+pub struct ControlSplitter<Com> {
     backend: Arc<Com>,
     tracker: Arc<ReachabilityTracker>,
 }
@@ -88,7 +92,8 @@ impl<Com: CommunicationBackend> CommunicationBackend for ControlSplitter<Com> {
 }
 
 /// Receiver wrapper that drops control-topic frames so the crypto layer never sees them.
-pub(crate) struct ControlSplitterReceiver<R> {
+#[doc(hidden)]
+pub struct ControlSplitterReceiver<R> {
     inner: R,
 }
 

--- a/crates/bitwarden-ipc/src/control_splitter.rs
+++ b/crates/bitwarden-ipc/src/control_splitter.rs
@@ -11,11 +11,15 @@
 
 use std::sync::Arc;
 
+use bitwarden_threading::cancellation_token::CancellationToken;
+use tokio::select;
+
 use crate::{
+    control::is_control_topic,
     endpoint::Endpoint,
     error::IpcErrorKind,
     message::{IncomingMessage, OutgoingMessage},
-    reachability::{ReachabilityTracker, is_control_topic},
+    reachability::ReachabilityTracker,
     traits::{CommunicationBackend, CommunicationBackendReceiver, Reachability},
 };
 
@@ -34,21 +38,25 @@ impl<Com: CommunicationBackend> ControlSplitter<Com> {
 
     /// Spawn the single task that consumes control frames from the raw transport and drives the
     /// tracker. Spawned once when the client starts, so there is exactly one auto-pong responder
-    /// regardless of how many crypto receivers exist.
-    pub(crate) fn spawn_control_handler(&self) {
+    /// regardless of how many crypto receivers exist. The task stops when `cancellation_token` is
+    /// cancelled (i.e. when the client stops), so it does not leak across a stop/restart.
+    pub(crate) fn spawn_control_handler(&self, cancellation_token: CancellationToken) {
         let backend = self.backend.clone();
         let tracker = self.tracker.clone();
         let future = async move {
             let receiver = backend.subscribe().await;
             loop {
-                match receiver.receive().await {
-                    Ok(message) if is_control_topic(message.topic.as_deref()) => {
-                        tracker.handle_inbound(message).await;
-                    }
-                    // Data frames are delivered to the crypto layer's own receivers; ignore them.
-                    Ok(_) => {}
-                    Err(error) if error.is_fatal() => break,
-                    Err(_) => {}
+                select! {
+                    _ = cancellation_token.cancelled() => break,
+                    received = receiver.receive() => match received {
+                        Ok(message) if is_control_topic(message.topic.as_deref()) => {
+                            tracker.handle_inbound(message).await;
+                        }
+                        // Data frames are delivered to the crypto layer's own receivers; ignore them.
+                        Ok(_) => {}
+                        Err(error) if error.is_fatal() => break,
+                        Err(_) => {}
+                    },
                 }
             }
         };

--- a/crates/bitwarden-ipc/src/control_splitter.rs
+++ b/crates/bitwarden-ipc/src/control_splitter.rs
@@ -3,72 +3,43 @@
 //!
 //! Reachability ping/pong frames travel over the raw transport (so they can measure liveness
 //! without a crypto session), but the crypto layer reads the same transport and would try to decode
-//! them as Noise frames, aborting in-flight handshakes. This wrapper peels reserved control-topic
-//! frames off before any crypto-facing receiver yields them, and routes them to the
-//! [`ReachabilityTracker`] from a single dedicated handler task. `send` and `reachability` pass
-//! straight through to the inner backend, so the crypto provider stays entirely unaware of
+//! them as Noise frames, aborting in-flight handshakes. This wrapper splits the inbound stream in
+//! two: the receivers handed to the crypto layer ([`CommunicationBackend::subscribe`]) drop control
+//! frames, while [`ControlSplitter::subscribe_control`] yields only the control messages. `send`
+//! and `reachability` pass straight through, so the crypto provider stays entirely unaware of
 //! reachability.
 
 use std::sync::Arc;
 
-use bitwarden_threading::cancellation_token::CancellationToken;
-use tokio::select;
-
 use crate::{
-    control::is_control_topic,
+    control::{ControlMessage, IncomingControlMessage, is_control_topic},
     endpoint::Endpoint,
-    error::IpcErrorKind,
     message::{IncomingMessage, OutgoingMessage},
-    reachability::ReachabilityTracker,
     traits::{CommunicationBackend, CommunicationBackendReceiver, Reachability},
 };
 
-/// Wraps a communication backend so reachability control frames bypass crypto. The receivers handed
-/// to the crypto layer silently drop control frames; a single dedicated handler task routes them to
-/// the tracker (recording liveness and answering pings).
+/// Wraps a communication backend so reachability control frames are separated from data frames. The
+/// crypto layer only ever sees data; the reachability tracker consumes the control stream.
 // Public (but hidden) only because it appears in `IpcClientImpl`'s public trait bounds: the client
 // hands this wrapper to the crypto provider so control frames never reach it. It is not part of the
 // supported API and should not be used directly.
 #[doc(hidden)]
 pub struct ControlSplitter<Com> {
     backend: Arc<Com>,
-    tracker: Arc<ReachabilityTracker>,
 }
 
 impl<Com: CommunicationBackend> ControlSplitter<Com> {
-    pub(crate) fn new(backend: Arc<Com>, tracker: Arc<ReachabilityTracker>) -> Self {
-        Self { backend, tracker }
+    pub(crate) fn new(backend: Arc<Com>) -> Self {
+        Self { backend }
     }
 
-    /// Spawn the single task that consumes control frames from the raw transport and drives the
-    /// tracker. Spawned once when the client starts, so there is exactly one auto-pong responder
-    /// regardless of how many crypto receivers exist. The task stops when `cancellation_token` is
-    /// cancelled (i.e. when the client stops), so it does not leak across a stop/restart.
-    pub(crate) fn spawn_control_handler(&self, cancellation_token: CancellationToken) {
-        let backend = self.backend.clone();
-        let tracker = self.tracker.clone();
-        let future = async move {
-            let receiver = backend.subscribe().await;
-            loop {
-                select! {
-                    _ = cancellation_token.cancelled() => break,
-                    received = receiver.receive() => match received {
-                        Ok(message) if is_control_topic(message.topic.as_deref()) => {
-                            tracker.handle_inbound(message).await;
-                        }
-                        // Data frames are delivered to the crypto layer's own receivers; ignore them.
-                        Ok(_) => {}
-                        Err(error) if error.is_fatal() => break,
-                        Err(_) => {}
-                    },
-                }
-            }
-        };
-
-        #[cfg(not(target_arch = "wasm32"))]
-        tokio::spawn(future);
-        #[cfg(target_arch = "wasm32")]
-        wasm_bindgen_futures::spawn_local(future);
+    /// Subscribe to the inbound control-plane stream. Mirrors [`CommunicationBackendReceiver`]:
+    /// call [`ControlReceiver::receive`] for the next control message. Data frames are filtered
+    /// out (they reach the crypto layer via [`CommunicationBackend::subscribe`]).
+    pub(crate) async fn subscribe_control(&self) -> ControlReceiver<Com::Receiver> {
+        ControlReceiver {
+            inner: self.backend.subscribe().await,
+        }
     }
 }
 
@@ -91,7 +62,8 @@ impl<Com: CommunicationBackend> CommunicationBackend for ControlSplitter<Com> {
     }
 }
 
-/// Receiver wrapper that drops control-topic frames so the crypto layer never sees them.
+/// Data-frame receiver handed to the crypto layer: drops control-topic frames so crypto never sees
+/// them.
 #[doc(hidden)]
 pub struct ControlSplitterReceiver<R> {
     inner: R,
@@ -107,6 +79,27 @@ impl<R: CommunicationBackendReceiver> CommunicationBackendReceiver for ControlSp
                 continue;
             }
             return Ok(message);
+        }
+    }
+}
+
+/// Control-frame receiver: yields inbound [`ControlMessage`]s, skipping data frames.
+pub(crate) struct ControlReceiver<R> {
+    inner: R,
+}
+
+impl<R: CommunicationBackendReceiver> ControlReceiver<R> {
+    /// Receive the next control message. Blocks asynchronously, skipping data frames, until a
+    /// control frame arrives or the underlying receiver errors.
+    pub(crate) async fn receive(&self) -> Result<IncomingControlMessage, R::ReceiveError> {
+        loop {
+            let message = self.inner.receive().await?;
+            if let Some(control) = ControlMessage::from_topic(message.topic.as_deref()) {
+                return Ok(IncomingControlMessage {
+                    message: control,
+                    source: message.source,
+                });
+            }
         }
     }
 }

--- a/crates/bitwarden-ipc/src/control_splitter.rs
+++ b/crates/bitwarden-ipc/src/control_splitter.rs
@@ -1,0 +1,99 @@
+//! A [`CommunicationBackend`] decorator that keeps reachability control frames off the crypto
+//! channel.
+//!
+//! Reachability ping/pong frames travel over the raw transport (so they can measure liveness
+//! without a crypto session), but the crypto layer reads the same transport and would try to decode
+//! them as Noise frames, aborting in-flight handshakes. This wrapper peels reserved control-topic
+//! frames off before any crypto-facing receiver yields them, and routes them to the
+//! [`ReachabilityTracker`] from a single dedicated handler task. `send` and `reachability` pass
+//! straight through to the inner backend, so the crypto provider stays entirely unaware of
+//! reachability.
+
+use std::sync::Arc;
+
+use crate::{
+    endpoint::Endpoint,
+    error::IpcErrorKind,
+    message::{IncomingMessage, OutgoingMessage},
+    reachability::{ReachabilityTracker, is_control_topic},
+    traits::{CommunicationBackend, CommunicationBackendReceiver, Reachability},
+};
+
+/// Wraps a communication backend so reachability control frames bypass crypto. The receivers handed
+/// to the crypto layer silently drop control frames; a single dedicated handler task routes them to
+/// the tracker (recording liveness and answering pings).
+pub(crate) struct ControlSplitter<Com> {
+    backend: Arc<Com>,
+    tracker: Arc<ReachabilityTracker>,
+}
+
+impl<Com: CommunicationBackend> ControlSplitter<Com> {
+    pub(crate) fn new(backend: Arc<Com>, tracker: Arc<ReachabilityTracker>) -> Self {
+        Self { backend, tracker }
+    }
+
+    /// Spawn the single task that consumes control frames from the raw transport and drives the
+    /// tracker. Spawned once when the client starts, so there is exactly one auto-pong responder
+    /// regardless of how many crypto receivers exist.
+    pub(crate) fn spawn_control_handler(&self) {
+        let backend = self.backend.clone();
+        let tracker = self.tracker.clone();
+        let future = async move {
+            let receiver = backend.subscribe().await;
+            loop {
+                match receiver.receive().await {
+                    Ok(message) if is_control_topic(message.topic.as_deref()) => {
+                        tracker.handle_inbound(message).await;
+                    }
+                    // Data frames are delivered to the crypto layer's own receivers; ignore them.
+                    Ok(_) => {}
+                    Err(error) if error.is_fatal() => break,
+                    Err(_) => {}
+                }
+            }
+        };
+
+        #[cfg(not(target_arch = "wasm32"))]
+        tokio::spawn(future);
+        #[cfg(target_arch = "wasm32")]
+        wasm_bindgen_futures::spawn_local(future);
+    }
+}
+
+impl<Com: CommunicationBackend> CommunicationBackend for ControlSplitter<Com> {
+    type SendError = Com::SendError;
+    type Receiver = ControlSplitterReceiver<Com::Receiver>;
+
+    async fn send(&self, message: OutgoingMessage) -> Result<(), Self::SendError> {
+        self.backend.send(message).await
+    }
+
+    async fn subscribe(&self) -> Self::Receiver {
+        ControlSplitterReceiver {
+            inner: self.backend.subscribe().await,
+        }
+    }
+
+    async fn reachability(&self, endpoint: &Endpoint) -> Reachability {
+        self.backend.reachability(endpoint).await
+    }
+}
+
+/// Receiver wrapper that drops control-topic frames so the crypto layer never sees them.
+pub(crate) struct ControlSplitterReceiver<R> {
+    inner: R,
+}
+
+impl<R: CommunicationBackendReceiver> CommunicationBackendReceiver for ControlSplitterReceiver<R> {
+    type ReceiveError = R::ReceiveError;
+
+    async fn receive(&self) -> Result<IncomingMessage, Self::ReceiveError> {
+        loop {
+            let message = self.inner.receive().await?;
+            if is_control_topic(message.topic.as_deref()) {
+                continue;
+            }
+            return Ok(message);
+        }
+    }
+}

--- a/crates/bitwarden-ipc/src/ipc_client.rs
+++ b/crates/bitwarden-ipc/src/ipc_client.rs
@@ -7,6 +7,7 @@ use tokio::select;
 
 use crate::{
     constants::CHANNEL_BUFFER_CAPACITY,
+    control_splitter::ControlSplitter,
     error::{
         AlreadyRunningError, IpcErrorKind, ReceiveError, SendError, SubscribeError,
         TypedReceiveError,
@@ -15,6 +16,7 @@ use crate::{
         IncomingMessage, OutgoingMessage, PayloadTypeName, TypedIncomingMessage,
         TypedOutgoingMessage,
     },
+    reachability::ReachabilityTracker,
     rpc::{
         exec::{handler::ErasedRpcHandler, handler_registry::RpcHandlerRegistry},
         request_message::{RPC_REQUEST_PAYLOAD_TYPE_NAME, RpcRequestPayload},
@@ -45,13 +47,17 @@ pub struct IpcClientTypedSubscription<Payload: DeserializeOwned + PayloadTypeNam
 /// Internal shared state for the IPC client.
 struct IpcClientInner<Crypto, Com, Ses>
 where
-    Crypto: CryptoProvider<Com, Ses>,
+    Crypto: CryptoProvider<ControlSplitter<Com>, Ses>,
     Com: CommunicationBackend,
     Ses: SessionRepository<Crypto::Session>,
 {
     crypto: Crypto,
-    communication: Com,
+    /// The raw backend wrapped so reachability control frames bypass the crypto layer.
+    communication: ControlSplitter<Com>,
     sessions: Ses,
+    /// Owns the per-endpoint ping loops and the auto-pong responder; handed to consumers via
+    /// [`IpcClient::reachability`](crate::IpcClient::reachability).
+    reachability: Arc<ReachabilityTracker>,
 
     handlers: RpcHandlerRegistry,
     incoming: Mutex<Option<tokio::sync::broadcast::Receiver<IncomingMessage>>>,
@@ -65,7 +71,7 @@ where
 /// This is the concrete implementation of the [`IpcClient`](crate::IpcClient) trait.
 pub struct IpcClientImpl<Crypto, Com, Ses>
 where
-    Crypto: CryptoProvider<Com, Ses>,
+    Crypto: CryptoProvider<ControlSplitter<Com>, Ses>,
     Com: CommunicationBackend,
     Ses: SessionRepository<Crypto::Session>,
 {
@@ -74,7 +80,7 @@ where
 
 impl<Crypto, Com, Ses> Clone for IpcClientImpl<Crypto, Com, Ses>
 where
-    Crypto: CryptoProvider<Com, Ses>,
+    Crypto: CryptoProvider<ControlSplitter<Com>, Ses>,
     Com: CommunicationBackend,
     Ses: SessionRepository<Crypto::Session>,
 {
@@ -87,18 +93,22 @@ where
 
 impl<Crypto, Com, Ses> IpcClientImpl<Crypto, Com, Ses>
 where
-    Crypto: CryptoProvider<Com, Ses>,
+    Crypto: CryptoProvider<ControlSplitter<Com>, Ses>,
     Com: CommunicationBackend,
     Ses: SessionRepository<Crypto::Session>,
 {
     /// Create a new IPC client with the provided crypto provider, communication backend, and
     /// session repository.
     pub fn new(crypto: Crypto, communication: Com, sessions: Ses) -> Self {
+        let backend = Arc::new(communication);
+        let reachability = Arc::new(ReachabilityTracker::from_backend(backend.clone()));
+        let communication = ControlSplitter::new(backend, reachability.clone());
         Self {
             inner: Arc::new(IpcClientInner {
                 crypto,
                 communication,
                 sessions,
+                reachability,
 
                 handlers: RpcHandlerRegistry::new(),
                 incoming: Mutex::new(None),
@@ -111,7 +121,7 @@ where
 #[async_trait::async_trait]
 impl<Crypto, Com, Ses> crate::ipc_client_trait::IpcClient for IpcClientImpl<Crypto, Com, Ses>
 where
-    Crypto: CryptoProvider<Com, Ses>,
+    Crypto: CryptoProvider<ControlSplitter<Com>, Ses>,
     Com: CommunicationBackend,
     Ses: SessionRepository<Crypto::Session>,
 {
@@ -129,6 +139,9 @@ where
             .lock()
             .expect("Failed to lock cancellation token mutex")
             .replace(cancellation_token.clone());
+
+        // Start the single reachability control-frame handler (auto-pong + liveness recording).
+        self.inner.communication.spawn_control_handler();
 
         let com_receiver = self.inner.communication.subscribe().await;
         let (client_tx, client_rx) = tokio::sync::broadcast::channel(CHANNEL_BUFFER_CAPACITY);
@@ -246,11 +259,15 @@ where
             .register_erased(name.to_owned(), handler)
             .await;
     }
+
+    fn reachability(&self) -> Arc<ReachabilityTracker> {
+        self.inner.reachability.clone()
+    }
 }
 
 fn stop_inner<Crypto, Com, Ses>(inner: &IpcClientInner<Crypto, Com, Ses>)
 where
-    Crypto: CryptoProvider<Com, Ses>,
+    Crypto: CryptoProvider<ControlSplitter<Com>, Ses>,
     Com: CommunicationBackend,
     Ses: SessionRepository<Crypto::Session>,
 {
@@ -268,7 +285,7 @@ fn handle_rpc_request<Crypto, Com, Ses>(
     inner: &Arc<IpcClientInner<Crypto, Com, Ses>>,
     incoming_message: IncomingMessage,
 ) where
-    Crypto: CryptoProvider<Com, Ses>,
+    Crypto: CryptoProvider<ControlSplitter<Com>, Ses>,
     Com: CommunicationBackend,
     Ses: SessionRepository<Crypto::Session>,
 {
@@ -426,15 +443,17 @@ mod tests {
     }
 
     type TestSessionRepository = InMemorySessionRepository<String>;
-    impl CryptoProvider<TestCommunicationBackend, TestSessionRepository> for TestCryptoProvider {
+    // Generic over the backend so it satisfies the client's `CryptoProvider<ControlSplitter<Com>>`
+    // bound as well as a bare backend in other tests.
+    impl<Com: CommunicationBackend> CryptoProvider<Com, TestSessionRepository> for TestCryptoProvider {
         type Session = String;
         type SendError = TestCryptoError;
         type ReceiveError = TestCryptoError;
 
         async fn receive(
             &self,
-            _receiver: &<TestCommunicationBackend as CommunicationBackend>::Receiver,
-            _communication: &TestCommunicationBackend,
+            _receiver: &Com::Receiver,
+            _communication: &Com,
             _sessions: &TestSessionRepository,
         ) -> Result<IncomingMessage, Self::ReceiveError> {
             match &self.receive_result {
@@ -459,7 +478,7 @@ mod tests {
 
         async fn send(
             &self,
-            _communication: &TestCommunicationBackend,
+            _communication: &Com,
             _sessions: &TestSessionRepository,
             _message: OutgoingMessage,
         ) -> Result<(), Self::SendError> {

--- a/crates/bitwarden-ipc/src/ipc_client.rs
+++ b/crates/bitwarden-ipc/src/ipc_client.rs
@@ -141,7 +141,10 @@ where
             .replace(cancellation_token.clone());
 
         // Start the single reachability control-frame handler (auto-pong + liveness recording).
-        self.inner.communication.spawn_control_handler();
+        // It shares the client's cancellation token so it stops on shutdown rather than leaking.
+        self.inner
+            .communication
+            .spawn_control_handler(cancellation_token.clone());
 
         let com_receiver = self.inner.communication.subscribe().await;
         let (client_tx, client_rx) = tokio::sync::broadcast::channel(CHANNEL_BUFFER_CAPACITY);

--- a/crates/bitwarden-ipc/src/ipc_client.rs
+++ b/crates/bitwarden-ipc/src/ipc_client.rs
@@ -102,7 +102,7 @@ where
     pub fn new(crypto: Crypto, communication: Com, sessions: Ses) -> Self {
         let backend = Arc::new(communication);
         let reachability = Arc::new(ReachabilityTracker::from_backend(backend.clone()));
-        let communication = ControlSplitter::new(backend, reachability.clone());
+        let communication = ControlSplitter::new(backend);
         Self {
             inner: Arc::new(IpcClientInner {
                 crypto,
@@ -140,11 +140,13 @@ where
             .expect("Failed to lock cancellation token mutex")
             .replace(cancellation_token.clone());
 
-        // Start the single reachability control-frame handler (auto-pong + liveness recording).
-        // It shares the client's cancellation token so it stops on shutdown rather than leaking.
+        // Feed the reachability tracker from the control-frame stream (auto-pong + liveness
+        // recording). It shares the client's cancellation token so it stops on shutdown rather than
+        // leaking, and runs even when nothing is tracked so passive peers still answer pings.
+        let control_receiver = self.inner.communication.subscribe_control().await;
         self.inner
-            .communication
-            .spawn_control_handler(cancellation_token.clone());
+            .reachability
+            .start(control_receiver, cancellation_token.clone());
 
         let com_receiver = self.inner.communication.subscribe().await;
         let (client_tx, client_rx) = tokio::sync::broadcast::channel(CHANNEL_BUFFER_CAPACITY);

--- a/crates/bitwarden-ipc/src/ipc_client_trait.rs
+++ b/crates/bitwarden-ipc/src/ipc_client_trait.rs
@@ -1,9 +1,12 @@
+use std::sync::Arc;
+
 use bitwarden_threading::cancellation_token::CancellationToken;
 
 use crate::{
     error::{AlreadyRunningError, SendError, SubscribeError},
     ipc_client::IpcClientSubscription,
     message::OutgoingMessage,
+    reachability::ReachabilityTracker,
     rpc::exec::handler::ErasedRpcHandler,
 };
 
@@ -46,4 +49,11 @@ pub trait IpcClient: Send + Sync {
     /// instead.
     #[doc(hidden)]
     async fn register_rpc_handler_erased(&self, name: &str, handler: Box<dyn ErasedRpcHandler>);
+
+    /// The reachability tracker for this client.
+    ///
+    /// Consumers that need to know whether a peer is reachable call
+    /// [`ReachabilityTracker::track`] with the peer's endpoint (typically discovered at runtime)
+    /// and hold the returned handle for as long as they care; dropping it stops tracking.
+    fn reachability(&self) -> Arc<ReachabilityTracker>;
 }

--- a/crates/bitwarden-ipc/src/lib.rs
+++ b/crates/bitwarden-ipc/src/lib.rs
@@ -1,6 +1,7 @@
 #![doc = include_str!("../README.md")]
 
 mod constants;
+mod control_splitter;
 mod crypto_provider;
 pub mod discover;
 mod endpoint;

--- a/crates/bitwarden-ipc/src/lib.rs
+++ b/crates/bitwarden-ipc/src/lib.rs
@@ -20,6 +20,10 @@ mod traits;
 #[cfg(feature = "wasm")]
 pub mod wasm;
 
+// Re-exported (hidden) only to satisfy `private_interfaces`: `ControlSplitter` appears in
+// `IpcClientImpl`'s public trait bounds. Not part of the supported API.
+#[doc(hidden)]
+pub use control_splitter::{ControlSplitter, ControlSplitterReceiver};
 pub use endpoint::{Endpoint, HostId, Source};
 pub use error::{
     IpcErrorKind, ReceiveError, RequestError, SendError, SubscribeError, TypedReceiveError,

--- a/crates/bitwarden-ipc/src/lib.rs
+++ b/crates/bitwarden-ipc/src/lib.rs
@@ -9,6 +9,7 @@ mod ipc_client;
 mod ipc_client_ext;
 mod ipc_client_trait;
 mod message;
+mod reachability;
 mod rpc;
 mod serde_utils;
 mod traits;
@@ -27,6 +28,7 @@ pub use ipc_client_trait::IpcClient;
 pub use message::{
     IncomingMessage, OutgoingMessage, PayloadTypeName, TypedIncomingMessage, TypedOutgoingMessage,
 };
+pub use reachability::{ReachabilityHandle, ReachabilityTracker};
 #[doc(hidden)]
 pub use rpc::exec::handler::ErasedRpcHandler;
 pub use rpc::{exec::handler::RpcHandler, request::RpcRequest};

--- a/crates/bitwarden-ipc/src/lib.rs
+++ b/crates/bitwarden-ipc/src/lib.rs
@@ -34,7 +34,7 @@ pub use rpc::{exec::handler::RpcHandler, request::RpcRequest};
 pub use traits::NoEncryptionCryptoProvider;
 #[cfg(any(test, feature = "test-support"))]
 pub use traits::TestCommunicationBackend;
-pub use traits::{InMemorySessionRepository, NoopCommunicationBackend};
+pub use traits::{InMemorySessionRepository, NoopCommunicationBackend, Reachability};
 
 // Test configuration of the IPC client, always available in test and test-support contexts.
 #[cfg(any(test, feature = "test-support"))]

--- a/crates/bitwarden-ipc/src/lib.rs
+++ b/crates/bitwarden-ipc/src/lib.rs
@@ -1,6 +1,7 @@
 #![doc = include_str!("../README.md")]
 
 mod constants;
+mod control;
 mod control_splitter;
 mod crypto_provider;
 pub mod discover;

--- a/crates/bitwarden-ipc/src/reachability.rs
+++ b/crates/bitwarden-ipc/src/reachability.rs
@@ -9,7 +9,7 @@
 //! - the transport answers [`Reachability::Reachable`]/[`Reachability::Unreachable`] -> that wins,
 //!   and no pings are sent;
 //! - the transport answers [`Reachability::Unknown`] -> fall back to ping/pong liveness: the
-//!   endpoint is reachable while a control frame was seen from it within [`ACTIVE_WINDOW`].
+//!   endpoint is reachable while replies to its pings keep arriving (see [`PING_INTERVAL`]).
 //!
 //! Ping/pong frames travel over the raw transport under a reserved control-topic namespace and are
 //! peeled off by the `ControlSplitter` before the crypto layer ever sees them, so they never abort
@@ -19,11 +19,12 @@ use std::{
     collections::HashMap,
     future::Future,
     pin::Pin,
-    sync::{Arc, Mutex, Weak},
+    sync::{
+        Arc, Mutex, Weak,
+        atomic::{AtomicBool, Ordering},
+    },
     time::Duration,
 };
-
-use web_time::Instant;
 
 use crate::{
     control::{CONTROL_PING_TOPIC, CONTROL_PONG_TOPIC},
@@ -32,13 +33,12 @@ use crate::{
     traits::{CommunicationBackend, Reachability},
 };
 
-/// An endpoint is considered live (when the transport can't tell) while a control frame was seen
-/// from it within this window.
-const ACTIVE_WINDOW: Duration = Duration::from_secs(5);
-/// Ping cadence while the peer is live. Must be `< ACTIVE_WINDOW` to sustain liveness.
-const ACTIVE_PING_INTERVAL: Duration = Duration::from_secs(2);
-/// Ping/poll cadence while the peer is not live (or the transport answers authoritatively).
-const INACTIVE_PING_INTERVAL: Duration = Duration::from_secs(10);
+/// Ping cadence while probing an endpoint whose transport reachability is `Unknown`. Each cycle
+/// sends a ping and, after this interval, marks the endpoint not-live unless a reply was seen — so
+/// it doubles as the liveness window. Kept clock-free (sleep-based) so it works on wasm too.
+const PING_INTERVAL: Duration = Duration::from_secs(2);
+/// Re-check cadence while the transport answers authoritatively (no pinging needed).
+const POLL_INTERVAL: Duration = Duration::from_secs(10);
 
 type BoxFuture<T> = Pin<Box<dyn Future<Output = T> + Send>>;
 /// Type-erased "send this frame over the raw transport".
@@ -60,9 +60,13 @@ fn prune(registry: &mut HashMap<Endpoint, Weak<TrackerInner>>) {
 /// (its weak upgrade fails) and removes the registry entry (see [`Drop`]).
 struct TrackerInner {
     endpoint: Endpoint,
-    /// Timestamp of the last control frame seen from `endpoint`; the liveness fallback derives
-    /// from it when the transport answers `Unknown`.
-    last_seen: Mutex<Option<Instant>>,
+    /// Whether the endpoint is currently live per ping/pong. Only consulted when the transport
+    /// answers `Unknown`. Set as soon as a control frame is seen; cleared by the ping loop after a
+    /// cycle with no reply.
+    live: AtomicBool,
+    /// Set whenever a control frame is seen from `endpoint`; the ping loop clears it before each
+    /// ping and reads it after the interval to detect a missed reply.
+    reply_seen: AtomicBool,
     reach_fn: ReachFn,
     /// Back-ref so this entry can remove itself from the owning tracker's registry on drop.
     registry: Weak<Registry>,
@@ -101,16 +105,9 @@ impl ReachabilityHandle {
         }
     }
 
-    /// Raw ping/pong liveness: whether a control frame was seen within [`ACTIVE_WINDOW`].
+    /// Raw ping/pong liveness: whether a reply was seen within the last [`PING_INTERVAL`] cycle.
     fn is_live(&self) -> bool {
-        within_window(
-            *self
-                .inner
-                .last_seen
-                .lock()
-                .expect("reachability last_seen mutex poisoned"),
-            ACTIVE_WINDOW,
-        )
+        self.inner.live.load(Ordering::Relaxed)
     }
 }
 
@@ -173,7 +170,8 @@ impl ReachabilityTracker {
 
         let inner = Arc::new(TrackerInner {
             endpoint: endpoint.clone(),
-            last_seen: Mutex::new(None),
+            live: AtomicBool::new(false),
+            reply_seen: AtomicBool::new(false),
             reach_fn: self.reach_fn.clone(),
             registry: Arc::downgrade(&self.registry),
         });
@@ -201,10 +199,10 @@ impl ReachabilityTracker {
             .get(&source)
             .and_then(Weak::upgrade)
         {
-            *inner
-                .last_seen
-                .lock()
-                .expect("reachability last_seen mutex poisoned") = Some(Instant::now());
+            // Any control frame from the endpoint proves it is alive; reflect that immediately and
+            // record the reply so the in-flight ping cycle does not clear liveness.
+            inner.live.store(true, Ordering::Relaxed);
+            inner.reply_seen.store(true, Ordering::Relaxed);
         }
 
         if message.topic.as_deref() == Some(CONTROL_PING_TOPIC) {
@@ -218,55 +216,53 @@ impl ReachabilityTracker {
     }
 }
 
-/// `true` when `last` is set and within `window` of now.
-fn within_window(last: Option<Instant>, window: Duration) -> bool {
-    matches!(last, Some(at) if at.elapsed() < window)
-}
-
 fn spawn_ping_loop(
-    inner: Weak<TrackerInner>,
+    weak: Weak<TrackerInner>,
     send_fn: SendFn,
     reach_fn: ReachFn,
     endpoint: Endpoint,
 ) {
     let future = async move {
         loop {
-            // The loop holds only a `Weak`; once the last handle is dropped this upgrade fails and
-            // the loop ends. The strong ref is released again before sleeping so a drop during the
-            // sleep is observed on the next cycle.
-            let Some(inner) = inner.upgrade() else {
+            // The loop holds only a `Weak`; once the last handle is dropped the upgrade fails and
+            // the loop ends. The strong ref is released before sleeping so a drop during the sleep
+            // is observed on the next cycle.
+            let Some(inner) = weak.upgrade() else {
                 break;
             };
 
-            let interval = match (reach_fn)(endpoint.clone()).await {
-                Reachability::Unknown => {
-                    (send_fn)(OutgoingMessage {
-                        payload: Vec::new(),
-                        destination: endpoint.clone(),
-                        topic: Some(CONTROL_PING_TOPIC.to_owned()),
-                    })
-                    .await;
-
-                    let live = within_window(
-                        *inner
-                            .last_seen
-                            .lock()
-                            .expect("reachability last_seen mutex poisoned"),
-                        ACTIVE_WINDOW,
-                    );
-                    if live {
-                        ACTIVE_PING_INTERVAL
-                    } else {
-                        INACTIVE_PING_INTERVAL
-                    }
-                }
+            let reachability = (reach_fn)(endpoint.clone()).await;
+            let interval = if reachability == Reachability::Unknown {
+                // Probe: clear the reply flag, ping, and let the interval below act as the window
+                // in which a reply must arrive.
+                inner.reply_seen.store(false, Ordering::Relaxed);
+                (send_fn)(OutgoingMessage {
+                    payload: Vec::new(),
+                    destination: endpoint.clone(),
+                    topic: Some(CONTROL_PING_TOPIC.to_owned()),
+                })
+                .await;
+                PING_INTERVAL
+            } else {
                 // The transport answered authoritatively; no ping needed. Keep polling at the
                 // backoff cadence so a later transition to `Unknown` resumes pinging.
-                Reachability::Reachable | Reachability::Unreachable => INACTIVE_PING_INTERVAL,
+                POLL_INTERVAL
             };
 
             drop(inner);
             bitwarden_threading::time::sleep(interval).await;
+
+            // After the probe window, if no reply was seen the endpoint is no longer live. A reply
+            // (handled in `handle_inbound`) sets `live` immediately, so liveness is not delayed by
+            // this cycle.
+            if reachability == Reachability::Unknown {
+                let Some(inner) = weak.upgrade() else {
+                    break;
+                };
+                if !inner.reply_seen.load(Ordering::Relaxed) {
+                    inner.live.store(false, Ordering::Relaxed);
+                }
+            }
         }
     };
 
@@ -306,16 +302,6 @@ mod tests {
             source,
             topic: topic.map(ToOwned::to_owned),
         }
-    }
-
-    #[test]
-    fn within_window_boundary() {
-        assert!(within_window(Some(Instant::now()), ACTIVE_WINDOW));
-        assert!(!within_window(None, ACTIVE_WINDOW));
-        assert!(!within_window(
-            Some(Instant::now() - (ACTIVE_WINDOW + Duration::from_secs(1))),
-            ACTIVE_WINDOW
-        ));
     }
 
     #[tokio::test]

--- a/crates/bitwarden-ipc/src/reachability.rs
+++ b/crates/bitwarden-ipc/src/reachability.rs
@@ -1,0 +1,447 @@
+//! Reachability tracking: a transport-authoritative signal with a ping/pong liveness fallback.
+//!
+//! A consumer that cares whether a peer is reachable (e.g. the shared-unlock follower) obtains a
+//! [`ReachabilityHandle`] from [`ReachabilityTracker::track`] *after* it knows the peer's endpoint.
+//! While a handle is held, the tracker keeps that endpoint's reachability fresh; when the last
+//! handle for an endpoint is dropped the per-endpoint ping loop stops on its own.
+//!
+//! Reachability resolves as follows:
+//! - the transport answers [`Reachability::Reachable`]/[`Reachability::Unreachable`] -> that wins,
+//!   and no pings are sent;
+//! - the transport answers [`Reachability::Unknown`] -> fall back to ping/pong liveness: the
+//!   endpoint is reachable while a control frame was seen from it within [`ACTIVE_WINDOW`].
+//!
+//! Ping/pong frames travel over the raw transport under a reserved control-topic namespace and are
+//! peeled off by the `ControlSplitter` before the crypto layer ever sees them, so they never abort
+//! a handshake.
+
+use std::{
+    collections::HashMap,
+    future::Future,
+    pin::Pin,
+    sync::{Arc, Mutex, Weak},
+    time::Duration,
+};
+
+use web_time::Instant;
+
+use crate::{
+    endpoint::Endpoint,
+    message::{IncomingMessage, OutgoingMessage},
+    traits::{CommunicationBackend, Reachability},
+};
+
+/// Reserved topic namespace for transport control frames that bypass the crypto channel.
+pub(crate) const CONTROL_TOPIC_PREFIX: &str = "$bw.control.";
+/// Topic marking a plaintext reachability ping.
+pub(crate) const CONTROL_PING_TOPIC: &str = "$bw.control.ping";
+/// Topic marking a plaintext reachability pong (the reply to a ping).
+pub(crate) const CONTROL_PONG_TOPIC: &str = "$bw.control.pong";
+
+/// Whether `topic` belongs to the reserved control-topic namespace and must bypass crypto.
+pub(crate) fn is_control_topic(topic: Option<&str>) -> bool {
+    topic.is_some_and(|t| t.starts_with(CONTROL_TOPIC_PREFIX))
+}
+
+/// An endpoint is considered live (when the transport can't tell) while a control frame was seen
+/// from it within this window.
+const ACTIVE_WINDOW: Duration = Duration::from_secs(5);
+/// Ping cadence while the peer is live. Must be `< ACTIVE_WINDOW` to sustain liveness.
+const ACTIVE_PING_INTERVAL: Duration = Duration::from_secs(2);
+/// Ping/poll cadence while the peer is not live (or the transport answers authoritatively).
+const INACTIVE_PING_INTERVAL: Duration = Duration::from_secs(10);
+
+type BoxFuture<T> = Pin<Box<dyn Future<Output = T> + Send>>;
+/// Type-erased "send this frame over the raw transport".
+type SendFn = Arc<dyn Fn(OutgoingMessage) -> BoxFuture<()> + Send + Sync>;
+/// Type-erased "ask the transport whether this endpoint is reachable".
+type ReachFn = Arc<dyn Fn(Endpoint) -> BoxFuture<Reachability> + Send + Sync>;
+
+type Registry = Mutex<HashMap<Endpoint, Weak<TrackerInner>>>;
+
+/// Per-endpoint tracking state, shared between the [`ReachabilityHandle`]s for that endpoint and
+/// (via a [`Weak`]) the ping loop. Dropping the last handle drops this, which both ends the loop
+/// (its weak upgrade fails) and removes the registry entry (see [`Drop`]).
+struct TrackerInner {
+    endpoint: Endpoint,
+    /// Timestamp of the last control frame seen from `endpoint`; the liveness fallback derives
+    /// from it when the transport answers `Unknown`.
+    last_seen: Mutex<Option<Instant>>,
+    reach_fn: ReachFn,
+    /// Back-ref so this entry can remove itself from the owning tracker's registry on drop.
+    registry: Weak<Registry>,
+}
+
+impl Drop for TrackerInner {
+    fn drop(&mut self) {
+        // Bound the registry to live entries. Removing by `retain(strong > 0)` rather than by key
+        // is race-safe: if a concurrent `track()` already replaced our (now-dead) entry with a new
+        // live one, that new entry has a strong count >= 1 and is preserved.
+        if let Some(registry) = self.registry.upgrade()
+            && let Ok(mut map) = registry.lock()
+        {
+            map.retain(|_, weak| weak.strong_count() > 0);
+        }
+    }
+}
+
+/// A scoped reachability subscription for a single endpoint. Holding it keeps that endpoint's
+/// reachability fresh; dropping the last handle for an endpoint stops its ping loop.
+#[derive(Clone)]
+pub struct ReachabilityHandle {
+    inner: Arc<TrackerInner>,
+}
+
+impl ReachabilityHandle {
+    /// Whether the tracked endpoint is currently reachable.
+    ///
+    /// Pulls the transport-native signal on demand; only when that is [`Reachability::Unknown`]
+    /// does it fall back to the ping/pong liveness window.
+    pub async fn is_reachable(&self) -> bool {
+        match (self.inner.reach_fn)(self.inner.endpoint.clone()).await {
+            Reachability::Reachable => true,
+            Reachability::Unreachable => false,
+            Reachability::Unknown => self.is_live(),
+        }
+    }
+
+    /// Raw ping/pong liveness: whether a control frame was seen within [`ACTIVE_WINDOW`].
+    fn is_live(&self) -> bool {
+        within_window(
+            *self
+                .inner
+                .last_seen
+                .lock()
+                .expect("reachability last_seen mutex poisoned"),
+            ACTIVE_WINDOW,
+        )
+    }
+}
+
+/// Tracks reachability of endpoints on behalf of consumers. Owned by the `IpcClient`; reachability
+/// pings and the auto-pong responder run over the transport this tracker was built from.
+pub struct ReachabilityTracker {
+    registry: Arc<Registry>,
+    send_fn: SendFn,
+    reach_fn: ReachFn,
+}
+
+impl ReachabilityTracker {
+    /// Build a tracker over `backend`, capturing it for sending pings/pongs and pulling the
+    /// transport-native reachability signal.
+    pub(crate) fn from_backend<Com: CommunicationBackend>(backend: Arc<Com>) -> Self {
+        let send_backend = backend.clone();
+        let send_fn: SendFn = Arc::new(move |message| {
+            let backend = send_backend.clone();
+            Box::pin(async move {
+                let _ = backend.send(message).await;
+            })
+        });
+        let reach_fn: ReachFn = Arc::new(move |endpoint| {
+            let backend = backend.clone();
+            Box::pin(async move { backend.reachability(&endpoint).await })
+        });
+        Self::new(send_fn, reach_fn)
+    }
+
+    fn new(send_fn: SendFn, reach_fn: ReachFn) -> Self {
+        Self {
+            registry: Arc::new(Mutex::new(HashMap::new())),
+            send_fn,
+            reach_fn,
+        }
+    }
+
+    /// Begin (or join) tracking `endpoint`, returning a handle. Calls for the same endpoint share a
+    /// single ping loop; the loop is spawned only when the first handle for an endpoint is created.
+    pub fn track(&self, endpoint: Endpoint) -> ReachabilityHandle {
+        let mut map = self
+            .registry
+            .lock()
+            .expect("reachability registry poisoned");
+        // Opportunistically drop dangling entries left by handles that have since been freed.
+        map.retain(|_, weak| weak.strong_count() > 0);
+
+        if let Some(inner) = map.get(&endpoint).and_then(Weak::upgrade) {
+            return ReachabilityHandle { inner };
+        }
+
+        let inner = Arc::new(TrackerInner {
+            endpoint: endpoint.clone(),
+            last_seen: Mutex::new(None),
+            reach_fn: self.reach_fn.clone(),
+            registry: Arc::downgrade(&self.registry),
+        });
+        map.insert(endpoint.clone(), Arc::downgrade(&inner));
+
+        spawn_ping_loop(
+            Arc::downgrade(&inner),
+            self.send_fn.clone(),
+            self.reach_fn.clone(),
+            endpoint,
+        );
+
+        ReachabilityHandle { inner }
+    }
+
+    /// Process an inbound control frame: record liveness for the source (if it is tracked) and, for
+    /// a ping, answer with a pong. Called by the `ControlSplitter`.
+    pub async fn handle_inbound(&self, message: IncomingMessage) {
+        let source = message.source.to_endpoint();
+
+        if let Some(inner) = self
+            .registry
+            .lock()
+            .expect("reachability registry poisoned")
+            .get(&source)
+            .and_then(Weak::upgrade)
+        {
+            *inner
+                .last_seen
+                .lock()
+                .expect("reachability last_seen mutex poisoned") = Some(Instant::now());
+        }
+
+        if message.topic.as_deref() == Some(CONTROL_PING_TOPIC) {
+            (self.send_fn)(OutgoingMessage {
+                payload: Vec::new(),
+                destination: source,
+                topic: Some(CONTROL_PONG_TOPIC.to_owned()),
+            })
+            .await;
+        }
+    }
+}
+
+/// `true` when `last` is set and within `window` of now.
+fn within_window(last: Option<Instant>, window: Duration) -> bool {
+    matches!(last, Some(at) if at.elapsed() < window)
+}
+
+fn spawn_ping_loop(
+    inner: Weak<TrackerInner>,
+    send_fn: SendFn,
+    reach_fn: ReachFn,
+    endpoint: Endpoint,
+) {
+    let future = async move {
+        loop {
+            // The loop holds only a `Weak`; once the last handle is dropped this upgrade fails and
+            // the loop ends. The strong ref is released again before sleeping so a drop during the
+            // sleep is observed on the next cycle.
+            let Some(inner) = inner.upgrade() else {
+                break;
+            };
+
+            let interval = match (reach_fn)(endpoint.clone()).await {
+                Reachability::Unknown => {
+                    (send_fn)(OutgoingMessage {
+                        payload: Vec::new(),
+                        destination: endpoint.clone(),
+                        topic: Some(CONTROL_PING_TOPIC.to_owned()),
+                    })
+                    .await;
+
+                    let live = within_window(
+                        *inner
+                            .last_seen
+                            .lock()
+                            .expect("reachability last_seen mutex poisoned"),
+                        ACTIVE_WINDOW,
+                    );
+                    if live {
+                        ACTIVE_PING_INTERVAL
+                    } else {
+                        INACTIVE_PING_INTERVAL
+                    }
+                }
+                // The transport answered authoritatively; no ping needed. Keep polling at the
+                // backoff cadence so a later transition to `Unknown` resumes pinging.
+                Reachability::Reachable | Reachability::Unreachable => INACTIVE_PING_INTERVAL,
+            };
+
+            drop(inner);
+            bitwarden_threading::time::sleep(interval).await;
+        }
+    };
+
+    #[cfg(not(target_arch = "wasm32"))]
+    tokio::spawn(future);
+    #[cfg(target_arch = "wasm32")]
+    wasm_bindgen_futures::spawn_local(future);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::endpoint::{HostId, Source};
+
+    const ENDPOINT: Endpoint = Endpoint::DesktopMain;
+
+    /// Builds a tracker whose transport answers `reach` and records every outgoing frame.
+    fn mock_tracker(
+        reach: Reachability,
+    ) -> (ReachabilityTracker, Arc<Mutex<Vec<OutgoingMessage>>>) {
+        let sent = Arc::new(Mutex::new(Vec::new()));
+        let sent_clone = sent.clone();
+        let send_fn: SendFn = Arc::new(move |message| {
+            let sent = sent_clone.clone();
+            Box::pin(async move {
+                sent.lock().unwrap().push(message);
+            })
+        });
+        let reach_fn: ReachFn = Arc::new(move |_| Box::pin(async move { reach }));
+        (ReachabilityTracker::new(send_fn, reach_fn), sent)
+    }
+
+    fn incoming(source: Source, topic: Option<&str>) -> IncomingMessage {
+        IncomingMessage {
+            payload: Vec::new(),
+            destination: ENDPOINT,
+            source,
+            topic: topic.map(ToOwned::to_owned),
+        }
+    }
+
+    #[test]
+    fn within_window_boundary() {
+        assert!(within_window(Some(Instant::now()), ACTIVE_WINDOW));
+        assert!(!within_window(None, ACTIVE_WINDOW));
+        assert!(!within_window(
+            Some(Instant::now() - (ACTIVE_WINDOW + Duration::from_secs(1))),
+            ACTIVE_WINDOW
+        ));
+    }
+
+    #[test]
+    fn is_control_topic_matches_namespace() {
+        assert!(is_control_topic(Some(CONTROL_PING_TOPIC)));
+        assert!(is_control_topic(Some(CONTROL_PONG_TOPIC)));
+        assert!(is_control_topic(Some("$bw.control.future")));
+        assert!(!is_control_topic(Some("some-rpc-topic")));
+        assert!(!is_control_topic(None));
+    }
+
+    #[tokio::test]
+    async fn transport_answer_wins_without_pinging() {
+        for (reach, expected) in [
+            (Reachability::Reachable, true),
+            (Reachability::Unreachable, false),
+        ] {
+            let (tracker, _sent) = mock_tracker(reach);
+            let handle = tracker.track(ENDPOINT);
+            assert_eq!(handle.is_reachable().await, expected);
+        }
+    }
+
+    #[tokio::test]
+    async fn unknown_falls_back_to_liveness_window() {
+        let (tracker, _sent) = mock_tracker(Reachability::Unknown);
+        let handle = tracker.track(ENDPOINT);
+
+        // No control frame seen yet -> not reachable.
+        assert!(!handle.is_reachable().await);
+
+        // An inbound control frame from the tracked endpoint marks it live.
+        tracker
+            .handle_inbound(incoming(Source::DesktopMain, Some(CONTROL_PONG_TOPIC)))
+            .await;
+        assert!(handle.is_reachable().await);
+    }
+
+    #[tokio::test]
+    async fn answers_inbound_ping_with_pong() {
+        let (tracker, sent) = mock_tracker(Reachability::Unknown);
+        let web = Source::Web {
+            tab_id: 7,
+            document_id: "doc".to_owned(),
+            origin: "https://example.com".to_owned(),
+        };
+
+        tracker
+            .handle_inbound(incoming(web, Some(CONTROL_PING_TOPIC)))
+            .await;
+
+        let sent = sent.lock().unwrap();
+        assert!(sent.iter().any(|m| {
+            m.topic.as_deref() == Some(CONTROL_PONG_TOPIC)
+                && m.destination
+                    == (Endpoint::Web {
+                        tab_id: 7,
+                        document_id: "doc".to_owned(),
+                    })
+        }));
+    }
+
+    #[tokio::test]
+    async fn track_dedupes_by_endpoint() {
+        let (tracker, _sent) = mock_tracker(Reachability::Unknown);
+        let handle_a = tracker.track(ENDPOINT);
+        let handle_b = tracker.track(ENDPOINT);
+
+        // Same shared inner -> a single ping loop, one registry entry.
+        assert!(Arc::ptr_eq(&handle_a.inner, &handle_b.inner));
+        assert_eq!(tracker.registry.lock().unwrap().len(), 1);
+
+        // A different endpoint gets its own entry.
+        let _handle_c = tracker.track(Endpoint::BrowserBackground { id: HostId::Own });
+        assert_eq!(tracker.registry.lock().unwrap().len(), 2);
+    }
+
+    #[tokio::test]
+    async fn dropping_last_handle_cleans_registry_entry() {
+        let (tracker, _sent) = mock_tracker(Reachability::Unknown);
+        let handle_a = tracker.track(ENDPOINT);
+        let handle_b = tracker.track(ENDPOINT);
+        assert_eq!(tracker.registry.lock().unwrap().len(), 1);
+
+        drop(handle_a);
+        // One handle still alive -> entry retained.
+        assert_eq!(tracker.registry.lock().unwrap().len(), 1);
+
+        drop(handle_b);
+        // Last handle gone -> Drop removed the entry.
+        assert_eq!(tracker.registry.lock().unwrap().len(), 0);
+    }
+
+    #[tokio::test]
+    async fn pings_only_when_transport_is_unknown() {
+        // Unknown -> the loop emits at least one ping promptly.
+        let (tracker, sent) = mock_tracker(Reachability::Unknown);
+        let _handle = tracker.track(ENDPOINT);
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        assert!(
+            sent.lock()
+                .unwrap()
+                .iter()
+                .any(|m| m.topic.as_deref() == Some(CONTROL_PING_TOPIC)),
+            "an Unknown transport should be probed with a ping"
+        );
+
+        // Reachable -> no pings.
+        let (tracker, sent) = mock_tracker(Reachability::Reachable);
+        let _handle = tracker.track(ENDPOINT);
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        assert!(
+            sent.lock().unwrap().is_empty(),
+            "an authoritative transport answer should not be pinged"
+        );
+    }
+
+    #[tokio::test]
+    async fn ping_loop_stops_after_last_handle_dropped() {
+        let (tracker, sent) = mock_tracker(Reachability::Unknown);
+        let handle = tracker.track(ENDPOINT);
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        drop(handle);
+        // Allow the loop to observe the drop and stop.
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        let count_after_drop = sent.lock().unwrap().len();
+        tokio::time::sleep(Duration::from_millis(200)).await;
+        assert_eq!(
+            sent.lock().unwrap().len(),
+            count_after_drop,
+            "no further pings should be emitted once the loop has stopped"
+        );
+    }
+}

--- a/crates/bitwarden-ipc/src/reachability.rs
+++ b/crates/bitwarden-ipc/src/reachability.rs
@@ -26,22 +26,11 @@ use std::{
 use web_time::Instant;
 
 use crate::{
+    control::{CONTROL_PING_TOPIC, CONTROL_PONG_TOPIC},
     endpoint::Endpoint,
     message::{IncomingMessage, OutgoingMessage},
     traits::{CommunicationBackend, Reachability},
 };
-
-/// Reserved topic namespace for transport control frames that bypass the crypto channel.
-pub(crate) const CONTROL_TOPIC_PREFIX: &str = "$bw.control.";
-/// Topic marking a plaintext reachability ping.
-pub(crate) const CONTROL_PING_TOPIC: &str = "$bw.control.ping";
-/// Topic marking a plaintext reachability pong (the reply to a ping).
-pub(crate) const CONTROL_PONG_TOPIC: &str = "$bw.control.pong";
-
-/// Whether `topic` belongs to the reserved control-topic namespace and must bypass crypto.
-pub(crate) fn is_control_topic(topic: Option<&str>) -> bool {
-    topic.is_some_and(|t| t.starts_with(CONTROL_TOPIC_PREFIX))
-}
 
 /// An endpoint is considered live (when the transport can't tell) while a control frame was seen
 /// from it within this window.
@@ -58,6 +47,13 @@ type SendFn = Arc<dyn Fn(OutgoingMessage) -> BoxFuture<()> + Send + Sync>;
 type ReachFn = Arc<dyn Fn(Endpoint) -> BoxFuture<Reachability> + Send + Sync>;
 
 type Registry = Mutex<HashMap<Endpoint, Weak<TrackerInner>>>;
+
+/// Remove registry entries whose handles have all been dropped (dangling weaks), keeping the map
+/// bounded to currently-tracked endpoints. Safe to call at any time: a concurrently-recreated entry
+/// for the same endpoint has a strong count >= 1 and is preserved.
+fn prune(registry: &mut HashMap<Endpoint, Weak<TrackerInner>>) {
+    registry.retain(|_, weak| weak.strong_count() > 0);
+}
 
 /// Per-endpoint tracking state, shared between the [`ReachabilityHandle`]s for that endpoint and
 /// (via a [`Weak`]) the ping loop. Dropping the last handle drops this, which both ends the loop
@@ -80,7 +76,7 @@ impl Drop for TrackerInner {
         if let Some(registry) = self.registry.upgrade()
             && let Ok(mut map) = registry.lock()
         {
-            map.retain(|_, weak| weak.strong_count() > 0);
+            prune(&mut map);
         }
     }
 }
@@ -118,8 +114,17 @@ impl ReachabilityHandle {
     }
 }
 
-/// Tracks reachability of endpoints on behalf of consumers. Owned by the `IpcClient`; reachability
-/// pings and the auto-pong responder run over the transport this tracker was built from.
+/// Tracks whether peer endpoints are reachable, so a caller can avoid sending to an absent peer.
+///
+/// Obtain one from [`IpcClient::reachability`](crate::IpcClient::reachability) and call
+/// [`track`](Self::track) with a peer's endpoint to get a [`ReachabilityHandle`]; query the handle
+/// with [`ReachabilityHandle::is_reachable`]. A handle is a live subscription — hold it for as long
+/// as you care about the endpoint and drop it to stop tracking.
+///
+/// Reachability is resolved by asking the transport first ([`Reachability::Reachable`] /
+/// [`Reachability::Unreachable`] are taken at face value); only when the transport answers
+/// [`Reachability::Unknown`] does the tracker fall back to a ping/pong liveness window, emitting
+/// pings to that endpoint and treating it as reachable while a reply was seen recently.
 pub struct ReachabilityTracker {
     registry: Arc<Registry>,
     send_fn: SendFn,
@@ -160,7 +165,7 @@ impl ReachabilityTracker {
             .lock()
             .expect("reachability registry poisoned");
         // Opportunistically drop dangling entries left by handles that have since been freed.
-        map.retain(|_, weak| weak.strong_count() > 0);
+        prune(&mut map);
 
         if let Some(inner) = map.get(&endpoint).and_then(Weak::upgrade) {
             return ReachabilityHandle { inner };
@@ -311,15 +316,6 @@ mod tests {
             Some(Instant::now() - (ACTIVE_WINDOW + Duration::from_secs(1))),
             ACTIVE_WINDOW
         ));
-    }
-
-    #[test]
-    fn is_control_topic_matches_namespace() {
-        assert!(is_control_topic(Some(CONTROL_PING_TOPIC)));
-        assert!(is_control_topic(Some(CONTROL_PONG_TOPIC)));
-        assert!(is_control_topic(Some("$bw.control.future")));
-        assert!(!is_control_topic(Some("some-rpc-topic")));
-        assert!(!is_control_topic(None));
     }
 
     #[tokio::test]

--- a/crates/bitwarden-ipc/src/reachability/handle.rs
+++ b/crates/bitwarden-ipc/src/reachability/handle.rs
@@ -3,7 +3,7 @@ use std::sync::{
     atomic::{AtomicBool, Ordering},
 };
 
-use super::{PING_INTERVAL, POLL_INTERVAL, ReachFn, Registry, SendFn, prune};
+use super::{PING_INTERVAL, ReachFn, Registry, SendFn, prune};
 use crate::{control::ControlMessage, endpoint::Endpoint, traits::Reachability};
 
 /// A scoped reachability subscription for a single endpoint. Holding it keeps that endpoint's
@@ -17,14 +17,14 @@ pub struct ReachabilityHandle {
 impl ReachabilityHandle {
     /// Whether the tracked endpoint is currently reachable.
     ///
-    /// Pulls the transport-native signal on demand; only when that is [`Reachability::Unknown`]
+    /// Pulls the transport-native signal on demand; only when that is [`Reachability::Unsupported`]
     /// does it fall back to the ping/pong liveness signal.
     pub async fn is_reachable(&self) -> bool {
         match (self.inner.reach_fn)(self.inner.endpoint.clone()).await {
             Reachability::Reachable => true,
             Reachability::Unreachable => false,
             // No transport opinion: reachable while a reply was seen within the last ping cycle.
-            Reachability::Unknown => self.inner.live.load(Ordering::Relaxed),
+            Reachability::Unsupported => self.inner.live.load(Ordering::Relaxed),
         }
     }
 }
@@ -35,8 +35,8 @@ impl ReachabilityHandle {
 pub(super) struct ReachabilityHandleInner {
     endpoint: Endpoint,
     /// Whether the endpoint is currently live per ping/pong. Only consulted when the transport
-    /// answers `Unknown`. Set as soon as a control frame is seen; cleared by the ping loop after a
-    /// cycle with no reply.
+    /// answers `Unsupported`. Set as soon as a control frame is seen; cleared by the ping loop
+    /// after a cycle with no reply.
     live: AtomicBool,
     /// Set whenever a control frame is seen from `endpoint`; the ping loop clears it before each
     /// ping and reads it after the interval to detect a missed reply.
@@ -71,9 +71,13 @@ impl ReachabilityHandleInner {
         self.reply_seen.store(true, Ordering::Relaxed);
     }
 
-    /// Spawn this endpoint's ping loop. The loop holds only a [`Weak`] to `self`, so it ends once
-    /// the last handle is dropped (the upgrade then fails). The strong ref is released before each
-    /// sleep so a drop during the sleep is observed on the next cycle.
+    /// Spawn this endpoint's ping loop, used only while the transport does not support
+    /// reachability.
+    ///
+    /// The loop holds only a [`Weak`] to `self`, so it ends once the last handle is dropped (the
+    /// upgrade then fails). It also exits as soon as the transport gives a definitive answer: a
+    /// supported transport is read on demand by [`is_reachable`](ReachabilityHandle::is_reachable),
+    /// so no loop is needed (a transport answers consistently — see [`Reachability`]).
     pub(super) fn spawn_loop(self: &Arc<Self>) {
         let weak = Arc::downgrade(self);
         let future = async move {
@@ -82,32 +86,28 @@ impl ReachabilityHandleInner {
                     break;
                 };
 
-                let reachability = (inner.reach_fn)(inner.endpoint.clone()).await;
-                let interval = if reachability == Reachability::Unknown {
-                    // Probe: clear the reply flag, ping, and let the interval act as the window in
-                    // which a reply must arrive.
-                    inner.reply_seen.store(false, Ordering::Relaxed);
-                    (inner.send_fn)(ControlMessage::Ping.to_outgoing(inner.endpoint.clone())).await;
-                    PING_INTERVAL
-                } else {
-                    // The transport answered authoritatively; no ping needed. Keep polling at the
-                    // backoff cadence so a later transition to `Unknown` resumes pinging.
-                    POLL_INTERVAL
-                };
+                // A supported transport is authoritative and read on demand, so stop pinging once
+                // we see a definitive answer.
+                if (inner.reach_fn)(inner.endpoint.clone()).await != Reachability::Unsupported {
+                    break;
+                }
 
+                // Probe: clear the reply flag, ping, and let `PING_INTERVAL` be the window in which
+                // a reply must arrive. The strong ref is released before sleeping so a drop during
+                // the sleep ends the loop on the next cycle.
+                inner.reply_seen.store(false, Ordering::Relaxed);
+                (inner.send_fn)(ControlMessage::Ping.to_outgoing(inner.endpoint.clone())).await;
                 drop(inner);
-                bitwarden_threading::time::sleep(interval).await;
+                bitwarden_threading::time::sleep(PING_INTERVAL).await;
 
-                // After the probe window, if no reply was seen the endpoint is no longer live. A
-                // reply (see `mark_alive`) sets `live` immediately, so liveness is not delayed by
-                // this cycle.
-                if reachability == Reachability::Unknown {
-                    let Some(inner) = weak.upgrade() else {
-                        break;
-                    };
-                    if !inner.reply_seen.load(Ordering::Relaxed) {
-                        inner.live.store(false, Ordering::Relaxed);
-                    }
+                // If no reply was seen this cycle the endpoint is no longer live. A reply (see
+                // `mark_alive`) sets `live` immediately, so liveness is never delayed by this
+                // cycle.
+                let Some(inner) = weak.upgrade() else {
+                    break;
+                };
+                if !inner.reply_seen.load(Ordering::Relaxed) {
+                    inner.live.store(false, Ordering::Relaxed);
                 }
             }
         };

--- a/crates/bitwarden-ipc/src/reachability/handle.rs
+++ b/crates/bitwarden-ipc/src/reachability/handle.rs
@@ -1,0 +1,27 @@
+use std::sync::{Arc, atomic::Ordering};
+
+use super::TrackerInner;
+use crate::traits::Reachability;
+
+/// A scoped reachability subscription for a single endpoint. Holding it keeps that endpoint's
+/// reachability fresh; dropping the last handle for an endpoint stops its ping loop.
+#[derive(Clone)]
+pub struct ReachabilityHandle {
+    // Visible to the rest of the `reachability` module so the tracker can construct handles.
+    pub(super) inner: Arc<TrackerInner>,
+}
+
+impl ReachabilityHandle {
+    /// Whether the tracked endpoint is currently reachable.
+    ///
+    /// Pulls the transport-native signal on demand; only when that is [`Reachability::Unknown`]
+    /// does it fall back to the ping/pong liveness signal.
+    pub async fn is_reachable(&self) -> bool {
+        match (self.inner.reach_fn)(self.inner.endpoint.clone()).await {
+            Reachability::Reachable => true,
+            Reachability::Unreachable => false,
+            // No transport opinion: reachable while a reply was seen within the last ping cycle.
+            Reachability::Unknown => self.inner.live.load(Ordering::Relaxed),
+        }
+    }
+}

--- a/crates/bitwarden-ipc/src/reachability/handle.rs
+++ b/crates/bitwarden-ipc/src/reachability/handle.rs
@@ -1,14 +1,17 @@
-use std::sync::{Arc, atomic::Ordering};
+use std::sync::{
+    Arc, Weak,
+    atomic::{AtomicBool, Ordering},
+};
 
-use super::TrackerInner;
-use crate::traits::Reachability;
+use super::{PING_INTERVAL, POLL_INTERVAL, ReachFn, Registry, SendFn, prune};
+use crate::{control::ControlMessage, endpoint::Endpoint, traits::Reachability};
 
 /// A scoped reachability subscription for a single endpoint. Holding it keeps that endpoint's
 /// reachability fresh; dropping the last handle for an endpoint stops its ping loop.
 #[derive(Clone)]
 pub struct ReachabilityHandle {
     // Visible to the rest of the `reachability` module so the tracker can construct handles.
-    pub(super) inner: Arc<TrackerInner>,
+    pub(super) inner: Arc<ReachabilityHandleInner>,
 }
 
 impl ReachabilityHandle {
@@ -22,6 +25,109 @@ impl ReachabilityHandle {
             Reachability::Unreachable => false,
             // No transport opinion: reachable while a reply was seen within the last ping cycle.
             Reachability::Unknown => self.inner.live.load(Ordering::Relaxed),
+        }
+    }
+}
+
+/// Shared per-endpoint state behind one or more [`ReachabilityHandle`]s. It owns the endpoint's
+/// ping loop (spawned in [`spawn_loop`](Self::spawn_loop)); the loop holds only a [`Weak`] to this,
+/// so dropping the last handle ends the loop and (via [`Drop`]) prunes the registry entry.
+pub(super) struct ReachabilityHandleInner {
+    endpoint: Endpoint,
+    /// Whether the endpoint is currently live per ping/pong. Only consulted when the transport
+    /// answers `Unknown`. Set as soon as a control frame is seen; cleared by the ping loop after a
+    /// cycle with no reply.
+    live: AtomicBool,
+    /// Set whenever a control frame is seen from `endpoint`; the ping loop clears it before each
+    /// ping and reads it after the interval to detect a missed reply.
+    reply_seen: AtomicBool,
+    send_fn: SendFn,
+    reach_fn: ReachFn,
+    /// Back-ref so this entry can remove itself from the owning tracker's registry on drop.
+    registry: Weak<Registry>,
+}
+
+impl ReachabilityHandleInner {
+    pub(super) fn new(
+        endpoint: Endpoint,
+        send_fn: SendFn,
+        reach_fn: ReachFn,
+        registry: Weak<Registry>,
+    ) -> Arc<Self> {
+        Arc::new(Self {
+            endpoint,
+            live: AtomicBool::new(false),
+            reply_seen: AtomicBool::new(false),
+            send_fn,
+            reach_fn,
+            registry,
+        })
+    }
+
+    /// Record that a control frame was just seen from this endpoint: it is alive now, and the
+    /// in-flight ping cycle should not clear liveness.
+    pub(super) fn mark_alive(&self) {
+        self.live.store(true, Ordering::Relaxed);
+        self.reply_seen.store(true, Ordering::Relaxed);
+    }
+
+    /// Spawn this endpoint's ping loop. The loop holds only a [`Weak`] to `self`, so it ends once
+    /// the last handle is dropped (the upgrade then fails). The strong ref is released before each
+    /// sleep so a drop during the sleep is observed on the next cycle.
+    pub(super) fn spawn_loop(self: &Arc<Self>) {
+        let weak = Arc::downgrade(self);
+        let future = async move {
+            loop {
+                let Some(inner) = weak.upgrade() else {
+                    break;
+                };
+
+                let reachability = (inner.reach_fn)(inner.endpoint.clone()).await;
+                let interval = if reachability == Reachability::Unknown {
+                    // Probe: clear the reply flag, ping, and let the interval act as the window in
+                    // which a reply must arrive.
+                    inner.reply_seen.store(false, Ordering::Relaxed);
+                    (inner.send_fn)(ControlMessage::Ping.to_outgoing(inner.endpoint.clone())).await;
+                    PING_INTERVAL
+                } else {
+                    // The transport answered authoritatively; no ping needed. Keep polling at the
+                    // backoff cadence so a later transition to `Unknown` resumes pinging.
+                    POLL_INTERVAL
+                };
+
+                drop(inner);
+                bitwarden_threading::time::sleep(interval).await;
+
+                // After the probe window, if no reply was seen the endpoint is no longer live. A
+                // reply (see `mark_alive`) sets `live` immediately, so liveness is not delayed by
+                // this cycle.
+                if reachability == Reachability::Unknown {
+                    let Some(inner) = weak.upgrade() else {
+                        break;
+                    };
+                    if !inner.reply_seen.load(Ordering::Relaxed) {
+                        inner.live.store(false, Ordering::Relaxed);
+                    }
+                }
+            }
+        };
+
+        #[cfg(not(target_arch = "wasm32"))]
+        tokio::spawn(future);
+        #[cfg(target_arch = "wasm32")]
+        wasm_bindgen_futures::spawn_local(future);
+    }
+}
+
+impl Drop for ReachabilityHandleInner {
+    fn drop(&mut self) {
+        // Bound the registry to live entries. Removing by `retain(strong > 0)` rather than by key
+        // is race-safe: if a concurrent `track()` already replaced our (now-dead) entry with a new
+        // live one, that new entry has a strong count >= 1 and is preserved.
+        if let Some(registry) = self.registry.upgrade()
+            && let Ok(mut map) = registry.lock()
+        {
+            prune(&mut map);
         }
     }
 }

--- a/crates/bitwarden-ipc/src/reachability/mod.rs
+++ b/crates/bitwarden-ipc/src/reachability/mod.rs
@@ -1,0 +1,84 @@
+//! Reachability tracking: a transport-authoritative signal with a ping/pong liveness fallback.
+//!
+//! A consumer that cares whether a peer is reachable (e.g. the shared-unlock follower) obtains a
+//! [`ReachabilityHandle`] from [`ReachabilityTracker::track`] *after* it knows the peer's endpoint.
+//! While a handle is held, the tracker keeps that endpoint's reachability fresh; when the last
+//! handle for an endpoint is dropped the per-endpoint ping loop stops on its own.
+//!
+//! Reachability resolves as follows:
+//! - the transport answers [`Reachability::Reachable`]/[`Reachability::Unreachable`] -> that wins,
+//!   and no pings are sent;
+//! - the transport answers [`Reachability::Unknown`] -> fall back to ping/pong liveness: the
+//!   endpoint is reachable while replies to its pings keep arriving (see [`PING_INTERVAL`]).
+//!
+//! Ping/pong frames travel over the raw transport under a reserved control-topic namespace and are
+//! peeled off by the [`ControlSplitter`](crate::control_splitter::ControlSplitter) before the
+//! crypto layer ever sees them, so they never abort a handshake.
+
+mod handle;
+mod tracker;
+
+use std::{
+    collections::HashMap,
+    future::Future,
+    pin::Pin,
+    sync::{Arc, Mutex, Weak, atomic::AtomicBool},
+    time::Duration,
+};
+
+pub use handle::ReachabilityHandle;
+pub use tracker::ReachabilityTracker;
+
+use crate::{endpoint::Endpoint, message::OutgoingMessage, traits::Reachability};
+
+/// Ping cadence while probing an endpoint whose transport reachability is `Unknown`. Each cycle
+/// sends a ping and, after this interval, marks the endpoint not-live unless a reply was seen — so
+/// it doubles as the liveness window. Kept clock-free (sleep-based) so it works on wasm too.
+const PING_INTERVAL: Duration = Duration::from_secs(2);
+/// Re-check cadence while the transport answers authoritatively (no pinging needed).
+const POLL_INTERVAL: Duration = Duration::from_secs(10);
+
+type BoxFuture<T> = Pin<Box<dyn Future<Output = T> + Send>>;
+/// Type-erased "send this frame over the raw transport".
+type SendFn = Arc<dyn Fn(OutgoingMessage) -> BoxFuture<()> + Send + Sync>;
+/// Type-erased "ask the transport whether this endpoint is reachable".
+type ReachFn = Arc<dyn Fn(Endpoint) -> BoxFuture<Reachability> + Send + Sync>;
+
+type Registry = Mutex<HashMap<Endpoint, Weak<TrackerInner>>>;
+
+/// Remove registry entries whose handles have all been dropped (dangling weaks), keeping the map
+/// bounded to currently-tracked endpoints. Safe to call at any time: a concurrently-recreated entry
+/// for the same endpoint has a strong count >= 1 and is preserved.
+fn prune(registry: &mut HashMap<Endpoint, Weak<TrackerInner>>) {
+    registry.retain(|_, weak| weak.strong_count() > 0);
+}
+
+/// Per-endpoint tracking state, shared between the [`ReachabilityHandle`]s for that endpoint and
+/// (via a [`Weak`]) the ping loop. Dropping the last handle drops this, which both ends the loop
+/// (its weak upgrade fails) and removes the registry entry (see [`Drop`]).
+struct TrackerInner {
+    endpoint: Endpoint,
+    /// Whether the endpoint is currently live per ping/pong. Only consulted when the transport
+    /// answers `Unknown`. Set as soon as a control frame is seen; cleared by the ping loop after a
+    /// cycle with no reply.
+    live: AtomicBool,
+    /// Set whenever a control frame is seen from `endpoint`; the ping loop clears it before each
+    /// ping and reads it after the interval to detect a missed reply.
+    reply_seen: AtomicBool,
+    reach_fn: ReachFn,
+    /// Back-ref so this entry can remove itself from the owning tracker's registry on drop.
+    registry: Weak<Registry>,
+}
+
+impl Drop for TrackerInner {
+    fn drop(&mut self) {
+        // Bound the registry to live entries. Removing by `retain(strong > 0)` rather than by key
+        // is race-safe: if a concurrent `track()` already replaced our (now-dead) entry with a new
+        // live one, that new entry has a strong count >= 1 and is preserved.
+        if let Some(registry) = self.registry.upgrade()
+            && let Ok(mut map) = registry.lock()
+        {
+            prune(&mut map);
+        }
+    }
+}

--- a/crates/bitwarden-ipc/src/reachability/mod.rs
+++ b/crates/bitwarden-ipc/src/reachability/mod.rs
@@ -2,8 +2,8 @@
 //!
 //! A consumer that cares whether a peer is reachable (e.g. the shared-unlock follower) obtains a
 //! [`ReachabilityHandle`] from [`ReachabilityTracker::track`] *after* it knows the peer's endpoint.
-//! While a handle is held, the tracker keeps that endpoint's reachability fresh; when the last
-//! handle for an endpoint is dropped the per-endpoint ping loop stops on its own.
+//! While a handle is held, that endpoint's reachability is kept fresh; when the last handle for an
+//! endpoint is dropped the per-endpoint ping loop stops on its own.
 //!
 //! Reachability resolves as follows:
 //! - the transport answers [`Reachability::Reachable`]/[`Reachability::Unreachable`] -> that wins,
@@ -14,6 +14,9 @@
 //! Ping/pong frames travel over the raw transport under a reserved control-topic namespace and are
 //! peeled off by the [`ControlSplitter`](crate::control_splitter::ControlSplitter) before the
 //! crypto layer ever sees them, so they never abort a handshake.
+//!
+//! Layout: [`ReachabilityHandle`] and its shared inner (which owns the ping loop) live in `handle`;
+//! the [`ReachabilityTracker`] that hands out and routes to handles lives in `tracker`.
 
 mod handle;
 mod tracker;
@@ -22,13 +25,14 @@ use std::{
     collections::HashMap,
     future::Future,
     pin::Pin,
-    sync::{Arc, Mutex, Weak, atomic::AtomicBool},
+    sync::{Arc, Mutex, Weak},
     time::Duration,
 };
 
 pub use handle::ReachabilityHandle;
 pub use tracker::ReachabilityTracker;
 
+use self::handle::ReachabilityHandleInner;
 use crate::{endpoint::Endpoint, message::OutgoingMessage, traits::Reachability};
 
 /// Ping cadence while probing an endpoint whose transport reachability is `Unknown`. Each cycle
@@ -44,41 +48,13 @@ type SendFn = Arc<dyn Fn(OutgoingMessage) -> BoxFuture<()> + Send + Sync>;
 /// Type-erased "ask the transport whether this endpoint is reachable".
 type ReachFn = Arc<dyn Fn(Endpoint) -> BoxFuture<Reachability> + Send + Sync>;
 
-type Registry = Mutex<HashMap<Endpoint, Weak<TrackerInner>>>;
+/// Maps each tracked endpoint to its shared handle state. Used both to dedup handles (one inner,
+/// one ping loop per endpoint) and to route inbound control frames to the right endpoint's state.
+type Registry = Mutex<HashMap<Endpoint, Weak<ReachabilityHandleInner>>>;
 
 /// Remove registry entries whose handles have all been dropped (dangling weaks), keeping the map
 /// bounded to currently-tracked endpoints. Safe to call at any time: a concurrently-recreated entry
 /// for the same endpoint has a strong count >= 1 and is preserved.
-fn prune(registry: &mut HashMap<Endpoint, Weak<TrackerInner>>) {
+fn prune(registry: &mut HashMap<Endpoint, Weak<ReachabilityHandleInner>>) {
     registry.retain(|_, weak| weak.strong_count() > 0);
-}
-
-/// Per-endpoint tracking state, shared between the [`ReachabilityHandle`]s for that endpoint and
-/// (via a [`Weak`]) the ping loop. Dropping the last handle drops this, which both ends the loop
-/// (its weak upgrade fails) and removes the registry entry (see [`Drop`]).
-struct TrackerInner {
-    endpoint: Endpoint,
-    /// Whether the endpoint is currently live per ping/pong. Only consulted when the transport
-    /// answers `Unknown`. Set as soon as a control frame is seen; cleared by the ping loop after a
-    /// cycle with no reply.
-    live: AtomicBool,
-    /// Set whenever a control frame is seen from `endpoint`; the ping loop clears it before each
-    /// ping and reads it after the interval to detect a missed reply.
-    reply_seen: AtomicBool,
-    reach_fn: ReachFn,
-    /// Back-ref so this entry can remove itself from the owning tracker's registry on drop.
-    registry: Weak<Registry>,
-}
-
-impl Drop for TrackerInner {
-    fn drop(&mut self) {
-        // Bound the registry to live entries. Removing by `retain(strong > 0)` rather than by key
-        // is race-safe: if a concurrent `track()` already replaced our (now-dead) entry with a new
-        // live one, that new entry has a strong count >= 1 and is preserved.
-        if let Some(registry) = self.registry.upgrade()
-            && let Ok(mut map) = registry.lock()
-        {
-            prune(&mut map);
-        }
-    }
 }

--- a/crates/bitwarden-ipc/src/reachability/mod.rs
+++ b/crates/bitwarden-ipc/src/reachability/mod.rs
@@ -8,7 +8,7 @@
 //! Reachability resolves as follows:
 //! - the transport answers [`Reachability::Reachable`]/[`Reachability::Unreachable`] -> that wins,
 //!   and no pings are sent;
-//! - the transport answers [`Reachability::Unknown`] -> fall back to ping/pong liveness: the
+//! - the transport answers [`Reachability::Unsupported`] -> fall back to ping/pong liveness: the
 //!   endpoint is reachable while replies to its pings keep arriving (see [`PING_INTERVAL`]).
 //!
 //! Ping/pong frames travel over the raw transport under a reserved control-topic namespace and are
@@ -35,12 +35,10 @@ pub use tracker::ReachabilityTracker;
 use self::handle::ReachabilityHandleInner;
 use crate::{endpoint::Endpoint, message::OutgoingMessage, traits::Reachability};
 
-/// Ping cadence while probing an endpoint whose transport reachability is `Unknown`. Each cycle
-/// sends a ping and, after this interval, marks the endpoint not-live unless a reply was seen — so
-/// it doubles as the liveness window. Kept clock-free (sleep-based) so it works on wasm too.
+/// Ping cadence while probing an endpoint whose transport is `Unsupported`. Each cycle sends a ping
+/// and, after this interval, marks the endpoint not-live unless a reply was seen — so it doubles as
+/// the liveness window. Kept clock-free (sleep-based) so it works on wasm too.
 const PING_INTERVAL: Duration = Duration::from_secs(2);
-/// Re-check cadence while the transport answers authoritatively (no pinging needed).
-const POLL_INTERVAL: Duration = Duration::from_secs(10);
 
 type BoxFuture<T> = Pin<Box<dyn Future<Output = T> + Send>>;
 /// Type-erased "send this frame over the raw transport".

--- a/crates/bitwarden-ipc/src/reachability/tracker.rs
+++ b/crates/bitwarden-ipc/src/reachability/tracker.rs
@@ -184,8 +184,8 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn unknown_falls_back_to_liveness() {
-        let (tracker, _sent) = mock_tracker(Reachability::Unknown);
+    async fn unsupported_falls_back_to_liveness() {
+        let (tracker, _sent) = mock_tracker(Reachability::Unsupported);
         let handle = tracker.track(ENDPOINT);
 
         // No control frame seen yet -> not reachable.
@@ -200,7 +200,7 @@ mod tests {
 
     #[tokio::test]
     async fn answers_inbound_ping_with_pong() {
-        let (tracker, sent) = mock_tracker(Reachability::Unknown);
+        let (tracker, sent) = mock_tracker(Reachability::Unsupported);
         let web = Source::Web {
             tab_id: 7,
             document_id: "doc".to_owned(),
@@ -224,7 +224,7 @@ mod tests {
 
     #[tokio::test]
     async fn track_dedupes_by_endpoint() {
-        let (tracker, _sent) = mock_tracker(Reachability::Unknown);
+        let (tracker, _sent) = mock_tracker(Reachability::Unsupported);
         let handle_a = tracker.track(ENDPOINT);
         let handle_b = tracker.track(ENDPOINT);
 
@@ -239,7 +239,7 @@ mod tests {
 
     #[tokio::test]
     async fn dropping_last_handle_cleans_registry_entry() {
-        let (tracker, _sent) = mock_tracker(Reachability::Unknown);
+        let (tracker, _sent) = mock_tracker(Reachability::Unsupported);
         let handle_a = tracker.track(ENDPOINT);
         let handle_b = tracker.track(ENDPOINT);
         assert_eq!(tracker.registry.lock().unwrap().len(), 1);
@@ -255,8 +255,8 @@ mod tests {
 
     #[tokio::test]
     async fn pings_only_when_transport_is_unknown() {
-        // Unknown -> the loop emits at least one ping promptly.
-        let (tracker, sent) = mock_tracker(Reachability::Unknown);
+        // Unsupported -> the loop emits at least one ping promptly.
+        let (tracker, sent) = mock_tracker(Reachability::Unsupported);
         let _handle = tracker.track(ENDPOINT);
         tokio::time::sleep(Duration::from_millis(50)).await;
         assert!(
@@ -264,7 +264,7 @@ mod tests {
                 .unwrap()
                 .iter()
                 .any(|m| m.topic.as_deref() == Some(ControlMessage::Ping.topic())),
-            "an Unknown transport should be probed with a ping"
+            "an Unsupported transport should be probed with a ping"
         );
 
         // Reachable -> no pings.
@@ -279,7 +279,7 @@ mod tests {
 
     #[tokio::test]
     async fn ping_loop_stops_after_last_handle_dropped() {
-        let (tracker, sent) = mock_tracker(Reachability::Unknown);
+        let (tracker, sent) = mock_tracker(Reachability::Unsupported);
         let handle = tracker.track(ENDPOINT);
         tokio::time::sleep(Duration::from_millis(50)).await;
         drop(handle);

--- a/crates/bitwarden-ipc/src/reachability/tracker.rs
+++ b/crates/bitwarden-ipc/src/reachability/tracker.rs
@@ -1,115 +1,25 @@
-//! Reachability tracking: a transport-authoritative signal with a ping/pong liveness fallback.
-//!
-//! A consumer that cares whether a peer is reachable (e.g. the shared-unlock follower) obtains a
-//! [`ReachabilityHandle`] from [`ReachabilityTracker::track`] *after* it knows the peer's endpoint.
-//! While a handle is held, the tracker keeps that endpoint's reachability fresh; when the last
-//! handle for an endpoint is dropped the per-endpoint ping loop stops on its own.
-//!
-//! Reachability resolves as follows:
-//! - the transport answers [`Reachability::Reachable`]/[`Reachability::Unreachable`] -> that wins,
-//!   and no pings are sent;
-//! - the transport answers [`Reachability::Unknown`] -> fall back to ping/pong liveness: the
-//!   endpoint is reachable while replies to its pings keep arriving (see [`PING_INTERVAL`]).
-//!
-//! Ping/pong frames travel over the raw transport under a reserved control-topic namespace and are
-//! peeled off by the `ControlSplitter` before the crypto layer ever sees them, so they never abort
-//! a handshake.
-
 use std::{
     collections::HashMap,
-    future::Future,
-    pin::Pin,
     sync::{
         Arc, Mutex, Weak,
         atomic::{AtomicBool, Ordering},
     },
-    time::Duration,
 };
 
+use bitwarden_threading::cancellation_token::CancellationToken;
+use tokio::select;
+
+use super::{
+    PING_INTERVAL, POLL_INTERVAL, ReachFn, Registry, SendFn, TrackerInner,
+    handle::ReachabilityHandle, prune,
+};
 use crate::{
-    control::{CONTROL_PING_TOPIC, CONTROL_PONG_TOPIC},
+    control::{ControlMessage, IncomingControlMessage},
+    control_splitter::ControlReceiver,
     endpoint::Endpoint,
-    message::{IncomingMessage, OutgoingMessage},
-    traits::{CommunicationBackend, Reachability},
+    error::IpcErrorKind,
+    traits::{CommunicationBackend, CommunicationBackendReceiver, Reachability},
 };
-
-/// Ping cadence while probing an endpoint whose transport reachability is `Unknown`. Each cycle
-/// sends a ping and, after this interval, marks the endpoint not-live unless a reply was seen — so
-/// it doubles as the liveness window. Kept clock-free (sleep-based) so it works on wasm too.
-const PING_INTERVAL: Duration = Duration::from_secs(2);
-/// Re-check cadence while the transport answers authoritatively (no pinging needed).
-const POLL_INTERVAL: Duration = Duration::from_secs(10);
-
-type BoxFuture<T> = Pin<Box<dyn Future<Output = T> + Send>>;
-/// Type-erased "send this frame over the raw transport".
-type SendFn = Arc<dyn Fn(OutgoingMessage) -> BoxFuture<()> + Send + Sync>;
-/// Type-erased "ask the transport whether this endpoint is reachable".
-type ReachFn = Arc<dyn Fn(Endpoint) -> BoxFuture<Reachability> + Send + Sync>;
-
-type Registry = Mutex<HashMap<Endpoint, Weak<TrackerInner>>>;
-
-/// Remove registry entries whose handles have all been dropped (dangling weaks), keeping the map
-/// bounded to currently-tracked endpoints. Safe to call at any time: a concurrently-recreated entry
-/// for the same endpoint has a strong count >= 1 and is preserved.
-fn prune(registry: &mut HashMap<Endpoint, Weak<TrackerInner>>) {
-    registry.retain(|_, weak| weak.strong_count() > 0);
-}
-
-/// Per-endpoint tracking state, shared between the [`ReachabilityHandle`]s for that endpoint and
-/// (via a [`Weak`]) the ping loop. Dropping the last handle drops this, which both ends the loop
-/// (its weak upgrade fails) and removes the registry entry (see [`Drop`]).
-struct TrackerInner {
-    endpoint: Endpoint,
-    /// Whether the endpoint is currently live per ping/pong. Only consulted when the transport
-    /// answers `Unknown`. Set as soon as a control frame is seen; cleared by the ping loop after a
-    /// cycle with no reply.
-    live: AtomicBool,
-    /// Set whenever a control frame is seen from `endpoint`; the ping loop clears it before each
-    /// ping and reads it after the interval to detect a missed reply.
-    reply_seen: AtomicBool,
-    reach_fn: ReachFn,
-    /// Back-ref so this entry can remove itself from the owning tracker's registry on drop.
-    registry: Weak<Registry>,
-}
-
-impl Drop for TrackerInner {
-    fn drop(&mut self) {
-        // Bound the registry to live entries. Removing by `retain(strong > 0)` rather than by key
-        // is race-safe: if a concurrent `track()` already replaced our (now-dead) entry with a new
-        // live one, that new entry has a strong count >= 1 and is preserved.
-        if let Some(registry) = self.registry.upgrade()
-            && let Ok(mut map) = registry.lock()
-        {
-            prune(&mut map);
-        }
-    }
-}
-
-/// A scoped reachability subscription for a single endpoint. Holding it keeps that endpoint's
-/// reachability fresh; dropping the last handle for an endpoint stops its ping loop.
-#[derive(Clone)]
-pub struct ReachabilityHandle {
-    inner: Arc<TrackerInner>,
-}
-
-impl ReachabilityHandle {
-    /// Whether the tracked endpoint is currently reachable.
-    ///
-    /// Pulls the transport-native signal on demand; only when that is [`Reachability::Unknown`]
-    /// does it fall back to the ping/pong liveness window.
-    pub async fn is_reachable(&self) -> bool {
-        match (self.inner.reach_fn)(self.inner.endpoint.clone()).await {
-            Reachability::Reachable => true,
-            Reachability::Unreachable => false,
-            Reachability::Unknown => self.is_live(),
-        }
-    }
-
-    /// Raw ping/pong liveness: whether a reply was seen within the last [`PING_INTERVAL`] cycle.
-    fn is_live(&self) -> bool {
-        self.inner.live.load(Ordering::Relaxed)
-    }
-}
 
 /// Tracks whether peer endpoints are reachable, so a caller can avoid sending to an absent peer.
 ///
@@ -121,7 +31,7 @@ impl ReachabilityHandle {
 /// Reachability is resolved by asking the transport first ([`Reachability::Reachable`] /
 /// [`Reachability::Unreachable`] are taken at face value); only when the transport answers
 /// [`Reachability::Unknown`] does the tracker fall back to a ping/pong liveness window, emitting
-/// pings to that endpoint and treating it as reachable while a reply was seen recently.
+/// pings to that endpoint and treating it as reachable while replies keep arriving.
 pub struct ReachabilityTracker {
     registry: Arc<Registry>,
     send_fn: SendFn,
@@ -187,10 +97,39 @@ impl ReachabilityTracker {
         ReachabilityHandle { inner }
     }
 
-    /// Process an inbound control frame: record liveness for the source (if it is tracked) and, for
-    /// a ping, answer with a pong. Called by the `ControlSplitter`.
-    pub async fn handle_inbound(&self, message: IncomingMessage) {
-        let source = message.source.to_endpoint();
+    /// Start consuming the inbound control stream: record liveness for every control frame and
+    /// answer pings with a pong. Runs until `cancellation_token` is cancelled.
+    ///
+    /// Call this once when the client starts. It is required even when the tracker is not actively
+    /// tracking anything, so a passive peer (e.g. the desktop leader) still answers pings.
+    pub(crate) fn start<R: CommunicationBackendReceiver>(
+        self: &Arc<Self>,
+        control: ControlReceiver<R>,
+        cancellation_token: CancellationToken,
+    ) {
+        let tracker = self.clone();
+        let future = async move {
+            loop {
+                select! {
+                    _ = cancellation_token.cancelled() => break,
+                    received = control.receive() => match received {
+                        Ok(incoming) => tracker.handle_inbound(incoming).await,
+                        Err(error) if error.is_fatal() => break,
+                        Err(_) => {}
+                    },
+                }
+            }
+        };
+
+        #[cfg(not(target_arch = "wasm32"))]
+        tokio::spawn(future);
+        #[cfg(target_arch = "wasm32")]
+        wasm_bindgen_futures::spawn_local(future);
+    }
+
+    /// Record liveness for the source (if it is tracked) and, for a ping, answer with a pong.
+    async fn handle_inbound(&self, incoming: IncomingControlMessage) {
+        let source = incoming.source.to_endpoint();
 
         if let Some(inner) = self
             .registry
@@ -205,13 +144,8 @@ impl ReachabilityTracker {
             inner.reply_seen.store(true, Ordering::Relaxed);
         }
 
-        if message.topic.as_deref() == Some(CONTROL_PING_TOPIC) {
-            (self.send_fn)(OutgoingMessage {
-                payload: Vec::new(),
-                destination: source,
-                topic: Some(CONTROL_PONG_TOPIC.to_owned()),
-            })
-            .await;
+        if incoming.message == ControlMessage::Ping {
+            (self.send_fn)(ControlMessage::Pong.to_outgoing(source)).await;
         }
     }
 }
@@ -236,12 +170,7 @@ fn spawn_ping_loop(
                 // Probe: clear the reply flag, ping, and let the interval below act as the window
                 // in which a reply must arrive.
                 inner.reply_seen.store(false, Ordering::Relaxed);
-                (send_fn)(OutgoingMessage {
-                    payload: Vec::new(),
-                    destination: endpoint.clone(),
-                    topic: Some(CONTROL_PING_TOPIC.to_owned()),
-                })
-                .await;
+                (send_fn)(ControlMessage::Ping.to_outgoing(endpoint.clone())).await;
                 PING_INTERVAL
             } else {
                 // The transport answered authoritatively; no ping needed. Keep polling at the
@@ -274,15 +203,20 @@ fn spawn_ping_loop(
 
 #[cfg(test)]
 mod tests {
+    use std::time::Duration;
+
     use super::*;
-    use crate::endpoint::{HostId, Source};
+    use crate::{
+        endpoint::{HostId, Source},
+        message::OutgoingMessage,
+    };
 
     const ENDPOINT: Endpoint = Endpoint::DesktopMain;
 
     /// Builds a tracker whose transport answers `reach` and records every outgoing frame.
     fn mock_tracker(
         reach: Reachability,
-    ) -> (ReachabilityTracker, Arc<Mutex<Vec<OutgoingMessage>>>) {
+    ) -> (Arc<ReachabilityTracker>, Arc<Mutex<Vec<OutgoingMessage>>>) {
         let sent = Arc::new(Mutex::new(Vec::new()));
         let sent_clone = sent.clone();
         let send_fn: SendFn = Arc::new(move |message| {
@@ -292,16 +226,11 @@ mod tests {
             })
         });
         let reach_fn: ReachFn = Arc::new(move |_| Box::pin(async move { reach }));
-        (ReachabilityTracker::new(send_fn, reach_fn), sent)
+        (Arc::new(ReachabilityTracker::new(send_fn, reach_fn)), sent)
     }
 
-    fn incoming(source: Source, topic: Option<&str>) -> IncomingMessage {
-        IncomingMessage {
-            payload: Vec::new(),
-            destination: ENDPOINT,
-            source,
-            topic: topic.map(ToOwned::to_owned),
-        }
+    fn incoming(source: Source, message: ControlMessage) -> IncomingControlMessage {
+        IncomingControlMessage { message, source }
     }
 
     #[tokio::test]
@@ -317,7 +246,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn unknown_falls_back_to_liveness_window() {
+    async fn unknown_falls_back_to_liveness() {
         let (tracker, _sent) = mock_tracker(Reachability::Unknown);
         let handle = tracker.track(ENDPOINT);
 
@@ -326,7 +255,7 @@ mod tests {
 
         // An inbound control frame from the tracked endpoint marks it live.
         tracker
-            .handle_inbound(incoming(Source::DesktopMain, Some(CONTROL_PONG_TOPIC)))
+            .handle_inbound(incoming(Source::DesktopMain, ControlMessage::Pong))
             .await;
         assert!(handle.is_reachable().await);
     }
@@ -341,12 +270,12 @@ mod tests {
         };
 
         tracker
-            .handle_inbound(incoming(web, Some(CONTROL_PING_TOPIC)))
+            .handle_inbound(incoming(web, ControlMessage::Ping))
             .await;
 
         let sent = sent.lock().unwrap();
         assert!(sent.iter().any(|m| {
-            m.topic.as_deref() == Some(CONTROL_PONG_TOPIC)
+            m.topic.as_deref() == Some(ControlMessage::Pong.topic())
                 && m.destination
                     == (Endpoint::Web {
                         tab_id: 7,
@@ -396,7 +325,7 @@ mod tests {
             sent.lock()
                 .unwrap()
                 .iter()
-                .any(|m| m.topic.as_deref() == Some(CONTROL_PING_TOPIC)),
+                .any(|m| m.topic.as_deref() == Some(ControlMessage::Ping.topic())),
             "an Unknown transport should be probed with a ping"
         );
 

--- a/crates/bitwarden-ipc/src/reachability/tracker.rs
+++ b/crates/bitwarden-ipc/src/reachability/tracker.rs
@@ -1,24 +1,22 @@
 use std::{
     collections::HashMap,
-    sync::{
-        Arc, Mutex, Weak,
-        atomic::{AtomicBool, Ordering},
-    },
+    sync::{Arc, Mutex, Weak},
 };
 
 use bitwarden_threading::cancellation_token::CancellationToken;
 use tokio::select;
 
 use super::{
-    PING_INTERVAL, POLL_INTERVAL, ReachFn, Registry, SendFn, TrackerInner,
-    handle::ReachabilityHandle, prune,
+    ReachFn, Registry, SendFn,
+    handle::{ReachabilityHandle, ReachabilityHandleInner},
+    prune,
 };
 use crate::{
     control::{ControlMessage, IncomingControlMessage},
     control_splitter::ControlReceiver,
     endpoint::Endpoint,
     error::IpcErrorKind,
-    traits::{CommunicationBackend, CommunicationBackendReceiver, Reachability},
+    traits::{CommunicationBackend, CommunicationBackendReceiver},
 };
 
 /// Tracks whether peer endpoints are reachable, so a caller can avoid sending to an absent peer.
@@ -28,10 +26,9 @@ use crate::{
 /// with [`ReachabilityHandle::is_reachable`]. A handle is a live subscription — hold it for as long
 /// as you care about the endpoint and drop it to stop tracking.
 ///
-/// Reachability is resolved by asking the transport first ([`Reachability::Reachable`] /
-/// [`Reachability::Unreachable`] are taken at face value); only when the transport answers
-/// [`Reachability::Unknown`] does the tracker fall back to a ping/pong liveness window, emitting
-/// pings to that endpoint and treating it as reachable while replies keep arriving.
+/// The tracker is the factory and router: it hands out (deduped) handles, and feeds inbound control
+/// frames to the right endpoint's handle state. The per-endpoint ping loop lives on the handle's
+/// shared inner (see [`ReachabilityHandle`]).
 pub struct ReachabilityTracker {
     registry: Arc<Registry>,
     send_fn: SendFn,
@@ -65,7 +62,8 @@ impl ReachabilityTracker {
     }
 
     /// Begin (or join) tracking `endpoint`, returning a handle. Calls for the same endpoint share a
-    /// single ping loop; the loop is spawned only when the first handle for an endpoint is created.
+    /// single inner (and its single ping loop); the loop is spawned only when the first handle for
+    /// an endpoint is created.
     pub fn track(&self, endpoint: Endpoint) -> ReachabilityHandle {
         let mut map = self
             .registry
@@ -78,21 +76,14 @@ impl ReachabilityTracker {
             return ReachabilityHandle { inner };
         }
 
-        let inner = Arc::new(TrackerInner {
-            endpoint: endpoint.clone(),
-            live: AtomicBool::new(false),
-            reply_seen: AtomicBool::new(false),
-            reach_fn: self.reach_fn.clone(),
-            registry: Arc::downgrade(&self.registry),
-        });
-        map.insert(endpoint.clone(), Arc::downgrade(&inner));
-
-        spawn_ping_loop(
-            Arc::downgrade(&inner),
+        let inner = ReachabilityHandleInner::new(
+            endpoint.clone(),
             self.send_fn.clone(),
             self.reach_fn.clone(),
-            endpoint,
+            Arc::downgrade(&self.registry),
         );
+        map.insert(endpoint, Arc::downgrade(&inner));
+        inner.spawn_loop();
 
         ReachabilityHandle { inner }
     }
@@ -138,67 +129,13 @@ impl ReachabilityTracker {
             .get(&source)
             .and_then(Weak::upgrade)
         {
-            // Any control frame from the endpoint proves it is alive; reflect that immediately and
-            // record the reply so the in-flight ping cycle does not clear liveness.
-            inner.live.store(true, Ordering::Relaxed);
-            inner.reply_seen.store(true, Ordering::Relaxed);
+            inner.mark_alive();
         }
 
         if incoming.message == ControlMessage::Ping {
             (self.send_fn)(ControlMessage::Pong.to_outgoing(source)).await;
         }
     }
-}
-
-fn spawn_ping_loop(
-    weak: Weak<TrackerInner>,
-    send_fn: SendFn,
-    reach_fn: ReachFn,
-    endpoint: Endpoint,
-) {
-    let future = async move {
-        loop {
-            // The loop holds only a `Weak`; once the last handle is dropped the upgrade fails and
-            // the loop ends. The strong ref is released before sleeping so a drop during the sleep
-            // is observed on the next cycle.
-            let Some(inner) = weak.upgrade() else {
-                break;
-            };
-
-            let reachability = (reach_fn)(endpoint.clone()).await;
-            let interval = if reachability == Reachability::Unknown {
-                // Probe: clear the reply flag, ping, and let the interval below act as the window
-                // in which a reply must arrive.
-                inner.reply_seen.store(false, Ordering::Relaxed);
-                (send_fn)(ControlMessage::Ping.to_outgoing(endpoint.clone())).await;
-                PING_INTERVAL
-            } else {
-                // The transport answered authoritatively; no ping needed. Keep polling at the
-                // backoff cadence so a later transition to `Unknown` resumes pinging.
-                POLL_INTERVAL
-            };
-
-            drop(inner);
-            bitwarden_threading::time::sleep(interval).await;
-
-            // After the probe window, if no reply was seen the endpoint is no longer live. A reply
-            // (handled in `handle_inbound`) sets `live` immediately, so liveness is not delayed by
-            // this cycle.
-            if reachability == Reachability::Unknown {
-                let Some(inner) = weak.upgrade() else {
-                    break;
-                };
-                if !inner.reply_seen.load(Ordering::Relaxed) {
-                    inner.live.store(false, Ordering::Relaxed);
-                }
-            }
-        }
-    };
-
-    #[cfg(not(target_arch = "wasm32"))]
-    tokio::spawn(future);
-    #[cfg(target_arch = "wasm32")]
-    wasm_bindgen_futures::spawn_local(future);
 }
 
 #[cfg(test)]
@@ -209,6 +146,7 @@ mod tests {
     use crate::{
         endpoint::{HostId, Source},
         message::OutgoingMessage,
+        traits::Reachability,
     };
 
     const ENDPOINT: Endpoint = Endpoint::DesktopMain;

--- a/crates/bitwarden-ipc/src/traits/communication_backend.rs
+++ b/crates/bitwarden-ipc/src/traits/communication_backend.rs
@@ -15,8 +15,11 @@ use crate::{
 /// content script that may or may not exist), it returns [`Reachability::Unknown`] and reachability
 /// falls back to the ping/pong liveness window tracked by the `ReachabilityTracker`.
 #[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq)]
-#[cfg_attr(feature = "wasm", derive(tsify::Tsify))]
-#[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
+#[cfg_attr(
+    feature = "wasm",
+    derive(tsify::Tsify),
+    tsify(into_wasm_abi, from_wasm_abi)
+)]
 pub enum Reachability {
     /// The transport knows the endpoint is reachable.
     Reachable,

--- a/crates/bitwarden-ipc/src/traits/communication_backend.rs
+++ b/crates/bitwarden-ipc/src/traits/communication_backend.rs
@@ -147,6 +147,9 @@ pub(crate) mod test_support {
         outgoing: Arc<RwLock<Vec<OutgoingMessage>>>,
         incoming_tx: Sender<IncomingMessage>,
         incoming_rx: Receiver<IncomingMessage>,
+        /// Transport-native reachability reported for every endpoint. Defaults to `Reachable` so
+        /// tests that assume a connected peer work unchanged; set it to exercise gating.
+        reachability: Arc<RwLock<Reachability>>,
     }
 
     impl Clone for TestCommunicationBackend {
@@ -157,6 +160,7 @@ pub(crate) mod test_support {
                 outgoing: self.outgoing.clone(),
                 incoming_tx: self.incoming_tx.clone(),
                 incoming_rx: self.incoming_rx.resubscribe(),
+                reachability: self.reachability.clone(),
             }
         }
     }
@@ -182,6 +186,7 @@ pub(crate) mod test_support {
                 outgoing: Arc::new(RwLock::new(Vec::new())),
                 incoming_tx,
                 incoming_rx,
+                reachability: Arc::new(RwLock::new(Reachability::Reachable)),
             }
         }
 
@@ -190,6 +195,11 @@ pub(crate) mod test_support {
             self.incoming_tx
                 .send(message)
                 .expect("Failed to send incoming message");
+        }
+
+        /// Set the reachability this backend reports for every endpoint.
+        pub async fn set_reachability(&self, reachability: Reachability) {
+            *self.reachability.write().await = reachability;
         }
 
         /// Get a copy of all the outgoing messages that have been sent.
@@ -214,6 +224,10 @@ pub(crate) mod test_support {
 
         async fn subscribe(&self) -> Self::Receiver {
             TestCommunicationBackendReceiver(RwLock::new(self.incoming_rx.resubscribe()))
+        }
+
+        async fn reachability(&self, _endpoint: &Endpoint) -> Reachability {
+            *self.reachability.read().await
         }
     }
 

--- a/crates/bitwarden-ipc/src/traits/communication_backend.rs
+++ b/crates/bitwarden-ipc/src/traits/communication_backend.rs
@@ -1,9 +1,30 @@
 use std::fmt::Debug;
 
+use serde::{Deserialize, Serialize};
+
 use crate::{
+    endpoint::Endpoint,
     error::IpcErrorKind,
     message::{IncomingMessage, OutgoingMessage},
 };
+
+/// A transport-native answer to "is this endpoint reachable right now?".
+///
+/// The transport answers authoritatively when it can (e.g. a native-messaging port is either
+/// connected or not). When it has no synchronous way to tell (e.g. a `postMessage` relay to a
+/// content script that may or may not exist), it returns [`Reachability::Unknown`] and reachability
+/// falls back to the ping/pong liveness window tracked by the `ReachabilityTracker`.
+#[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "wasm", derive(tsify::Tsify))]
+#[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
+pub enum Reachability {
+    /// The transport knows the endpoint is reachable.
+    Reachable,
+    /// The transport knows the endpoint is not reachable.
+    Unreachable,
+    /// The transport cannot tell; fall back to ping/pong liveness.
+    Unknown,
+}
 
 /// This trait defines the interface that will be used to send and receive messages over IPC.
 /// It is up to the platform to implement this trait and any necessary thread synchronization and
@@ -26,6 +47,18 @@ pub trait CommunicationBackend: Send + Sync + 'static {
         &self,
         message: OutgoingMessage,
     ) -> impl std::future::Future<Output = Result<(), Self::SendError>> + Send + Sync;
+
+    /// Query the transport-native reachability of `endpoint`.
+    ///
+    /// The default implementation returns [`Reachability::Unknown`], which makes reachability fall
+    /// back entirely to ping/pong liveness. Backends that can answer authoritatively (e.g. by
+    /// inspecting a connected port) should override this.
+    fn reachability(
+        &self,
+        _endpoint: &Endpoint,
+    ) -> impl std::future::Future<Output = Reachability> + Send + Sync {
+        async { Reachability::Unknown }
+    }
 
     /// Subscribe to receive messages. This function will return a receiver that can be used to
     /// receive messages asynchronously.

--- a/crates/bitwarden-ipc/src/traits/communication_backend.rs
+++ b/crates/bitwarden-ipc/src/traits/communication_backend.rs
@@ -10,10 +10,15 @@ use crate::{
 
 /// A transport-native answer to "is this endpoint reachable right now?".
 ///
-/// The transport answers authoritatively when it can (e.g. a native-messaging port is either
-/// connected or not). When it has no synchronous way to tell (e.g. a `postMessage` relay to a
-/// content script that may or may not exist), it returns [`Reachability::Unknown`] and reachability
-/// falls back to the ping/pong liveness window tracked by the `ReachabilityTracker`.
+/// A transport either *supports* reachability — it can authoritatively answer
+/// [`Reachable`](Reachability::Reachable)/[`Unreachable`](Reachability::Unreachable), e.g. by
+/// inspecting a connected port — or it doesn't, in which case it returns
+/// [`Unsupported`](Reachability::Unsupported) and reachability falls back to the ping/pong liveness
+/// signal tracked by the `ReachabilityTracker`.
+///
+/// A backend must answer *consistently* for a given endpoint: either always definitive or always
+/// `Unsupported`. The tracker stops its liveness loop once it sees a definitive answer, so a
+/// transport that flipped from definitive to `Unsupported` would not resume ping/pong.
 #[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq)]
 #[cfg_attr(
     feature = "wasm",
@@ -25,8 +30,8 @@ pub enum Reachability {
     Reachable,
     /// The transport knows the endpoint is not reachable.
     Unreachable,
-    /// The transport cannot tell; fall back to ping/pong liveness.
-    Unknown,
+    /// The transport does not support reachability; fall back to ping/pong liveness.
+    Unsupported,
 }
 
 /// This trait defines the interface that will be used to send and receive messages over IPC.
@@ -53,14 +58,15 @@ pub trait CommunicationBackend: Send + Sync + 'static {
 
     /// Query the transport-native reachability of `endpoint`.
     ///
-    /// The default implementation returns [`Reachability::Unknown`], which makes reachability fall
-    /// back entirely to ping/pong liveness. Backends that can answer authoritatively (e.g. by
-    /// inspecting a connected port) should override this.
+    /// The default implementation returns [`Reachability::Unsupported`], which makes reachability
+    /// fall back entirely to ping/pong liveness. Backends that can answer authoritatively (e.g. by
+    /// inspecting a connected port) should override this — and must do so consistently per endpoint
+    /// (see [`Reachability`]).
     fn reachability(
         &self,
         _endpoint: &Endpoint,
     ) -> impl std::future::Future<Output = Reachability> + Send + Sync {
-        async { Reachability::Unknown }
+        async { Reachability::Unsupported }
     }
 
     /// Subscribe to receive messages. This function will return a receiver that can be used to

--- a/crates/bitwarden-ipc/src/traits/mod.rs
+++ b/crates/bitwarden-ipc/src/traits/mod.rs
@@ -7,7 +7,8 @@ pub use communication_backend::test_support::TestCommunicationBackend;
 #[cfg(test)]
 pub(crate) use communication_backend::test_support::TestTwoWayCommunicationBackend;
 pub use communication_backend::{
-    CommunicationBackend, CommunicationBackendReceiver, noop::NoopCommunicationBackend,
+    CommunicationBackend, CommunicationBackendReceiver, Reachability,
+    noop::NoopCommunicationBackend,
 };
 pub use crypto_provider::CryptoProvider;
 #[cfg(any(test, feature = "test-support"))]

--- a/crates/bitwarden-ipc/src/wasm/communication_backend.rs
+++ b/crates/bitwarden-ipc/src/wasm/communication_backend.rs
@@ -156,10 +156,19 @@ impl CommunicationBackend for JsCommunicationBackend {
 
     async fn reachability(&self, endpoint: &Endpoint) -> Reachability {
         let endpoint = endpoint.clone();
-        // A sender that does not implement `reachability` (or one whose implementation throws)
-        // rejects the call; treat any failure as Unknown so reachability falls back to ping/pong.
         self.sender
             .run_in_thread(|sender| async move {
+                // `reachability` is optional on the sender. Calling a missing async method traps
+                // (panic=abort poisons the whole instance), so feature-detect it first and fall
+                // back to Unknown when it is absent or its implementation rejects.
+                let sender_value: &JsValue = sender.as_ref();
+                let implemented =
+                    js_sys::Reflect::get(sender_value, &JsValue::from_str("reachability"))
+                        .map(|value| value.is_function())
+                        .unwrap_or(false);
+                if !implemented {
+                    return Reachability::Unknown;
+                }
                 sender
                     .reachability(endpoint)
                     .await

--- a/crates/bitwarden-ipc/src/wasm/communication_backend.rs
+++ b/crates/bitwarden-ipc/src/wasm/communication_backend.rs
@@ -7,9 +7,10 @@ use tokio::sync::RwLock;
 use wasm_bindgen::prelude::*;
 
 use crate::{
+    endpoint::Endpoint,
     error::IpcErrorKind,
     message::{IncomingMessage, OutgoingMessage},
-    traits::{CommunicationBackend, CommunicationBackendReceiver},
+    traits::{CommunicationBackend, CommunicationBackendReceiver, Reachability},
 };
 
 #[allow(missing_docs)]
@@ -58,6 +59,12 @@ impl IpcErrorKind for WasmCommunicationError {
 const TS_CUSTOM_TYPES: &'static str = r#"
 export interface IpcCommunicationBackendSender {
     send(message: OutgoingMessage): Promise<void>;
+    /**
+     * Optional transport-native reachability query. When implemented, the SDK trusts a definite
+     * answer (Reachable/Unreachable) and skips ping/pong; when omitted or it returns Unknown,
+     * reachability falls back to ping/pong liveness.
+     */
+    reachability?(endpoint: Endpoint): Promise<Reachability>;
 }
 "#;
 
@@ -77,6 +84,14 @@ extern "C" {
     /// Used by JavaScript to provide an incoming message to the IPC framework.
     #[wasm_bindgen(catch, method, structural)]
     pub async fn receive(this: &JsCommunicationBackendSender) -> Result<JsValue, JsValue>;
+
+    /// Optional transport-native reachability query. A sender that does not implement this method
+    /// causes the call to reject, which is mapped to [`Reachability::Unknown`].
+    #[wasm_bindgen(catch, method, structural)]
+    pub async fn reachability(
+        this: &JsCommunicationBackendSender,
+        endpoint: Endpoint,
+    ) -> Result<Reachability, JsValue>;
 }
 
 /// JavaScript implementation of the `CommunicationBackend` trait for IPC communication.
@@ -137,6 +152,21 @@ impl CommunicationBackend for JsCommunicationBackend {
 
     async fn subscribe(&self) -> Self::Receiver {
         RwLock::new(self.receive_rx.resubscribe())
+    }
+
+    async fn reachability(&self, endpoint: &Endpoint) -> Reachability {
+        let endpoint = endpoint.clone();
+        // A sender that does not implement `reachability` (or one whose implementation throws)
+        // rejects the call; treat any failure as Unknown so reachability falls back to ping/pong.
+        self.sender
+            .run_in_thread(|sender| async move {
+                sender
+                    .reachability(endpoint)
+                    .await
+                    .unwrap_or(Reachability::Unknown)
+            })
+            .await
+            .unwrap_or(Reachability::Unknown)
     }
 }
 

--- a/crates/bitwarden-ipc/src/wasm/communication_backend.rs
+++ b/crates/bitwarden-ipc/src/wasm/communication_backend.rs
@@ -61,7 +61,7 @@ export interface IpcCommunicationBackendSender {
     send(message: OutgoingMessage): Promise<void>;
     /**
      * Optional transport-native reachability query. When implemented, the SDK trusts a definite
-     * answer (Reachable/Unreachable) and skips ping/pong; when omitted or it returns Unknown,
+     * answer (Reachable/Unreachable) and skips ping/pong; when omitted or it returns Unsupported,
      * reachability falls back to ping/pong liveness.
      */
     reachability?(endpoint: Endpoint): Promise<Reachability>;
@@ -86,7 +86,7 @@ extern "C" {
     pub async fn receive(this: &JsCommunicationBackendSender) -> Result<JsValue, JsValue>;
 
     /// Optional transport-native reachability query. A sender that does not implement this method
-    /// causes the call to reject, which is mapped to [`Reachability::Unknown`].
+    /// causes the call to reject, which is mapped to [`Reachability::Unsupported`].
     #[wasm_bindgen(catch, method, structural)]
     pub async fn reachability(
         this: &JsCommunicationBackendSender,
@@ -160,22 +160,22 @@ impl CommunicationBackend for JsCommunicationBackend {
             .run_in_thread(|sender| async move {
                 // `reachability` is optional on the sender. Calling a missing async method traps
                 // (panic=abort poisons the whole instance), so feature-detect it first and fall
-                // back to Unknown when it is absent or its implementation rejects.
+                // back to Unsupported when it is absent or its implementation rejects.
                 let sender_value: &JsValue = sender.as_ref();
                 let implemented =
                     js_sys::Reflect::get(sender_value, &JsValue::from_str("reachability"))
                         .map(|value| value.is_function())
                         .unwrap_or(false);
                 if !implemented {
-                    return Reachability::Unknown;
+                    return Reachability::Unsupported;
                 }
                 sender
                     .reachability(endpoint)
                     .await
-                    .unwrap_or(Reachability::Unknown)
+                    .unwrap_or(Reachability::Unsupported)
             })
             .await
-            .unwrap_or(Reachability::Unknown)
+            .unwrap_or(Reachability::Unsupported)
     }
 }
 

--- a/crates/bitwarden-ipc/src/wasm/ipc_client.rs
+++ b/crates/bitwarden-ipc/src/wasm/ipc_client.rs
@@ -7,10 +7,12 @@ use super::communication_backend::JsCommunicationBackend;
 use crate::{
     IpcClientImpl,
     crypto_provider::noise::crypto_provider::NoiseCryptoProvider,
+    endpoint::Endpoint,
     error::{AlreadyRunningError, ReceiveError, SubscribeError},
     ipc_client::IpcClientSubscription,
     ipc_client_trait::IpcClient,
     message::{IncomingMessage, OutgoingMessage},
+    reachability::{ReachabilityHandle, ReachabilityTracker},
     traits::InMemorySessionRepository,
     wasm::{
         JsSessionRepository, RawJsSessionRepository,
@@ -125,5 +127,53 @@ impl JsIpcClient {
     pub async fn subscribe(&self) -> Result<JsIpcClientSubscription, SubscribeError> {
         let subscription = self.client.subscribe(None).await?;
         Ok(JsIpcClientSubscription { subscription })
+    }
+
+    /// The reachability tracker for this client. Use it to track a peer endpoint and query whether
+    /// it is reachable.
+    #[wasm_only]
+    pub fn reachability(&self) -> JsReachabilityTracker {
+        JsReachabilityTracker {
+            tracker: self.client.reachability(),
+        }
+    }
+}
+
+/// JavaScript wrapper around the reachability tracker. See
+/// [`ReachabilityTracker`](crate::ReachabilityTracker).
+#[wasm_bindgen(js_name = ReachabilityTracker)]
+pub struct JsReachabilityTracker {
+    tracker: Arc<ReachabilityTracker>,
+}
+
+#[bitwarden_ffi::wasm_export]
+#[wasm_bindgen(js_class = ReachabilityTracker)]
+impl JsReachabilityTracker {
+    /// Begin tracking `endpoint`'s reachability, returning a handle. Hold the handle for as long as
+    /// you care about the endpoint; calling `free()` on it (or letting it be garbage-collected)
+    /// stops tracking that endpoint.
+    #[wasm_only]
+    pub fn track(&self, endpoint: Endpoint) -> JsReachabilityHandle {
+        JsReachabilityHandle {
+            handle: self.tracker.track(endpoint),
+        }
+    }
+}
+
+/// JavaScript wrapper around a reachability handle. See
+/// [`ReachabilityHandle`](crate::ReachabilityHandle).
+#[wasm_bindgen(js_name = ReachabilityHandle)]
+pub struct JsReachabilityHandle {
+    handle: ReachabilityHandle,
+}
+
+#[bitwarden_ffi::wasm_export]
+#[wasm_bindgen(js_class = ReachabilityHandle)]
+impl JsReachabilityHandle {
+    /// Whether the tracked endpoint is currently reachable.
+    #[wasm_only]
+    #[wasm_bindgen(js_name = isReachable)]
+    pub async fn is_reachable(&self) -> bool {
+        self.handle.is_reachable().await
     }
 }

--- a/crates/bitwarden-ipc/src/wasm/ipc_client.rs
+++ b/crates/bitwarden-ipc/src/wasm/ipc_client.rs
@@ -3,16 +3,14 @@ use std::{collections::HashMap, sync::Arc};
 use bitwarden_threading::cancellation_token::wasm::{AbortSignal, AbortSignalExt};
 use wasm_bindgen::prelude::*;
 
-use super::communication_backend::JsCommunicationBackend;
+use super::{communication_backend::JsCommunicationBackend, reachability::JsReachabilityTracker};
 use crate::{
     IpcClientImpl,
     crypto_provider::noise::crypto_provider::NoiseCryptoProvider,
-    endpoint::Endpoint,
     error::{AlreadyRunningError, ReceiveError, SubscribeError},
     ipc_client::IpcClientSubscription,
     ipc_client_trait::IpcClient,
     message::{IncomingMessage, OutgoingMessage},
-    reachability::{ReachabilityHandle, ReachabilityTracker},
     traits::InMemorySessionRepository,
     wasm::{
         JsSessionRepository, RawJsSessionRepository,
@@ -136,44 +134,5 @@ impl JsIpcClient {
         JsReachabilityTracker {
             tracker: self.client.reachability(),
         }
-    }
-}
-
-/// JavaScript wrapper around the reachability tracker. See
-/// [`ReachabilityTracker`](crate::ReachabilityTracker).
-#[wasm_bindgen(js_name = ReachabilityTracker)]
-pub struct JsReachabilityTracker {
-    tracker: Arc<ReachabilityTracker>,
-}
-
-#[bitwarden_ffi::wasm_export]
-#[wasm_bindgen(js_class = ReachabilityTracker)]
-impl JsReachabilityTracker {
-    /// Begin tracking `endpoint`'s reachability, returning a handle. Hold the handle for as long as
-    /// you care about the endpoint; calling `free()` on it (or letting it be garbage-collected)
-    /// stops tracking that endpoint.
-    #[wasm_only]
-    pub fn track(&self, endpoint: Endpoint) -> JsReachabilityHandle {
-        JsReachabilityHandle {
-            handle: self.tracker.track(endpoint),
-        }
-    }
-}
-
-/// JavaScript wrapper around a reachability handle. See
-/// [`ReachabilityHandle`](crate::ReachabilityHandle).
-#[wasm_bindgen(js_name = ReachabilityHandle)]
-pub struct JsReachabilityHandle {
-    handle: ReachabilityHandle,
-}
-
-#[bitwarden_ffi::wasm_export]
-#[wasm_bindgen(js_class = ReachabilityHandle)]
-impl JsReachabilityHandle {
-    /// Whether the tracked endpoint is currently reachable.
-    #[wasm_only]
-    #[wasm_bindgen(js_name = isReachable)]
-    pub async fn is_reachable(&self) -> bool {
-        self.handle.is_reachable().await
     }
 }

--- a/crates/bitwarden-ipc/src/wasm/mod.rs
+++ b/crates/bitwarden-ipc/src/wasm/mod.rs
@@ -4,9 +4,11 @@ mod generic_session_repository;
 mod ipc_client;
 mod js_session_repository;
 mod message;
+mod reachability;
 
 // Re-export types to make sure wasm_bindgen picks them up
 pub use communication_backend::*;
 pub use discover::*;
 pub use ipc_client::*;
 pub use js_session_repository::*;
+pub use reachability::*;

--- a/crates/bitwarden-ipc/src/wasm/reachability.rs
+++ b/crates/bitwarden-ipc/src/wasm/reachability.rs
@@ -7,8 +7,7 @@ use crate::{
     reachability::{ReachabilityHandle, ReachabilityTracker},
 };
 
-/// JavaScript wrapper around the reachability tracker. See
-/// [`ReachabilityTracker`](crate::ReachabilityTracker).
+/// JavaScript wrapper around the reachability tracker. See [`ReachabilityTracker`].
 #[wasm_bindgen(js_name = ReachabilityTracker)]
 pub struct JsReachabilityTracker {
     pub(crate) tracker: Arc<ReachabilityTracker>,
@@ -28,8 +27,7 @@ impl JsReachabilityTracker {
     }
 }
 
-/// JavaScript wrapper around a reachability handle. See
-/// [`ReachabilityHandle`](crate::ReachabilityHandle).
+/// JavaScript wrapper around a reachability handle. See [`ReachabilityHandle`].
 #[wasm_bindgen(js_name = ReachabilityHandle)]
 pub struct JsReachabilityHandle {
     handle: ReachabilityHandle,

--- a/crates/bitwarden-ipc/src/wasm/reachability.rs
+++ b/crates/bitwarden-ipc/src/wasm/reachability.rs
@@ -1,0 +1,47 @@
+use std::sync::Arc;
+
+use wasm_bindgen::prelude::*;
+
+use crate::{
+    endpoint::Endpoint,
+    reachability::{ReachabilityHandle, ReachabilityTracker},
+};
+
+/// JavaScript wrapper around the reachability tracker. See
+/// [`ReachabilityTracker`](crate::ReachabilityTracker).
+#[wasm_bindgen(js_name = ReachabilityTracker)]
+pub struct JsReachabilityTracker {
+    pub(crate) tracker: Arc<ReachabilityTracker>,
+}
+
+#[bitwarden_ffi::wasm_export]
+#[wasm_bindgen(js_class = ReachabilityTracker)]
+impl JsReachabilityTracker {
+    /// Begin tracking `endpoint`'s reachability, returning a handle. Hold the handle for as long as
+    /// you care about the endpoint; calling `free()` on it (or letting it be garbage-collected)
+    /// stops tracking that endpoint.
+    #[wasm_only]
+    pub fn track(&self, endpoint: Endpoint) -> JsReachabilityHandle {
+        JsReachabilityHandle {
+            handle: self.tracker.track(endpoint),
+        }
+    }
+}
+
+/// JavaScript wrapper around a reachability handle. See
+/// [`ReachabilityHandle`](crate::ReachabilityHandle).
+#[wasm_bindgen(js_name = ReachabilityHandle)]
+pub struct JsReachabilityHandle {
+    handle: ReachabilityHandle,
+}
+
+#[bitwarden_ffi::wasm_export]
+#[wasm_bindgen(js_class = ReachabilityHandle)]
+impl JsReachabilityHandle {
+    /// Whether the tracked endpoint is currently reachable.
+    #[wasm_only]
+    #[wasm_bindgen(js_name = isReachable)]
+    pub async fn is_reachable(&self) -> bool {
+        self.handle.is_reachable().await
+    }
+}

--- a/crates/bitwarden-shared-unlock/src/follower.rs
+++ b/crates/bitwarden-shared-unlock/src/follower.rs
@@ -1,7 +1,12 @@
-use std::{ops::Add, sync::Arc};
+use std::{
+    ops::Add,
+    sync::{Arc, Mutex},
+};
 
 use bitwarden_error::bitwarden_error;
-use bitwarden_ipc::{Endpoint, IpcClient, IpcClientExt, SubscribeError, TypedIncomingMessage};
+use bitwarden_ipc::{
+    Endpoint, IpcClient, IpcClientExt, ReachabilityHandle, SubscribeError, TypedIncomingMessage,
+};
 use bitwarden_threading::{cancellation_token, time::sleep};
 use thiserror::Error;
 
@@ -28,6 +33,9 @@ impl<L: SharedUnlockDriver> Clone for Follower<L> {
 struct InnerFollower<D: SharedUnlockDriver> {
     driver: D,
     ipc_client: Arc<dyn IpcClient>,
+    /// Reachability handle for the discovered leader, tracked lazily on first use and held for the
+    /// follower's lifetime so its ping loop keeps running between heartbeats.
+    leader_reachability: Mutex<Option<ReachabilityHandle>>,
 }
 
 impl<L: SharedUnlockDriver + Send + Sync + 'static> Follower<L> {
@@ -36,17 +44,44 @@ impl<L: SharedUnlockDriver + Send + Sync + 'static> Follower<L> {
     /// During startup, a `StartSession` message is sent per user so the leader can reconcile
     /// initial lock state.
     pub fn create(driver: L, ipc_client: Arc<dyn IpcClient>) -> Self {
-        Self(Arc::new(InnerFollower { driver, ipc_client }))
+        Self(Arc::new(InnerFollower {
+            driver,
+            ipc_client,
+            leader_reachability: Mutex::new(None),
+        }))
+    }
+
+    /// Discover the leader and return a reachability handle for it.
+    ///
+    /// The handle is tracked on first use and cached, so a single ping loop is kept alive for the
+    /// follower's lifetime (dropping it per call would restart the loop and lose accumulated
+    /// liveness). Returns `None` when there is no leader to talk to.
+    async fn leader_handle(&self) -> Option<(Endpoint, ReachabilityHandle)> {
+        let leader = self.0.driver.discover_leader().await?;
+        let handle = self
+            .0
+            .leader_reachability
+            .lock()
+            .expect("leader reachability mutex poisoned")
+            .get_or_insert_with(|| self.0.ipc_client.reachability().track(leader.clone()))
+            .clone();
+        Some((leader, handle))
     }
 
     pub(crate) async fn start_sessions(&self) {
+        let Some((leader, reachability)) = self.leader_handle().await else {
+            return;
+        };
+
+        // Don't start sessions against a leader that isn't reachable: this is what avoids the Noise
+        // handshake churn (and the resulting error spam) when the leader is absent. A leader whose
+        // transport answers Unknown becomes reachable once the ping/pong round trip lands.
+        if !reachability.is_reachable().await {
+            tracing::debug!("Leader not reachable; not starting shared unlock sessions");
+            return;
+        }
+
         let users: Vec<bitwarden_core::UserId> = self.0.driver.list_users().await;
-        let leader = self
-            .0
-            .driver
-            .discover_leader()
-            .await
-            .expect("leader discovery should return a leader");
 
         if !users.is_empty() {
             tracing::info!("Starting shared unlock sessions for users: {:?}", users);
@@ -121,7 +156,13 @@ impl<L: SharedUnlockDriver + Send + Sync + 'static> Follower<L> {
                         break;
                     }
                     _ = bitwarden_threading::time::sleep(crate::HEARTBEAT_INTERVAL) => {
-                        if let Some(leader) = follower.0.driver.discover_leader().await {
+                        if let Some((leader, reachability)) = follower.leader_handle().await {
+                            // Skip the heartbeat against an unreachable leader so we don't trigger a
+                            // Noise handshake (and reconnect churn) every interval while it is absent.
+                            if !reachability.is_reachable().await {
+                                tracing::debug!("Leader not reachable; skipping heartbeat");
+                                continue;
+                            }
                             // For all users that are logged in, send a heartbeat message to the leader.
                             for user_id in follower.0.driver.list_users().await {
                                 let message = FollowerMessage::HeartBeat { user_id };

--- a/crates/bitwarden-shared-unlock/src/lib.rs
+++ b/crates/bitwarden-shared-unlock/src/lib.rs
@@ -172,7 +172,7 @@ pub enum DeviceEvent {
         /// User whose vault was manually unlocked.
         user_id: UserId,
         /// Raw user key bytes used to unlock the vault.
-        #[tsify(type = "SymmetricKey")]
+        #[cfg_attr(feature = "wasm", tsify(type = "SymmetricKey"))]
         user_key: SymmetricCryptoKey,
     },
 }

--- a/crates/bitwarden-shared-unlock/src/tests.rs
+++ b/crates/bitwarden-shared-unlock/src/tests.rs
@@ -12,8 +12,8 @@ use bitwarden_crypto::SymmetricCryptoKey;
 use bitwarden_encoding::B64;
 use bitwarden_ipc::{
     Endpoint, HostId, InMemorySessionRepository, IncomingMessage, IpcClient,
-    NoEncryptionCryptoProvider, Source, TestCommunicationBackend, TestIpcClient,
-    TypedIncomingMessage,
+    NoEncryptionCryptoProvider, OutgoingMessage, PayloadTypeName, Reachability, Source,
+    TestCommunicationBackend, TestIpcClient, TypedIncomingMessage,
 };
 
 use crate::{
@@ -232,6 +232,70 @@ impl Harness {
 }
 
 // --- Tests ---
+
+/// Builds a follower whose transport reports `reachability` for the leader, without auto-starting
+/// sessions (so the gating in `start_sessions` can be exercised directly).
+async fn follower_with_reachability(
+    states: HashMap<UserId, LockState>,
+    reachability: Reachability,
+) -> (Follower<MockDriver>, TestCommunicationBackend) {
+    let backend = TestCommunicationBackend::new();
+    backend.set_reachability(reachability).await;
+    let ipc_client: Arc<dyn IpcClient> = Arc::new(TestIpcClient::new(
+        NoEncryptionCryptoProvider,
+        backend.clone(),
+        InMemorySessionRepository::new(HashMap::new()),
+    ));
+    let follower = Follower::create(MockDriver::new(states), ipc_client);
+    (follower, backend)
+}
+
+/// Counts the `StartSession` (follower-to-leader) frames among `outgoing`, ignoring any
+/// reachability control frames.
+fn count_start_sessions(outgoing: &[OutgoingMessage]) -> usize {
+    outgoing
+        .iter()
+        .filter(|m| m.topic.as_deref() == Some(FollowerMessage::PAYLOAD_TYPE_NAME))
+        .count()
+}
+
+#[tokio::test]
+async fn test_follower_starts_sessions_when_leader_reachable() {
+    let states = HashMap::from([(
+        user_a(),
+        LockState::Unlocked {
+            user_key: test_user_key(),
+        },
+    )]);
+    let (follower, backend) = follower_with_reachability(states, Reachability::Reachable).await;
+
+    follower.start_sessions().await;
+
+    assert_eq!(
+        count_start_sessions(&backend.drain_outgoing().await),
+        1,
+        "a StartSession should be sent to a reachable leader"
+    );
+}
+
+#[tokio::test]
+async fn test_follower_skips_start_sessions_when_leader_unreachable() {
+    let states = HashMap::from([(
+        user_a(),
+        LockState::Unlocked {
+            user_key: test_user_key(),
+        },
+    )]);
+    let (follower, backend) = follower_with_reachability(states, Reachability::Unreachable).await;
+
+    follower.start_sessions().await;
+
+    assert_eq!(
+        count_start_sessions(&backend.drain_outgoing().await),
+        0,
+        "no StartSession should be sent while the leader is unreachable"
+    );
+}
 
 #[tokio::test]
 async fn test_follower_startup_locked() {

--- a/crates/bitwarden-wasm-internal/integration-tests/tests/reachability-ipc.test.ts
+++ b/crates/bitwarden-wasm-internal/integration-tests/tests/reachability-ipc.test.ts
@@ -1,0 +1,91 @@
+import {
+  Endpoint,
+  IpcClient,
+  IpcCommunicationBackend,
+  IpcCommunicationBackendSender,
+  OutgoingMessage,
+  Reachability,
+  init_sdk,
+} from "@bitwarden/sdk-internal";
+
+import { makeMockTransportPair, sleep } from "./utils";
+
+const PING_TOPIC = "$bw.control.ping";
+
+async function waitForReachable(
+  handle: { isReachable(): Promise<boolean> },
+  timeoutMs = 1000,
+): Promise<boolean> {
+  for (let elapsed = 0; elapsed < timeoutMs; elapsed += 20) {
+    if (await handle.isReachable()) {
+      return true;
+    }
+    await sleep(20);
+  }
+  return handle.isReachable();
+}
+
+describe("reachability ipc", () => {
+  it("pings a leader whose transport is Unknown and becomes reachable once it pongs", async () => {
+    init_sdk();
+
+    // first stamps "DesktopMain", second stamps "DesktopRenderer".
+    const [followerBackend, leaderBackend] = makeMockTransportPair();
+    const follower = IpcClient.newWithSdkInMemorySessions(followerBackend);
+    const leader = IpcClient.newWithSdkInMemorySessions(leaderBackend);
+
+    // Start the responder first so it is listening before the follower's first ping.
+    await leader.start();
+    await follower.start();
+
+    // The follower sees the leader as the source it stamps on inbound frames.
+    const leaderEndpoint: Endpoint = "DesktopRenderer";
+    const handle = follower.reachability().track(leaderEndpoint);
+
+    // The mock transport does not implement reachability(), so it answers Unknown: the leader is
+    // gated until the ping/pong round trip lands.
+    expect(await handle.isReachable()).toBe(false);
+    expect(await waitForReachable(handle)).toBe(true);
+  });
+
+  it("never pings a transport that answers Reachable", async () => {
+    init_sdk();
+
+    const outgoing: OutgoingMessage[] = [];
+    const sender: IpcCommunicationBackendSender = {
+      send: async (message: OutgoingMessage) => {
+        outgoing.push(message);
+      },
+      reachability: async (_endpoint: Endpoint): Promise<Reachability> => "Reachable",
+    };
+    const client = IpcClient.newWithSdkInMemorySessions(new IpcCommunicationBackend(sender));
+    await client.start();
+
+    const handle = client.reachability().track("DesktopRenderer");
+
+    // An authoritative Reachable answer is trusted directly, and no ping is ever emitted.
+    expect(await handle.isReachable()).toBe(true);
+    await sleep(100);
+    expect(outgoing.some((m) => m.topic === PING_TOPIC)).toBe(false);
+  });
+
+  it("reports Unreachable directly from the transport without pinging", async () => {
+    init_sdk();
+
+    const outgoing: OutgoingMessage[] = [];
+    const sender: IpcCommunicationBackendSender = {
+      send: async (message: OutgoingMessage) => {
+        outgoing.push(message);
+      },
+      reachability: async (_endpoint: Endpoint): Promise<Reachability> => "Unreachable",
+    };
+    const client = IpcClient.newWithSdkInMemorySessions(new IpcCommunicationBackend(sender));
+    await client.start();
+
+    const handle = client.reachability().track("DesktopRenderer");
+
+    expect(await handle.isReachable()).toBe(false);
+    await sleep(100);
+    expect(outgoing.some((m) => m.topic === PING_TOPIC)).toBe(false);
+  });
+});

--- a/crates/bitwarden-wasm-internal/integration-tests/tests/reachability-ipc.test.ts
+++ b/crates/bitwarden-wasm-internal/integration-tests/tests/reachability-ipc.test.ts
@@ -26,7 +26,7 @@ async function waitForReachable(
 }
 
 describe("reachability ipc", () => {
-  it("pings a leader whose transport is Unknown and becomes reachable once it pongs", async () => {
+  it("pings a leader whose transport does not support reachability and becomes reachable once it pongs", async () => {
     init_sdk();
 
     // first stamps "DesktopMain", second stamps "DesktopRenderer".
@@ -42,7 +42,7 @@ describe("reachability ipc", () => {
     const leaderEndpoint: Endpoint = "DesktopRenderer";
     const handle = follower.reachability().track(leaderEndpoint);
 
-    // The mock transport does not implement reachability(), so it answers Unknown: the leader is
+    // The mock transport does not implement reachability(), so it answers Unsupported: the leader is
     // gated until the ping/pong round trip lands.
     expect(await handle.isReachable()).toBe(false);
     expect(await waitForReachable(handle)).toBe(true);

--- a/crates/bitwarden-wasm-internal/integration-tests/tests/utils.ts
+++ b/crates/bitwarden-wasm-internal/integration-tests/tests/utils.ts
@@ -16,6 +16,8 @@ import {
   IncomingMessage,
   OutgoingMessage,
   Source,
+  Endpoint,
+  Reachability,
   BiometricsUnlock,
   BiometricsStatus,
   SharedUnlockDriver,
@@ -229,9 +231,16 @@ export interface MockTransportRouter {
 export function makeMockTransportPair(
   firstSource: Source = "DesktopMain",
   secondSource: Source = "DesktopRenderer",
+  reachability?: Reachability,
 ): [IpcCommunicationBackend, IpcCommunicationBackend, MockTransportRouter] {
   let receiveOnFirst: (m: IncomingMessage) => void;
   let receiveOnSecond: (m: IncomingMessage) => void;
+
+  // When a reachability is given, both senders answer it natively (so the SDK trusts it and skips
+  // ping/pong); otherwise the method is absent and the SDK treats the transport as Unknown.
+  const reachabilityMethod = reachability
+    ? { reachability: async (_endpoint: Endpoint): Promise<Reachability> => reachability }
+    : {};
 
   const firstSender: IpcCommunicationBackendSender = {
     send: async (outgoing: OutgoingMessage) => {
@@ -239,6 +248,7 @@ export function makeMockTransportPair(
         new IncomingMessage(outgoing.payload, outgoing.destination, firstSource, outgoing.topic),
       );
     },
+    ...reachabilityMethod,
   };
   const secondSender: IpcCommunicationBackendSender = {
     send: async (outgoing: OutgoingMessage) => {
@@ -246,6 +256,7 @@ export function makeMockTransportPair(
         new IncomingMessage(outgoing.payload, outgoing.destination, secondSource, outgoing.topic),
       );
     },
+    ...reachabilityMethod,
   };
 
   const first = new IpcCommunicationBackend(firstSender);
@@ -393,9 +404,13 @@ export async function setupSharedUnlockPair(options: {
   // Second peer = leader (replies to DesktopMain = follower's source).
   const followerSource: Source = "DesktopMain";
   const leaderSource: Source = "DesktopRenderer";
+  // The leader is genuinely present in these tests, so the transport reports Reachable and the
+  // follower's reachability gating passes immediately (no ping/pong round trip needed). The
+  // ping/pong fallback path is covered by reachability-ipc.test.ts.
   const [followerBackend, leaderBackend, router] = makeMockTransportPair(
     followerSource,
     leaderSource,
+    "Reachable",
   );
 
   const leaderIpc = IpcClient.newWithSdkInMemorySessions(leaderBackend);
@@ -455,6 +470,7 @@ export async function reloadFollower(
         new IncomingMessage(outgoing.payload, outgoing.destination, followerSource, outgoing.topic),
       );
     },
+    reachability: async (_endpoint: Endpoint): Promise<Reachability> => "Reachable",
   };
   const newFollowerBackend = new IpcCommunicationBackend(newFollowerSender);
 

--- a/crates/bitwarden-wasm-internal/integration-tests/tests/utils.ts
+++ b/crates/bitwarden-wasm-internal/integration-tests/tests/utils.ts
@@ -237,7 +237,7 @@ export function makeMockTransportPair(
   let receiveOnSecond: (m: IncomingMessage) => void;
 
   // When a reachability is given, both senders answer it natively (so the SDK trusts it and skips
-  // ping/pong); otherwise the method is absent and the SDK treats the transport as Unknown.
+  // ping/pong); otherwise the method is absent and the SDK treats the transport as Unsupported.
   const reachabilityMethod = reachability
     ? { reachability: async (_endpoint: Endpoint): Promise<Reachability> => reachability }
     : {};


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-39294

Companion clients PR: bitwarden/clients#21551

## 📔 Objective

Shared-unlock followers repeatedly attempt Noise crypto handshakes against a leader (e.g. the desktop app) that often isn't running. Each attempt hits the 2s handshake timeout and surfaces as error spam plus reconnect churn. This introduces a lightweight **reachability** layer so a follower only talks to a leader it knows is present.

Design (an alternative to #1213):

- **Transport-authoritative, ping fallback.** New `CommunicationBackend::reachability(endpoint) -> Reachable | Unreachable | Unknown` (default `Unknown`). A definite transport answer wins; only `Unknown` falls back to a plaintext ping/pong liveness window. So browser↔desktop (native port state is known) never pings, while web↔extension (`postMessage`, no synchronous signal) uses ping/pong.
- **Owned, RAII-scoped tracking.** Consumers call `ReachabilityTracker::track(endpoint)` *after* discovering the peer and hold a `ReachabilityHandle`; dropping the last handle stops that endpoint's ping loop. One loop per endpoint via a weak registry, with deterministic cleanup on `Drop`.
- **Consumer-side gating.** `IpcClient::send` stays a dumb pipe; the shared-unlock `Follower` checks `is_reachable()` before `start_sessions`/heartbeat.
- **Crypto stays unaware.** A `ControlSplitter` backend decorator peels reserved control-topic (`$bw.control.*`) frames off before any crypto receiver sees them and routes them to the tracker, so `NoiseCryptoProvider` is unchanged — no handshake-abort guard needed.

## 🚨 Breaking Changes

`CommunicationBackend` gains a `reachability()` method, but it has a default (`Unknown`) so existing backends are unaffected.

## ⏰ Reminders

- Validated: `bitwarden-ipc` (40 tests), `bitwarden-shared-unlock` (14 tests), and wasm integration tests (reachability round-trip, transport-authoritative, shared-unlock, biometrics).
- The `crypto-bigint`/`rsa` commit is a build-resolution fix (yanked crates.io 0.7.x); it can be reviewed/reverted independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)