### PR TITLE
Auth/PM-40520 - Registration - Open Org Invite Seal / Unseal Support - Fast Follow

### DIFF
--- a/crates/bitwarden-auth/src/registration/open_org_invite_crypto/README.md
+++ b/crates/bitwarden-auth/src/registration/open_org_invite_crypto/README.md
@@ -1,0 +1,34 @@
+# open_org_invite_crypto
+
+Open-organization-invite registration crossing.
+
+The app seals an open org invite context on registration-start submit and unseals it on the accept
+open-org-invite component after a successful registration-finish. This module owns the versioned
+plaintext payload (`data_v1`), the domain types and crypto operations (`open_org_invite`), their
+wire encoding (`serialization`), and the FFI-facing client methods (`client`).
+
+Two envelopes protect the invite: a fresh CEK encrypts the plaintext, and a fresh 256-bit
+`HighEntropySecret` encrypts that CEK. The paired envelopes travel together as
+`SealedOpenOrgInviteData`; the `HighEntropySecret` is returned separately to the caller and kept
+client-side. Both halves are required to unseal.
+
+## Key-protection diagram
+
+- _Audience:_ engineers touching this module.
+- _Intent:_ show which key protects what.
+- _Scope:_ the two envelopes composing `SealedOpenOrgInviteData` (excludes app flow, wire encoding,
+  and FFI).
+
+```mermaid
+flowchart LR
+    HES["HighEntropySecret<br/>(kept client-side)"]
+    CEK[CEK]
+    Plain["OpenOrgInvite<br/>{ organization_id, invite_link_code, invite_secret }"]
+    HES -->|"SecretProtectedKeyEnvelope<br/>(key_envelope)"| CEK
+    CEK -->|"DataEnvelope<br/>(data_envelope)"| Plain
+```
+
+- `HighEntropySecret -> SecretProtectedKeyEnvelope -> CEK` (`key_envelope`): the CEK sealed under a
+  fresh 32-byte `HighEntropySecret` returned to the caller and kept client-side.
+- `CEK -> DataEnvelope -> OpenOrgInvite` (`data_envelope`): the versioned invite plaintext sealed
+  under the fresh CEK. AES-GCM's auth tag at each layer is the substitution defense.

--- a/crates/bitwarden-auth/src/registration/open_org_invite_crypto/mod.rs
+++ b/crates/bitwarden-auth/src/registration/open_org_invite_crypto/mod.rs
@@ -1,10 +1,4 @@
-//! Open-organization-invite registration crossing.
-//!
-//! The app seals an invite context on registration-start submit and unseals it on the accept
-//! open-org-invite component after a successful registration-finish. This module owns the
-//! versioned plaintext payload (`data_v1`), the domain types and crypto operations
-//! (`open_org_invite`), their wire encoding (`serialization`), and the FFI-facing client
-//! methods (`client`).
+#![doc = include_str!("./README.md")]
 
 mod client;
 mod data_v1;

--- a/crates/bitwarden-auth/src/registration/open_org_invite_crypto/open_org_invite.rs
+++ b/crates/bitwarden-auth/src/registration/open_org_invite_crypto/open_org_invite.rs
@@ -39,7 +39,9 @@ pub struct OpenOrgInvite {
 /// The two sealed envelopes that together carry an open-organization-invite payload.
 #[derive(Debug, Clone)]
 pub struct SealedOpenOrgInviteData {
+    /// The OpenOrgInvite plaintext, encrypted under a fresh CEK.
     pub(super) data_envelope: DataEnvelope,
+    /// That CEK, encrypted under the caller's HighEntropySecret.
     pub(super) key_envelope: SecretProtectedKeyEnvelope,
 }
 

--- a/crates/bitwarden-auth/src/registration/open_org_invite_crypto/open_org_invite.rs
+++ b/crates/bitwarden-auth/src/registration/open_org_invite_crypto/open_org_invite.rs
@@ -41,7 +41,7 @@ pub struct OpenOrgInvite {
 pub struct SealedOpenOrgInviteData {
     /// The OpenOrgInvite plaintext, encrypted under a fresh CEK.
     pub(super) data_envelope: DataEnvelope,
-    /// That CEK, encrypted under the caller's HighEntropySecret.
+    /// The CEK, encrypted under the caller's HighEntropySecret.
     pub(super) key_envelope: SecretProtectedKeyEnvelope,
 }
 

--- a/crates/bitwarden-auth/src/registration/open_org_invite_crypto/serialization.rs
+++ b/crates/bitwarden-auth/src/registration/open_org_invite_crypto/serialization.rs
@@ -17,8 +17,10 @@ use super::SealedOpenOrgInviteData;
 #[derive(Serialize, Deserialize)]
 struct SealedOpenOrgInviteDataWire {
     // Without serde_bytes, Vec<u8> encodes as a CBOR array of integers (~2x the size).
+    /// Bytes of the data envelope (OpenOrgInvite plaintext encrypted under a fresh CEK).
     #[serde(rename = "d", with = "serde_bytes")]
     data_envelope: Vec<u8>,
+    /// Bytes of the key envelope (the CEK encrypted under the caller's HighEntropySecret).
     #[serde(rename = "k", with = "serde_bytes")]
     key_envelope: Vec<u8>,
 }


### PR DESCRIPTION
## 🎟️ Tracking
<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-40520
Follow up from https://github.com/bitwarden/sdk-internal/pull/1295

## 📔 Objective
<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
To clean up some small remaining items on the new, simple API on the Auth registration client to seal and unseal the new open organization invite link data as requested by @quexten https://github.com/bitwarden/sdk-internal/pull/1295#pullrequestreview-4805616046