### PR TITLE
[PM-40047] Refactor cipher blob serialization to JSON to drop redundant base64

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1401,7 +1401,6 @@ dependencies = [
  "bitwarden-test",
  "bitwarden-uuid",
  "chrono",
- "ciborium",
  "data-encoding",
  "futures",
  "hmac 0.13.0",

--- a/crates/bitwarden-vault/Cargo.toml
+++ b/crates/bitwarden-vault/Cargo.toml
@@ -45,7 +45,6 @@ bitwarden-state = { workspace = true }
 bitwarden-sync = { workspace = true }
 bitwarden-uuid = { workspace = true }
 chrono = { workspace = true }
-ciborium = { workspace = true }
 data-encoding = { workspace = true }
 futures = { workspace = true }
 hmac = { workspace = true }

--- a/crates/bitwarden-vault/src/cipher/README.md
+++ b/crates/bitwarden-vault/src/cipher/README.md
@@ -21,21 +21,26 @@ A `Cipher` can be stored in one of two formats at rest, detected per-cipher:
   are each encrypted as separate `EncString`s.
 - **Blob** — sensitive item content (name, notes, type-data, custom fields, password history) sealed
   into a single `Cipher.data` opaque string via a data envelope (CEK + wrapped key, see
-  [`blob/`](./blob/)). Everything else — non-sensitive metadata (`favorite`, `folder_id`, dates) and
-  separately-encrypted data (`attachments`, `local_data`) — stays alongside the blob on the `Cipher`
-  struct.
+  [`blob/`](./blob/)). The opaque string is JSON stored verbatim —
+  `{"format_version":…,"wrapped_cek":…,"envelope":…}` — where `wrapped_cek` and `envelope` are the
+  base64 inner crypto material. Everything else — non-sensitive metadata (`favorite`, `folder_id`,
+  dates) and separately-encrypted data (`attachments`, `local_data`) — stays alongside the blob on
+  the `Cipher` struct.
 
-Detection happens via `blob::is_blob_encrypted(&Cipher)`. Blob and legacy ciphers coexist during
-rollout — a single `Vec<Cipher>` from the API routinely contains both.
+Detection happens via `blob::try_parse_blob(&Cipher)`, which returns `Some(SealedCipherBlob)` when
+the `data` string is a JSON object carrying the top-level `format_version` key and `None` otherwise
+(legacy field-level `CipherData` never contains it — the same probe is mirrored server-side). Blob
+and legacy ciphers coexist during rollout — a single `Vec<Cipher>` from the API routinely contains
+both.
 
 ## Decryption flow
 
 `Cipher` implements `Decryptable<…, CipherView>` and `Decryptable<…, CipherListView>` directly, so
 external callers (`bitwarden-exporters`, `bitwarden-user-crypto-management` key rotation, and tests)
-just call `key_store.decrypt(&cipher)` without choosing a path. The impl checks
-`blob::is_blob_encrypted(&Cipher)` and dispatches to the blob unseal flow when the cipher is in the
-blob format, or to the legacy lenient path when it is in the field-level format. `decrypt_list`
-likewise accepts a homogeneous `Vec<Cipher>` and routes per-cipher.
+just call `key_store.decrypt(&cipher)` without choosing a path. The impl calls
+`blob::try_parse_blob(&Cipher)` and, when it returns `Some`, dispatches to the blob unseal flow; a
+`None` routes to the legacy lenient path. `decrypt_list` likewise accepts a homogeneous
+`Vec<Cipher>` and routes per-cipher.
 
 `StrictDecrypt<Cipher>` is a `pub(crate)` wrapper that implements the same `Decryptable` traits, but
 its legacy branch propagates field decryption errors instead of silently nulling them out. It also
@@ -46,10 +51,10 @@ The flag and `StrictDecrypt` are both scheduled for removal in PM-34531.
 
 ```mermaid
 flowchart LR
-    A[Cipher] --> C{is_blob_encrypted?}
+    A[Cipher] --> C{try_parse_blob = Some?}
     C -->|Yes| D[decrypt_blob_cipher]
     C -->|No| F[lenient_decrypt_*]
-    SC[StrictDecrypt&lt;Cipher&gt;] --> SCC{is_blob_encrypted?}
+    SC[StrictDecrypt&lt;Cipher&gt;] --> SCC{try_parse_blob = Some?}
     SCC -->|Yes| D
     SCC -->|No| E[strict_decrypt_*]
     D --> G[CipherView]

--- a/crates/bitwarden-vault/src/cipher/blob/sealed.rs
+++ b/crates/bitwarden-vault/src/cipher/blob/sealed.rs
@@ -3,7 +3,6 @@ use bitwarden_crypto::{
     EncString, KeyStoreContext,
     safe::{DataEnvelope, DataEnvelopeError},
 };
-use bitwarden_encoding::B64;
 use bitwarden_logging::instrument;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
@@ -18,15 +17,12 @@ pub enum SealedCipherBlobError {
     /// The format version is newer or older than this client supports.
     #[error("Unsupported format version: {0}")]
     UnsupportedFormatVersion(u8),
-    /// Encoding the sealed container to CBOR failed.
-    #[error("CBOR encoding error")]
-    CborEncoding,
-    /// The bytes did not parse as a valid CBOR-encoded sealed container.
-    #[error("CBOR decoding error")]
-    CborDecoding,
-    /// The container's base64 wrapper did not decode.
-    #[error("Base64 decoding error")]
-    Base64Decoding,
+    /// Serializing the sealed container to JSON failed.
+    #[error("JSON encoding error")]
+    JsonEncoding,
+    /// The string did not parse as a JSON object carrying a `format_version` key.
+    #[error("JSON decoding error")]
+    JsonDecoding,
     /// The inner `DataEnvelope` could not be sealed or opened.
     #[error(transparent)]
     DataEnvelope(#[from] DataEnvelopeError),
@@ -76,20 +72,25 @@ impl SealedCipherBlob {
             .unseal_with_wrapping_key(wrapping_key, &self.wrapped_cek, ctx)?)
     }
 
-    /// Serializes this container into an opaque base64-encoded CBOR string.
+    /// Serializes this container into an opaque JSON string.
     pub(super) fn to_opaque_string(&self) -> Result<String, SealedCipherBlobError> {
-        let mut buf = Vec::new();
-        ciborium::ser::into_writer(self, &mut buf)
-            .map_err(|_| SealedCipherBlobError::CborEncoding)?;
-        Ok(B64::from(buf).to_string())
+        serde_json::to_string(self).map_err(|_| SealedCipherBlobError::JsonEncoding)
     }
 
-    /// Deserializes a `SealedCipherBlob` from an opaque base64-encoded CBOR string.
+    /// Deserializes a `SealedCipherBlob` from an opaque JSON string.
+    ///
+    /// Requires the JSON to be an object carrying a `format_version` key; legacy
+    /// field-level `CipherData` never contains it, so it is rejected here.
     pub(super) fn from_opaque_string(s: &str) -> Result<Self, SealedCipherBlobError> {
-        let bytes = B64::try_from(s)
-            .map_err(|_| SealedCipherBlobError::Base64Decoding)?
-            .into_bytes();
-        ciborium::de::from_reader(bytes.as_slice()).map_err(|_| SealedCipherBlobError::CborDecoding)
+        let value: serde_json::Value =
+            serde_json::from_str(s).map_err(|_| SealedCipherBlobError::JsonDecoding)?;
+        if !value
+            .as_object()
+            .is_some_and(|o| o.contains_key("format_version"))
+        {
+            return Err(SealedCipherBlobError::JsonDecoding);
+        }
+        serde_json::from_value(value).map_err(|_| SealedCipherBlobError::JsonDecoding)
     }
 }
 
@@ -160,16 +161,15 @@ mod tests {
     }
 
     #[test]
-    fn test_invalid_base64() {
-        let result = SealedCipherBlob::from_opaque_string("not valid base64!@#$");
-        assert!(matches!(result, Err(SealedCipherBlobError::Base64Decoding)));
+    fn test_invalid_json() {
+        let result = SealedCipherBlob::from_opaque_string("not json");
+        assert!(matches!(result, Err(SealedCipherBlobError::JsonDecoding)));
     }
 
     #[test]
-    fn test_invalid_cbor() {
-        let not_cbor = B64::from(b"this is not valid cbor data".as_slice()).to_string();
-        let result = SealedCipherBlob::from_opaque_string(&not_cbor);
-        assert!(matches!(result, Err(SealedCipherBlobError::CborDecoding)));
+    fn test_missing_format_version() {
+        let result = SealedCipherBlob::from_opaque_string("{\"Name\":\"x\"}");
+        assert!(matches!(result, Err(SealedCipherBlobError::JsonDecoding)));
     }
 
     #[test]
@@ -192,8 +192,8 @@ mod tests {
     }
 
     const TEST_VECTOR_WRAPPING_KEY: &str =
-        "e0MSZ4/Z4AS7fzjxMos7MXibNALU4mDJQwmge+uVwahg9P25cuaNiSpLvYMk2BgJfntbQs4FszcnY5nPe2FpVA==";
-    const TEST_VECTOR_SEALED_BLOB: &str = "o25mb3JtYXRfdmVyc2lvbgFrd3JhcHBlZF9jZWt4tDIub1dJMUloMDVleWxpeGxCQUM4V253QT09fDdOTVFiU3JXS3ZOWFNoTkNHdmZZWld0T2doMEcvZ294YXdod01UWm5PR1hLeVZ6RXA1WWRXRUhoRnQ0UFVrbVVOT204Z2JMRlhyTFN4MW5CU25PdjlEeEJLNFp6ejNJVFp3dm92Z3NBTFQwPXxBMzhlZkFhSlhmMnk2aFdxTHBUanJ6NlF5OS9FRERMWnpJOWZFSGhtVExJPWhlbnZlbG9wZXkBKGcxaExwUUU2QUFFUmJ3TjRJMkZ3Y0d4cFkyRjBhVzl1TDNndVltbDBkMkZ5WkdWdUxtTmliM0l0Y0dGa1pHVmtCRkFQV0dnR1lPblBYVGlNY2NUOVVrVUFPZ0FCT0lFQ09nQUJPSUFCb1FWWUdDeWk1cEtQSHQ2NXAwU0MxR1FGMTZ1TE85SEtUODFmZWxoeFF2UDBrTlYyQXpibks5RXlSUjlSRUUvUURYK0JVcE53bkxjUTZKZldJb2cycHp4TjBBNUlKTmhmZ1Uzd0NMSS9WOVZHcThkM1RZanBLSm9MNitKSVhVQnI0UWtHeGgzekZmci8rQThGN3RwR2dSK0tnLzVQRGJLMk9ENjdkM0ZnOW12b2t2UVBzQ0F5MnlIaVJ6aHdONUU9";
+        "z27dMz/RK4wboY/Ako0YVFr9jaiSjgQQyGkTZ4LIuNrOXyeDAjeD41qbhVKl0OSjP3QuN9xmAJQE8+V5/Tl7ig==";
+    const TEST_VECTOR_SEALED_BLOB: &str = r#"{"format_version":1,"wrapped_cek":"2.LQJf2BbznXX+NelBY4pSJg==|txMmjZEOhSMA7Jrm+rZt1LDfA6s3G2QU5Z8MqO4nG9s2ZXuzSLU/iYOUXD8xw+eHVSu7IUHu1LsCm4SLf+ZhkX5QIo4hJT3DHSbgu6VPUC0=|yuU/EWQWyihf2Yh9lQ1NP+zTROEpnXoRS//GfxDgC4k=","envelope":"g1hLpQE6AAERbwN4I2FwcGxpY2F0aW9uL3guYml0d2FyZGVuLmNib3ItcGFkZGVkBFBoHnjLne8MPV72YPXuskd6OgABOIECOgABOIABoQVYGA00vxb7gF7Y3SUyoCMy34C1HrB3fSY3jVhxZXQmmotGEIwwRlG+SpTcyTl5m4lUnozWrjAYfWitl1+cz457Wq3iDW/MvrHE7c1g38QJxY6t1yhQL0dQy9DyDXQDiWGPtYzic2Ay+GtrlIERN37wOdhQ1HZDeoobHL+aKomvPTems/Ta2SqWC9HfE38="}"#;
 
     #[test]
     fn test_recorded_sealed_blob_test_vector() {


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-40047

## 📔 Objective

Blob-encrypted ciphers stored their sealed payload as base64-encoded CBOR in `Cipher.data`. Because the inner fields (`wrapped_cek`, `envelope`) are already base64 strings, the outer base64 added ~33% overhead for no benefit. This switches the sealed container to JSON stored verbatim (no outer base64), cutting stored blob size ~24% with no change to the inner crypto envelope. Format detection now keys off a top-level `format_version` key instead of base64/CBOR parse-success. Test vectors regenerated; the now-unused `ciborium` dependency removed.

## 🚨 Breaking Changes

None for stored data — this is a pre-release feature, so only test vectors regenerate (no migration). Requires the paired server-side detection change (also PM-40047). No client change needed — `data` is an opaque pass-through, and detection ships via the SDK bump.