### PR TITLE
Remove aes_armv8 flag

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,9 +1,6 @@
 [resolver]
 incompatible-rust-versions = "fallback"
 
-[target.'cfg(target_arch="aarch64")']
-rustflags = ["--cfg", "aes_armv8"]
-
 [target.wasm32-unknown-unknown]
 rustflags = ['--cfg', 'getrandom_backend="wasm_js"']
 runner = 'cargo run -p wasm-bindgen-cli-runner --bin wasm-bindgen-test-runner'


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective

This has been enabled by default in `aes 0.9` already: https://github.com/RustCrypto/block-ciphers/blob/master/aes/CHANGELOG.md#changed

## 🚨 Breaking Changes

<!-- Does this PR introduce any breaking changes? If so, please describe the impact and migration path for clients.

If you're unsure, the automated TypeScript compatibility check will run when you open/update this PR and provide feedback.

For breaking changes:
1. Describe what changed in the client interface
2. Explain why the change was necessary
3. Provide migration steps for client developers
4. Link to any paired client PRs if needed

Otherwise, you can remove this section. -->
