### PR TITLE
fix(passkey): fido2 assertion overwrites creation date of passkey

### DIFF
--- a/crates/bitwarden-fido/src/lib.rs
+++ b/crates/bitwarden-fido/src/lib.rs
@@ -172,7 +172,7 @@ pub fn fill_with_credential(
         user_name: view.user_name.clone(),
         user_display_name: view.user_display_name.clone(),
         discoverable: "true".to_owned(),
-        creation_date: chrono::offset::Utc::now(),
+        creation_date: view.creation_date,
     })
 }
 


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-40658

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Probably related to passkey corruption bugs. Updating creds on usage should not update the creation date. This is just misleading.

## 🚨 Breaking Changes

<!-- Does this PR introduce any breaking changes? If so, please describe the impact and migration path for clients.

If you're unsure, the automated TypeScript compatibility check will run when you open/update this PR and provide feedback.

For breaking changes:
1. Describe what changed in the client interface
2. Explain why the change was necessary
3. Provide migration steps for client developers
4. Link to any paired client PRs if needed

Otherwise, you can remove this section. -->
