### PR TITLE
feat(crypto): add cose key thumbprint support

### DIFF
--- a/crates/bitwarden-crypto/src/cose/mod.rs
+++ b/crates/bitwarden-crypto/src/cose/mod.rs
@@ -6,13 +6,15 @@
 use std::fmt::Debug;
 
 pub(crate) mod symmetric;
-
+mod thumbprint;
 use coset::{
     ContentType, Header, Label,
     iana::{self, CoapContentFormat, KeyOperation},
 };
 use hybrid_array::Array;
 use thiserror::Error;
+pub(crate) use thumbprint::thumbprint_from_required_params;
+pub use thumbprint::{CoseKeyThumbprint, CoseKeyThumbprintExt};
 use typenum::U32;
 
 use crate::{

--- a/crates/bitwarden-crypto/src/cose/thumbprint.rs
+++ b/crates/bitwarden-crypto/src/cose/thumbprint.rs
@@ -1,0 +1,147 @@
+//! [RFC 9679](https://www.rfc-editor.org/rfc/rfc9679) COSE Key Thumbprints.
+//!
+//! A COSE Key Thumbprint is a deterministic hash of a COSE_Key — the COSE analogue of the JWK
+//! thumbprint ([RFC 7638](https://www.rfc-editor.org/rfc/rfc7638)). It is computed by:
+//!
+//! 1. Collecting **only** the parameters required for that key type (e.g. for an OKP key `kty`,
+//!    `crv`, and `x`), excluding `kid`, `key_ops`, and any private material.
+//! 2. Encoding those parameters as a CBOR map using the deterministic encoding of [RFC 8949 §4.2.1](https://www.rfc-editor.org/rfc/rfc8949#section-4.2.1)
+//!    (definite-length map, shortest-form integers, map keys sorted bytewise-lexicographically by
+//!    their encoded bytes).
+//! 3. Hashing the result. This implementation only supports the RFC 9679 default hash, SHA-256.
+//!
+//! Because the thumbprint is computed over public material for asymmetric keys, a private key and
+//! its corresponding public key produce the same thumbprint. The same applies for signature key
+//! pairs / their verification key.
+
+use ciborium::{Value, value::Integer};
+use sha2::{Digest, Sha256};
+
+/// An [RFC 9679](https://www.rfc-editor.org/rfc/rfc9679) COSE Key Thumbprint.
+///
+/// ```no_run
+/// use bitwarden_crypto::{CoseKeyThumbprintExt, SignatureAlgorithm, SigningKey};
+///
+/// let key = SigningKey::make(SignatureAlgorithm::Ed25519);
+/// let thumbprint = key.thumbprint().expect("Ed25519 keys are always COSE-representable");
+/// println!("{}", thumbprint); // e.g. "SHA256:50d858e0985ecc7f60418aaf0cc5ab587f42c2570a884095a9e8ccacd0f6545c"
+/// ```
+#[derive(Clone, PartialEq, Eq)]
+pub struct CoseKeyThumbprint([u8; 32]);
+
+impl CoseKeyThumbprint {
+    /// The raw 32-byte SHA-256 digest.
+    pub fn as_bytes(&self) -> &[u8; 32] {
+        &self.0
+    }
+
+    /// The thumbprint as a lowercase hex string.
+    pub fn to_hex(&self) -> String {
+        hex::encode(self.0)
+    }
+}
+
+impl std::fmt::Display for CoseKeyThumbprint {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "SHA256:{}", self.to_hex())
+    }
+}
+
+impl std::fmt::Debug for CoseKeyThumbprint {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "CoseKeyThumbprint({})", self.to_hex())
+    }
+}
+
+/// Computes the [RFC 9679](https://www.rfc-editor.org/rfc/rfc9679) COSE Key Thumbprint of a key.
+pub trait CoseKeyThumbprintExt {
+    /// Returns the SHA-256 COSE Key Thumbprint of this key.
+    fn thumbprint(&self) -> Result<CoseKeyThumbprint, crate::CryptoError>;
+}
+
+/// Builds the RFC 9679 thumbprint from a key type's required parameters.
+///
+/// `params` is the list of `(label, value)` pairs of the required parameters (order does not
+/// matter; this function sorts them into the RFC 8949 §4.2.1 deterministic order). The pairs are
+/// encoded as a canonical CBOR map and hashed with SHA-256.
+pub(crate) fn thumbprint_from_required_params(mut params: Vec<(i64, Value)>) -> CoseKeyThumbprint {
+    // RFC 8949 §4.2.1: map keys are sorted by the bytewise lexicographic order of their encoded
+    // representation. Encoding each label to CBOR and comparing the bytes is exactly this rule.
+    params.sort_by_key(|(label, _)| encoded_label(*label));
+
+    let map = Value::Map(
+        params
+            .into_iter()
+            .map(|(label, value)| (Value::Integer(Integer::from(label)), value))
+            .collect(),
+    );
+
+    let mut buf = Vec::new();
+    ciborium::into_writer(&map, &mut buf)
+        .expect("CBOR serialization of a COSE key parameter map cannot fail");
+    CoseKeyThumbprint(Sha256::digest(&buf).into())
+}
+
+/// Returns the CBOR encoding of an integer label, used as the sort key for canonical ordering.
+fn encoded_label(label: i64) -> Vec<u8> {
+    let mut buf = Vec::new();
+    ciborium::into_writer(&Value::Integer(Integer::from(label)), &mut buf)
+        .expect("CBOR serialization of an integer label cannot fail");
+    buf
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Example from RFC 9679 §6, an EC2 / P-256 key, given in CBOR extended diagnostic notation:
+    ///
+    /// ```text
+    /// {
+    ///   / kty set to EC2 = Elliptic Curve Keys /
+    ///   1:2,
+    ///   / crv set to P-256 /
+    ///   -1:1,
+    ///   / public key: x-coordinate /
+    ///   -2:h'65eda5a12577c2bae829437fe338701a10aaa375e1bb5b5de108de439c08551d',
+    ///   / public key: y-coordinate /
+    ///   -3:h'1e52ed75701163f7f9e40ddf9f341b3dc9ba860af7e0ca7ca7e9eecd0084d19c',
+    ///   / kid is bstr, not used in COSE Key Thumbprint /
+    ///   2:h'496bd8afadf307e5b08c64b0421bf9dc01528a344a43bda88fadd1669da253ec'
+    /// }
+    /// ```
+    ///
+    /// EC2 is not a key type we otherwise support, but validating against it exercises the shared
+    /// canonicalization + CBOR + SHA-256 pipeline against the RFC's own test vector. Note the
+    /// `kid` above happens to equal the thumbprint (the RFC reuses it as a worked example of a
+    /// `kid` set from a key's own thumbprint), but it is not itself hashed — like any other
+    /// non-required parameter, it's excluded from the input.
+    #[test]
+    fn test_rfc9679_ec2_example() {
+        let x = hex::decode("65eda5a12577c2bae829437fe338701a10aaa375e1bb5b5de108de439c08551d")
+            .unwrap();
+        let y = hex::decode("1e52ed75701163f7f9e40ddf9f341b3dc9ba860af7e0ca7ca7e9eecd0084d19c")
+            .unwrap();
+        let expected_thumbprint =
+            "496bd8afadf307e5b08c64b0421bf9dc01528a344a43bda88fadd1669da253ec";
+
+        // Intentionally provide the params out of canonical order to exercise the sort.
+        let params = vec![
+            (-3i64, Value::Bytes(y)),
+            (1i64, Value::Integer(Integer::from(2))),
+            (-2i64, Value::Bytes(x)),
+            (-1i64, Value::Integer(Integer::from(1))),
+        ];
+
+        let thumbprint = thumbprint_from_required_params(params);
+        assert_eq!(thumbprint.to_hex(), expected_thumbprint);
+    }
+
+    #[test]
+    fn test_accessors() {
+        let thumbprint =
+            thumbprint_from_required_params(vec![(1i64, Value::Integer(Integer::from(4)))]);
+        assert_eq!(thumbprint.as_bytes().len(), 32);
+        assert_eq!(thumbprint.to_hex().len(), 64);
+    }
+}

--- a/crates/bitwarden-crypto/src/keys/public_key_encryption.rs
+++ b/crates/bitwarden-crypto/src/keys/public_key_encryption.rs
@@ -1,7 +1,9 @@
 use std::{fmt::Display, pin::Pin, str::FromStr};
 
 use bitwarden_encoding::{B64, FromStrVisitor};
-use rsa::{RsaPrivateKey, RsaPublicKey, pkcs8::DecodePublicKey};
+use ciborium::{Value, value::Integer};
+use coset::iana::{EnumI64, KeyParameter, KeyType, RsaKeyParameter};
+use rsa::{RsaPrivateKey, RsaPublicKey, pkcs8::DecodePublicKey, traits::PublicKeyParts};
 use serde::{Deserialize, Serialize};
 use serde_repr::{Deserialize_repr, Serialize_repr};
 #[cfg(feature = "wasm")]
@@ -9,7 +11,8 @@ use wasm_bindgen::convert::FromWasmAbi;
 
 use super::key_encryptable::CryptoKey;
 use crate::{
-    Pkcs8PrivateKeyBytes, SpkiPublicKeyBytes,
+    CoseKeyThumbprint, Pkcs8PrivateKeyBytes, SpkiPublicKeyBytes,
+    cose::{CoseKeyThumbprintExt, thumbprint_from_required_params},
     error::{CryptoError, Result},
 };
 
@@ -104,6 +107,31 @@ impl PublicKey {
                 .to_owned()
                 .into()),
         }
+    }
+}
+
+impl CoseKeyThumbprintExt for PublicKey {
+    fn thumbprint(&self) -> Result<CoseKeyThumbprint> {
+        let params = match &self.inner {
+            RawPublicKey::RsaOaepSha1(key) => vec![
+                (
+                    KeyParameter::Kty.to_i64(),
+                    Value::Integer(Integer::from(KeyType::RSA.to_i64())),
+                ),
+                // Per RFC 8230, `n` and `e` are unsigned big-endian byte strings with no leading
+                // zero or sign byte. `to_be_bytes_trimmed_vartime` yields exactly this minimal
+                // form; variable-time is acceptable as `n` and `e` are public.
+                (
+                    RsaKeyParameter::N.to_i64(),
+                    Value::Bytes(key.n().to_be_bytes_trimmed_vartime().into_vec()),
+                ),
+                (
+                    RsaKeyParameter::E.to_i64(),
+                    Value::Bytes(key.e().to_be_bytes_trimmed_vartime().into_vec()),
+                ),
+            ],
+        };
+        Ok(thumbprint_from_required_params(params))
     }
 }
 
@@ -269,6 +297,12 @@ impl PrivateKey {
     }
 }
 
+impl CoseKeyThumbprintExt for PrivateKey {
+    fn thumbprint(&self) -> Result<CoseKeyThumbprint> {
+        self.to_public_key().thumbprint()
+    }
+}
+
 // We manually implement these to make sure we don't print any sensitive data
 impl std::fmt::Debug for PrivateKey {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -294,8 +328,8 @@ mod tests {
     use bitwarden_encoding::B64;
 
     use crate::{
-        Pkcs8PrivateKeyBytes, PrivateKey, PublicKey, PublicKeyEncryptionAlgorithm,
-        SpkiPublicKeyBytes, SymmetricCryptoKey, UnsignedSharedKey,
+        CoseKeyThumbprintExt, Pkcs8PrivateKeyBytes, PrivateKey, PublicKey,
+        PublicKeyEncryptionAlgorithm, SpkiPublicKeyBytes, SymmetricCryptoKey, UnsignedSharedKey,
         content_format::{Bytes, Pkcs8PrivateKeyDerContentFormat},
     };
 
@@ -489,5 +523,74 @@ DnqOsltgPomWZ7xVfMkm9niL2OA=
         // Not a string
         let result: Result<PublicKey, _> = serde_json::from_str("123");
         assert!(result.is_err());
+    }
+
+    // A fixed RSA-2048 key pair (PKCS#8 / SPKI base64), reused from the encrypt/decrypt test.
+    const RSA_PRIVATE_KEY_B64: &str = concat!(
+        "MIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQCu9xd+vmkIPoqH",
+        "NejsFZzkd1xuCn1TqGTT7ANhAEnbI/yaVt3caI30kwUC2WIToFpNgu7Ej0x2TteY",
+        "OgrLrdcC4jy1SifmKYv/v3ZZxrd/eqttmH2k588panseRwHK3LVk7xA+URhQ/bjL",
+        "gPM59V0uR1l+z1fmooeJPFz5WSXNObc9Jqnh45FND+U/UYHXTLSomTn7jgZFxJBK",
+        "veS7q6Lat7wAnYZCF2dnPmhZoJv+SKPltA8HAGsgQGWBF1p5qxV1HrAUk8kBBnG2",
+        "paj0w8p5UM6RpDdCuvKH7j1LiuWffn3b9Z4dgzmE7jsMmvzoQtypzIKaSxhqzvFO",
+        "od9V8dJdAgMBAAECggEAGGIYjOIB1rOKkDHP4ljXutI0mCRPl3FMDemiBeppoIfZ",
+        "G/Q3qpAKmndDt0Quwh/yfcNdvZhf1kwCCTWri/uPz5fSUIyDV3TaTRu0ZWoHaBVj",
+        "Hxylg+4HRZUQj+Vi50/PWr/jQmAAVMcrMfcoTl82q2ynmP/R1vM3EsXOCjTliv5B",
+        "XlMPRjj/9PDBH0dnnVcAPDOpflzOTL2f4HTFEMlmg9/tZBnd96J/cmfhjAv9XpFL",
+        "FBAFZzs5pz0rwCNSR8QZNonnK7pngVUlGDLORK58y84tGmxZhGdne3CtCWey/sJ4",
+        "7QF0Pe8YqWBU56926IY6DcSVBuQGZ6vMCNlU7J8D2QKBgQDXyh3t2TicM/n1QBLk",
+        "zLoGmVUmxUGziHgl2dnJiGDtyOAU3+yCorPgFaCie29s5qm4b0YEGxUxPIrRrEro",
+        "h0FfKn9xmr8CdmTPTcjJW1+M7bxxq7oBoU/QzKXgIHlpeCjjnvPJt0PcNkNTjCXv",
+        "shsrINh2rENoe/x79eEfM/N5eQKBgQDPkYSmYyALoNq8zq0A4BdR+F5lb5Fj5jBH",
+        "Jk68l6Uti+0hRbJ2d1tQTLkU+eCPQLGBl6fuc1i4K5FV7v14jWtRPdD7wxrkRi3j",
+        "ilqQwLBOU6Bj3FK4DvlLF+iYTuBWj2/KcxflXECmsjitKHLK6H7kFEiuJql+NAHU",
+        "U9EFXepLBQKBgQDQ+HCnZ1bFHiiP8m7Zl9EGlvK5SwlnPV9s+F1KJ4IGhCNM09UM",
+        "ZVfgR9F5yCONyIrPiyK40ylgtwqQJlOcf281I8irUXpsfg7+Gou5Q31y0r9NLUpC",
+        "Td8niyePtqMdGjouxD2+OHXFCd+FRxFt4IMi7vnxYr0csAVAXkqWlw7PsQKBgH/G",
+        "/PnQm7GM3BrOwAGB8dksJDAddkshMScblezTDYP0V43b8firkTLliCo5iNum357/",
+        "VQmdSEhXyag07yR/Kklg3H2fpbZQ3X7tdMMXW3FcWagfwWw9C4oGtdDM/Z1Lv23J",
+        "XDR9je8QV4OBGul+Jl8RfYx3kG94ZIfo8Qt0vP5hAoGARjAzdCGYz42NwaUk8n94",
+        "W2RuKHtTV9vtjaAbfPFbZoGkT7sXNJVlrA0C+9f+H9rOTM3mX59KrjmLVzde4Vhs",
+        "avWMShuK4vpAiDQLU7GyABvi5CR6Ld+AT+LSzxHhVe0ASOQPNCA2SOz3RQvgPi7R",
+        "GDgRMUB6cL3IRVzcR0dC6cY=",
+    );
+    const RSA_PUBLIC_KEY_B64: &str = concat!(
+        "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEArvcXfr5pCD6KhzXo7BWc",
+        "5Hdcbgp9U6hk0+wDYQBJ2yP8mlbd3GiN9JMFAtliE6BaTYLuxI9Mdk7XmDoKy63X",
+        "AuI8tUon5imL/792Wca3f3qrbZh9pOfPKWp7HkcByty1ZO8QPlEYUP24y4DzOfVd",
+        "LkdZfs9X5qKHiTxc+VklzTm3PSap4eORTQ/lP1GB10y0qJk5+44GRcSQSr3ku6ui",
+        "2re8AJ2GQhdnZz5oWaCb/kij5bQPBwBrIEBlgRdaeasVdR6wFJPJAQZxtqWo9MPK",
+        "eVDOkaQ3Qrryh+49S4rln3592/WeHYM5hO47DJr86ELcqcyCmksYas7xTqHfVfHS",
+        "XQIDAQAB",
+    );
+
+    #[test]
+    fn test_thumbprint_private_matches_public() {
+        let private_key = PrivateKey::make(PublicKeyEncryptionAlgorithm::RsaOaepSha1);
+        assert_eq!(
+            private_key.thumbprint().unwrap(),
+            private_key.to_public_key().thumbprint().unwrap()
+        );
+    }
+
+    #[test]
+    fn test_thumbprint_rsa_vector() {
+        let private_key_bytes: B64 = RSA_PRIVATE_KEY_B64.parse().unwrap();
+        let private_key =
+            PrivateKey::from_der(&Pkcs8PrivateKeyBytes::from(private_key_bytes.as_bytes()))
+                .unwrap();
+        let public_key = PublicKey::from_der(&SpkiPublicKeyBytes::from(
+            RSA_PUBLIC_KEY_B64.parse::<B64>().unwrap().as_bytes(),
+        ))
+        .unwrap();
+
+        assert_eq!(
+            private_key.thumbprint().unwrap(),
+            public_key.thumbprint().unwrap()
+        );
+        assert_eq!(
+            public_key.thumbprint().unwrap().to_hex(),
+            "04fbcfa50c5805171304cc5b4794c25d77f7359d8a201828a5d7ef89162463aa"
+        );
     }
 }

--- a/crates/bitwarden-crypto/src/keys/symmetric_crypto_key.rs
+++ b/crates/bitwarden-crypto/src/keys/symmetric_crypto_key.rs
@@ -1,7 +1,11 @@
 use std::{pin::Pin, str::FromStr};
 
 use bitwarden_encoding::{B64, FromStrVisitor};
-use coset::{CborSerializable, RegisteredLabelWithPrivate, iana::KeyOperation};
+use ciborium::{Value, value::Integer};
+use coset::{
+    CborSerializable, RegisteredLabelWithPrivate,
+    iana::{EnumI64, KeyOperation, KeyParameter, KeyType, SymmetricKeyParameter},
+};
 use hybrid_array::Array;
 use rand::RngExt;
 #[cfg(test)]
@@ -18,7 +22,11 @@ use wasm_bindgen::convert::{FromWasmAbi, IntoWasmAbi, OptionFromWasmAbi};
 use zeroize::{Zeroize, ZeroizeOnDrop};
 
 use super::{key_encryptable::CryptoKey, key_id::KeyId};
-use crate::{BitwardenLegacyKeyBytes, ContentFormat, CoseKeyBytes, CryptoError, cose};
+use crate::{
+    BitwardenLegacyKeyBytes, ContentFormat, CoseKeyBytes, CoseKeyThumbprint, CryptoError, cose,
+    cose::{CoseKeyThumbprintExt, thumbprint_from_required_params},
+    error::EncodingError,
+};
 
 #[cfg(feature = "wasm")]
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
@@ -451,6 +459,31 @@ impl SymmetricCryptoKey {
     }
 }
 
+impl CoseKeyThumbprintExt for SymmetricCryptoKey {
+    /// Computes the RFC 9679 thumbprint of this symmetric key.
+    ///
+    /// Returns an error for the legacy AES-CBC keys, which are not representable as COSE keys
+    /// currently.
+    fn thumbprint(&self) -> Result<CoseKeyThumbprint, CryptoError> {
+        let view = self
+            .as_cose_key_view()
+            .ok_or(EncodingError::UnsupportedValue(
+                "legacy AES-CBC keys are not COSE keys and have no thumbprint",
+            ))?;
+        let params = vec![
+            (
+                KeyParameter::Kty.to_i64(),
+                Value::Integer(Integer::from(KeyType::Symmetric.to_i64())),
+            ),
+            (
+                SymmetricKeyParameter::K.to_i64(),
+                Value::Bytes(view.key_bytes().to_vec()),
+            ),
+        ];
+        Ok(thumbprint_from_required_params(params))
+    }
+}
+
 impl ConstantTimeEq for SymmetricCryptoKey {
     /// Note: This is constant time with respect to comparing two keys of the same type, but not
     /// constant type with respect to the fact that different keys are compared. If two types of
@@ -726,7 +759,8 @@ mod tests {
 
     use super::{SymmetricCryptoKey, derive_symmetric_key};
     use crate::{
-        Aes256CbcHmacKey, Aes256CbcKey, BitwardenLegacyKeyBytes, XChaCha20Poly1305Key,
+        Aes256CbcHmacKey, Aes256CbcKey, BitwardenLegacyKeyBytes, CoseKeyThumbprintExt,
+        XChaCha20Poly1305Key,
         keys::{
             KeyId,
             symmetric_crypto_key::{pad_key, unpad_key},
@@ -970,5 +1004,61 @@ mod tests {
         let key1 = SymmetricCryptoKey::XChaCha20Poly1305Key(key1);
         let key2 = SymmetricCryptoKey::XChaCha20Poly1305Key(key2);
         assert_ne!(key1, key2);
+    }
+
+    const AES256_GCM_KEY: &str =
+        "pQEEAlACAgICAgICAgICAgICAgICAwMEhAMEBQYgWCABAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQE=";
+    const AES256_GCM_KEY_THUMBPRINT: &str =
+        "3810c7275ee292caca13d938a057a94c75210087d960d3eb6868c0ffe99b5643";
+
+    const XCHACHA20_POLY1305_KEY: &str = "pQEEAlDib+JxbqMBlcd3KTUesbufAzoAARFvBIQDBAUGIFggt79surJXmqhPhYuuqi9ZyPfieebmtw2OsmN5SDrb4yUB";
+    const XCHACHA20_POLY1305_KEY_THUMBPRINT: &str =
+        "64aec2d09ef5ba8b310ef9a70346b03422443e295b6f045e38169ae97e579d85";
+
+    #[test]
+    fn test_decode_new_aes256_gcm_key() {
+        let key: B64 = AES256_GCM_KEY.parse().unwrap();
+        let key = SymmetricCryptoKey::try_from(&BitwardenLegacyKeyBytes::from(&key)).unwrap();
+        match key {
+            SymmetricCryptoKey::Aes256GcmKey(_) => (),
+            _ => panic!("Invalid key type"),
+        }
+    }
+
+    #[test]
+    fn test_thumbprint_aes256_gcm_vector() {
+        // A fixed AES-256-GCM COSE key.
+        let key: B64 = AES256_GCM_KEY.parse().unwrap();
+        let key = SymmetricCryptoKey::try_from(&BitwardenLegacyKeyBytes::from(&key)).unwrap();
+        assert_eq!(
+            key.thumbprint().unwrap().to_hex(),
+            AES256_GCM_KEY_THUMBPRINT
+        );
+    }
+
+    #[test]
+    fn test_thumbprint_xchacha20_poly1305_vector() {
+        // A fixed XChaCha20Poly1305 COSE key.
+        let key: B64 = XCHACHA20_POLY1305_KEY.parse().unwrap();
+        let key = SymmetricCryptoKey::try_from(&BitwardenLegacyKeyBytes::from(&key)).unwrap();
+        assert_eq!(
+            key.thumbprint().unwrap().to_hex(),
+            XCHACHA20_POLY1305_KEY_THUMBPRINT
+        );
+    }
+
+    #[test]
+    fn test_thumbprint_is_deterministic() {
+        let key = SymmetricCryptoKey::make_xchacha20_poly1305_key();
+        assert_eq!(key.thumbprint().unwrap(), key.thumbprint().unwrap());
+    }
+
+    #[test]
+    fn test_thumbprint_errors_for_legacy_aes_cbc() {
+        assert!(
+            SymmetricCryptoKey::make_aes256_cbc_hmac_key()
+                .thumbprint()
+                .is_err()
+        );
     }
 }

--- a/crates/bitwarden-crypto/src/lib.rs
+++ b/crates/bitwarden-crypto/src/lib.rs
@@ -39,7 +39,7 @@ pub use store::{
 };
 mod cose;
 pub(crate) use cose::CONTENT_TYPE_PADDED_CBOR;
-pub use cose::CoseSerializable;
+pub use cose::{CoseKeyThumbprint, CoseKeyThumbprintExt, CoseSerializable};
 pub mod safe;
 mod signing;
 pub use signing::*;

--- a/crates/bitwarden-crypto/src/signing/signing_key.rs
+++ b/crates/bitwarden-crypto/src/signing/signing_key.rs
@@ -17,9 +17,9 @@ use super::{
     verifying_key::{RawVerifyingKey, VerifyingKey},
 };
 use crate::{
-    CoseKeyBytes, CryptoKey,
+    CoseKeyBytes, CoseKeyThumbprint, CryptoError, CryptoKey,
     content_format::CoseKeyContentFormat,
-    cose::CoseSerializable,
+    cose::{CoseKeyThumbprintExt, CoseSerializable},
     error::{EncodingError, Result},
     keys::KeyId,
 };
@@ -216,6 +216,12 @@ impl CoseSerializable<CoseKeyContentFormat> for SigningKey {
     }
 }
 
+impl CoseKeyThumbprintExt for SigningKey {
+    fn thumbprint(&self) -> Result<CoseKeyThumbprint, CryptoError> {
+        self.to_verifying_key().thumbprint()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -317,6 +323,44 @@ mod tests {
             verifying_key
                 .verify_raw(&signature, b"Test message")
                 .is_ok()
+        );
+    }
+
+    #[test]
+    fn test_thumbprint_matches_verifying_key_ed25519() {
+        let signing_key = SigningKey::make(SignatureAlgorithm::Ed25519);
+        assert_eq!(
+            signing_key.thumbprint().unwrap(),
+            signing_key.to_verifying_key().thumbprint().unwrap()
+        );
+    }
+
+    #[test]
+    fn test_thumbprint_matches_verifying_key_mldsa44() {
+        let signing_key = SigningKey::make(SignatureAlgorithm::MlDsa44);
+        assert_eq!(
+            signing_key.thumbprint().unwrap(),
+            signing_key.to_verifying_key().thumbprint().unwrap()
+        );
+    }
+
+    #[test]
+    fn test_thumbprint_mldsa44_vector() {
+        let signing_key = SigningKey::from_cose(&CoseKeyBytes::from(
+            hex::decode(MLDSA44_SIGNING_KEY).unwrap(),
+        ))
+        .unwrap();
+        let verifying_key = VerifyingKey::from_cose(&CoseKeyBytes::from(
+            hex::decode(MLDSA44_VERIFYING_KEY).unwrap(),
+        ))
+        .unwrap();
+        assert_eq!(
+            signing_key.thumbprint().unwrap(),
+            verifying_key.thumbprint().unwrap()
+        );
+        assert_eq!(
+            signing_key.thumbprint().unwrap().to_hex(),
+            "fb932d165a6ff31caf0537ecb3c267dcbdac69773de6b739211c00e68969e233"
         );
     }
 }

--- a/crates/bitwarden-crypto/src/signing/verifying_key.rs
+++ b/crates/bitwarden-crypto/src/signing/verifying_key.rs
@@ -6,15 +6,18 @@
 use ciborium::{Value, value::Integer};
 use coset::{
     CborSerializable, MlDsaVariant, RegisteredLabel, RegisteredLabelWithPrivate,
-    iana::{Algorithm, EllipticCurve, EnumI64, KeyOperation, KeyType, OkpKeyParameter},
+    iana::{
+        AkpKeyParameter, Algorithm, EllipticCurve, EnumI64, KeyOperation, KeyParameter, KeyType,
+        OkpKeyParameter,
+    },
 };
 use ml_dsa::{MlDsa44, signature::Verifier};
 
 use super::{SignatureAlgorithm, ed25519_verifying_key, key_id, mldsa44_verifying_key};
 use crate::{
-    CoseKeyBytes, CryptoError,
+    CoseKeyBytes, CoseKeyThumbprint, CryptoError,
     content_format::CoseKeyContentFormat,
-    cose::CoseSerializable,
+    cose::{CoseKeyThumbprintExt, CoseSerializable, thumbprint_from_required_params},
     error::{EncodingError, SignatureError},
     keys::KeyId,
 };
@@ -157,6 +160,45 @@ impl CoseSerializable<CoseKeyContentFormat> for VerifyingKey {
     }
 }
 
+impl CoseKeyThumbprintExt for VerifyingKey {
+    fn thumbprint(&self) -> Result<CoseKeyThumbprint, CryptoError> {
+        let params = match &self.inner {
+            // https://datatracker.ietf.org/doc/rfc9679/
+            RawVerifyingKey::Ed25519(key) => vec![
+                (
+                    KeyParameter::Kty.to_i64(),
+                    Value::Integer(Integer::from(KeyType::OKP.to_i64())),
+                ),
+                (
+                    OkpKeyParameter::Crv.to_i64(),
+                    Value::Integer(Integer::from(EllipticCurve::Ed25519.to_i64())),
+                ),
+                // `x` is the compressed Ed25519 public key (see the note in `to_cose`).
+                (
+                    OkpKeyParameter::X.to_i64(),
+                    Value::Bytes(key.to_bytes().to_vec()),
+                ),
+            ],
+            // https://datatracker.ietf.org/doc/rfc9964/
+            RawVerifyingKey::MlDsa44(key) => vec![
+                (
+                    KeyParameter::Kty.to_i64(),
+                    Value::Integer(Integer::from(KeyType::AKP.to_i64())),
+                ),
+                (
+                    KeyParameter::Alg.to_i64(),
+                    Value::Integer(Integer::from(Algorithm::ML_DSA_44.to_i64())),
+                ),
+                (
+                    AkpKeyParameter::Pub.to_i64(),
+                    Value::Bytes(key.encode().to_vec()),
+                ),
+            ],
+        };
+        Ok(thumbprint_from_required_params(params))
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -173,6 +215,9 @@ mod tests {
         184, 1, 22, 113, 134, 154, 108, 24, 83, 78, 2, 23, 235, 80, 22, 57, 110, 100, 24, 151, 33,
         186, 12,
     ];
+    // Same key as `MLDSA44_VERIFYING_KEY` in `signing_key.rs`'s tests, kept in sync so both
+    // modules pin the same underlying key.
+    const MLDSA44_VERIFYING_KEY: &str = "a501070250e11a339366953128787c1b2c16b6945803382f048102205905205cc3620a551a0213972ad845e4930f4ecdfe1d10a81ffde8cdd1a0fffc38eefa3fd659028cad345c823074e870ffb9ed12e1d08a407db8f2431f2b75d3934e8a2662c033c8337aec1afdc1bb1babf185d709365a3057b41774dcf08e3877d4fdca2111b778ed53f6cf5b2d46d4a2427ee72c1c08a87e4e231794d8418513bae5e57d65428c41fa0b1031d6bc3b07a15f3349c4361a627c736d4e86fe3285e74277117f57df4bc53a98afcd55a77aee7e1b1465abb72e68ab2da897ceecfb8f7d4f0ced0dcf39506b31a46b795c8cee3ee6d789a1f8f7c35eb20eb17c6af5402954ec6eb41576eb2d65078b9755aca0e3af11f438df2a8abfb35d75b3fd151099735908f9b15a42f5211d4ea691014142adae9c9fdf0cf704bc4197d10f8f5f60be29abc805c6fa0f6192e4d12c8f7d50289e0ea796217f453730ca5af1ac3eb3c8ccc4bc161925806506160489a175a07bcf0f9323a4d05013117ba5f3c6d5bc6f6feadcfd093e40efbc19b8648cc8251d6d2faca5da7b506ec4b9e66b821c4176205b9ce0cd4c358b5e2a742c93b9ddb481feca10bb213925e1c661149c04e84a7809e440c190977cf015f12b6259581c368c70eec633985b78c1108f7ff42d1cb03d9ce957f705b871b57c3705ada6d6b386e647a3bacf846da4feb5c508bc4960c2d1f5378700b118fd2ea20db2790aafb7d39043bd2ab6f8902111a45fb181be8e83fa5a4c43e5d2d56797042f8d0c3e832857db0fccc61e7ea3616b70da0439eedf1a1a40196435c99b24e2ab07f8515272972faeafb2670ff66b237b00bf092da2de98a99ed4319498b4d8385aa68e36974b9c31d44b2dfebda78b3465b859296c63958cbcb587dd82e04c51986fdb9e0f3a2941ef1eac8d3b08c2fcd32ceb9dc434096c7f03e529c82132cd7e242a5668520baf00332a2de8a4f52420378350993bd35c573ba4f32e5ad89ddca1b7b3ddb0a21b0faa3674de2bdcb3519b86ed33a8939e6c7cbb9b9493279db28739b163916776bdcc40f7368000b5cefb3425b77dce84a957642319cb95226e30e119a4e455795b24e627b69881dc87084c3c1972fd170c87bcf4cc228beb4083a063e7a44c4fa8490f48457d12e4cf44b84ef41556e53599c5b4a030b4d07ee6594b6830ac0cb7823f908130fd6d2f3f9b5d65012f8e9abeeb74f4042a2a8c05fcb28f968f15f4230dfce034595141c770c200c1fd710e86d9b4d820ee0f015762526cb5a148e18874a385acef6f9efb77d43bc14936e8aa966dd53a1d2403a820f735fd60f5867570fa93ffae3214dc9ac93b2c191115a0045f71923249a10fdd8aa6ca35f6420fa1c80a867d7f54ef54b465f151de0b9a040c31d7373c81565d503cc1332dc6808533171ff2513a7139dad63b1848ba46f09255e81f7edab6208e62d17955aa43e27c74b5ed77b8d3c66ea50c478760e0db5c1b8970a22e74a29bd07bed0ba7e9c7a1866531889fa516ffd66c363d9558b2716d67809d85f16b4e18f456d5ec2343d08ea601da77676246c26432bfcd935c0d80a1e32fc41b380dff041a2629683540d5f2b9d9ef6101114242508c68987a44a0169bf8fbdabf1954bd54d745f1d66b7367848e43e0c94a6d88ccbdfd65333301d34d06d400e643e36c681c7f475b0026967d68e58af2fbf4800ca7aad6a43a3782b1d9452226ef881d50fcbb7b4df0c8c3b15ca80321cbb928fa8dce4048f01fc48121eaa1da0a954a6150c3d2e42add1b4f58910c2db0869a5481d469ef4bdccec3e7c0a21253fd19ce941b16808bf14fca6fec2b1ba7f771580235034e5ca95763721d6add9aa3914f476b37097ce67b000d5d";
 
     #[test]
     fn test_cose_roundtrip_encode_verifying() {
@@ -203,6 +248,27 @@ mod tests {
             verifying_key
                 .verify_raw(SIGNED_DATA_RAW, b"Invalid message")
                 .is_err()
+        );
+    }
+
+    #[test]
+    fn test_thumbprint_ed25519_vector() {
+        let verifying_key = VerifyingKey::from_cose(&CoseKeyBytes::from(VERIFYING_KEY)).unwrap();
+        assert_eq!(
+            verifying_key.thumbprint().unwrap().to_hex(),
+            "ea38af8eb96812daa5217a342946814921f0ebc74edaa1e9832cbc4daf9ba803"
+        );
+    }
+
+    #[test]
+    fn test_thumbprint_mldsa44_vector() {
+        let verifying_key = VerifyingKey::from_cose(&CoseKeyBytes::from(
+            hex::decode(MLDSA44_VERIFYING_KEY).unwrap(),
+        ))
+        .unwrap();
+        assert_eq!(
+            verifying_key.thumbprint().unwrap().to_hex(),
+            "fb932d165a6ff31caf0537ecb3c267dcbdac69773de6b739211c00e68969e233"
         );
     }
 }


### PR DESCRIPTION
Add support for https://www.rfc-editor.org/rfc/rfc9679 COSE Key Thumbprints, as a canonical, compact representation of keys. This representation - in contrast to key ids - can be used for cryptographic purposes

## Ticket
https://bitwarden.atlassian.net/browse/PM-40307
