### PR TITLE
chore(deps): add license for crates owned by @bitwarden/team-vault-dev

### DIFF
--- a/crates/bitwarden-vault/Cargo.toml
+++ b/crates/bitwarden-vault/Cargo.toml
@@ -11,7 +11,7 @@ rust-version.workspace = true
 readme.workspace = true
 homepage.workspace = true
 repository.workspace = true
-license-file.workspace = true
+license = "GPL-3.0-only OR LicenseRef-Bitwarden-SDK"
 keywords.workspace = true
 
 [features]


### PR DESCRIPTION
https://bitwarden.atlassian.net/browse/PM-40213

Cargo deny needs a proper license entry instead of a license file. We add "GPL-3.0-only OR LicenseRef-Bitwarden-SDK"