### PR TITLE
chore(deps): add license for crates owned by @bitwarden/team-key-management-dev

### DIFF
--- a/crates/bitwarden-crypto/Cargo.toml
+++ b/crates/bitwarden-crypto/Cargo.toml
@@ -11,7 +11,7 @@ rust-version.workspace = true
 readme.workspace = true
 homepage.workspace = true
 repository.workspace = true
-license-file.workspace = true
+license = "GPL-3.0-only OR LicenseRef-Bitwarden-SDK"
 keywords.workspace = true
 
 [features]

--- a/crates/bitwarden-organization-crypto/Cargo.toml
+++ b/crates/bitwarden-organization-crypto/Cargo.toml
@@ -10,7 +10,7 @@ edition.workspace = true
 rust-version.workspace = true
 homepage.workspace = true
 repository.workspace = true
-license-file.workspace = true
+license = "GPL-3.0-only OR LicenseRef-Bitwarden-SDK"
 readme.workspace = true
 keywords.workspace = true
 

--- a/crates/bitwarden-random/Cargo.toml
+++ b/crates/bitwarden-random/Cargo.toml
@@ -11,7 +11,7 @@ rust-version.workspace = true
 readme.workspace = true
 homepage.workspace = true
 repository.workspace = true
-license-file.workspace = true
+license = "GPL-3.0-only OR LicenseRef-Bitwarden-SDK"
 keywords.workspace = true
 
 [package.metadata.cargo-udeps.ignore]

--- a/crates/bitwarden-sensitive-value/Cargo.toml
+++ b/crates/bitwarden-sensitive-value/Cargo.toml
@@ -11,7 +11,7 @@ rust-version.workspace = true
 readme.workspace = true
 homepage.workspace = true
 repository.workspace = true
-license-file.workspace = true
+license = "GPL-3.0-only OR LicenseRef-Bitwarden-SDK"
 keywords.workspace = true
 
 [features]

--- a/crates/bitwarden-shared-unlock/Cargo.toml
+++ b/crates/bitwarden-shared-unlock/Cargo.toml
@@ -9,7 +9,7 @@ rust-version.workspace = true
 readme.workspace = true
 homepage.workspace = true
 repository.workspace = true
-license-file.workspace = true
+license = "GPL-3.0-only OR LicenseRef-Bitwarden-SDK"
 keywords.workspace = true
 
 [features]

--- a/crates/bitwarden-state-bridge-macro/Cargo.toml
+++ b/crates/bitwarden-state-bridge-macro/Cargo.toml
@@ -11,7 +11,7 @@ rust-version.workspace = true
 readme.workspace = true
 homepage.workspace = true
 repository.workspace = true
-license-file.workspace = true
+license = "GPL-3.0-only OR LicenseRef-Bitwarden-SDK"
 keywords.workspace = true
 
 [lib]

--- a/crates/bitwarden-unlock/Cargo.toml
+++ b/crates/bitwarden-unlock/Cargo.toml
@@ -11,7 +11,7 @@ rust-version.workspace = true
 readme.workspace = true
 homepage.workspace = true
 repository.workspace = true
-license-file.workspace = true
+license = "GPL-3.0-only OR LicenseRef-Bitwarden-SDK"
 keywords.workspace = true
 
 [features]

--- a/crates/bitwarden-user-crypto-management/Cargo.toml
+++ b/crates/bitwarden-user-crypto-management/Cargo.toml
@@ -11,7 +11,7 @@ rust-version.workspace = true
 readme.workspace = true
 homepage.workspace = true
 repository.workspace = true
-license-file.workspace = true
+license = "GPL-3.0-only OR LicenseRef-Bitwarden-SDK"
 keywords.workspace = true
 
 [features]


### PR DESCRIPTION
https://bitwarden.atlassian.net/browse/PM-40213

Cargo deny needs a proper license entry instead of a license file. We add "GPL-3.0-only OR LicenseRef-Bitwarden-SDK"