### PR TITLE
refactor(crypto): implement AES256-CBC, AES256-CBC-HMAC256 hazmat primitives

### DIFF
--- a/crates/bitwarden-crypto/src/hazmat/symmetric_encryption/aes256_cbc.rs
+++ b/crates/bitwarden-crypto/src/hazmat/symmetric_encryption/aes256_cbc.rs
@@ -1,0 +1,116 @@
+//! # Legacy AES-256-CBC operations (unauthenticated)
+//!
+//! Contains the legacy AES-256-CBC primitive used by the type 0 `EncString` format. The data is
+//! **not authenticated**, so this must only be used to decrypt existing data, never to encrypt
+//! new data.
+//!
+//! In most cases you should use the [EncString][crate::EncString] with
+//! [KeyDecryptable][crate::KeyDecryptable] instead.
+
+use aes::cipher::{BlockModeDecrypt, KeyIvInit, block_padding::Pkcs7};
+
+use super::SymmetricEncryptionError;
+
+pub(crate) const IV_SIZE: usize = 16;
+pub(crate) const KEY_SIZE: usize = 32;
+
+/// The unauthenticated legacy AES-256-CBC cipher.
+pub(crate) struct Aes256Cbc;
+
+impl Aes256Cbc {
+    /// Decrypt using AES-256 in CBC mode.
+    pub(crate) fn decrypt(
+        iv: &[u8; IV_SIZE],
+        ciphertext: &[u8],
+        key: &[u8; KEY_SIZE],
+    ) -> Result<Vec<u8>, SymmetricEncryptionError> {
+        // Decrypt data in place in a copy of the ciphertext
+        let mut data = ciphertext.to_vec();
+        let decrypted_key_slice = cbc::Decryptor::<aes::Aes256>::new(key.into(), iv.into())
+            .decrypt_padded::<Pkcs7>(&mut data)
+            .map_err(|_| SymmetricEncryptionError::FormatWrong)?;
+
+        // Decryption returns a subslice of the buffer; truncate to the subslice length instead of
+        // cloning it
+        let decrypted_len = decrypted_key_slice.len();
+        data.truncate(decrypted_len);
+
+        Ok(data)
+    }
+
+    /// Encrypt using AES-256 in CBC mode.
+    #[cfg(test)]
+    fn encrypt(iv: &[u8; IV_SIZE], plaintext: &[u8], key: &[u8; KEY_SIZE]) -> Vec<u8> {
+        use aes::cipher::BlockModeEncrypt;
+
+        cbc::Encryptor::<aes::Aes256>::new(key.into(), iv.into())
+            .encrypt_padded_vec::<Pkcs7>(plaintext)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use bitwarden_encoding::B64;
+
+    use super::*;
+
+    const TESTVECTOR_PLAINTEXT: &[u8] = b"Bitwarden SDK test vector";
+    const TESTVECTOR_CIPHERTEXT: &[u8] = &[
+        111, 16, 33, 143, 207, 253, 106, 89, 58, 52, 145, 240, 140, 213, 149, 83, 168, 188, 122,
+        57, 130, 28, 35, 182, 114, 227, 215, 250, 175, 182, 169, 102,
+    ];
+    const TESTVECTOR_KEY: [u8; KEY_SIZE] = [
+        0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24,
+        25, 26, 27, 28, 29, 30, 31,
+    ];
+    const TESTVECTOR_IV: [u8; IV_SIZE] = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15];
+
+    #[test]
+    #[ignore = "Generates test vectors; run manually"]
+    fn generate_test_vectors() {
+        let ciphertext = Aes256Cbc::encrypt(&TESTVECTOR_IV, TESTVECTOR_PLAINTEXT, &TESTVECTOR_KEY);
+        let decrypted = Aes256Cbc::decrypt(&TESTVECTOR_IV, &ciphertext, &TESTVECTOR_KEY).unwrap();
+        assert_eq!(decrypted, TESTVECTOR_PLAINTEXT);
+
+        println!("const TESTVECTOR_CIPHERTEXT: &[u8] = &{ciphertext:?};");
+    }
+
+    /// Locks in the serialized format of the type 0 ciphertext; must never break, or existing
+    /// data will no longer decrypt.
+    #[test]
+    fn test_decrypt_testvector() {
+        let decrypted =
+            Aes256Cbc::decrypt(&TESTVECTOR_IV, TESTVECTOR_CIPHERTEXT, &TESTVECTOR_KEY).unwrap();
+
+        assert_eq!(decrypted, TESTVECTOR_PLAINTEXT);
+    }
+
+    #[test]
+    fn test_encrypt_decrypt_roundtrip() {
+        let plaintext = b"EncryptMe!";
+
+        let encrypted = Aes256Cbc::encrypt(&TESTVECTOR_IV, plaintext, &TESTVECTOR_KEY);
+        let decrypted = Aes256Cbc::decrypt(&TESTVECTOR_IV, &encrypted, &TESTVECTOR_KEY).unwrap();
+
+        assert_eq!(decrypted, plaintext);
+    }
+
+    #[test]
+    fn test_decrypt_aes256() {
+        let data: B64 = ("ByUF8vhyX4ddU9gcooznwA==").parse().unwrap();
+
+        let decrypted =
+            Aes256Cbc::decrypt(&TESTVECTOR_IV, data.as_bytes(), &TESTVECTOR_KEY).unwrap();
+
+        assert_eq!(String::from_utf8(decrypted).unwrap(), "EncryptMe!");
+    }
+
+    #[test]
+    fn test_decrypt_aes256_fails_on_invalid_padding() {
+        let iv = [0u8; IV_SIZE];
+
+        // Random block that will not decrypt to valid PKCS7 padding under this key/IV.
+        let result = Aes256Cbc::decrypt(&iv, &[0u8; 16], &TESTVECTOR_KEY);
+        assert_eq!(result, Err(SymmetricEncryptionError::FormatWrong));
+    }
+}

--- a/crates/bitwarden-crypto/src/hazmat/symmetric_encryption/aes256_cbc_hmac_sha256_ae.rs
+++ b/crates/bitwarden-crypto/src/hazmat/symmetric_encryption/aes256_cbc_hmac_sha256_ae.rs
@@ -1,0 +1,206 @@
+//! # Legacy AES-256-CBC-HMAC-SHA256 operations
+//!
+//! Aes256CbcHmacSha256 is the construct used in type 2 EncStrings. It is authenticated encryption
+//! (AE) via Encrypt-then-MAC, but has no support for associated data (it is not AEAD).
+
+use aes::cipher::{BlockModeDecrypt, BlockModeEncrypt, KeyIvInit, block_padding::Pkcs7};
+use hmac::{KeyInit, Mac};
+use subtle::ConstantTimeEq;
+
+use super::SymmetricEncryptionError;
+
+type HmacSha256 = hmac::Hmac<sha2::Sha256>;
+
+pub(crate) const IV_SIZE: usize = 16;
+pub(crate) const ENC_KEY_SIZE: usize = 32;
+pub(crate) const MAC_KEY_SIZE: usize = 32;
+pub(crate) const KEY_SIZE: usize = ENC_KEY_SIZE + MAC_KEY_SIZE;
+pub(crate) const MAC_SIZE: usize = 32;
+
+/// The legacy AES-256-CBC-HMAC-SHA256 Encrypt-then-MAC cipher. The 64-byte composite key is the
+/// AES-256-CBC encryption sub-key (first 32 bytes) followed by the HMAC-SHA256 authentication
+/// sub-key (last 32 bytes).
+pub(crate) struct Aes256CbcHmacSha256;
+
+impl Aes256CbcHmacSha256 {
+    /// Encrypt using AES-256 in CBC mode, returning the MAC over the IV and ciphertext along
+    /// with the ciphertext.
+    ///
+    /// A fresh, cryptographically random IV must be supplied for every message encrypted under a
+    /// given key; generating it is the caller's responsibility.
+    pub(crate) fn encrypt(
+        iv: &[u8; IV_SIZE],
+        plaintext: &[u8],
+        key: &[u8; KEY_SIZE],
+    ) -> ([u8; MAC_SIZE], Vec<u8>) {
+        let (enc_key, mac_key) = split_to_subkeys(key);
+
+        let data = cbc::Encryptor::<aes::Aes256>::new(enc_key.into(), iv.into())
+            .encrypt_padded_vec::<Pkcs7>(plaintext);
+        let mac = calculate_mac(iv, &data, mac_key);
+
+        (mac, data)
+    }
+
+    /// Decrypt using AES-256 in CBC mode, validating the MAC over the IV and ciphertext.
+    pub(crate) fn decrypt(
+        iv: &[u8; IV_SIZE],
+        ciphertext: &[u8],
+        mac: &[u8; MAC_SIZE],
+        key: &[u8; KEY_SIZE],
+    ) -> Result<Vec<u8>, SymmetricEncryptionError> {
+        let (enc_key, mac_key) = split_to_subkeys(key);
+
+        let expected_mac = calculate_mac(iv, ciphertext, mac_key);
+        if expected_mac.ct_ne(mac).into() {
+            return Err(SymmetricEncryptionError::IntegrityCheckFailed);
+        }
+
+        // Decrypt data in place in a copy of the ciphertext
+        let mut data = ciphertext.to_vec();
+        let decrypted_slice = cbc::Decryptor::<aes::Aes256>::new(enc_key.into(), iv.into())
+            .decrypt_padded::<Pkcs7>(&mut data)
+            .map_err(|_| SymmetricEncryptionError::FormatWrong)?;
+
+        // Decryption returns a subslice of the buffer; truncate to the subslice length instead of
+        // cloning it
+        let decrypted_len = decrypted_slice.len();
+        data.truncate(decrypted_len);
+
+        Ok(data)
+    }
+}
+
+/// Splits the 64-byte composite key into zero-copy views over its encryption and MAC halves.
+fn split_to_subkeys(key: &[u8; KEY_SIZE]) -> (&[u8; ENC_KEY_SIZE], &[u8; MAC_KEY_SIZE]) {
+    let (enc_key, mac_key) = key.split_at(ENC_KEY_SIZE);
+    let enc_key = enc_key
+        .try_into()
+        .expect("first half of a 64-byte key is always 32 bytes");
+    let mac_key = mac_key
+        .try_into()
+        .expect("second half of a 64-byte key is always 32 bytes");
+    (enc_key, mac_key)
+}
+
+/// Generate a MAC using HMAC-SHA256 over the IV and ciphertext, without length prefixes or
+/// associated data.
+fn calculate_mac(iv: &[u8], data: &[u8], mac_key: &[u8; MAC_KEY_SIZE]) -> [u8; MAC_SIZE] {
+    let mut hmac =
+        HmacSha256::new_from_slice(mac_key).expect("hmac new_from_slice should not fail");
+    hmac.update(iv);
+    hmac.update(data);
+    let mac: [u8; MAC_SIZE] = (*hmac.finalize().into_bytes())
+        .try_into()
+        // This is safe because HMAC-SHA256 output size is always 32 bytes
+        .expect("HMAC output size to be correct");
+    mac
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const TESTVECTOR_PLAINTEXT: &[u8] = b"Bitwarden SDK test vector";
+    const TESTVECTOR_IV: [u8; IV_SIZE] = [
+        216, 218, 36, 0, 196, 186, 150, 85, 49, 147, 110, 168, 185, 227, 42, 172,
+    ];
+    const TESTVECTOR_MAC: [u8; MAC_SIZE] = [
+        60, 78, 44, 111, 72, 233, 3, 6, 86, 250, 217, 242, 62, 229, 184, 221, 231, 150, 189, 44,
+        99, 189, 220, 55, 196, 194, 101, 60, 102, 195, 149, 130,
+    ];
+    const TESTVECTOR_DATA: &[u8] = &[
+        234, 77, 16, 15, 189, 82, 36, 188, 182, 88, 64, 67, 145, 94, 30, 178, 36, 235, 130, 67,
+        255, 207, 183, 168, 73, 231, 82, 122, 193, 139, 25, 129,
+    ];
+
+    const TESTVECTOR_KEY: [u8; KEY_SIZE] = [
+        0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24,
+        25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47,
+        48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63,
+    ];
+
+    #[test]
+    #[ignore = "Generates test vectors; run manually"]
+    fn generate_test_vectors() {
+        let (mac, data) =
+            Aes256CbcHmacSha256::encrypt(&TESTVECTOR_IV, TESTVECTOR_PLAINTEXT, &TESTVECTOR_KEY);
+        let decrypted =
+            Aes256CbcHmacSha256::decrypt(&TESTVECTOR_IV, &data, &mac, &TESTVECTOR_KEY).unwrap();
+        assert_eq!(decrypted, TESTVECTOR_PLAINTEXT);
+
+        println!("const TESTVECTOR_MAC: [u8; MAC_SIZE] = {mac:?};");
+        println!("const TESTVECTOR_DATA: &[u8] = &{data:?};");
+    }
+
+    /// Locks in the serialized format of the type 2 (iv, mac, ciphertext) triple; must never
+    /// break, or existing data will no longer decrypt.
+    #[test]
+    fn test_decrypt_testvector() {
+        let decrypted = Aes256CbcHmacSha256::decrypt(
+            &TESTVECTOR_IV,
+            TESTVECTOR_DATA,
+            &TESTVECTOR_MAC,
+            &TESTVECTOR_KEY,
+        )
+        .unwrap();
+
+        assert_eq!(decrypted, TESTVECTOR_PLAINTEXT);
+    }
+
+    #[test]
+    fn test_encrypt_is_deterministic() {
+        const IV: [u8; IV_SIZE] = [
+            62, 0, 239, 47, 137, 95, 64, 214, 127, 91, 184, 232, 31, 9, 165, 161,
+        ];
+
+        let (_mac, data) =
+            Aes256CbcHmacSha256::encrypt(&IV, "EncryptMe!".as_bytes(), &TESTVECTOR_KEY);
+        assert_eq!(
+            data,
+            vec![
+                214, 76, 187, 97, 58, 146, 212, 140, 95, 164, 177, 204, 179, 133, 172, 148
+            ]
+        );
+    }
+
+    #[test]
+    fn test_calculate_mac() {
+        const MAC_KEY: [u8; MAC_KEY_SIZE] = [
+            0, 8, 16, 24, 32, 40, 48, 56, 64, 72, 80, 88, 96, 104, 112, 120, 128, 136, 144, 152,
+            160, 168, 176, 184, 192, 200, 208, 216, 224, 232, 240, 248,
+        ];
+        const IV: [u8; IV_SIZE] = [
+            0, 16, 32, 48, 64, 80, 96, 112, 128, 144, 160, 176, 192, 208, 224, 240,
+        ];
+        const DATA: [u8; 16] = [
+            0, 16, 32, 48, 64, 80, 96, 112, 128, 144, 160, 176, 192, 208, 224, 240,
+        ];
+
+        let mac = calculate_mac(&IV, &DATA, &MAC_KEY);
+        assert!(mac.iter().any(|&b| b != 0));
+    }
+
+    #[test]
+    fn test_encrypt_decrypt_roundtrip() {
+        let plaintext = b"EncryptMe!";
+
+        let (mac, data) = Aes256CbcHmacSha256::encrypt(&TESTVECTOR_IV, plaintext, &TESTVECTOR_KEY);
+        let decrypted =
+            Aes256CbcHmacSha256::decrypt(&TESTVECTOR_IV, &data, &mac, &TESTVECTOR_KEY).unwrap();
+
+        assert_eq!(decrypted, plaintext);
+    }
+
+    #[test]
+    fn test_decrypt_fails_when_mac_changed() {
+        let plaintext = b"EncryptMe!";
+
+        let (mut mac, data) =
+            Aes256CbcHmacSha256::encrypt(&TESTVECTOR_IV, plaintext, &TESTVECTOR_KEY);
+        mac[0] = mac[0].wrapping_add(1);
+        let result = Aes256CbcHmacSha256::decrypt(&TESTVECTOR_IV, &data, &mac, &TESTVECTOR_KEY);
+
+        assert_eq!(result, Err(SymmetricEncryptionError::IntegrityCheckFailed));
+    }
+}

--- a/crates/bitwarden-crypto/src/hazmat/symmetric_encryption/mod.rs
+++ b/crates/bitwarden-crypto/src/hazmat/symmetric_encryption/mod.rs
@@ -10,12 +10,37 @@
 //! envelope or data envelope) instead.
 
 use crate::CryptoError;
+#[allow(dead_code)]
+pub(crate) mod aes256_cbc;
+
+#[allow(dead_code)]
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) enum SymmetricEncryptionError {
+    /// The input is malformed — wrong length, invalid padding, or otherwise not a valid
+    /// ciphertext for the cipher.
+    FormatWrong,
+    /// The integrity check (MAC / authentication tag) failed; the ciphertext, associated data,
+    /// nonce/IV, and key do not match.
+    IntegrityCheckFailed,
+}
+
+impl From<SymmetricEncryptionError> for CryptoError {
+    fn from(_: SymmetricEncryptionError) -> Self {
+        CryptoError::KeyDecrypt
+    }
+}
+#[allow(dead_code)]
+pub(crate) mod aes256_cbc_hmac_sha256_ae;
 pub(crate) mod aes_gcm;
 pub(crate) mod xaes_256_gcm;
 pub(crate) mod xchacha20;
 
 #[allow(unused_imports)]
 pub(crate) use aes_gcm::Aes256Gcm;
+#[allow(unused_imports)]
+pub(crate) use aes256_cbc::Aes256Cbc;
+#[allow(unused_imports)]
+pub(crate) use aes256_cbc_hmac_sha256_ae::Aes256CbcHmacSha256;
 #[allow(unused_imports)]
 pub(crate) use xaes_256_gcm::XAes256Gcm;
 #[allow(unused_imports)]


### PR DESCRIPTION
Implements aes256-cbc (as legacy compat for old user-keys), and AES256-CBC-HMAC-SHA256 in the hazmat module. This will replace the `aes.rs` file at the crate root. These implementations are close to being zero-copy. Only the plaintext buffer that is passed out is allocated.

https://bitwarden.atlassian.net/browse/PM-40756