### PR TITLE
fix(two_factor): update two-factor email model to match server API

### DIFF
--- a/crates/bitwarden-core/src/auth/login/two_factor.rs
+++ b/crates/bitwarden-core/src/auth/login/two_factor.rs
@@ -1,4 +1,4 @@
-use bitwarden_api_api::models::TwoFactorEmailRequestModel;
+use bitwarden_api_api::models::TwoFactorEmailLoginRequestModel;
 use bitwarden_crypto::HashPurpose;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -49,7 +49,7 @@ pub(crate) async fn send_two_factor_email(
     config
         .api_client
         .two_factor_api()
-        .send_email_login(Some(TwoFactorEmailRequestModel {
+        .send_email_login(Some(TwoFactorEmailLoginRequestModel {
             master_password_hash: Some(password_hash.to_string()),
             otp: None,
             auth_request_access_code: None,
@@ -88,4 +88,92 @@ pub struct TwoFactorRequest {
     pub provider: TwoFactorProvider,
     /// Two-factor remember
     pub remember: bool,
+}
+
+#[cfg(test)]
+mod tests {
+    use bitwarden_api_api::ResponseContent;
+    use bitwarden_api_identity::models::KdfType;
+    use serde_json::json;
+    use wiremock::{
+        Mock, MockServer, ResponseTemplate,
+        matchers::{method, path},
+    };
+
+    use super::*;
+    use crate::{ClientSettings, DeviceType};
+
+    fn settings_for(server: &MockServer) -> ClientSettings {
+        ClientSettings {
+            identity_url: format!("http://{}", server.address()),
+            api_url: format!("http://{}", server.address()),
+            user_agent: "two-factor-tests".to_string(),
+            device_type: DeviceType::SDK,
+            device_identifier: None,
+            bitwarden_client_version: None,
+            bitwarden_package_type: None,
+        }
+    }
+
+    async fn mock_prelogin_success(server: &MockServer) {
+        Mock::given(method("POST"))
+            .and(path("/accounts/prelogin/password"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "kdf": KdfType::PBKDF2_SHA256.as_i64(),
+                "kdfIterations": 600_000,
+            })))
+            .mount(server)
+            .await;
+    }
+
+    fn test_input() -> TwoFactorEmailRequest {
+        TwoFactorEmailRequest {
+            password: "test123".to_string(),
+            email: "test@bitwarden.com".to_string(),
+        }
+    }
+
+    #[tokio::test]
+    async fn send_two_factor_email_success() {
+        let server = MockServer::start().await;
+        mock_prelogin_success(&server).await;
+        Mock::given(method("POST"))
+            .and(path("/two-factor/send-email-login"))
+            .respond_with(ResponseTemplate::new(200))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let client = Client::new(Some(settings_for(&server)));
+
+        let result = send_two_factor_email(&client, &test_input()).await;
+
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn send_two_factor_email_api_error() {
+        let server = MockServer::start().await;
+        mock_prelogin_success(&server).await;
+        Mock::given(method("POST"))
+            .and(path("/two-factor/send-email-login"))
+            .respond_with(ResponseTemplate::new(500))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let client = Client::new(Some(settings_for(&server)));
+
+        let result = send_two_factor_email(&client, &test_input()).await;
+
+        match result {
+            Err(TwoFactorEmailError::Api(ApiError::Response(ResponseContent {
+                status,
+                message: _,
+            }))) => {
+                assert_eq!(status, reqwest::StatusCode::INTERNAL_SERVER_ERROR);
+            }
+            other => panic!("Expected Api Response error, got {:?}", other),
+        }
+    }
 }


### PR DESCRIPTION
refactor

## 🎟️ Tracking

N/A

## 📔 Objective

Standalone/no-issue update so the binding-gen #1254 can pass. 
Server refactor of `TwoFactorEmailRequestModel` to purpose-built request models for login, setup, and update means this needs updated on this side.

Also adds a brief test suite for two_factor.

## 🚨 Breaking Changes

<!-- Does this PR introduce any breaking changes? If so, please describe the impact and migration path for clients.

If you're unsure, the automated TypeScript compatibility check will run when you open/update this PR and provide feedback.

For breaking changes:
1. Describe what changed in the client interface
2. Explain why the change was necessary
3. Provide migration steps for client developers
4. Link to any paired client PRs if needed

Otherwise, you can remove this section. -->
