### PR TITLE
Make cryptographic provider more stable

### DIFF
--- a/crates/bitwarden-ipc/src/crypto_provider/noise/crypto_provider.rs
+++ b/crates/bitwarden-ipc/src/crypto_provider/noise/crypto_provider.rs
@@ -21,7 +21,6 @@ use crate::{
 };
 
 /// Noise-based crypto provider for IPC.
-
 #[derive(Default)]
 pub struct NoiseCryptoProvider {
     // Serializes all crypto-state access of this provider (its session repository): concurrent
@@ -776,18 +775,6 @@ mod tests {
     /// must not destroy a *freshly established* session. `CryptoInvalidated` echoes the session
     /// id of the offending transport frame, and the receiver ignores invalidations that do not
     /// match its current session.
-    ///
-    /// This ordering is realistic even over an in-order transport, because the client consumes
-    /// the incoming frame stream through two independent subscribers (the main receive loop and
-    /// the per-handshake subscription in `perform_handshake`): the main loop can process a stale
-    /// `CryptoInvalidated` *after* the handshake subscription has already completed a new
-    /// handshake.
-    ///
-    /// Sequence: peer restarts (loses its session) → client's msg1 (old session S1) is answered
-    /// with `CryptoInvalidated{S1}` → client immediately re-handshakes and retransmits msg1
-    /// under fresh S2, then delivers msg2 on the same session → a second, delayed
-    /// `CryptoInvalidated{S1}` (for another stale-session message) arrives and must be ignored,
-    /// keeping S2 intact.
     #[tokio::test]
     async fn delayed_crypto_invalidated_does_not_destroy_fresh_session() {
         let (client, peer_backend, peer_receiver) = client_with_scripted_peer().await;

--- a/crates/bitwarden-ipc/src/crypto_provider/noise/crypto_provider.rs
+++ b/crates/bitwarden-ipc/src/crypto_provider/noise/crypto_provider.rs
@@ -165,9 +165,10 @@ impl NoiseCryptoProvider {
     /// Encrypts `payload` under the existing session for `destination`, stamps it with
     /// `message_id` and sends it as a transport frame.
     ///
-    /// Preconditions: the caller holds the provider's crypto-state guard and a session for `destination`
-    /// exists (established by a preceding handshake under the same guard). Takes no lock itself
-    /// so it can be shared by `send` and the retransmit recovery path without double-locking.
+    /// Preconditions: the caller holds the provider's crypto-state guard and a session for
+    /// `destination` exists (established by a preceding handshake under the same guard). Takes
+    /// no lock itself so it can be shared by `send` and the retransmit recovery path without
+    /// double-locking.
     ///
     /// Returns the id of the session the frame was sent under, so callers can tag retransmit
     /// buffer entries.
@@ -1036,8 +1037,7 @@ mod tests {
         );
 
         // The lost message is retransmitted under the new session with its original message id.
-        let Frame::TransportFrame(retransmitted) = peer_receive_frame(&peer_receiver).await
-        else {
+        let Frame::TransportFrame(retransmitted) = peer_receive_frame(&peer_receiver).await else {
             panic!("Expected the lost message to be retransmitted as a TransportFrame");
         };
         assert_eq!(
@@ -1119,8 +1119,7 @@ mod tests {
         let mut new_peer_session = peer_answer_handshake(&peer_backend, &peer_receiver).await;
 
         // Only "b" is retransmitted: "establish" and "a" were confirmed by the echoed id.
-        let Frame::TransportFrame(retransmitted) = peer_receive_frame(&peer_receiver).await
-        else {
+        let Frame::TransportFrame(retransmitted) = peer_receive_frame(&peer_receiver).await else {
             panic!("Expected the lost message to be retransmitted as a TransportFrame");
         };
         assert_eq!(retransmitted.message_id, frame_b.message_id);

--- a/crates/bitwarden-ipc/src/crypto_provider/noise/crypto_provider.rs
+++ b/crates/bitwarden-ipc/src/crypto_provider/noise/crypto_provider.rs
@@ -1,4 +1,4 @@
-use std::{sync::LazyLock, time::Duration};
+use std::time::Duration;
 
 use bitwarden_threading::time::timeout;
 use serde::{Deserialize, Serialize};
@@ -10,7 +10,8 @@ use crate::{
             CipherSuite, HandshakeFinishMessage, HandshakeInitiator, HandshakeResponder,
             HandshakeStartMessage,
         },
-        transport_state::{PersistentTransportState, TransportFrame},
+        retransmit_buffer::{BufferedSend, RetransmitBuffer},
+        transport_state::{PersistentTransportState, SessionId, TransportFrame},
     },
     error::IpcErrorKind,
     message::{IncomingMessage, OutgoingMessage},
@@ -19,7 +20,27 @@ use crate::{
     },
 };
 
-pub struct NoiseCryptoProvider;
+/// Noise-based crypto provider for IPC.
+
+#[derive(Default)]
+pub struct NoiseCryptoProvider {
+    // Serializes all crypto-state access of this provider (its session repository): concurrent
+    // operations could otherwise read the same persisted transport state before the nonce is
+    // updated, and nonce re-use is a catastrophic cryptographic failure. Scoped to the provider
+    // because session repositories are per client; unrelated clients in the same process need
+    // no serialization against each other.
+    crypto_state_guard: tokio::sync::Mutex<()>,
+    // Sent plaintexts retained for retransmission after a session invalidation. Only accessed
+    // while `crypto_state_guard` is held and never across an await point
+    retransmit_buffer: std::sync::Mutex<RetransmitBuffer>,
+}
+
+impl NoiseCryptoProvider {
+    /// Creates a new provider
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
 
 #[derive(Debug)]
 pub enum NoiseCryptoProviderError {
@@ -53,11 +74,6 @@ impl IpcErrorKind for NoiseCryptoProviderError {
         }
     }
 }
-
-// Serialize send operations to prevent concurrent reads of the same persisted
-// transport state, which can cause nonce reuse.
-static CRYPTO_STATE_GUARD: LazyLock<tokio::sync::Mutex<()>> =
-    LazyLock::new(|| tokio::sync::Mutex::new(()));
 
 impl NoiseCryptoProvider {
     async fn perform_handshake<Com, Ses>(
@@ -145,6 +161,57 @@ impl NoiseCryptoProvider {
 
         Ok(())
     }
+
+    /// Encrypts `payload` under the existing session for `destination`, stamps it with
+    /// `message_id` and sends it as a transport frame.
+    ///
+    /// Preconditions: the caller holds the provider's crypto-state guard and a session for `destination`
+    /// exists (established by a preceding handshake under the same guard). Takes no lock itself
+    /// so it can be shared by `send` and the retransmit recovery path without double-locking.
+    ///
+    /// Returns the id of the session the frame was sent under, so callers can tag retransmit
+    /// buffer entries.
+    async fn encrypt_and_send_with_session<Com, Ses>(
+        communication: &Com,
+        sessions: &Ses,
+        destination: crate::endpoint::Endpoint,
+        payload: &[u8],
+        topic: Option<String>,
+        message_id: u64,
+    ) -> Result<SessionId, NoiseCryptoProviderError>
+    where
+        Com: CommunicationBackend,
+        Ses: SessionRepository<NoiseCryptoProviderState>,
+    {
+        let mut crypto_state = sessions
+            .get(destination.clone())
+            .await
+            .expect("Get session should not fail")
+            .expect("Session should exist after handshake");
+
+        let transport_frame = crypto_state
+            .state
+            .send(payload.to_vec().into(), message_id)
+            .map_err(|_| NoiseCryptoProviderError::DecryptionFailure)?;
+        let session_id = transport_frame.session_id.clone();
+        communication
+            .send(OutgoingMessage {
+                payload: Frame::TransportFrame(transport_frame).to_cbor(),
+                destination: destination.clone(),
+                topic,
+            })
+            .await
+            .map_err(|e| NoiseCryptoProviderError::TransportSend {
+                fatal: e.is_fatal(),
+            })?;
+
+        sessions
+            .save(destination, crypto_state)
+            .await
+            .expect("Save session should not fail");
+
+        Ok(session_id)
+    }
 }
 
 /// Re-handshake interval in seconds. Sessions older than this will automatically
@@ -178,7 +245,7 @@ where
         // Send operations *MUST* be serialized, otherwise nonce re-use may happen since
         // concurrent sends may acquire the same copy of the transport state before nonce
         // updating.
-        let _crypto_state_guard = CRYPTO_STATE_GUARD.lock().await;
+        let _crypto_state_guard = self.crypto_state_guard.lock().await;
 
         let destination = message.destination.clone();
 
@@ -199,6 +266,12 @@ where
                 .remove(destination.clone())
                 .await
                 .expect("Delete session should not fail");
+            // The old session was healthy, so its buffered messages are presumed delivered, and
+            // an invalidation for it can no longer match once the new session is established.
+            self.retransmit_buffer
+                .lock()
+                .expect("Retransmit buffer mutex should not be poisoned")
+                .clear_endpoint(&destination);
             should_handshake = true;
         }
 
@@ -218,32 +291,39 @@ where
             Self::perform_handshake(communication, sessions, destination.clone()).await?;
         }
 
-        let mut crypto_state = sessions
-            .get(destination.clone())
-            .await
-            .expect("Get session should not fail")
-            .expect("Session should exist after handshake");
+        let message_id = self
+            .retransmit_buffer
+            .lock()
+            .expect("Retransmit buffer mutex should not be poisoned")
+            .next_message_id(&destination);
+        let payload = zeroize::Zeroizing::new(message.payload);
 
         // Encrypt and send the payload
-        let transport_frame = crypto_state
-            .state
-            .send(message.payload.into())
-            .map_err(|_| NoiseCryptoProviderError::DecryptionFailure)?;
-        communication
-            .send(OutgoingMessage {
-                payload: Frame::TransportFrame(transport_frame).to_cbor(),
-                destination: destination.clone(),
-                topic: message.topic,
-            })
-            .await
-            .map_err(|e| NoiseCryptoProviderError::TransportSend {
-                fatal: e.is_fatal(),
-            })?;
+        let session_id = Self::encrypt_and_send_with_session(
+            communication,
+            sessions,
+            destination.clone(),
+            &payload,
+            message.topic.clone(),
+            message_id,
+        )
+        .await?;
 
-        sessions
-            .save(destination, crypto_state)
-            .await
-            .expect("Save session should not fail");
+        // Only a message that actually went out is retained for retransmission; buffering a
+        // failed send would duplicate it when the caller retries.
+        self.retransmit_buffer
+            .lock()
+            .expect("Retransmit buffer mutex should not be poisoned")
+            .record(
+                destination,
+                BufferedSend {
+                    payload,
+                    topic: message.topic,
+                    session_id,
+                    message_id,
+                    retransmissions: 0,
+                },
+            );
 
         Ok(())
     }
@@ -300,14 +380,18 @@ where
                         .expect("Save session should not fail");
                 }
                 Frame::TransportFrame(transport_frame) => {
-                    let _crypto_state_guard = CRYPTO_STATE_GUARD.lock().await;
+                    let _crypto_state_guard = self.crypto_state_guard.lock().await;
                     let crypto_state = sessions
                         .get(source_endpoint.clone())
                         .await
                         .expect("Get session should not fail");
                     let Some(mut state) = crypto_state else {
                         info!("No session for {:?}, waiting for handshake", message.source);
-                        let frame = Frame::CryptoInvalidated.to_cbor();
+                        let frame = Frame::CryptoInvalidated {
+                            session_id: transport_frame.session_id.clone(),
+                            message_id: transport_frame.message_id,
+                        }
+                        .to_cbor();
                         communication
                             .send(OutgoingMessage {
                                 payload: frame,
@@ -339,17 +423,114 @@ where
                         topic: message.topic,
                     });
                 }
-                Frame::CryptoInvalidated => {
+                Frame::CryptoInvalidated {
+                    session_id,
+                    message_id,
+                } => {
+                    let _crypto_state_guard = self.crypto_state_guard.lock().await;
+                    let crypto_state = sessions
+                        .get(source_endpoint.clone())
+                        .await
+                        .expect("Get session should not fail");
+                    let Some(state) = crypto_state else {
+                        info!(
+                            "Received CryptoInvalidated from {:?} but no session exists, ignoring",
+                            message.source
+                        );
+                        continue;
+                    };
+                    // Only an invalidation bound to the *current* session may destroy it.
+                    if state.state.session_id() != &session_id {
+                        info!(
+                            "Received CryptoInvalidated from {:?} for a different session, ignoring",
+                            message.source
+                        );
+                        continue;
+                    }
                     info!(
-                        "Invalidated session for {:?} due to crypto error, deleting session and waiting for handshake",
+                        "Invalidated session for {:?} due to crypto error, deleting session",
                         message.source
                     );
                     sessions
-                        .remove(source_endpoint)
+                        .remove(source_endpoint.clone())
                         .await
                         .expect("Delete session should not fail");
+
+                    // Recover the messages the peer signalled as unprocessed (message id >= the
+                    // echoed one): re-establish the session and retransmit them, so the peer
+                    // losing its session state does not silently lose messages.
+                    let lost = self
+                        .retransmit_buffer
+                        .lock()
+                        .expect("Retransmit buffer mutex should not be poisoned")
+                        .take_from(&source_endpoint, &session_id, message_id);
+                    info!(
+                        "Re-handshaking with {:?} and retransmitting {} message(s) the peer could not process",
+                        message.source,
+                        lost.len()
+                    );
+                    if let Err(error) =
+                        Self::perform_handshake(communication, sessions, source_endpoint.clone())
+                            .await
+                    {
+                        warn!(
+                            ?error,
+                            "Recovery re-handshake failed, dropping the peer's lost messages"
+                        );
+                        continue;
+                    }
+                    for entry in lost {
+                        // A retransmit keeps its original message id: it is the same logical
+                        // message, re-sent under a fresh session.
+                        match Self::encrypt_and_send_with_session(
+                            communication,
+                            sessions,
+                            source_endpoint.clone(),
+                            &entry.payload,
+                            entry.topic.clone(),
+                            entry.message_id,
+                        )
+                        .await
+                        {
+                            Ok(new_session_id) => {
+                                // Re-buffer under the fresh session so a peer that loses its
+                                // state again mid-recovery gets another chance, bounded by the
+                                // per-message retransmission budget.
+                                self.retransmit_buffer
+                                    .lock()
+                                    .expect("Retransmit buffer mutex should not be poisoned")
+                                    .record(
+                                        source_endpoint.clone(),
+                                        BufferedSend {
+                                            payload: entry.payload,
+                                            topic: entry.topic,
+                                            session_id: new_session_id,
+                                            message_id: entry.message_id,
+                                            retransmissions: entry.retransmissions + 1,
+                                        },
+                                    );
+                            }
+                            Err(error) => {
+                                // Dropping the remainder preserves per-endpoint ordering: never
+                                // send a later message when an earlier one failed.
+                                warn!(
+                                    ?error,
+                                    "Retransmit failed, dropping the remaining lost messages"
+                                );
+                                break;
+                            }
+                        }
+                    }
                 }
-                _ => continue,
+                // E.g. a HandshakeFinish already consumed by the per-handshake subscription in
+                // `perform_handshake`; its copy in the main loop's receiver is expected noise.
+                frame => {
+                    tracing::debug!(
+                        "Ignoring {} frame in the main receive loop",
+                        frame.variant_name()
+                    );
+                    continue;
+                }
             }
         }
     }
@@ -363,9 +544,13 @@ pub(super) enum Frame {
     HandshakeFinish(HandshakeFinishMessage),
     // After the handshake is done, transport frames are used to wrap ciphertexts
     TransportFrame(TransportFrame),
-    // If crypto is invalidated, this message is sent by the device noticing
-    // the invalidation so that both sides reset the crypto.
-    CryptoInvalidated,
+    // If crypto is invalidated, this message is sent by the device noticing the invalidation so
+    // that both sides reset the crypto.
+    CryptoInvalidated {
+        session_id: SessionId,
+        #[serde(default)]
+        message_id: u64,
+    },
 }
 
 impl Frame {
@@ -378,19 +563,39 @@ impl Frame {
     pub(crate) fn from_cbor(buffer: &[u8]) -> Result<Self, ()> {
         ciborium::from_reader(buffer).map_err(|_| ())
     }
+
+    /// Returns the frame variant name for logging, without exposing any payload or key material.
+    fn variant_name(&self) -> &'static str {
+        match self {
+            Frame::HandshakeStart(_) => "HandshakeStart",
+            Frame::HandshakeFinish(_) => "HandshakeFinish",
+            Frame::TransportFrame(_) => "TransportFrame",
+            Frame::CryptoInvalidated { .. } => "CryptoInvalidated",
+        }
+    }
 }
 
 #[cfg(test)]
 mod tests {
-    use std::collections::HashMap;
+    use std::{collections::HashMap, time::Duration};
 
+    use super::Frame;
     use crate::{
         IpcClientImpl,
-        crypto_provider::noise::crypto_provider::NoiseCryptoProvider,
+        crypto_provider::noise::{
+            crypto_provider::NoiseCryptoProvider,
+            handshake::{CipherSuite, HandshakeInitiator, HandshakeResponder},
+            transport_state::{
+                Payload, PersistentTransportState, SESSION_ID_SIZE, SessionId, TransportFrame,
+            },
+        },
         endpoint::Endpoint,
         ipc_client_trait::IpcClient,
         message::OutgoingMessage,
-        traits::{InMemorySessionRepository, TestTwoWayCommunicationBackend},
+        traits::{
+            CommunicationBackend, CommunicationBackendReceiver, InMemorySessionRepository,
+            TestTwoWayCommunicationBackend,
+        },
     };
 
     #[tokio::test]
@@ -398,12 +603,12 @@ mod tests {
         let (provider_1, provider_2) = TestTwoWayCommunicationBackend::new();
 
         let session_map_1 = InMemorySessionRepository::new(HashMap::new());
-        let client_1 = IpcClientImpl::new(NoiseCryptoProvider, provider_1, session_map_1);
+        let client_1 = IpcClientImpl::new(NoiseCryptoProvider::new(), provider_1, session_map_1);
         let _ = client_1.start(None).await;
         let mut recv_1 = client_1.subscribe(None).await.unwrap();
 
         let session_map_2 = InMemorySessionRepository::new(HashMap::new());
-        let client_2 = IpcClientImpl::new(NoiseCryptoProvider, provider_2, session_map_2);
+        let client_2 = IpcClientImpl::new(NoiseCryptoProvider::new(), provider_2, session_map_2);
         let _ = client_2.start(None).await;
         let mut recv_2 = client_2.subscribe(None).await.unwrap();
 
@@ -441,5 +646,605 @@ mod tests {
         });
 
         let _ = tokio::join!(handle_1, handle_2);
+    }
+
+    /// The endpoint under which the scripted peer's frames arrive at the client.
+    /// `TestTwoWayCommunicationBackendReceiver` stamps every incoming message with
+    /// `Source::DesktopMain`, so the client keys its session for the peer under this endpoint.
+    const PEER_ENDPOINT: Endpoint = Endpoint::DesktopMain;
+
+    /// Creates a real noise IPC client on one side of a two-way test backend and returns the
+    /// other side as a raw backend for a scripted peer, plus a raw-frame receiver for it.
+    async fn client_with_scripted_peer() -> (
+        IpcClientImpl<
+            NoiseCryptoProvider,
+            TestTwoWayCommunicationBackend,
+            InMemorySessionRepository<super::NoiseCryptoProviderState>,
+        >,
+        TestTwoWayCommunicationBackend,
+        impl CommunicationBackendReceiver<ReceiveError = ()>,
+    ) {
+        let (client_backend, peer_backend) = TestTwoWayCommunicationBackend::new();
+        // Subscribe the peer before the client is started so no frame can be missed.
+        let peer_receiver = peer_backend.subscribe().await;
+        let client = IpcClientImpl::new(
+            NoiseCryptoProvider::new(),
+            client_backend,
+            InMemorySessionRepository::new(HashMap::new()),
+        );
+        client.start(None).await.expect("Client should start");
+        (client, peer_backend, peer_receiver)
+    }
+
+    /// Receives and decodes the next raw frame arriving at the scripted peer.
+    async fn peer_receive_frame(
+        peer_receiver: &impl CommunicationBackendReceiver<ReceiveError = ()>,
+    ) -> Frame {
+        let message = tokio::time::timeout(Duration::from_secs(1), peer_receiver.receive())
+            .await
+            .expect("Peer should receive a frame in time")
+            .expect("Receive should not fail");
+        Frame::from_cbor(&message.payload).expect("Peer should receive valid cbor frames")
+    }
+
+    /// Sends a raw frame from the scripted peer to the client.
+    async fn peer_send_frame(peer_backend: &TestTwoWayCommunicationBackend, frame: Frame) {
+        peer_backend
+            .send(OutgoingMessage {
+                payload: frame.to_cbor(),
+                destination: PEER_ENDPOINT,
+                topic: None,
+            })
+            .await
+            .expect("Peer send should not fail");
+    }
+
+    /// Establishes a session between the client and the scripted peer (peer as honest
+    /// responder) by driving one client `send` through the handshake, and verifies the sent
+    /// payload decrypts on the peer side. Returns the peer's transport state for the session
+    /// and the transport frame the client sent (so tests can echo its ids in invalidations).
+    async fn establish_session_with_peer(
+        client: &IpcClientImpl<
+            NoiseCryptoProvider,
+            TestTwoWayCommunicationBackend,
+            InMemorySessionRepository<super::NoiseCryptoProviderState>,
+        >,
+        peer_backend: &TestTwoWayCommunicationBackend,
+        peer_receiver: &impl CommunicationBackendReceiver<ReceiveError = ()>,
+    ) -> (PersistentTransportState, TransportFrame) {
+        let client_for_send = client.clone();
+        let send_task = tokio::spawn(async move {
+            client_for_send
+                .send(OutgoingMessage {
+                    payload: b"establish".to_vec(),
+                    destination: PEER_ENDPOINT,
+                    topic: None,
+                })
+                .await
+        });
+        let Frame::HandshakeStart(start) = peer_receive_frame(peer_receiver).await else {
+            panic!("Expected HandshakeStart from client");
+        };
+        let mut responder = HandshakeResponder::new(&start.ciphersuite);
+        responder
+            .read_start_message(&start)
+            .expect("Peer should read HandshakeStart");
+        let finish = responder
+            .write_response_message()
+            .expect("Handshake finish message should be buildable");
+        peer_send_frame(peer_backend, Frame::HandshakeFinish(finish)).await;
+        let mut peer_session: PersistentTransportState = (&mut responder).into();
+        send_task
+            .await
+            .expect("Send task should not panic")
+            .expect("Client send should succeed");
+        let Frame::TransportFrame(frame) = peer_receive_frame(peer_receiver).await else {
+            panic!("Expected TransportFrame from client");
+        };
+        assert_eq!(
+            peer_session
+                .receive(&frame)
+                .expect("Established session should decrypt the client's payload")
+                .as_ref(),
+            b"establish"
+        );
+        (peer_session, frame)
+    }
+
+    /// Scripted-peer half of a handshake: answers the client's `HandshakeStart` as an honest
+    /// responder and returns the resulting peer transport state.
+    async fn peer_answer_handshake(
+        peer_backend: &TestTwoWayCommunicationBackend,
+        peer_receiver: &impl CommunicationBackendReceiver<ReceiveError = ()>,
+    ) -> PersistentTransportState {
+        let Frame::HandshakeStart(start) = peer_receive_frame(peer_receiver).await else {
+            panic!("Expected HandshakeStart from client");
+        };
+        let mut responder = HandshakeResponder::new(&start.ciphersuite);
+        responder
+            .read_start_message(&start)
+            .expect("Peer should read HandshakeStart");
+        let finish = responder
+            .write_response_message()
+            .expect("Handshake finish message should be buildable");
+        peer_send_frame(peer_backend, Frame::HandshakeFinish(finish)).await;
+        (&mut responder).into()
+    }
+
+    /// A delayed/stale `CryptoInvalidated` — generated for a message sent on an *old* session —
+    /// must not destroy a *freshly established* session. `CryptoInvalidated` echoes the session
+    /// id of the offending transport frame, and the receiver ignores invalidations that do not
+    /// match its current session.
+    ///
+    /// This ordering is realistic even over an in-order transport, because the client consumes
+    /// the incoming frame stream through two independent subscribers (the main receive loop and
+    /// the per-handshake subscription in `perform_handshake`): the main loop can process a stale
+    /// `CryptoInvalidated` *after* the handshake subscription has already completed a new
+    /// handshake.
+    ///
+    /// Sequence: peer restarts (loses its session) → client's msg1 (old session S1) is answered
+    /// with `CryptoInvalidated{S1}` → client immediately re-handshakes and retransmits msg1
+    /// under fresh S2, then delivers msg2 on the same session → a second, delayed
+    /// `CryptoInvalidated{S1}` (for another stale-session message) arrives and must be ignored,
+    /// keeping S2 intact.
+    #[tokio::test]
+    async fn delayed_crypto_invalidated_does_not_destroy_fresh_session() {
+        let (client, peer_backend, peer_receiver) = client_with_scripted_peer().await;
+        let mut client_subscription = client.subscribe(None).await.unwrap();
+
+        // Establish a healthy session S1 (peer as honest responder).
+        let client_for_send = client.clone();
+        let send_task = tokio::spawn(async move {
+            client_for_send
+                .send(OutgoingMessage {
+                    payload: b"msg0".to_vec(),
+                    destination: PEER_ENDPOINT,
+                    topic: None,
+                })
+                .await
+        });
+        let Frame::HandshakeStart(start_1) = peer_receive_frame(&peer_receiver).await else {
+            panic!("Expected HandshakeStart from client");
+        };
+        let mut responder_1 = HandshakeResponder::new(&start_1.ciphersuite);
+        responder_1
+            .read_start_message(&start_1)
+            .expect("Peer should read HandshakeStart");
+        let finish_1 = responder_1
+            .write_response_message()
+            .expect("Handshake finish message should be buildable");
+        peer_send_frame(&peer_backend, Frame::HandshakeFinish(finish_1)).await;
+        let mut peer_session_1: PersistentTransportState = (&mut responder_1).into();
+        send_task
+            .await
+            .expect("Send task should not panic")
+            .expect("Client send should succeed");
+        let Frame::TransportFrame(frame_msg0) = peer_receive_frame(&peer_receiver).await else {
+            panic!("Expected TransportFrame(msg0) from client");
+        };
+        assert_eq!(
+            peer_session_1
+                .receive(&frame_msg0)
+                .expect("Session S1 should decrypt msg0")
+                .as_ref(),
+            b"msg0"
+        );
+
+        // Peer "restarts": it forgets S1. The client's next message is encrypted under S1, so
+        // the restarted peer answers with CryptoInvalidated (this is the designed reset path).
+        client
+            .send(OutgoingMessage {
+                payload: b"msg1".to_vec(),
+                destination: PEER_ENDPOINT,
+                topic: None,
+            })
+            .await
+            .expect("Client send should succeed");
+        let Frame::TransportFrame(stale_frame) = peer_receive_frame(&peer_receiver).await else {
+            panic!("Expected TransportFrame(msg1) from client");
+        };
+        // A restarted peer has no session, so it echoes the offending frame's session and
+        // message id (S1, msg1). The client immediately re-handshakes to retransmit the lost
+        // msg1 — the peer answers as responder.
+        peer_send_frame(
+            &peer_backend,
+            Frame::CryptoInvalidated {
+                session_id: stale_frame.session_id.clone(),
+                message_id: stale_frame.message_id,
+            },
+        )
+        .await;
+        let Frame::HandshakeStart(start_2) = peer_receive_frame(&peer_receiver).await else {
+            panic!("Expected recovery HandshakeStart from client");
+        };
+        let mut responder_2 = HandshakeResponder::new(&start_2.ciphersuite);
+        responder_2
+            .read_start_message(&start_2)
+            .expect("Peer should read HandshakeStart");
+        let finish_2 = responder_2
+            .write_response_message()
+            .expect("Handshake finish message should be buildable");
+        peer_send_frame(&peer_backend, Frame::HandshakeFinish(finish_2)).await;
+        let mut peer_session_2: PersistentTransportState = (&mut responder_2).into();
+
+        // The lost msg1 is retransmitted under fresh S2 (msg0 was confirmed delivered by the
+        // echoed message id and is not resent).
+        let Frame::TransportFrame(frame_msg1) = peer_receive_frame(&peer_receiver).await else {
+            panic!("Expected retransmitted TransportFrame(msg1) from client");
+        };
+        assert_eq!(
+            peer_session_2
+                .receive(&frame_msg1)
+                .expect("Session S2 should decrypt the retransmitted msg1")
+                .as_ref(),
+            b"msg1"
+        );
+
+        // The client's next send reuses S2 — no further handshake — and msg2 is delivered.
+        client
+            .send(OutgoingMessage {
+                payload: b"msg2".to_vec(),
+                destination: PEER_ENDPOINT,
+                topic: None,
+            })
+            .await
+            .expect("Client send should succeed");
+        let Frame::TransportFrame(frame_msg2) = peer_receive_frame(&peer_receiver).await else {
+            panic!("Expected TransportFrame(msg2) from client");
+        };
+        assert_eq!(
+            peer_session_2
+                .receive(&frame_msg2)
+                .expect("Session S2 should decrypt msg2")
+                .as_ref(),
+            b"msg2"
+        );
+
+        // A second, *delayed* CryptoInvalidated for S1 arrives (in production: generated for
+        // another message sent on stale S1, but processed by the main receive loop only after
+        // the re-handshake completed). It must NOT affect the healthy session S2.
+        peer_send_frame(
+            &peer_backend,
+            Frame::CryptoInvalidated {
+                session_id: stale_frame.session_id.clone(),
+                message_id: stale_frame.message_id,
+            },
+        )
+        .await;
+        for _ in 0..10 {
+            tokio::task::yield_now().await;
+        }
+
+        // Session S2 survives the stale invalidation, so the peer's next message is decrypted
+        // and delivered.
+        let peer_frame = peer_session_2
+            .send(Payload(b"after-stale-invalidation".to_vec()), 1)
+            .expect("Peer encryption should succeed");
+        peer_send_frame(&peer_backend, Frame::TransportFrame(peer_frame)).await;
+        let received = tokio::time::timeout(
+            Duration::from_secs(1),
+            client_subscription.receive(None),
+        )
+        .await
+        .expect(
+            "the fresh session must survive a stale CryptoInvalidated and deliver the peer's \
+                 message, but nothing was delivered (the fresh session was destroyed)",
+        )
+        .expect("Receive should not fail");
+        assert_eq!(received.payload, b"after-stale-invalidation");
+    }
+
+    /// A `CryptoInvalidated` bound to a session id *different* from the client's current session
+    /// must be ignored: the session survives and stays usable in both directions, without any
+    /// re-handshake.
+    #[tokio::test]
+    async fn crypto_invalidated_with_mismatched_session_id_is_ignored() {
+        let (client, peer_backend, peer_receiver) = client_with_scripted_peer().await;
+        let mut client_subscription = client.subscribe(None).await.unwrap();
+        let (mut peer_session, _) =
+            establish_session_with_peer(&client, &peer_backend, &peer_receiver).await;
+
+        // An invalidation for some *other* session must not affect the current one.
+        let wrong_id = SessionId([0xAB; SESSION_ID_SIZE]);
+        assert_ne!(
+            &wrong_id,
+            peer_session.session_id(),
+            "precondition: the fabricated id must differ from the current session's id"
+        );
+        peer_send_frame(
+            &peer_backend,
+            Frame::CryptoInvalidated {
+                session_id: wrong_id,
+                message_id: 1,
+            },
+        )
+        .await;
+        // Let the client's receive loop process the invalidation deterministically
+        // (current-thread test runtime: yielding runs all ready tasks).
+        for _ in 0..10 {
+            tokio::task::yield_now().await;
+        }
+
+        // Peer -> client still decrypts and delivers.
+        let peer_frame = peer_session
+            .send(Payload(b"still-alive".to_vec()), 1)
+            .expect("Peer encryption should succeed");
+        peer_send_frame(&peer_backend, Frame::TransportFrame(peer_frame)).await;
+        let received = tokio::time::timeout(
+            Duration::from_secs(1),
+            client_subscription.receive(None),
+        )
+        .await
+        .expect(
+            "the session must survive a mismatched CryptoInvalidated, but nothing was delivered",
+        )
+        .expect("Receive should not fail");
+        assert_eq!(received.payload, b"still-alive");
+
+        // Client -> peer still uses the same session: the next send must be a transport frame,
+        // not a re-handshake.
+        client
+            .send(OutgoingMessage {
+                payload: b"no-rehandshake".to_vec(),
+                destination: PEER_ENDPOINT,
+                topic: None,
+            })
+            .await
+            .expect("Client send should succeed");
+        let Frame::TransportFrame(frame) = peer_receive_frame(&peer_receiver).await else {
+            panic!(
+                "Expected TransportFrame — a HandshakeStart would mean the session was wrongly \
+                 invalidated"
+            );
+        };
+        assert_eq!(
+            peer_session
+                .receive(&frame)
+                .expect("The surviving session should decrypt the client's payload")
+                .as_ref(),
+            b"no-rehandshake"
+        );
+    }
+
+    /// A `CryptoInvalidated` carrying the client's *current* session id is the designed reset
+    /// path: the client deletes the session, immediately re-handshakes, and transparently
+    /// retransmits the message the peer could not process — keeping its original message id —
+    /// so a peer that lost its session state loses no messages. Subsequent sends reuse the
+    /// fresh session without another handshake.
+    #[tokio::test]
+    async fn crypto_invalidated_with_current_session_id_invalidates_and_retransmits() {
+        let (client, peer_backend, peer_receiver) = client_with_scripted_peer().await;
+        let (peer_session, establish_frame) =
+            establish_session_with_peer(&client, &peer_backend, &peer_receiver).await;
+
+        // The peer "lost" its session: it echoes the offending frame's session and message id.
+        peer_send_frame(
+            &peer_backend,
+            Frame::CryptoInvalidated {
+                session_id: peer_session.session_id().clone(),
+                message_id: establish_frame.message_id,
+            },
+        )
+        .await;
+
+        // The client immediately starts a recovery handshake; the peer answers it.
+        let mut new_peer_session = peer_answer_handshake(&peer_backend, &peer_receiver).await;
+        assert_ne!(
+            peer_session.session_id(),
+            new_peer_session.session_id(),
+            "the re-handshake must establish a session with a new id"
+        );
+
+        // The lost message is retransmitted under the new session with its original message id.
+        let Frame::TransportFrame(retransmitted) = peer_receive_frame(&peer_receiver).await
+        else {
+            panic!("Expected the lost message to be retransmitted as a TransportFrame");
+        };
+        assert_eq!(
+            retransmitted.message_id, establish_frame.message_id,
+            "a retransmitted message must keep its original message id"
+        );
+        assert_eq!(
+            new_peer_session
+                .receive(&retransmitted)
+                .expect("The new session should decrypt the retransmitted payload")
+                .as_ref(),
+            b"establish"
+        );
+
+        // The next send reuses the fresh session: a transport frame, not another handshake.
+        client
+            .send(OutgoingMessage {
+                payload: b"after-reset".to_vec(),
+                destination: PEER_ENDPOINT,
+                topic: None,
+            })
+            .await
+            .expect("Client send should succeed");
+        let Frame::TransportFrame(frame) = peer_receive_frame(&peer_receiver).await else {
+            panic!("Expected TransportFrame — the recovery already re-established the session");
+        };
+        assert_eq!(
+            new_peer_session
+                .receive(&frame)
+                .expect("The new session should decrypt the client's payload")
+                .as_ref(),
+            b"after-reset"
+        );
+    }
+
+    /// The echoed message id is the retransmission cursor: everything the peer processed (lower
+    /// ids) stays confirmed, everything from the echoed id onwards is retransmitted in order.
+    #[tokio::test]
+    async fn retransmit_starts_at_the_echoed_message_id() {
+        let (client, peer_backend, peer_receiver) = client_with_scripted_peer().await;
+        let (mut peer_session, establish_frame) =
+            establish_session_with_peer(&client, &peer_backend, &peer_receiver).await;
+
+        // Two more messages; the peer processes "a" but "restarts" before processing "b".
+        for payload in [b"a".to_vec(), b"b".to_vec()] {
+            client
+                .send(OutgoingMessage {
+                    payload,
+                    destination: PEER_ENDPOINT,
+                    topic: None,
+                })
+                .await
+                .expect("Client send should succeed");
+        }
+        let Frame::TransportFrame(frame_a) = peer_receive_frame(&peer_receiver).await else {
+            panic!("Expected TransportFrame(a) from client");
+        };
+        assert_eq!(
+            peer_session
+                .receive(&frame_a)
+                .expect("Session should decrypt a")
+                .as_ref(),
+            b"a"
+        );
+        let Frame::TransportFrame(frame_b) = peer_receive_frame(&peer_receiver).await else {
+            panic!("Expected TransportFrame(b) from client");
+        };
+
+        // The restarted peer echoes the first frame it could not process: "b".
+        peer_send_frame(
+            &peer_backend,
+            Frame::CryptoInvalidated {
+                session_id: frame_b.session_id.clone(),
+                message_id: frame_b.message_id,
+            },
+        )
+        .await;
+
+        let mut new_peer_session = peer_answer_handshake(&peer_backend, &peer_receiver).await;
+
+        // Only "b" is retransmitted: "establish" and "a" were confirmed by the echoed id.
+        let Frame::TransportFrame(retransmitted) = peer_receive_frame(&peer_receiver).await
+        else {
+            panic!("Expected the lost message to be retransmitted as a TransportFrame");
+        };
+        assert_eq!(retransmitted.message_id, frame_b.message_id);
+        assert_eq!(
+            new_peer_session
+                .receive(&retransmitted)
+                .expect("The new session should decrypt the retransmitted payload")
+                .as_ref(),
+            b"b"
+        );
+        assert!(
+            establish_frame.message_id < frame_b.message_id,
+            "precondition: message ids increment per endpoint"
+        );
+        // No further frame follows: nothing below the echoed id is resent.
+        tokio::time::timeout(Duration::from_millis(200), peer_receiver.receive())
+            .await
+            .expect_err("messages confirmed by the echoed id must not be retransmitted");
+    }
+
+    /// If the recovery handshake fails (peer unreachable), the lost messages are dropped — the
+    /// pre-recovery behavior — and the channel stays usable: a later send re-handshakes and
+    /// goes through.
+    #[tokio::test]
+    async fn failed_recovery_handshake_drops_buffered_payloads() {
+        let (client, peer_backend, peer_receiver) = client_with_scripted_peer().await;
+        let (peer_session, establish_frame) =
+            establish_session_with_peer(&client, &peer_backend, &peer_receiver).await;
+
+        peer_send_frame(
+            &peer_backend,
+            Frame::CryptoInvalidated {
+                session_id: peer_session.session_id().clone(),
+                message_id: establish_frame.message_id,
+            },
+        )
+        .await;
+
+        // The client starts a recovery handshake, but the peer never answers; the handshake
+        // times out (HANDSHAKE_TIMEOUT_SECS) and the buffered message is dropped.
+        let Frame::HandshakeStart(_) = peer_receive_frame(&peer_receiver).await else {
+            panic!("Expected recovery HandshakeStart from client");
+        };
+        tokio::time::sleep(Duration::from_secs(super::HANDSHAKE_TIMEOUT_SECS + 1)).await;
+
+        // A later send re-handshakes and only the new payload arrives.
+        let client_for_send = client.clone();
+        let send_task = tokio::spawn(async move {
+            client_for_send
+                .send(OutgoingMessage {
+                    payload: b"new".to_vec(),
+                    destination: PEER_ENDPOINT,
+                    topic: None,
+                })
+                .await
+        });
+        let mut new_peer_session = peer_answer_handshake(&peer_backend, &peer_receiver).await;
+        send_task
+            .await
+            .expect("Send task should not panic")
+            .expect("Client send should succeed");
+        let Frame::TransportFrame(frame) = peer_receive_frame(&peer_receiver).await else {
+            panic!("Expected TransportFrame from client");
+        };
+        assert_eq!(
+            new_peer_session
+                .receive(&frame)
+                .expect("The new session should decrypt the payload")
+                .as_ref(),
+            b"new"
+        );
+        // The dropped message is not resent.
+        tokio::time::timeout(Duration::from_millis(200), peer_receiver.receive())
+            .await
+            .expect_err("messages dropped after a failed recovery must not reappear");
+    }
+
+    /// A client that receives a transport frame for which it holds *no* session replies with
+    /// `CryptoInvalidated` echoing the offending frame's session id and message id, so the
+    /// sender can reset exactly the session the frame belongs to and retransmit from exactly
+    /// the first message the receiver could not process.
+    #[tokio::test]
+    async fn sessionless_receiver_echoes_offending_session_and_message_id() {
+        let (_client, peer_backend, peer_receiver) = client_with_scripted_peer().await;
+
+        // Build a session the client knows nothing about (peer handshakes with itself) and send
+        // the client a transport frame from it.
+        let ciphersuite = CipherSuite::default();
+        let mut initiator = HandshakeInitiator::new(&ciphersuite);
+        let start = initiator
+            .write_start_message()
+            .expect("Handshake start message should be buildable");
+        let mut responder = HandshakeResponder::new(&ciphersuite);
+        responder
+            .read_start_message(&start)
+            .expect("Responder should read HandshakeStart");
+        let finish = responder
+            .write_response_message()
+            .expect("Handshake finish message should be buildable");
+        initiator
+            .read_response_message(&finish)
+            .expect("Initiator should read HandshakeFinish");
+        let mut orphan_session: PersistentTransportState = (&mut initiator).into();
+
+        let frame = orphan_session
+            .send(Payload(b"hello?".to_vec()), 7)
+            .expect("Peer encryption should succeed");
+        let expected_id = frame.session_id.clone();
+        peer_send_frame(&peer_backend, Frame::TransportFrame(frame)).await;
+
+        let Frame::CryptoInvalidated {
+            session_id,
+            message_id,
+        } = peer_receive_frame(&peer_receiver).await
+        else {
+            panic!("Expected CryptoInvalidated for a transport frame without a session");
+        };
+        assert_eq!(
+            session_id, expected_id,
+            "the invalidation must echo the offending frame's session id"
+        );
+        assert_eq!(
+            message_id, 7,
+            "the invalidation must echo the offending frame's message id"
+        );
     }
 }

--- a/crates/bitwarden-ipc/src/crypto_provider/noise/handshake.rs
+++ b/crates/bitwarden-ipc/src/crypto_provider/noise/handshake.rs
@@ -17,7 +17,7 @@ use std::fmt::{Display, Formatter};
 use serde::{Deserialize, Serialize};
 
 use crate::crypto_provider::noise::transport_state::{
-    PersistentTransportState, SymmetricKey, TransportCipher,
+    PersistentTransportState, SessionId, SymmetricKey, TransportCipher,
 };
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, Default)]
@@ -62,6 +62,11 @@ impl Display for CipherSuite {
 pub(crate) struct HandshakeStartMessage {
     pub(super) ciphersuite: CipherSuite,
     pub(super) noise_frame: Vec<u8>,
+    // The session identifier decided by the initiator; the responder adopts it for the session
+    // established by this handshake. `serde(default)` keeps start messages from peers that
+    // predate this field parseable; they get the all-zero sentinel.
+    #[serde(default)]
+    pub(super) session_id: SessionId,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -73,6 +78,7 @@ pub(crate) struct HandshakeFinishMessage {
 pub(crate) struct HandshakeInitiator {
     ciphersuite: CipherSuite,
     state: snow::HandshakeState,
+    session_id: SessionId,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -95,6 +101,8 @@ impl HandshakeInitiator {
         Self {
             ciphersuite: *ciphersuite,
             state: handshake_state,
+            // The initiator decides the identifier of the session this handshake establishes.
+            session_id: SessionId::generate(),
         }
     }
 
@@ -107,6 +115,7 @@ impl HandshakeInitiator {
         Ok(HandshakeStartMessage {
             ciphersuite: self.ciphersuite,
             noise_frame: buf[..len].to_vec(),
+            session_id: self.session_id.clone(),
         })
     }
 
@@ -129,6 +138,7 @@ impl From<&mut HandshakeInitiator> for PersistentTransportState {
             SymmetricKey(i2r),
             SymmetricKey(r2i),
             initiator.ciphersuite.transport_cipher(),
+            initiator.session_id.clone(),
         )
     }
 }
@@ -136,6 +146,8 @@ impl From<&mut HandshakeInitiator> for PersistentTransportState {
 pub(crate) struct HandshakeResponder {
     ciphersuite: CipherSuite,
     state: snow::HandshakeState,
+    // The session identifier decided by the initiator, adopted from the handshake start message.
+    session_id: Option<SessionId>,
 }
 
 impl HandshakeResponder {
@@ -152,6 +164,7 @@ impl HandshakeResponder {
         Self {
             ciphersuite: *ciphersuite,
             state: handshake_state,
+            session_id: None,
         }
     }
 
@@ -163,6 +176,7 @@ impl HandshakeResponder {
         self.state
             .read_message(&message.noise_frame, &mut buf)
             .map_err(|_| ReadError)?;
+        self.session_id = Some(message.session_id.clone());
         Ok(())
     }
 
@@ -180,11 +194,16 @@ impl HandshakeResponder {
 
 impl From<&mut HandshakeResponder> for PersistentTransportState {
     fn from(responder: &mut HandshakeResponder) -> Self {
+        let session_id = responder
+            .session_id
+            .clone()
+            .expect("The handshake start message has been read before deriving transport keys");
         let (i2r, r2i) = responder.state.dangerously_get_raw_split();
         PersistentTransportState::new(
             SymmetricKey(r2i),
             SymmetricKey(i2r),
             responder.ciphersuite.transport_cipher(),
+            session_id,
         )
     }
 }
@@ -194,7 +213,9 @@ mod tests {
     use super::*;
     use crate::crypto_provider::noise::transport_state::assert_matching_pair;
 
-    fn run_handshake(ciphersuite: &CipherSuite) {
+    fn run_handshake(
+        ciphersuite: &CipherSuite,
+    ) -> (PersistentTransportState, PersistentTransportState) {
         let mut initiator = HandshakeInitiator::new(ciphersuite);
         let mut responder = HandshakeResponder::new(ciphersuite);
 
@@ -203,9 +224,10 @@ mod tests {
         let response_message = responder.write_response_message().unwrap();
         initiator.read_response_message(&response_message).unwrap();
 
-        let initiator_transport_state = (&mut initiator).into();
-        let responder_transport_state = (&mut responder).into();
+        let initiator_transport_state: PersistentTransportState = (&mut initiator).into();
+        let responder_transport_state: PersistentTransportState = (&mut responder).into();
         assert_matching_pair(&initiator_transport_state, &responder_transport_state);
+        (initiator_transport_state, responder_transport_state)
     }
 
     #[test]
@@ -217,5 +239,17 @@ mod tests {
         ] {
             run_handshake(&ciphersuite);
         }
+    }
+
+    #[test]
+    fn test_distinct_handshakes_yield_distinct_session_ids() {
+        let (first, _) = run_handshake(&CipherSuite::default());
+        let (second, _) = run_handshake(&CipherSuite::default());
+
+        assert_ne!(
+            first.session_id(),
+            second.session_id(),
+            "each handshake must produce a unique session id"
+        );
     }
 }

--- a/crates/bitwarden-ipc/src/crypto_provider/noise/mod.rs
+++ b/crates/bitwarden-ipc/src/crypto_provider/noise/mod.rs
@@ -70,4 +70,5 @@ const NOISE_MAX_MESSAGE_LEN: usize = 65535;
 
 pub mod crypto_provider;
 pub(super) mod handshake;
+mod retransmit_buffer;
 mod transport_state;

--- a/crates/bitwarden-ipc/src/crypto_provider/noise/retransmit_buffer.rs
+++ b/crates/bitwarden-ipc/src/crypto_provider/noise/retransmit_buffer.rs
@@ -1,0 +1,202 @@
+//! Sender-side buffering of recently sent plaintexts so that messages dropped by a peer that
+//! lost its session state (see
+//! [`Frame::CryptoInvalidated`](super::crypto_provider::Frame::CryptoInvalidated)) can be
+//! retransmitted under a freshly established session instead of being silently lost.
+
+use std::collections::{HashMap, VecDeque};
+
+use tracing::warn;
+use zeroize::Zeroizing;
+
+use crate::{crypto_provider::noise::transport_state::SessionId, endpoint::Endpoint};
+
+/// Maximum number of buffered sends retained per endpoint.
+const MAX_BUFFERED_SENDS_PER_ENDPOINT: usize = 16;
+
+/// Maximum number of times a single message is retransmitted
+const MAX_RETRANSMISSIONS: u8 = 2;
+
+/// A plaintext message retained for potential retransmission.
+pub(super) struct BufferedSend {
+    /// The plaintext payload. May contain sensitive data (e.g. user keys)
+    pub(super) payload: Zeroizing<Vec<u8>>,
+    pub(super) topic: Option<String>,
+    /// The session the message was (last) sent under.
+    pub(super) session_id: SessionId,
+    /// The message's delivery identity; stable across retransmissions.
+    pub(super) message_id: u64,
+    /// How many times this message has already been retransmitted.
+    pub(super) retransmissions: u8,
+}
+
+/// Per-endpoint retransmit state: the increment-only message-id counters and the buffered
+/// recently sent messages.
+///
+/// Counters and buffer are in-memory only and reset together with the process. That is sound:
+/// after a restart the buffer is empty, so no stale entry can be matched against a
+/// freshly started counter.
+#[derive(Default)]
+pub(super) struct RetransmitBuffer {
+    entries: HashMap<Endpoint, VecDeque<BufferedSend>>,
+    next_message_id: HashMap<Endpoint, u64>,
+}
+
+impl RetransmitBuffer {
+    /// Returns the next message id for `endpoint` and advances the counter
+    pub(super) fn next_message_id(&mut self, endpoint: &Endpoint) -> u64 {
+        let counter = self.next_message_id.entry(endpoint.clone()).or_insert(1);
+        let id = *counter;
+        *counter += 1;
+        id
+    }
+
+    /// Buffers a sent message for potential retransmission, evicting the oldest entry if the
+    /// per-endpoint cap is exceeded.
+    pub(super) fn record(&mut self, endpoint: Endpoint, entry: BufferedSend) {
+        let queue = self.entries.entry(endpoint.clone()).or_default();
+        queue.push_back(entry);
+        if queue.len() > MAX_BUFFERED_SENDS_PER_ENDPOINT {
+            queue.pop_front();
+            warn!(
+                "Retransmit buffer for {:?} exceeded {} entries, dropping the oldest message; \
+                 it can no longer be recovered if the peer loses its session",
+                endpoint, MAX_BUFFERED_SENDS_PER_ENDPOINT
+            );
+        }
+    }
+
+    /// Drains the endpoint's buffer and returns, in message-id order
+    pub(super) fn take_from(
+        &mut self,
+        endpoint: &Endpoint,
+        session_id: &SessionId,
+        first_lost_message_id: u64,
+    ) -> Vec<BufferedSend> {
+        let Some(queue) = self.entries.remove(endpoint) else {
+            return Vec::new();
+        };
+        let mut lost: Vec<BufferedSend> = queue
+            .into_iter()
+            .filter(|entry| {
+                &entry.session_id == session_id
+                    && entry.message_id >= first_lost_message_id
+                    && entry.retransmissions < MAX_RETRANSMISSIONS
+            })
+            .collect();
+        lost.sort_by_key(|entry| entry.message_id);
+        lost
+    }
+
+    /// Drops all buffered entries for the endpoint
+    pub(super) fn clear_endpoint(&mut self, endpoint: &Endpoint) {
+        self.entries.remove(endpoint);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::crypto_provider::noise::transport_state::SESSION_ID_SIZE;
+
+    const ENDPOINT: Endpoint = Endpoint::DesktopMain;
+    const OTHER_ENDPOINT: Endpoint = Endpoint::DesktopRenderer;
+
+    fn session(byte: u8) -> SessionId {
+        SessionId([byte; SESSION_ID_SIZE])
+    }
+
+    fn entry(session_id: SessionId, message_id: u64) -> BufferedSend {
+        BufferedSend {
+            payload: Zeroizing::new(format!("msg-{message_id}").into_bytes()),
+            topic: None,
+            session_id,
+            message_id,
+            retransmissions: 0,
+        }
+    }
+
+    #[test]
+    fn message_ids_increment_per_endpoint() {
+        let mut buffer = RetransmitBuffer::default();
+
+        assert_eq!(buffer.next_message_id(&ENDPOINT), 1);
+        assert_eq!(buffer.next_message_id(&ENDPOINT), 2);
+        // A different endpoint has its own counter.
+        assert_eq!(buffer.next_message_id(&OTHER_ENDPOINT), 1);
+        assert_eq!(buffer.next_message_id(&ENDPOINT), 3);
+    }
+
+    #[test]
+    fn take_from_returns_only_lost_messages_of_the_session_in_order() {
+        let mut buffer = RetransmitBuffer::default();
+        buffer.record(ENDPOINT, entry(session(1), 1));
+        buffer.record(ENDPOINT, entry(session(1), 2));
+        buffer.record(ENDPOINT, entry(session(2), 3)); // different session: stale
+        buffer.record(ENDPOINT, entry(session(1), 4));
+
+        let lost = buffer.take_from(&ENDPOINT, &session(1), 2);
+
+        let ids: Vec<u64> = lost.iter().map(|e| e.message_id).collect();
+        assert_eq!(ids, vec![2, 4], "id 1 was delivered, id 3 is stale");
+        // The buffer is drained: a second invalidation finds nothing.
+        assert!(buffer.take_from(&ENDPOINT, &session(1), 0).is_empty());
+    }
+
+    #[test]
+    fn take_from_with_legacy_zero_id_returns_everything_for_the_session() {
+        let mut buffer = RetransmitBuffer::default();
+        buffer.record(ENDPOINT, entry(session(1), 1));
+        buffer.record(ENDPOINT, entry(session(1), 2));
+
+        let lost = buffer.take_from(&ENDPOINT, &session(1), 0);
+
+        assert_eq!(lost.len(), 2);
+    }
+
+    #[test]
+    fn take_from_skips_entries_that_exhausted_their_retransmission_budget() {
+        let mut buffer = RetransmitBuffer::default();
+        let mut exhausted = entry(session(1), 1);
+        exhausted.retransmissions = MAX_RETRANSMISSIONS;
+        buffer.record(ENDPOINT, exhausted);
+        buffer.record(ENDPOINT, entry(session(1), 2));
+
+        let lost = buffer.take_from(&ENDPOINT, &session(1), 0);
+
+        let ids: Vec<u64> = lost.iter().map(|e| e.message_id).collect();
+        assert_eq!(ids, vec![2]);
+    }
+
+    #[test]
+    fn record_evicts_the_oldest_entry_over_the_cap() {
+        let mut buffer = RetransmitBuffer::default();
+        for id in 1..=(MAX_BUFFERED_SENDS_PER_ENDPOINT as u64 + 1) {
+            buffer.record(ENDPOINT, entry(session(1), id));
+        }
+
+        let lost = buffer.take_from(&ENDPOINT, &session(1), 0);
+
+        assert_eq!(lost.len(), MAX_BUFFERED_SENDS_PER_ENDPOINT);
+        assert_eq!(
+            lost.first().map(|e| e.message_id),
+            Some(2),
+            "the oldest entry (id 1) must have been evicted"
+        );
+    }
+
+    #[test]
+    fn clear_endpoint_drops_entries_but_keeps_the_counter() {
+        let mut buffer = RetransmitBuffer::default();
+        assert_eq!(buffer.next_message_id(&ENDPOINT), 1);
+        buffer.record(ENDPOINT, entry(session(1), 1));
+
+        buffer.clear_endpoint(&ENDPOINT);
+
+        assert!(buffer.take_from(&ENDPOINT, &session(1), 0).is_empty());
+        assert_eq!(
+            buffer.next_message_id(&ENDPOINT),
+            2,
+            "the counter must never go backwards"
+        );
+    }
+}

--- a/crates/bitwarden-ipc/src/crypto_provider/noise/transport_state.rs
+++ b/crates/bitwarden-ipc/src/crypto_provider/noise/transport_state.rs
@@ -8,6 +8,9 @@ use crate::crypto_provider::noise::NOISE_MAX_MESSAGE_LEN;
 // Ref: http://noiseprotocol.org/noise.html#message-format
 const KEY_SIZE: usize = 32;
 
+/// Size of a [`SessionId`] in bytes.
+pub(super) const SESSION_ID_SIZE: usize = 16;
+
 /// Supported ciphers for the transport mode of noise.
 #[derive(Default, Debug, Clone, Serialize, Deserialize)]
 pub(crate) enum TransportCipher {
@@ -27,10 +30,28 @@ impl std::fmt::Debug for SymmetricKey {
     }
 }
 
+/// Identifies a single noise session. The initiator of a handshake decides the identifier and
+/// transmits it in the handshake start message, so both peers of a session hold the same one.
+#[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize)]
+pub(crate) struct SessionId(#[serde(with = "serde_bytes")] pub(crate) [u8; SESSION_ID_SIZE]);
+
+impl SessionId {
+    /// Generates a new random session identifier.
+    pub(crate) fn generate() -> Self {
+        Self(uuid::Uuid::new_v4().into_bytes())
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub(crate) struct PersistentTransportState {
     // The symmetric algorithm used for transport encryption
     transport_cipher: TransportCipher,
+
+    // Identifies this session. Stamped on outgoing transport frames so that session-reset
+    // signals ([`Frame::CryptoInvalidated`](super::crypto_provider::Frame)) can be bound to the
+    // session they were generated for.
+    #[serde(default)]
+    session_id: SessionId,
 
     // Noise has two keys, the initiator to responder key (i2r) and the responder to initiator key
     // (r2i).
@@ -51,20 +72,27 @@ pub(crate) struct PersistentTransportState {
 }
 
 impl PersistentTransportState {
-    /// Create a new transport state with the given keys and cipher.
+    /// Create a new transport state with the given keys, cipher and session identifier.
     pub(crate) fn new(
         send_key: SymmetricKey,
         receive_key: SymmetricKey,
         transport_cipher: TransportCipher,
+        session_id: SessionId,
     ) -> Self {
         Self {
             transport_cipher,
+            session_id,
             send_key,
             receive_key,
             send_nonce: 0,
             receive_nonce: 0,
             last_handshake_time: current_epoch_secs(),
         }
+    }
+
+    /// Returns the identifier of this session.
+    pub(crate) fn session_id(&self) -> &SessionId {
+        &self.session_id
     }
 
     pub(crate) fn should_rehandshake(&self, rehandshake_interval_secs: u64) -> bool {
@@ -100,7 +128,10 @@ impl AsRef<[u8]> for Payload {
 impl PersistentTransportState {
     /// Encrypts the message, mutates the state and returns the transport frame to be sent over
     /// IPC.
-    pub(crate) fn send(&mut self, payload: Payload) -> Result<TransportFrame, ()> {
+    ///
+    /// `message_id` is the delivery-layer identity assigned by the caller (see
+    /// [`TransportFrame::message_id`])
+    pub(crate) fn send(&mut self, payload: Payload, message_id: u64) -> Result<TransportFrame, ()> {
         // Increase nonce. WARNING: Re-used nonces lead to catastrophic
         // crypto failure. Ensure this increases always. It is impossible to send 2^64 messages
         // within the lifetime of a session. Nonetheless, the cryptographic guarantees are
@@ -116,6 +147,8 @@ impl PersistentTransportState {
         Ok(TransportFrame {
             payload: encrypted_message.into(),
             nonce: self.send_nonce,
+            session_id: self.session_id.clone(),
+            message_id,
         })
     }
 
@@ -207,6 +240,12 @@ fn get_cipher_with_key(
 pub(crate) struct TransportFrame {
     pub(crate) payload: ByteBuf,
     pub(crate) nonce: u64,
+    // The sender's session identifier. 
+    #[serde(default)]
+    pub(crate) session_id: SessionId,
+    // Increment-only per-message identifier assigned by the sender
+    #[serde(default)]
+    pub(crate) message_id: u64,
 }
 
 #[cfg(test)]
@@ -216,6 +255,15 @@ pub(crate) fn assert_matching_pair(
 ) {
     assert_eq!(state_1.send_key.0, state_2.receive_key.0);
     assert_eq!(state_1.receive_key.0, state_2.send_key.0);
+    assert_eq!(
+        state_1.session_id, state_2.session_id,
+        "both peers of a session must derive the same session id"
+    );
+    assert_ne!(
+        state_1.session_id,
+        SessionId::default(),
+        "a freshly established session must not have the all-zero sentinel id"
+    );
 }
 
 #[cfg(test)]
@@ -228,16 +276,47 @@ mod tests {
         (send_key, receive_key)
     }
 
+    fn test_session_id() -> SessionId {
+        SessionId([3u8; SESSION_ID_SIZE])
+    }
+
     fn make_pair() -> (PersistentTransportState, PersistentTransportState) {
         let (send_key, receive_key) = test_keys();
         let sender = PersistentTransportState::new(
             send_key.clone(),
             receive_key.clone(),
             TransportCipher::default(),
+            test_session_id(),
         );
-        let receiver =
-            PersistentTransportState::new(receive_key, send_key, TransportCipher::default());
+        let receiver = PersistentTransportState::new(
+            receive_key,
+            send_key,
+            TransportCipher::default(),
+            test_session_id(),
+        );
         (sender, receiver)
+    }
+
+    #[test]
+    fn test_send_stamps_frames_with_the_session_id() {
+        let (mut sender, _) = make_pair();
+
+        let frame = sender
+            .send(b"ping".to_vec().into(), 1)
+            .expect("send should succeed");
+
+        assert_eq!(frame.session_id, test_session_id());
+    }
+
+    #[test]
+    fn test_send_stamps_frames_with_the_message_id() {
+        let (mut sender, _) = make_pair();
+
+        let frame = sender
+            .send(b"ping".to_vec().into(), 42)
+            .expect("send should succeed");
+
+        assert_eq!(frame.message_id, 42);
     }
 
     #[test]
@@ -245,7 +324,7 @@ mod tests {
         let (mut sender, mut receiver) = make_pair();
 
         let payload: Payload = b"ping".to_vec().into();
-        let frame = sender.send(payload).expect("send should succeed");
+        let frame = sender.send(payload, 1).expect("send should succeed");
         let received = receiver.receive(&frame).expect("receive should succeed");
 
         assert_eq!(received.as_ref(), b"ping");
@@ -257,7 +336,7 @@ mod tests {
 
         for i in 0..5 {
             let payload: Payload = format!("msg-{i}").into_bytes().into();
-            let frame = sender.send(payload).expect("send should succeed");
+            let frame = sender.send(payload, i + 1).expect("send should succeed");
             let received = receiver.receive(&frame).expect("receive should succeed");
             assert_eq!(received.as_ref(), format!("msg-{i}").as_bytes());
         }
@@ -268,7 +347,7 @@ mod tests {
         let (mut sender, mut receiver) = make_pair();
 
         let payload: Payload = b"first".to_vec().into();
-        let frame = sender.send(payload).expect("send should succeed");
+        let frame = sender.send(payload, 1).expect("send should succeed");
 
         // First receive succeeds
         let replayed_frame = frame.clone();
@@ -288,8 +367,8 @@ mod tests {
         // Send two messages
         let msg1: Payload = b"first".to_vec().into();
         let msg2: Payload = b"second".to_vec().into();
-        let frame1 = sender.send(msg1).expect("send should succeed");
-        let frame2 = sender.send(msg2).expect("send should succeed");
+        let frame1 = sender.send(msg1, 1).expect("send should succeed");
+        let frame2 = sender.send(msg2, 2).expect("send should succeed");
 
         // Receive the second message first (higher nonce)
         receiver.receive(&frame2).expect("receive should succeed");
@@ -304,7 +383,7 @@ mod tests {
         let (mut sender, mut receiver) = make_pair();
 
         let payload: Payload = b"important".to_vec().into();
-        let mut frame = sender.send(payload).expect("send should succeed");
+        let mut frame = sender.send(payload, 1).expect("send should succeed");
 
         // Tamper with the ciphertext
         frame.payload[0] ^= 0xFF;

--- a/crates/bitwarden-ipc/src/crypto_provider/noise/transport_state.rs
+++ b/crates/bitwarden-ipc/src/crypto_provider/noise/transport_state.rs
@@ -240,7 +240,7 @@ fn get_cipher_with_key(
 pub(crate) struct TransportFrame {
     pub(crate) payload: ByteBuf,
     pub(crate) nonce: u64,
-    // The sender's session identifier. 
+    // The sender's session identifier.
     #[serde(default)]
     pub(crate) session_id: SessionId,
     // Increment-only per-message identifier assigned by the sender

--- a/crates/bitwarden-ipc/src/wasm/ipc_client.rs
+++ b/crates/bitwarden-ipc/src/wasm/ipc_client.rs
@@ -65,7 +65,7 @@ impl JsIpcClient {
     ) -> JsIpcClient {
         JsIpcClient {
             client: Arc::new(IpcClientImpl::new(
-                NoiseCryptoProvider,
+                NoiseCryptoProvider::new(),
                 communication_provider.clone(),
                 GenericSessionRepository::InMemory(Arc::new(InMemorySessionRepository::new(
                     HashMap::new(),
@@ -84,7 +84,7 @@ impl JsIpcClient {
     ) -> JsIpcClient {
         JsIpcClient {
             client: Arc::new(IpcClientImpl::new(
-                NoiseCryptoProvider,
+                NoiseCryptoProvider::new(),
                 communication_provider.clone(),
                 GenericSessionRepository::JsSessionRepository(Arc::new(JsSessionRepository::new(
                     session_repository,

--- a/crates/bitwarden-shared-unlock/src/tests.rs
+++ b/crates/bitwarden-shared-unlock/src/tests.rs
@@ -592,3 +592,78 @@ async fn test_non_web_source_skips_origin_validation() {
         LockState::Unlocked { user_key: key }
     );
 }
+
+/// Drains a leader IPC backend's outgoing queue and decodes the messages without delivering
+/// them (used to inspect what a leader emitted).
+async fn drain_leader_messages(backend: &TestCommunicationBackend) -> Vec<LeaderMessage> {
+    backend
+        .drain_outgoing()
+        .await
+        .into_iter()
+        .map(|outgoing| {
+            let incoming = IncomingMessage {
+                payload: outgoing.payload,
+                destination: outgoing.destination,
+                source: Source::DesktopMain,
+                topic: outgoing.topic,
+            };
+            TypedIncomingMessage::<LeaderMessage>::try_from(incoming)
+                .expect("Failed to decode leader message")
+                .payload
+        })
+        .collect()
+}
+
+/// A heartbeat from an unknown endpoint should make the leader ask for a session start once,
+/// then record the endpoint so later heartbeats are answered with a `HeartBeat` echo. Without
+/// that, a lost `StartSession` reply leaves the endpoint unknown and every heartbeat re-triggers
+/// `RequestSessionStart`, churning indefinitely.
+#[tokio::test]
+async fn heartbeat_from_unknown_follower_does_not_churn_request_session_start() {
+    let user = user_a();
+
+    // A freshly reloaded leader: it knows the user is locked but has an empty session table.
+    let leader_lock = MockDriver::new(HashMap::from([(user, LockState::Locked)]));
+    let leader_ipc_backend = TestCommunicationBackend::new();
+    let leader_ipc_client: Arc<dyn IpcClient> = Arc::new(TestIpcClient::new(
+        NoEncryptionCryptoProvider,
+        leader_ipc_backend.clone(),
+        InMemorySessionRepository::new(HashMap::new()),
+    ));
+    let leader = Leader::create(leader_lock, leader_ipc_client);
+
+    // Send several heartbeats from the same endpoint without ever delivering a StartSession
+    // reply back to it. Desired behavior: at most the first heartbeat asks for a session start;
+    // once the leader knows the endpoint, later heartbeats are answered with a HeartBeat echo,
+    // not another RequestSessionStart.
+    for iteration in 0..5 {
+        leader
+            .receive_message(TypedIncomingMessage {
+                payload: FollowerMessage::HeartBeat { user_id: user },
+                destination: LEADER_ENDPOINT,
+                source: follower_source(),
+            })
+            .await
+            .unwrap();
+
+        let emitted = drain_leader_messages(&leader_ipc_backend).await;
+        if iteration == 0 {
+            // A single session-start request on first contact is acceptable.
+            continue;
+        }
+        assert!(
+            emitted
+                .iter()
+                .any(|m| matches!(m, LeaderMessage::HeartBeat { .. })),
+            "after first contact the leader must recognize the endpoint and echo the heartbeat, \
+             but it emitted {emitted:?}"
+        );
+        assert!(
+            !emitted
+                .iter()
+                .any(|m| matches!(m, LeaderMessage::RequestSessionStart { .. })),
+            "repeated heartbeats from a known endpoint must not keep re-triggering \
+             RequestSessionStart (got {emitted:?})"
+        );
+    }
+}

--- a/crates/bitwarden-wasm-internal/integration-tests/tests/unlock/shared-unlock.test.ts
+++ b/crates/bitwarden-wasm-internal/integration-tests/tests/unlock/shared-unlock.test.ts
@@ -77,6 +77,32 @@ describe("shared unlock ipc", () => {
     expect(reloaded.leaderDriver.getUserKey(USER_A)).toBe(USER_KEY);
   });
 
+  it("delivers the follower's first message after a leader reload", async () => {
+    const pair = await setupSharedUnlockPair({
+      leader: { initialStates: USER_A_UNLOCKED_STATE },
+      follower: { initialStates: USER_A_UNLOCKED_STATE },
+    });
+    await sleep(20);
+    expect(pair.leaderDriver.getUserKey(USER_A)).toBe(USER_KEY);
+    expect(pair.followerDriver.getUserKey(USER_A)).toBe(USER_KEY);
+
+    // The leader reloads and comes back locked with no crypto sessions. The
+    // follower is untouched: it stays unlocked and still holds the pre-reload
+    // crypto session. Leader (locked) and follower (unlocked) are now out of
+    // sync, so a follower unlock event should propagate to the leader.
+    const reloaded = await reloadLeader(pair, {
+      leader: { initialStates: USER_A_LOCKED_STATE },
+    });
+
+    // First contact after the reload is encrypted with the now-stale session.
+    // Desired behavior: the unlock still reaches the leader (transparent
+    // re-handshake + retry). FAILS today — the reloaded leader replies
+    // `CryptoInvalidated` and drops the payload, so the leader stays locked.
+    await reloaded.follower.handle_device_event(UNLOCK_EVENT);
+    await sleep(50);
+    expect(reloaded.leaderDriver.getUserKey(USER_A)).toBe(USER_KEY);
+  }, 15000);
+
   it("reconnects after process-reloading the leader", async () => {
     const pair = await setupSharedUnlockPair({
       leader: { initialStates: USER_A_UNLOCKED_STATE },

--- a/crates/bitwarden-wasm-internal/integration-tests/tests/unlock/shared-unlock.test.ts
+++ b/crates/bitwarden-wasm-internal/integration-tests/tests/unlock/shared-unlock.test.ts
@@ -96,7 +96,7 @@ describe("shared unlock ipc", () => {
 
     // First contact after the reload is encrypted with the now-stale session.
     // Desired behavior: the unlock still reaches the leader (transparent
-    // re-handshake + retry). 
+    // re-handshake + retry).
     await reloaded.follower.handle_device_event(UNLOCK_EVENT);
     await sleep(50);
     expect(reloaded.leaderDriver.getUserKey(USER_A)).toBe(USER_KEY);
@@ -114,15 +114,10 @@ describe("shared unlock ipc", () => {
     const reloaded = await reloadLeader(pair, {
       leader: { initialStates: USER_A_LOCKED_STATE },
     });
-    // Wait for heartbeat
-    // Note: Currently, there is two heartbeats necessary; Basically:
-    // - Leader reloads, has no crypto state, follower still has crypto session A
-    // - Follower sends heartbeat 1 with session A, leader doesn't recognize session A, sends crypto state invalidated back
-    // - Follower performs handshake, now both follower and leader have crypto session B
-    // - Follower sends heartbeat 2 with session B, leader sets up unlock sharing session
-    // - As of here, a unlock event will work.
-    //
-    // This could be fixed differently on the crypto layer in the future
+    // Wait for a heartbeat. A single heartbeat suffices: the leader answers the
+    // stale-session heartbeat with `CryptoInvalidated`, and the follower's crypto
+    // layer transparently re-handshakes and retransmits the heartbeat, so the
+    // leader sets up the unlock sharing session right away.
     await sleep(5000);
 
     expect(reloaded.leaderDriver.getUserKey(USER_A)).toBe(USER_KEY);

--- a/crates/bitwarden-wasm-internal/integration-tests/tests/unlock/shared-unlock.test.ts
+++ b/crates/bitwarden-wasm-internal/integration-tests/tests/unlock/shared-unlock.test.ts
@@ -96,8 +96,7 @@ describe("shared unlock ipc", () => {
 
     // First contact after the reload is encrypted with the now-stale session.
     // Desired behavior: the unlock still reaches the leader (transparent
-    // re-handshake + retry). FAILS today — the reloaded leader replies
-    // `CryptoInvalidated` and drops the payload, so the leader stays locked.
+    // re-handshake + retry). 
     await reloaded.follower.handle_device_event(UNLOCK_EVENT);
     await sleep(50);
     expect(reloaded.leaderDriver.getUserKey(USER_A)).toBe(USER_KEY);


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
There are currently two bugs:
- For peer A, B, if B process reloads and has no session, A sends a message M to it, and B cannot decrypt and requests a new crypto session. The message M is dropped, and only M+1 is received.
  - Fixed by the introduction of a re-transmit buffer
- For peer A, B, if B process reloads, and A sends message to B, B will request a re-handshake. If A still has messages in-flight, B may *again* request a new session
  - Fixed by session id binding

## 🚨 Breaking Changes

<!-- Does this PR introduce any breaking changes? If so, please describe the impact and migration path for clients.

If you're unsure, the automated TypeScript compatibility check will run when you open/update this PR and provide feedback.

For breaking changes:
1. Describe what changed in the client interface
2. Explain why the change was necessary
3. Provide migration steps for client developers
4. Link to any paired client PRs if needed

Otherwise, you can remove this section. -->
