### PR TITLE
fix(vault): fix per-field encryption being used for blob encryption users for certain actions

### DIFF
--- a/crates/bitwarden-exporters/src/export.rs
+++ b/crates/bitwarden-exporters/src/export.rs
@@ -1,7 +1,9 @@
 use bitwarden_collections::collection::Collection;
 use bitwarden_core::{Client, OrganizationId, key_management::KeySlotIds};
 use bitwarden_crypto::{CompositeEncryptable, IdentifyKey, KeyStoreContext};
-use bitwarden_vault::{Cipher, CipherView, Folder, FolderView};
+use bitwarden_vault::{
+    Cipher, CipherView, EncryptMode, Folder, FolderView, should_use_blob_encryption,
+};
 
 use crate::{
     ExportError, ExportFormat, ImportingCipher,
@@ -93,7 +95,15 @@ pub fn encrypt_import(
         view.set_new_fido2_credentials(ctx, passkeys)?;
     }
 
-    let new_cipher = view.encrypt_composite(ctx, view.key_identifier())?;
+    // Select the encryption format based on the account's current security state, matching how
+    // regular cipher saves choose between the blob and legacy field-level formats.
+    let key = view.key_identifier();
+    let mode = if should_use_blob_encryption(ctx, organization_id) {
+        EncryptMode::Blob(view)
+    } else {
+        EncryptMode::Legacy(view)
+    };
+    let new_cipher = mode.encrypt_composite(ctx, key)?;
 
     Ok(new_cipher)
 }

--- a/crates/bitwarden-exporters/src/models.rs
+++ b/crates/bitwarden-exporters/src/models.rs
@@ -247,7 +247,7 @@ impl From<crate::SecureNoteType> for SecureNoteType {
 mod tests {
     use bitwarden_core::key_management::create_test_crypto_with_user_key;
     use bitwarden_crypto::{SymmetricCryptoKey, SymmetricKeyAlgorithm};
-    use bitwarden_vault::{CipherId, CipherRepromptType, FolderId, LoginView};
+    use bitwarden_vault::{CipherId, CipherRepromptType, EncryptMode, FolderId, LoginView};
     use chrono::{DateTime, Utc};
 
     use super::*;
@@ -370,7 +370,7 @@ mod tests {
             revision_date: "2024-01-30T17:55:36.150Z".parse().unwrap(),
             archived_date: None,
         };
-        let encrypted = key_store.encrypt(cipher_view).unwrap();
+        let encrypted = key_store.encrypt(EncryptMode::Legacy(cipher_view)).unwrap();
 
         let cipher: crate::Cipher = crate::Cipher::from_cipher(&key_store, encrypted).unwrap();
 

--- a/crates/bitwarden-user-crypto-management/src/key_rotation/data.rs
+++ b/crates/bitwarden-user-crypto-management/src/key_rotation/data.rs
@@ -381,7 +381,9 @@ mod tests {
             ctx.make_symmetric_key(bitwarden_crypto::SymmetricKeyAlgorithm::Aes256CbcHmac);
 
         let cipher = make_cipher_view();
-        let encrypted_cipher = cipher.encrypt_composite(&mut ctx, user_key_old).unwrap();
+        let encrypted_cipher = EncryptMode::Legacy(cipher.clone())
+            .encrypt_composite(&mut ctx, user_key_old)
+            .unwrap();
 
         // Rotate it
         let ciphers = vec![encrypted_cipher];

--- a/crates/bitwarden-vault/src/cipher/cipher.rs
+++ b/crates/bitwarden-vault/src/cipher/cipher.rs
@@ -651,8 +651,8 @@ impl CipherListView {
 // ciphertext (`key`, the cipher content-encryption key wrapped under the decrypting key) and copies
 // it through unchanged (`key: cipher_view.key` below) instead of re-wrapping it under `key`. As a
 // result decrypt(K) -> encrypt(K1) -> decrypt(K1) does NOT round-trip.
-impl CompositeEncryptable<KeySlotIds, SymmetricKeySlotId, Cipher> for CipherView {
-    fn encrypt_composite(
+impl CipherView {
+    fn encrypt_legacy_field_encryption(
         &self,
         ctx: &mut KeyStoreContext<KeySlotIds>,
         key: SymmetricKeySlotId,
@@ -1844,7 +1844,7 @@ impl CompositeEncryptable<KeySlotIds, SymmetricKeySlotId, Cipher> for EncryptMod
                 encrypt_blob_cipher_with_wrapping_key(&mut owned, ctx, key)
                     .map_err(CryptoError::from)
             }
-            Self::Legacy(view) => view.encrypt_composite(ctx, key),
+            Self::Legacy(view) => view.encrypt_legacy_field_encryption(ctx, key),
         }
     }
 }
@@ -2401,7 +2401,9 @@ mod tests {
         ));
 
         // Encrypt a valid cipher, then swap name with an EncString from a different key
-        let cipher = key_store.encrypt(generate_cipher()).unwrap();
+        let cipher = key_store
+            .encrypt(EncryptMode::Legacy(generate_cipher()))
+            .unwrap();
         let cipher = Cipher {
             name: Some(TEST_CIPHER_NAME.parse().unwrap()), // encrypted with a different key
             ..cipher
@@ -2434,7 +2436,9 @@ mod tests {
         ));
 
         // Encrypt a valid cipher, then corrupt the login username
-        let cipher = key_store.encrypt(generate_cipher()).unwrap();
+        let cipher = key_store
+            .encrypt(EncryptMode::Legacy(generate_cipher()))
+            .unwrap();
         let cipher = Cipher {
             login: Some(Login {
                 username: Some(TEST_CIPHER_NAME.parse().unwrap()), // encrypted with a different key
@@ -2476,7 +2480,7 @@ mod tests {
 
         // Check that the cipher gets encrypted correctly without it's own key
         let cipher = generate_cipher();
-        let no_key_cipher_enc = key_store.encrypt(cipher).unwrap();
+        let no_key_cipher_enc = key_store.encrypt(EncryptMode::Legacy(cipher)).unwrap();
         let no_key_cipher_dec: CipherView = key_store.decrypt(&no_key_cipher_enc).unwrap();
         assert!(no_key_cipher_dec.key.is_none());
         assert_eq!(no_key_cipher_dec.name, original_cipher.name);
@@ -2487,7 +2491,7 @@ mod tests {
             .unwrap();
 
         // Check that the cipher gets encrypted correctly when it's assigned it's own key
-        let key_cipher_enc = key_store.encrypt(cipher).unwrap();
+        let key_cipher_enc = key_store.encrypt(EncryptMode::Legacy(cipher)).unwrap();
         let key_cipher_dec: CipherView = key_store.decrypt(&key_cipher_enc).unwrap();
         assert!(key_cipher_dec.key.is_some());
         assert_eq!(key_cipher_dec.name, original_cipher.name);
@@ -2606,7 +2610,7 @@ mod tests {
         assert_eq!(cipher.organization_id, Some(org));
 
         // Check that the cipher can be encrypted/decrypted with the new org key
-        let cipher_enc = key_store.encrypt(cipher).unwrap();
+        let cipher_enc = key_store.encrypt(EncryptMode::Legacy(cipher)).unwrap();
         let cipher_dec: CipherView = key_store.decrypt(&cipher_enc).unwrap();
 
         assert_eq!(cipher_dec.name, "My test login");
@@ -2629,7 +2633,7 @@ mod tests {
 
         // Check that the cipher can not be encrypted, as the
         // cipher key is tied to the user key and not the org key
-        assert!(key_store.encrypt(cipher).is_err());
+        assert!(key_store.encrypt(EncryptMode::Legacy(cipher)).is_err());
     }
 
     #[test]
@@ -3490,7 +3494,7 @@ mod tests {
             ..generate_cipher()
         };
 
-        let cipher: Cipher = key_store.encrypt(cipher_view).unwrap();
+        let cipher: Cipher = key_store.encrypt(EncryptMode::Legacy(cipher_view)).unwrap();
         let list_view: CipherListView = key_store.decrypt(&cipher).unwrap();
 
         assert_eq!(list_view.r#type, CipherListViewType::Passport);
@@ -3523,7 +3527,7 @@ mod tests {
             ..generate_cipher()
         };
 
-        let cipher: Cipher = key_store.encrypt(cipher_view).unwrap();
+        let cipher: Cipher = key_store.encrypt(EncryptMode::Legacy(cipher_view)).unwrap();
         let list_view: CipherListView = key_store.decrypt(&cipher).unwrap();
 
         assert_eq!(list_view.r#type, CipherListViewType::DriversLicense);
@@ -3567,7 +3571,7 @@ mod tests {
             ..generate_cipher()
         };
 
-        let encrypted: Cipher = key_store.encrypt(cipher_view).unwrap();
+        let encrypted: Cipher = key_store.encrypt(EncryptMode::Legacy(cipher_view)).unwrap();
         let decrypted: CipherView = key_store.decrypt(&encrypted).unwrap();
 
         assert_eq!(decrypted.r#type, CipherType::Passport);
@@ -3602,7 +3606,7 @@ mod tests {
             ..generate_cipher()
         };
 
-        let encrypted: Cipher = key_store.encrypt(cipher_view).unwrap();
+        let encrypted: Cipher = key_store.encrypt(EncryptMode::Legacy(cipher_view)).unwrap();
         let decrypted: CipherView = key_store.decrypt(&encrypted).unwrap();
 
         assert_eq!(decrypted.r#type, CipherType::DriversLicense);
@@ -3667,7 +3671,7 @@ mod tests {
 
         /// Encrypt a view through the legacy field-level path.
         fn encrypt_legacy(view: CipherView, key_store: &KeyStore<KeySlotIds>) -> Cipher {
-            key_store.encrypt(view).unwrap()
+            key_store.encrypt(EncryptMode::Legacy(view)).unwrap()
         }
 
         /// Encrypt a view through the blob path.

--- a/crates/bitwarden-vault/src/cipher/cipher_client/admin/create.rs
+++ b/crates/bitwarden-vault/src/cipher/cipher_client/admin/create.rs
@@ -119,7 +119,7 @@ impl CipherAdminClient {
             view.generate_cipher_key(&mut key_store.context(), key)?;
         }
 
-        let use_blob = should_use_blob_encryption(&self.client, view.organization_id);
+        let use_blob = should_use_blob_encryption(&key_store.context(), view.organization_id);
 
         create_cipher(
             view,

--- a/crates/bitwarden-vault/src/cipher/cipher_client/admin/edit.rs
+++ b/crates/bitwarden-vault/src/cipher/cipher_client/admin/edit.rs
@@ -170,7 +170,7 @@ impl CipherAdminClient {
         let enable_cipher_key_encryption =
             self.client.flags().get().await.enable_cipher_key_encryption;
 
-        let use_blob = should_use_blob_encryption(&self.client, request.organization_id);
+        let use_blob = should_use_blob_encryption(&key_store.context(), request.organization_id);
 
         edit_cipher(
             key_store,

--- a/crates/bitwarden-vault/src/cipher/cipher_client/mod.rs
+++ b/crates/bitwarden-vault/src/cipher/cipher_client/mod.rs
@@ -7,7 +7,7 @@ use bitwarden_core::{
 };
 #[cfg(feature = "wasm")]
 use bitwarden_crypto::{CompositeEncryptable, SymmetricCryptoKey};
-use bitwarden_crypto::{IdentifyKey, KeyStore};
+use bitwarden_crypto::{IdentifyKey, KeyStore, KeyStoreContext};
 #[cfg(feature = "wasm")]
 use bitwarden_encoding::B64;
 use bitwarden_state::repository::{Repository, RepositoryError};
@@ -21,10 +21,7 @@ use crate::{
     cipher_client::admin::CipherAdminClient,
 };
 #[cfg(feature = "wasm")]
-use crate::{
-    Fido2CredentialFullView,
-    cipher::{blob::encrypt_blob_cipher_with_wrapping_key, cipher::DecryptCipherResult},
-};
+use crate::{Fido2CredentialFullView, cipher::cipher::DecryptCipherResult};
 
 mod admin;
 mod bulk_update_collections;
@@ -39,20 +36,14 @@ mod restore;
 mod share_cipher;
 
 /// Returns `true` when cipher data for the given scope should be written in the blob-encrypted
-/// format, based on the client's current security state version. Individual-vault ciphers qualify
-/// once the security state has reached [`BLOB_SECURITY_VERSION`]. Organization-vault support is
-/// tracked in PM-32430.
-pub(crate) fn should_use_blob_encryption(
-    client: &Client,
+/// format, based on the current security state version. Individual-vault ciphers qualify once the
+/// security state has reached [`BLOB_SECURITY_VERSION`]. Organization-vault support is tracked in
+/// PM-32430.
+pub fn should_use_blob_encryption(
+    ctx: &KeyStoreContext<KeySlotIds>,
     organization_id: Option<OrganizationId>,
 ) -> bool {
-    organization_id.is_none()
-        && client
-            .internal
-            .get_key_store()
-            .context()
-            .get_security_state_version()
-            >= BLOB_SECURITY_VERSION
+    organization_id.is_none() && ctx.get_security_state_version() >= BLOB_SECURITY_VERSION
 }
 
 #[allow(missing_docs)]
@@ -87,7 +78,8 @@ impl CiphersClient {
         &self,
         organization_id: Option<OrganizationId>,
     ) -> bool {
-        should_use_blob_encryption(&self.client, organization_id)
+        let key_store = self.client.internal.get_key_store();
+        should_use_blob_encryption(&key_store.context(), organization_id)
     }
 
     #[allow(missing_docs)]
@@ -160,19 +152,15 @@ impl CiphersClient {
             cipher_view.reencrypt_cipher_keys(&mut ctx, new_key_id)?;
         }
 
-        let cipher = if self.should_use_blob_encryption(cipher_view.organization_id) {
-            // Rotation installs the new key under a `Local` slot id (`new_key_id`),
-            // not under the view's natural `User`/`Organization` slot — so we must
-            // pass it explicitly as the outer wrapping key.
-            encrypt_blob_cipher_with_wrapping_key(&mut cipher_view, &mut ctx, new_key_id).map_err(
-                |err| {
-                    tracing::warn!(%err, "blob rotation encryption failed");
-                    EncryptError::from(err)
-                },
-            )?
+        // Rotation installs the new key under a `Local` slot id (`new_key_id`), not the view's
+        // natural `User`/`Organization` slot — so pass it explicitly to `encrypt_composite` rather
+        // than going through `key_store.encrypt`, which uses the view's natural key identifier.
+        let mode = if self.should_use_blob_encryption(cipher_view.organization_id) {
+            EncryptMode::Blob(cipher_view)
         } else {
-            cipher_view.encrypt_composite(&mut ctx, new_key_id)?
+            EncryptMode::Legacy(cipher_view)
         };
+        let cipher = mode.encrypt_composite(&mut ctx, new_key_id)?;
 
         Ok(EncryptionContext {
             cipher,

--- a/crates/bitwarden-vault/src/cipher/mod.rs
+++ b/crates/bitwarden-vault/src/cipher/mod.rs
@@ -37,7 +37,9 @@ pub use cipher::{
     CipherType, CipherView, DecryptCipherListResult, DecryptCipherResult, EncryptMode,
     EncryptionContext, ListOrganizationCiphersResult,
 };
-pub use cipher_client::{CiphersClient, GetAssignedOrgCiphersAdminError};
+pub use cipher_client::{
+    CiphersClient, GetAssignedOrgCiphersAdminError, should_use_blob_encryption,
+};
 pub use cipher_view_type::CipherViewType;
 pub use drivers_license::DriversLicenseView;
 #[cfg(feature = "wasm")]


### PR DESCRIPTION
Currently, the CompositeEncryptable trait is implemented for vault items. The trait is public, and so the impl is public, and any other crate can use composite_encrypt. Due to the specific usage of vault items, this is incorrectly uses composite_encrypt.

https://bitwarden.atlassian.net/browse/PM-40912