### PR TITLE
chore(deps): add license for crates owned by @bitwarden/team-admin-console-dev

### DIFF
--- a/crates/bitwarden-collections/Cargo.toml
+++ b/crates/bitwarden-collections/Cargo.toml
@@ -6,7 +6,7 @@ edition.workspace = true
 rust-version.workspace = true
 homepage.workspace = true
 repository.workspace = true
-license-file.workspace = true
+license = "GPL-3.0-only OR LicenseRef-Bitwarden-SDK"
 readme.workspace = true
 keywords.workspace = true
 

--- a/crates/bitwarden-organization-invite-link/Cargo.toml
+++ b/crates/bitwarden-organization-invite-link/Cargo.toml
@@ -11,7 +11,7 @@ rust-version.workspace = true
 readme.workspace = true
 homepage.workspace = true
 repository.workspace = true
-license-file.workspace = true
+license = "GPL-3.0-only OR LicenseRef-Bitwarden-SDK"
 keywords.workspace = true
 
 [features]

--- a/crates/bitwarden-organizations/Cargo.toml
+++ b/crates/bitwarden-organizations/Cargo.toml
@@ -10,7 +10,7 @@ edition.workspace = true
 rust-version.workspace = true
 homepage.workspace = true
 repository.workspace = true
-license-file.workspace = true
+license = "GPL-3.0-only OR LicenseRef-Bitwarden-SDK"
 readme.workspace = true
 keywords.workspace = true
 

--- a/crates/bitwarden-policies/Cargo.toml
+++ b/crates/bitwarden-policies/Cargo.toml
@@ -9,7 +9,7 @@ edition.workspace = true
 rust-version.workspace = true
 homepage.workspace = true
 repository.workspace = true
-license-file.workspace = true
+license = "GPL-3.0-only OR LicenseRef-Bitwarden-SDK"
 readme.workspace = true
 keywords.workspace = true
 


### PR DESCRIPTION
https://bitwarden.atlassian.net/browse/PM-40213

Cargo deny needs a proper license entry instead of a license file. We add "GPL-3.0-only OR LicenseRef-Bitwarden-SDK"