### PR TITLE
feat(crypto): add safe crypto based invites

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -969,7 +969,10 @@ version = "3.0.0"
 dependencies = [
  "bitwarden-crypto",
  "bitwarden-encoding",
+ "bitwarden-random",
+ "bitwarden-sensitive-value",
  "ciborium",
+ "rand 0.10.1",
  "serde",
  "serde_json",
  "subtle",
@@ -977,6 +980,7 @@ dependencies = [
  "tsify",
  "uuid",
  "wasm-bindgen",
+ "zeroize",
 ]
 
 [[package]]

--- a/crates/bitwarden-crypto/examples/protect_key_with_key.rs
+++ b/crates/bitwarden-crypto/examples/protect_key_with_key.rs
@@ -2,8 +2,7 @@
 //! [`SymmetrickeyEnvelope`].
 
 use bitwarden_crypto::{
-    KeyStore, KeyStoreContext, SymmetricKeyAlgorithm, key_slot_ids,
-    safe::{SymmetricKeyEnvelope, SymmetricKeyEnvelopeError, SymmetricKeyEnvelopeNamespace},
+    KeyStore, KeyStoreContext, SymmetricKeyAlgorithm, key_slot_ids, safe::{KeyEncryptionKey, SymmetricKeyEnvelope, SymmetricKeyEnvelopeError, SymmetricKeyEnvelopeNamespace},
 };
 
 fn main() {
@@ -13,14 +12,14 @@ fn main() {
 
     // Alice has a vault key and wants to protect it with another key.
     // For example, this can be used to persist the vault key while keeping it encrypted at rest.
-    let vault_key = ctx.generate_symmetric_key();
-    let wrapping_key = ctx.make_symmetric_key(SymmetricKeyAlgorithm::XAes256Gcm);
+    let vault_key = KeyEncryptionKey::make(&mut ctx);
+    let wrapping_key = KeyEncryptionKey::make(&mut ctx);
 
     // Seal the vault key with the wrapping key, then store the envelope on disk.
     let envelope = SymmetricKeyEnvelope::seal(
         vault_key,
         wrapping_key,
-        // IMPORTANT: Use a unique namespace for your use-case.
+        // The namespace must be replaced with an appropriate namespace for the use-case
         SymmetricKeyEnvelopeNamespace::SessionKey,
         &ctx,
     )
@@ -37,6 +36,7 @@ fn main() {
     let _unsealed_key = deserialized
         .unseal(
             wrapping_key,
+            // The namespace must be replaced with an appropriate namespace for the use-case
             SymmetricKeyEnvelopeNamespace::SessionKey,
             &mut ctx,
         )
@@ -47,6 +47,7 @@ fn main() {
     assert!(matches!(
         envelope.unseal(
             wrong_wrapping_key,
+            // The namespace must be replaced with an appropriate namespace for the use-case
             SymmetricKeyEnvelopeNamespace::SessionKey,
             &mut ctx
         ),

--- a/crates/bitwarden-crypto/examples/protect_key_with_key.rs
+++ b/crates/bitwarden-crypto/examples/protect_key_with_key.rs
@@ -2,7 +2,11 @@
 //! [`SymmetrickeyEnvelope`].
 
 use bitwarden_crypto::{
-    KeyStore, KeyStoreContext, SymmetricKeyAlgorithm, key_slot_ids, safe::{KeyEncryptionKey, SymmetricKeyEnvelope, SymmetricKeyEnvelopeError, SymmetricKeyEnvelopeNamespace},
+    KeyStore, KeyStoreContext, SymmetricKeyAlgorithm, key_slot_ids,
+    safe::{
+        KeyEncryptionKey, SymmetricKeyEnvelope, SymmetricKeyEnvelopeError,
+        SymmetricKeyEnvelopeNamespace,
+    },
 };
 
 fn main() {

--- a/crates/bitwarden-crypto/examples/protect_key_with_password.rs
+++ b/crates/bitwarden-crypto/examples/protect_key_with_password.rs
@@ -2,10 +2,8 @@
 //! [PasswordProtectedKeyEnvelope].
 
 use bitwarden_crypto::{
-    KeyStore, KeyStoreContext, key_slot_ids,
-    safe::{
-        PasswordProtectedKeyEnvelope, PasswordProtectedKeyEnvelopeError,
-        PasswordProtectedKeyEnvelopeNamespace,
+    KeyStore, KeyStoreContext, key_slot_ids, safe::{
+        KeyEncryptionKey, PasswordProtectedKeyEnvelope, PasswordProtectedKeyEnvelopeError, PasswordProtectedKeyEnvelopeNamespace,
     },
 };
 
@@ -23,7 +21,7 @@ fn main() {
 
     // Alice has a vault protected with a symmetric key. She wants the symmetric key protected with
     // a PIN.
-    let vault_key = ctx.generate_symmetric_key();
+    let vault_key = KeyEncryptionKey::make(&mut ctx);
 
     // Seal the key with the PIN
     // The KDF settings are chosen for you, and do not need to be separately tracked or synced
@@ -32,6 +30,7 @@ fn main() {
     let envelope = PasswordProtectedKeyEnvelope::seal(
         vault_key,
         pin,
+        // The namespace must be replaced with an appropriate namespace for the use-case
         PasswordProtectedKeyEnvelopeNamespace::PinUnlock,
         &ctx,
     )
@@ -50,6 +49,7 @@ fn main() {
     let _unsealed_vault_key = deserialized
         .unseal(
             pin,
+            // The namespace must be replaced with an appropriate namespace for the use-case
             PasswordProtectedKeyEnvelopeNamespace::PinUnlock,
             &mut ctx,
         )
@@ -61,6 +61,7 @@ fn main() {
         .reseal(
             pin,
             "0000",
+            // The namespace must be replaced with an appropriate namespace for the use-case
             PasswordProtectedKeyEnvelopeNamespace::PinUnlock,
         )
         .expect("The password should be valid");
@@ -71,6 +72,7 @@ fn main() {
     let envelope = PasswordProtectedKeyEnvelope::seal(
         vault_key,
         "0000",
+        // The namespace must be replaced with an appropriate namespace for the use-case
         PasswordProtectedKeyEnvelopeNamespace::PinUnlock,
         &ctx,
     )
@@ -81,6 +83,7 @@ fn main() {
     assert!(matches!(
         envelope.unseal(
             "9999",
+            // The namespace must be replaced with an appropriate namespace for the use-case
             PasswordProtectedKeyEnvelopeNamespace::PinUnlock,
             &mut ctx
         ),

--- a/crates/bitwarden-crypto/examples/protect_key_with_password.rs
+++ b/crates/bitwarden-crypto/examples/protect_key_with_password.rs
@@ -2,8 +2,10 @@
 //! [PasswordProtectedKeyEnvelope].
 
 use bitwarden_crypto::{
-    KeyStore, KeyStoreContext, key_slot_ids, safe::{
-        KeyEncryptionKey, PasswordProtectedKeyEnvelope, PasswordProtectedKeyEnvelopeError, PasswordProtectedKeyEnvelopeNamespace,
+    KeyStore, KeyStoreContext, key_slot_ids,
+    safe::{
+        KeyEncryptionKey, PasswordProtectedKeyEnvelope, PasswordProtectedKeyEnvelopeError,
+        PasswordProtectedKeyEnvelopeNamespace,
     },
 };
 

--- a/crates/bitwarden-crypto/examples/protect_key_with_secret.rs
+++ b/crates/bitwarden-crypto/examples/protect_key_with_secret.rs
@@ -7,10 +7,8 @@
 //! bytes) and uses a cheap KDF.
 
 use bitwarden_crypto::{
-    KeyStore, KeyStoreContext, SymmetricKeyAlgorithm, key_slot_ids,
-    safe::{
-        HighEntropySecret, SecretProtectedKeyEnvelope, SecretProtectedKeyEnvelopeError,
-        SecretProtectedKeyEnvelopeNamespace,
+    KeyStore, KeyStoreContext, SymmetricKeyAlgorithm, key_slot_ids, safe::{
+        ContentEncryptionKey, HighEntropySecret, SecretProtectedKeyEnvelope, SecretProtectedKeyEnvelopeError, SecretProtectedKeyEnvelopeNamespace,
     },
 };
 
@@ -28,7 +26,7 @@ fn main() {
 
     // Alice has some data protected with a symmetric key. She wants the symmetric key protected
     // with a high-entropy secret (here, 16 random bytes).
-    let data_key = ctx.make_symmetric_key(SymmetricKeyAlgorithm::Aes256CbcHmac);
+    let data_key = ContentEncryptionKey::make(&mut ctx); 
     let secret = HighEntropySecret::make(16).expect("16 bytes is a valid size");
 
     // Seal the key with the secret.
@@ -37,6 +35,7 @@ fn main() {
     let envelope = SecretProtectedKeyEnvelope::seal(
         data_key,
         &secret,
+        // The namespace must be replaced with an appropriate namespace for the use-case
         SecretProtectedKeyEnvelopeNamespace::OrganizationInvite,
         &ctx,
     )
@@ -66,16 +65,18 @@ fn main() {
         .reseal(
             &secret,
             &new_secret,
+            // The namespace must be replaced with an appropriate namespace for the use-case
             SecretProtectedKeyEnvelopeNamespace::OrganizationInvite,
         )
         .expect("The secret should be valid");
     disk.save("data_key_envelope", (&envelope).into());
 
     // Alice wants to change the protected key. This requires creating a new envelope
-    let data_key = ctx.make_symmetric_key(SymmetricKeyAlgorithm::Aes256CbcHmac);
+    let data_key = ContentEncryptionKey::make(&mut ctx);
     let envelope = SecretProtectedKeyEnvelope::seal(
         data_key,
         &new_secret,
+        // The namespace must be replaced with an appropriate namespace for the use-case
         SecretProtectedKeyEnvelopeNamespace::OrganizationInvite,
         &ctx,
     )
@@ -87,6 +88,7 @@ fn main() {
     assert!(matches!(
         envelope.unseal(
             &wrong_secret,
+            // The namespace must be replaced with an appropriate namespace for the use-case
             SecretProtectedKeyEnvelopeNamespace::OrganizationInvite,
             &mut ctx
         ),

--- a/crates/bitwarden-crypto/examples/protect_key_with_secret.rs
+++ b/crates/bitwarden-crypto/examples/protect_key_with_secret.rs
@@ -22,7 +22,9 @@ fn main() {
     // Alice wants to protect a key with a high-entropy secret.
     // For example to:
     // - Protect a send with a random URL fragment secret
-    // - Protect a key with another (derived) key
+    //   - Here, The secret key envelope wraps a KEK, the KEK wraps a CEK, and the CEK wraps the data.
+    // - Protect a key with a (derived) secret, external to the SDK
+    //   - Here, the secret key envelope wraps a the key
     // For this, the `SecretProtectedKeyEnvelope` is used.
     // (For low-entropy secrets such as a PIN, use the `PasswordProtectedKeyEnvelope` instead.)
 

--- a/crates/bitwarden-crypto/examples/protect_key_with_secret.rs
+++ b/crates/bitwarden-crypto/examples/protect_key_with_secret.rs
@@ -22,7 +22,8 @@ fn main() {
     // Alice wants to protect a key with a high-entropy secret.
     // For example to:
     // - Protect a send with a random URL fragment secret
-    //   - Here, The secret key envelope wraps a KEK, the KEK wraps a CEK, and the CEK wraps the data.
+    //   - Here, The secret key envelope wraps a KEK, the KEK wraps a CEK, and the CEK wraps the
+    //     data.
     // - Protect a key with a (derived) secret, external to the SDK
     //   - Here, the secret key envelope wraps a the key
     // For this, the `SecretProtectedKeyEnvelope` is used.
@@ -58,6 +59,7 @@ fn main() {
     let _unsealed_data_key = deserialized
         .unseal(
             &secret,
+            // The namespace must be replaced with an appropriate namespace for the use-case
             SecretProtectedKeyEnvelopeNamespace::OrganizationInvite,
             &mut ctx,
         )

--- a/crates/bitwarden-crypto/examples/protect_key_with_secret.rs
+++ b/crates/bitwarden-crypto/examples/protect_key_with_secret.rs
@@ -7,8 +7,10 @@
 //! bytes) and uses a cheap KDF.
 
 use bitwarden_crypto::{
-    KeyStore, KeyStoreContext, SymmetricKeyAlgorithm, key_slot_ids, safe::{
-        ContentEncryptionKey, HighEntropySecret, SecretProtectedKeyEnvelope, SecretProtectedKeyEnvelopeError, SecretProtectedKeyEnvelopeNamespace,
+    KeyStore, KeyStoreContext, SymmetricKeyAlgorithm, key_slot_ids,
+    safe::{
+        ContentEncryptionKey, HighEntropySecret, SecretProtectedKeyEnvelope,
+        SecretProtectedKeyEnvelopeError, SecretProtectedKeyEnvelopeNamespace,
     },
 };
 
@@ -26,7 +28,7 @@ fn main() {
 
     // Alice has some data protected with a symmetric key. She wants the symmetric key protected
     // with a high-entropy secret (here, 16 random bytes).
-    let data_key = ContentEncryptionKey::make(&mut ctx); 
+    let data_key = ContentEncryptionKey::make(&mut ctx);
     let secret = HighEntropySecret::make(16).expect("16 bytes is a valid size");
 
     // Seal the key with the secret.

--- a/crates/bitwarden-crypto/examples/protect_key_with_secret.rs
+++ b/crates/bitwarden-crypto/examples/protect_key_with_secret.rs
@@ -7,7 +7,7 @@
 //! bytes) and uses a cheap KDF.
 
 use bitwarden_crypto::{
-    KeyStore, KeyStoreContext, SymmetricKeyAlgorithm, key_slot_ids,
+    KeyStore, KeyStoreContext, key_slot_ids,
     safe::{
         ContentEncryptionKey, HighEntropySecret, SecretProtectedKeyEnvelope,
         SecretProtectedKeyEnvelopeError, SecretProtectedKeyEnvelopeNamespace,

--- a/crates/bitwarden-crypto/examples/protect_key_with_secret.rs
+++ b/crates/bitwarden-crypto/examples/protect_key_with_secret.rs
@@ -37,7 +37,7 @@ fn main() {
     let envelope = SecretProtectedKeyEnvelope::seal(
         data_key,
         &secret,
-        SecretProtectedKeyEnvelopeNamespace::ExampleUse,
+        SecretProtectedKeyEnvelopeNamespace::OrganizationInvite,
         &ctx,
     )
     .expect("Sealing should work");
@@ -55,7 +55,7 @@ fn main() {
     let _unsealed_data_key = deserialized
         .unseal(
             &secret,
-            SecretProtectedKeyEnvelopeNamespace::ExampleUse,
+            SecretProtectedKeyEnvelopeNamespace::OrganizationInvite,
             &mut ctx,
         )
         .expect("Unsealing should work");
@@ -66,7 +66,7 @@ fn main() {
         .reseal(
             &secret,
             &new_secret,
-            SecretProtectedKeyEnvelopeNamespace::ExampleUse,
+            SecretProtectedKeyEnvelopeNamespace::OrganizationInvite,
         )
         .expect("The secret should be valid");
     disk.save("data_key_envelope", (&envelope).into());
@@ -76,7 +76,7 @@ fn main() {
     let envelope = SecretProtectedKeyEnvelope::seal(
         data_key,
         &new_secret,
-        SecretProtectedKeyEnvelopeNamespace::ExampleUse,
+        SecretProtectedKeyEnvelopeNamespace::OrganizationInvite,
         &ctx,
     )
     .expect("Sealing should work");
@@ -87,7 +87,7 @@ fn main() {
     assert!(matches!(
         envelope.unseal(
             &wrong_secret,
-            SecretProtectedKeyEnvelopeNamespace::ExampleUse,
+            SecretProtectedKeyEnvelopeNamespace::OrganizationInvite,
             &mut ctx
         ),
         Err(SecretProtectedKeyEnvelopeError::WrongSecret)

--- a/crates/bitwarden-crypto/src/cose/thumbprint.rs
+++ b/crates/bitwarden-crypto/src/cose/thumbprint.rs
@@ -35,6 +35,11 @@ impl CoseKeyThumbprint {
         &self.0
     }
 
+    /// Constructs a thumbprint from a raw 32-byte SHA-256 digest.
+    pub fn from_bytes(bytes: [u8; 32]) -> Self {
+        CoseKeyThumbprint(bytes)
+    }
+
     /// The thumbprint as a lowercase hex string.
     pub fn to_hex(&self) -> String {
         hex::encode(self.0)

--- a/crates/bitwarden-crypto/src/safe/data_envelope.rs
+++ b/crates/bitwarden-crypto/src/safe/data_envelope.rs
@@ -496,6 +496,9 @@ macro_rules! generate_versioned_sealable {
 pub enum DataEnvelopeNamespace {
     /// The namespace for vault items ("ciphers")
     VaultItem = 1,
+    /// The namespace for organization member invite data (the organization public-key thumbprint
+    /// and the invite secret), sealed with the invite key.
+    OrganizationInvite = 2,
     /// This namespace is only used in tests
     #[cfg(test)]
     ExampleNamespace = -1,
@@ -517,6 +520,7 @@ impl TryFrom<i128> for DataEnvelopeNamespace {
     fn try_from(value: i128) -> Result<Self, Self::Error> {
         match value {
             1 => Ok(DataEnvelopeNamespace::VaultItem),
+            2 => Ok(DataEnvelopeNamespace::OrganizationInvite),
             #[cfg(test)]
             -1 => Ok(DataEnvelopeNamespace::ExampleNamespace),
             #[cfg(test)]

--- a/crates/bitwarden-crypto/src/safe/secret_protected_key_envelope.rs
+++ b/crates/bitwarden-crypto/src/safe/secret_protected_key_envelope.rs
@@ -559,9 +559,9 @@ impl TryFrom<wasm_bindgen::JsValue> for SecretProtectedKeyEnvelope {
 /// The content-layer separation namespace for secret protected key envelopes.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SecretProtectedKeyEnvelopeNamespace {
-    /// Neutral placeholder so the public API and example are usable. Replace with a
-    /// product-specific variant when the first real consumer lands.
-    ExampleUse = 1,
+    /// Organization member invite links. The high-entropy secret is the random invite secret
+    /// carried in the invite link, and the sealed key is the invite key.
+    OrganizationInvite = 1,
     /// Bitwarden Desktop biometric (Windows Hello) unlock. The high-entropy secret is a PRF derived
     /// from the Windows Hello signing credential, and the sealed key is the user key.
     DesktopBiometricUnlock = 2,
@@ -585,7 +585,7 @@ impl TryFrom<i128> for SecretProtectedKeyEnvelopeNamespace {
 
     fn try_from(value: i128) -> Result<Self, Self::Error> {
         match value {
-            1 => Ok(SecretProtectedKeyEnvelopeNamespace::ExampleUse),
+            1 => Ok(SecretProtectedKeyEnvelopeNamespace::OrganizationInvite),
             2 => Ok(SecretProtectedKeyEnvelopeNamespace::DesktopBiometricUnlock),
             #[cfg(test)]
             -1 => Ok(SecretProtectedKeyEnvelopeNamespace::ExampleNamespace),

--- a/crates/bitwarden-crypto/src/safe/symmetric_key_envelope.rs
+++ b/crates/bitwarden-crypto/src/safe/symmetric_key_envelope.rs
@@ -50,6 +50,7 @@ pub enum SymmetricKeyEnvelopeError {
 }
 
 /// A symmetric key protected by an XAES-256-GCM wrapping key.
+#[derive(Clone)]
 pub struct SymmetricKeyEnvelope {
     cose_encrypt0: coset::CoseEncrypt0,
 }
@@ -270,6 +271,9 @@ impl FromWasmAbi for SymmetricKeyEnvelope {
 pub enum SymmetricKeyEnvelopeNamespace {
     /// A key used for re-hydration of the SDK
     SessionKey = 1,
+    /// Organization member invites. Used to seal the invite-data content-encryption key and the
+    /// organization key with the invite key.
+    OrganizationInvite = 2,
     #[cfg(test)]
     /// Example namespace for testing purposes.
     ExampleNamespace = -3,
@@ -291,6 +295,7 @@ impl TryFrom<i128> for SymmetricKeyEnvelopeNamespace {
     fn try_from(value: i128) -> Result<Self, Self::Error> {
         match value {
             1 => Ok(SymmetricKeyEnvelopeNamespace::SessionKey),
+            2 => Ok(SymmetricKeyEnvelopeNamespace::OrganizationInvite),
             #[cfg(test)]
             -3 => Ok(SymmetricKeyEnvelopeNamespace::ExampleNamespace),
             #[cfg(test)]

--- a/crates/bitwarden-organization-crypto/Cargo.toml
+++ b/crates/bitwarden-organization-crypto/Cargo.toml
@@ -32,6 +32,7 @@ bitwarden-sensitive-value = { workspace = true }
 ciborium = { workspace = true }
 rand = { workspace = true }
 serde = { workspace = true }
+serde_json = { workspace = true }
 subtle = { workspace = true }
 thiserror = { workspace = true }
 tsify = { workspace = true, optional = true }
@@ -40,7 +41,6 @@ zeroize = { workspace = true }
 
 [dev-dependencies]
 bitwarden-crypto = { workspace = true, features = ["test-utils"] }
-serde_json = { workspace = true }
 uuid = { workspace = true }
 
 [lints]

--- a/crates/bitwarden-organization-crypto/Cargo.toml
+++ b/crates/bitwarden-organization-crypto/Cargo.toml
@@ -21,17 +21,22 @@ wasm = [
     "dep:wasm-bindgen",
     "bitwarden-crypto/wasm",
     "bitwarden-encoding/wasm",
+    "bitwarden-random/wasm",
 ] # WASM support
 
 [dependencies]
 bitwarden-crypto = { workspace = true }
 bitwarden-encoding = { workspace = true }
+bitwarden-random = { workspace = true }
+bitwarden-sensitive-value = { workspace = true }
 ciborium = { workspace = true }
+rand = { workspace = true }
 serde = { workspace = true }
 subtle = { workspace = true }
 thiserror = { workspace = true }
 tsify = { workspace = true, optional = true }
 wasm-bindgen = { workspace = true, optional = true }
+zeroize = { workspace = true }
 
 [dev-dependencies]
 bitwarden-crypto = { workspace = true, features = ["test-utils"] }

--- a/crates/bitwarden-organization-crypto/examples/invite.rs
+++ b/crates/bitwarden-organization-crypto/examples/invite.rs
@@ -1,0 +1,135 @@
+//! This example demonstrates the full lifecycle of an organization invite [`InviteBundle`]:
+//! creating it, reconstructing the invite link (admin), confirm-joining (invitee), and enabling
+//! account recovery (verifying the organization public key bound into the invite).
+
+use bitwarden_crypto::{
+    CoseKeyThumbprintExt, KeyStore, KeyStoreContext, PublicKeyEncryptionAlgorithm,
+    SymmetricKeyAlgorithm::Aes256CbcHmac, key_slot_ids,
+};
+use bitwarden_organization_crypto::invite::{Invite, InviteSecret};
+
+fn main() {
+    let key_store = KeyStore::<ExampleIds>::default();
+    let mut ctx: KeyStoreContext<'_, ExampleIds> = key_store.context_mut();
+    let org_id = uuid::Uuid::default();
+
+    // For the sdk, this is automatically done during initialization by
+    // `init_org`. Persisting moves the key into the organization slot, so all invite operations
+    // reference it by that global id.
+    let org_key = ExampleSymmetricKey::Organization(org_id);
+    let local_org_key = ctx.make_symmetric_key(Aes256CbcHmac);
+    ctx.persist_symmetric_key(local_org_key, org_key)
+        .expect("switching key ids should work");
+
+    // The invite binds the organization public-key thumbprint, derived from the organization's
+    // (wrapped) private key. Here we make an organization key pair and wrap the private key with
+    // the organization key, as `make_for_private_key` expects.
+    let org_private_key = ctx.make_private_key(PublicKeyEncryptionAlgorithm::RsaOaepSha1);
+    let thumbprint = ctx
+        .get_public_key(org_private_key)
+        .expect("getting the public key should work")
+        .thumbprint()
+        .expect("computing the thumbprint should work");
+    let wrapped_private_key = ctx
+        .wrap_private_key(org_key, org_private_key)
+        .expect("wrapping the private key with the org key should work");
+
+    // 1. Create an invite. `make_for_private_key` returns two parts as a tuple.
+    let (secret, invite): (InviteSecret, Invite) =
+        Invite::make_for_private_key(org_key, &wrapped_private_key, &mut ctx)
+            .expect("generating an invite should work");
+
+    // 2. The first part is the `InviteSecret`: the raw URL-fragment secret carried in the invite
+    // link. `InviteSecret` automatically serializes to `B64Url` when used in WASM bindings, or use
+    // `String::from(&invite_secret)` to manually generate a base64Url-encoded string.
+    //
+    // CRITICAL: this object must never be shared with the server.
+
+    // 3. The second part is the `Invite`. This is the server-safe bundle of wrapped envelopes. It
+    // serializes to a base64-encoded CBOR structure via serde, `String::from(&invite)`, or wasm abi
+    // serialization.
+    //
+    // This can be sent to the server, and should be persisted there:
+    // ```
+    // { // Request model
+    //   "invite": "abcdef==",
+    //   "otherData":...
+    // }
+    // ```
+
+    // 4. Admin direction: recover the invite key from the organization key, then use it to recover
+    // the invite secret, e.g. to reconstruct an invite link.
+    let invite_key = invite
+        .invite_key_from_organization_key(org_key, &mut ctx)
+        .expect("recovering the invite key from the org key should work");
+    let recovered_secret = invite
+        .get_invite_secret(invite_key, &mut ctx)
+        .expect("recovering the invite secret should work");
+    assert_eq!(&secret, &recovered_secret);
+    assert_eq!(String::from(&secret), String::from(&recovered_secret));
+
+    // 5. Confirm-joining (invitee direction): an invitee holds ONLY the invite secret from the
+    // link. From it they recover the invite key, and from the invite key the organization key,
+    // without ever seeing the organization key beforehand. No verification is performed here.
+    let invitee_secret: InviteSecret = String::from(&secret)
+        .parse()
+        .expect("the invite secret round-trips through its base64url form");
+    let invitee_invite_key = invite
+        .invite_key_from_invite_secret(&invitee_secret, &mut ctx)
+        .expect("an invitee should recover the invite key from the invite secret");
+    let recovered_org_key_id = invite
+        .unseal_organization_key(invitee_invite_key, &mut ctx)
+        .expect("an invitee should recover the organization key from the invite key");
+    #[allow(deprecated)]
+    {
+        let recovered = ctx
+            .dangerous_get_symmetric_key(recovered_org_key_id)
+            .expect("the recovered organization key should be in the store");
+        let original = ctx
+            .dangerous_get_symmetric_key(org_key)
+            .expect("the organization key should be in the store");
+        assert_eq!(recovered, original);
+    }
+
+    // 6. Enabling account recovery: recover the invite key from the organization key, read the
+    // organization public-key thumbprint bound into the invite, and confirm it matches the
+    // organization public key we are about to enroll against. A substituted public key would not
+    // match, so the organization key cannot be captured by an attacker-supplied recovery key.
+    let recovery_invite_key = invite
+        .invite_key_from_organization_key(org_key, &mut ctx)
+        .expect("recovering the invite key from the org key should work");
+    let bound_thumbprint = invite
+        .get_public_key_thumbprint(recovery_invite_key, &mut ctx)
+        .expect("recovering the bound thumbprint should work");
+    assert_eq!(bound_thumbprint, thumbprint);
+    // (In the SDK, `InviteLinkClient::enroll_account_recovery` performs exactly this check before
+    // encapsulating the organization key to the recovery public key.)
+}
+
+key_slot_ids! {
+    #[symmetric]
+    pub enum ExampleSymmetricKey {
+        UserId,
+        Organization(uuid::Uuid),
+        #[local]
+        LocalKey(LocalId),
+    }
+
+    #[private]
+    pub enum ExamplePrivateKey {
+        UserId,
+        Organization(uuid::Uuid),
+        #[local]
+        LocalKey(LocalId),
+    }
+
+    #[signing]
+    pub enum ExampleSigningKey {
+        UserId,
+        Organization(uuid::Uuid),
+        #[local]
+        LocalKey(LocalId),
+    }
+
+    pub ExampleIds => ExampleSymmetricKey, ExamplePrivateKey, ExampleSigningKey;
+}

--- a/crates/bitwarden-organization-crypto/examples/invite.rs
+++ b/crates/bitwarden-organization-crypto/examples/invite.rs
@@ -1,4 +1,4 @@
-//! This example demonstrates the full lifecycle of an organization invite [`InviteBundle`]:
+//! This example demonstrates the full lifecycle of an organization invite,
 //! creating it, reconstructing the invite link (admin), confirm-joining (invitee), and enabling
 //! account recovery (verifying the organization public key bound into the invite).
 
@@ -46,7 +46,7 @@ fn main() {
     // CRITICAL: this object must never be shared with the server.
 
     // 3. The second part is the `Invite`. This is the server-safe bundle of wrapped envelopes. It
-    // serializes to a base64-encoded CBOR structure via serde, `String::from(&invite)`, or wasm abi
+    // serializes to a base64-encoded JSON structure via serde, `String::from(&invite)`, or wasm abi
     // serialization.
     //
     // This can be sent to the server, and should be persisted there:
@@ -60,7 +60,7 @@ fn main() {
     // 4. Admin direction: recover the invite key from the organization key, then use it to recover
     // the invite secret, e.g. to reconstruct an invite link.
     let invite_key = invite
-        .invite_key_from_organization_key(org_key, &mut ctx)
+        .unseal_invite_key_with_organization_key(org_key, &mut ctx)
         .expect("recovering the invite key from the org key should work");
     let recovered_secret = invite
         .get_invite_secret(invite_key, &mut ctx)
@@ -75,28 +75,19 @@ fn main() {
         .parse()
         .expect("the invite secret round-trips through its base64url form");
     let invitee_invite_key = invite
-        .invite_key_from_invite_secret(&invitee_secret, &mut ctx)
+        .unseal_invite_key_with_invite_secret(&invitee_secret, &mut ctx)
         .expect("an invitee should recover the invite key from the invite secret");
     let recovered_org_key_id = invite
         .unseal_organization_key(invitee_invite_key, &mut ctx)
         .expect("an invitee should recover the organization key from the invite key");
-    #[allow(deprecated)]
-    {
-        let recovered = ctx
-            .dangerous_get_symmetric_key(recovered_org_key_id)
-            .expect("the recovered organization key should be in the store");
-        let original = ctx
-            .dangerous_get_symmetric_key(org_key)
-            .expect("the organization key should be in the store");
-        assert_eq!(recovered, original);
-    }
+    ctx.assert_symmetric_keys_equal(recovered_org_key_id, org_key);
 
     // 6. Enabling account recovery: recover the invite key from the organization key, read the
     // organization public-key thumbprint bound into the invite, and confirm it matches the
     // organization public key we are about to enroll against. A substituted public key would not
     // match, so the organization key cannot be captured by an attacker-supplied recovery key.
     let recovery_invite_key = invite
-        .invite_key_from_organization_key(org_key, &mut ctx)
+        .unseal_invite_key_with_organization_key(org_key, &mut ctx)
         .expect("recovering the invite key from the org key should work");
     let bound_thumbprint = invite
         .get_public_key_thumbprint(recovery_invite_key, &mut ctx)

--- a/crates/bitwarden-organization-crypto/src/invite.rs
+++ b/crates/bitwarden-organization-crypto/src/invite.rs
@@ -1,7 +1,31 @@
-//! Cryptographic organization invites built around an AES-256-GCM invite key (see [`Invite`]).
+//! Cryptographic organization invites
 //!
-//! This module is the successor to [`crate::invite_key_bundle`]; the two coexist for now and a
-//! follow-up will promote this one to the crate root.
+//! An invite is built around an AES-256-GCM **invite key** that acts as the hub tying every wrapped
+//! object together. Two independent secrets can recover the invite key (the invite secret from the
+//! link, or the organization key held by admins), and from the invite key everything else — the
+//! invite data and, when confirmation is enabled, the organization key — can be unwrapped:
+//!
+//! ```text
+//! InviteSecret -> SecretProtectedKeyEnvelope -> InviteKey -> DataEnvelope -+-> InviteSecret
+//!                                                ^     |                    +-> OrgPubKeyPrint
+//!                                                |     |
+//! OrganizationKey -> EncString ------------------+     +-> SymmetricKeyEnvelope -> OrganizationKey
+//! ```
+//!
+//! - `InviteSecret -> SecretProtectedKeyEnvelope -> InviteKey`
+//!   (`invite_secret_wrapped_invite_key`): the invite key sealed with the high-entropy invite
+//!   secret, so an invitee holding only the secret from the link recovers the invite key.
+//! - `OrganizationKey -> EncString -> InviteKey` (`organization_key_wrapped_invite_key`): the
+//!   invite key wrapped with the organization key, so anyone holding the organization key recovers
+//!   the invite key (and thus the invite data).
+//! - `InviteKey -> DataEnvelope -> InviteSecret + OrgPubKeyPrint`
+//!   (`invite_key_wrapped_invite_data`): the `InviteDataV1` sealed with the invite key, binding the
+//!   organization public-key thumbprint and a copy of the invite secret (so the invite link can be
+//!   reconstructed from the invite key).
+//! - `InviteKey -> SymmetricKeyEnvelope -> OrganizationKey`
+//!   (`invite_key_wrapped_organization_key`): the organization key sealed with the invite key, so a
+//!   redeeming invitee can recover the organization key. It is present if and exactly if
+//!   confirmation is enabled for the invite.
 
 use std::str::FromStr;
 
@@ -25,16 +49,6 @@ use zeroize::Zeroizing;
 /// Length, in bytes, of the raw invite secret. 32 bytes provides 256 bits of entropy, which is why
 /// the invite secret is safe to use directly as a [`HighEntropySecret`].
 const INVITE_SECRET_LEN: usize = 32;
-
-/// The namespace binding the invite's [`SecretProtectedKeyEnvelope`] to organization invites, so it
-/// cannot be substituted for an envelope minted for another purpose.
-const INVITE_SECRET_ENVELOPE_NAMESPACE: SecretProtectedKeyEnvelopeNamespace =
-    SecretProtectedKeyEnvelopeNamespace::OrganizationInvite;
-
-/// The namespace binding the invite's [`SymmetricKeyEnvelope`] (the organization key wrapped by the
-/// invite key) to organization invites.
-const INVITE_ORG_KEY_ENVELOPE_NAMESPACE: SymmetricKeyEnvelopeNamespace =
-    SymmetricKeyEnvelopeNamespace::OrganizationInvite;
 
 /// Errors that can occur when creating or opening an invite.
 #[derive(Debug, Error)]
@@ -66,15 +80,7 @@ const TS_INVITE_SECRET: &'static str = r#"
 export type InviteSecret = Tagged<string, "InviteSecret">;
 "#;
 
-/// The invite secret: 32 random, high-entropy bytes carried in the invite link. It is not a keyed
-/// cryptographic object; it protects the invite key. Supports WASM bindings, automatically using
-/// base64Url encoding for both `wasm-bindgen` and `tsify`.
-///
-/// To manually encode as a `base64URL` string:
-/// ```ignore
-/// String::from(&invite_secret);
-/// ```
-/// Also supports serde serialization/deserialization using the base64Url format.
+/// The invite secret: 32 random, high-entropy bytes carried in the invite link.
 ///
 /// CRITICAL: This must never be sent to the server.
 #[derive(Clone)]
@@ -172,29 +178,27 @@ const TS_INVITE: &'static str = r#"
 export type Invite = Tagged<string, "Invite">;
 "#;
 
-/// Cryptographic invite for an organization, built around an AES-256-GCM **invite key** that
-/// acts as the hub tying everything together:
-///
-/// - `invite_key_wrapped_invite_data`: the `InviteData` (org public-key thumbprint + invite secret)
-///   sealed with the invite key.
-/// - `invite_secret_wrapped_invite_key`: the invite key sealed with the high-entropy invite secret,
-///   letting an invitee (who holds only the invite secret from the link) recover the invite key.
-/// - `invite_key_wrapped_organization_key`: the organization key sealed with the invite key,
-///   letting a redeeming invitee recover the organization key once they hold the invite key. This
-///   is **optional**: its presence is what "confirmation" means. When confirmation is enabled the
-///   invitee can self-confirm by recovering the organization key; when disabled, this field is
-///   absent and an admin must confirm the invitee out of band.
-/// - `organization_key_wrapped_invite_key`: the invite key wrapped with the organization key,
-///   letting anyone holding the organization key recover the invite key (and thus the invite data).
+/// Cryptographic invite for an organization, built around an AES-256-GCM invite key that acts as
+/// the hub tying everything together. See the module-level docs for the overall diagram.
 #[derive(Clone)]
 pub struct Invite {
+    /// The `InviteData` (org public-key thumbprint + invite secret) sealed with the invite key.
     invite_key_wrapped_invite_data: DataEnvelope,
+    /// The invite key sealed with the high-entropy invite secret, letting an invitee (who holds
+    /// only the invite secret from the link) recover the invite key.
     invite_secret_wrapped_invite_key: SecretProtectedKeyEnvelope,
+    /// The organization key sealed with the invite key, letting a redeeming invitee recover the
+    /// organization key once they hold the invite key. This is **optional**: its presence is what
+    /// "confirmation" means. When confirmation is enabled the invitee can self-confirm by
+    /// recovering the organization key; when disabled, this field is absent and an admin must
+    /// confirm the invitee out of band.
     invite_key_wrapped_organization_key: Option<SymmetricKeyEnvelope>,
+    /// The invite key wrapped with the organization key, letting anyone holding the organization
+    /// key recover the invite key (and thus the invite data).
     organization_key_wrapped_invite_key: EncString,
 }
 
-/// Wire format for [`Invite`]. This is what's serialized by serde (as base64-encoded CBOR).
+/// Wire format for [`Invite`]. This is what's serialized by serde (as base64-encoded JSON).
 #[derive(Serialize, Deserialize)]
 struct InviteWire {
     invite_key_wrapped_invite_data: DataEnvelope,
@@ -216,9 +220,8 @@ impl From<&Invite> for InviteWire {
 
 impl From<&Invite> for String {
     fn from(invite: &Invite) -> Self {
-        let mut buf = Vec::new();
-        ciborium::ser::into_writer(&InviteWire::from(invite), &mut buf)
-            .expect("CBOR serialization of Invite never fails");
+        let buf = serde_json::to_vec(&InviteWire::from(invite))
+            .expect("JSON serialization of Invite never fails");
         B64::from(buf).to_string()
     }
 }
@@ -230,7 +233,7 @@ impl FromStr for Invite {
         let bytes = B64::try_from(s)
             .map_err(|_| InviteKeyBundleError::DecodingFailed)?
             .into_bytes();
-        let data: InviteWire = ciborium::de::from_reader(bytes.as_slice())
+        let data: InviteWire = serde_json::from_slice(bytes.as_slice())
             .map_err(|_| InviteKeyBundleError::DecodingFailed)?;
         Ok(Invite {
             invite_key_wrapped_invite_data: data.invite_key_wrapped_invite_data,
@@ -286,7 +289,7 @@ impl std::fmt::Debug for Invite {
 
 impl Invite {
     /// Recovers the invite key using the organization key
-    pub fn invite_key_from_organization_key<Ids: KeySlotIds>(
+    pub fn unseal_invite_key_with_organization_key<Ids: KeySlotIds>(
         &self,
         organization_key: Ids::Symmetric,
         ctx: &mut KeyStoreContext<Ids>,
@@ -296,14 +299,18 @@ impl Invite {
     }
 
     /// Recovers the invite key from the invite secret
-    pub fn invite_key_from_invite_secret<Ids: KeySlotIds>(
+    pub fn unseal_invite_key_with_invite_secret<Ids: KeySlotIds>(
         &self,
         invite_secret: &InviteSecret,
         ctx: &mut KeyStoreContext<Ids>,
     ) -> Result<Ids::Symmetric, InviteKeyBundleError> {
         let secret = HighEntropySecret::from(invite_secret.clone());
         self.invite_secret_wrapped_invite_key
-            .unseal(&secret, INVITE_SECRET_ENVELOPE_NAMESPACE, ctx)
+            .unseal(
+                &secret,
+                SecretProtectedKeyEnvelopeNamespace::OrganizationInvite,
+                ctx,
+            )
             .map_err(|_| InviteKeyBundleError::KeyUnsealingFailed)
     }
 
@@ -357,21 +364,25 @@ impl Invite {
         self.invite_key_wrapped_organization_key
             .as_ref()
             .ok_or(InviteKeyBundleError::ConfirmationNotEnabled)?
-            .unseal(invite_key, INVITE_ORG_KEY_ENVELOPE_NAMESPACE, ctx)
+            .unseal(
+                invite_key,
+                SymmetricKeyEnvelopeNamespace::OrganizationInvite,
+                ctx,
+            )
             .map_err(|_| InviteKeyBundleError::KeyUnsealingFailed)
     }
 
-    /// Enables confirmatio
+    /// Enables confirmation
     pub fn enable_confirmation<Ids: KeySlotIds>(
         &mut self,
         organization_key: Ids::Symmetric,
         ctx: &mut KeyStoreContext<Ids>,
     ) -> Result<(), InviteKeyBundleError> {
-        let invite_key = self.invite_key_from_organization_key(organization_key, ctx)?;
+        let invite_key = self.unseal_invite_key_with_organization_key(organization_key, ctx)?;
         let envelope = SymmetricKeyEnvelope::seal(
             organization_key,
             invite_key,
-            INVITE_ORG_KEY_ENVELOPE_NAMESPACE,
+            SymmetricKeyEnvelopeNamespace::OrganizationInvite,
             ctx,
         )
         .map_err(|_| InviteKeyBundleError::KeySealingFailed)?;
@@ -387,19 +398,19 @@ impl Invite {
     /// Generates a brand new invite around a fresh AES-256-GCM invite key, binding it to the
     /// provided organization key and the organization's public-key thumbprint (see [`Invite`]).
     ///
-    /// `wrapped_private_key` is the organization's private key wrapped with `organization_key`; the
-    /// public-key thumbprint bound into the invite is derived from it.
+    /// `wrapped_organization_private_key` is the organization's private key wrapped with
+    /// `organization_key`; the public-key thumbprint bound into the invite is derived from it.
     ///
     /// Returns the raw [`InviteSecret`] (which MUST NOT be sent to the server) together with the
     /// server-safe [`Invite`].
     pub fn make_for_private_key<Ids: KeySlotIds>(
         organization_key: Ids::Symmetric,
-        wrapped_private_key: &EncString,
+        wrapped_organization_private_key: &EncString,
         ctx: &mut KeyStoreContext<Ids>,
     ) -> Result<(InviteSecret, Invite), InviteKeyBundleError> {
         // Derive the organization public-key thumbprint from the wrapped private key.
         let private_key_id = ctx
-            .unwrap_private_key(organization_key, wrapped_private_key)
+            .unwrap_private_key(organization_key, wrapped_organization_private_key)
             .map_err(|_| InviteKeyBundleError::InvalidPrivateKey)?;
         let thumbprint = ctx
             .get_public_key(private_key_id)
@@ -432,7 +443,7 @@ impl Invite {
         let invite_secret_wrapped_invite_key = SecretProtectedKeyEnvelope::seal(
             invite_key,
             &secret,
-            INVITE_SECRET_ENVELOPE_NAMESPACE,
+            SecretProtectedKeyEnvelopeNamespace::OrganizationInvite,
             ctx,
         )
         .map_err(|_| InviteKeyBundleError::KeySealingFailed)?;
@@ -444,7 +455,7 @@ impl Invite {
             SymmetricKeyEnvelope::seal(
                 organization_key,
                 invite_key,
-                INVITE_ORG_KEY_ENVELOPE_NAMESPACE,
+                SymmetricKeyEnvelopeNamespace::OrganizationInvite,
                 ctx,
             )
             .map_err(|_| InviteKeyBundleError::KeySealingFailed)?,
@@ -470,41 +481,39 @@ impl Invite {
 #[cfg(test)]
 mod tests {
     use bitwarden_crypto::{
-        CoseKeyThumbprint, CoseKeyThumbprintExt, EncString, KeyStore, KeyStoreContext,
-        PublicKeyEncryptionAlgorithm, SymmetricCryptoKey, key_slot_ids,
+        CoseKeyThumbprintExt, EncString, KeyStore, KeyStoreContext, PublicKeyEncryptionAlgorithm,
+        SymmetricCryptoKey, key_slot_ids,
     };
     use bitwarden_encoding::{B64, B64Url};
 
     use crate::invite::{Invite, InviteKeyBundleError, InviteSecret};
 
-    /// Makes an organization private key in `ctx`, wraps it with `organization_key`, and returns
-    /// the wrapped private key together with the thumbprint of its public key (as
-    /// `make_for_private_key` expects and derives).
-    fn org_wrapped_private_key(
-        organization_key: TestSymmKey,
-        ctx: &mut KeyStoreContext<'_, TestIds>,
-    ) -> (EncString, CoseKeyThumbprint) {
-        let private_key_id = ctx.make_private_key(PublicKeyEncryptionAlgorithm::RsaOaepSha1);
-        let thumbprint = ctx
-            .get_public_key(private_key_id)
-            .unwrap()
-            .thumbprint()
+    // Test vectors captured from `generate_test_vectors`. They freeze a real organization key, the
+    // organization private key wrapped with it, and an invite, so backward compatibility (old data
+    // must remain decryptable) is verified by `test_invite_test_vector`.
+    const TEST_VECTOR_ORG_KEY: &str =
+        "KGP9Nc2/91w+42Z9VzY0m7h18avuZcq4ICM8Rhdc3BD92LbWS2TQkVBzavvUM684WKXiC22NJi2EwaiDW4YTAA==";
+    const TEST_VECTOR_WRAPPED_PRIVATE_KEY: &str = "2.Fi0VHpgZgBQWB8x+fLhjbg==|1Kdwcx5HIrnzHsw9vmlaEdsSUGrixdPjC2Tcl9QijlBJrNWSaaWW+sMCTZ71IC18ORFYp8QDICs7aUqE3RaM8zTdXM1Gaf+OJbr29UGyRwiN6flnrjrwsVSSeEGyTUBNS0eSdlaurOu9Eo+CtUmXWsKiGLVYINgYmUims4JsFQ/J8JOG5tkVy9onZc9TIOULSlCqXZ53g7u4Nbvqgdr6qMzuBuO9s0OVStORmliRYTMbGivqiOW27VKk89OMTwuomeC25m5Gh4LwuAcTQob9SnuAssVjGLb2H1HvjdFafAnk2N979hx6u9bgl83dKNa00rbZiGkhxTJIam9pwFuoudP8o4wsv7SeXV86XEq49xJSDD0FGowcHZ8iC9bI28h12vzOAzaA6Om1MUIc38sL/YBwkQyIxeWqFILOuoXPWsZ/fGomSI/mijCIGChzB+YS7W6GbFF50lYJukWPophLL+d8nx/5JuH2m3AfusM4ml2qMjHJ9Lf6ToedDr5ap4hHUPcMSiT/qilt0sjhqP+TAqpp0QxM20QCA9zW/FLBUKpiT/8LhC2eZM2eQlKYwabg4DGy+Wu6s4E5kJJ9jrdN3RCpgy/BDAjyd6+taixvR1ejH/J0T6WirNP5lGo7bdlCiq4mWnqbALtRfQmz1e/7pWhRZv7hHhWurqdZQLuAOdKYe89aQj316NAgPKlMJWiLuT1rC94EmPuiXl54WDjYH2xgnprKwqXdNls+0dbiXSvejXod2b8FD263mUwN+OluwyyI6YeOZge3HAmmmXBUbYgunyqBK1QoMgc5Oj6QyBnzMYc5vE7NuEzjncFMNZc+XjxrAwJS1J2ZR6SjzrQjAAaoGA2fTBQ2NYpr/bf91dbJJkzZZBpHMoJWU0zyE3I4AEs48JS7VW++uM6pIkBdg67JsxaSS3h7E3nJEd8qQScbn+AgFVy6FT1W+dUr+FoaP7N2U0r9qxWh6anZlfWIS4Sw7Sr5plR24SyevrLkIXWoK2T1mFzRnGtP2KaYoIr2oGtx0PGM5ZSzUQJhURKt7Nx9X34AKh3/yI4BLQmx8FVVLhh0mONQrmPx5VgodxxYwh1nIRgMG1BPE8SOj1sXsgzhu2jmUfhFJXpbL//3zr7z5f461ungPN+Dj4dAThf4N+XktskNN3eaIfnHwK4+st97qTA060oe7qqLbMvuR8pj0slvA2HTxcsIFDEUvCJipeTZrOjJHW59co15DDjbXHXrSXDhtfWh6EWSbh+m+q5OldkI30INhNNvKx5LqBCFonONekRD/1qzxFLE8Arlsu0R1OmtQjnbj1Lt5yUkFlL5KIOSETg0BGWqhhkLRXq3URylxTe/An5H9Q0xaqfQtaUOMbdaxSMq4HokSlxLOHGWiWMlPBQQT93XO96wPs13Sytzl0Wcu4kx+Ttlx6EmHPfd1jjDZdSaR0wM8+HA74jC70wwqc2FJzBoCm/O1Da8b0yNb26PTNmkhFjL95XvQERom3hkOf8LaA8metq/OT4jHDU/Tci2GYYxNjoDBYj/JyrKpODPQ4GfmxzzeYyNav+ZFGCDbYa5rvixwddAIAZLB+IBaDx0SnKe/a3rrerjx4GWPo/HHzRjoeLvHVjX1RA4bwIq6icROhBFRDkUZbY=|Y9md9PASfsT04OYaj1P6FL9cXUc/m8PloWizzuWT84E=";
+    const TEST_VECTOR_INVITE: &str = "eyJpbnZpdGVfa2V5X3dyYXBwZWRfaW52aXRlX2RhdGEiOiJnMWhIcFFFREEzZ2pZWEJ3YkdsallYUnBiMjR2ZUM1aWFYUjNZWEprWlc0dVkySnZjaTF3WVdSa1pXUUVVSTdrc014MGNNNi9VQ2VVY2pMcVdIRTZBQUU0Z1FJNkFBRTRnQUtoQlV3a0hhWW0yK3Z1aGFIRXJmbFl4VWV6dkN2NzVuMzRHSk5ubWJ5NzFyb1lYQ3ZNaWE1dVZ0cmkwSWN5NEQ2WVM1YjFGM2l2MVVwRXU3Q2pnb01pNXZqNFlxRUZZQ3pabGx6MXBybnM5aENjSzlyVkFxREM2QTlDTGRMWG9HeWE2ZlNySGhXaW1kZWd5bnA0UHphczVsbGxibTJUMENFaWdod1FuUVIyRzN3QmlUUnNVZG00dWR2eWVKWWlOYWZ6VFE5V25BWlhSOG1pVVZyVHkxWDIzbHhYWE55UnhrTjNYemlTc0RvY2JYVEJvRlJkR1hGWURiSjhrU2cvZVQrWHJqdDlrYmxzTnZaYVlvemtBWVlYWnIxcnhvMDYiLCJpbnZpdGVfc2VjcmV0X3dyYXBwZWRfaW52aXRlX2tleSI6ImhGZ29wUUVEQXhobE9nQUJGVnhRanVTd3pIUnd6cjlRSjVSeU11cFljVG9BQVRpQkJqb0FBVGlBQWFFRlRJaDJmOVkzdGsyTXpvWnhpVmhRQjdkcFhNRjBGak1ISEl0UWt2RDMxNTUvV1VMQmVldW9zbHlUNm5xMEQ0WTJieFZnZjFaQnRNaUoweUQxeVVFMGJaS0tMZS93NmNab3h4YzlsTGRjL05iNHQ2Wmo0L0NDOG9HWTBnVTkxNG1CZzBDaUFTa3pXQ0EwT0VxK1ZsQVlKTnVvZWRSNENtWUVWV0NDOVVIUmNyRWs4NWFSQkpaczV2WT0iLCJpbnZpdGVfa2V5X3dyYXBwZWRfb3JnYW5pemF0aW9uX2tleSI6ImcxaEdwUUVEQTNnaVlYQndiR2xqWVhScGIyNHZlQzVpYVhSM1lYSmtaVzR1YkdWbllXTjVMV3RsZVFSUWp1U3d6SFJ3enI5UUo1UnlNdXBZY1RvQUFUaUJBem9BQVRpQUFxRUZURnd0NWxZQTU0Z3B3MFpSU0ZoUXlYMlB6UEN5QkdPdDVLd29rc21KMTlWWHJXVVJjd1M2RDNVaHhkVm5UQnZOU0pSSjhLZ2VNVEpJYlNldVdSbkpydnJaYzdacEo5bzJnVXg0TTV0aCtod1RVTXN0N3lMNVNzMEFyeFNJRjJvPSIsIm9yZ2FuaXphdGlvbl9rZXlfd3JhcHBlZF9pbnZpdGVfa2V5IjoiMi5OVXkyQW44YVZHaVpObDZLMGFxNHdRPT18bFhvMXhWQTFzc3dKbG1mQ1grNG5vZjlXSURGS1hOcStMS280TkIwVWVtQkFQQlkvK3p2dnlHOUp0QkxnYkU5aTMzaGYvK0FJa0ltTUxzcUNjL0QrU2RxQUhPU3hXV1hLVzJUb0RvRGRldzQ9fDdlQ2MxN2E2TXVCa0J6M3lxcHFuaWp4MlpXVE01ZW1ZcE1aS2tEN2daMEk9In0=";
+    const TEST_VECTOR_INVITE_SECRET: &str = "rAI7b5drK7fgI-PToxddm4-9py1UFdHbaxczIgf7KHk";
+
+    /// Loads the const `TEST_VECTOR_ORG_KEY` into the `Organization` slot and returns the parsed
+    /// const wrapped organization private key. Sharing fixed vectors keeps tests deterministic and
+    /// avoids generating a fresh RSA key on every run.
+    fn load_test_vectors(ctx: &mut KeyStoreContext<'_, TestIds>) -> EncString {
+        let org_key =
+            SymmetricCryptoKey::try_from(B64::try_from(TEST_VECTOR_ORG_KEY).unwrap()).unwrap();
+        let local_org_key_id = ctx.add_local_symmetric_key(org_key);
+        ctx.persist_symmetric_key(local_org_key_id, TestSymmKey::Organization)
             .unwrap();
-        let wrapped = ctx
-            .wrap_private_key(organization_key, private_key_id)
-            .unwrap();
-        (wrapped, thumbprint)
+        TEST_VECTOR_WRAPPED_PRIVATE_KEY.parse().unwrap()
     }
 
     #[test]
     fn test_basic_invitation_bundle() {
         let key_store = KeyStore::<TestIds>::default();
         let mut ctx = key_store.context_mut();
-
-        let local_org_key_id = ctx.generate_symmetric_key();
-        ctx.persist_symmetric_key(local_org_key_id, TestSymmKey::Organization)
-            .unwrap();
-        let (wrapped_private_key, _) = org_wrapped_private_key(TestSymmKey::Organization, &mut ctx);
+        let wrapped_private_key = load_test_vectors(&mut ctx);
 
         let (secret1, _) =
             Invite::make_for_private_key(TestSymmKey::Organization, &wrapped_private_key, &mut ctx)
@@ -520,18 +529,14 @@ mod tests {
     fn test_admin_recovers_invite_secret() {
         let key_store = KeyStore::<TestIds>::default();
         let mut ctx = key_store.context_mut();
-
-        let local_org_key_id = ctx.generate_symmetric_key();
-        ctx.persist_symmetric_key(local_org_key_id, TestSymmKey::Organization)
-            .unwrap();
-        let (wrapped_private_key, _) = org_wrapped_private_key(TestSymmKey::Organization, &mut ctx);
+        let wrapped_private_key = load_test_vectors(&mut ctx);
 
         let (invite_secret, invite) =
             Invite::make_for_private_key(TestSymmKey::Organization, &wrapped_private_key, &mut ctx)
                 .unwrap();
 
         let invite_key = invite
-            .invite_key_from_organization_key(TestSymmKey::Organization, &mut ctx)
+            .unseal_invite_key_with_organization_key(TestSymmKey::Organization, &mut ctx)
             .unwrap();
         let recovered = invite.get_invite_secret(invite_key, &mut ctx).unwrap();
 
@@ -542,36 +547,38 @@ mod tests {
     fn test_admin_recovers_thumbprint() {
         let key_store = KeyStore::<TestIds>::default();
         let mut ctx = key_store.context_mut();
+        let wrapped_private_key = load_test_vectors(&mut ctx);
 
-        let local_org_key_id = ctx.generate_symmetric_key();
-        ctx.persist_symmetric_key(local_org_key_id, TestSymmKey::Organization)
+        // The expected thumbprint is derived from the same wrapped private key that
+        // `make_for_private_key` binds into the invite.
+        let private_key_id = ctx
+            .unwrap_private_key(TestSymmKey::Organization, &wrapped_private_key)
             .unwrap();
-        let (wrapped_private_key, thumbprint) =
-            org_wrapped_private_key(TestSymmKey::Organization, &mut ctx);
+        let expected = ctx
+            .get_public_key(private_key_id)
+            .unwrap()
+            .thumbprint()
+            .unwrap();
 
         let (_, invite) =
             Invite::make_for_private_key(TestSymmKey::Organization, &wrapped_private_key, &mut ctx)
                 .unwrap();
 
         let invite_key = invite
-            .invite_key_from_organization_key(TestSymmKey::Organization, &mut ctx)
+            .unseal_invite_key_with_organization_key(TestSymmKey::Organization, &mut ctx)
             .unwrap();
         let recovered = invite
             .get_public_key_thumbprint(invite_key, &mut ctx)
             .unwrap();
 
-        assert_eq!(recovered, thumbprint);
+        assert_eq!(recovered, expected);
     }
 
     #[test]
     fn test_invitee_recovers_organization_key() {
         let key_store = KeyStore::<TestIds>::default();
         let mut ctx = key_store.context_mut();
-
-        let local_org_key_id = ctx.generate_symmetric_key();
-        ctx.persist_symmetric_key(local_org_key_id, TestSymmKey::Organization)
-            .unwrap();
-        let (wrapped_private_key, _) = org_wrapped_private_key(TestSymmKey::Organization, &mut ctx);
+        let wrapped_private_key = load_test_vectors(&mut ctx);
 
         let (invite_secret, invite) =
             Invite::make_for_private_key(TestSymmKey::Organization, &wrapped_private_key, &mut ctx)
@@ -580,34 +587,20 @@ mod tests {
         // Using only the raw invite secret, an invitee can recover the invite key and then the
         // organization key.
         let invite_key = invite
-            .invite_key_from_invite_secret(&invite_secret, &mut ctx)
+            .unseal_invite_key_with_invite_secret(&invite_secret, &mut ctx)
             .unwrap();
         let recovered_org_key_id = invite
             .unseal_organization_key(invite_key, &mut ctx)
             .unwrap();
 
-        #[allow(deprecated)]
-        let recovered_org_key = ctx
-            .dangerous_get_symmetric_key(recovered_org_key_id)
-            .unwrap()
-            .clone();
-        #[allow(deprecated)]
-        let org_key = ctx
-            .dangerous_get_symmetric_key(TestSymmKey::Organization)
-            .unwrap()
-            .clone();
-        assert_eq!(recovered_org_key, org_key);
+        ctx.assert_symmetric_keys_equal(recovered_org_key_id, TestSymmKey::Organization);
     }
 
     #[test]
     fn test_confirmation_toggle() {
         let key_store = KeyStore::<TestIds>::default();
         let mut ctx = key_store.context_mut();
-
-        let local_org_key_id = ctx.generate_symmetric_key();
-        ctx.persist_symmetric_key(local_org_key_id, TestSymmKey::Organization)
-            .unwrap();
-        let (wrapped_private_key, _) = org_wrapped_private_key(TestSymmKey::Organization, &mut ctx);
+        let wrapped_private_key = load_test_vectors(&mut ctx);
 
         let (invite_secret, mut invite) =
             Invite::make_for_private_key(TestSymmKey::Organization, &wrapped_private_key, &mut ctx)
@@ -621,7 +614,7 @@ mod tests {
         invite.disable_confirmation();
         assert!(!invite.supports_confirmation());
         let invite_key = invite
-            .invite_key_from_invite_secret(&invite_secret, &mut ctx)
+            .unseal_invite_key_with_invite_secret(&invite_secret, &mut ctx)
             .unwrap();
         assert!(matches!(
             invite.unseal_organization_key(invite_key, &mut ctx),
@@ -634,34 +627,19 @@ mod tests {
             .unwrap();
         assert!(invite.supports_confirmation());
         let invite_key = invite
-            .invite_key_from_invite_secret(&invite_secret, &mut ctx)
+            .unseal_invite_key_with_invite_secret(&invite_secret, &mut ctx)
             .unwrap();
         let recovered_org_key_id = invite
             .unseal_organization_key(invite_key, &mut ctx)
             .unwrap();
-        #[allow(deprecated)]
-        {
-            let recovered = ctx
-                .dangerous_get_symmetric_key(recovered_org_key_id)
-                .unwrap()
-                .clone();
-            let org_key = ctx
-                .dangerous_get_symmetric_key(TestSymmKey::Organization)
-                .unwrap()
-                .clone();
-            assert_eq!(recovered, org_key);
-        }
+        ctx.assert_symmetric_keys_equal(recovered_org_key_id, TestSymmKey::Organization);
     }
 
     #[test]
     fn test_invite_string_round_trip() {
         let key_store = KeyStore::<TestIds>::default();
         let mut ctx = key_store.context_mut();
-
-        let local_org_key_id = ctx.generate_symmetric_key();
-        ctx.persist_symmetric_key(local_org_key_id, TestSymmKey::Organization)
-            .unwrap();
-        let (wrapped_private_key, _) = org_wrapped_private_key(TestSymmKey::Organization, &mut ctx);
+        let wrapped_private_key = load_test_vectors(&mut ctx);
 
         let (invite_secret, invite) =
             Invite::make_for_private_key(TestSymmKey::Organization, &wrapped_private_key, &mut ctx)
@@ -673,7 +651,7 @@ mod tests {
 
         // The decoded invite still recovers the invite secret.
         let invite_key = decoded
-            .invite_key_from_organization_key(TestSymmKey::Organization, &mut ctx)
+            .unseal_invite_key_with_organization_key(TestSymmKey::Organization, &mut ctx)
             .unwrap();
         let recovered = decoded.get_invite_secret(invite_key, &mut ctx).unwrap();
         assert_eq!(invite_secret, recovered);
@@ -682,6 +660,104 @@ mod tests {
         let json = serde_json::to_string(&invite).unwrap();
         let from_json: Invite = serde_json::from_str(&json).unwrap();
         assert_eq!(String::from(&from_json), encoded);
+    }
+
+    #[test]
+    fn test_wrong_invite_secret_fails() {
+        let key_store = KeyStore::<TestIds>::default();
+        let mut ctx = key_store.context_mut();
+        let wrapped_private_key = load_test_vectors(&mut ctx);
+
+        let (_, invite) =
+            Invite::make_for_private_key(TestSymmKey::Organization, &wrapped_private_key, &mut ctx)
+                .unwrap();
+
+        // A different invite secret cannot unseal the invite key.
+        let wrong_secret = InviteSecret(zeroize::Zeroizing::new([7u8; 32]));
+        assert!(matches!(
+            invite.unseal_invite_key_with_invite_secret(&wrong_secret, &mut ctx),
+            Err(InviteKeyBundleError::KeyUnsealingFailed)
+        ));
+    }
+
+    #[test]
+    fn test_wrong_organization_key_fails() {
+        let key_store = KeyStore::<TestIds>::default();
+        let mut ctx = key_store.context_mut();
+        let wrapped_private_key = load_test_vectors(&mut ctx);
+
+        let (_, invite) =
+            Invite::make_for_private_key(TestSymmKey::Organization, &wrapped_private_key, &mut ctx)
+                .unwrap();
+
+        // A different organization key cannot unwrap the invite key.
+        let wrong_org_key = ctx.generate_symmetric_key();
+        assert!(matches!(
+            invite.unseal_invite_key_with_organization_key(wrong_org_key, &mut ctx),
+            Err(InviteKeyBundleError::KeyUnsealingFailed)
+        ));
+    }
+
+    #[test]
+    fn test_invitee_recovers_thumbprint() {
+        let key_store = KeyStore::<TestIds>::default();
+        let mut ctx = key_store.context_mut();
+        let wrapped_private_key = load_test_vectors(&mut ctx);
+
+        let private_key_id = ctx
+            .unwrap_private_key(TestSymmKey::Organization, &wrapped_private_key)
+            .unwrap();
+        let expected = ctx
+            .get_public_key(private_key_id)
+            .unwrap()
+            .thumbprint()
+            .unwrap();
+
+        let (invite_secret, invite) =
+            Invite::make_for_private_key(TestSymmKey::Organization, &wrapped_private_key, &mut ctx)
+                .unwrap();
+
+        // The invitee reaches the invite key via the invite secret and reads the same bound
+        // thumbprint the admin would.
+        let invite_key = invite
+            .unseal_invite_key_with_invite_secret(&invite_secret, &mut ctx)
+            .unwrap();
+        let recovered = invite
+            .get_public_key_thumbprint(invite_key, &mut ctx)
+            .unwrap();
+
+        assert_eq!(recovered, expected);
+    }
+
+    #[test]
+    fn test_malformed_invite_string_fails() {
+        // Not base64 at all.
+        assert!(matches!(
+            "not valid base64 !!!".parse::<Invite>(),
+            Err(InviteKeyBundleError::DecodingFailed)
+        ));
+
+        // Valid base64, but the decoded bytes are not valid JSON.
+        let valid_b64_not_json = B64::from(&b"not json"[..]).to_string();
+        assert!(matches!(
+            valid_b64_not_json.parse::<Invite>(),
+            Err(InviteKeyBundleError::DecodingFailed)
+        ));
+    }
+
+    #[test]
+    fn test_invalid_wrapped_private_key_fails() {
+        let key_store = KeyStore::<TestIds>::default();
+        let mut ctx = key_store.context_mut();
+        let wrapped_private_key = load_test_vectors(&mut ctx);
+
+        // The wrapped private key can only be unwrapped with the organization key it was wrapped
+        // with; a different key makes `make_for_private_key` fail before building the invite.
+        let wrong_org_key = ctx.generate_symmetric_key();
+        assert!(matches!(
+            Invite::make_for_private_key(wrong_org_key, &wrapped_private_key, &mut ctx),
+            Err(InviteKeyBundleError::InvalidPrivateKey)
+        ));
     }
 
     #[test]
@@ -704,14 +780,6 @@ mod tests {
         assert_eq!(reparsed, secret);
     }
 
-    // Test vectors captured from `generate_test_vectors`. These freeze a real invite so that
-    // backward compatibility (old data must remain decryptable) is verified by
-    // `test_invite_test_vector`.
-    const TEST_VECTOR_ORG_KEY: &str =
-        "KGP9Nc2/91w+42Z9VzY0m7h18avuZcq4ICM8Rhdc3BD92LbWS2TQkVBzavvUM684WKXiC22NJi2EwaiDW4YTAA==";
-    const TEST_VECTOR_INVITE: &str = "pHgeaW52aXRlX2tleV93cmFwcGVkX2ludml0ZV9kYXRheQGEZzFoSHBRRURBM2dqWVhCd2JHbGpZWFJwYjI0dmVDNWlhWFIzWVhKa1pXNHVZMkp2Y2kxd1lXUmtaV1FFVU8yS1A5c3pkbVF6MDlQTm1HeVZOOWc2QUFFNGdRSTZBQUU0Z0FLaEJVeUJjVUJCWCtScWk5UlM1KzlZeG8rZmpkdHJQemRVQ0FUSitGaTZtQ2puNCtYUmdwN1FEdHlLOXVjQlJiR2hKb2tHcWxqQko0RXhOOENnSEhwUGc0U0JqcGhOVE95TElZOXZ6bEZRcGV3djR3a3FaeUZkNGh0TXk4L3M0R3R0K1hkRjEzR1EvKzRMcFc0b04yOHRDdDNDcTNxbExUUGZaL09VNm1zTUlRaGhIZm1NWXI3eWwra0FiU09KQkwwek40bGNwbXRGZGtEYkRSRkdqdUx5YkRONHJ6cjRBTmdhaUJkMkZ6Q09UdjRRWGdLek5oazVWMEdiM3lrSjhlcGpJSUhRM3cyYWdIRXJJRmtoNE13R1ZzN2NXVDNka3c9PXggaW52aXRlX3NlY3JldF93cmFwcGVkX2ludml0ZV9rZXl49GhGZ29wUUVEQXhobE9nQUJGVnhRN1lvLzJ6TjJaRFBUMDgyWWJKVTMyRG9BQVRpQkJqb0FBVGlBQWFFRlRNZlJWRXFWUWxWMVlFQ1B0MWhRTTVyVVZjVVRmQkNYbzJvVFJkNW9URnRZblNvNWVpakh1UzhJcjlhT3daay83Y2dTeVhWSDh6NWl2QmYxVitqMitBT3B5dVBLTTQ4NGJva3owSmJEUW9KK2REQzNFMFVMQnVTVXFsbm5TcXVCZzBDaUFTa3pXQ0FUMEk1NC9OSFBnNFRQWjB5RjBsNlk3M3FNbG1XYVg2RThBdU1UcHBvQTdQWT14I2ludml0ZV9rZXlfd3JhcHBlZF9vcmdhbml6YXRpb25fa2V5eORnMWhHcFFFREEzZ2lZWEJ3YkdsallYUnBiMjR2ZUM1aWFYUjNZWEprWlc0dWJHVm5ZV041TFd0bGVRUlE3WW8vMnpOMlpEUFQwODJZYkpVMzJEb0FBVGlCQXpvQUFUaUFBcUVGVFBWSzVFUEVYbXVwZ29mMkRWaFF2Mlg2QkdKcCthb0pocnZjbTRxaUJMRTJHMHZhbzE3SjhXOEQxRGJvM0lpZWFzSXRsNzJwenloY21uMWh4WmM4c0k3RThIZGlRSXF6N1lSc2lQdlpUSEVJSHZqeUFrTG8reE10QW1xbUZacz14I29yZ2FuaXphdGlvbl9rZXlfd3JhcHBlZF9pbnZpdGVfa2V5eLQyLkNsM2JGTzFETENndzJ3elJ3bmtSa2c9PXw5aDEwbStqb1hmcE5pTHpnRS8yclBqaituS3JWWVl1bXBBQ2dEa2h6RUEyNVo3WjNUVTJuYnNLN2J5SWZWV0NkQ1lrQTFlQk5BNk9WN3NpcGhXWmVzRmpoVTYyT0Voc0FzOUo3K2xxODVXMD18Qk14TW52Y1JtNldSV0FveUppTnRjTjZaQkpSRE82YkFPTjZhaVhHbExBYz0=";
-    const TEST_VECTOR_INVITE_SECRET: &str = "CptXaIhmgvJ7YMNA9h9DDe13ad7ayxGPPGxik-fNWls";
-
     #[test]
     #[ignore = "Manual test to generate test vectors"]
     fn generate_test_vectors() {
@@ -721,11 +789,18 @@ mod tests {
         let org_key =
             SymmetricCryptoKey::try_from(B64::try_from(TEST_VECTOR_ORG_KEY).unwrap()).unwrap();
         let org_key_id = ctx.add_local_symmetric_key(org_key);
-        let (wrapped_private_key, _) = org_wrapped_private_key(org_key_id, &mut ctx);
+
+        // Make and wrap a fresh organization private key so it can be recorded as a fixed vector.
+        let private_key_id = ctx.make_private_key(PublicKeyEncryptionAlgorithm::RsaOaepSha1);
+        let wrapped_private_key = ctx.wrap_private_key(org_key_id, private_key_id).unwrap();
 
         let (invite_secret, invite) =
             Invite::make_for_private_key(org_key_id, &wrapped_private_key, &mut ctx).unwrap();
 
+        println!(
+            "const TEST_VECTOR_WRAPPED_PRIVATE_KEY: &str = \"{}\";",
+            wrapped_private_key.to_string()
+        );
         println!(
             "const TEST_VECTOR_INVITE: &str = \"{}\";",
             String::from(&invite)
@@ -747,7 +822,7 @@ mod tests {
 
         let invite: Invite = TEST_VECTOR_INVITE.parse().unwrap();
         let invite_key = invite
-            .invite_key_from_organization_key(org_key_id, &mut ctx)
+            .unseal_invite_key_with_organization_key(org_key_id, &mut ctx)
             .unwrap();
         let recovered = invite.get_invite_secret(invite_key, &mut ctx).unwrap();
 
@@ -759,11 +834,7 @@ mod tests {
     fn test_debug() {
         let key_store = KeyStore::<TestIds>::default();
         let mut ctx = key_store.context_mut();
-
-        let org_key_id = ctx.generate_symmetric_key();
-        ctx.persist_symmetric_key(org_key_id, TestSymmKey::Organization)
-            .unwrap();
-        let (wrapped_private_key, _) = org_wrapped_private_key(TestSymmKey::Organization, &mut ctx);
+        let wrapped_private_key = load_test_vectors(&mut ctx);
 
         let (invite_secret, invite) =
             Invite::make_for_private_key(TestSymmKey::Organization, &wrapped_private_key, &mut ctx)

--- a/crates/bitwarden-organization-crypto/src/invite.rs
+++ b/crates/bitwarden-organization-crypto/src/invite.rs
@@ -38,7 +38,7 @@ use bitwarden_crypto::{
         SecretProtectedKeyEnvelopeNamespace, SymmetricKeyEnvelope, SymmetricKeyEnvelopeNamespace,
     },
 };
-use bitwarden_encoding::{B64, B64Url, FromStrVisitor};
+use bitwarden_encoding::{B64Url, FromStrVisitor};
 use bitwarden_sensitive_value::{Sensitive, SensitiveSlice};
 use rand::Rng;
 use serde::{Deserialize, Serialize};
@@ -198,7 +198,7 @@ pub struct Invite {
     organization_key_wrapped_invite_key: EncString,
 }
 
-/// Wire format for [`Invite`]. This is what's serialized by serde (as base64-encoded JSON).
+/// Wire format for [`Invite`]. This is what's serialized by serde (as JSON).
 #[derive(Serialize, Deserialize)]
 struct InviteWire {
     invite_key_wrapped_invite_data: DataEnvelope,
@@ -220,9 +220,8 @@ impl From<&Invite> for InviteWire {
 
 impl From<&Invite> for String {
     fn from(invite: &Invite) -> Self {
-        let buf = serde_json::to_vec(&InviteWire::from(invite))
-            .expect("JSON serialization of Invite never fails");
-        B64::from(buf).to_string()
+        serde_json::to_string(&InviteWire::from(invite))
+            .expect("JSON serialization of Invite never fails")
     }
 }
 
@@ -230,11 +229,8 @@ impl FromStr for Invite {
     type Err = InviteKeyBundleError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let bytes = B64::try_from(s)
-            .map_err(|_| InviteKeyBundleError::DecodingFailed)?
-            .into_bytes();
-        let data: InviteWire = serde_json::from_slice(bytes.as_slice())
-            .map_err(|_| InviteKeyBundleError::DecodingFailed)?;
+        let data: InviteWire =
+            serde_json::from_str(s).map_err(|_| InviteKeyBundleError::DecodingFailed)?;
         Ok(Invite {
             invite_key_wrapped_invite_data: data.invite_key_wrapped_invite_data,
             invite_secret_wrapped_invite_key: data.invite_secret_wrapped_invite_key,
@@ -493,9 +489,9 @@ mod tests {
     // must remain decryptable) is verified by `test_invite_test_vector`.
     const TEST_VECTOR_ORG_KEY: &str =
         "KGP9Nc2/91w+42Z9VzY0m7h18avuZcq4ICM8Rhdc3BD92LbWS2TQkVBzavvUM684WKXiC22NJi2EwaiDW4YTAA==";
-    const TEST_VECTOR_WRAPPED_PRIVATE_KEY: &str = "2.Fi0VHpgZgBQWB8x+fLhjbg==|1Kdwcx5HIrnzHsw9vmlaEdsSUGrixdPjC2Tcl9QijlBJrNWSaaWW+sMCTZ71IC18ORFYp8QDICs7aUqE3RaM8zTdXM1Gaf+OJbr29UGyRwiN6flnrjrwsVSSeEGyTUBNS0eSdlaurOu9Eo+CtUmXWsKiGLVYINgYmUims4JsFQ/J8JOG5tkVy9onZc9TIOULSlCqXZ53g7u4Nbvqgdr6qMzuBuO9s0OVStORmliRYTMbGivqiOW27VKk89OMTwuomeC25m5Gh4LwuAcTQob9SnuAssVjGLb2H1HvjdFafAnk2N979hx6u9bgl83dKNa00rbZiGkhxTJIam9pwFuoudP8o4wsv7SeXV86XEq49xJSDD0FGowcHZ8iC9bI28h12vzOAzaA6Om1MUIc38sL/YBwkQyIxeWqFILOuoXPWsZ/fGomSI/mijCIGChzB+YS7W6GbFF50lYJukWPophLL+d8nx/5JuH2m3AfusM4ml2qMjHJ9Lf6ToedDr5ap4hHUPcMSiT/qilt0sjhqP+TAqpp0QxM20QCA9zW/FLBUKpiT/8LhC2eZM2eQlKYwabg4DGy+Wu6s4E5kJJ9jrdN3RCpgy/BDAjyd6+taixvR1ejH/J0T6WirNP5lGo7bdlCiq4mWnqbALtRfQmz1e/7pWhRZv7hHhWurqdZQLuAOdKYe89aQj316NAgPKlMJWiLuT1rC94EmPuiXl54WDjYH2xgnprKwqXdNls+0dbiXSvejXod2b8FD263mUwN+OluwyyI6YeOZge3HAmmmXBUbYgunyqBK1QoMgc5Oj6QyBnzMYc5vE7NuEzjncFMNZc+XjxrAwJS1J2ZR6SjzrQjAAaoGA2fTBQ2NYpr/bf91dbJJkzZZBpHMoJWU0zyE3I4AEs48JS7VW++uM6pIkBdg67JsxaSS3h7E3nJEd8qQScbn+AgFVy6FT1W+dUr+FoaP7N2U0r9qxWh6anZlfWIS4Sw7Sr5plR24SyevrLkIXWoK2T1mFzRnGtP2KaYoIr2oGtx0PGM5ZSzUQJhURKt7Nx9X34AKh3/yI4BLQmx8FVVLhh0mONQrmPx5VgodxxYwh1nIRgMG1BPE8SOj1sXsgzhu2jmUfhFJXpbL//3zr7z5f461ungPN+Dj4dAThf4N+XktskNN3eaIfnHwK4+st97qTA060oe7qqLbMvuR8pj0slvA2HTxcsIFDEUvCJipeTZrOjJHW59co15DDjbXHXrSXDhtfWh6EWSbh+m+q5OldkI30INhNNvKx5LqBCFonONekRD/1qzxFLE8Arlsu0R1OmtQjnbj1Lt5yUkFlL5KIOSETg0BGWqhhkLRXq3URylxTe/An5H9Q0xaqfQtaUOMbdaxSMq4HokSlxLOHGWiWMlPBQQT93XO96wPs13Sytzl0Wcu4kx+Ttlx6EmHPfd1jjDZdSaR0wM8+HA74jC70wwqc2FJzBoCm/O1Da8b0yNb26PTNmkhFjL95XvQERom3hkOf8LaA8metq/OT4jHDU/Tci2GYYxNjoDBYj/JyrKpODPQ4GfmxzzeYyNav+ZFGCDbYa5rvixwddAIAZLB+IBaDx0SnKe/a3rrerjx4GWPo/HHzRjoeLvHVjX1RA4bwIq6icROhBFRDkUZbY=|Y9md9PASfsT04OYaj1P6FL9cXUc/m8PloWizzuWT84E=";
-    const TEST_VECTOR_INVITE: &str = "eyJpbnZpdGVfa2V5X3dyYXBwZWRfaW52aXRlX2RhdGEiOiJnMWhIcFFFREEzZ2pZWEJ3YkdsallYUnBiMjR2ZUM1aWFYUjNZWEprWlc0dVkySnZjaTF3WVdSa1pXUUVVSTdrc014MGNNNi9VQ2VVY2pMcVdIRTZBQUU0Z1FJNkFBRTRnQUtoQlV3a0hhWW0yK3Z1aGFIRXJmbFl4VWV6dkN2NzVuMzRHSk5ubWJ5NzFyb1lYQ3ZNaWE1dVZ0cmkwSWN5NEQ2WVM1YjFGM2l2MVVwRXU3Q2pnb01pNXZqNFlxRUZZQ3pabGx6MXBybnM5aENjSzlyVkFxREM2QTlDTGRMWG9HeWE2ZlNySGhXaW1kZWd5bnA0UHphczVsbGxibTJUMENFaWdod1FuUVIyRzN3QmlUUnNVZG00dWR2eWVKWWlOYWZ6VFE5V25BWlhSOG1pVVZyVHkxWDIzbHhYWE55UnhrTjNYemlTc0RvY2JYVEJvRlJkR1hGWURiSjhrU2cvZVQrWHJqdDlrYmxzTnZaYVlvemtBWVlYWnIxcnhvMDYiLCJpbnZpdGVfc2VjcmV0X3dyYXBwZWRfaW52aXRlX2tleSI6ImhGZ29wUUVEQXhobE9nQUJGVnhRanVTd3pIUnd6cjlRSjVSeU11cFljVG9BQVRpQkJqb0FBVGlBQWFFRlRJaDJmOVkzdGsyTXpvWnhpVmhRQjdkcFhNRjBGak1ISEl0UWt2RDMxNTUvV1VMQmVldW9zbHlUNm5xMEQ0WTJieFZnZjFaQnRNaUoweUQxeVVFMGJaS0tMZS93NmNab3h4YzlsTGRjL05iNHQ2Wmo0L0NDOG9HWTBnVTkxNG1CZzBDaUFTa3pXQ0EwT0VxK1ZsQVlKTnVvZWRSNENtWUVWV0NDOVVIUmNyRWs4NWFSQkpaczV2WT0iLCJpbnZpdGVfa2V5X3dyYXBwZWRfb3JnYW5pemF0aW9uX2tleSI6ImcxaEdwUUVEQTNnaVlYQndiR2xqWVhScGIyNHZlQzVpYVhSM1lYSmtaVzR1YkdWbllXTjVMV3RsZVFSUWp1U3d6SFJ3enI5UUo1UnlNdXBZY1RvQUFUaUJBem9BQVRpQUFxRUZURnd0NWxZQTU0Z3B3MFpSU0ZoUXlYMlB6UEN5QkdPdDVLd29rc21KMTlWWHJXVVJjd1M2RDNVaHhkVm5UQnZOU0pSSjhLZ2VNVEpJYlNldVdSbkpydnJaYzdacEo5bzJnVXg0TTV0aCtod1RVTXN0N3lMNVNzMEFyeFNJRjJvPSIsIm9yZ2FuaXphdGlvbl9rZXlfd3JhcHBlZF9pbnZpdGVfa2V5IjoiMi5OVXkyQW44YVZHaVpObDZLMGFxNHdRPT18bFhvMXhWQTFzc3dKbG1mQ1grNG5vZjlXSURGS1hOcStMS280TkIwVWVtQkFQQlkvK3p2dnlHOUp0QkxnYkU5aTMzaGYvK0FJa0ltTUxzcUNjL0QrU2RxQUhPU3hXV1hLVzJUb0RvRGRldzQ9fDdlQ2MxN2E2TXVCa0J6M3lxcHFuaWp4MlpXVE01ZW1ZcE1aS2tEN2daMEk9In0=";
-    const TEST_VECTOR_INVITE_SECRET: &str = "rAI7b5drK7fgI-PToxddm4-9py1UFdHbaxczIgf7KHk";
+    const TEST_VECTOR_WRAPPED_PRIVATE_KEY: &str = "2.bi9TWF/zrujUg1y+v8ECtQ==|kEMkuRt42j65YZnPEc4bLOT0/WDZwWSNJNGlUMdr/LRF3qi/vCnZ7eT0+7MruTccmyoAjKmsXdoBcufrOdPBUguFQn1LQMGqHqCyyB3SIijOlLyOOmxWYqoLUjihy8o8URGWjrAGWZnkeYWHTlFZP09Fag2xCwiQ/qS32Q+qTGGHDs0FiwjplcPkW9knlmgCXbuyPqDnEYoa0Qs/CC1hUCzFFrWs7QkE+5eLaNHxuBPpsrY6y795kEu9ve38F3piY9b6lQpc/iPGv8Zfh1isI7Mpy1zMwntXGSHjUOy17nPxCqkgYufuNGnwGNwsGjkLAl7e7bD39SYfEpTDaRUgmTl8UrZDx274e6Um1LLvokf3HiL1tboJ9/TW8IiMuAdrb3PLTH6Sep8lqZ3WhNADfMMJle9kCojHp6XSB14in1JqP0636exYeJu+FhUC1TfrthuQN2QDQ8LAvgZR7YvzkTJX3Sc5jP7m/yCmCbHhIqIAaGqJsRwAee0EMsKcALz3/akVoyjHU2LHD3dzQnyMyszyRNYViBNYAM9qBN2DqwWRDOtM171xNVJcTFsAh4mBSLiLOlDsXqLqHVKu2VJNE1XhTQ5Szubqefa/Or7nfxXcxDvivqZ7d5NfDFEskUMqh5yq1KoLK0oK5c+KvY/COIZr/kct+qtfZsXo3w5xJnPOqrAKGm+9CF4OINpLM8Z3csdZf9l5XjlmO1kIuBbquQZ0EZCHzD/GEfXRGB8BEkugdTfpnTDtmmuAJXkIY6t6e6pRUU9u4/sl+U7Iuh22fOA59SuQOElr5Lxre+hQBrRfJS3tSMEtMjYhVmltrngH+SLRxMxH/evbe2uvNaaxlFJe6EK1vqchyTX6nM8Z+2Yjb5pOAzrKQYqwwmVys9IHfjXhybqv10gFpDXBE/eq8u9xs9LbQQ03EbveQUtqdh/ms8SxLOQA9Sm9JwHEL0Zni+8NdAa5orDYzOi53bQLgrs+uUldgB/KOW2goTnKGm4YTbMAXEbum8pST8EXB9jNDXyofyN8IQUoLRvVkEgzbSPBS1sYpkkKdLZy3ojOCKnMnHXIVtzJojFckiutbj6d927X5w51E/RDMoAdylGRVKnmqLKysFRqL+pZK8Cyo+ECr7notG8kr7pVnofzigjKZS9qkRmqEa9bju1GgI20g4cxro8/0O0XnU1o0Mx46qH3niORY59i5bdMwaDS6H2c6+rmf9bIFwwgyAZvHlVdcGNoBGPR3ZXHThwI1OmWSslLWVW0IaS4utB1jL4zvHPCqh/ButA8HeRmU/NYSfaqb9YXyzn+C7ED15MWXkYmZzeE38HHxhqs12+oj+WFcg4d5/e2UcccuVi36SWhA0xWk8Kk2D6e1Pz1lmaw20vpb0eUq4AS5ZnMmWTEiKORFeGNTIROq9vuPuitLrREedu9PGjf5aeKcNqlq2nr7fOaxyi2ocKs7pLqVBUH1G7zHpCo3Rt1+o18guXFHT56vQFfkzoUNXiS6TRM4Mkl3s0TyGgBhxZkNJleTI6y4xhfH1iathBnLcfelLbxZhDB1wh3RXowS32jpM/J4pSUuNEmSLSqRQtRJY41BG00nYY02qEbakkgk6pS6a0/CWphyLfHAzUWbabOhqR1iPN9/ZiecjI=|eoklmBw+LYy2NNwjLOuA4+szKH5SzLGPlrhIJ/vfmW4=";
+    const TEST_VECTOR_INVITE: &str = r#"{"invite_key_wrapped_invite_data":"g1hHpQEDA3gjYXBwbGljYXRpb24veC5iaXR3YXJkZW4uY2Jvci1wYWRkZWQEULAvkABNEIqBWSbJbR5w/PU6AAE4gQI6AAE4gAKhBUzu06Qb8Rqlag8wxIVYyAOEYjj8vngz+6efiYs4aJqpGKMDNYgXM7QEYDH85RfElcQ3tkBm5lNsLWy04I2gFaJV6hGRN8fZSG9Br3Q11yUIkTna6wy112uCn/szWnrceGg+tTUKjErl9FmkN6yzoSskR1U10dqVeG7AJRjzkAgZFHol1JycPVxhuJdszrF/HpNEOKUbw94vA8kVRQV7+JWJKgeUki0gb9kHPpE+P2vxtM7YJU5uhQXukKVg2KXkNTX7BwXDZ1aofIkFHzSzMtRuRVrEUjAn","invite_secret_wrapped_invite_key":"hFgopQEDAxhlOgABFVxQsC+QAE0QioFZJsltHnD89ToAATiBBjoAATiAAaEFTH8P6s7widuCRd5gsVhQ8Qdi4roT2jBcAb9Qn6f4pJL/BKGvWTrN3D9wvK3bT/AOgEcoiP3gZPZ8qvCiFBgErQ+IudaHnPxw1/W2QXvvZGbkaa1vnqL8eIPuzWrGVVyBg0CiASkzWCAIfgngqsWpnHP3zFYH88LcFD13xgvwzmmN0nirJ6BUZPY=","invite_key_wrapped_organization_key":"g1hGpQEDA3giYXBwbGljYXRpb24veC5iaXR3YXJkZW4ubGVnYWN5LWtleQRQsC+QAE0QioFZJsltHnD89ToAATiBAzoAATiAAqEFTMKnS2tiogG0nXwKFVhQvhXuJ7yorAyslqDLYYjUblYqKryq4aNOS9nGpHkJd+39Uo8cYblbqkBs6x7degHq+bj80RQUoNGpWBLGOPNkIP6tqMnAxQy0NR6sIm7trkI=","organization_key_wrapped_invite_key":"2.xpuLCrOF/Ai7q+zGn5ftSQ==|AyGdogR5TKqIO9nbABdtb57uJ/G/6J5Cj4AajWjWppe6ZJSfqt65fAmgT954+Qgf10ah9L+34jW27yOVitwXMEq/+7b8FaAUDJoh89Yi36Q=|BK4onlURPXFoaUt48UoUeD1BhFREYHHs1tuY6MoR7lQ="}"#;
+    const TEST_VECTOR_INVITE_SECRET: &str = "Q4PavSCGSc10mROp_3gsoufZyiYx830Thcs2iprt1X8";
 
     /// Loads the const `TEST_VECTOR_ORG_KEY` into the `Organization` slot and returns the parsed
     /// const wrapped organization private key. Sharing fixed vectors keeps tests deterministic and
@@ -731,16 +727,15 @@ mod tests {
 
     #[test]
     fn test_malformed_invite_string_fails() {
-        // Not base64 at all.
+        // Not JSON at all.
         assert!(matches!(
-            "not valid base64 !!!".parse::<Invite>(),
+            "not valid json !!!".parse::<Invite>(),
             Err(InviteKeyBundleError::DecodingFailed)
         ));
 
-        // Valid base64, but the decoded bytes are not valid JSON.
-        let valid_b64_not_json = B64::from(&b"not json"[..]).to_string();
+        // Valid JSON, but missing the required invite fields.
         assert!(matches!(
-            valid_b64_not_json.parse::<Invite>(),
+            "{}".parse::<Invite>(),
             Err(InviteKeyBundleError::DecodingFailed)
         ));
     }
@@ -802,7 +797,7 @@ mod tests {
             wrapped_private_key.to_string()
         );
         println!(
-            "const TEST_VECTOR_INVITE: &str = \"{}\";",
+            "const TEST_VECTOR_INVITE: &str = r#\"{}\"#;",
             String::from(&invite)
         );
         println!(

--- a/crates/bitwarden-organization-crypto/src/invite.rs
+++ b/crates/bitwarden-organization-crypto/src/invite.rs
@@ -364,8 +364,9 @@ impl Invite {
         self.invite_key_sealed_organization_key = None;
     }
 
-    /// Generates a brand new invite around a fresh AES-256-GCM invite key, binding it to the
-    /// provided organization key and the organization's public-key thumbprint (see [`Invite`]).
+    /// Generates a brand new invite around a new invite key. The invite is sealed for the
+    /// provided organization key and bound to the organization's public-key thumbprint (see
+    /// [`Invite`]).
     ///
     /// `wrapped_organization_private_key` is the organization's private key wrapped with
     /// `organization_key`; the public-key thumbprint bound into the invite is derived from it.

--- a/crates/bitwarden-organization-crypto/src/invite.rs
+++ b/crates/bitwarden-organization-crypto/src/invite.rs
@@ -394,11 +394,8 @@ impl Invite {
             .thumbprint()
             .map_err(|_| InviteKeyBundleError::InvalidPrivateKey)?;
 
-        // Generate the URL-fragment invite secret (goes in the invite link).
         let invite_secret = InviteSecret::make();
 
-        // Generate the invite key (the hub). It only ever acts as a key-encryption key — sealing
-        // the invite-data CEK and the organization key via `SymmetricKeyEnvelope`.
         let invite_key = KeyEncryptionKey::make(ctx);
 
         // Seal the invite data (thumbprint + a copy of the invite secret) under a fresh

--- a/crates/bitwarden-organization-crypto/src/invite.rs
+++ b/crates/bitwarden-organization-crypto/src/invite.rs
@@ -395,7 +395,6 @@ impl Invite {
             .map_err(|_| InviteKeyBundleError::InvalidPrivateKey)?;
 
         let invite_secret = InviteSecret::make();
-
         let invite_key = KeyEncryptionKey::make(ctx);
 
         // Seal the invite data (thumbprint + a copy of the invite secret) under a fresh

--- a/crates/bitwarden-organization-crypto/src/invite.rs
+++ b/crates/bitwarden-organization-crypto/src/invite.rs
@@ -1,0 +1,802 @@
+//! Cryptographic organization invites built around an AES-256-GCM invite key (see [`Invite`]).
+//!
+//! This module is the successor to [`crate::invite_key_bundle`]; the two coexist for now and a
+//! follow-up will promote this one to the crate root.
+
+use std::str::FromStr;
+
+use bitwarden_crypto::{
+    CoseKeyThumbprint, CoseKeyThumbprintExt, EncString, KeySlotIds, KeyStoreContext,
+    SymmetricKeyAlgorithm, generate_versioned_sealable,
+    safe::{
+        DataEnvelope, DataEnvelopeNamespace, HighEntropySecret, HighEntropySecretSource,
+        SealableData, SealableVersionedData, SecretProtectedKeyEnvelope,
+        SecretProtectedKeyEnvelopeNamespace, SymmetricKeyEnvelope, SymmetricKeyEnvelopeNamespace,
+    },
+};
+use bitwarden_encoding::{B64, B64Url, FromStrVisitor};
+use bitwarden_sensitive_value::{Sensitive, SensitiveSlice};
+use rand::Rng;
+use serde::{Deserialize, Serialize};
+use subtle::{Choice, ConstantTimeEq};
+use thiserror::Error;
+use zeroize::Zeroizing;
+
+/// Length, in bytes, of the raw invite secret. 32 bytes provides 256 bits of entropy, which is why
+/// the invite secret is safe to use directly as a [`HighEntropySecret`].
+const INVITE_SECRET_LEN: usize = 32;
+
+/// The namespace binding the invite's [`SecretProtectedKeyEnvelope`] to organization invites, so it
+/// cannot be substituted for an envelope minted for another purpose.
+const INVITE_SECRET_ENVELOPE_NAMESPACE: SecretProtectedKeyEnvelopeNamespace =
+    SecretProtectedKeyEnvelopeNamespace::OrganizationInvite;
+
+/// The namespace binding the invite's [`SymmetricKeyEnvelope`] (the organization key wrapped by the
+/// invite key) to organization invites.
+const INVITE_ORG_KEY_ENVELOPE_NAMESPACE: SymmetricKeyEnvelopeNamespace =
+    SymmetricKeyEnvelopeNamespace::OrganizationInvite;
+
+/// Errors that can occur when creating or opening an invite.
+#[derive(Debug, Error)]
+pub enum InviteKeyBundleError {
+    /// Decoding the encrypted invite failed
+    #[error("Decoding failed")]
+    DecodingFailed,
+    /// Sealing one of the invite's envelopes failed
+    #[error("Unable to seal invite")]
+    KeySealingFailed,
+    /// Opening one of the invite's envelopes failed
+    #[error("Unable to unseal invite")]
+    KeyUnsealingFailed,
+    /// A required key was not found in the key store context
+    #[error("Missing Key for Id: {0}")]
+    MissingKeyId(String),
+    /// The organization private key could not be unwrapped, or its public-key thumbprint could not
+    /// be derived
+    #[error("Invalid organization private key")]
+    InvalidPrivateKey,
+    /// The organization key cannot be recovered from the invite because confirmation is disabled
+    #[error("Confirmation is not enabled on this invite")]
+    ConfirmationNotEnabled,
+}
+
+#[cfg(feature = "wasm")]
+#[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
+const TS_INVITE_SECRET: &'static str = r#"
+export type InviteSecret = Tagged<string, "InviteSecret">;
+"#;
+
+/// The invite secret: 32 random, high-entropy bytes carried in the invite link. It is not a keyed
+/// cryptographic object; it protects the invite key. Supports WASM bindings, automatically using
+/// base64Url encoding for both `wasm-bindgen` and `tsify`.
+///
+/// To manually encode as a `base64URL` string:
+/// ```ignore
+/// String::from(&invite_secret);
+/// ```
+/// Also supports serde serialization/deserialization using the base64Url format.
+///
+/// CRITICAL: This must never be sent to the server.
+#[derive(Clone)]
+pub struct InviteSecret(Zeroizing<[u8; INVITE_SECRET_LEN]>);
+
+impl ConstantTimeEq for InviteSecret {
+    fn ct_eq(&self, other: &InviteSecret) -> Choice {
+        self.0.as_slice().ct_eq(other.0.as_slice())
+    }
+}
+
+impl PartialEq for InviteSecret {
+    fn eq(&self, other: &Self) -> bool {
+        self.ct_eq(other).into()
+    }
+}
+
+// Manually implemented so the raw invite secret bytes are never printed.
+impl std::fmt::Debug for InviteSecret {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("InviteSecret").finish()
+    }
+}
+
+/// Exposes the invite secret as a [`HighEntropySecret`]. This is sound because the invite secret is
+/// 32 bytes sampled from a CSPRNG.
+impl HighEntropySecretSource for InviteSecret {
+    fn provide_high_entropy_bytes(&self) -> SensitiveSlice<'_> {
+        Sensitive::from(self.0.as_slice())
+    }
+}
+
+impl From<&InviteSecret> for String {
+    fn from(secret: &InviteSecret) -> Self {
+        B64Url::from(secret.0.as_slice()).to_string()
+    }
+}
+
+impl FromStr for InviteSecret {
+    type Err = InviteKeyBundleError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let data = B64Url::try_from(s).map_err(|_| InviteKeyBundleError::DecodingFailed)?;
+        let bytes: [u8; INVITE_SECRET_LEN] = data
+            .as_bytes()
+            .try_into()
+            .map_err(|_| InviteKeyBundleError::DecodingFailed)?;
+        Ok(InviteSecret(Zeroizing::new(bytes)))
+    }
+}
+
+impl<'de> Deserialize<'de> for InviteSecret {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_str(FromStrVisitor::new())
+    }
+}
+
+impl Serialize for InviteSecret {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_str(&String::from(self))
+    }
+}
+
+/// The plaintext data sealed inside the invite's [`DataEnvelope`] with the invite key.
+///
+/// It binds the organization public-key thumbprint (so account-recovery enrollment can verify the
+/// organization key belongs to the expected identity) and a copy of the invite secret (so a holder
+/// of the invite key can reconstruct the invite link).
+#[derive(Serialize, Deserialize, Debug, PartialEq)]
+struct InviteDataV1 {
+    /// RFC 9679 COSE Key Thumbprint (SHA-256) of the organization public key.
+    public_key_thumbprint: [u8; 32],
+    /// The raw invite secret bytes.
+    invite_secret: [u8; INVITE_SECRET_LEN],
+}
+impl SealableData for InviteDataV1 {}
+
+generate_versioned_sealable!(
+    InviteData,
+    DataEnvelopeNamespace::OrganizationInvite,
+    [
+        InviteDataV1 => "1",
+    ]
+);
+
+#[cfg(feature = "wasm")]
+#[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
+const TS_INVITE: &'static str = r#"
+export type Invite = Tagged<string, "Invite">;
+"#;
+
+/// Cryptographic invite for an organization, built around an AES-256-GCM **invite key** that
+/// acts as the hub tying everything together:
+///
+/// - `invite_key_wrapped_invite_data`: the `InviteData` (org public-key thumbprint + invite secret)
+///   sealed with the invite key.
+/// - `invite_secret_wrapped_invite_key`: the invite key sealed with the high-entropy invite secret,
+///   letting an invitee (who holds only the invite secret from the link) recover the invite key.
+/// - `invite_key_wrapped_organization_key`: the organization key sealed with the invite key,
+///   letting a redeeming invitee recover the organization key once they hold the invite key. This
+///   is **optional**: its presence is what "confirmation" means. When confirmation is enabled the
+///   invitee can self-confirm by recovering the organization key; when disabled, this field is
+///   absent and an admin must confirm the invitee out of band.
+/// - `organization_key_wrapped_invite_key`: the invite key wrapped with the organization key,
+///   letting anyone holding the organization key recover the invite key (and thus the invite data).
+#[derive(Clone)]
+pub struct Invite {
+    invite_key_wrapped_invite_data: DataEnvelope,
+    invite_secret_wrapped_invite_key: SecretProtectedKeyEnvelope,
+    invite_key_wrapped_organization_key: Option<SymmetricKeyEnvelope>,
+    organization_key_wrapped_invite_key: EncString,
+}
+
+/// Wire format for [`Invite`]. This is what's serialized by serde (as base64-encoded CBOR).
+#[derive(Serialize, Deserialize)]
+struct InviteWire {
+    invite_key_wrapped_invite_data: DataEnvelope,
+    invite_secret_wrapped_invite_key: SecretProtectedKeyEnvelope,
+    invite_key_wrapped_organization_key: Option<SymmetricKeyEnvelope>,
+    organization_key_wrapped_invite_key: EncString,
+}
+
+impl From<&Invite> for InviteWire {
+    fn from(invite: &Invite) -> Self {
+        InviteWire {
+            invite_key_wrapped_invite_data: invite.invite_key_wrapped_invite_data.clone(),
+            invite_secret_wrapped_invite_key: invite.invite_secret_wrapped_invite_key.clone(),
+            invite_key_wrapped_organization_key: invite.invite_key_wrapped_organization_key.clone(),
+            organization_key_wrapped_invite_key: invite.organization_key_wrapped_invite_key.clone(),
+        }
+    }
+}
+
+impl From<&Invite> for String {
+    fn from(invite: &Invite) -> Self {
+        let mut buf = Vec::new();
+        ciborium::ser::into_writer(&InviteWire::from(invite), &mut buf)
+            .expect("CBOR serialization of Invite never fails");
+        B64::from(buf).to_string()
+    }
+}
+
+impl FromStr for Invite {
+    type Err = InviteKeyBundleError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let bytes = B64::try_from(s)
+            .map_err(|_| InviteKeyBundleError::DecodingFailed)?
+            .into_bytes();
+        let data: InviteWire = ciborium::de::from_reader(bytes.as_slice())
+            .map_err(|_| InviteKeyBundleError::DecodingFailed)?;
+        Ok(Invite {
+            invite_key_wrapped_invite_data: data.invite_key_wrapped_invite_data,
+            invite_secret_wrapped_invite_key: data.invite_secret_wrapped_invite_key,
+            invite_key_wrapped_organization_key: data.invite_key_wrapped_organization_key,
+            organization_key_wrapped_invite_key: data.organization_key_wrapped_invite_key,
+        })
+    }
+}
+
+impl<'de> Deserialize<'de> for Invite {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_str(FromStrVisitor::new())
+    }
+}
+
+impl Serialize for Invite {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_str(&String::from(self))
+    }
+}
+
+// Manually implemented to mirror the safe key-envelope primitives: it surfaces the wrapped fields
+// without ever printing key material (each field's own `Debug` is key-material-safe).
+impl std::fmt::Debug for Invite {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Invite")
+            .field(
+                "invite_key_wrapped_invite_data",
+                &self.invite_key_wrapped_invite_data,
+            )
+            .field(
+                "invite_secret_wrapped_invite_key",
+                &self.invite_secret_wrapped_invite_key,
+            )
+            .field(
+                "invite_key_wrapped_organization_key",
+                &self.invite_key_wrapped_organization_key,
+            )
+            .field(
+                "organization_key_wrapped_invite_key",
+                &self.organization_key_wrapped_invite_key,
+            )
+            .finish()
+    }
+}
+
+impl Invite {
+    /// Recovers the invite key using the organization key
+    pub fn invite_key_from_organization_key<Ids: KeySlotIds>(
+        &self,
+        organization_key: Ids::Symmetric,
+        ctx: &mut KeyStoreContext<Ids>,
+    ) -> Result<Ids::Symmetric, InviteKeyBundleError> {
+        ctx.unwrap_symmetric_key(organization_key, &self.organization_key_wrapped_invite_key)
+            .map_err(|_| InviteKeyBundleError::KeyUnsealingFailed)
+    }
+
+    /// Recovers the invite key from the invite secret
+    pub fn invite_key_from_invite_secret<Ids: KeySlotIds>(
+        &self,
+        invite_secret: &InviteSecret,
+        ctx: &mut KeyStoreContext<Ids>,
+    ) -> Result<Ids::Symmetric, InviteKeyBundleError> {
+        let secret = HighEntropySecret::from(invite_secret.clone());
+        self.invite_secret_wrapped_invite_key
+            .unseal(&secret, INVITE_SECRET_ENVELOPE_NAMESPACE, ctx)
+            .map_err(|_| InviteKeyBundleError::KeyUnsealingFailed)
+    }
+
+    /// Unseals the `InviteDataV1` using an invite key
+    fn unseal_invite_data<Ids: KeySlotIds>(
+        &self,
+        invite_key: Ids::Symmetric,
+        ctx: &mut KeyStoreContext<Ids>,
+    ) -> Result<InviteDataV1, InviteKeyBundleError> {
+        let data: InviteData = self
+            .invite_key_wrapped_invite_data
+            .unseal(invite_key, ctx)
+            .map_err(|_| InviteKeyBundleError::KeyUnsealingFailed)?;
+        let InviteData::InviteDataV1(data) = data;
+        Ok(data)
+    }
+
+    /// Recovers the [`InviteSecret`] using an invite key
+    pub fn get_invite_secret<Ids: KeySlotIds>(
+        &self,
+        invite_key: Ids::Symmetric,
+        ctx: &mut KeyStoreContext<Ids>,
+    ) -> Result<InviteSecret, InviteKeyBundleError> {
+        let data = self.unseal_invite_data(invite_key, ctx)?;
+        Ok(InviteSecret(Zeroizing::new(data.invite_secret)))
+    }
+
+    /// Recovers the organization public-key thumbprint bound into the invite using an invite key
+    pub fn get_public_key_thumbprint<Ids: KeySlotIds>(
+        &self,
+        invite_key: Ids::Symmetric,
+        ctx: &mut KeyStoreContext<Ids>,
+    ) -> Result<CoseKeyThumbprint, InviteKeyBundleError> {
+        let data = self.unseal_invite_data(invite_key, ctx)?;
+        Ok(CoseKeyThumbprint::from_bytes(data.public_key_thumbprint))
+    }
+
+    /// Whether confirmation is enabled on this invite, i.e. whether the organization key can be
+    /// recovered from the invite key.
+    pub fn supports_confirmation(&self) -> bool {
+        self.invite_key_wrapped_organization_key.is_some()
+    }
+
+    /// Unseals the organization key using an invite key, storing it in the key store context and
+    /// returning its id.
+    pub fn unseal_organization_key<Ids: KeySlotIds>(
+        &self,
+        invite_key: Ids::Symmetric,
+        ctx: &mut KeyStoreContext<Ids>,
+    ) -> Result<Ids::Symmetric, InviteKeyBundleError> {
+        self.invite_key_wrapped_organization_key
+            .as_ref()
+            .ok_or(InviteKeyBundleError::ConfirmationNotEnabled)?
+            .unseal(invite_key, INVITE_ORG_KEY_ENVELOPE_NAMESPACE, ctx)
+            .map_err(|_| InviteKeyBundleError::KeyUnsealingFailed)
+    }
+
+    /// Enables confirmatio
+    pub fn enable_confirmation<Ids: KeySlotIds>(
+        &mut self,
+        organization_key: Ids::Symmetric,
+        ctx: &mut KeyStoreContext<Ids>,
+    ) -> Result<(), InviteKeyBundleError> {
+        let invite_key = self.invite_key_from_organization_key(organization_key, ctx)?;
+        let envelope = SymmetricKeyEnvelope::seal(
+            organization_key,
+            invite_key,
+            INVITE_ORG_KEY_ENVELOPE_NAMESPACE,
+            ctx,
+        )
+        .map_err(|_| InviteKeyBundleError::KeySealingFailed)?;
+        self.invite_key_wrapped_organization_key = Some(envelope);
+        Ok(())
+    }
+
+    /// Disables confirmation
+    pub fn disable_confirmation(&mut self) {
+        self.invite_key_wrapped_organization_key = None;
+    }
+
+    /// Generates a brand new invite around a fresh AES-256-GCM invite key, binding it to the
+    /// provided organization key and the organization's public-key thumbprint (see [`Invite`]).
+    ///
+    /// `wrapped_private_key` is the organization's private key wrapped with `organization_key`; the
+    /// public-key thumbprint bound into the invite is derived from it.
+    ///
+    /// Returns the raw [`InviteSecret`] (which MUST NOT be sent to the server) together with the
+    /// server-safe [`Invite`].
+    pub fn make_for_private_key<Ids: KeySlotIds>(
+        organization_key: Ids::Symmetric,
+        wrapped_private_key: &EncString,
+        ctx: &mut KeyStoreContext<Ids>,
+    ) -> Result<(InviteSecret, Invite), InviteKeyBundleError> {
+        // Derive the organization public-key thumbprint from the wrapped private key.
+        let private_key_id = ctx
+            .unwrap_private_key(organization_key, wrapped_private_key)
+            .map_err(|_| InviteKeyBundleError::InvalidPrivateKey)?;
+        let thumbprint = ctx
+            .get_public_key(private_key_id)
+            .map_err(|_| InviteKeyBundleError::InvalidPrivateKey)?
+            .thumbprint()
+            .map_err(|_| InviteKeyBundleError::InvalidPrivateKey)?;
+
+        // Generate the URL-fragment invite secret (goes in the invite link).
+        let mut bytes = Zeroizing::new([0u8; INVITE_SECRET_LEN]);
+        bitwarden_random::rng().fill_bytes(bytes.as_mut_slice());
+        let invite_secret = InviteSecret(bytes);
+
+        // Generate the AES-256-GCM invite key (the hub). It is used for exactly two AES-256-GCM
+        // messages below (the invite-data DataEnvelope and the org-key SymmetricKeyEnvelope), each
+        // with a fresh random nonce, so there is no nonce-reuse concern.
+        let invite_key = ctx.make_symmetric_key(SymmetricKeyAlgorithm::Aes256Gcm);
+
+        // Seal the invite data (thumbprint + a copy of the invite secret) with the invite key.
+        let invite_data: InviteData = InviteDataV1 {
+            public_key_thumbprint: *thumbprint.as_bytes(),
+            invite_secret: *invite_secret.0,
+        }
+        .into();
+        let invite_key_wrapped_invite_data =
+            DataEnvelope::seal_with_provided_key(invite_data, invite_key, ctx)
+                .map_err(|_| InviteKeyBundleError::KeySealingFailed)?;
+
+        // Seal the invite key with the invite secret (invitee -> invite key direction).
+        let secret = HighEntropySecret::from(invite_secret.clone());
+        let invite_secret_wrapped_invite_key = SecretProtectedKeyEnvelope::seal(
+            invite_key,
+            &secret,
+            INVITE_SECRET_ENVELOPE_NAMESPACE,
+            ctx,
+        )
+        .map_err(|_| InviteKeyBundleError::KeySealingFailed)?;
+
+        // Seal the organization key with the invite key (invite key -> organization key direction).
+        // New invites are created with confirmation enabled; callers can disable it afterwards via
+        // `Invite::disable_confirmation`.
+        let invite_key_wrapped_organization_key = Some(
+            SymmetricKeyEnvelope::seal(
+                organization_key,
+                invite_key,
+                INVITE_ORG_KEY_ENVELOPE_NAMESPACE,
+                ctx,
+            )
+            .map_err(|_| InviteKeyBundleError::KeySealingFailed)?,
+        );
+
+        // Wrap the invite key with the organization key (organization key -> invite key direction).
+        let organization_key_wrapped_invite_key = ctx
+            .wrap_symmetric_key(organization_key, invite_key)
+            .map_err(|_| InviteKeyBundleError::KeySealingFailed)?;
+
+        Ok((
+            invite_secret,
+            Invite {
+                invite_key_wrapped_invite_data,
+                invite_secret_wrapped_invite_key,
+                invite_key_wrapped_organization_key,
+                organization_key_wrapped_invite_key,
+            },
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use bitwarden_crypto::{
+        CoseKeyThumbprint, CoseKeyThumbprintExt, EncString, KeyStore, KeyStoreContext,
+        PublicKeyEncryptionAlgorithm, SymmetricCryptoKey, key_slot_ids,
+    };
+    use bitwarden_encoding::{B64, B64Url};
+
+    use crate::invite::{Invite, InviteKeyBundleError, InviteSecret};
+
+    /// Makes an organization private key in `ctx`, wraps it with `organization_key`, and returns
+    /// the wrapped private key together with the thumbprint of its public key (as
+    /// `make_for_private_key` expects and derives).
+    fn org_wrapped_private_key(
+        organization_key: TestSymmKey,
+        ctx: &mut KeyStoreContext<'_, TestIds>,
+    ) -> (EncString, CoseKeyThumbprint) {
+        let private_key_id = ctx.make_private_key(PublicKeyEncryptionAlgorithm::RsaOaepSha1);
+        let thumbprint = ctx
+            .get_public_key(private_key_id)
+            .unwrap()
+            .thumbprint()
+            .unwrap();
+        let wrapped = ctx
+            .wrap_private_key(organization_key, private_key_id)
+            .unwrap();
+        (wrapped, thumbprint)
+    }
+
+    #[test]
+    fn test_basic_invitation_bundle() {
+        let key_store = KeyStore::<TestIds>::default();
+        let mut ctx = key_store.context_mut();
+
+        let local_org_key_id = ctx.generate_symmetric_key();
+        ctx.persist_symmetric_key(local_org_key_id, TestSymmKey::Organization)
+            .unwrap();
+        let (wrapped_private_key, _) = org_wrapped_private_key(TestSymmKey::Organization, &mut ctx);
+
+        let (secret1, _) =
+            Invite::make_for_private_key(TestSymmKey::Organization, &wrapped_private_key, &mut ctx)
+                .unwrap();
+        let (secret2, _) =
+            Invite::make_for_private_key(TestSymmKey::Organization, &wrapped_private_key, &mut ctx)
+                .unwrap();
+
+        assert_ne!(secret1, secret2);
+    }
+
+    #[test]
+    fn test_admin_recovers_invite_secret() {
+        let key_store = KeyStore::<TestIds>::default();
+        let mut ctx = key_store.context_mut();
+
+        let local_org_key_id = ctx.generate_symmetric_key();
+        ctx.persist_symmetric_key(local_org_key_id, TestSymmKey::Organization)
+            .unwrap();
+        let (wrapped_private_key, _) = org_wrapped_private_key(TestSymmKey::Organization, &mut ctx);
+
+        let (invite_secret, invite) =
+            Invite::make_for_private_key(TestSymmKey::Organization, &wrapped_private_key, &mut ctx)
+                .unwrap();
+
+        let invite_key = invite
+            .invite_key_from_organization_key(TestSymmKey::Organization, &mut ctx)
+            .unwrap();
+        let recovered = invite.get_invite_secret(invite_key, &mut ctx).unwrap();
+
+        assert_eq!(invite_secret, recovered);
+    }
+
+    #[test]
+    fn test_admin_recovers_thumbprint() {
+        let key_store = KeyStore::<TestIds>::default();
+        let mut ctx = key_store.context_mut();
+
+        let local_org_key_id = ctx.generate_symmetric_key();
+        ctx.persist_symmetric_key(local_org_key_id, TestSymmKey::Organization)
+            .unwrap();
+        let (wrapped_private_key, thumbprint) =
+            org_wrapped_private_key(TestSymmKey::Organization, &mut ctx);
+
+        let (_, invite) =
+            Invite::make_for_private_key(TestSymmKey::Organization, &wrapped_private_key, &mut ctx)
+                .unwrap();
+
+        let invite_key = invite
+            .invite_key_from_organization_key(TestSymmKey::Organization, &mut ctx)
+            .unwrap();
+        let recovered = invite
+            .get_public_key_thumbprint(invite_key, &mut ctx)
+            .unwrap();
+
+        assert_eq!(recovered, thumbprint);
+    }
+
+    #[test]
+    fn test_invitee_recovers_organization_key() {
+        let key_store = KeyStore::<TestIds>::default();
+        let mut ctx = key_store.context_mut();
+
+        let local_org_key_id = ctx.generate_symmetric_key();
+        ctx.persist_symmetric_key(local_org_key_id, TestSymmKey::Organization)
+            .unwrap();
+        let (wrapped_private_key, _) = org_wrapped_private_key(TestSymmKey::Organization, &mut ctx);
+
+        let (invite_secret, invite) =
+            Invite::make_for_private_key(TestSymmKey::Organization, &wrapped_private_key, &mut ctx)
+                .unwrap();
+
+        // Using only the raw invite secret, an invitee can recover the invite key and then the
+        // organization key.
+        let invite_key = invite
+            .invite_key_from_invite_secret(&invite_secret, &mut ctx)
+            .unwrap();
+        let recovered_org_key_id = invite
+            .unseal_organization_key(invite_key, &mut ctx)
+            .unwrap();
+
+        #[allow(deprecated)]
+        let recovered_org_key = ctx
+            .dangerous_get_symmetric_key(recovered_org_key_id)
+            .unwrap()
+            .clone();
+        #[allow(deprecated)]
+        let org_key = ctx
+            .dangerous_get_symmetric_key(TestSymmKey::Organization)
+            .unwrap()
+            .clone();
+        assert_eq!(recovered_org_key, org_key);
+    }
+
+    #[test]
+    fn test_confirmation_toggle() {
+        let key_store = KeyStore::<TestIds>::default();
+        let mut ctx = key_store.context_mut();
+
+        let local_org_key_id = ctx.generate_symmetric_key();
+        ctx.persist_symmetric_key(local_org_key_id, TestSymmKey::Organization)
+            .unwrap();
+        let (wrapped_private_key, _) = org_wrapped_private_key(TestSymmKey::Organization, &mut ctx);
+
+        let (invite_secret, mut invite) =
+            Invite::make_for_private_key(TestSymmKey::Organization, &wrapped_private_key, &mut ctx)
+                .unwrap();
+
+        // New invites are created with confirmation enabled.
+        assert!(invite.supports_confirmation());
+
+        // Disabling confirmation removes the org-key envelope, so an invitee can no longer recover
+        // the organization key.
+        invite.disable_confirmation();
+        assert!(!invite.supports_confirmation());
+        let invite_key = invite
+            .invite_key_from_invite_secret(&invite_secret, &mut ctx)
+            .unwrap();
+        assert!(matches!(
+            invite.unseal_organization_key(invite_key, &mut ctx),
+            Err(InviteKeyBundleError::ConfirmationNotEnabled)
+        ));
+
+        // Re-enabling confirmation restores the invitee's ability to recover the organization key.
+        invite
+            .enable_confirmation(TestSymmKey::Organization, &mut ctx)
+            .unwrap();
+        assert!(invite.supports_confirmation());
+        let invite_key = invite
+            .invite_key_from_invite_secret(&invite_secret, &mut ctx)
+            .unwrap();
+        let recovered_org_key_id = invite
+            .unseal_organization_key(invite_key, &mut ctx)
+            .unwrap();
+        #[allow(deprecated)]
+        {
+            let recovered = ctx
+                .dangerous_get_symmetric_key(recovered_org_key_id)
+                .unwrap()
+                .clone();
+            let org_key = ctx
+                .dangerous_get_symmetric_key(TestSymmKey::Organization)
+                .unwrap()
+                .clone();
+            assert_eq!(recovered, org_key);
+        }
+    }
+
+    #[test]
+    fn test_invite_string_round_trip() {
+        let key_store = KeyStore::<TestIds>::default();
+        let mut ctx = key_store.context_mut();
+
+        let local_org_key_id = ctx.generate_symmetric_key();
+        ctx.persist_symmetric_key(local_org_key_id, TestSymmKey::Organization)
+            .unwrap();
+        let (wrapped_private_key, _) = org_wrapped_private_key(TestSymmKey::Organization, &mut ctx);
+
+        let (invite_secret, invite) =
+            Invite::make_for_private_key(TestSymmKey::Organization, &wrapped_private_key, &mut ctx)
+                .unwrap();
+
+        let encoded = String::from(&invite);
+        let decoded: Invite = encoded.parse().unwrap();
+        assert_eq!(String::from(&decoded), encoded);
+
+        // The decoded invite still recovers the invite secret.
+        let invite_key = decoded
+            .invite_key_from_organization_key(TestSymmKey::Organization, &mut ctx)
+            .unwrap();
+        let recovered = decoded.get_invite_secret(invite_key, &mut ctx).unwrap();
+        assert_eq!(invite_secret, recovered);
+
+        // The custom serde impls delegate to the string round-trip.
+        let json = serde_json::to_string(&invite).unwrap();
+        let from_json: Invite = serde_json::from_str(&json).unwrap();
+        assert_eq!(String::from(&from_json), encoded);
+    }
+
+    #[test]
+    fn test_into_base64_url() {
+        let data: [u8; 32] = *b"+/=Hello, World!AAAAAAAAAAAAAAAA";
+        let secret = InviteSecret(zeroize::Zeroizing::new(data));
+
+        let encoded = String::from(&secret);
+
+        assert_eq!(encoded, "Ky89SGVsbG8sIFdvcmxkIUFBQUFBQUFBQUFBQUFBQUE");
+        assert!(!encoded.contains('+'));
+        assert!(!encoded.contains('/'));
+        assert!(!encoded.contains('='));
+
+        let decoded = B64Url::try_from(encoded.as_str()).unwrap();
+        assert_eq!(decoded.as_bytes(), data);
+
+        // Round-trips back to the same invite secret.
+        let reparsed: InviteSecret = encoded.parse().unwrap();
+        assert_eq!(reparsed, secret);
+    }
+
+    // Test vectors captured from `generate_test_vectors`. These freeze a real invite so that
+    // backward compatibility (old data must remain decryptable) is verified by
+    // `test_invite_test_vector`.
+    const TEST_VECTOR_ORG_KEY: &str =
+        "KGP9Nc2/91w+42Z9VzY0m7h18avuZcq4ICM8Rhdc3BD92LbWS2TQkVBzavvUM684WKXiC22NJi2EwaiDW4YTAA==";
+    const TEST_VECTOR_INVITE: &str = "pHgeaW52aXRlX2tleV93cmFwcGVkX2ludml0ZV9kYXRheQGEZzFoSHBRRURBM2dqWVhCd2JHbGpZWFJwYjI0dmVDNWlhWFIzWVhKa1pXNHVZMkp2Y2kxd1lXUmtaV1FFVU8yS1A5c3pkbVF6MDlQTm1HeVZOOWc2QUFFNGdRSTZBQUU0Z0FLaEJVeUJjVUJCWCtScWk5UlM1KzlZeG8rZmpkdHJQemRVQ0FUSitGaTZtQ2puNCtYUmdwN1FEdHlLOXVjQlJiR2hKb2tHcWxqQko0RXhOOENnSEhwUGc0U0JqcGhOVE95TElZOXZ6bEZRcGV3djR3a3FaeUZkNGh0TXk4L3M0R3R0K1hkRjEzR1EvKzRMcFc0b04yOHRDdDNDcTNxbExUUGZaL09VNm1zTUlRaGhIZm1NWXI3eWwra0FiU09KQkwwek40bGNwbXRGZGtEYkRSRkdqdUx5YkRONHJ6cjRBTmdhaUJkMkZ6Q09UdjRRWGdLek5oazVWMEdiM3lrSjhlcGpJSUhRM3cyYWdIRXJJRmtoNE13R1ZzN2NXVDNka3c9PXggaW52aXRlX3NlY3JldF93cmFwcGVkX2ludml0ZV9rZXl49GhGZ29wUUVEQXhobE9nQUJGVnhRN1lvLzJ6TjJaRFBUMDgyWWJKVTMyRG9BQVRpQkJqb0FBVGlBQWFFRlRNZlJWRXFWUWxWMVlFQ1B0MWhRTTVyVVZjVVRmQkNYbzJvVFJkNW9URnRZblNvNWVpakh1UzhJcjlhT3daay83Y2dTeVhWSDh6NWl2QmYxVitqMitBT3B5dVBLTTQ4NGJva3owSmJEUW9KK2REQzNFMFVMQnVTVXFsbm5TcXVCZzBDaUFTa3pXQ0FUMEk1NC9OSFBnNFRQWjB5RjBsNlk3M3FNbG1XYVg2RThBdU1UcHBvQTdQWT14I2ludml0ZV9rZXlfd3JhcHBlZF9vcmdhbml6YXRpb25fa2V5eORnMWhHcFFFREEzZ2lZWEJ3YkdsallYUnBiMjR2ZUM1aWFYUjNZWEprWlc0dWJHVm5ZV041TFd0bGVRUlE3WW8vMnpOMlpEUFQwODJZYkpVMzJEb0FBVGlCQXpvQUFUaUFBcUVGVFBWSzVFUEVYbXVwZ29mMkRWaFF2Mlg2QkdKcCthb0pocnZjbTRxaUJMRTJHMHZhbzE3SjhXOEQxRGJvM0lpZWFzSXRsNzJwenloY21uMWh4WmM4c0k3RThIZGlRSXF6N1lSc2lQdlpUSEVJSHZqeUFrTG8reE10QW1xbUZacz14I29yZ2FuaXphdGlvbl9rZXlfd3JhcHBlZF9pbnZpdGVfa2V5eLQyLkNsM2JGTzFETENndzJ3elJ3bmtSa2c9PXw5aDEwbStqb1hmcE5pTHpnRS8yclBqaituS3JWWVl1bXBBQ2dEa2h6RUEyNVo3WjNUVTJuYnNLN2J5SWZWV0NkQ1lrQTFlQk5BNk9WN3NpcGhXWmVzRmpoVTYyT0Voc0FzOUo3K2xxODVXMD18Qk14TW52Y1JtNldSV0FveUppTnRjTjZaQkpSRE82YkFPTjZhaVhHbExBYz0=";
+    const TEST_VECTOR_INVITE_SECRET: &str = "CptXaIhmgvJ7YMNA9h9DDe13ad7ayxGPPGxik-fNWls";
+
+    #[test]
+    #[ignore = "Manual test to generate test vectors"]
+    fn generate_test_vectors() {
+        let key_store = KeyStore::<TestIds>::default();
+        let mut ctx = key_store.context_mut();
+
+        let org_key =
+            SymmetricCryptoKey::try_from(B64::try_from(TEST_VECTOR_ORG_KEY).unwrap()).unwrap();
+        let org_key_id = ctx.add_local_symmetric_key(org_key);
+        let (wrapped_private_key, _) = org_wrapped_private_key(org_key_id, &mut ctx);
+
+        let (invite_secret, invite) =
+            Invite::make_for_private_key(org_key_id, &wrapped_private_key, &mut ctx).unwrap();
+
+        println!(
+            "const TEST_VECTOR_INVITE: &str = \"{}\";",
+            String::from(&invite)
+        );
+        println!(
+            "const TEST_VECTOR_INVITE_SECRET: &str = \"{}\";",
+            String::from(&invite_secret)
+        );
+    }
+
+    #[test]
+    fn test_invite_test_vector() {
+        let key_store = KeyStore::<TestIds>::default();
+        let mut ctx = key_store.context_mut();
+
+        let org_key =
+            SymmetricCryptoKey::try_from(B64::try_from(TEST_VECTOR_ORG_KEY).unwrap()).unwrap();
+        let org_key_id = ctx.add_local_symmetric_key(org_key);
+
+        let invite: Invite = TEST_VECTOR_INVITE.parse().unwrap();
+        let invite_key = invite
+            .invite_key_from_organization_key(org_key_id, &mut ctx)
+            .unwrap();
+        let recovered = invite.get_invite_secret(invite_key, &mut ctx).unwrap();
+
+        assert_eq!(String::from(&recovered), TEST_VECTOR_INVITE_SECRET);
+    }
+
+    #[test]
+    #[ignore = "Manual test to verify debug format"]
+    fn test_debug() {
+        let key_store = KeyStore::<TestIds>::default();
+        let mut ctx = key_store.context_mut();
+
+        let org_key_id = ctx.generate_symmetric_key();
+        ctx.persist_symmetric_key(org_key_id, TestSymmKey::Organization)
+            .unwrap();
+        let (wrapped_private_key, _) = org_wrapped_private_key(TestSymmKey::Organization, &mut ctx);
+
+        let (invite_secret, invite) =
+            Invite::make_for_private_key(TestSymmKey::Organization, &wrapped_private_key, &mut ctx)
+                .unwrap();
+        // Exercises both the `InviteSecret` and `Invite` `Debug` impls.
+        println!("{invite_secret:?}");
+        println!("{invite:?}");
+    }
+
+    key_slot_ids! {
+        #[symmetric]
+        pub enum TestSymmKey {
+            Organization,
+            #[local]
+            Local(LocalId),
+        }
+
+        #[private]
+        pub enum TestPrivateKey {
+            A(u8),
+            B,
+            #[local]
+            C(LocalId),
+        }
+
+        #[signing]
+        pub enum TestSigningKey {
+            A(u8),
+            B,
+            #[local]
+            C(LocalId),
+        }
+
+       pub TestIds => TestSymmKey, TestPrivateKey, TestSigningKey;
+    }
+}

--- a/crates/bitwarden-organization-crypto/src/invite.rs
+++ b/crates/bitwarden-organization-crypto/src/invite.rs
@@ -1,40 +1,42 @@
 //! Cryptographic organization invites
 //!
-//! An invite is built around an AES-256-GCM **invite key** that acts as the hub tying every wrapped
+//! An invite is built around an XAES-256-GCM **invite key** that acts as the hub tying every sealed
 //! object together. Two independent secrets can recover the invite key (the invite secret from the
 //! link, or the organization key held by admins), and from the invite key everything else — the
-//! invite data and, when confirmation is enabled, the organization key — can be unwrapped:
+//! invite data and, when confirmation is enabled, the organization key — can be unsealed:
 //!
 //! ```text
-//! InviteSecret -> SecretProtectedKeyEnvelope -> InviteKey -> DataEnvelope -+-> InviteSecret
-//!                                                ^     |                    +-> OrgPubKeyPrint
-//!                                                |     |
+//! InviteSecret -> SecretProtectedKeyEnvelope -> InviteKey -> SymmetricKeyEnvelope -> InviteDataCEK
+//!                                                ^     |                                   |
+//!                                                |     |               DataEnvelope --------+
+//!                                                |     |                    +-> InviteSecret
+//!                                                |     |                    +-> OrgPubKeyPrint
 //! OrganizationKey -> EncString ------------------+     +-> SymmetricKeyEnvelope -> OrganizationKey
 //! ```
 //!
-//! - `InviteSecret -> SecretProtectedKeyEnvelope -> InviteKey`
-//!   (`invite_secret_wrapped_invite_key`): the invite key sealed with the high-entropy invite
-//!   secret, so an invitee holding only the secret from the link recovers the invite key.
-//! - `OrganizationKey -> EncString -> InviteKey` (`organization_key_wrapped_invite_key`): the
-//!   invite key wrapped with the organization key, so anyone holding the organization key recovers
-//!   the invite key (and thus the invite data).
-//! - `InviteKey -> DataEnvelope -> InviteSecret + OrgPubKeyPrint`
-//!   (`invite_key_wrapped_invite_data`): the `InviteDataV1` sealed with the invite key, binding the
-//!   organization public-key thumbprint and a copy of the invite secret (so the invite link can be
-//!   reconstructed from the invite key).
-//! - `InviteKey -> SymmetricKeyEnvelope -> OrganizationKey`
-//!   (`invite_key_wrapped_organization_key`): the organization key sealed with the invite key, so a
-//!   redeeming invitee can recover the organization key. It is present if and exactly if
-//!   confirmation is enabled for the invite.
+//! - `InviteSecret -> SecretProtectedKeyEnvelope -> InviteKey` (`invite_secret_sealed_invite_key`):
+//!   the invite key sealed with the high-entropy invite secret, so an invitee holding only the
+//!   secret from the link recovers the invite key.
+//! - `OrganizationKey -> EncString -> InviteKey` (`organization_key_sealed_invite_key`): the invite
+//!   key sealed with the organization key, so anyone holding the organization key recovers the
+//!   invite key (and thus the invite data).
+//! - `InviteKey -> SymmetricKeyEnvelope -> InviteDataCEK -> DataEnvelope -> InviteSecret +
+//!   OrgPubKeyPrint` (`invite_key_sealed_invite_data_cek` + `invite_key_sealed_invite_data`): the
+//!   `InviteDataV1` is sealed under its own content-encryption key (CEK), and that CEK is sealed
+//!   with the invite key. The data binds the organization public-key thumbprint and a copy of the
+//!   invite secret (so the invite link can be reconstructed from the invite key).
+//! - `InviteKey -> SymmetricKeyEnvelope -> OrganizationKey` (`invite_key_sealed_organization_key`):
+//!   the organization key sealed with the invite key, so a redeeming invitee can recover the
+//!   organization key. It is present if and exactly if confirmation is enabled for the invite.
 
 use std::str::FromStr;
 
 use bitwarden_crypto::{
     CoseKeyThumbprint, CoseKeyThumbprintExt, EncString, KeySlotIds, KeyStoreContext,
-    SymmetricKeyAlgorithm, generate_versioned_sealable,
+    generate_versioned_sealable,
     safe::{
         DataEnvelope, DataEnvelopeNamespace, HighEntropySecret, HighEntropySecretSource,
-        SealableData, SealableVersionedData, SecretProtectedKeyEnvelope,
+        KeyEncryptionKey, SealableData, SealableVersionedData, SecretProtectedKeyEnvelope,
         SecretProtectedKeyEnvelopeNamespace, SymmetricKeyEnvelope, SymmetricKeyEnvelopeNamespace,
     },
 };
@@ -178,50 +180,33 @@ const TS_INVITE: &'static str = r#"
 export type Invite = Tagged<string, "Invite">;
 "#;
 
-/// Cryptographic invite for an organization, built around an AES-256-GCM invite key that acts as
+/// Cryptographic invite for an organization, built around an XAES-256-GCM invite key that acts as
 /// the hub tying everything together. See the module-level docs for the overall diagram.
-#[derive(Clone)]
+#[derive(Clone, Serialize, Deserialize)]
 pub struct Invite {
-    /// The `InviteData` (org public-key thumbprint + invite secret) sealed with the invite key.
-    invite_key_wrapped_invite_data: DataEnvelope,
+    /// The `InviteData` (org public-key thumbprint + invite secret) sealed with its own
+    /// content-encryption key (CEK).
+    invite_key_sealed_invite_data: DataEnvelope,
+    /// The invite-data content-encryption key sealed with the invite key, so a holder of the
+    /// invite key can recover the CEK and open [`Self::invite_key_sealed_invite_data`].
+    invite_key_sealed_invite_data_cek: SymmetricKeyEnvelope,
     /// The invite key sealed with the high-entropy invite secret, letting an invitee (who holds
     /// only the invite secret from the link) recover the invite key.
-    invite_secret_wrapped_invite_key: SecretProtectedKeyEnvelope,
+    invite_secret_sealed_invite_key: SecretProtectedKeyEnvelope,
     /// The organization key sealed with the invite key, letting a redeeming invitee recover the
     /// organization key once they hold the invite key. This is **optional**: its presence is what
     /// "confirmation" means. When confirmation is enabled the invitee can self-confirm by
     /// recovering the organization key; when disabled, this field is absent and an admin must
     /// confirm the invitee out of band.
-    invite_key_wrapped_organization_key: Option<SymmetricKeyEnvelope>,
-    /// The invite key wrapped with the organization key, letting anyone holding the organization
+    invite_key_sealed_organization_key: Option<SymmetricKeyEnvelope>,
+    /// The invite key sealed with the organization key, letting anyone holding the organization
     /// key recover the invite key (and thus the invite data).
-    organization_key_wrapped_invite_key: EncString,
-}
-
-/// Wire format for [`Invite`]. This is what's serialized by serde (as JSON).
-#[derive(Serialize, Deserialize)]
-struct InviteWire {
-    invite_key_wrapped_invite_data: DataEnvelope,
-    invite_secret_wrapped_invite_key: SecretProtectedKeyEnvelope,
-    invite_key_wrapped_organization_key: Option<SymmetricKeyEnvelope>,
-    organization_key_wrapped_invite_key: EncString,
-}
-
-impl From<&Invite> for InviteWire {
-    fn from(invite: &Invite) -> Self {
-        InviteWire {
-            invite_key_wrapped_invite_data: invite.invite_key_wrapped_invite_data.clone(),
-            invite_secret_wrapped_invite_key: invite.invite_secret_wrapped_invite_key.clone(),
-            invite_key_wrapped_organization_key: invite.invite_key_wrapped_organization_key.clone(),
-            organization_key_wrapped_invite_key: invite.organization_key_wrapped_invite_key.clone(),
-        }
-    }
+    organization_key_sealed_invite_key: EncString,
 }
 
 impl From<&Invite> for String {
     fn from(invite: &Invite) -> Self {
-        serde_json::to_string(&InviteWire::from(invite))
-            .expect("JSON serialization of Invite never fails")
+        serde_json::to_string(invite).expect("JSON serialization of Invite never fails")
     }
 }
 
@@ -229,55 +214,34 @@ impl FromStr for Invite {
     type Err = InviteKeyBundleError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let data: InviteWire =
-            serde_json::from_str(s).map_err(|_| InviteKeyBundleError::DecodingFailed)?;
-        Ok(Invite {
-            invite_key_wrapped_invite_data: data.invite_key_wrapped_invite_data,
-            invite_secret_wrapped_invite_key: data.invite_secret_wrapped_invite_key,
-            invite_key_wrapped_organization_key: data.invite_key_wrapped_organization_key,
-            organization_key_wrapped_invite_key: data.organization_key_wrapped_invite_key,
-        })
+        serde_json::from_str(s).map_err(|_| InviteKeyBundleError::DecodingFailed)
     }
 }
 
-impl<'de> Deserialize<'de> for Invite {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: serde::Deserializer<'de>,
-    {
-        deserializer.deserialize_str(FromStrVisitor::new())
-    }
-}
-
-impl Serialize for Invite {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: serde::Serializer,
-    {
-        serializer.serialize_str(&String::from(self))
-    }
-}
-
-// Manually implemented to mirror the safe key-envelope primitives: it surfaces the wrapped fields
+// Manually implemented to mirror the safe key-envelope primitives: it surfaces the sealed fields
 // without ever printing key material (each field's own `Debug` is key-material-safe).
 impl std::fmt::Debug for Invite {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("Invite")
             .field(
-                "invite_key_wrapped_invite_data",
-                &self.invite_key_wrapped_invite_data,
+                "invite_key_sealed_invite_data",
+                &self.invite_key_sealed_invite_data,
             )
             .field(
-                "invite_secret_wrapped_invite_key",
-                &self.invite_secret_wrapped_invite_key,
+                "invite_key_sealed_invite_data_cek",
+                &self.invite_key_sealed_invite_data_cek,
             )
             .field(
-                "invite_key_wrapped_organization_key",
-                &self.invite_key_wrapped_organization_key,
+                "invite_secret_sealed_invite_key",
+                &self.invite_secret_sealed_invite_key,
             )
             .field(
-                "organization_key_wrapped_invite_key",
-                &self.organization_key_wrapped_invite_key,
+                "invite_key_sealed_organization_key",
+                &self.invite_key_sealed_organization_key,
+            )
+            .field(
+                "organization_key_sealed_invite_key",
+                &self.organization_key_sealed_invite_key,
             )
             .finish()
     }
@@ -290,7 +254,7 @@ impl Invite {
         organization_key: Ids::Symmetric,
         ctx: &mut KeyStoreContext<Ids>,
     ) -> Result<Ids::Symmetric, InviteKeyBundleError> {
-        ctx.unwrap_symmetric_key(organization_key, &self.organization_key_wrapped_invite_key)
+        ctx.unwrap_symmetric_key(organization_key, &self.organization_key_sealed_invite_key)
             .map_err(|_| InviteKeyBundleError::KeyUnsealingFailed)
     }
 
@@ -301,7 +265,7 @@ impl Invite {
         ctx: &mut KeyStoreContext<Ids>,
     ) -> Result<Ids::Symmetric, InviteKeyBundleError> {
         let secret = HighEntropySecret::from(invite_secret.clone());
-        self.invite_secret_wrapped_invite_key
+        self.invite_secret_sealed_invite_key
             .unseal(
                 &secret,
                 SecretProtectedKeyEnvelopeNamespace::OrganizationInvite,
@@ -316,9 +280,18 @@ impl Invite {
         invite_key: Ids::Symmetric,
         ctx: &mut KeyStoreContext<Ids>,
     ) -> Result<InviteDataV1, InviteKeyBundleError> {
+        // Recover the invite-data CEK by unsealing it with the invite key, then open the data.
+        let cek = self
+            .invite_key_sealed_invite_data_cek
+            .unseal(
+                invite_key,
+                SymmetricKeyEnvelopeNamespace::OrganizationInvite,
+                ctx,
+            )
+            .map_err(|_| InviteKeyBundleError::KeyUnsealingFailed)?;
         let data: InviteData = self
-            .invite_key_wrapped_invite_data
-            .unseal(invite_key, ctx)
+            .invite_key_sealed_invite_data
+            .unseal(cek, ctx)
             .map_err(|_| InviteKeyBundleError::KeyUnsealingFailed)?;
         let InviteData::InviteDataV1(data) = data;
         Ok(data)
@@ -347,7 +320,7 @@ impl Invite {
     /// Whether confirmation is enabled on this invite, i.e. whether the organization key can be
     /// recovered from the invite key.
     pub fn supports_confirmation(&self) -> bool {
-        self.invite_key_wrapped_organization_key.is_some()
+        self.invite_key_sealed_organization_key.is_some()
     }
 
     /// Unseals the organization key using an invite key, storing it in the key store context and
@@ -357,7 +330,7 @@ impl Invite {
         invite_key: Ids::Symmetric,
         ctx: &mut KeyStoreContext<Ids>,
     ) -> Result<Ids::Symmetric, InviteKeyBundleError> {
-        self.invite_key_wrapped_organization_key
+        self.invite_key_sealed_organization_key
             .as_ref()
             .ok_or(InviteKeyBundleError::ConfirmationNotEnabled)?
             .unseal(
@@ -382,13 +355,13 @@ impl Invite {
             ctx,
         )
         .map_err(|_| InviteKeyBundleError::KeySealingFailed)?;
-        self.invite_key_wrapped_organization_key = Some(envelope);
+        self.invite_key_sealed_organization_key = Some(envelope);
         Ok(())
     }
 
     /// Disables confirmation
     pub fn disable_confirmation(&mut self) {
-        self.invite_key_wrapped_organization_key = None;
+        self.invite_key_sealed_organization_key = None;
     }
 
     /// Generates a brand new invite around a fresh AES-256-GCM invite key, binding it to the
@@ -419,24 +392,31 @@ impl Invite {
         bitwarden_random::rng().fill_bytes(bytes.as_mut_slice());
         let invite_secret = InviteSecret(bytes);
 
-        // Generate the AES-256-GCM invite key (the hub). It is used for exactly two AES-256-GCM
-        // messages below (the invite-data DataEnvelope and the org-key SymmetricKeyEnvelope), each
-        // with a fresh random nonce, so there is no nonce-reuse concern.
-        let invite_key = ctx.make_symmetric_key(SymmetricKeyAlgorithm::Aes256Gcm);
+        // Generate the invite key (the hub). It only ever acts as a key-encryption key — sealing
+        // the invite-data CEK and the organization key via `SymmetricKeyEnvelope`.
+        let invite_key = KeyEncryptionKey::make(ctx);
 
-        // Seal the invite data (thumbprint + a copy of the invite secret) with the invite key.
+        // Seal the invite data (thumbprint + a copy of the invite secret) under a fresh
+        // content-encryption key (CEK), then seal that CEK with the invite key so a holder of the
+        // invite key can open the data.
         let invite_data: InviteData = InviteDataV1 {
             public_key_thumbprint: *thumbprint.as_bytes(),
             invite_secret: *invite_secret.0,
         }
         .into();
-        let invite_key_wrapped_invite_data =
-            DataEnvelope::seal_with_provided_key(invite_data, invite_key, ctx)
-                .map_err(|_| InviteKeyBundleError::KeySealingFailed)?;
+        let (invite_key_sealed_invite_data, invite_data_cek) = DataEnvelope::seal(invite_data, ctx)
+            .map_err(|_| InviteKeyBundleError::KeySealingFailed)?;
+        let invite_key_sealed_invite_data_cek = SymmetricKeyEnvelope::seal(
+            invite_data_cek,
+            invite_key,
+            SymmetricKeyEnvelopeNamespace::OrganizationInvite,
+            ctx,
+        )
+        .map_err(|_| InviteKeyBundleError::KeySealingFailed)?;
 
         // Seal the invite key with the invite secret (invitee -> invite key direction).
         let secret = HighEntropySecret::from(invite_secret.clone());
-        let invite_secret_wrapped_invite_key = SecretProtectedKeyEnvelope::seal(
+        let invite_secret_sealed_invite_key = SecretProtectedKeyEnvelope::seal(
             invite_key,
             &secret,
             SecretProtectedKeyEnvelopeNamespace::OrganizationInvite,
@@ -447,7 +427,7 @@ impl Invite {
         // Seal the organization key with the invite key (invite key -> organization key direction).
         // New invites are created with confirmation enabled; callers can disable it afterwards via
         // `Invite::disable_confirmation`.
-        let invite_key_wrapped_organization_key = Some(
+        let invite_key_sealed_organization_key = Some(
             SymmetricKeyEnvelope::seal(
                 organization_key,
                 invite_key,
@@ -457,18 +437,19 @@ impl Invite {
             .map_err(|_| InviteKeyBundleError::KeySealingFailed)?,
         );
 
-        // Wrap the invite key with the organization key (organization key -> invite key direction).
-        let organization_key_wrapped_invite_key = ctx
+        // Seal the invite key with the organization key (organization key -> invite key direction).
+        let organization_key_sealed_invite_key = ctx
             .wrap_symmetric_key(organization_key, invite_key)
             .map_err(|_| InviteKeyBundleError::KeySealingFailed)?;
 
         Ok((
             invite_secret,
             Invite {
-                invite_key_wrapped_invite_data,
-                invite_secret_wrapped_invite_key,
-                invite_key_wrapped_organization_key,
-                organization_key_wrapped_invite_key,
+                invite_key_sealed_invite_data,
+                invite_key_sealed_invite_data_cek,
+                invite_secret_sealed_invite_key,
+                invite_key_sealed_organization_key,
+                organization_key_sealed_invite_key,
             },
         ))
     }
@@ -490,8 +471,8 @@ mod tests {
     const TEST_VECTOR_ORG_KEY: &str =
         "KGP9Nc2/91w+42Z9VzY0m7h18avuZcq4ICM8Rhdc3BD92LbWS2TQkVBzavvUM684WKXiC22NJi2EwaiDW4YTAA==";
     const TEST_VECTOR_WRAPPED_PRIVATE_KEY: &str = "2.bi9TWF/zrujUg1y+v8ECtQ==|kEMkuRt42j65YZnPEc4bLOT0/WDZwWSNJNGlUMdr/LRF3qi/vCnZ7eT0+7MruTccmyoAjKmsXdoBcufrOdPBUguFQn1LQMGqHqCyyB3SIijOlLyOOmxWYqoLUjihy8o8URGWjrAGWZnkeYWHTlFZP09Fag2xCwiQ/qS32Q+qTGGHDs0FiwjplcPkW9knlmgCXbuyPqDnEYoa0Qs/CC1hUCzFFrWs7QkE+5eLaNHxuBPpsrY6y795kEu9ve38F3piY9b6lQpc/iPGv8Zfh1isI7Mpy1zMwntXGSHjUOy17nPxCqkgYufuNGnwGNwsGjkLAl7e7bD39SYfEpTDaRUgmTl8UrZDx274e6Um1LLvokf3HiL1tboJ9/TW8IiMuAdrb3PLTH6Sep8lqZ3WhNADfMMJle9kCojHp6XSB14in1JqP0636exYeJu+FhUC1TfrthuQN2QDQ8LAvgZR7YvzkTJX3Sc5jP7m/yCmCbHhIqIAaGqJsRwAee0EMsKcALz3/akVoyjHU2LHD3dzQnyMyszyRNYViBNYAM9qBN2DqwWRDOtM171xNVJcTFsAh4mBSLiLOlDsXqLqHVKu2VJNE1XhTQ5Szubqefa/Or7nfxXcxDvivqZ7d5NfDFEskUMqh5yq1KoLK0oK5c+KvY/COIZr/kct+qtfZsXo3w5xJnPOqrAKGm+9CF4OINpLM8Z3csdZf9l5XjlmO1kIuBbquQZ0EZCHzD/GEfXRGB8BEkugdTfpnTDtmmuAJXkIY6t6e6pRUU9u4/sl+U7Iuh22fOA59SuQOElr5Lxre+hQBrRfJS3tSMEtMjYhVmltrngH+SLRxMxH/evbe2uvNaaxlFJe6EK1vqchyTX6nM8Z+2Yjb5pOAzrKQYqwwmVys9IHfjXhybqv10gFpDXBE/eq8u9xs9LbQQ03EbveQUtqdh/ms8SxLOQA9Sm9JwHEL0Zni+8NdAa5orDYzOi53bQLgrs+uUldgB/KOW2goTnKGm4YTbMAXEbum8pST8EXB9jNDXyofyN8IQUoLRvVkEgzbSPBS1sYpkkKdLZy3ojOCKnMnHXIVtzJojFckiutbj6d927X5w51E/RDMoAdylGRVKnmqLKysFRqL+pZK8Cyo+ECr7notG8kr7pVnofzigjKZS9qkRmqEa9bju1GgI20g4cxro8/0O0XnU1o0Mx46qH3niORY59i5bdMwaDS6H2c6+rmf9bIFwwgyAZvHlVdcGNoBGPR3ZXHThwI1OmWSslLWVW0IaS4utB1jL4zvHPCqh/ButA8HeRmU/NYSfaqb9YXyzn+C7ED15MWXkYmZzeE38HHxhqs12+oj+WFcg4d5/e2UcccuVi36SWhA0xWk8Kk2D6e1Pz1lmaw20vpb0eUq4AS5ZnMmWTEiKORFeGNTIROq9vuPuitLrREedu9PGjf5aeKcNqlq2nr7fOaxyi2ocKs7pLqVBUH1G7zHpCo3Rt1+o18guXFHT56vQFfkzoUNXiS6TRM4Mkl3s0TyGgBhxZkNJleTI6y4xhfH1iathBnLcfelLbxZhDB1wh3RXowS32jpM/J4pSUuNEmSLSqRQtRJY41BG00nYY02qEbakkgk6pS6a0/CWphyLfHAzUWbabOhqR1iPN9/ZiecjI=|eoklmBw+LYy2NNwjLOuA4+szKH5SzLGPlrhIJ/vfmW4=";
-    const TEST_VECTOR_INVITE: &str = r#"{"invite_key_wrapped_invite_data":"g1hHpQEDA3gjYXBwbGljYXRpb24veC5iaXR3YXJkZW4uY2Jvci1wYWRkZWQEULAvkABNEIqBWSbJbR5w/PU6AAE4gQI6AAE4gAKhBUzu06Qb8Rqlag8wxIVYyAOEYjj8vngz+6efiYs4aJqpGKMDNYgXM7QEYDH85RfElcQ3tkBm5lNsLWy04I2gFaJV6hGRN8fZSG9Br3Q11yUIkTna6wy112uCn/szWnrceGg+tTUKjErl9FmkN6yzoSskR1U10dqVeG7AJRjzkAgZFHol1JycPVxhuJdszrF/HpNEOKUbw94vA8kVRQV7+JWJKgeUki0gb9kHPpE+P2vxtM7YJU5uhQXukKVg2KXkNTX7BwXDZ1aofIkFHzSzMtRuRVrEUjAn","invite_secret_wrapped_invite_key":"hFgopQEDAxhlOgABFVxQsC+QAE0QioFZJsltHnD89ToAATiBBjoAATiAAaEFTH8P6s7widuCRd5gsVhQ8Qdi4roT2jBcAb9Qn6f4pJL/BKGvWTrN3D9wvK3bT/AOgEcoiP3gZPZ8qvCiFBgErQ+IudaHnPxw1/W2QXvvZGbkaa1vnqL8eIPuzWrGVVyBg0CiASkzWCAIfgngqsWpnHP3zFYH88LcFD13xgvwzmmN0nirJ6BUZPY=","invite_key_wrapped_organization_key":"g1hGpQEDA3giYXBwbGljYXRpb24veC5iaXR3YXJkZW4ubGVnYWN5LWtleQRQsC+QAE0QioFZJsltHnD89ToAATiBAzoAATiAAqEFTMKnS2tiogG0nXwKFVhQvhXuJ7yorAyslqDLYYjUblYqKryq4aNOS9nGpHkJd+39Uo8cYblbqkBs6x7degHq+bj80RQUoNGpWBLGOPNkIP6tqMnAxQy0NR6sIm7trkI=","organization_key_wrapped_invite_key":"2.xpuLCrOF/Ai7q+zGn5ftSQ==|AyGdogR5TKqIO9nbABdtb57uJ/G/6J5Cj4AajWjWppe6ZJSfqt65fAmgT954+Qgf10ah9L+34jW27yOVitwXMEq/+7b8FaAUDJoh89Yi36Q=|BK4onlURPXFoaUt48UoUeD1BhFREYHHs1tuY6MoR7lQ="}"#;
-    const TEST_VECTOR_INVITE_SECRET: &str = "Q4PavSCGSc10mROp_3gsoufZyiYx830Thcs2iprt1X8";
+    const TEST_VECTOR_INVITE: &str = r#"{"invite_key_sealed_invite_data":"g1hHpQEDA3gjYXBwbGljYXRpb24veC5iaXR3YXJkZW4uY2Jvci1wYWRkZWQEUPw60HtcnAwO6kRKd7MnQz86AAE4gQI6AAE4gAKhBUz+fzObmLDLKRDeBJJYxX9qAxhXIe1Ri1CJw3ojv7WUEwBpVWeMEGTK7HHbp9WnTDjK849psMx6EOpQ7B/BYGiO28Zn0tjtQ85zwShii4FRK39mtJFE8XxV46hxW9+LlH6EPt4yfzHVkTNZ3vgOiSXcs6zyKXIhQaz6yh8eyA653m4DJEHV00JjdQ/jSfTEfyDf6LiflGntDZ7gSYlQMRxuS71yVP9Mgm79yFY4aIw703G/HUjvIEt4XlWCLzvaLDmegpDz9z4eQCVk8v8JM1fS7BsA","invite_key_sealed_invite_data_cek":"g1g+pgE6AAEReQMYZQRQ7raDdes1HnAgiuiZWXyS9ToAARVcUPw60HtcnAwO6kRKd7MnQz86AAE4gQM6AAE4gAKhBVgYvxSL4XPZLwEXHPnEWweqeeKjyH9r85/ZWE3rsZy1MLmzkFOCJa8a0o20b1P3IH6c5NYtT3v1a50+X0GmgDKiMf/omjhwRRQ7ua6wK0O2JBlhM4JIE8jmtsyMd46mFDbURK1kGRvl7Q==","invite_secret_sealed_invite_key":"hFgopQEDAxhlOgABFVxQ7raDdes1HnAgiuiZWXyS9ToAATiBBjoAATiAAaEFTJvCToVTNSe1uWbD5FhUf061kAAj1sMGWjJ8IWPV2e2xk5Z+ownZ1RqUXG2jv9h2vnsEFZ2yglvKaSCGTsOuvOXv0ESwQk6eUtFAaZjxV/Rajyuu6YgEa712Tfb9Jz13QLGngYNAogEpM1gg1MsuVokUsK8WkqggHRdJ4jvzFsbN/bP4g0l+j6f97qb2","invite_key_sealed_organization_key":"g1hKpQE6AAEReQN4ImFwcGxpY2F0aW9uL3guYml0d2FyZGVuLmxlZ2FjeS1rZXkEUO62g3XrNR5wIIromVl8kvU6AAE4gQM6AAE4gAKhBVgYoth3hg+yUTLXF4ksaeT42IWGKuTv27B4WFAKV8Z7uKGZNHOONGgZQLbQMozgYX9tseuet413M314W0sV3cBKZIRSEZfj3NvHU8tE/6b2oGxPQIPKP3Tyhl84zhI4uG+Mo5WKkvtdPonD0A==","organization_key_sealed_invite_key":"2.XjZXnAwXK/cXCmHNgCPQzw==|WEGa37JPdNWVnMPWlfinyvZdXpMW8kpTBypXPWf/abbG4/+6vp/WJQmVlkVEflEkuZwjKWSkMWJPcACGBoabeBHgzqpkSYf3kyQb7VhePHQ=|kZLDCLGm1nCJhlVuNahFiZOecy5tKG2fXGCNZZzbDjk="}"#;
+    const TEST_VECTOR_INVITE_SECRET: &str = "Ttas45_CvZi1yoFJ3bMCHx0DAAGGxDi-1BhHCutwDjI";
 
     /// Loads the const `TEST_VECTOR_ORG_KEY` into the `Organization` slot and returns the parsed
     /// const wrapped organization private key. Sharing fixed vectors keeps tests deterministic and

--- a/crates/bitwarden-organization-crypto/src/invite.rs
+++ b/crates/bitwarden-organization-crypto/src/invite.rs
@@ -820,7 +820,6 @@ mod tests {
         let (invite_secret, invite) =
             Invite::make_for_private_key(TestSymmKey::Organization, &wrapped_private_key, &mut ctx)
                 .unwrap();
-        // Exercises both the `InviteSecret` and `Invite` `Debug` impls.
         println!("{invite_secret:?}");
         println!("{invite:?}");
     }

--- a/crates/bitwarden-organization-crypto/src/invite.rs
+++ b/crates/bitwarden-organization-crypto/src/invite.rs
@@ -21,7 +21,7 @@
 //!   key sealed with the organization key, so anyone holding the organization key recovers the
 //!   invite key (and thus the invite data).
 //! - `InviteKey -> SymmetricKeyEnvelope -> InviteDataCEK -> DataEnvelope -> InviteSecret +
-//!   OrgPubKeyPrint` (`invite_key_sealed_invite_data_cek` + `invite_key_sealed_invite_data`): the
+//!   OrgPubKeyPrint` (`invite_key_sealed_invite_data_cek` + `sealed_invite_data`): the
 //!   `InviteDataV1` is sealed under its own content-encryption key (CEK), and that CEK is sealed
 //!   with the invite key. The data binds the organization public-key thumbprint and a copy of the
 //!   invite secret (so the invite link can be reconstructed from the invite key).
@@ -87,6 +87,15 @@ export type InviteSecret = Tagged<string, "InviteSecret">;
 /// CRITICAL: This must never be sent to the server.
 #[derive(Clone)]
 pub struct InviteSecret(Zeroizing<[u8; INVITE_SECRET_LEN]>);
+
+impl InviteSecret {
+    /// Generates a fresh invite secret: 32 random, high-entropy bytes drawn from the SDK CSPRNG.
+    fn make() -> Self {
+        let mut bytes = Zeroizing::new([0u8; INVITE_SECRET_LEN]);
+        bitwarden_random::rng().fill_bytes(bytes.as_mut_slice());
+        InviteSecret(bytes)
+    }
+}
 
 impl ConstantTimeEq for InviteSecret {
     fn ct_eq(&self, other: &InviteSecret) -> Choice {
@@ -186,9 +195,9 @@ export type Invite = Tagged<string, "Invite">;
 pub struct Invite {
     /// The `InviteData` (org public-key thumbprint + invite secret) sealed with its own
     /// content-encryption key (CEK).
-    invite_key_sealed_invite_data: DataEnvelope,
+    sealed_invite_data: DataEnvelope,
     /// The invite-data content-encryption key sealed with the invite key, so a holder of the
-    /// invite key can recover the CEK and open [`Self::invite_key_sealed_invite_data`].
+    /// invite key can recover the CEK and open [`Self::sealed_invite_data`].
     invite_key_sealed_invite_data_cek: SymmetricKeyEnvelope,
     /// The invite key sealed with the high-entropy invite secret, letting an invitee (who holds
     /// only the invite secret from the link) recover the invite key.
@@ -223,10 +232,7 @@ impl FromStr for Invite {
 impl std::fmt::Debug for Invite {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("Invite")
-            .field(
-                "invite_key_sealed_invite_data",
-                &self.invite_key_sealed_invite_data,
-            )
+            .field("sealed_invite_data", &self.sealed_invite_data)
             .field(
                 "invite_key_sealed_invite_data_cek",
                 &self.invite_key_sealed_invite_data_cek,
@@ -290,7 +296,7 @@ impl Invite {
             )
             .map_err(|_| InviteKeyBundleError::KeyUnsealingFailed)?;
         let data: InviteData = self
-            .invite_key_sealed_invite_data
+            .sealed_invite_data
             .unseal(cek, ctx)
             .map_err(|_| InviteKeyBundleError::KeyUnsealingFailed)?;
         let InviteData::InviteDataV1(data) = data;
@@ -389,9 +395,7 @@ impl Invite {
             .map_err(|_| InviteKeyBundleError::InvalidPrivateKey)?;
 
         // Generate the URL-fragment invite secret (goes in the invite link).
-        let mut bytes = Zeroizing::new([0u8; INVITE_SECRET_LEN]);
-        bitwarden_random::rng().fill_bytes(bytes.as_mut_slice());
-        let invite_secret = InviteSecret(bytes);
+        let invite_secret = InviteSecret::make();
 
         // Generate the invite key (the hub). It only ever acts as a key-encryption key — sealing
         // the invite-data CEK and the organization key via `SymmetricKeyEnvelope`.
@@ -405,7 +409,7 @@ impl Invite {
             invite_secret: *invite_secret.0,
         }
         .into();
-        let (invite_key_sealed_invite_data, invite_data_cek) = DataEnvelope::seal(invite_data, ctx)
+        let (sealed_invite_data, invite_data_cek) = DataEnvelope::seal(invite_data, ctx)
             .map_err(|_| InviteKeyBundleError::KeySealingFailed)?;
         let invite_key_sealed_invite_data_cek = SymmetricKeyEnvelope::seal(
             invite_data_cek,
@@ -446,7 +450,7 @@ impl Invite {
         Ok((
             invite_secret,
             Invite {
-                invite_key_sealed_invite_data,
+                sealed_invite_data,
                 invite_key_sealed_invite_data_cek,
                 invite_secret_sealed_invite_key,
                 invite_key_sealed_organization_key,
@@ -472,7 +476,7 @@ mod tests {
     const TEST_VECTOR_ORG_KEY: &str =
         "KGP9Nc2/91w+42Z9VzY0m7h18avuZcq4ICM8Rhdc3BD92LbWS2TQkVBzavvUM684WKXiC22NJi2EwaiDW4YTAA==";
     const TEST_VECTOR_WRAPPED_PRIVATE_KEY: &str = "2.bi9TWF/zrujUg1y+v8ECtQ==|kEMkuRt42j65YZnPEc4bLOT0/WDZwWSNJNGlUMdr/LRF3qi/vCnZ7eT0+7MruTccmyoAjKmsXdoBcufrOdPBUguFQn1LQMGqHqCyyB3SIijOlLyOOmxWYqoLUjihy8o8URGWjrAGWZnkeYWHTlFZP09Fag2xCwiQ/qS32Q+qTGGHDs0FiwjplcPkW9knlmgCXbuyPqDnEYoa0Qs/CC1hUCzFFrWs7QkE+5eLaNHxuBPpsrY6y795kEu9ve38F3piY9b6lQpc/iPGv8Zfh1isI7Mpy1zMwntXGSHjUOy17nPxCqkgYufuNGnwGNwsGjkLAl7e7bD39SYfEpTDaRUgmTl8UrZDx274e6Um1LLvokf3HiL1tboJ9/TW8IiMuAdrb3PLTH6Sep8lqZ3WhNADfMMJle9kCojHp6XSB14in1JqP0636exYeJu+FhUC1TfrthuQN2QDQ8LAvgZR7YvzkTJX3Sc5jP7m/yCmCbHhIqIAaGqJsRwAee0EMsKcALz3/akVoyjHU2LHD3dzQnyMyszyRNYViBNYAM9qBN2DqwWRDOtM171xNVJcTFsAh4mBSLiLOlDsXqLqHVKu2VJNE1XhTQ5Szubqefa/Or7nfxXcxDvivqZ7d5NfDFEskUMqh5yq1KoLK0oK5c+KvY/COIZr/kct+qtfZsXo3w5xJnPOqrAKGm+9CF4OINpLM8Z3csdZf9l5XjlmO1kIuBbquQZ0EZCHzD/GEfXRGB8BEkugdTfpnTDtmmuAJXkIY6t6e6pRUU9u4/sl+U7Iuh22fOA59SuQOElr5Lxre+hQBrRfJS3tSMEtMjYhVmltrngH+SLRxMxH/evbe2uvNaaxlFJe6EK1vqchyTX6nM8Z+2Yjb5pOAzrKQYqwwmVys9IHfjXhybqv10gFpDXBE/eq8u9xs9LbQQ03EbveQUtqdh/ms8SxLOQA9Sm9JwHEL0Zni+8NdAa5orDYzOi53bQLgrs+uUldgB/KOW2goTnKGm4YTbMAXEbum8pST8EXB9jNDXyofyN8IQUoLRvVkEgzbSPBS1sYpkkKdLZy3ojOCKnMnHXIVtzJojFckiutbj6d927X5w51E/RDMoAdylGRVKnmqLKysFRqL+pZK8Cyo+ECr7notG8kr7pVnofzigjKZS9qkRmqEa9bju1GgI20g4cxro8/0O0XnU1o0Mx46qH3niORY59i5bdMwaDS6H2c6+rmf9bIFwwgyAZvHlVdcGNoBGPR3ZXHThwI1OmWSslLWVW0IaS4utB1jL4zvHPCqh/ButA8HeRmU/NYSfaqb9YXyzn+C7ED15MWXkYmZzeE38HHxhqs12+oj+WFcg4d5/e2UcccuVi36SWhA0xWk8Kk2D6e1Pz1lmaw20vpb0eUq4AS5ZnMmWTEiKORFeGNTIROq9vuPuitLrREedu9PGjf5aeKcNqlq2nr7fOaxyi2ocKs7pLqVBUH1G7zHpCo3Rt1+o18guXFHT56vQFfkzoUNXiS6TRM4Mkl3s0TyGgBhxZkNJleTI6y4xhfH1iathBnLcfelLbxZhDB1wh3RXowS32jpM/J4pSUuNEmSLSqRQtRJY41BG00nYY02qEbakkgk6pS6a0/CWphyLfHAzUWbabOhqR1iPN9/ZiecjI=|eoklmBw+LYy2NNwjLOuA4+szKH5SzLGPlrhIJ/vfmW4=";
-    const TEST_VECTOR_INVITE: &str = r#"{"invite_key_sealed_invite_data":"g1hHpQEDA3gjYXBwbGljYXRpb24veC5iaXR3YXJkZW4uY2Jvci1wYWRkZWQEUPw60HtcnAwO6kRKd7MnQz86AAE4gQI6AAE4gAKhBUz+fzObmLDLKRDeBJJYxX9qAxhXIe1Ri1CJw3ojv7WUEwBpVWeMEGTK7HHbp9WnTDjK849psMx6EOpQ7B/BYGiO28Zn0tjtQ85zwShii4FRK39mtJFE8XxV46hxW9+LlH6EPt4yfzHVkTNZ3vgOiSXcs6zyKXIhQaz6yh8eyA653m4DJEHV00JjdQ/jSfTEfyDf6LiflGntDZ7gSYlQMRxuS71yVP9Mgm79yFY4aIw703G/HUjvIEt4XlWCLzvaLDmegpDz9z4eQCVk8v8JM1fS7BsA","invite_key_sealed_invite_data_cek":"g1g+pgE6AAEReQMYZQRQ7raDdes1HnAgiuiZWXyS9ToAARVcUPw60HtcnAwO6kRKd7MnQz86AAE4gQM6AAE4gAKhBVgYvxSL4XPZLwEXHPnEWweqeeKjyH9r85/ZWE3rsZy1MLmzkFOCJa8a0o20b1P3IH6c5NYtT3v1a50+X0GmgDKiMf/omjhwRRQ7ua6wK0O2JBlhM4JIE8jmtsyMd46mFDbURK1kGRvl7Q==","invite_secret_sealed_invite_key":"hFgopQEDAxhlOgABFVxQ7raDdes1HnAgiuiZWXyS9ToAATiBBjoAATiAAaEFTJvCToVTNSe1uWbD5FhUf061kAAj1sMGWjJ8IWPV2e2xk5Z+ownZ1RqUXG2jv9h2vnsEFZ2yglvKaSCGTsOuvOXv0ESwQk6eUtFAaZjxV/Rajyuu6YgEa712Tfb9Jz13QLGngYNAogEpM1gg1MsuVokUsK8WkqggHRdJ4jvzFsbN/bP4g0l+j6f97qb2","invite_key_sealed_organization_key":"g1hKpQE6AAEReQN4ImFwcGxpY2F0aW9uL3guYml0d2FyZGVuLmxlZ2FjeS1rZXkEUO62g3XrNR5wIIromVl8kvU6AAE4gQM6AAE4gAKhBVgYoth3hg+yUTLXF4ksaeT42IWGKuTv27B4WFAKV8Z7uKGZNHOONGgZQLbQMozgYX9tseuet413M314W0sV3cBKZIRSEZfj3NvHU8tE/6b2oGxPQIPKP3Tyhl84zhI4uG+Mo5WKkvtdPonD0A==","organization_key_sealed_invite_key":"2.XjZXnAwXK/cXCmHNgCPQzw==|WEGa37JPdNWVnMPWlfinyvZdXpMW8kpTBypXPWf/abbG4/+6vp/WJQmVlkVEflEkuZwjKWSkMWJPcACGBoabeBHgzqpkSYf3kyQb7VhePHQ=|kZLDCLGm1nCJhlVuNahFiZOecy5tKG2fXGCNZZzbDjk="}"#;
+    const TEST_VECTOR_INVITE: &str = r#"{"sealed_invite_data":"g1hHpQEDA3gjYXBwbGljYXRpb24veC5iaXR3YXJkZW4uY2Jvci1wYWRkZWQEUPw60HtcnAwO6kRKd7MnQz86AAE4gQI6AAE4gAKhBUz+fzObmLDLKRDeBJJYxX9qAxhXIe1Ri1CJw3ojv7WUEwBpVWeMEGTK7HHbp9WnTDjK849psMx6EOpQ7B/BYGiO28Zn0tjtQ85zwShii4FRK39mtJFE8XxV46hxW9+LlH6EPt4yfzHVkTNZ3vgOiSXcs6zyKXIhQaz6yh8eyA653m4DJEHV00JjdQ/jSfTEfyDf6LiflGntDZ7gSYlQMRxuS71yVP9Mgm79yFY4aIw703G/HUjvIEt4XlWCLzvaLDmegpDz9z4eQCVk8v8JM1fS7BsA","invite_key_sealed_invite_data_cek":"g1g+pgE6AAEReQMYZQRQ7raDdes1HnAgiuiZWXyS9ToAARVcUPw60HtcnAwO6kRKd7MnQz86AAE4gQM6AAE4gAKhBVgYvxSL4XPZLwEXHPnEWweqeeKjyH9r85/ZWE3rsZy1MLmzkFOCJa8a0o20b1P3IH6c5NYtT3v1a50+X0GmgDKiMf/omjhwRRQ7ua6wK0O2JBlhM4JIE8jmtsyMd46mFDbURK1kGRvl7Q==","invite_secret_sealed_invite_key":"hFgopQEDAxhlOgABFVxQ7raDdes1HnAgiuiZWXyS9ToAATiBBjoAATiAAaEFTJvCToVTNSe1uWbD5FhUf061kAAj1sMGWjJ8IWPV2e2xk5Z+ownZ1RqUXG2jv9h2vnsEFZ2yglvKaSCGTsOuvOXv0ESwQk6eUtFAaZjxV/Rajyuu6YgEa712Tfb9Jz13QLGngYNAogEpM1gg1MsuVokUsK8WkqggHRdJ4jvzFsbN/bP4g0l+j6f97qb2","invite_key_sealed_organization_key":"g1hKpQE6AAEReQN4ImFwcGxpY2F0aW9uL3guYml0d2FyZGVuLmxlZ2FjeS1rZXkEUO62g3XrNR5wIIromVl8kvU6AAE4gQM6AAE4gAKhBVgYoth3hg+yUTLXF4ksaeT42IWGKuTv27B4WFAKV8Z7uKGZNHOONGgZQLbQMozgYX9tseuet413M314W0sV3cBKZIRSEZfj3NvHU8tE/6b2oGxPQIPKP3Tyhl84zhI4uG+Mo5WKkvtdPonD0A==","organization_key_sealed_invite_key":"2.XjZXnAwXK/cXCmHNgCPQzw==|WEGa37JPdNWVnMPWlfinyvZdXpMW8kpTBypXPWf/abbG4/+6vp/WJQmVlkVEflEkuZwjKWSkMWJPcACGBoabeBHgzqpkSYf3kyQb7VhePHQ=|kZLDCLGm1nCJhlVuNahFiZOecy5tKG2fXGCNZZzbDjk="}"#;
     const TEST_VECTOR_INVITE_SECRET: &str = "Ttas45_CvZi1yoFJ3bMCHx0DAAGGxDi-1BhHCutwDjI";
 
     /// Loads the const `TEST_VECTOR_ORG_KEY` into the `Organization` slot and returns the parsed
@@ -738,7 +742,7 @@ mod tests {
     }
 
     #[test]
-    fn test_into_base64_url() {
+    fn test_invite_secret_into_base64_url() {
         let data: [u8; 32] = *b"+/=Hello, World!AAAAAAAAAAAAAAAA";
         let secret = InviteSecret(zeroize::Zeroizing::new(data));
 

--- a/crates/bitwarden-organization-crypto/src/lib.rs
+++ b/crates/bitwarden-organization-crypto/src/lib.rs
@@ -2,6 +2,7 @@
 
 mod invite_key_bundle;
 pub use invite_key_bundle::{Invite, InviteBundle, InviteKeyBundleError, InviteKeyData};
+pub mod invite;
 
 #[cfg(feature = "wasm")]
 pub mod wasm;


### PR DESCRIPTION
Re-implements invites based on safe primitives. The cryptographic design is:
Rewrite the invite based on safe primitives. The construction is:

```
InviteSecret->SecretProtectedKeyEnvelope->InviteKey->DataEnvelope -> InviteSecret
                                            ^     |             |--> OrgPubKeyPrint
                                            |     |
OrganizationKey -> EncString ---------------|     ->SymmetricKeyEnvelope->OrganizationKey
```

The organization key still has access to the Invite Secret (via the invite key). The Invite Secret has access to the pub key print in an authenticated fashion, and to the organization key (if present) for milestone 3 - autoconfirmation.

https://bitwarden.atlassian.net/browse/PM-40307