### PR TITLE
Support full-object encodedJson input on Send create and edit

### DIFF
--- a/crates/bw/src/tools/send.rs
+++ b/crates/bw/src/tools/send.rs
@@ -6,12 +6,16 @@
 //! (which is part of the user contract) stays close to the rest of the
 //! `tools` family.
 
-use std::path::PathBuf;
+use std::{
+    io::{IsTerminal as _, Read as _},
+    path::PathBuf,
+};
 
+use base64::{Engine as _, engine::general_purpose::STANDARD};
 use bitwarden_pm::PasswordManagerClient;
 use bitwarden_send::{
     AuthEdit, SendAddRequest, SendAuthType, SendEditRequest, SendFileView, SendId, SendTextView,
-    SendViewType,
+    SendType, SendView, SendViewType,
 };
 use chrono::{Duration, Utc};
 use clap::{
@@ -278,29 +282,35 @@ impl BwCommand for SendArgs {
                 let LoggedIn { user, .. } = LoggedIn::try_from(ctx)?;
                 create_shortcut(&user, self).await
             }
-            // `encoded_json` is intentionally pre-empted *before* `dispatch` extracts
-            // `LoggedIn`. The integration tests in `tests/send.rs` assert that supplying
-            // `encoded_json` to `create`/`edit` returns the "not yet implemented" error
-            // even when the caller is logged out — that signals the input is unsupported
-            // rather than burying it behind a confusing auth error.
-            Some(SendCommands::Create(args)) if args.encoded_json.is_some() => Err(eyre!(
-                "`encoded_json` input on `bw send create` is not yet implemented (tracked under PM-39240)."
-            )),
-            Some(SendCommands::Edit(args)) if args.encoded_json.is_some() => Err(eyre!(
-                "`encoded_json` input on `bw send edit` is not yet implemented (tracked under PM-39240)."
-            )),
-            // `--output` on `get` similarly fails before the auth check: silently
-            // emitting JSON to stdout while the requested file path goes uncreated would
-            // be a worse UX than an explicit "not implemented" error.
+            // `--output` on `get` fails before the auth check: silently emitting JSON to
+            // stdout while the requested file path goes uncreated would be a worse UX than
+            // an explicit "not implemented" error.
             Some(SendCommands::Get(args)) if args.output_path.is_some() => Err(eyre!(
                 "`--output` on `bw send get` is not yet implemented (tracked under PM-39238)."
             )),
+            // `create`/`edit` resolve and parse their full-object JSON input *before*
+            // extracting `LoggedIn`, so malformed input surfaces a clear parse error rather
+            // than a confusing "not logged in" message (the integration tests assert this
+            // ordering). Input comes from the positional `encoded_json` or, when absent and
+            // stdin is piped, from stdin.
+            Some(SendCommands::Create(args)) => {
+                let json = read_encoded_json_input(args.encoded_json.clone())?
+                    .map(|raw| parse_encoded_send_view(&raw))
+                    .transpose()?;
+                let LoggedIn { user, .. } = LoggedIn::try_from(ctx)?;
+                dispatch_create(&user, args, json).await
+            }
+            Some(SendCommands::Edit(args)) => {
+                let json = read_encoded_json_input(args.encoded_json.clone())?
+                    .map(|raw| parse_encoded_send_view(&raw))
+                    .transpose()?;
+                let LoggedIn { user, .. } = LoggedIn::try_from(ctx)?;
+                dispatch_edit(&user, args, json).await
+            }
             Some(SendCommands::List(args)) => args.dispatch(ctx).await,
             Some(SendCommands::Template(args)) => args.dispatch(ctx).await,
             Some(SendCommands::Get(args)) => args.dispatch(ctx).await,
             Some(SendCommands::Receive(args)) => args.dispatch(ctx).await,
-            Some(SendCommands::Create(args)) => args.dispatch(ctx).await,
-            Some(SendCommands::Edit(args)) => args.dispatch(ctx).await,
             Some(SendCommands::RemovePassword(args)) => args.dispatch(ctx).await,
             Some(SendCommands::Delete(args)) => args.dispatch(ctx).await,
         }
@@ -351,79 +361,96 @@ impl BwCommand for SendReceiveArgs {
     }
 }
 
-impl BwCommand for SendCreateArgs {
-    type Client = LoggedIn;
+/// Run `bw send create`, either from a full-object `SendView` (`json`) or from the
+/// individual CLI flags. The JSON input, when present, has already been resolved and parsed
+/// in [`SendArgs::run`] so parse errors surface before the auth check.
+async fn dispatch_create(
+    user: &PasswordManagerClient,
+    args: SendCreateArgs,
+    json: Option<SendView>,
+) -> CommandResult {
+    let SendCreateArgs {
+        encoded_json: _,
+        file,
+        text,
+        delete_in_days,
+        max_access_count,
+        hidden,
+        name,
+        notes,
+        password,
+        emails,
+        full_object,
+    } = args;
 
-    async fn run(self, LoggedIn { user, .. }: LoggedIn) -> CommandResult {
-        // The `encoded_json` early-error gate lives in [`SendArgs::run`] above so it can
-        // fire *before* the `LoggedIn` typestate extractor. Encoded-JSON support is PM-39240.
-        let SendCreateArgs {
-            encoded_json: _,
-            file,
-            text,
-            delete_in_days,
-            max_access_count,
-            hidden,
-            name,
-            notes,
-            password,
-            emails,
-            full_object,
-        } = self;
-
-        let request = build_create_request(CreateInputs {
-            file,
-            text,
-            delete_in_days,
-            max_access_count,
-            hidden,
-            name,
-            notes,
-            password,
-            emails,
-        })?;
-
-        run_create(&user, request, full_object).await
-    }
-}
-
-impl BwCommand for SendEditArgs {
-    type Client = LoggedIn;
-
-    async fn run(self, LoggedIn { user, .. }: LoggedIn) -> CommandResult {
-        // The `encoded_json` early-error gate lives in [`SendArgs::run`] above so it can
-        // fire *before* the `LoggedIn` typestate extractor. Encoded-JSON support is PM-39240.
-        let SendEditArgs {
-            encoded_json: _,
-            itemid,
-            delete_in_days,
-            max_access_count,
-            hidden,
-            password,
-            emails,
-        } = self;
-
-        let send_id = itemid.ok_or_else(|| {
-            eyre!("--itemid is required (or provide it via encoded JSON; see PM-39240).")
-        })?;
-
-        // PM-39240: support full-object JSON input and reject text↔file type changes on edit.
-        let existing = user.sends().get(send_id).await?;
-
-        let request = build_edit_request(
-            existing,
-            EditOverrides {
-                delete_in_days,
+    let request = match json {
+        Some(view) => build_create_request_from_view(
+            view,
+            CreateOverrides {
+                name,
+                notes,
                 max_access_count,
                 hidden,
                 password,
                 emails,
             },
-        )?;
+        )?,
+        None => build_create_request(CreateInputs {
+            file,
+            text,
+            delete_in_days,
+            max_access_count,
+            hidden,
+            name,
+            notes,
+            password,
+            emails,
+        })?,
+    };
 
-        let view = user.sends().edit(send_id, request).await?;
-        Ok(CommandOutput::Object(Box::new(view)))
-    }
+    run_create(user, request, full_object).await
+}
+
+/// Run `bw send edit`, either merging a full-object `SendView` (`json`) into the existing
+/// server row or applying the individual CLI-flag overrides. The JSON input, when present,
+/// has already been resolved and parsed in [`SendArgs::run`].
+async fn dispatch_edit(
+    user: &PasswordManagerClient,
+    args: SendEditArgs,
+    json: Option<SendView>,
+) -> CommandResult {
+    let SendEditArgs {
+        encoded_json: _,
+        itemid,
+        delete_in_days,
+        max_access_count,
+        hidden,
+        password,
+        emails,
+    } = args;
+
+    // `--itemid` overrides the `id` carried in the JSON object (legacy precedence); fall back
+    // to the JSON object's own `id` when the flag is absent.
+    let send_id = itemid
+        .or_else(|| json.as_ref().and_then(|v| v.id))
+        .ok_or_else(|| eyre!("--itemid is required (or provide `id` in the encoded JSON)."))?;
+
+    let existing = user.sends().get(send_id).await?;
+
+    let overrides = EditOverrides {
+        delete_in_days,
+        max_access_count,
+        hidden,
+        password,
+        emails,
+    };
+    let request = match json {
+        Some(req) => build_edit_request_from_json(existing, req, overrides)?,
+        None => build_edit_request(existing, overrides)?,
+    };
+
+    let view = user.sends().edit(send_id, request).await?;
+    Ok(CommandOutput::Object(Box::new(view)))
 }
 
 impl BwCommand for SendRemovePasswordArgs {
@@ -505,6 +532,46 @@ struct SendFileTemplate {
 #[serde(rename_all = "camelCase")]
 struct SendFileTemplateBody {
     file_name: String,
+}
+
+/// Resolve the raw full-object JSON input for `create`/`edit`.
+///
+/// Precedence mirrors the legacy CLI: an explicit positional argument wins; otherwise, when
+/// stdin is piped (not an interactive terminal), read it. When stdin is a TTY and no
+/// positional was given, there is no JSON input and the flag-only path runs. The `is_terminal`
+/// guard is what keeps an interactive shell (and the test harness, which doesn't pipe stdin)
+/// from blocking on a read.
+fn read_encoded_json_input(positional: Option<String>) -> color_eyre::eyre::Result<Option<String>> {
+    if let Some(raw) = positional {
+        return Ok(Some(raw));
+    }
+    if std::io::stdin().is_terminal() {
+        return Ok(None);
+    }
+    let mut buf = String::new();
+    std::io::stdin().read_to_string(&mut buf)?;
+    if buf.trim().is_empty() {
+        return Ok(None);
+    }
+    Ok(Some(buf))
+}
+
+/// Decode and parse the full-object JSON input into a [`SendView`].
+///
+/// The input may be base64-encoded JSON (legacy CLI behavior) or raw JSON (this CLI's
+/// convenience). We try base64 → UTF-8 → JSON first and fall back to parsing the original
+/// string as JSON if any step fails. Real JSON text starts with `{` and contains characters
+/// outside the base64 alphabet, so the base64 attempt fails fast on raw JSON and the fallback
+/// is taken — no explicit disambiguation is needed.
+fn parse_encoded_send_view(raw: &str) -> color_eyre::eyre::Result<SendView> {
+    if let Ok(decoded) = STANDARD.decode(raw.trim())
+        && let Ok(text) = std::str::from_utf8(&decoded)
+        && let Ok(view) = serde_json::from_str::<SendView>(text)
+    {
+        return Ok(view);
+    }
+
+    serde_json::from_str::<SendView>(raw).wrap_err("Error parsing the encoded request data.")
 }
 
 struct CreateInputs {
@@ -589,6 +656,88 @@ fn build_create_request(inputs: CreateInputs) -> color_eyre::eyre::Result<SendAd
     })
 }
 
+/// CLI-flag overrides applied on top of a full-object JSON `create`.
+struct CreateOverrides {
+    name: Option<String>,
+    notes: Option<String>,
+    max_access_count: Option<u32>,
+    hidden: bool,
+    password: Option<String>,
+    emails: Option<String>,
+}
+
+/// Build a create request from a full-object [`SendView`] (the `encoded_json` path).
+///
+/// This builds the [`SendAddRequest`] directly from the parsed view rather than routing
+/// through [`CreateInputs`]/[`build_create_request`]: `CreateInputs` is flag-shaped (a
+/// relative `--deleteInDays`, a file *path*) and cannot represent the absolute `deletionDate`,
+/// `expirationDate`, `disabled`, or `hideEmail` a full JSON object carries. The JSON object is
+/// authoritative; a CLI flag, when explicitly provided, overrides the corresponding field.
+fn build_create_request_from_view(
+    view: SendView,
+    overrides: CreateOverrides,
+) -> color_eyre::eyre::Result<SendAddRequest> {
+    let CreateOverrides {
+        name,
+        notes,
+        max_access_count,
+        hidden,
+        password,
+        emails,
+    } = overrides;
+
+    let view_type = match view.r#type {
+        SendType::Text => {
+            let text = view.text.unwrap_or(SendTextView {
+                text: None,
+                hidden: false,
+            });
+            SendViewType::Text(SendTextView {
+                text: text.text,
+                hidden: text.hidden || hidden,
+            })
+        }
+        SendType::File => {
+            // Creating a file Send needs the local file bytes to encrypt and upload; a JSON
+            // object only carries the file name, so this can't be supported without a local
+            // `--file <path>`. (File-send creation over the Rust CLI is tracked under PM-39238
+            // regardless of input source.)
+            return Err(eyre!(
+                "Creating file Sends from JSON is not supported: the CLI needs a local file path \
+                 to read and encrypt the contents. Use `--file <path>` instead (file-send \
+                 creation is tracked under PM-39238)."
+            ));
+        }
+    };
+
+    let resolved_name = name.unwrap_or(view.name);
+    if resolved_name.is_empty() {
+        return Err(eyre!("--name is required for text Sends."));
+    }
+
+    // Auth precedence: CLI `--password`/`--emails` win as a unit; otherwise fall back to the
+    // auth carried in the JSON object (`newPassword` / `emails`).
+    let (password, emails) = if password.is_some() || emails.is_some() {
+        (password, emails)
+    } else {
+        let json_emails = (!view.emails.is_empty()).then(|| view.emails.join(","));
+        (view.new_password, json_emails)
+    };
+    let auth = build_auth(password, emails.as_deref())?;
+
+    Ok(SendAddRequest {
+        name: resolved_name,
+        notes: notes.or(view.notes),
+        view_type,
+        max_access_count: max_access_count.or(view.max_access_count),
+        disabled: view.disabled,
+        hide_email: view.hide_email,
+        deletion_date: view.deletion_date,
+        expiration_date: view.expiration_date,
+        auth,
+    })
+}
+
 struct EditOverrides {
     delete_in_days: Option<u64>,
     max_access_count: Option<u32>,
@@ -645,6 +794,83 @@ fn build_edit_request(
         hide_email: existing.hide_email,
         deletion_date,
         expiration_date: existing.expiration_date,
+        auth,
+    })
+}
+
+/// Build an edit request by merging a full-object [`SendView`] (`req`) over the existing
+/// server row, replicating the legacy CLI's precedence.
+///
+/// Unlike the flag-only [`build_edit_request`], the JSON object is a *full replace*, not a
+/// sparse patch: every JSON-owned field (`name`, `notes`, `disabled`, `hideEmail`,
+/// `expirationDate`, `text`/`file`, ...) unconditionally overwrites the existing value, so a
+/// field absent from the JSON is cleared — matching legacy's documented "fetch the full
+/// object, edit it, resubmit the whole thing" workflow.
+///
+/// Precedence exceptions: `--deleteInDays`, `--maxAccessCount`, `--password`, and `--emails`
+/// CLI flags win over the JSON field when explicitly provided (`flag > JSON > existing`), and
+/// auth falls back to `AuthEdit::Preserve` when neither a flag nor the JSON supplies one — so
+/// a resubmit never silently strips a previously configured password/email gate.
+fn build_edit_request_from_json(
+    existing: SendView,
+    req: SendView,
+    overrides: EditOverrides,
+) -> color_eyre::eyre::Result<SendEditRequest> {
+    let EditOverrides {
+        delete_in_days,
+        max_access_count,
+        hidden,
+        password,
+        emails,
+    } = overrides;
+
+    // A Send's type is immutable. Legacy rejects a type change before any encryption/API call;
+    // do the same so the user gets a clear error rather than a server rejection.
+    if req.r#type != existing.r#type {
+        return Err(eyre!("Cannot change a Send's type."));
+    }
+
+    let view_type = match req.r#type {
+        SendType::Text => {
+            let text = req.text.unwrap_or(SendTextView {
+                text: None,
+                hidden: false,
+            });
+            SendViewType::Text(SendTextView {
+                text: text.text,
+                hidden: text.hidden || hidden,
+            })
+        }
+        SendType::File => SendViewType::File(req.file.ok_or_else(|| {
+            eyre!("JSON declares a file Send (type 1) but is missing the `file` object.")
+        })?),
+    };
+
+    let deletion_date = match delete_in_days {
+        Some(d) => compute_deletion_date(d)?,
+        None => req.deletion_date,
+    };
+
+    // Auth precedence: CLI flag > JSON field > preserve existing. Routing through
+    // `build_auth_for_edit` keeps the preserve-by-default fix — `(None, None)` resolves to
+    // `AuthEdit::Preserve`, never a silent auth strip.
+    let (password, emails) = if password.is_some() || emails.is_some() {
+        (password, emails)
+    } else {
+        let json_emails = (!req.emails.is_empty()).then(|| req.emails.join(","));
+        (req.new_password, json_emails)
+    };
+    let auth = build_auth_for_edit(password, emails.as_deref())?;
+
+    Ok(SendEditRequest {
+        name: req.name,
+        notes: req.notes,
+        view_type,
+        max_access_count: max_access_count.or(req.max_access_count),
+        disabled: req.disabled,
+        hide_email: req.hide_email,
+        deletion_date,
+        expiration_date: req.expiration_date,
         auth,
     })
 }
@@ -1474,5 +1700,290 @@ mod tests {
         )
         .unwrap_err();
         assert!(err.to_string().contains("mutually exclusive"));
+    }
+
+    // ---- encoded_json parsing ----
+
+    /// A full-object text `SendView` in raw JSON, matching `bw send get`/`create --fullObject`
+    /// output.
+    const RAW_TEXT_SEND_JSON: &str = r#"{"name":"My Send","hasPassword":false,"type":0,"text":{"text":"hello","hidden":false},"accessCount":0,"disabled":false,"hideEmail":false,"revisionDate":"2025-01-01T00:00:00Z","deletionDate":"2030-01-01T00:00:00Z","emails":[],"authType":2}"#;
+
+    /// The "accept both transparently" decision: raw JSON and base64-of-JSON must parse to the
+    /// same `SendView`.
+    #[test]
+    fn parse_encoded_send_view_accepts_raw_and_base64_equivalently() {
+        let from_raw = parse_encoded_send_view(RAW_TEXT_SEND_JSON).unwrap();
+        let b64 = STANDARD.encode(RAW_TEXT_SEND_JSON);
+        let from_b64 = parse_encoded_send_view(&b64).unwrap();
+        assert_eq!(from_raw, from_b64);
+        assert_eq!(from_raw.name, "My Send");
+        assert_eq!(from_raw.r#type, SendType::Text);
+    }
+
+    #[test]
+    fn parse_encoded_send_view_rejects_garbage() {
+        let err = parse_encoded_send_view("!!!not-base64-and-not-json!!!").unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("Error parsing the encoded request data")
+        );
+    }
+
+    // ---- build_create_request_from_view ----
+
+    fn make_text_json(name: &str, notes: Option<&str>, hidden: bool, max: Option<u32>) -> SendView {
+        SendView {
+            id: None,
+            access_id: None,
+            name: name.to_string(),
+            notes: notes.map(String::from),
+            key: None,
+            new_password: None,
+            has_password: false,
+            r#type: SendType::Text,
+            file: None,
+            text: Some(SendTextView {
+                text: Some("body".to_string()),
+                hidden,
+            }),
+            max_access_count: max,
+            access_count: 0,
+            disabled: false,
+            hide_email: false,
+            revision_date: "2025-01-01T00:00:00Z".parse().unwrap(),
+            deletion_date: "2030-06-01T00:00:00Z".parse().unwrap(),
+            expiration_date: None,
+            emails: Vec::new(),
+            auth_type: AuthType::None,
+        }
+    }
+
+    fn no_create_overrides() -> CreateOverrides {
+        CreateOverrides {
+            name: None,
+            notes: None,
+            max_access_count: None,
+            hidden: false,
+            password: None,
+            emails: None,
+        }
+    }
+
+    #[test]
+    fn build_create_request_from_view_honors_json_fields() {
+        let view = make_text_json("JSON Name", Some("json notes"), true, Some(9));
+        let req = build_create_request_from_view(view, no_create_overrides()).unwrap();
+
+        assert_eq!(req.name, "JSON Name");
+        assert_eq!(req.notes.as_deref(), Some("json notes"));
+        assert_eq!(req.max_access_count, Some(9));
+        assert_eq!(
+            req.deletion_date,
+            "2030-06-01T00:00:00Z"
+                .parse::<chrono::DateTime<Utc>>()
+                .unwrap()
+        );
+        match req.view_type {
+            SendViewType::Text(t) => {
+                assert_eq!(t.text.as_deref(), Some("body"));
+                assert!(t.hidden);
+            }
+            other => panic!("expected Text, got {other:?}"),
+        }
+        assert!(matches!(req.auth, SendAuthType::None));
+    }
+
+    #[test]
+    fn build_create_request_from_view_flags_override_json() {
+        let view = make_text_json("JSON Name", Some("json notes"), false, Some(9));
+        let req = build_create_request_from_view(
+            view,
+            CreateOverrides {
+                name: Some("Flag Name".into()),
+                notes: Some("flag notes".into()),
+                max_access_count: Some(3),
+                hidden: true,
+                password: Some("pw".into()),
+                emails: None,
+            },
+        )
+        .unwrap();
+
+        assert_eq!(req.name, "Flag Name");
+        assert_eq!(req.notes.as_deref(), Some("flag notes"));
+        assert_eq!(req.max_access_count, Some(3));
+        match req.view_type {
+            SendViewType::Text(t) => assert!(t.hidden, "--hidden must OR in over JSON"),
+            other => panic!("expected Text, got {other:?}"),
+        }
+        assert!(matches!(req.auth, SendAuthType::Password { .. }));
+    }
+
+    #[test]
+    fn build_create_request_from_view_uses_json_auth_when_no_flags() {
+        let mut view = make_text_json("n", None, false, None);
+        view.emails = vec!["a@b.com".into(), "c@d.com".into()];
+        let req = build_create_request_from_view(view, no_create_overrides()).unwrap();
+        match req.auth {
+            SendAuthType::Emails { emails } => assert_eq!(emails.len(), 2),
+            other => panic!("expected Emails from JSON, got {other:?}"),
+        }
+    }
+
+    /// File Sends can't be created from JSON alone — the CLI needs the local file bytes. This
+    /// must produce a clear, documented error rather than a confusing downstream failure.
+    #[test]
+    fn build_create_request_from_view_rejects_file_type() {
+        let mut view = make_text_json("f", None, false, None);
+        view.r#type = SendType::File;
+        view.text = None;
+        view.file = Some(SendFileView {
+            id: None,
+            file_name: "secret.txt".into(),
+            size: None,
+            size_name: None,
+        });
+        let err = build_create_request_from_view(view, no_create_overrides()).unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("file Sends from JSON is not supported"),
+            "got: {err}"
+        );
+    }
+
+    // ---- build_edit_request_from_json ----
+
+    /// Full-object edit honors every JSON-owned field (name, notes, maxAccessCount, deletion
+    /// date, disabled, hideEmail, text/hidden). No auth source → `AuthEdit::Preserve`.
+    #[test]
+    fn build_edit_request_from_json_honors_every_field() {
+        let existing = make_existing(AuthType::None, false, vec![]);
+        let mut req = make_text_json("New Name", Some("new notes"), true, Some(7));
+        req.disabled = true;
+        req.hide_email = true;
+        req.deletion_date = "2031-02-02T00:00:00Z".parse().unwrap();
+
+        let out = build_edit_request_from_json(existing, req, no_override_edit()).unwrap();
+
+        assert_eq!(out.name, "New Name");
+        assert_eq!(out.notes.as_deref(), Some("new notes"));
+        assert_eq!(out.max_access_count, Some(7));
+        assert!(out.disabled);
+        assert!(out.hide_email);
+        assert_eq!(
+            out.deletion_date,
+            "2031-02-02T00:00:00Z"
+                .parse::<chrono::DateTime<Utc>>()
+                .unwrap()
+        );
+        match out.view_type {
+            SendViewType::Text(t) => {
+                assert_eq!(t.text.as_deref(), Some("body"));
+                assert!(t.hidden);
+            }
+            other => panic!("expected Text, got {other:?}"),
+        }
+        assert!(matches!(out.auth, AuthEdit::Preserve));
+    }
+
+    /// Full replace, not sparse patch: a field absent from the JSON is cleared, not carried
+    /// over from the existing server row. (`make_existing` has notes + maxAccessCount set.)
+    #[test]
+    fn build_edit_request_from_json_clears_fields_absent_from_json() {
+        let existing = make_existing(AuthType::None, false, vec![]);
+        let req = make_text_json("n", None, false, None);
+        let out = build_edit_request_from_json(existing, req, no_override_edit()).unwrap();
+        assert_eq!(out.notes, None, "notes absent from JSON must be cleared");
+        assert_eq!(
+            out.max_access_count, None,
+            "maxAccessCount absent from JSON must be cleared"
+        );
+    }
+
+    /// Type is immutable on edit: a text→file (or file→text) change is rejected before any
+    /// API call.
+    #[test]
+    fn build_edit_request_from_json_rejects_type_change() {
+        let existing = make_existing(AuthType::None, false, vec![]);
+        let mut req = make_text_json("n", None, false, None);
+        req.r#type = SendType::File;
+        req.text = None;
+        req.file = Some(SendFileView {
+            id: None,
+            file_name: "f".into(),
+            size: None,
+            size_name: None,
+        });
+        let err = build_edit_request_from_json(existing, req, no_override_edit()).unwrap_err();
+        assert!(
+            err.to_string().contains("Cannot change a Send's type"),
+            "got: {err}"
+        );
+    }
+
+    /// Auth precedence: a CLI `--password` flag beats a JSON-provided email gate.
+    #[test]
+    fn build_edit_request_from_json_cli_flag_beats_json_auth() {
+        let existing = make_existing(AuthType::None, false, vec![]);
+        let mut req = make_text_json("n", None, false, None);
+        req.emails = vec!["a@b.com".into()];
+        let out = build_edit_request_from_json(
+            existing,
+            req,
+            EditOverrides {
+                delete_in_days: None,
+                max_access_count: None,
+                hidden: false,
+                password: Some("pw".into()),
+                emails: None,
+            },
+        )
+        .unwrap();
+        assert!(matches!(
+            out.auth,
+            AuthEdit::Set {
+                auth: SendAuthType::Password { .. }
+            }
+        ));
+    }
+
+    /// Auth precedence: with no CLI flags, a JSON-provided email gate is applied (Set).
+    #[test]
+    fn build_edit_request_from_json_uses_json_auth_when_no_flags() {
+        let existing = make_existing(AuthType::Password, true, vec![]);
+        let mut req = make_text_json("n", None, false, None);
+        req.emails = vec!["a@b.com".into(), "c@d.com".into()];
+        let out = build_edit_request_from_json(existing, req, no_override_edit()).unwrap();
+        match out.auth {
+            AuthEdit::Set {
+                auth: SendAuthType::Emails { emails },
+            } => assert_eq!(emails.len(), 2),
+            other => panic!("expected AuthEdit::Set {{ Emails }}, got {other:?}"),
+        }
+    }
+
+    /// `--deleteInDays` overrides the JSON's absolute `deletionDate` (flag > JSON).
+    #[test]
+    fn build_edit_request_from_json_delete_in_days_flag_overrides_json_date() {
+        let existing = make_existing(AuthType::None, false, vec![]);
+        let mut req = make_text_json("n", None, false, None);
+        req.deletion_date = "2031-01-01T00:00:00Z".parse().unwrap();
+        let out = build_edit_request_from_json(
+            existing,
+            req,
+            EditOverrides {
+                delete_in_days: Some(7),
+                max_access_count: None,
+                hidden: false,
+                password: None,
+                emails: None,
+            },
+        )
+        .unwrap();
+        let diff = out.deletion_date - Utc::now();
+        assert!(
+            diff.num_days() >= 6 && diff.num_days() <= 7,
+            "flag deletion date should win over JSON's 2031 date"
+        );
     }
 }

--- a/crates/bw/src/tools/send.rs
+++ b/crates/bw/src/tools/send.rs
@@ -14,16 +14,16 @@ use std::{
 use base64::{Engine as _, engine::general_purpose::STANDARD};
 use bitwarden_pm::PasswordManagerClient;
 use bitwarden_send::{
-    AuthEdit, SendAddRequest, SendAuthType, SendEditRequest, SendFileView, SendId, SendTextView,
-    SendType, SendView, SendViewType,
+    AuthEdit, AuthType, SendAddRequest, SendAuthType, SendEditRequest, SendFileView, SendId,
+    SendTextView, SendType, SendView, SendViewType,
 };
-use chrono::{Duration, Utc};
+use chrono::{DateTime, Duration, Utc};
 use clap::{
     Args, Subcommand,
     builder::{PossibleValuesParser, TypedValueParser as _},
 };
 use color_eyre::eyre::{Context as _, eyre};
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
 use crate::{
     client_state::{AnyState, BwCommand, BwCommandExt as _, ClientContext, LoggedIn},
@@ -285,23 +285,31 @@ impl BwCommand for SendArgs {
             // `--output` on `get` fails before the auth check: silently emitting JSON to
             // stdout while the requested file path goes uncreated would be a worse UX than
             // an explicit "not implemented" error.
-            Some(SendCommands::Get(args)) if args.output_path.is_some() => Err(eyre!(
-                "`--output` on `bw send get` is not yet implemented (tracked under PM-39238)."
-            )),
+            Some(SendCommands::Get(args)) if args.output_path.is_some() => {
+                Err(eyre!("`--output` on `bw send get` is not yet implemented"))
+            }
             // `create`/`edit` resolve and parse their full-object JSON input *before*
             // extracting `LoggedIn`, so malformed input surfaces a clear parse error rather
             // than a confusing "not logged in" message (the integration tests assert this
             // ordering). Input comes from the positional `encoded_json` or, when absent and
-            // stdin is piped, from stdin.
+            // stdin is piped, from stdin. Stdin is only consulted when no other input source
+            // was given: a fully specified flag-only invocation must not block on (or
+            // consume) a caller's stdin pipe.
             Some(SendCommands::Create(args)) => {
-                let json = read_encoded_json_input(args.encoded_json.clone())?
+                let stdin_eligible = args.text.is_none() && args.file.is_none();
+                let json = read_encoded_json_input(args.encoded_json.clone(), stdin_eligible)?
                     .map(|raw| parse_encoded_send_view(&raw))
                     .transpose()?;
                 let LoggedIn { user, .. } = LoggedIn::try_from(ctx)?;
                 dispatch_create(&user, args, json).await
             }
             Some(SendCommands::Edit(args)) => {
-                let json = read_encoded_json_input(args.encoded_json.clone())?
+                let stdin_eligible = args.delete_in_days.is_none()
+                    && args.max_access_count.is_none()
+                    && !args.hidden
+                    && args.password.is_none()
+                    && args.emails.is_none();
+                let json = read_encoded_json_input(args.encoded_json.clone(), stdin_eligible)?
                     .map(|raw| parse_encoded_send_view(&raw))
                     .transpose()?;
                 let LoggedIn { user, .. } = LoggedIn::try_from(ctx)?;
@@ -537,15 +545,24 @@ struct SendFileTemplateBody {
 /// Resolve the raw full-object JSON input for `create`/`edit`.
 ///
 /// Precedence mirrors the legacy CLI: an explicit positional argument wins; otherwise, when
-/// stdin is piped (not an interactive terminal), read it. When stdin is a TTY and no
-/// positional was given, there is no JSON input and the flag-only path runs. The `is_terminal`
-/// guard is what keeps an interactive shell (and the test harness, which doesn't pipe stdin)
-/// from blocking on a read.
-fn read_encoded_json_input(positional: Option<String>) -> color_eyre::eyre::Result<Option<String>> {
+/// `stdin_eligible` (the caller supplied no other flag that already fully specifies the
+/// command) and stdin is piped (not an interactive terminal), read it. When stdin is a TTY, no
+/// positional was given, or `stdin_eligible` is false, there is no JSON input and the
+/// flag-only path runs.
+///
+/// `stdin_eligible` exists so a fully flag-specified `create`/`edit` never touches stdin: an
+/// unconditional read would block (or silently swallow bytes) when stdin is a non-TTY pipe
+/// that stays open, e.g. `ssh host 'bw send edit --itemid <id> --deleteInDays 3'` or
+/// `docker run -i`. The `is_terminal` guard separately keeps an interactive shell (and the
+/// test harness, which doesn't pipe stdin) from blocking on a read.
+fn read_encoded_json_input(
+    positional: Option<String>,
+    stdin_eligible: bool,
+) -> color_eyre::eyre::Result<Option<String>> {
     if let Some(raw) = positional {
         return Ok(Some(raw));
     }
-    if std::io::stdin().is_terminal() {
+    if !stdin_eligible || std::io::stdin().is_terminal() {
         return Ok(None);
     }
     let mut buf = String::new();
@@ -556,22 +573,101 @@ fn read_encoded_json_input(positional: Option<String>) -> color_eyre::eyre::Resu
     Ok(Some(buf))
 }
 
+/// CLI-local shape for the full-object JSON accepted by `create`/`edit`.
+///
+/// Deliberately distinct from [`SendView`] (`deny_unknown_fields`, no field defaults — the
+/// wire contract other SDK consumers rely on): the JSON this command accepts comes from three
+/// sources with different completeness —
+///   - `bw send template` output, which only carries the fields relevant to creation (`name`,
+///     `notes`, `type`, `text`/`file`, `deletionDate`)
+///   - `bw send get`/`--fullObject` output, a full `SendView` that also carries fields this CLI
+///     doesn't model (`object`, `accessUrl`, ...)
+///   - a hand-authored object supplying just the fields the caller cares about
+///
+/// Server-owned/read-only fields default when absent so all three shapes parse, and unknown
+/// keys are silently ignored (no `deny_unknown_fields`) so `bw send get` output round-trips.
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct SendJsonInput {
+    id: Option<SendId>,
+    access_id: Option<String>,
+    #[serde(default)]
+    name: String,
+    notes: Option<String>,
+    key: Option<String>,
+    new_password: Option<String>,
+    #[serde(default)]
+    has_password: bool,
+    r#type: SendType,
+    file: Option<SendFileView>,
+    text: Option<SendTextView>,
+    max_access_count: Option<u32>,
+    #[serde(default)]
+    access_count: u32,
+    #[serde(default)]
+    disabled: bool,
+    #[serde(default)]
+    hide_email: bool,
+    #[serde(default = "Utc::now")]
+    revision_date: DateTime<Utc>,
+    deletion_date: DateTime<Utc>,
+    expiration_date: Option<DateTime<Utc>>,
+    #[serde(default)]
+    emails: Vec<String>,
+    #[serde(default = "default_auth_type")]
+    auth_type: AuthType,
+}
+
+fn default_auth_type() -> AuthType {
+    AuthType::None
+}
+
+impl From<SendJsonInput> for SendView {
+    fn from(input: SendJsonInput) -> Self {
+        SendView {
+            id: input.id,
+            access_id: input.access_id,
+            name: input.name,
+            notes: input.notes,
+            key: input.key,
+            new_password: input.new_password,
+            has_password: input.has_password,
+            r#type: input.r#type,
+            file: input.file,
+            text: input.text,
+            max_access_count: input.max_access_count,
+            access_count: input.access_count,
+            disabled: input.disabled,
+            hide_email: input.hide_email,
+            revision_date: input.revision_date,
+            deletion_date: input.deletion_date,
+            expiration_date: input.expiration_date,
+            emails: input.emails,
+            auth_type: input.auth_type,
+        }
+    }
+}
+
 /// Decode and parse the full-object JSON input into a [`SendView`].
 ///
 /// The input may be base64-encoded JSON (legacy CLI behavior) or raw JSON (this CLI's
-/// convenience). We try base64 → UTF-8 → JSON first and fall back to parsing the original
-/// string as JSON if any step fails. Real JSON text starts with `{` and contains characters
-/// outside the base64 alphabet, so the base64 attempt fails fast on raw JSON and the fallback
-/// is taken — no explicit disambiguation is needed.
+/// convenience). Real JSON text starts with `{` and contains characters outside the base64
+/// alphabet, so decoding as base64 fails fast on raw JSON; when decoding fails (or the decoded
+/// bytes aren't valid UTF-8) we fall back to treating the original string as the JSON text
+/// directly. Either way, JSON is parsed exactly once, so a deserialize failure (e.g. a missing
+/// required field) is always the *real* error — we never re-parse the encoded string as JSON
+/// and mask it behind a generic "expected value" message.
 fn parse_encoded_send_view(raw: &str) -> color_eyre::eyre::Result<SendView> {
-    if let Ok(decoded) = STANDARD.decode(raw.trim())
-        && let Ok(text) = std::str::from_utf8(&decoded)
-        && let Ok(view) = serde_json::from_str::<SendView>(text)
-    {
-        return Ok(view);
-    }
+    let trimmed = raw.trim();
+    let json_text = STANDARD
+        .decode(trimmed)
+        .ok()
+        .and_then(|decoded| String::from_utf8(decoded).ok())
+        .unwrap_or_else(|| trimmed.to_string());
 
-    serde_json::from_str::<SendView>(raw).wrap_err("Error parsing the encoded request data.")
+    let input: SendJsonInput =
+        serde_json::from_str(&json_text).wrap_err("Error parsing the encoded request data.")?;
+    Ok(input.into())
 }
 
 struct CreateInputs {
@@ -704,15 +800,14 @@ fn build_create_request_from_view(
             // regardless of input source.)
             return Err(eyre!(
                 "Creating file Sends from JSON is not supported: the CLI needs a local file path \
-                 to read and encrypt the contents. Use `--file <path>` instead (file-send \
-                 creation is tracked under PM-39238)."
+                 to read and encrypt the contents. Use `--file <path>` instead."
             ));
         }
     };
 
     let resolved_name = name.unwrap_or(view.name);
     if resolved_name.is_empty() {
-        return Err(eyre!("--name is required for text Sends."));
+        return Err(eyre!("--name is required."));
     }
 
     // Auth precedence: CLI `--password`/`--emails` win as a unit; otherwise fall back to the
@@ -1726,6 +1821,71 @@ mod tests {
         assert!(
             err.to_string()
                 .contains("Error parsing the encoded request data")
+        );
+    }
+
+    /// Mirrors `bw send template send.text` output with only the fields the template emits
+    /// (`name`, `notes`, `type`, `text`, `deletionDate`) filled in — the documented
+    /// template -> create round trip. Server-owned fields (`hasPassword`, `accessCount`,
+    /// `revisionDate`, `emails`, `authType`, `disabled`, `hideEmail`) must not be required.
+    #[test]
+    fn parse_encoded_send_view_accepts_template_shaped_json() {
+        let json = r#"{
+            "name": "My Send",
+            "notes": "",
+            "type": 0,
+            "text": {"text": "hello", "hidden": false},
+            "deletionDate": "2030-01-01T00:00:00Z"
+        }"#;
+
+        let view = parse_encoded_send_view(json).expect("template-shaped JSON should parse");
+        assert_eq!(view.name, "My Send");
+        assert!(!view.has_password);
+        assert_eq!(view.access_count, 0);
+        assert!(!view.disabled);
+        assert!(!view.hide_email);
+        assert!(view.emails.is_empty());
+        assert!(matches!(view.auth_type, AuthType::None));
+    }
+
+    /// `bw send get` output carries fields (`object`, `accessUrl`, ...) this CLI doesn't model.
+    /// Rejecting them outright would break the `bw send get <id> | bw send edit` workflow.
+    #[test]
+    fn parse_encoded_send_view_tolerates_unknown_fields() {
+        let json = r#"{
+            "object": "send",
+            "accessUrl": "https://vault.bitwarden.com/#/send/abc/def",
+            "name": "My Send",
+            "hasPassword": false,
+            "type": 0,
+            "text": {"text": "hello", "hidden": false},
+            "accessCount": 0,
+            "disabled": false,
+            "hideEmail": false,
+            "revisionDate": "2025-01-01T00:00:00Z",
+            "deletionDate": "2030-01-01T00:00:00Z",
+            "emails": [],
+            "authType": 2
+        }"#;
+
+        let view = parse_encoded_send_view(json).expect("unknown fields should be ignored");
+        assert_eq!(view.name, "My Send");
+    }
+
+    /// When the input decodes cleanly as base64 but the resulting JSON fails to deserialize,
+    /// the *real* error (e.g. a missing required field) must surface — not a generic
+    /// "expected value" error from re-parsing the base64 string itself as JSON.
+    #[test]
+    fn parse_encoded_send_view_surfaces_real_error_for_valid_base64_invalid_json() {
+        let b64 = STANDARD.encode(r#"{"name": "My Send"}"#);
+        let err = parse_encoded_send_view(&b64).unwrap_err();
+        // `to_string()` only shows the top-level `wrap_err` message; the underlying
+        // serde_json cause (what actually pins this down as the *real* error, not a
+        // re-parse-as-JSON failure) is in the `{:?}` chain.
+        let chain = format!("{err:?}");
+        assert!(
+            chain.contains("missing field"),
+            "expected the real deserialize error, got: {chain}"
         );
     }
 

--- a/crates/bw/tests/send.rs
+++ b/crates/bw/tests/send.rs
@@ -311,13 +311,53 @@ fn send_edit_with_password_flag_parses() {
     );
 }
 
+// A full-object text `SendView` JSON payload, matching the wire shape `bw send get` and
+// `bw send create --fullObject` emit. Used to exercise the `encoded_json` input path. The
+// binary-driven tests can't reach a real API (no logged-in session/mock server here), so they
+// assert the input *parses* and falls through to the auth check; the field-level merge
+// semantics are unit-tested against the builder functions in `src/tools/send.rs`.
+const FULL_TEXT_SEND_JSON: &str = r#"{
+  "name": "My Send",
+  "hasPassword": false,
+  "type": 0,
+  "text": {"text": "hello", "hidden": false},
+  "accessCount": 0,
+  "disabled": false,
+  "hideEmail": false,
+  "revisionDate": "2025-01-01T00:00:00Z",
+  "deletionDate": "2030-01-01T00:00:00Z",
+  "emails": [],
+  "authType": 2
+}"#;
+
+/// Run `bw <args>` (logged out) piping `stdin_data` to the child's stdin.
+fn bw_with_stdin(args: &[&str], stdin_data: &str) -> std::process::Output {
+    use std::{io::Write as _, process::Stdio};
+
+    let mut child = bw()
+        .args(args)
+        .env_remove("BW_EMAIL")
+        .env_remove("BW_PASSWORD")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("Failed to spawn");
+    child
+        .stdin
+        .take()
+        .expect("stdin is piped")
+        .write_all(stdin_data.as_bytes())
+        .expect("write to stdin");
+    child.wait_with_output().expect("wait for child")
+}
+
 #[test]
-fn send_create_encoded_json_returns_not_implemented_error() {
-    // full-object JSON input is not yet implemented. Supplying it should fail
-    // loudly (before the auth check) rather than silently discarding the input and creating
-    // a Send with the CLI-flag defaults.
+fn send_create_encoded_json_positional_parses_then_hits_auth() {
+    // A valid full-object JSON positional must parse and fall through to the auth check
+    // (which fails logged out) — proving the input is accepted, not rejected up-front.
     let output = bw()
-        .args(["send", "create", r#"{"name":"x","type":0}"#])
+        .args(["send", "create", FULL_TEXT_SEND_JSON])
         .env_remove("BW_EMAIL")
         .env_remove("BW_PASSWORD")
         .output()
@@ -325,21 +365,65 @@ fn send_create_encoded_json_returns_not_implemented_error() {
     assert!(!output.status.success());
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(
-        stderr.contains("encoded_json") && stderr.contains("not yet implemented"),
-        "expected `encoded_json ... not yet implemented` error, got:\n{stderr}"
+        stderr.contains("not logged in") || stderr.contains("logged in"),
+        "valid JSON should parse and reach the auth check; got:\n{stderr}"
     );
-    // Crucially: the encoded_json error must fire *before* the auth check, so the user sees
-    // their input was unsupported rather than a confusing "not logged in" message.
     assert!(
-        !stderr.contains("not logged in"),
-        "encoded_json check should pre-empt the auth check; got:\n{stderr}"
+        !stderr.contains("Error parsing"),
+        "valid JSON should not produce a parse error; got:\n{stderr}"
     );
 }
 
 #[test]
-fn send_edit_encoded_json_returns_not_implemented_error() {
+fn send_create_encoded_json_via_stdin_matches_positional() {
+    // Piping the same JSON via stdin (no positional) takes the same path as the positional
+    // form: parse succeeds, then auth fails. Also proves the stdin read does not hang.
+    let output = bw_with_stdin(&["send", "create"], FULL_TEXT_SEND_JSON);
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("not logged in") || stderr.contains("logged in"),
+        "stdin JSON should parse and reach the auth check; got:\n{stderr}"
+    );
+    assert!(
+        !stderr.contains("Error parsing"),
+        "stdin JSON should not produce a parse error; got:\n{stderr}"
+    );
+}
+
+#[test]
+fn send_edit_encoded_json_via_stdin_matches_positional() {
+    let id = "25afb11c-9c95-4db5-8bac-c21cb204a3f1";
+    let via_stdin = bw_with_stdin(&["send", "edit", "--itemid", id], FULL_TEXT_SEND_JSON);
+    let via_positional = bw()
+        .args(["send", "edit", "--itemid", id, FULL_TEXT_SEND_JSON])
+        .env_remove("BW_EMAIL")
+        .env_remove("BW_PASSWORD")
+        .output()
+        .expect("Failed to execute");
+
+    for (label, output) in [("stdin", &via_stdin), ("positional", &via_positional)] {
+        assert!(!output.status.success(), "{label}: should fail logged out");
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert!(
+            stderr.contains("not logged in") || stderr.contains("logged in"),
+            "{label}: JSON should parse and reach the auth check; got:\n{stderr}"
+        );
+        assert!(
+            !stderr.contains("Error parsing"),
+            "{label}: JSON should not produce a parse error; got:\n{stderr}"
+        );
+    }
+}
+
+#[test]
+fn send_create_encoded_json_base64_parses_like_raw() {
+    // The "accept both transparently" decision: base64-encoded JSON must parse just like raw
+    // JSON and reach the auth check.
+    use base64::{Engine as _, engine::general_purpose::STANDARD};
+    let b64 = STANDARD.encode(FULL_TEXT_SEND_JSON);
     let output = bw()
-        .args(["send", "edit", r#"{"name":"x"}"#])
+        .args(["send", "create", &b64])
         .env_remove("BW_EMAIL")
         .env_remove("BW_PASSWORD")
         .output()
@@ -347,12 +431,60 @@ fn send_edit_encoded_json_returns_not_implemented_error() {
     assert!(!output.status.success());
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(
-        stderr.contains("encoded_json") && stderr.contains("not yet implemented"),
-        "expected `encoded_json ... not yet implemented` error, got:\n{stderr}"
+        stderr.contains("not logged in") || stderr.contains("logged in"),
+        "base64-encoded JSON should parse and reach the auth check; got:\n{stderr}"
+    );
+    assert!(
+        !stderr.contains("Error parsing"),
+        "base64-encoded JSON should not produce a parse error; got:\n{stderr}"
+    );
+}
+
+#[test]
+fn send_create_malformed_json_is_rejected_before_auth() {
+    // Input that is neither valid base64-of-JSON nor valid raw JSON must fail with a clear
+    // parse error that fires *before* the auth check (so the user sees the real problem).
+    let output = bw()
+        .args(["send", "create", "!!!not-base64-and-not-json!!!"])
+        .env_remove("BW_EMAIL")
+        .env_remove("BW_PASSWORD")
+        .output()
+        .expect("Failed to execute");
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("Error parsing the encoded request data"),
+        "expected a clear parse error, got:\n{stderr}"
     );
     assert!(
         !stderr.contains("not logged in"),
-        "encoded_json check should pre-empt the auth check; got:\n{stderr}"
+        "the parse error must pre-empt the auth check; got:\n{stderr}"
+    );
+}
+
+#[test]
+fn send_edit_malformed_json_is_rejected_before_auth() {
+    let output = bw()
+        .args([
+            "send",
+            "edit",
+            "--itemid",
+            "25afb11c-9c95-4db5-8bac-c21cb204a3f1",
+            "{not valid json",
+        ])
+        .env_remove("BW_EMAIL")
+        .env_remove("BW_PASSWORD")
+        .output()
+        .expect("Failed to execute");
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("Error parsing the encoded request data"),
+        "expected a clear parse error, got:\n{stderr}"
+    );
+    assert!(
+        !stderr.contains("not logged in"),
+        "the parse error must pre-empt the auth check; got:\n{stderr}"
     );
 }
 


### PR DESCRIPTION
## 🎟️ Tracking

PM-39240 (https://bitwarden.atlassian.net/browse/PM-39240)

## 📔 Objective

Implements full-object encodedJson input support for bw send create and bw send edit, completing the work deferred from PR #1176 (PM-34719).
