### PR TITLE
[PM-39259] Implement bitwarden-random crate

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -25,6 +25,8 @@ Monorepo crates organized in **four architectural layers**:
   marker)
 - **bitwarden-ipc**: Type-safe IPC framework with pluggable encryption/transport
 - **bitwarden-error**: Error handling across platforms (basic/flat/full modes via proc macro)
+- **bitwarden-random**: Single CRNG source for the SDK (`rng()` / `SdkRngImpl`); Use this instead of
+  `rand::rng()` directly.
 - **bitwarden-encoding**, **bitwarden-uuid**: Encoding and UUID utilities
 
 ### 2. Core Infrastructure

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -46,6 +46,7 @@ crates/bitwarden-organization-crypto/** @bitwarden/team-key-management-dev
 crates/bitwarden-organization-invite-link/** @bitwarden/team-admin-console-dev
 crates/bitwarden-organizations/** @bitwarden/team-admin-console-dev
 crates/bitwarden-policies/** @bitwarden/team-admin-console-dev
+crates/bitwarden-random/** @bitwarden/team-key-management-dev
 crates/bitwarden-sensitive-value/** @bitwarden/team-key-management-dev
 crates/bitwarden-send/** @bitwarden/team-tools-dev @bitwarden/team-platform-dev
 crates/bitwarden-shared-unlock/** @bitwarden/team-key-management-dev

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -626,6 +626,7 @@ dependencies = [
  "bitwarden-encoding",
  "bitwarden-error",
  "bitwarden-logging",
+ "bitwarden-random",
  "bitwarden-state",
  "bitwarden-state-bridge-macro",
  "bitwarden-test",
@@ -682,6 +683,7 @@ dependencies = [
  "bitwarden-encoding",
  "bitwarden-error",
  "bitwarden-logging",
+ "bitwarden-random",
  "bitwarden-sensitive-value",
  "bitwarden-uniffi-error",
  "cbc",
@@ -859,6 +861,7 @@ dependencies = [
  "bitwarden-core",
  "bitwarden-crypto",
  "bitwarden-error",
+ "bitwarden-random",
  "password-rules-parser",
  "rand 0.10.1",
  "rand_chacha 0.10.0",
@@ -906,6 +909,7 @@ dependencies = [
  "async-trait",
  "bitwarden-error",
  "bitwarden-ffi",
+ "bitwarden-random",
  "bitwarden-threading",
  "ciborium",
  "erased-serde",
@@ -1043,6 +1047,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "bitwarden-random"
+version = "3.0.0"
+dependencies = [
+ "bitwarden-error",
+ "getrandom 0.4.2",
+ "rand 0.10.1",
+ "rand_chacha 0.10.0",
+ "snow",
+ "thiserror 1.0.69",
+ "uniffi",
+ "uuid",
+ "wasm-bindgen",
+ "wasm-bindgen-test",
+]
+
+[[package]]
 name = "bitwarden-send"
 version = "3.0.0"
 dependencies = [
@@ -1154,6 +1174,7 @@ name = "bitwarden-ssh"
 version = "3.0.0"
 dependencies = [
  "bitwarden-error",
+ "bitwarden-random",
  "bitwarden-vault",
  "block-padding",
  "ed25519",
@@ -1290,6 +1311,7 @@ dependencies = [
  "bitwarden-organizations",
  "bitwarden-pm",
  "bitwarden-policies",
+ "bitwarden-random",
  "bitwarden-send",
  "bitwarden-server-communication-config",
  "bitwarden-ssh",
@@ -1441,6 +1463,7 @@ dependencies = [
  "bitwarden-organization-invite-link",
  "bitwarden-pm",
  "bitwarden-policies",
+ "bitwarden-random",
  "bitwarden-send",
  "bitwarden-server-communication-config",
  "bitwarden-shared-unlock",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,6 +51,7 @@ bitwarden-organization-invite-link = { path = "crates/bitwarden-organization-inv
 bitwarden-organizations = { path = "crates/bitwarden-organizations", version = "=3.0.0" }
 bitwarden-pm = { path = "crates/bitwarden-pm", version = "=3.0.0" }
 bitwarden-policies = { path = "crates/bitwarden-policies", version = "=3.0.0" }
+bitwarden-random = { path = "crates/bitwarden-random", version = "=3.0.0" }
 bitwarden-send = { path = "crates/bitwarden-send", version = "=3.0.0" }
 bitwarden-sensitive-value = { path = "crates/bitwarden-sensitive-value", version = "=3.0.0" }
 bitwarden-server-communication-config = { path = "crates/bitwarden-server-communication-config", version = "=3.0.0" }

--- a/crates/bitwarden-core/Cargo.toml
+++ b/crates/bitwarden-core/Cargo.toml
@@ -66,6 +66,7 @@ bitwarden-crypto = { workspace = true }
 bitwarden-encoding = { workspace = true }
 bitwarden-error = { workspace = true }
 bitwarden-logging = { workspace = true }
+bitwarden-random = { workspace = true }
 bitwarden-state = { workspace = true }
 bitwarden-state-bridge-macro = { workspace = true }
 bitwarden-test = { workspace = true, optional = true }

--- a/crates/bitwarden-core/src/auth/auth_client.rs
+++ b/crates/bitwarden-core/src/auth/auth_client.rs
@@ -94,7 +94,7 @@ impl AuthClient {
 
     #[allow(missing_docs)]
     pub fn make_key_connector_keys(&self) -> Result<KeyConnectorResponse, CryptoError> {
-        let mut rng = rand::rng();
+        let mut rng = bitwarden_random::rng();
         make_key_connector_keys(&mut rng)
     }
 

--- a/crates/bitwarden-crypto/Cargo.toml
+++ b/crates/bitwarden-crypto/Cargo.toml
@@ -41,6 +41,7 @@ bitwarden-api-key-connector = { workspace = true }
 bitwarden-encoding = { workspace = true }
 bitwarden-error = { workspace = true }
 bitwarden-logging = { workspace = true }
+bitwarden-random = { workspace = true }
 bitwarden-sensitive-value = { workspace = true }
 bitwarden-uniffi-error = { workspace = true, optional = true }
 cbc = { version = "0.2.0", features = ["alloc", "zeroize"] }

--- a/crates/bitwarden-crypto/src/aes.rs
+++ b/crates/bitwarden-crypto/src/aes.rs
@@ -69,7 +69,7 @@ pub(crate) fn encrypt_aes256_hmac(
     mac_key: &Array<u8, U32>,
     key: &Array<u8, U32>,
 ) -> Result<([u8; 16], [u8; 32], Vec<u8>)> {
-    let rng = rand::rng();
+    let rng = bitwarden_random::rng();
     let (iv, data) = encrypt_aes256_internal(rng, data_dec, key);
     let mac = generate_mac(mac_key, &iv, &data);
 

--- a/crates/bitwarden-crypto/src/hazmat/symmetric_encryption/aes_gcm.rs
+++ b/crates/bitwarden-crypto/src/hazmat/symmetric_encryption/aes_gcm.rs
@@ -79,7 +79,7 @@ pub(crate) struct Aes256GcmNonce(Nonce<Aes256GcmAlg>);
 impl Aes256GcmNonce {
     /// Generates a fresh, cryptographically random nonce.
     pub(crate) fn make() -> Self {
-        let mut rng = rand::rng();
+        let mut rng = bitwarden_random::rng();
         Aes256GcmNonce(Nonce::<Aes256GcmAlg>::generate_from_rng(&mut rng))
     }
 

--- a/crates/bitwarden-crypto/src/hazmat/symmetric_encryption/xchacha20.rs
+++ b/crates/bitwarden-crypto/src/hazmat/symmetric_encryption/xchacha20.rs
@@ -82,7 +82,7 @@ pub(crate) struct XChaCha20Poly1305Nonce(Nonce<XChaCha20Poly1305Alg>);
 impl XChaCha20Poly1305Nonce {
     /// Generates a fresh, cryptographically random nonce.
     pub(crate) fn make() -> Self {
-        let mut rng = rand::rng();
+        let mut rng = bitwarden_random::rng();
         XChaCha20Poly1305Nonce(Nonce::<XChaCha20Poly1305Alg>::generate_from_rng(&mut rng))
     }
 

--- a/crates/bitwarden-crypto/src/keys/key_connector_key.rs
+++ b/crates/bitwarden-crypto/src/keys/key_connector_key.rs
@@ -18,7 +18,7 @@ pub struct KeyConnectorKey(pub(super) Pin<Box<Array<u8, U32>>>);
 impl KeyConnectorKey {
     /// Make a new random key for KeyConnector.
     pub fn make() -> Self {
-        let mut rng = rand::rng();
+        let mut rng = bitwarden_random::rng();
         let mut key = Box::pin(Array::<u8, U32>::default());
 
         rng.fill(key.as_mut_slice());

--- a/crates/bitwarden-crypto/src/keys/key_id.rs
+++ b/crates/bitwarden-crypto/src/keys/key_id.rs
@@ -29,7 +29,7 @@ impl ConstantTimeEq for KeyId {
 impl KeyId {
     /// Creates a new random key ID randomly, sampled from the crates CSPRNG.
     pub fn make() -> Self {
-        let mut rng = rand::rng();
+        let mut rng = bitwarden_random::rng();
         let mut key_id = [0u8; KEY_ID_SIZE];
         rng.fill(&mut key_id);
         Self(key_id)

--- a/crates/bitwarden-crypto/src/keys/master_key.rs
+++ b/crates/bitwarden-crypto/src/keys/master_key.rs
@@ -85,7 +85,7 @@ impl MasterKey {
 
     /// Generate a new random user key and encrypt it with the master key.
     pub fn make_user_key(&self) -> Result<(UserKey, EncString)> {
-        make_user_key(rand::rng(), self)
+        make_user_key(bitwarden_random::rng(), self)
     }
 
     /// Encrypt the users user key

--- a/crates/bitwarden-crypto/src/keys/public_key_encryption.rs
+++ b/crates/bitwarden-crypto/src/keys/public_key_encryption.rs
@@ -172,7 +172,7 @@ impl CryptoKey for PrivateKey {}
 impl PrivateKey {
     /// Generate a random PrivateKey (RSA-2048).
     pub fn make(algorithm: PublicKeyEncryptionAlgorithm) -> Self {
-        Self::make_internal(algorithm, &mut rand::rng())
+        Self::make_internal(algorithm, &mut bitwarden_random::rng())
     }
 
     fn make_internal<R: rand::CryptoRng + rand::Rng>(

--- a/crates/bitwarden-crypto/src/keys/symmetric_crypto_key.rs
+++ b/crates/bitwarden-crypto/src/keys/symmetric_crypto_key.rs
@@ -143,7 +143,7 @@ pub struct XChaCha20Poly1305Key {
 impl XChaCha20Poly1305Key {
     /// Creates a new XChaCha20Poly1305Key with a securely sampled cryptographic key and key id.
     pub fn make() -> Self {
-        let mut rng = rand::rng();
+        let mut rng = bitwarden_random::rng();
         let mut enc_key = Box::pin(Array::<u8, U32>::default());
         rng.fill(enc_key.as_mut_slice());
         let key_id = KeyId::make();
@@ -221,13 +221,13 @@ impl SymmetricCryptoKey {
 
     /// Generate a new random AES256_CBC_HMAC [SymmetricCryptoKey]
     pub(crate) fn make_aes256_cbc_hmac_key() -> Self {
-        let rng = rand::rng();
+        let rng = bitwarden_random::rng();
         Self::make_aes256_cbc_hmac_key_internal(rng)
     }
 
     /// Generate a new random XChaCha20Poly1305 [SymmetricCryptoKey]
     pub(crate) fn make_xchacha20_poly1305_key() -> Self {
-        let mut rng = rand::rng();
+        let mut rng = bitwarden_random::rng();
         let mut enc_key = Box::pin(Array::<u8, U32>::default());
         rng.fill(enc_key.as_mut_slice());
         Self::XChaCha20Poly1305Key(XChaCha20Poly1305Key {

--- a/crates/bitwarden-crypto/src/rsa.rs
+++ b/crates/bitwarden-crypto/src/rsa.rs
@@ -23,7 +23,7 @@ pub struct RsaKeyPair {
 
 /// Generate a new RSA key pair of 2048 bits
 pub(crate) fn make_key_pair(key: &SymmetricCryptoKey) -> Result<RsaKeyPair> {
-    let mut rng = rand::rng();
+    let mut rng = bitwarden_random::rng();
     let bits = 2048;
     let priv_key = RsaPrivateKey::new(&mut rng, bits).expect("failed to generate a key");
     let pub_key = RsaPublicKey::from(&priv_key);
@@ -56,7 +56,7 @@ pub(crate) fn make_key_pair(key: &SymmetricCryptoKey) -> Result<RsaKeyPair> {
 
 /// Encrypt data using RSA-OAEP-SHA1 with a 2048 bit key
 pub(super) fn encrypt_rsa2048_oaep_sha1(public_key: &RsaPublicKey, data: &[u8]) -> Result<Vec<u8>> {
-    let mut rng = rand::rng();
+    let mut rng = bitwarden_random::rng();
 
     let padding = Oaep::<Sha1>::new();
     public_key

--- a/crates/bitwarden-crypto/src/safe/high_entropy_secret.rs
+++ b/crates/bitwarden-crypto/src/safe/high_entropy_secret.rs
@@ -70,7 +70,7 @@ impl HighEntropySecret {
         }
 
         let mut secret = Zeroizing::new(vec![0u8; desired_size]);
-        rand::rng().fill_bytes(secret.as_mut_slice());
+        bitwarden_random::rng().fill_bytes(secret.as_mut_slice());
         Ok(Self { secret })
     }
 

--- a/crates/bitwarden-crypto/src/safe/password_protected_key_envelope.rs
+++ b/crates/bitwarden-crypto/src/safe/password_protected_key_envelope.rs
@@ -444,7 +444,7 @@ impl TryInto<Argon2RawSettings> for &Header {
 
 fn make_salt() -> [u8; ENVELOPE_ARGON2_SALT_SIZE] {
     let mut salt = [0u8; ENVELOPE_ARGON2_SALT_SIZE];
-    rand::rng().fill_bytes(&mut salt);
+    bitwarden_random::rng().fill_bytes(&mut salt);
     salt
 }
 

--- a/crates/bitwarden-crypto/src/signing/signing_key.rs
+++ b/crates/bitwarden-crypto/src/signing/signing_key.rs
@@ -83,13 +83,13 @@ impl SigningKey {
             SignatureAlgorithm::Ed25519 => SigningKey {
                 id: KeyId::make(),
                 inner: RawSigningKey::Ed25519(Box::pin(ed25519_dalek::SigningKey::generate(
-                    &mut rand::rng(),
+                    &mut bitwarden_random::rng(),
                 ))),
             },
             SignatureAlgorithm::MlDsa44 => {
                 // This is heap allocated from the start, so will be zeroized on drop
                 let mut seed = Box::pin(Array::from([0u8; 32]));
-                rand::rng().fill_bytes(&mut seed);
+                bitwarden_random::rng().fill_bytes(&mut seed);
 
                 let kp = ml_dsa::ExpandedSigningKey::<MlDsa44>::from_seed(&seed);
                 SigningKey {
@@ -133,7 +133,7 @@ impl SigningKey {
         match &self.inner {
             RawSigningKey::Ed25519(key) => key.sign(data).to_bytes().to_vec(),
             RawSigningKey::MlDsa44 { signing_key, .. } => signing_key
-                .sign_randomized(data, &[], &mut rand::rng())
+                .sign_randomized(data, &[], &mut bitwarden_random::rng())
                 .expect("Empty ML-DSA context must be accepted")
                 .encode()
                 .as_slice()

--- a/crates/bitwarden-crypto/src/stream/aes256_cbc_hmac_legacy_stream.rs
+++ b/crates/bitwarden-crypto/src/stream/aes256_cbc_hmac_legacy_stream.rs
@@ -498,7 +498,7 @@ impl StreamingAes256CbcHmacEncryptor {
         };
 
         let mut iv: Iv = [0u8; AES256_CBC_IV_SIZE];
-        rand::rng().fill_bytes(&mut iv);
+        bitwarden_random::rng().fill_bytes(&mut iv);
 
         // The CBC ciphertext is the PKCS7-padded plaintext, which is always rounded up to the next
         // full block (a full padding block is added when already block-aligned).

--- a/crates/bitwarden-crypto/src/util.rs
+++ b/crates/bitwarden-crypto/src/util.rs
@@ -43,7 +43,7 @@ where
     StandardUniform: Distribution<T>,
     T: Zeroize,
 {
-    Zeroizing::new(rand::rng().random::<T>())
+    Zeroizing::new(bitwarden_random::rng().random::<T>())
 }
 
 /// Generate a random alphanumeric string of a given length
@@ -51,7 +51,7 @@ where
 /// Note: Do not use this generating user facing passwords. Use the `bitwarden-generator` crate for
 /// that.
 pub fn generate_random_alphanumeric(len: usize) -> String {
-    Alphanumeric.sample_string(&mut rand::rng(), len)
+    Alphanumeric.sample_string(&mut bitwarden_random::rng(), len)
 }
 
 /// Derive pbkdf2 of a given password and salt

--- a/crates/bitwarden-generators/Cargo.toml
+++ b/crates/bitwarden-generators/Cargo.toml
@@ -22,6 +22,7 @@ wasm = ["bitwarden-core/wasm", "dep:tsify", "dep:wasm-bindgen"]
 bitwarden-core = { workspace = true, features = ["internal"] }
 bitwarden-crypto = { workspace = true }
 bitwarden-error = { workspace = true }
+bitwarden-random = { workspace = true }
 password-rules-parser = { workspace = true }
 rand = { workspace = true }
 reqwest = { workspace = true }

--- a/crates/bitwarden-generators/src/passphrase.rs
+++ b/crates/bitwarden-generators/src/passphrase.rs
@@ -87,7 +87,7 @@ impl PassphraseGeneratorRequest {
 /// Implementation of the random passphrase generator.
 pub(crate) fn passphrase(request: PassphraseGeneratorRequest) -> Result<String, PassphraseError> {
     let options = request.validate_options()?;
-    Ok(passphrase_with_rng(rand::rng(), options))
+    Ok(passphrase_with_rng(bitwarden_random::rng(), options))
 }
 
 fn passphrase_with_rng(mut rng: impl Rng, options: ValidPassphraseGeneratorOptions) -> String {

--- a/crates/bitwarden-generators/src/password.rs
+++ b/crates/bitwarden-generators/src/password.rs
@@ -325,7 +325,7 @@ impl PasswordGeneratorRequest {
 /// Implementation of the random password generator.
 pub(crate) fn password(input: PasswordGeneratorRequest) -> Result<String, PasswordError> {
     let options = input.validate_options()?;
-    Ok(password_with_rng(rand::rng(), options))
+    Ok(password_with_rng(bitwarden_random::rng(), options))
 }
 
 /// Test-only helper that validates a request and runs the generator with a caller-supplied RNG.

--- a/crates/bitwarden-generators/src/username.rs
+++ b/crates/bitwarden-generators/src/username.rs
@@ -157,7 +157,7 @@ pub(crate) async fn username(
     http: &reqwest::Client,
 ) -> Result<String, UsernameError> {
     use UsernameGeneratorRequest::*;
-    use rand::rng;
+    use bitwarden_random::rng;
     match input {
         Word {
             capitalize,

--- a/crates/bitwarden-ipc/Cargo.toml
+++ b/crates/bitwarden-ipc/Cargo.toml
@@ -24,6 +24,7 @@ test-support = [] # Expose test utilities (InMemoryCommunicationBackend) for dow
 async-trait = { workspace = true }
 bitwarden-error = { workspace = true }
 bitwarden-ffi = { workspace = true }
+bitwarden-random = { workspace = true, features = ["snow"] }
 bitwarden-threading = { workspace = true }
 ciborium = { workspace = true }
 erased-serde = ">=0.4.6, <0.5"

--- a/crates/bitwarden-ipc/src/crypto_provider/noise/handshake.rs
+++ b/crates/bitwarden-ipc/src/crypto_provider/noise/handshake.rs
@@ -83,11 +83,12 @@ pub(crate) struct ReadError;
 
 impl HandshakeInitiator {
     pub(crate) fn new(ciphersuite: &CipherSuite) -> Self {
-        let builder = snow::Builder::new(
+        let builder = snow::Builder::with_resolver(
             ciphersuite
                 .to_string()
                 .parse()
                 .expect("Ciphersuite should be valid"),
+            Box::new(bitwarden_random::SdkCryptoResolver),
         );
         let handshake_state = builder
             .build_initiator()
@@ -140,11 +141,12 @@ pub(crate) struct HandshakeResponder {
 
 impl HandshakeResponder {
     pub(crate) fn new(ciphersuite: &CipherSuite) -> Self {
-        let builder = snow::Builder::new(
+        let builder = snow::Builder::with_resolver(
             ciphersuite
                 .to_string()
                 .parse()
                 .expect("Ciphersuite should be valid"),
+            Box::new(bitwarden_random::SdkCryptoResolver),
         );
         let handshake_state = builder
             .build_responder()

--- a/crates/bitwarden-random/CLAUDE.md
+++ b/crates/bitwarden-random/CLAUDE.md
@@ -1,0 +1,23 @@
+# bitwarden-random
+
+Read any available documentation: [README.md](./README.md) for architecture,
+[examples/](./examples/) for usage patterns, and [tests/](./tests/) for integration tests.
+
+The single random-number source for the SDK. Wraps the OS CRNG behind [`SdkRngImpl`] and the `rng()`
+constructor, and exposes cross-platform generation through [`SdkRandomNumberClient`].
+
+## Critical Rules
+
+**Use `rng()`, never `rand::rng()` directly**: All SDK crates draw randomness through
+`bitwarden_random::rng()` so a single, auditable CRNG (and the test seeding hook) backs every
+generator. Do not call `rand::rng()`, `rand::rngs::OsRng`, or `SysRng` from other crates.
+
+**Only OS entropy in production**: The default `SdkRngImpl` is OS-backed. The seeded stream exists
+solely for reproducible tests.
+
+**`dangerous-seeded-rng-for-testing` is test-only**: It installs a deterministic ChaCha8 stream on
+the current thread. NEVER enable it in a production code path, since it makes all randomness
+predictable.
+
+**Implements standard traits**: The crate implements standard traits for the `SdkRngImpl`. It can be
+dropped in and used for all external libraries that accept an RNG.

--- a/crates/bitwarden-random/Cargo.toml
+++ b/crates/bitwarden-random/Cargo.toml
@@ -1,0 +1,55 @@
+[package]
+name = "bitwarden-random"
+description = """
+Internal crate for the bitwarden crate. Do not use.
+"""
+
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+readme.workspace = true
+homepage.workspace = true
+repository.workspace = true
+license-file.workspace = true
+keywords.workspace = true
+
+[package.metadata.cargo-udeps.ignore]
+normal = ["getrandom4"] # Only used to enable WASM support, not used directly
+
+[features]
+# Provides a snow (Noise) CryptoResolver + `snow::types::Random` impl for `SdkRngImpl`.
+snow = ["dep:snow"]
+# Allows constructing a deterministic, seeded ChaCha-based `SdkRngImpl`. NEVER enable in production
+# code paths — only in tests/benches that need reproducible randomness.
+dangerous-seeded-rng-for-testing = ["dep:rand_chacha"]
+uniffi = [
+    "dep:uniffi",
+]                                                    # Uniffi bindings
+wasm = [
+    "bitwarden-error/wasm",
+    "getrandom4/wasm_js",
+    "dep:wasm-bindgen",
+] # WASM support
+
+[dependencies]
+bitwarden-error = { workspace = true }
+# We don't use this directly (it's used by rand and uuid), but we need it here to enable WASM
+# support for the getrandom version they pull in.
+getrandom4 = { package = "getrandom", version = "0.4", optional = true }
+rand = { workspace = true }
+rand_chacha = { workspace = true, optional = true }
+snow = { version = "0.10.0", default-features = false, features = [
+    "default-resolver",
+    "default-resolver-crypto",
+], optional = true }
+thiserror = { workspace = true }
+uniffi = { workspace = true, optional = true }
+uuid = { workspace = true }
+wasm-bindgen = { workspace = true, optional = true }
+
+[dev-dependencies]
+wasm-bindgen-test = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/bitwarden-random/README.md
+++ b/crates/bitwarden-random/README.md
@@ -1,0 +1,4 @@
+# Bitwarden Random
+
+Provides an abstraction to provide the single rng impl for the sdk. This can be seeded if the
+`dangerous-seeded-rng-for-testing` feature is enabled, but by default uses the OS CRNG.

--- a/crates/bitwarden-random/examples/deterministic_scene.rs
+++ b/crates/bitwarden-random/examples/deterministic_scene.rs
@@ -1,0 +1,38 @@
+//! Demonstrates deterministic, reproducible randomness for tests via the
+//! `dangerous-seeded-rng-for-testing` feature.
+//!
+//! Run with:
+//! `cargo run --example deterministic_scene -p bitwarden-random --features
+//! dangerous-seeded-rng-for-testing`
+
+#[cfg(feature = "dangerous-seeded-rng-for-testing")]
+fn main() {
+    use bitwarden_random::{Scene, clear_seed, rng, rng_set_scene, set_seed_raw};
+    use rand::RngExt;
+
+    // Selecting a scene makes every subsequent `rng()` on this thread deterministic.
+    rng_set_scene(Scene::SceneA);
+    let first: [u8; 8] = rng().random();
+
+    // Re-selecting the same scene reproduces the exact same stream.
+    rng_set_scene(Scene::SceneA);
+    let again: [u8; 8] = rng().random();
+    assert_eq!(first, again);
+
+    // A different scene maps to a different seed, and hence a different stream.
+    rng_set_scene(Scene::SceneB);
+    let other: [u8; 8] = rng().random();
+    assert_ne!(first, other);
+
+    // For full control, seed with raw bytes directly.
+    set_seed_raw([42u8; 32]);
+    let _raw: [u8; 8] = rng().random();
+
+    // Revert to the OS entropy source when done.
+    clear_seed();
+}
+
+#[cfg(not(feature = "dangerous-seeded-rng-for-testing"))]
+fn main() {
+    // This example only does something with the `dangerous-seeded-rng-for-testing` feature enabled.
+}

--- a/crates/bitwarden-random/examples/generate_random.rs
+++ b/crates/bitwarden-random/examples/generate_random.rs
@@ -1,0 +1,29 @@
+//! Demonstrates the default Bitwarden SDK RNG: [`bitwarden_random::rng`] returns an OS-backed
+//! generator that implements `rand::Rng` / `rand::CryptoRng`, so it is a drop-in within the `rand`
+//! ecosystem.
+//!
+//! Run with: `cargo run --example generate_random -p bitwarden-random`
+
+use rand::RngExt;
+
+fn main() {
+    // `rng()` mirrors `rand::rng()`. By default it draws from the operating system's CSPRNG.
+    let mut rng = bitwarden_random::rng();
+
+    // Fill a buffer with random bytes — e.g. an IV or salt.
+    let mut iv = [0u8; 16];
+    rng.fill(&mut iv);
+
+    // Generate a typed random value, and one within a range.
+    let token: u64 = rng.random();
+    let dice = rng.random_range(1..=6);
+    assert!((1..=6).contains(&dice));
+
+    // Two independent draws differ with overwhelming probability.
+    let other_token: u64 = rng.random();
+    assert_ne!(token, other_token);
+
+    // `SdkRngImpl` is `Send + Sync` and satisfies the `SdkRng` marker trait.
+    fn assert_sdk_rng<T: bitwarden_random::SdkRng>(_: &T) {}
+    assert_sdk_rng(&rng);
+}

--- a/crates/bitwarden-random/examples/random_client.rs
+++ b/crates/bitwarden-random/examples/random_client.rs
@@ -1,0 +1,29 @@
+//! Demonstrates [`bitwarden_random::SdkRandomNumberClient`], the cross-platform (WASM / UniFFI)
+//! entry point for random-number generation. It is constructed and then used through
+//!
+//! Run with: `cargo run --example random_client -p bitwarden-random`
+
+use bitwarden_random::{GenBytesError, SdkRandomNumberClient};
+
+fn main() -> Result<(), GenBytesError> {
+    let client = SdkRandomNumberClient::new();
+
+    // Request cryptographically-secure random bytes — e.g. a 32-byte key or salt.
+    let bytes = client.gen_bytes(32)?;
+    assert_eq!(bytes.len(), 32);
+
+    // Two independent draws differ with overwhelming probability.
+    assert_ne!(client.gen_bytes(32)?, client.gen_bytes(32)?);
+
+    // `gen_bytes` is capped at 1 KiB; requesting more returns an error. The boundary itself is
+    // fine.
+    assert_eq!(client.gen_bytes(1024)?.len(), 1024);
+    assert!(client.gen_bytes(1025).is_err());
+
+    // Generate a random v4 UUID, returned as a hyphenated string (as the bindings expose it).
+    let uuid = client.gen_uuid();
+    assert_eq!(uuid.len(), 36);
+    assert_ne!(client.gen_uuid(), client.gen_uuid());
+
+    Ok(())
+}

--- a/crates/bitwarden-random/src/ffi.rs
+++ b/crates/bitwarden-random/src/ffi.rs
@@ -1,0 +1,163 @@
+//! Cross-platform (WASM / UniFFI) bindings for random-number generation.
+
+use bitwarden_error::bitwarden_error;
+use rand::{Rng, RngExt};
+use thiserror::Error;
+#[cfg(feature = "wasm")]
+use wasm_bindgen::prelude::*;
+
+use crate::rng;
+
+/// Error returned by [`SdkRandomNumberClient::gen_bytes`].
+#[bitwarden_error(flat)]
+#[derive(Debug, Error)]
+pub enum GenBytesError {
+    /// More than 1 KiB of randomness was requested.
+    #[error("gen_bytes() is limited to 1KiB; requested {requested} bytes")]
+    TooManyBytes {
+        /// The number of bytes that was requested.
+        requested: u32,
+    },
+}
+
+/// Error returned by [`SdkRandomNumberClient::gen_range`].
+#[bitwarden_error(flat)]
+#[derive(Debug, Error)]
+pub enum GenRangeError {
+    /// `min` was greater than `max`, so the range is empty.
+    #[error("Invalid range: min ({min}) must not exceed max ({max})")]
+    InvalidRange {
+        /// The requested lower bound.
+        min: u32,
+        /// The requested upper bound.
+        max: u32,
+    },
+}
+
+/// Client exposing random-number generation to cross-platform bindings.
+#[derive(Default)]
+#[cfg_attr(feature = "uniffi", derive(uniffi::Object))]
+#[cfg_attr(feature = "wasm", wasm_bindgen)]
+pub struct SdkRandomNumberClient;
+
+#[cfg_attr(feature = "wasm", wasm_bindgen)]
+#[cfg_attr(feature = "uniffi", uniffi::export)]
+impl SdkRandomNumberClient {
+    /// Construct a new client.
+    #[cfg_attr(feature = "wasm", wasm_bindgen(constructor))]
+    #[cfg_attr(feature = "uniffi", uniffi::constructor)]
+    pub fn new() -> Self {
+        // UniFFI does not support associated (static) functions, so the client is exposed as an
+        // object with a constructor and `&self` methods. The WASM binding mirrors that
+        // shape (constructor + instance methods) so a single impl block serves both.
+        SdkRandomNumberClient
+    }
+
+    /// Generate `len` cryptographically-secure random bytes.
+    ///
+    /// Returns [`GenBytesError::TooManyBytes`] if `len` exceeds 1 KiB. If you want over 1KiB of
+    /// randomness, please reconsider your design.
+    pub fn gen_bytes(&self, len: u32) -> Result<Vec<u8>, GenBytesError> {
+        if len > 1024 {
+            return Err(GenBytesError::TooManyBytes { requested: len });
+        }
+
+        let mut buf = vec![0u8; len as usize];
+        rng().fill_bytes(&mut buf);
+        Ok(buf)
+    }
+
+    /// Generate a random v4 UUID, sampled from a CRNG
+    ///
+    /// This has 122 random bits of entropy.
+    pub fn gen_uuid(&self) -> String {
+        let mut bytes = [0u8; 16];
+        rng().fill_bytes(&mut bytes);
+        uuid::Builder::from_random_bytes(bytes)
+            .with_variant(uuid::Variant::RFC4122)
+            .with_version(uuid::Version::Random)
+            .into_uuid()
+            .to_string()
+    }
+
+    /// Generate a cryptographically-secure random number in the range `[min, max]` (inclusive).
+    ///
+    /// Returns [`GenRangeError::InvalidRange`] if `min > max`.
+    pub fn gen_range(&self, min: u32, max: u32) -> Result<u32, GenRangeError> {
+        if min > max {
+            return Err(GenRangeError::InvalidRange { min, max });
+        }
+        Ok(rng().random_range(min..=max))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use uuid::Uuid;
+
+    use super::*;
+
+    #[test]
+    fn gen_bytes_returns_requested_length() {
+        let client = SdkRandomNumberClient::new();
+        assert_eq!(client.gen_bytes(0).unwrap().len(), 0);
+        assert_eq!(client.gen_bytes(1).unwrap().len(), 1);
+        assert_eq!(client.gen_bytes(32).unwrap().len(), 32);
+        // 1 KiB is the documented maximum and must succeed.
+        assert_eq!(client.gen_bytes(1024).unwrap().len(), 1024);
+    }
+
+    #[test]
+    fn gen_bytes_is_random() {
+        let client = SdkRandomNumberClient::new();
+        // Two independent draws differ with overwhelming probability.
+        assert_ne!(client.gen_bytes(32).unwrap(), client.gen_bytes(32).unwrap());
+    }
+
+    #[test]
+    fn gen_bytes_errors_above_1_kib() {
+        let err = SdkRandomNumberClient::new().gen_bytes(1025).unwrap_err();
+        assert!(matches!(
+            err,
+            GenBytesError::TooManyBytes { requested: 1025 }
+        ));
+    }
+
+    #[test]
+    fn gen_uuid_is_a_valid_random_v4_uuid() {
+        let client = SdkRandomNumberClient::new();
+        let uuid = Uuid::parse_str(&client.gen_uuid()).expect("a valid UUID string");
+        assert_eq!(uuid.get_version(), Some(uuid::Version::Random));
+        assert_eq!(uuid.get_variant(), uuid::Variant::RFC4122);
+    }
+
+    #[test]
+    fn gen_uuid_is_distinct() {
+        let client = SdkRandomNumberClient::new();
+        assert_ne!(client.gen_uuid(), client.gen_uuid());
+    }
+
+    #[test]
+    fn gen_range_stays_within_inclusive_bounds() {
+        let client = SdkRandomNumberClient::new();
+        for _ in 0..1000 {
+            let n = client.gen_range(10, 20).unwrap();
+            assert!((10..=20).contains(&n));
+        }
+    }
+
+    #[test]
+    fn gen_range_with_single_value_is_that_value() {
+        let client = SdkRandomNumberClient::new();
+        assert_eq!(client.gen_range(7, 7).unwrap(), 7);
+    }
+
+    #[test]
+    fn gen_range_errors_when_min_exceeds_max() {
+        let err = SdkRandomNumberClient::new().gen_range(20, 10).unwrap_err();
+        assert!(matches!(
+            err,
+            GenRangeError::InvalidRange { min: 20, max: 10 }
+        ));
+    }
+}

--- a/crates/bitwarden-random/src/lib.rs
+++ b/crates/bitwarden-random/src/lib.rs
@@ -1,0 +1,122 @@
+#![doc = include_str!("../README.md")]
+
+use std::convert::Infallible;
+
+use rand::TryRng;
+
+#[cfg(feature = "uniffi")]
+uniffi::setup_scaffolding!();
+
+mod ffi;
+pub use ffi::{GenBytesError, GenRangeError, SdkRandomNumberClient};
+
+#[cfg(feature = "dangerous-seeded-rng-for-testing")]
+mod seeded;
+#[cfg(feature = "dangerous-seeded-rng-for-testing")]
+pub use seeded::{Scene, clear_seed, rng_set_scene, set_seed_raw};
+
+#[cfg(feature = "snow")]
+mod snow_resolver;
+#[cfg(feature = "snow")]
+pub use snow_resolver::SdkCryptoResolver;
+
+/// Marker trait for random number generators usable within the Bitwarden SDK.
+///
+/// Supertrait of [`rand::CryptoRng`] (hence also [`rand::Rng`] / [`rand::RngExt`]) and additionally
+/// requires `Send + Sync`, so any `SdkRng` is a drop-in wherever the SDK or third-party crates
+/// expect a cryptographically secure, thread-safe RNG.
+pub trait SdkRng: rand::CryptoRng + Send + Sync {}
+
+impl<T: rand::CryptoRng + Send + Sync + ?Sized> SdkRng for T {}
+
+/// The default Bitwarden RNG.
+#[derive(Clone, Debug)]
+pub struct SdkRngImpl(Inner);
+
+#[derive(Clone, Debug)]
+enum Inner {
+    /// OS entropy source.
+    Os,
+    /// Draws from the thread-local stream installed by [`set_seed_raw`]. Carries no data, so the
+    /// struct stays `Send + Sync`.
+    #[cfg(feature = "dangerous-seeded-rng-for-testing")]
+    Seeded,
+}
+
+impl Default for SdkRngImpl {
+    fn default() -> Self {
+        Self(Inner::Os)
+    }
+}
+
+impl SdkRngImpl {
+    /// Creates a new OS-backed RNG.
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+/// Returns an [`SdkRngImpl`]. Mirrors [`rand::rng`] for ergonomic drop-in replacement.
+pub fn rng() -> SdkRngImpl {
+    #[cfg(feature = "dangerous-seeded-rng-for-testing")]
+    if seeded::is_seeded() {
+        return SdkRngImpl(Inner::Seeded);
+    }
+    SdkRngImpl::default()
+}
+
+impl TryRng for SdkRngImpl {
+    type Error = Infallible;
+
+    fn try_next_u32(&mut self) -> Result<u32, Self::Error> {
+        match &self.0 {
+            Inner::Os => Ok(rand::rngs::SysRng
+                .try_next_u32()
+                .expect("system RNG must not fail")),
+            #[cfg(feature = "dangerous-seeded-rng-for-testing")]
+            Inner::Seeded => Ok(seeded::next_u32()),
+        }
+    }
+
+    fn try_next_u64(&mut self) -> Result<u64, Self::Error> {
+        match &self.0 {
+            Inner::Os => Ok(rand::rngs::SysRng
+                .try_next_u64()
+                .expect("system RNG must not fail")),
+            #[cfg(feature = "dangerous-seeded-rng-for-testing")]
+            Inner::Seeded => Ok(seeded::next_u64()),
+        }
+    }
+
+    fn try_fill_bytes(&mut self, dst: &mut [u8]) -> Result<(), Self::Error> {
+        match &self.0 {
+            Inner::Os => rand::rngs::SysRng
+                .try_fill_bytes(dst)
+                .expect("system RNG must not fail"),
+            #[cfg(feature = "dangerous-seeded-rng-for-testing")]
+            Inner::Seeded => seeded::fill_bytes(dst),
+        }
+        Ok(())
+    }
+}
+
+impl rand::TryCryptoRng for SdkRngImpl {}
+
+#[cfg(test)]
+mod tests {
+    use rand::RngExt;
+
+    use super::*;
+
+    // Compile-time checks: SdkRngImpl satisfies SdkRng + third-party bounds, and is Send + Sync.
+    fn _assert_bounds<T: SdkRng + rand::CryptoRng + rand::Rng + Send + Sync>() {}
+    const _: fn() = || _assert_bounds::<SdkRngImpl>();
+
+    #[test]
+    fn os_rng_produces_distinct_bytes() {
+        let mut rng = rng();
+        let a: [u8; 32] = rng.random();
+        let b: [u8; 32] = rng.random();
+        assert_ne!(a, b);
+    }
+}

--- a/crates/bitwarden-random/src/seeded.rs
+++ b/crates/bitwarden-random/src/seeded.rs
@@ -1,0 +1,102 @@
+//! Deterministic, seeded RNG support for tests/benches.
+
+use rand::SeedableRng;
+
+thread_local! {
+    /// When `Some`, [`crate::rng`] returns a handle that advances this single stream across all
+    /// `rng()` calls on the thread (keeping IVs/nonces unique while reproducible).
+    static SEEDED_STREAM: core::cell::RefCell<Option<rand_chacha::ChaCha8Rng>> =
+        const { core::cell::RefCell::new(None) };
+}
+
+/// Sets up a deterministic, seeded ChaCha8 stream for the current thread.
+/// Where possible, the higher level [`rng_set_scene`] should be used instead.
+pub fn set_seed_raw(seed: [u8; 32]) {
+    SEEDED_STREAM.with(|c| *c.borrow_mut() = Some(rand_chacha::ChaCha8Rng::from_seed(seed)));
+}
+
+/// A named, reproducible RNG scene for tests. Each variant maps to a fixed seed.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Scene {
+    /// Deterministic scene A.
+    SceneA,
+    /// Deterministic scene B.
+    SceneB,
+    /// Deterministic scene C.
+    SceneC,
+}
+
+/// Seeds the current thread's RNG with the deterministic seed for the given [`Scene`].
+///
+/// The scene is mapped to a number which is used as the seed (via [`set_seed_raw`]).
+pub fn rng_set_scene(scene: Scene) {
+    set_seed_raw([scene as u8; 32]);
+}
+
+/// Removes any thread-local seed, reverting [`crate::rng`] to the OS entropy source on this thread.
+pub fn clear_seed() {
+    SEEDED_STREAM.with(|c| *c.borrow_mut() = None);
+}
+
+pub(crate) fn is_seeded() -> bool {
+    SEEDED_STREAM.with(|c| c.borrow().is_some())
+}
+
+pub(crate) fn next_u32() -> u32 {
+    SEEDED_STREAM
+        .with(|c| rand::Rng::next_u32(c.borrow_mut().as_mut().expect("seed set for this thread")))
+}
+
+pub(crate) fn next_u64() -> u64 {
+    SEEDED_STREAM
+        .with(|c| rand::Rng::next_u64(c.borrow_mut().as_mut().expect("seed set for this thread")))
+}
+
+pub(crate) fn fill_bytes(dst: &mut [u8]) {
+    SEEDED_STREAM.with(|c| {
+        rand::Rng::fill_bytes(
+            c.borrow_mut().as_mut().expect("seed set for this thread"),
+            dst,
+        )
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use rand::RngExt;
+
+    use super::*;
+    use crate::rng;
+
+    #[test]
+    fn set_seed_makes_rng_calls_deterministic_and_advancing() {
+        // Two separate `rng()` calls draw from the SAME advancing stream — distinct values...
+        set_seed_raw([7u8; 32]);
+        let a: [u8; 16] = rng().random();
+        let b: [u8; 16] = rng().random();
+        assert_ne!(a, b, "successive rng() must not repeat (no IV/nonce reuse)");
+
+        // ...and re-seeding reproduces the exact sequence.
+        set_seed_raw([7u8; 32]);
+        let a2: [u8; 16] = rng().random();
+        let b2: [u8; 16] = rng().random();
+        assert_eq!((a, b), (a2, b2));
+
+        clear_seed();
+    }
+
+    #[test]
+    fn rng_set_scene_is_deterministic_and_distinct_per_scene() {
+        rng_set_scene(Scene::SceneA);
+        let a1: [u8; 16] = rng().random();
+        rng_set_scene(Scene::SceneA);
+        let a2: [u8; 16] = rng().random();
+        assert_eq!(a1, a2, "same scene must reproduce the same stream");
+
+        rng_set_scene(Scene::SceneB);
+        let b: [u8; 16] = rng().random();
+        assert_ne!(a1, b, "different scenes must use different seeds");
+
+        clear_seed();
+    }
+}

--- a/crates/bitwarden-random/src/snow_resolver.rs
+++ b/crates/bitwarden-random/src/snow_resolver.rs
@@ -1,0 +1,38 @@
+use snow::{
+    Error,
+    params::{CipherChoice, DHChoice, HashChoice},
+    resolvers::{CryptoResolver, DefaultResolver},
+    types::{Cipher, Dh, Hash, Random},
+};
+
+use crate::SdkRngImpl;
+
+impl Random for SdkRngImpl {
+    fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), Error> {
+        rand::Rng::fill_bytes(self, dest);
+        Ok(())
+    }
+}
+
+/// A snow [`CryptoResolver`] that supplies the SDK's [`SdkRngImpl`]
+#[derive(Default)]
+pub struct SdkCryptoResolver;
+
+impl CryptoResolver for SdkCryptoResolver {
+    fn resolve_rng(&self) -> Option<Box<dyn Random>> {
+        Some(Box::new(SdkRngImpl::default()))
+    }
+
+    fn resolve_dh(&self, choice: &DHChoice) -> Option<Box<dyn Dh>> {
+        DefaultResolver.resolve_dh(choice)
+    }
+
+    fn resolve_hash(&self, choice: &HashChoice) -> Option<Box<dyn Hash>> {
+        DefaultResolver.resolve_hash(choice)
+    }
+
+    fn resolve_cipher(&self, choice: &CipherChoice) -> Option<Box<dyn Cipher>> {
+        DefaultResolver.resolve_cipher(choice)
+    }
+    // `resolve_kem` is behind snow's `hfs` feature (not enabled); its default returns None.
+}

--- a/crates/bitwarden-random/tests/wasm.rs
+++ b/crates/bitwarden-random/tests/wasm.rs
@@ -1,0 +1,57 @@
+//! WASM integration tests for the [`SdkRandomNumberClient`] FFI, exercising the bindings as
+//! compiled for the `wasm32` target (including the `getrandom` `wasm_js` backend).
+//!
+//! Run with:
+//! `cargo test --target wasm32-unknown-unknown --features wasm -p bitwarden-random`
+#![cfg(all(target_arch = "wasm32", feature = "wasm"))]
+
+use bitwarden_random::SdkRandomNumberClient;
+use uuid::Uuid;
+use wasm_bindgen_test::*;
+
+#[wasm_bindgen_test]
+fn gen_bytes_returns_requested_length() {
+    let client = SdkRandomNumberClient::new();
+    assert_eq!(client.gen_bytes(0).unwrap().len(), 0);
+    assert_eq!(client.gen_bytes(32).unwrap().len(), 32);
+    // 1 KiB is the documented maximum and must succeed.
+    assert_eq!(client.gen_bytes(1024).unwrap().len(), 1024);
+}
+
+#[wasm_bindgen_test]
+fn gen_bytes_errors_above_1_kib() {
+    // Over the 1 KiB limit returns an error instead of trapping.
+    assert!(SdkRandomNumberClient::new().gen_bytes(1025).is_err());
+}
+
+#[wasm_bindgen_test]
+fn gen_bytes_is_random() {
+    let client = SdkRandomNumberClient::new();
+    assert_ne!(client.gen_bytes(32).unwrap(), client.gen_bytes(32).unwrap());
+}
+
+#[wasm_bindgen_test]
+fn gen_uuid_is_a_valid_random_v4_uuid() {
+    let client = SdkRandomNumberClient::new();
+    let uuid = Uuid::parse_str(&client.gen_uuid()).expect("a valid UUID string");
+    assert_eq!(uuid.get_version(), Some(uuid::Version::Random));
+    assert_eq!(uuid.get_variant(), uuid::Variant::RFC4122);
+}
+
+#[wasm_bindgen_test]
+fn gen_uuid_is_distinct() {
+    let client = SdkRandomNumberClient::new();
+    assert_ne!(client.gen_uuid(), client.gen_uuid());
+}
+
+#[wasm_bindgen_test]
+fn gen_range_stays_within_inclusive_bounds() {
+    let client = SdkRandomNumberClient::new();
+    for _ in 0..1000 {
+        let n = client.gen_range(10, 20).unwrap();
+        assert!((10..=20).contains(&n));
+    }
+    assert_eq!(client.gen_range(7, 7).unwrap(), 7);
+    // An inverted range returns an error instead of trapping.
+    assert!(client.gen_range(20, 10).is_err());
+}

--- a/crates/bitwarden-random/uniffi.toml
+++ b/crates/bitwarden-random/uniffi.toml
@@ -1,0 +1,11 @@
+[bindings.kotlin]
+package_name = "com.bitwarden.random"
+generate_immutable_records = true
+android = true
+# Temporary workaround for https://github.com/mozilla/uniffi-rs/issues/2740
+omit_checksums = true
+
+[bindings.swift]
+ffi_module_name = "BitwardenRandomFFI"
+module_name = "BitwardenRandom"
+generate_immutable_records = true

--- a/crates/bitwarden-ssh/Cargo.toml
+++ b/crates/bitwarden-ssh/Cargo.toml
@@ -25,6 +25,7 @@ uniffi = ["dep:uniffi"] # Uniffi bindings
 
 [dependencies]
 bitwarden-error = { workspace = true }
+bitwarden-random = { workspace = true }
 bitwarden-vault = { workspace = true }
 block-padding = { version = "=0.4.2" }
 ed25519 = { version = "3.0.0-rc.4", features = ["pkcs8"] }

--- a/crates/bitwarden-ssh/src/generator.rs
+++ b/crates/bitwarden-ssh/src/generator.rs
@@ -30,7 +30,7 @@ pub enum KeyAlgorithm {
 pub fn generate_sshkey(
     key_algorithm: KeyAlgorithm,
 ) -> Result<SshKeyView, error::KeyGenerationError> {
-    let mut rng = rand::rng();
+    let mut rng = bitwarden_random::rng();
     generate_sshkey_internal(key_algorithm, &mut rng)
 }
 

--- a/crates/bitwarden-uniffi/Cargo.toml
+++ b/crates/bitwarden-uniffi/Cargo.toml
@@ -36,6 +36,7 @@ bitwarden-importers = { workspace = true, features = ["uniffi"] }
 bitwarden-organizations = { workspace = true, features = ["uniffi"] }
 bitwarden-pm = { workspace = true, features = ["uniffi"] }
 bitwarden-policies = { workspace = true, features = ["uniffi"] }
+bitwarden-random = { workspace = true, features = ["uniffi"] }
 bitwarden-send = { workspace = true, features = ["uniffi"] }
 bitwarden-server-communication-config = { workspace = true, features = ["uniffi"] }
 bitwarden-ssh = { workspace = true, features = ["uniffi"] }

--- a/crates/bitwarden-uniffi/src/lib.rs
+++ b/crates/bitwarden-uniffi/src/lib.rs
@@ -117,6 +117,11 @@ impl Client {
         SshClient()
     }
 
+    /// Random-number generation operations
+    pub fn random(&self) -> bitwarden_random::SdkRandomNumberClient {
+        bitwarden_random::SdkRandomNumberClient::new()
+    }
+
     /// Auth operations
     pub fn auth(&self) -> AuthClient {
         AuthClient(self.0.0.clone())

--- a/crates/bitwarden-uniffi/swift/integration-tests/Tests/IntegrationTests/RandomNumberClientTests.swift
+++ b/crates/bitwarden-uniffi/swift/integration-tests/Tests/IntegrationTests/RandomNumberClientTests.swift
@@ -1,0 +1,47 @@
+import BitwardenSdk
+import XCTest
+
+/// Swift integration tests for `SdkRandomNumberClient`, the UniFFI binding for
+/// `bitwarden-random`'s cross-platform FFI.
+final class RandomNumberClientTests: XCTestCase {
+    func testGenBytesReturnsRequestedLength() throws {
+        let client = SdkRandomNumberClient()
+        XCTAssertEqual(try client.genBytes(len: 0).count, 0)
+        XCTAssertEqual(try client.genBytes(len: 32).count, 32)
+        // 1 KiB is the documented maximum and must succeed.
+        XCTAssertEqual(try client.genBytes(len: 1024).count, 1024)
+    }
+
+    func testGenBytesAboveLimitThrows() throws {
+        let client = SdkRandomNumberClient()
+        // Over the 1 KiB limit throws a catchable error instead of trapping.
+        XCTAssertThrowsError(try client.genBytes(len: 1025))
+    }
+
+    func testGenBytesIsRandom() throws {
+        let client = SdkRandomNumberClient()
+        XCTAssertNotEqual(try client.genBytes(len: 32), try client.genBytes(len: 32))
+    }
+
+    func testGenUuidIsAValidUuid() throws {
+        let client = SdkRandomNumberClient()
+        let uuid = client.genUuid()
+        XCTAssertNotNil(UUID(uuidString: uuid), "gen_uuid should return a parseable UUID string")
+    }
+
+    func testGenUuidIsDistinct() throws {
+        let client = SdkRandomNumberClient()
+        XCTAssertNotEqual(client.genUuid(), client.genUuid())
+    }
+
+    func testGenRangeStaysWithinInclusiveBounds() throws {
+        let client = SdkRandomNumberClient()
+        for _ in 0..<1000 {
+            let n = try client.genRange(min: 10, max: 20)
+            XCTAssertTrue((10...20).contains(n))
+        }
+        XCTAssertEqual(try client.genRange(min: 7, max: 7), 7)
+        // An inverted range throws a catchable error instead of trapping.
+        XCTAssertThrowsError(try client.genRange(min: 20, max: 10))
+    }
+}

--- a/crates/bitwarden-wasm-internal/Cargo.toml
+++ b/crates/bitwarden-wasm-internal/Cargo.toml
@@ -47,6 +47,7 @@ bitwarden-organization-crypto = { workspace = true, features = ["wasm"] }
 bitwarden-organization-invite-link = { workspace = true, features = ["wasm"] }
 bitwarden-pm = { workspace = true, features = ["wasm"] }
 bitwarden-policies = { workspace = true, features = ["wasm"] }
+bitwarden-random = { workspace = true, features = ["wasm"] }
 bitwarden-send = { workspace = true, features = ["wasm"] }
 bitwarden-server-communication-config = { workspace = true, features = ["wasm"] }
 bitwarden-shared-unlock = { workspace = true, features = ["wasm"] }

--- a/crates/bitwarden-wasm-internal/integration-tests/package-lock.json
+++ b/crates/bitwarden-wasm-internal/integration-tests/package-lock.json
@@ -1310,9 +1310,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1327,9 +1324,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1344,9 +1338,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1361,9 +1352,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1378,9 +1366,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1395,9 +1380,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1412,9 +1394,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1429,9 +1408,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1446,9 +1422,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1463,9 +1436,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [

--- a/crates/bitwarden-wasm-internal/integration-tests/tests/crypto/pure-crypto.test.ts
+++ b/crates/bitwarden-wasm-internal/integration-tests/tests/crypto/pure-crypto.test.ts
@@ -1,0 +1,21 @@
+import { PureCrypto } from "@bitwarden/sdk-internal";
+
+// `SymmetricKey` is exposed across the FFI as a base64-encoded `Tagged<string>`.
+const decode = (key: unknown): Buffer => Buffer.from(key as unknown as string, "base64");
+
+describe("PureCrypto.make_aes256_cbc_hmac_key", () => {
+  it("generates a 64-byte AES256-CBC-HMAC key", () => {
+    const key = PureCrypto.make_aes256_cbc_hmac_key();
+
+    // AES256-CBC-HMAC keys are 64 bytes: a 32-byte encryption key + a 32-byte MAC key.
+    expect(decode(key).length).toBe(64);
+  });
+
+  it("produces a distinct key on each call", () => {
+    const first = PureCrypto.make_aes256_cbc_hmac_key();
+    const second = PureCrypto.make_aes256_cbc_hmac_key();
+
+    // Two independently generated keys are overwhelmingly unlikely to collide.
+    expect(decode(first).equals(decode(second))).toBe(false);
+  });
+});

--- a/crates/bitwarden-wasm-internal/src/pure_crypto.rs
+++ b/crates/bitwarden-wasm-internal/src/pure_crypto.rs
@@ -150,6 +150,11 @@ impl PureCrypto {
             .to_vec()
     }
 
+    #[wasm_bindgen(unchecked_return_type = "SymmetricKey")]
+    pub fn make_aes256_cbc_hmac_key() -> SymmetricCryptoKey {
+        SymmetricCryptoKey::make(SymmetricKeyAlgorithm::Aes256CbcHmac)
+    }
+
     /// Wraps (encrypts) a symmetric key using a symmetric wrapping key, returning the wrapped key
     /// as an EncString.
     pub fn wrap_symmetric_key(
@@ -406,7 +411,7 @@ impl PureCrypto {
         let public_key = RsaPublicKey::from_public_key_der(public_key.as_slice())
             .map_err(|_| RsaError::KeyParse)?;
         let padding = Oaep::<Sha1>::new();
-        let mut rng = rand::rng();
+        let mut rng = bitwarden_random::rng();
         public_key
             .encrypt(&mut rng, padding, &plain_data)
             .map_err(|_| RsaError::Encryption)
@@ -414,13 +419,21 @@ impl PureCrypto {
 
     /// Generates a cryptographically secure random number between the given min and max
     /// (inclusive).
+    #[deprecated(
+        note = "Use `SdkRandomNumberClient::gen_range` instead. This method will be removed in a future release."
+    )]
+    #[allow(deprecated, reason = "wasm_bindgen glue calls this deprecated method")]
     pub fn random_number(min: u32, max: u32) -> u32 {
         let _span = tracing::info_span!("PureCrypto::random_number").entered();
-        let mut rng = rand::rng();
+        let mut rng = bitwarden_random::rng();
         rng.random_range(min..=max)
     }
 
     /// Generates a new v4 UUID using a cryptographically secure random number generator
+    #[deprecated(
+        note = "Use `SdkRandomNumberClient::gen_uuid` instead. This method will be removed in a future release."
+    )]
+    #[allow(deprecated, reason = "wasm_bindgen glue calls this deprecated method")]
     pub fn new_guid() -> String {
         let _span = tracing::info_span!("PureCrypto::new_guid").entered();
         uuid::Uuid::new_v4().to_string()
@@ -809,6 +822,10 @@ DnqOsltgPomWZ7xVfMkm9niL2OA=
     }
 
     #[test]
+    #[expect(
+        deprecated,
+        reason = "Exercises the deprecated new_guid until it is removed"
+    )]
     fn test_new_guid_is_v4_and_unique() {
         let first = PureCrypto::new_guid();
         let second = PureCrypto::new_guid();


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-39259
https://github.com/bitwarden/clients/pull/21576

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Adds the `bitwarden-random` crate and migrates callers to it. Currently, various crates directly use ThreadRng. ThreadRng does not use FIPS approved algorithms, and we want to use SysRng / OsRng instead. To make future changes easier, and to ease testing, instead of just migrating the callsites, we instead implement a new crate - `bitwarden-random` - that provides a struct that implements all necessary random traits.

By default it just maps through to SysRng. An optional feature for seeded testing is provided, that does not require breaking the public API of cryptographic functions by seeding a thread-local RNG. This is behind a compile time flag and should never be enabled in production.

Further, we add an FFI exposed client for making byte arrays and UUIDs for both wasm and swift. This is to consolidate the random implementations into just one.

## 🚨 Breaking Changes

<!-- Does this PR introduce any breaking changes? If so, please describe the impact and migration path for clients.

If you're unsure, the automated TypeScript compatibility check will run when you open/update this PR and provide feedback.

For breaking changes:
1. Describe what changed in the client interface
2. Explain why the change was necessary
3. Provide migration steps for client developers
4. Link to any paired client PRs if needed

Otherwise, you can remove this section. -->
