### PR TITLE
[PM-40201] Derive missing SSH public key and fingerprint in the SDK

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -50,6 +50,7 @@ crates/bitwarden-random/** @bitwarden/team-key-management-dev
 crates/bitwarden-sensitive-value/** @bitwarden/team-key-management-dev
 crates/bitwarden-send/** @bitwarden/team-tools-dev @bitwarden/team-platform-dev
 crates/bitwarden-shared-unlock/** @bitwarden/team-key-management-dev
+crates/bitwarden-ssh/** @bitwarden/team-tools-dev
 crates/bitwarden-state-bridge-macro/** @bitwarden/team-key-management-dev
 crates/bitwarden-unlock/** @bitwarden/team-key-management-dev
 crates/bitwarden-user-crypto-management/** @bitwarden/team-key-management-dev

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1175,7 +1175,6 @@ version = "3.0.0"
 dependencies = [
  "bitwarden-error",
  "bitwarden-random",
- "bitwarden-vault",
  "block-padding",
  "ed25519",
  "ed25519-dalek",
@@ -1418,6 +1417,7 @@ dependencies = [
  "bitwarden-encoding",
  "bitwarden-error",
  "bitwarden-logging",
+ "bitwarden-ssh",
  "bitwarden-state",
  "bitwarden-sync",
  "bitwarden-test",

--- a/crates/bitwarden-ssh/Cargo.toml
+++ b/crates/bitwarden-ssh/Cargo.toml
@@ -26,7 +26,6 @@ uniffi = ["dep:uniffi"] # Uniffi bindings
 [dependencies]
 bitwarden-error = { workspace = true }
 bitwarden-random = { workspace = true }
-bitwarden-vault = { workspace = true }
 block-padding = { version = "=0.4.2" }
 ed25519 = { version = "3.0.0-rc.4", features = ["pkcs8"] }
 ed25519-dalek = { workspace = true, features = ["alloc", "pkcs8"] }

--- a/crates/bitwarden-ssh/src/generator.rs
+++ b/crates/bitwarden-ssh/src/generator.rs
@@ -1,4 +1,3 @@
-use bitwarden_vault::SshKeyView;
 use rand::CryptoRng;
 use serde::{Deserialize, Serialize};
 use ssh_key::{Algorithm, EcdsaCurve};
@@ -6,8 +5,9 @@ use ssh_key::{Algorithm, EcdsaCurve};
 use tsify::Tsify;
 
 use crate::{
+    SshKeyData,
     error::{self, KeyGenerationError},
-    ssh_private_key_to_view,
+    ssh_private_key_to_data,
 };
 
 #[derive(Serialize, Deserialize)]
@@ -24,12 +24,12 @@ pub enum KeyAlgorithm {
 
 /**
  * Generate a new SSH key pair, for the provided key algorithm, returning
- * an [SshKeyView] struct containing the private key, public key, and key fingerprint,
+ * an [SshKeyData] struct containing the private key, public key, and key fingerprint,
  * with the private key in OpenSSH format.
  */
 pub fn generate_sshkey(
     key_algorithm: KeyAlgorithm,
-) -> Result<SshKeyView, error::KeyGenerationError> {
+) -> Result<SshKeyData, error::KeyGenerationError> {
     let mut rng = bitwarden_random::rng();
     generate_sshkey_internal(key_algorithm, &mut rng)
 }
@@ -37,7 +37,7 @@ pub fn generate_sshkey(
 fn generate_sshkey_internal<R: CryptoRng + ?Sized>(
     key_algorithm: KeyAlgorithm,
     rng: &mut R,
-) -> Result<SshKeyView, error::KeyGenerationError> {
+) -> Result<SshKeyData, error::KeyGenerationError> {
     let private_key = match key_algorithm {
         KeyAlgorithm::Ed25519 => ssh_key::PrivateKey::random(rng, Algorithm::Ed25519)
             .map_err(KeyGenerationError::KeyGeneration),
@@ -66,7 +66,7 @@ fn generate_sshkey_internal<R: CryptoRng + ?Sized>(
         .map_err(KeyGenerationError::KeyGeneration),
     }?;
 
-    ssh_private_key_to_view(private_key).map_err(|_| KeyGenerationError::KeyConversion)
+    ssh_private_key_to_data(private_key).map_err(|_| KeyGenerationError::KeyConversion)
 }
 
 fn create_rsa_key<R: CryptoRng + ?Sized>(

--- a/crates/bitwarden-ssh/src/import.rs
+++ b/crates/bitwarden-ssh/src/import.rs
@@ -1,4 +1,3 @@
-use bitwarden_vault::SshKeyView;
 use ed25519;
 use pem_rfc7468::PemLabel;
 use pkcs8::{DecodePrivateKey, PrivateKeyInfo, SecretDocument, der::Decode, pkcs5};
@@ -7,9 +6,9 @@ use ssh_key::{
     sec1,
 };
 
-use crate::{error::SshKeyImportError, ssh_private_key_to_view};
+use crate::{SshKeyData, error::SshKeyImportError, ssh_private_key_to_data};
 
-/// Import a PKCS8 or OpenSSH encoded private key, and returns a decoded [SshKeyView],
+/// Import a PKCS8 or OpenSSH encoded private key, and returns a decoded [SshKeyData],
 /// with the public key and fingerprint, and the private key in OpenSSH format.
 /// A password can be provided for encrypted keys.
 /// # Returns
@@ -20,7 +19,7 @@ use crate::{error::SshKeyImportError, ssh_private_key_to_view};
 pub fn import_key(
     encoded_key: String,
     password: Option<String>,
-) -> Result<SshKeyView, SshKeyImportError> {
+) -> Result<SshKeyData, SshKeyImportError> {
     let label = pem_rfc7468::decode_label(encoded_key.as_bytes())
         .map_err(|_| SshKeyImportError::Parsing)?;
 
@@ -38,7 +37,7 @@ pub fn import_key(
 fn import_pkcs8_key(
     encoded_key: String,
     password: Option<String>,
-) -> Result<SshKeyView, SshKeyImportError> {
+) -> Result<SshKeyData, SshKeyImportError> {
     match parse_pkcs8_pem(&encoded_key, password.as_deref()) {
         // Some exporters (e.g. 1Password's 1PUX) emit the base64 body on a single line, which the
         // strict RFC 7468 parser rejects. Re-wrap to 64-character lines and retry once. Only
@@ -54,7 +53,7 @@ fn import_pkcs8_key(
 fn parse_pkcs8_pem(
     encoded_key: &str,
     password: Option<&str>,
-) -> Result<SshKeyView, SshKeyImportError> {
+) -> Result<SshKeyData, SshKeyImportError> {
     let doc = if let Some(password) = password {
         SecretDocument::from_pkcs8_encrypted_pem(encoded_key, password.as_bytes()).map_err(
             |err| match err {
@@ -114,9 +113,9 @@ fn rewrap_pem(pem: &str) -> Option<String> {
     Some(out)
 }
 
-/// Import a DER encoded private key, and returns a decoded [SshKeyView]. This is primarily used for
+/// Import a DER encoded private key, and returns a decoded [SshKeyData]. This is primarily used for
 /// importing SSH keys from other Credential Managers through Credential Exchange.
-pub fn import_pkcs8_der_key(encoded_key: &[u8]) -> Result<SshKeyView, SshKeyImportError> {
+pub fn import_pkcs8_der_key(encoded_key: &[u8]) -> Result<SshKeyData, SshKeyImportError> {
     let private_key_info =
         PrivateKeyInfo::from_der(encoded_key).map_err(|_| SshKeyImportError::Parsing)?;
 
@@ -141,13 +140,13 @@ pub fn import_pkcs8_der_key(encoded_key: &[u8]) -> Result<SshKeyView, SshKeyImpo
         _ => return Err(SshKeyImportError::UnsupportedKeyType),
     };
 
-    ssh_private_key_to_view(private_key).map_err(|_| SshKeyImportError::Parsing)
+    ssh_private_key_to_data(private_key).map_err(|_| SshKeyImportError::Parsing)
 }
 
 fn import_openssh_key(
     encoded_key: String,
     password: Option<String>,
-) -> Result<SshKeyView, SshKeyImportError> {
+) -> Result<SshKeyData, SshKeyImportError> {
     let private_key =
         ssh_key::private::PrivateKey::from_openssh(&encoded_key).map_err(|err| match err {
             ssh_key::Error::AlgorithmUnknown | ssh_key::Error::AlgorithmUnsupported { .. } => {
@@ -165,7 +164,7 @@ fn import_openssh_key(
         private_key
     };
 
-    ssh_private_key_to_view(private_key).map_err(|_| SshKeyImportError::Parsing)
+    ssh_private_key_to_data(private_key).map_err(|_| SshKeyImportError::Parsing)
 }
 
 fn import_ecdsa_pkcs8_der(encoded_key: &[u8]) -> Result<ssh_key::PrivateKey, SshKeyImportError> {

--- a/crates/bitwarden-ssh/src/lib.rs
+++ b/crates/bitwarden-ssh/src/lib.rs
@@ -9,7 +9,6 @@ pub mod generator;
 #[allow(missing_docs)]
 pub mod import;
 
-use bitwarden_vault::SshKeyView;
 use error::SshKeyExportError;
 use pkcs8::LineEnding;
 use ssh_key::{HashAlg, PrivateKey};
@@ -17,12 +16,23 @@ use ssh_key::{HashAlg, PrivateKey};
 #[cfg(feature = "uniffi")]
 uniffi::setup_scaffolding!();
 
-fn ssh_private_key_to_view(value: PrivateKey) -> Result<SshKeyView, SshKeyExportError> {
+/// Decoded SSH key material returned by this crate's import/generate functions.
+#[derive(Debug)]
+pub struct SshKeyData {
+    /// SSH private key in unencrypted OpenSSH format.
+    pub private_key: String,
+    /// SSH public key according to RFC 4253.
+    pub public_key: String,
+    /// SSH fingerprint using SHA256 in the format: `SHA256:BASE64_ENCODED_FINGERPRINT`.
+    pub fingerprint: String,
+}
+
+fn ssh_private_key_to_data(value: PrivateKey) -> Result<SshKeyData, SshKeyExportError> {
     let private_key_openssh = value
         .to_openssh(LineEnding::LF)
         .map_err(|_| SshKeyExportError::KeyConversion)?;
 
-    Ok(SshKeyView {
+    Ok(SshKeyData {
         private_key: private_key_openssh.to_string(),
         public_key: value.public_key().to_string(),
         fingerprint: value.fingerprint(HashAlg::Sha256).to_string(),

--- a/crates/bitwarden-uniffi/src/tool/ssh.rs
+++ b/crates/bitwarden-uniffi/src/tool/ssh.rs
@@ -11,7 +11,9 @@ impl SshClient {
         &self,
         key_algorithm: bitwarden_ssh::generator::KeyAlgorithm,
     ) -> Result<SshKeyView> {
-        bitwarden_ssh::generator::generate_sshkey(key_algorithm).map_err(Into::into)
+        bitwarden_ssh::generator::generate_sshkey(key_algorithm)
+            .map(Into::into)
+            .map_err(Into::into)
     }
 
     pub fn import_ssh_key(
@@ -19,6 +21,8 @@ impl SshClient {
         imported_key: String,
         password: Option<String>,
     ) -> Result<SshKeyView> {
-        bitwarden_ssh::import::import_key(imported_key, password).map_err(Into::into)
+        bitwarden_ssh::import::import_key(imported_key, password)
+            .map(Into::into)
+            .map_err(Into::into)
     }
 }

--- a/crates/bitwarden-vault/Cargo.toml
+++ b/crates/bitwarden-vault/Cargo.toml
@@ -41,6 +41,7 @@ bitwarden-crypto = { workspace = true }
 bitwarden-encoding = { workspace = true }
 bitwarden-error = { workspace = true }
 bitwarden-logging = { workspace = true }
+bitwarden-ssh = { workspace = true }
 bitwarden-state = { workspace = true }
 bitwarden-sync = { workspace = true }
 bitwarden-uuid = { workspace = true }

--- a/crates/bitwarden-vault/src/cipher/cipher.rs
+++ b/crates/bitwarden-vault/src/cipher/cipher.rs
@@ -3224,8 +3224,8 @@ mod tests {
         assert!(cipher.ssh_key.is_some());
         let ssh_key = cipher.ssh_key.unwrap();
         assert_eq!(ssh_key.private_key.to_string(), TEST_ENC_STRING_1);
-        assert_eq!(ssh_key.public_key.to_string(), TEST_ENC_STRING_2);
-        assert_eq!(ssh_key.fingerprint.to_string(), TEST_ENC_STRING_3);
+        assert_eq!(ssh_key.public_key.unwrap().to_string(), TEST_ENC_STRING_2);
+        assert_eq!(ssh_key.fingerprint.unwrap().to_string(), TEST_ENC_STRING_3);
     }
 
     #[test]

--- a/crates/bitwarden-vault/src/cipher/ssh_key.rs
+++ b/crates/bitwarden-vault/src/cipher/ssh_key.rs
@@ -21,10 +21,10 @@ use crate::{Cipher, VaultParseError, cipher::cipher::CopyableCipherFields};
 pub struct SshKey {
     /// SSH private key (ed25519/rsa) in unencrypted openssh private key format [OpenSSH private key](https://github.com/openssh/openssh-portable/blob/master/PROTOCOL.key)
     pub private_key: EncString,
-    /// SSH public key (ed25519/rsa) according to [RFC4253](https://datatracker.ietf.org/doc/html/rfc4253#section-6.6)
-    pub public_key: EncString,
-    /// SSH fingerprint using SHA256 in the format: `SHA256:BASE64_ENCODED_FINGERPRINT`
-    pub fingerprint: EncString,
+    /// SSH public key (ed25519/rsa) according to [RFC4253](https://datatracker.ietf.org/doc/html/rfc4253#section-6.6).
+    pub public_key: Option<EncString>,
+    /// SSH fingerprint using SHA256 in the format: `SHA256:BASE64_ENCODED_FINGERPRINT`.
+    pub fingerprint: Option<EncString>,
 }
 
 #[allow(missing_docs)]
@@ -41,16 +41,50 @@ pub struct SshKeyView {
     pub fingerprint: String,
 }
 
+impl From<bitwarden_ssh::SshKeyData> for SshKeyView {
+    fn from(key: bitwarden_ssh::SshKeyData) -> Self {
+        SshKeyView {
+            private_key: key.private_key,
+            public_key: key.public_key,
+            fingerprint: key.fingerprint,
+        }
+    }
+}
+
+/// Derive the public key and fingerprint from an unencrypted OpenSSH private key.
+///
+/// Returns empty strings if the key cannot be parsed.
+fn derive_public_key_and_fingerprint(private_key: &str) -> (String, String) {
+    bitwarden_ssh::import::import_key(private_key.to_string(), None)
+        .map(|data| (data.public_key, data.fingerprint))
+        .unwrap_or_default()
+}
+
 impl CompositeEncryptable<KeySlotIds, SymmetricKeySlotId, SshKey> for SshKeyView {
     fn encrypt_composite(
         &self,
         ctx: &mut KeyStoreContext<KeySlotIds>,
         key: SymmetricKeySlotId,
     ) -> Result<SshKey, CryptoError> {
+        // Derive the public key/fingerprint from the private key when absent, so stored data is
+        // always complete.
+        let mut public_key = self.public_key.clone();
+        let mut fingerprint = self.fingerprint.clone();
+        if public_key.is_empty() || fingerprint.is_empty() {
+            let (derived_public_key, derived_fingerprint) =
+                derive_public_key_and_fingerprint(&self.private_key);
+            if public_key.is_empty() {
+                public_key = derived_public_key;
+            }
+            if fingerprint.is_empty() {
+                fingerprint = derived_fingerprint;
+            }
+        }
+
         Ok(SshKey {
             private_key: self.private_key.encrypt(ctx, key)?,
-            public_key: self.public_key.encrypt(ctx, key)?,
-            fingerprint: self.fingerprint.encrypt(ctx, key)?,
+            public_key: Some(public_key.encrypt(ctx, key)?),
+            fingerprint: Some(fingerprint.encrypt(ctx, key)?),
         })
     }
 }
@@ -61,11 +95,24 @@ impl Decryptable<KeySlotIds, SymmetricKeySlotId, SshKeyView> for SshKey {
         ctx: &mut KeyStoreContext<KeySlotIds>,
         key: SymmetricKeySlotId,
     ) -> Result<SshKeyView, CryptoError> {
-        Ok(SshKeyView {
-            private_key: self.private_key.decrypt(ctx, key)?,
-            public_key: self.public_key.decrypt(ctx, key)?,
-            fingerprint: self.fingerprint.decrypt(ctx, key)?,
-        })
+        let private_key: String = self.private_key.decrypt(ctx, key)?;
+
+        match (&self.public_key, &self.fingerprint) {
+            (Some(public_key), Some(fingerprint)) => Ok(SshKeyView {
+                private_key,
+                public_key: public_key.decrypt(ctx, key)?,
+                fingerprint: fingerprint.decrypt(ctx, key)?,
+            }),
+            // Derive both from the private key when either is absent.
+            _ => {
+                let (public_key, fingerprint) = derive_public_key_and_fingerprint(&private_key);
+                Ok(SshKeyView {
+                    private_key,
+                    public_key,
+                    fingerprint,
+                })
+            }
+        }
     }
 }
 
@@ -75,7 +122,15 @@ impl CipherKind for SshKey {
         ctx: &mut KeyStoreContext<KeySlotIds>,
         key: SymmetricKeySlotId,
     ) -> Result<String, CryptoError> {
-        self.fingerprint.decrypt(ctx, key)
+        match &self.fingerprint {
+            Some(fingerprint) => fingerprint.decrypt(ctx, key),
+            // Derive the fingerprint from the private key when it isn't stored.
+            None => {
+                let private_key: String = self.private_key.decrypt(ctx, key)?;
+                let (_, fingerprint) = derive_public_key_and_fingerprint(&private_key);
+                Ok(fingerprint)
+            }
+        }
     }
 
     fn get_copyable_fields(&self, _: Option<&Cipher>) -> Vec<CopyableCipherFields> {
@@ -89,8 +144,8 @@ impl TryFrom<CipherSshKeyModel> for SshKey {
     fn try_from(ssh_key: CipherSshKeyModel) -> Result<Self, Self::Error> {
         Ok(Self {
             private_key: require!(EncString::try_from_optional(ssh_key.private_key)?),
-            public_key: require!(EncString::try_from_optional(ssh_key.public_key)?),
-            fingerprint: require!(EncString::try_from_optional(ssh_key.key_fingerprint)?),
+            public_key: EncString::try_from_optional(ssh_key.public_key)?,
+            fingerprint: EncString::try_from_optional(ssh_key.key_fingerprint)?,
         })
     }
 }
@@ -99,8 +154,8 @@ impl From<SshKey> for CipherSshKeyModel {
     fn from(ssh_key: SshKey) -> Self {
         Self {
             private_key: Some(ssh_key.private_key.to_string()),
-            public_key: Some(ssh_key.public_key.to_string()),
-            key_fingerprint: Some(ssh_key.fingerprint.to_string()),
+            public_key: ssh_key.public_key.map(|e| e.to_string()),
+            key_fingerprint: ssh_key.fingerprint.map(|e| e.to_string()),
         }
     }
 }
@@ -127,8 +182,8 @@ mod tests {
 
         let ssh_key = SshKey {
             private_key: private_key_encrypted,
-            public_key: public_key_encrypted,
-            fingerprint: fingerprint_encrypted,
+            public_key: Some(public_key_encrypted),
+            fingerprint: Some(fingerprint_encrypted),
         };
 
         assert_eq!(
@@ -138,11 +193,115 @@ mod tests {
     }
 
     #[test]
+    fn test_deserialize_missing_public_key_and_fingerprint() {
+        // A cipher with only a private key deserializes with the missing fields as None.
+        let absent = r#"{"privateKey":"2.tMIugb6zQOL+EuOizna1wQ==|W5dDLoNJtajN68yeOjrr6w==|qS4hwJB0B0gNLI0o+jxn+sKMBmvtVgJCRYNEXBZoGeE="}"#;
+        let ssh_key: SshKey = serde_json::from_str(absent).unwrap();
+        assert!(ssh_key.public_key.is_none());
+        assert!(ssh_key.fingerprint.is_none());
+
+        let null = r#"{"privateKey":"2.tMIugb6zQOL+EuOizna1wQ==|W5dDLoNJtajN68yeOjrr6w==|qS4hwJB0B0gNLI0o+jxn+sKMBmvtVgJCRYNEXBZoGeE=","publicKey":null,"fingerprint":null}"#;
+        let ssh_key: SshKey = serde_json::from_str(null).unwrap();
+        assert!(ssh_key.public_key.is_none());
+        assert!(ssh_key.fingerprint.is_none());
+    }
+
+    #[test]
+    fn test_decrypt_unparseable_private_key_falls_back_to_empty() {
+        // An absent public key/fingerprint with an unparseable private key decrypts to empty.
+        let key = SymmetricCryptoKey::try_from("hvBMMb1t79YssFZkpetYsM3deyVuQv4r88Uj9gvYe0+G8EwxvW3v1iywVmSl61iwzd17JW5C/ivzxSP2C9h7Tw==".to_string()).unwrap();
+        let key_store = create_test_crypto_with_user_key(key);
+        let key = SymmetricKeySlotId::User;
+        let mut ctx = key_store.context();
+
+        let ssh_key = SshKey {
+            private_key: "the-private-key"
+                .to_string()
+                .encrypt(&mut ctx, key)
+                .unwrap(),
+            public_key: None,
+            fingerprint: None,
+        };
+
+        let view = ssh_key.decrypt(&mut ctx, key).unwrap();
+        assert_eq!(view.private_key, "the-private-key");
+        assert_eq!(view.public_key, "");
+        assert_eq!(view.fingerprint, "");
+    }
+
+    #[test]
+    fn test_decrypt_derives_missing_public_key_and_fingerprint() {
+        // A cipher with only a private key decrypts to a complete view, deriving the public key
+        // and fingerprint.
+        let key = SymmetricCryptoKey::try_from("hvBMMb1t79YssFZkpetYsM3deyVuQv4r88Uj9gvYe0+G8EwxvW3v1iywVmSl61iwzd17JW5C/ivzxSP2C9h7Tw==".to_string()).unwrap();
+        let key_store = create_test_crypto_with_user_key(key);
+        let key = SymmetricKeySlotId::User;
+        let mut ctx = key_store.context();
+
+        // A real key whose public key and fingerprint are derivable from the private key.
+        let generated = bitwarden_ssh::generator::generate_sshkey(
+            bitwarden_ssh::generator::KeyAlgorithm::Ed25519,
+        )
+        .unwrap();
+
+        let ssh_key = SshKey {
+            private_key: generated
+                .private_key
+                .clone()
+                .encrypt(&mut ctx, key)
+                .unwrap(),
+            public_key: None,
+            fingerprint: None,
+        };
+
+        let view = ssh_key.decrypt(&mut ctx, key).unwrap();
+        assert_eq!(view.private_key, generated.private_key);
+        assert_eq!(view.public_key, generated.public_key);
+        assert_eq!(view.fingerprint, generated.fingerprint);
+        assert!(!view.public_key.is_empty());
+        assert!(!view.fingerprint.is_empty());
+
+        // The list subtitle derives the same fingerprint.
+        assert_eq!(
+            ssh_key.decrypt_subtitle(&mut ctx, key).unwrap(),
+            generated.fingerprint
+        );
+    }
+
+    #[test]
+    fn test_encrypt_composite_derives_missing_fields() {
+        // Write path: a view lacking the public key/fingerprint must persist derived values.
+        let key = SymmetricCryptoKey::try_from("hvBMMb1t79YssFZkpetYsM3deyVuQv4r88Uj9gvYe0+G8EwxvW3v1iywVmSl61iwzd17JW5C/ivzxSP2C9h7Tw==".to_string()).unwrap();
+        let key_store = create_test_crypto_with_user_key(key);
+        let key = SymmetricKeySlotId::User;
+        let mut ctx = key_store.context();
+
+        let generated = bitwarden_ssh::generator::generate_sshkey(
+            bitwarden_ssh::generator::KeyAlgorithm::Ed25519,
+        )
+        .unwrap();
+
+        let view = SshKeyView {
+            private_key: generated.private_key.clone(),
+            public_key: String::new(),
+            fingerprint: String::new(),
+        };
+
+        let encrypted = view.encrypt_composite(&mut ctx, key).unwrap();
+        assert!(encrypted.public_key.is_some());
+        assert!(encrypted.fingerprint.is_some());
+
+        let decrypted = encrypted.decrypt(&mut ctx, key).unwrap();
+        assert_eq!(decrypted.public_key, generated.public_key);
+        assert_eq!(decrypted.fingerprint, generated.fingerprint);
+    }
+
+    #[test]
     fn test_get_copyable_fields_sshkey() {
         let ssh_key = SshKey {
             private_key: "2.tMIugb6zQOL+EuOizna1wQ==|W5dDLoNJtajN68yeOjrr6w==|qS4hwJB0B0gNLI0o+jxn+sKMBmvtVgJCRYNEXBZoGeE=".parse().unwrap(),
-            public_key: "2.tMIugb6zQOL+EuOizna1wQ==|W5dDLoNJtajN68yeOjrr6w==|qS4hwJB0B0gNLI0o+jxn+sKMBmvtVgJCRYNEXBZoGeE=".parse().unwrap(),
-            fingerprint: "2.tMIugb6zQOL+EuOizna1wQ==|W5dDLoNJtajN68yeOjrr6w==|qS4hwJB0B0gNLI0o+jxn+sKMBmvtVgJCRYNEXBZoGeE=".parse().unwrap(),
+            public_key: Some("2.tMIugb6zQOL+EuOizna1wQ==|W5dDLoNJtajN68yeOjrr6w==|qS4hwJB0B0gNLI0o+jxn+sKMBmvtVgJCRYNEXBZoGeE=".parse().unwrap()),
+            fingerprint: Some("2.tMIugb6zQOL+EuOizna1wQ==|W5dDLoNJtajN68yeOjrr6w==|qS4hwJB0B0gNLI0o+jxn+sKMBmvtVgJCRYNEXBZoGeE=".parse().unwrap()),
         };
 
         let copyable_fields = ssh_key.get_copyable_fields(None);

--- a/crates/bitwarden-wasm-internal/src/ssh.rs
+++ b/crates/bitwarden-wasm-internal/src/ssh.rs
@@ -13,7 +13,7 @@ use wasm_bindgen::prelude::*;
 pub fn generate_ssh_key(
     key_algorithm: bitwarden_ssh::generator::KeyAlgorithm,
 ) -> Result<SshKeyView, bitwarden_ssh::error::KeyGenerationError> {
-    bitwarden_ssh::generator::generate_sshkey(key_algorithm)
+    bitwarden_ssh::generator::generate_sshkey(key_algorithm).map(Into::into)
 }
 
 /// Convert a PCKS8 or OpenSSH encrypted or unencrypted private key
@@ -34,5 +34,5 @@ pub fn import_ssh_key(
     imported_key: &str,
     password: Option<String>,
 ) -> Result<SshKeyView, bitwarden_ssh::error::SshKeyImportError> {
-    bitwarden_ssh::import::import_key(imported_key.to_string(), password)
+    bitwarden_ssh::import::import_key(imported_key.to_string(), password).map(Into::into)
 }


### PR DESCRIPTION
## 🎟️ Tracking
https://bitwarden.atlassian.net/browse/PM-40201
<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective
Some SSH key ciphers are stored with a private key but a null `publicKey` and/or `keyFingerprint`, created through a since-closed client loophole. When one of these items is present, decryption fails and the user's vault breaks completely
<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

## 🚨 Breaking Changes
1. Encrypted SshKey fields are now optional: public_key/fingerprint went EncString → Option<EncString>, making them nullable/optional in the mobile (uniffi) and TS (tsify) bindings; consumers reading or constructing the encrypted SSH key must handle absence.
2. bitwarden-ssh return type changed:  `import_key/import_pkcs8_der_key/generate_sshkey` now return `SshKeyData` instead of `SshKeyView`; Rust-only (doesn't cross FFI).
<!-- Does this PR introduce any breaking changes? If so, please describe the impact and migration path for clients.

If you're unsure, the automated TypeScript compatibility check will run when you open/update this PR and provide feedback.

For breaking changes:
1. Describe what changed in the client interface
2. Explain why the change was necessary
3. Provide migration steps for client developers
4. Link to any paired client PRs if needed

Otherwise, you can remove this section. -->
