### PR TITLE
[PM-40375] Update doc comment to reflect correct SSH key parsing error variant name

### DIFF
--- a/crates/bitwarden-wasm-internal/src/ssh.rs
+++ b/crates/bitwarden-wasm-internal/src/ssh.rs
@@ -27,7 +27,7 @@ pub fn generate_ssh_key(
 /// - `Ok(SshKey)` if the key was successfully coneverted
 /// - `Err(PasswordRequired)` if the key is encrypted and no password was provided
 /// - `Err(WrongPassword)` if the password provided is incorrect
-/// - `Err(ParsingError)` if the key could not be parsed
+/// - `Err(Parsing)` if the key could not be parsed
 /// - `Err(UnsupportedKeyType)` if the key type is not supported
 #[wasm_bindgen]
 pub fn import_ssh_key(


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-40375

## 📔 Objective

The error variant expected by current [production code](https://github.com/bitwarden/clients/blob/84e3298320c9c0524290126f74ed81afc9f0f292/libs/vault/src/services/default-ssh-import-prompt.service.ts#L120) does not match the variant emitted [by the SDK](https://github.com/bitwarden/sdk-internal/blob/31b18f02ec8f5713133ea67d42993c12c5923782/crates/bitwarden-ssh/src/error.rs#L19). This PR corrects only the doc comment in the SDK, which is used to generate the doc comment in the corresponding `bitwarden_wasm_internal.d.ts` file. 

If the doc comment in the WASM file is not correct, developers are likely to use a non-existent error variant. 

@BMcS  I am looping you in, in case mobile teams are expecting the non-existent error variant. 
