### PR TITLE
chore(deps): reassign rand to Key Management in renovate

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -83,6 +83,12 @@
     },
     {
       matchManagers: ["cargo"],
+      matchPackageNames: ["rand"],
+      commitMessagePrefix: "[deps] Key Management (cargo):",
+      reviewers: ["team:team-key-management-dev"],
+    },
+    {
+      matchManagers: ["cargo"],
       matchPackageNames: [
         "async-trait",
         "cargo-dylint",
@@ -103,7 +109,6 @@
         "password-rules-parser",
         "proc-macro2",
         "quote",
-        "rand",
         "rand_chacha",
         "reqwest",
         "reqwest-middleware",


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-35046

## 📔 Objective

KM has agreed to take ownership of the rand dependency, as they maintain the new `bitwarden-random` crate. This PR updates the renovate config to symbolize this. Once merged I'll be regenerating https://github.com/bitwarden/clients/pull/20133

## 🚨 Breaking Changes

<!-- Does this PR introduce any breaking changes? If so, please describe the impact and migration path for clients.

If you're unsure, the automated TypeScript compatibility check will run when you open/update this PR and provide feedback.

For breaking changes:
1. Describe what changed in the client interface
2. Explain why the change was necessary
3. Provide migration steps for client developers
4. Link to any paired client PRs if needed

Otherwise, you can remove this section. -->
