### PR TITLE
chore(vault): unconditionally enable cipher-keys

### DIFF
--- a/crates/bitwarden-core/src/client/flags.rs
+++ b/crates/bitwarden-core/src/client/flags.rs
@@ -9,10 +9,6 @@
 #[derive(Debug, Default, Clone, serde::Serialize, serde::Deserialize)]
 #[serde(default, rename_all = "kebab-case")]
 pub struct Flags {
-    /// Enable cipher key encryption.
-    #[serde(alias = "enableCipherKeyEncryption", alias = "cipher-key-encryption")]
-    pub enable_cipher_key_encryption: bool,
-
     /// Enable strict cipher field decryption (propagates errors instead of nulling fields).
     #[serde(alias = "pm-34500-strict-cipher-decryption")]
     pub strict_cipher_decryption: bool,
@@ -41,23 +37,23 @@ mod tests {
     fn test_load_empty_map() {
         let map = std::collections::HashMap::new();
         let flags = Flags::load_from_map(map);
-        assert!(!flags.enable_cipher_key_encryption);
+        assert!(!flags.strict_cipher_decryption);
     }
 
     #[test]
     fn test_load_valid_map() {
         let mut map = std::collections::HashMap::new();
-        map.insert("enableCipherKeyEncryption".into(), true);
+        map.insert("strict-cipher-decryption".into(), true);
         let flags = Flags::load_from_map(map);
-        assert!(flags.enable_cipher_key_encryption);
+        assert!(flags.strict_cipher_decryption);
     }
 
     #[test]
     fn test_load_valid_map_alias() {
         let mut map = std::collections::HashMap::new();
-        map.insert("cipher-key-encryption".into(), true);
+        map.insert("pm-34500-strict-cipher-decryption".into(), true);
         let flags = Flags::load_from_map(map);
-        assert!(flags.enable_cipher_key_encryption);
+        assert!(flags.strict_cipher_decryption);
     }
 
     #[test]
@@ -65,6 +61,6 @@ mod tests {
         let mut map = std::collections::HashMap::new();
         map.insert("thisIsNotAFlag".into(), true);
         let flags = Flags::load_from_map(map);
-        assert!(!flags.enable_cipher_key_encryption);
+        assert!(!flags.strict_cipher_decryption);
     }
 }

--- a/crates/bitwarden-core/src/client/flags_client.rs
+++ b/crates/bitwarden-core/src/client/flags_client.rs
@@ -158,18 +158,15 @@ mod tests {
 
         // With no flags loaded yet, get should return defaults.
         let initial = client.flags().get().await;
-        assert!(!initial.enable_cipher_key_encryption);
         assert!(!initial.strict_cipher_decryption);
 
         // Loading flags should persist them via the FLAGS setting.
         let mut map = HashMap::new();
-        map.insert("enableCipherKeyEncryption".to_string(), true);
         map.insert("pm-34500-strict-cipher-decryption".to_string(), true);
         client.flags().load(map).await;
 
         // get should now return the loaded values.
         let loaded = client.flags().get().await;
-        assert!(loaded.enable_cipher_key_encryption);
         assert!(loaded.strict_cipher_decryption);
 
         // The values should be readable directly from the setting too.
@@ -182,7 +179,6 @@ mod tests {
             .await
             .unwrap()
             .expect("flags should be persisted after load");
-        assert!(persisted.enable_cipher_key_encryption);
         assert!(persisted.strict_cipher_decryption);
     }
 
@@ -192,7 +188,7 @@ mod tests {
         Mock::given(method("GET"))
             .and(path("/config"))
             .respond_with(ResponseTemplate::new(200).set_body_json(json!({
-                "featureStates": { "enableCipherKeyEncryption": true }
+                "featureStates": { "pm-34500-strict-cipher-decryption": true }
             })))
             .expect(1)
             .mount(&server)
@@ -202,7 +198,7 @@ mod tests {
         let before = Utc::now();
         client.flags().fetch(true).await.unwrap();
 
-        assert!(client.flags().get().await.enable_cipher_key_encryption);
+        assert!(client.flags().get().await.strict_cipher_decryption);
         let fetched_at = read_fetched_at(&client)
             .await
             .expect("fetched_at must be set after a successful fetch");
@@ -247,7 +243,7 @@ mod tests {
         Mock::given(method("GET"))
             .and(path("/config"))
             .respond_with(ResponseTemplate::new(200).set_body_json(json!({
-                "featureStates": { "enableCipherKeyEncryption": true }
+                "featureStates": { "pm-34500-strict-cipher-decryption": true }
             })))
             .expect(1)
             .mount(&server)
@@ -259,7 +255,7 @@ mod tests {
 
         client.flags().fetch(false).await.unwrap();
 
-        assert!(client.flags().get().await.enable_cipher_key_encryption);
+        assert!(client.flags().get().await.strict_cipher_decryption);
         let fetched_at = read_fetched_at(&client).await.unwrap();
         assert!(fetched_at > stale);
     }
@@ -277,14 +273,14 @@ mod tests {
         client
             .flags()
             .load(HashMap::from([(
-                "enableCipherKeyEncryption".to_string(),
+                "pm-34500-strict-cipher-decryption".to_string(),
                 true,
             )]))
             .await;
 
         assert!(client.flags().fetch(true).await.is_err());
         assert!(
-            client.flags().get().await.enable_cipher_key_encryption,
+            client.flags().get().await.strict_cipher_decryption,
             "previously persisted flags must survive a failed fetch"
         );
     }

--- a/crates/bitwarden-core/src/client/test_accounts.rs
+++ b/crates/bitwarden-core/src/client/test_accounts.rs
@@ -43,14 +43,6 @@ impl Client {
         let client = Client::new_test(None);
 
         client
-            .flags()
-            .load(HashMap::from([(
-                "enableCipherKeyEncryption".to_owned(),
-                true,
-            )]))
-            .await;
-
-        client
             .crypto()
             .initialize_user_crypto(account.user)
             .await

--- a/crates/bitwarden-fido/src/authenticator.rs
+++ b/crates/bitwarden-fido/src/authenticator.rs
@@ -497,8 +497,7 @@ impl passkey::authenticator::CredentialStore for CredentialStoreImpl<'_> {
                 .client
                 .vault()
                 .ciphers()
-                .encrypt(selected)
-                .await?;
+                .encrypt(selected)?;
 
             this.authenticator
                 .credential_store
@@ -572,8 +571,7 @@ impl passkey::authenticator::CredentialStore for CredentialStoreImpl<'_> {
                 .client
                 .vault()
                 .ciphers()
-                .encrypt(selected)
-                .await?;
+                .encrypt(selected)?;
 
             this.authenticator
                 .credential_store

--- a/crates/bitwarden-uniffi/src/vault/ciphers.rs
+++ b/crates/bitwarden-uniffi/src/vault/ciphers.rs
@@ -14,8 +14,8 @@ pub struct CiphersClient(pub(crate) bitwarden_vault::CiphersClient);
 #[uniffi::export(async_runtime = "tokio")]
 impl CiphersClient {
     /// Encrypt cipher
-    pub async fn encrypt(&self, cipher_view: CipherView) -> Result<EncryptionContext> {
-        Ok(self.0.encrypt(cipher_view).await?)
+    pub fn encrypt(&self, cipher_view: CipherView) -> Result<EncryptionContext> {
+        Ok(self.0.encrypt(cipher_view)?)
     }
 
     /// Decrypt cipher

--- a/crates/bitwarden-vault/src/cipher/cipher_client/admin/create.rs
+++ b/crates/bitwarden-vault/src/cipher/cipher_client/admin/create.rs
@@ -112,12 +112,10 @@ impl CipherAdminClient {
 
         let mut view: CipherView = convert_request_to_cipher_view(request);
 
-        // TODO: Once this flag is removed, the key generation logic should
-        // be moved directly into the CompositeEncryptable implementation.
-        if self.client.flags().get().await.enable_cipher_key_encryption {
-            let key = view.key_identifier();
-            view.generate_cipher_key(&mut key_store.context(), key)?;
-        }
+        // TODO: The key generation logic should be moved directly into the
+        // CompositeEncryptable implementation.
+        let key = view.key_identifier();
+        view.generate_cipher_key(&mut key_store.context(), key)?;
 
         let use_blob = should_use_blob_encryption(&key_store.context(), view.organization_id);
 

--- a/crates/bitwarden-vault/src/cipher/cipher_client/admin/edit.rs
+++ b/crates/bitwarden-vault/src/cipher/cipher_client/admin/edit.rs
@@ -53,9 +53,9 @@ impl<T> From<bitwarden_api_api::apis::Error<T>> for EditCipherAdminError {
     }
 }
 
-// `use_strict_decryption`, `enable_cipher_key_encryption`, and `use_blob` are
-// short-lived feature-rollout flags that will be removed once their migrations
-// complete, at which point the argument count drops back under the limit.
+// `use_strict_decryption` and `use_blob` are short-lived feature-rollout flags
+// that will be removed once their migrations complete, at which point the
+// argument count drops back under the limit.
 #[allow(clippy::too_many_arguments)]
 async fn edit_cipher(
     key_store: &KeyStore<KeySlotIds>,
@@ -64,7 +64,6 @@ async fn edit_cipher(
     original_cipher_view: CipherView,
     request: CipherEditRequest,
     use_strict_decryption: bool,
-    enable_cipher_key_encryption: bool,
     use_blob: bool,
 ) -> Result<CipherView, EditCipherAdminError> {
     let cipher_id = request.id;
@@ -76,9 +75,9 @@ async fn edit_cipher(
     let mut view: CipherView = convert_request_to_cipher_view(request);
     view.update_password_history(&original_cipher_view);
 
-    // TODO: Once this flag is removed, the key generation logic should be
-    // moved directly into the CompositeEncryptable implementation.
-    if view.key.is_none() && enable_cipher_key_encryption {
+    // TODO: The key generation logic should be moved directly into the
+    // CompositeEncryptable implementation.
+    if view.key.is_none() {
         let key = view.key_identifier();
         view.generate_cipher_key(&mut key_store.context(), key)?;
     }
@@ -167,9 +166,6 @@ impl CipherAdminClient {
             .get_user_id()
             .ok_or(NotAuthenticatedError)?;
 
-        let enable_cipher_key_encryption =
-            self.client.flags().get().await.enable_cipher_key_encryption;
-
         let use_blob = should_use_blob_encryption(&key_store.context(), request.organization_id);
 
         edit_cipher(
@@ -179,7 +175,6 @@ impl CipherAdminClient {
             original_cipher_view,
             request,
             self.is_strict_decrypt().await,
-            enable_cipher_key_encryption,
             use_blob,
         )
         .await
@@ -327,7 +322,6 @@ mod tests {
             request,
             false,
             false,
-            false,
         )
         .await
         .unwrap();
@@ -383,7 +377,6 @@ mod tests {
             original_cipher_view,
             request,
             false,
-            false,
             true, // use_blob
         )
         .await
@@ -417,7 +410,6 @@ mod tests {
             TEST_USER_ID.parse().unwrap(),
             orig_cipher_view,
             request,
-            false,
             false,
             false,
         )

--- a/crates/bitwarden-vault/src/cipher/cipher_client/create.rs
+++ b/crates/bitwarden-vault/src/cipher/cipher_client/create.rs
@@ -179,12 +179,10 @@ impl CiphersClient {
 
         let mut view: CipherView = convert_request_to_cipher_view(request);
 
-        // TODO: Once this flag is removed, the key generation logic should
-        // be moved directly into the CompositeEncryptable implementation.
-        if self.client.flags().get().await.enable_cipher_key_encryption {
-            let key = view.key_identifier();
-            view.generate_cipher_key(&mut key_store.context(), key)?;
-        }
+        // TODO: The key generation logic should be moved directly into the
+        // CompositeEncryptable implementation.
+        let key = view.key_identifier();
+        view.generate_cipher_key(&mut key_store.context(), key)?;
 
         let use_blob = self.should_use_blob_encryption(view.organization_id);
 

--- a/crates/bitwarden-vault/src/cipher/cipher_client/edit.rs
+++ b/crates/bitwarden-vault/src/cipher/cipher_client/edit.rs
@@ -165,9 +165,9 @@ pub(crate) fn convert_request_to_cipher_view(r: CipherEditRequest) -> CipherView
     }
 }
 
-// `use_strict_decryption`, `enable_cipher_key_encryption`, and `use_blob` are
-// short-lived feature-rollout flags that will be removed once their migrations
-// complete, at which point the argument count drops back under the limit.
+// `use_strict_decryption` and `use_blob` are short-lived feature-rollout flags
+// that will be removed once their migrations complete, at which point the
+// argument count drops back under the limit.
 #[allow(clippy::too_many_arguments)]
 async fn edit_cipher<R: Repository<Cipher> + ?Sized>(
     key_store: &KeyStore<KeySlotIds>,
@@ -176,7 +176,6 @@ async fn edit_cipher<R: Repository<Cipher> + ?Sized>(
     encrypted_for: UserId,
     request: CipherEditRequest,
     use_strict_decryption: bool,
-    enable_cipher_key_encryption: bool,
     use_blob: bool,
 ) -> Result<CipherView, EditCipherError> {
     let cipher_id = request.id;
@@ -191,9 +190,9 @@ async fn edit_cipher<R: Repository<Cipher> + ?Sized>(
     let mut view: CipherView = convert_request_to_cipher_view(request);
     view.update_password_history(&original_cipher_view);
 
-    // TODO: Once this flag is removed, the key generation logic should be
-    // moved directly into the CompositeEncryptable implementation.
-    if view.key.is_none() && enable_cipher_key_encryption {
+    // TODO: The key generation logic should be moved directly into the
+    // CompositeEncryptable implementation.
+    if view.key.is_none() {
         let key = view.key_identifier();
         view.generate_cipher_key(&mut key_store.context(), key)?;
     }
@@ -273,9 +272,6 @@ impl CiphersClient {
             .get_user_id()
             .ok_or(NotAuthenticatedError)?;
 
-        let enable_cipher_key_encryption =
-            self.client.flags().get().await.enable_cipher_key_encryption;
-
         let use_blob = self.should_use_blob_encryption(request.organization_id);
 
         edit_cipher(
@@ -285,7 +281,6 @@ impl CiphersClient {
             user_id,
             request,
             self.is_strict_decrypt().await,
-            enable_cipher_key_encryption,
             use_blob,
         )
         .await
@@ -564,7 +559,6 @@ mod tests {
             request,
             false,
             false,
-            false,
         )
         .await
         .unwrap();
@@ -704,7 +698,6 @@ mod tests {
             request,
             false,
             false,
-            false,
         )
         .await;
 
@@ -745,7 +738,6 @@ mod tests {
             &repository,
             TEST_USER_ID.parse().unwrap(),
             request,
-            false,
             false,
             false,
         )

--- a/crates/bitwarden-vault/src/cipher/cipher_client/mod.rs
+++ b/crates/bitwarden-vault/src/cipher/cipher_client/mod.rs
@@ -83,10 +83,7 @@ impl CiphersClient {
     }
 
     #[allow(missing_docs)]
-    pub async fn encrypt(
-        &self,
-        mut cipher_view: CipherView,
-    ) -> Result<EncryptionContext, EncryptError> {
+    pub fn encrypt(&self, mut cipher_view: CipherView) -> Result<EncryptionContext, EncryptError> {
         let user_id = self
             .client
             .internal
@@ -94,10 +91,9 @@ impl CiphersClient {
             .ok_or(EncryptError::MissingUserId)?;
         let key_store = self.client.internal.get_key_store();
 
-        // TODO: Once this flag is removed, the key generation logic should
-        // be moved directly into the KeyEncryptable implementation
-        if cipher_view.key.is_none() && self.client.flags().get().await.enable_cipher_key_encryption
-        {
+        // TODO: The key generation logic should be moved directly into the
+        // KeyEncryptable implementation
+        if cipher_view.key.is_none() {
             let key = cipher_view.key_identifier();
             cipher_view.generate_cipher_key(&mut key_store.context(), key)?;
         }
@@ -121,11 +117,9 @@ impl CiphersClient {
     /// symmetric key in base64 format. See PM-23084
     ///
     /// If the cipher has a CipherKey, it will be re-encrypted with the new key.
-    /// If the cipher does not have a CipherKey and CipherKeyEncryption is enabled, one will be
-    /// generated using the new key. Otherwise, the cipher's data will be encrypted with the new
-    /// key directly.
+    /// If the cipher does not have a CipherKey, one will be generated using the new key.
     #[cfg(feature = "wasm")]
-    pub async fn encrypt_cipher_for_rotation(
+    pub fn encrypt_cipher_for_rotation(
         &self,
         mut cipher_view: CipherView,
         new_key: B64,
@@ -137,8 +131,6 @@ impl CiphersClient {
             .internal
             .get_user_id()
             .ok_or(EncryptError::MissingUserId)?;
-        let enable_cipher_key_encryption =
-            self.client.flags().get().await.enable_cipher_key_encryption;
 
         let key_store = self.client.internal.get_key_store();
         let mut ctx = key_store.context();
@@ -146,7 +138,7 @@ impl CiphersClient {
         // Set the new key in the key store context
         let new_key_id = ctx.add_local_symmetric_key(new_key);
 
-        if cipher_view.key.is_none() && enable_cipher_key_encryption {
+        if cipher_view.key.is_none() {
             cipher_view.generate_cipher_key(&mut ctx, new_key_id)?;
         } else {
             cipher_view.reencrypt_cipher_keys(&mut ctx, new_key_id)?;
@@ -173,7 +165,7 @@ impl CiphersClient {
     /// This method attempts to encrypt all ciphers in the list. If any cipher
     /// fails to encrypt, the entire operation fails and an error is returned.
     #[cfg(feature = "wasm")]
-    pub async fn encrypt_list(
+    pub fn encrypt_list(
         &self,
         cipher_views: Vec<CipherView>,
     ) -> Result<Vec<EncryptionContext>, EncryptError> {
@@ -183,14 +175,13 @@ impl CiphersClient {
             .get_user_id()
             .ok_or(EncryptError::MissingUserId)?;
         let key_store = self.client.internal.get_key_store();
-        let enable_cipher_key = self.client.flags().get().await.enable_cipher_key_encryption;
 
         let mut ctx = key_store.context();
 
         let prepared_modes: Vec<EncryptMode<CipherView>> = cipher_views
             .into_iter()
             .map(|mut cv| {
-                if cv.key.is_none() && enable_cipher_key {
+                if cv.key.is_none() {
                     let key = cv.key_identifier();
                     cv.generate_cipher_key(&mut ctx, key)?;
                 }
@@ -613,7 +604,7 @@ mod tests {
         let EncryptionContext {
             cipher: new_cipher,
             encrypted_for: _,
-        } = client.vault().ciphers().encrypt(view).await.unwrap();
+        } = client.vault().ciphers().encrypt(view).unwrap();
         assert!(new_cipher.key.is_some());
 
         let view = client.vault().ciphers().decrypt(new_cipher).await.unwrap();
@@ -660,7 +651,7 @@ mod tests {
         let EncryptionContext {
             cipher: new_cipher,
             encrypted_for: _,
-        } = client.vault().ciphers().encrypt(view).await.unwrap();
+        } = client.vault().ciphers().encrypt(view).unwrap();
         assert!(new_cipher.key.is_some());
 
         // The stored (wrapped) attachment key changed: it is now protected by the cipher key
@@ -714,7 +705,7 @@ mod tests {
         let EncryptionContext {
             cipher: new_cipher,
             encrypted_for: _,
-        } = client.vault().ciphers().encrypt(new_view).await.unwrap();
+        } = client.vault().ciphers().encrypt(new_view).unwrap();
 
         // The stored key remains present after the move. Its wrapped bytes are not compared: the
         // attachment key is re-wrapped (with a fresh IV) on every encryption, so the ciphertext
@@ -823,7 +814,6 @@ mod tests {
             .vault()
             .ciphers()
             .encrypt_cipher_for_rotation(cipher_view, new_key_b64)
-            .await
             .unwrap();
 
         assert!(ctx.cipher.key.is_some());
@@ -842,7 +832,7 @@ mod tests {
 
         let cipher_views = vec![test_cipher_view(), test_cipher_view()];
 
-        let result = client.vault().ciphers().encrypt_list(cipher_views).await;
+        let result = client.vault().ciphers().encrypt_list(cipher_views);
 
         assert!(result.is_ok());
         let contexts = result.unwrap();
@@ -859,7 +849,7 @@ mod tests {
     async fn test_encrypt_list_empty() {
         let client = Client::init_test_account(test_bitwarden_com_account()).await;
 
-        let result = client.vault().ciphers().encrypt_list(vec![]).await;
+        let result = client.vault().ciphers().encrypt_list(vec![]);
 
         assert!(result.is_ok());
         assert!(result.unwrap().is_empty());
@@ -877,7 +867,6 @@ mod tests {
             .vault()
             .ciphers()
             .encrypt_list(original_views)
-            .await
             .unwrap();
 
         // Decrypt each cipher and verify the name matches
@@ -900,12 +889,7 @@ mod tests {
         let expected_user_id = client.internal.get_user_id().unwrap();
 
         let cipher_views = vec![test_cipher_view(), test_cipher_view(), test_cipher_view()];
-        let contexts = client
-            .vault()
-            .ciphers()
-            .encrypt_list(cipher_views)
-            .await
-            .unwrap();
+        let contexts = client.vault().ciphers().encrypt_list(cipher_views).unwrap();
 
         for ctx in contexts {
             assert_eq!(ctx.encrypted_for, expected_user_id);
@@ -963,7 +947,6 @@ mod tests {
             .vault()
             .ciphers()
             .encrypt(test_cipher_view())
-            .await
             .unwrap();
 
         assert!(try_parse_blob(&ctx.cipher).is_some());
@@ -989,7 +972,6 @@ mod tests {
             .vault()
             .ciphers()
             .encrypt_list(vec![personal_view, org_view])
-            .await
             .unwrap();
 
         assert_eq!(contexts.len(), 2);
@@ -1021,7 +1003,6 @@ mod tests {
             .vault()
             .ciphers()
             .encrypt_cipher_for_rotation(test_cipher_view(), new_key_b64)
-            .await
             .unwrap();
 
         assert!(try_parse_blob(&ctx.cipher).is_some());

--- a/crates/bitwarden-vault/src/cipher/cipher_client/share_cipher.rs
+++ b/crates/bitwarden-vault/src/cipher/cipher_client/share_cipher.rs
@@ -195,7 +195,7 @@ impl CiphersClient {
         self.update_password_history(&mut cipher_view, original_cipher_view)
             .await?;
 
-        let encrypted_cipher = self.encrypt(cipher_view).await?;
+        let encrypted_cipher = self.encrypt(cipher_view)?;
 
         let api_client = &self.client.internal.get_api_configurations().api_client;
 
@@ -240,7 +240,7 @@ impl CiphersClient {
                 collection_ids.clone(),
             )?;
             self.update_password_history(&mut cv, None).await?;
-            encrypted_ciphers.push(self.encrypt(cv).await?);
+            encrypted_ciphers.push(self.encrypt(cv)?);
         }
         Ok(encrypted_ciphers)
     }
@@ -486,7 +486,7 @@ mod tests {
         cipher_view_2.organization_id = Some(TEST_ORG_ID.parse().unwrap());
 
         // Encrypt and store cipher_view_1 in repository for password history lookup
-        let encrypted_1 = cipher_client.encrypt(cipher_view_1.clone()).await.unwrap();
+        let encrypted_1 = cipher_client.encrypt(cipher_view_1.clone()).unwrap();
         let repository = cipher_client.get_repository().unwrap();
         repository
             .set(TEST_CIPHER_ID.parse().unwrap(), encrypted_1.cipher.clone())
@@ -814,14 +814,6 @@ mod tests {
 
         let client = Client::new_test(Some(settings));
 
-        client
-            .flags()
-            .load(std::collections::HashMap::from([(
-                "enableCipherKeyEncryption".to_owned(),
-                true,
-            )]))
-            .await;
-
         let user_request = InitUserCryptoRequest {
             user_id: Some(UserId::new(uuid::uuid!("060000fb-0922-4dd3-b170-6e15cb5df8c8"))),
             kdf_params: Kdf::PBKDF2 {
@@ -931,11 +923,7 @@ mod tests {
         repository
             .set(
                 TEST_CIPHER_ID.parse().unwrap(),
-                cipher_client
-                    .encrypt(original.clone())
-                    .await
-                    .unwrap()
-                    .cipher,
+                cipher_client.encrypt(original.clone()).unwrap().cipher,
             )
             .await
             .unwrap();
@@ -1045,7 +1033,7 @@ mod tests {
         let repository = std::sync::Arc::new(MemoryRepository::<Cipher>::default());
         let cipher_client = client.vault().ciphers();
 
-        let encrypted_original1 = cipher_client.encrypt(cipher_view1.clone()).await.unwrap();
+        let encrypted_original1 = cipher_client.encrypt(cipher_view1.clone()).unwrap();
         repository
             .set(
                 encrypted_original1.cipher.id.unwrap(),
@@ -1054,7 +1042,7 @@ mod tests {
             .await
             .unwrap();
 
-        let encrypted_original2 = cipher_client.encrypt(cipher_view2.clone()).await.unwrap();
+        let encrypted_original2 = cipher_client.encrypt(cipher_view2.clone()).unwrap();
         repository
             .set(
                 encrypted_original2.cipher.id.unwrap(),


### PR DESCRIPTION
Cipher-keys work in production. We need to simplify the logic around them, because it is getting hard to reason about under which condition they are enabled. This unconditionally enables them in all places where we trigger logic based on them.

We should make a follow-up in a few releases to reject all non-cipherkeyciphers on posting updates to the server.