### PR TITLE
[PM-41226] Add access-request and lease sub-clients

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1045,6 +1045,7 @@ dependencies = [
  "bitwarden-core",
  "bitwarden-error",
  "bitwarden-uuid",
+ "bitwarden-vault",
  "chrono",
  "reqwest",
  "serde",

--- a/bitwarden_license/bitwarden-pam/Cargo.toml
+++ b/bitwarden_license/bitwarden-pam/Cargo.toml
@@ -19,6 +19,7 @@ wasm = [
     "bitwarden-collections/wasm",
     "bitwarden-core/wasm",
     "bitwarden-error/wasm",
+    "bitwarden-vault/wasm",
     "dep:tsify",
     "dep:wasm-bindgen",
     "dep:wasm-bindgen-futures",
@@ -30,6 +31,7 @@ bitwarden-collections = { workspace = true }
 bitwarden-core = { workspace = true, features = ["internal"] }
 bitwarden-error = { workspace = true }
 bitwarden-uuid = { workspace = true }
+bitwarden-vault = { workspace = true }
 chrono = { workspace = true }
 reqwest = { workspace = true }
 serde = { workspace = true }

--- a/bitwarden_license/bitwarden-pam/src/access_requests/client.rs
+++ b/bitwarden_license/bitwarden-pam/src/access_requests/client.rs
@@ -1,0 +1,223 @@
+use std::sync::Arc;
+
+use bitwarden_core::{ApiError, FromClient, client::ApiConfigurations};
+#[cfg(feature = "wasm")]
+use wasm_bindgen::prelude::wasm_bindgen;
+
+use super::models::AccessRequestView;
+use crate::{AccessRequestId, error::LeasingError, leases::AccessLeaseView};
+
+/// Client for a requester's PAM access requests.
+///
+/// Covers the requester side of the request lifecycle: listing and reading the caller's own
+/// requests, [`activate`](AccessRequestsClient::activate)ing an approved request to mint a lease,
+/// and [`cancel`](AccessRequestsClient::cancel)ling a request that is still pending.
+///
+/// Creating a request (`POST /leases/ciphers/{id}`) is not yet exposed here - its binding lives on
+/// the not-yet-generated `cipher_lease_api` surface and lands with a later change.
+#[cfg_attr(feature = "wasm", wasm_bindgen)]
+#[derive(FromClient)]
+pub struct AccessRequestsClient {
+    pub(crate) api_configurations: Arc<ApiConfigurations>,
+}
+
+#[cfg_attr(feature = "wasm", wasm_bindgen)]
+impl AccessRequestsClient {
+    /// Lists the caller's own access requests.
+    pub async fn list_mine(&self) -> Result<Vec<AccessRequestView>, LeasingError> {
+        let response = self
+            .api_configurations
+            .api_client
+            .access_requests_api()
+            .get_mine()
+            .await
+            .map_err(ApiError::from)?;
+
+        response
+            .data
+            .unwrap_or_default()
+            .into_iter()
+            .map(AccessRequestView::try_from)
+            .collect()
+    }
+
+    /// Retrieves a single access request by ID.
+    pub async fn get(&self, id: AccessRequestId) -> Result<AccessRequestView, LeasingError> {
+        let response = self
+            .api_configurations
+            .api_client
+            .access_requests_api()
+            .get_details(id.into())
+            .await
+            .map_err(ApiError::from)?;
+
+        AccessRequestView::try_from(response)
+    }
+
+    /// Activates an approved request, minting and returning the resulting lease.
+    ///
+    /// This is the second half of the automatic flow: once a request reaches
+    /// [`Approved`](super::AccessRequestStatus::Approved), the requester activates it to obtain a
+    /// short-lived [`AccessLease`](AccessLeaseView) over the cipher.
+    pub async fn activate(&self, id: AccessRequestId) -> Result<AccessLeaseView, LeasingError> {
+        let response = self
+            .api_configurations
+            .api_client
+            .access_requests_api()
+            .activate(id.into())
+            .await
+            .map_err(ApiError::from)?;
+
+        AccessLeaseView::try_from(response)
+    }
+
+    /// Cancels the caller's own request while it is still pending.
+    pub async fn cancel(&self, id: AccessRequestId) -> Result<(), LeasingError> {
+        self.api_configurations
+            .api_client
+            .access_requests_api()
+            .revoke(id.into())
+            .await
+            .map_err(ApiError::from)?;
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use bitwarden_api_api::{
+        apis::ApiClient,
+        models::{
+            AccessLeaseResponseModel, AccessLeaseStatus as ApiAccessLeaseStatus,
+            AccessRequestDetailsResponseModel, AccessRequestDetailsResponseModelListResponseModel,
+            AccessRequestStatus as ApiAccessRequestStatus,
+        },
+    };
+    use uuid::uuid;
+
+    use super::*;
+    use crate::{AccessLeaseStatus, AccessRequestStatus};
+
+    fn request_id() -> AccessRequestId {
+        AccessRequestId::new(uuid!("44444444-4444-4444-4444-444444444444"))
+    }
+
+    fn client(api_client: ApiClient) -> AccessRequestsClient {
+        AccessRequestsClient {
+            api_configurations: Arc::new(ApiConfigurations::from_api_client(api_client)),
+        }
+    }
+
+    fn sample_request() -> AccessRequestDetailsResponseModel {
+        AccessRequestDetailsResponseModel {
+            id: Some(request_id().into()),
+            cipher_id: Some(uuid!("55555555-5555-5555-5555-555555555555")),
+            collection_id: Some(uuid!("66666666-6666-6666-6666-666666666666")),
+            requester_id: Some(uuid!("88888888-8888-8888-8888-888888888888")),
+            status: Some(ApiAccessRequestStatus::Approved),
+            lease_not_before: Some("2025-01-01T00:00:00Z".to_string()),
+            lease_not_after: Some("2025-01-01T01:00:00Z".to_string()),
+            submitted_at: Some("2025-01-01T00:00:00Z".to_string()),
+            ..Default::default()
+        }
+    }
+
+    fn sample_lease() -> AccessLeaseResponseModel {
+        AccessLeaseResponseModel {
+            id: Some(uuid!("33333333-3333-3333-3333-333333333333")),
+            request_id: Some(request_id().into()),
+            cipher_id: Some(uuid!("55555555-5555-5555-5555-555555555555")),
+            collection_id: Some(uuid!("66666666-6666-6666-6666-666666666666")),
+            requester_id: Some(uuid!("88888888-8888-8888-8888-888888888888")),
+            status: Some(ApiAccessLeaseStatus::Active),
+            not_before: Some("2025-01-01T00:00:00Z".to_string()),
+            not_after: Some("2025-01-01T01:00:00Z".to_string()),
+            ..Default::default()
+        }
+    }
+
+    #[tokio::test]
+    async fn list_mine_returns_views() {
+        let api_client = ApiClient::new_mocked(move |mock| {
+            mock.access_requests_api
+                .expect_get_mine()
+                .returning(move || {
+                    let mut list = AccessRequestDetailsResponseModelListResponseModel::new();
+                    list.data = Some(vec![sample_request()]);
+                    Ok(list)
+                })
+                .once();
+        });
+
+        let result = client(api_client).list_mine().await.unwrap();
+
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].id, request_id());
+        assert_eq!(result[0].status, AccessRequestStatus::Approved);
+    }
+
+    #[tokio::test]
+    async fn get_returns_view() {
+        let api_client = ApiClient::new_mocked(move |mock| {
+            mock.access_requests_api
+                .expect_get_details()
+                .returning(move |_id| Ok(sample_request()))
+                .once();
+        });
+
+        let result = client(api_client).get(request_id()).await.unwrap();
+
+        assert_eq!(result.id, request_id());
+    }
+
+    #[tokio::test]
+    async fn activate_mints_a_lease() {
+        let api_client = ApiClient::new_mocked(move |mock| {
+            mock.access_requests_api
+                .expect_activate()
+                .returning(move |_id| Ok(sample_lease()))
+                .once();
+        });
+
+        let lease = client(api_client).activate(request_id()).await.unwrap();
+
+        assert_eq!(lease.request_id, request_id());
+        assert_eq!(lease.status, AccessLeaseStatus::Active);
+    }
+
+    #[tokio::test]
+    async fn activate_surfaces_api_error() {
+        let api_client = ApiClient::new_mocked(move |mock| {
+            mock.access_requests_api
+                .expect_activate()
+                .returning(move |_id| {
+                    Err(bitwarden_api_api::apis::Error::Response(
+                        bitwarden_api_api::apis::ResponseContent {
+                            status: reqwest::StatusCode::CONFLICT,
+                            message: "Not approved".to_string(),
+                        },
+                    ))
+                })
+                .once();
+        });
+
+        let result = client(api_client).activate(request_id()).await;
+
+        assert!(matches!(result, Err(LeasingError::Api(_))));
+    }
+
+    #[tokio::test]
+    async fn cancel_succeeds() {
+        let api_client = ApiClient::new_mocked(move |mock| {
+            mock.access_requests_api
+                .expect_revoke()
+                .returning(move |_id| Ok(()))
+                .once();
+        });
+
+        let result = client(api_client).cancel(request_id()).await;
+
+        assert!(result.is_ok());
+    }
+}

--- a/bitwarden_license/bitwarden-pam/src/access_requests/client.rs
+++ b/bitwarden_license/bitwarden-pam/src/access_requests/client.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use bitwarden_core::{ApiError, FromClient, client::ApiConfigurations};
+use bitwarden_core::{FromClient, client::ApiConfigurations};
 #[cfg(feature = "wasm")]
 use wasm_bindgen::prelude::wasm_bindgen;
 
@@ -30,8 +30,7 @@ impl AccessRequestsClient {
             .api_client
             .access_requests_api()
             .get_mine()
-            .await
-            .map_err(ApiError::from)?;
+            .await?;
 
         response
             .data
@@ -48,8 +47,7 @@ impl AccessRequestsClient {
             .api_client
             .access_requests_api()
             .get_details(id.into())
-            .await
-            .map_err(ApiError::from)?;
+            .await?;
 
         AccessRequestView::try_from(response)
     }
@@ -65,8 +63,7 @@ impl AccessRequestsClient {
             .api_client
             .access_requests_api()
             .activate(id.into())
-            .await
-            .map_err(ApiError::from)?;
+            .await?;
 
         AccessLeaseView::try_from(response)
     }
@@ -77,8 +74,7 @@ impl AccessRequestsClient {
             .api_client
             .access_requests_api()
             .revoke(id.into())
-            .await
-            .map_err(ApiError::from)?;
+            .await?;
 
         Ok(())
     }

--- a/bitwarden_license/bitwarden-pam/src/access_requests/mod.rs
+++ b/bitwarden_license/bitwarden-pam/src/access_requests/mod.rs
@@ -22,6 +22,6 @@ mod models;
 
 pub use client::AccessRequestsClient;
 pub use models::{
-    AccessDeciderKind, AccessDecisionVerdict, AccessRequestDecisionView, AccessRequestStatus,
-    AccessRequestView,
+    AccessApprover, AccessDecider, AccessDecisionVerdict, AccessRequestDecisionView,
+    AccessRequestStatus, AccessRequestView,
 };

--- a/bitwarden_license/bitwarden-pam/src/access_requests/mod.rs
+++ b/bitwarden_license/bitwarden-pam/src/access_requests/mod.rs
@@ -21,4 +21,7 @@ mod client;
 mod models;
 
 pub use client::AccessRequestsClient;
-pub use models::{AccessRequestStatus, AccessRequestView};
+pub use models::{
+    AccessDeciderKind, AccessDecisionVerdict, AccessRequestDecisionView, AccessRequestStatus,
+    AccessRequestView,
+};

--- a/bitwarden_license/bitwarden-pam/src/access_requests/mod.rs
+++ b/bitwarden_license/bitwarden-pam/src/access_requests/mod.rs
@@ -1,0 +1,24 @@
+//! PAM access request operations.
+//!
+//! An *access request* is a member's ask to open a PAM-gated cipher. On the automatic (no human
+//! approval) path the server auto-approves it, and the requester
+//! [`activate`](AccessRequestsClient::activate)s the approved request to mint a short-lived
+//! [`AccessLease`](crate::AccessLeaseView) over the cipher.
+//!
+//! [`AccessRequestsClient`] is obtained from the [`PamClient`](crate::PamClient) and covers reading
+//! the caller's requests, activating an approved one, and cancelling a pending one.
+//!
+//! # Not yet exposed
+//!
+//! *Creating* a request (`POST /leases/ciphers/{id}`) and the per-cipher access-state / pre-check
+//! reads depend on the `cipher_lease_api` binding, which is not yet generated into
+//! `bitwarden-api-api`. Until it is, request creation stays on the clients' existing HTTP path and
+//! per-cipher state can be derived from
+//! [`LeasesClient::list_active`](crate::LeasesClient::list_active)
+//! plus [`AccessRequestsClient::list_mine`].
+
+mod client;
+mod models;
+
+pub use client::AccessRequestsClient;
+pub use models::{AccessRequestStatus, AccessRequestView};

--- a/bitwarden_license/bitwarden-pam/src/access_requests/models.rs
+++ b/bitwarden_license/bitwarden-pam/src/access_requests/models.rs
@@ -1,0 +1,110 @@
+use bitwarden_api_api::models::{
+    AccessRequestDetailsResponseModel, AccessRequestStatus as ApiAccessRequestStatus,
+};
+use bitwarden_collections::collection::CollectionId;
+use bitwarden_core::{OrganizationId, UserId, require};
+use bitwarden_vault::CipherId;
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+#[cfg(feature = "wasm")]
+use tsify::Tsify;
+
+use crate::{AccessRequestId, AccessRuleId, error::LeasingError};
+
+/// The lifecycle state of an access request.
+///
+/// The automatic (no human approval) path moves `Pending -> Approved -> Activated`; the requester
+/// activates the approved request to mint a lease. `Denied`, `Canceled`, and `Expired` are terminal
+/// states in which no lease exists.
+#[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "wasm", derive(Tsify), tsify(into_wasm_abi, from_wasm_abi))]
+#[serde(rename_all = "snake_case")]
+pub enum AccessRequestStatus {
+    /// Awaiting a decision (or, on the automatic path, awaiting the server's auto-approval).
+    Pending,
+    /// Approved but not yet activated; the requester may activate it to mint a lease.
+    Approved,
+    /// Activated - a lease has been minted from this request.
+    Activated,
+    /// Denied by an approver; terminal.
+    Denied,
+    /// Cancelled by the requester before resolution; terminal.
+    Canceled,
+    /// Approved but lapsed before the requester activated it; terminal.
+    Expired,
+    /// A status value this SDK version does not recognize. Kept as a distinct variant so listing
+    /// requests never fails on a newer server's status.
+    Unknown,
+}
+
+impl From<ApiAccessRequestStatus> for AccessRequestStatus {
+    fn from(status: ApiAccessRequestStatus) -> Self {
+        match status {
+            ApiAccessRequestStatus::Pending => Self::Pending,
+            ApiAccessRequestStatus::Approved => Self::Approved,
+            ApiAccessRequestStatus::Activated => Self::Activated,
+            ApiAccessRequestStatus::Denied => Self::Denied,
+            ApiAccessRequestStatus::Canceled => Self::Canceled,
+            ApiAccessRequestStatus::Expired => Self::Expired,
+            ApiAccessRequestStatus::__Unknown(_) => Self::Unknown,
+        }
+    }
+}
+
+/// A decrypted view of an access request, as its requester sees it.
+///
+/// An access request is a member's ask to open a PAM-gated cipher. Once approved, the requester
+/// [`activate`](crate::AccessRequestsClient::activate)s it to mint an
+/// [`AccessLease`](crate::AccessLeaseView).
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "wasm", derive(Tsify), tsify(into_wasm_abi, from_wasm_abi))]
+#[serde(rename_all = "camelCase")]
+pub struct AccessRequestView {
+    /// The request's unique identifier.
+    pub id: AccessRequestId,
+    /// The cipher access was requested for.
+    pub cipher_id: CipherId,
+    /// The collection the cipher belongs to, through which the request is governed.
+    pub collection_id: CollectionId,
+    /// The organization that owns the cipher. None when the server omits it.
+    pub organization_id: Option<OrganizationId>,
+    /// The member who opened the request.
+    pub requester_id: UserId,
+    /// The access rule pinned to the request at submit time. None for requests created before rule
+    /// pinning existed.
+    pub rule_id: Option<AccessRuleId>,
+    /// The request's lifecycle state.
+    pub status: AccessRequestStatus,
+    /// The start of the activation window resolved at submit (UTC) - the earliest the request may
+    /// be promoted to a lease.
+    pub lease_not_before: DateTime<Utc>,
+    /// The end of the activation window resolved at submit (UTC).
+    pub lease_not_after: DateTime<Utc>,
+    /// The optional justification the requester supplied when opening the request.
+    pub reason: Option<String>,
+    /// When the request was opened (UTC).
+    pub submitted_at: DateTime<Utc>,
+    /// When the request was approved, denied, or cancelled (UTC); None while pending.
+    pub resolved_at: Option<DateTime<Utc>>,
+}
+
+impl TryFrom<AccessRequestDetailsResponseModel> for AccessRequestView {
+    type Error = LeasingError;
+
+    fn try_from(response: AccessRequestDetailsResponseModel) -> Result<Self, Self::Error> {
+        Ok(Self {
+            id: AccessRequestId::new(require!(response.id)),
+            cipher_id: CipherId::new(require!(response.cipher_id)),
+            collection_id: CollectionId::new(require!(response.collection_id)),
+            organization_id: response.organization_id.map(OrganizationId::new),
+            requester_id: UserId::new(require!(response.requester_id)),
+            rule_id: response.rule_id.map(AccessRuleId::new),
+            status: AccessRequestStatus::from(require!(response.status)),
+            lease_not_before: require!(response.lease_not_before).parse()?,
+            lease_not_after: require!(response.lease_not_after).parse()?,
+            reason: response.reason,
+            submitted_at: require!(response.submitted_at).parse()?,
+            resolved_at: response.resolved_at.map(|d| d.parse()).transpose()?,
+        })
+    }
+}

--- a/bitwarden_license/bitwarden-pam/src/access_requests/models.rs
+++ b/bitwarden_license/bitwarden-pam/src/access_requests/models.rs
@@ -53,31 +53,6 @@ impl From<ApiAccessRequestStatus> for AccessRequestStatus {
     }
 }
 
-/// What produced a decision on an access request.
-#[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq)]
-#[cfg_attr(feature = "wasm", derive(Tsify), tsify(into_wasm_abi, from_wasm_abi))]
-#[serde(rename_all = "snake_case")]
-pub enum AccessDeciderKind {
-    /// The decision was made automatically by the governing access rule; no human approval was
-    /// required.
-    Automatic,
-    /// The decision was made by a human approver.
-    Human,
-    /// A decider kind value this SDK version does not recognize. Kept as a distinct variant so
-    /// reading a request's decision log never fails on a newer server's decider kind.
-    Unknown,
-}
-
-impl From<ApiDeciderKind> for AccessDeciderKind {
-    fn from(kind: ApiDeciderKind) -> Self {
-        match kind {
-            ApiDeciderKind::Automatic => Self::Automatic,
-            ApiDeciderKind::Human => Self::Human,
-            ApiDeciderKind::__Unknown(_) => Self::Unknown,
-        }
-    }
-}
-
 /// An approver's verdict on an access request decision.
 #[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq)]
 #[cfg_attr(feature = "wasm", derive(Tsify), tsify(into_wasm_abi, from_wasm_abi))]
@@ -104,42 +79,67 @@ impl From<ApiAccessDecisionVerdict> for AccessDecisionVerdict {
 
 /// A single decision recorded on an access request's decision log.
 ///
-/// For an [`Automatic`](AccessDeciderKind::Automatic) decision, `id`, `name`, and `email` are
-/// `None`; for a [`Human`](AccessDeciderKind::Human) decision they carry the approver's identity,
-/// denormalized by the server (`None` only when the user could not be resolved).
+/// Every decision carries a [`verdict`](Self::verdict), an optional [`comment`](Self::comment), and
+/// the time it was [`decided_at`](Self::decided_at). [`decider`](Self::decider) distinguishes an
+/// automatic (access-rule) decision from a human one and, for a human, carries the approver's
+/// identity.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "wasm", derive(Tsify), tsify(into_wasm_abi, from_wasm_abi))]
 #[serde(rename_all = "camelCase")]
 pub struct AccessRequestDecisionView {
     /// Who made the decision.
-    pub decider_kind: AccessDeciderKind,
-    /// The human approver's user id; `None` for an automatic decision.
-    pub id: Option<UserId>,
-    /// The human approver's display name; `None` for an automatic decision, or when the user
-    /// could not be resolved.
-    pub name: Option<String>,
-    /// The human approver's email; `None` for an automatic decision, or when the user could not
-    /// be resolved.
-    pub email: Option<String>,
-    /// The optional note the approver left with the decision.
-    pub comment: Option<String>,
+    pub decider: AccessDecider,
     /// The decision's verdict.
     pub verdict: AccessDecisionVerdict,
+    /// The optional note recorded with the decision.
+    pub comment: Option<String>,
     /// When the decision was recorded (UTC).
     pub decided_at: DateTime<Utc>,
+}
+
+/// Who made a decision on an access request.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "wasm", derive(Tsify), tsify(into_wasm_abi, from_wasm_abi))]
+#[serde(rename_all = "camelCase")]
+pub enum AccessDecider {
+    /// The decision was made automatically by the governing access rule; no human approval was
+    /// required.
+    Automatic,
+    /// The decision was made by a human approver, whose identity is denormalized by the server.
+    Human(AccessApprover),
+}
+
+/// The identity of a human approver, denormalized by the server.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "wasm", derive(Tsify), tsify(into_wasm_abi, from_wasm_abi))]
+#[serde(rename_all = "camelCase")]
+pub struct AccessApprover {
+    /// The approver's user id; `None` when the server omitted it.
+    pub id: Option<UserId>,
+    /// The approver's display name; `None` when the user could not be resolved.
+    pub name: Option<String>,
+    /// The approver's email; `None` when the user could not be resolved.
+    pub email: Option<String>,
 }
 
 impl TryFrom<AccessRequestDecisionResponseModel> for AccessRequestDecisionView {
     type Error = LeasingError;
 
     fn try_from(response: AccessRequestDecisionResponseModel) -> Result<Self, Self::Error> {
+        let decider = match require!(response.decider_kind) {
+            ApiDeciderKind::Automatic => AccessDecider::Automatic,
+            ApiDeciderKind::Human => AccessDecider::Human(AccessApprover {
+                id: response.id.map(UserId::new),
+                name: response.name,
+                email: response.email,
+            }),
+            ApiDeciderKind::__Unknown(_) => return Err(LeasingError::UnrecognizedDeciderKind),
+        };
+
         Ok(Self {
-            decider_kind: AccessDeciderKind::from(require!(response.decider_kind)),
-            id: response.id.map(UserId::new),
-            name: response.name,
-            email: response.email,
-            comment: response.comment,
+            decider,
             verdict: AccessDecisionVerdict::from(require!(response.verdict)),
+            comment: response.comment,
             decided_at: require!(response.decided_at).parse()?,
         })
     }
@@ -304,22 +304,26 @@ mod tests {
         assert_eq!(view.requester_name, Some("Rea Quester".to_string()));
         assert_eq!(view.requester_email, Some("rea@example.com".to_string()));
 
-        let human = &view.decisions[1];
-        assert_eq!(human.decider_kind, AccessDeciderKind::Human);
-        assert_eq!(human.name, Some("Ana Approver".to_string()));
-        assert_eq!(human.email, Some("ana@example.com".to_string()));
-        assert_eq!(human.comment, Some("Looks fine".to_string()));
-        assert_eq!(human.verdict, AccessDecisionVerdict::Approve);
+        assert!(matches!(
+            view.decisions[0].decider,
+            AccessDecider::Automatic
+        ));
+
+        let decision = &view.decisions[1];
+        let AccessDecider::Human(approver) = &decision.decider else {
+            panic!("expected a human decision, got {:?}", decision.decider);
+        };
+        assert_eq!(approver.name.as_deref(), Some("Ana Approver"));
+        assert_eq!(approver.email.as_deref(), Some("ana@example.com"));
+        assert_eq!(decision.comment.as_deref(), Some("Looks fine"));
+        assert_eq!(decision.verdict, AccessDecisionVerdict::Approve);
     }
 
     #[test]
     fn automatic_decision_has_no_approver_identity() {
         let view = AccessRequestDecisionView::try_from(automatic_decision()).unwrap();
 
-        assert_eq!(view.decider_kind, AccessDeciderKind::Automatic);
-        assert_eq!(view.id, None);
-        assert_eq!(view.name, None);
-        assert_eq!(view.email, None);
+        assert!(matches!(view.decider, AccessDecider::Automatic));
     }
 
     #[test]
@@ -335,16 +339,46 @@ mod tests {
     }
 
     #[test]
-    fn unknown_decider_kind_and_verdict_map_to_unknown() {
+    fn unknown_decider_kind_is_rejected() {
         let response = AccessRequestDecisionResponseModel {
             decider_kind: Some(DeciderKind::__Unknown(99)),
+            ..human_decision()
+        };
+
+        assert!(AccessRequestDecisionView::try_from(response).is_err());
+    }
+
+    #[test]
+    fn unknown_verdict_maps_to_unknown() {
+        let response = AccessRequestDecisionResponseModel {
             verdict: Some(ApiAccessDecisionVerdict::__Unknown(99)),
             ..human_decision()
         };
 
         let view = AccessRequestDecisionView::try_from(response).unwrap();
 
-        assert_eq!(view.decider_kind, AccessDeciderKind::Unknown);
         assert_eq!(view.verdict, AccessDecisionVerdict::Unknown);
+    }
+
+    #[test]
+    fn human_decision_serializes_with_nested_approver() {
+        let view = AccessRequestDecisionView::try_from(human_decision()).unwrap();
+
+        let json = serde_json::to_value(&view).unwrap();
+
+        assert_eq!(json["decider"]["human"]["name"], "Ana Approver");
+        assert_eq!(json["decider"]["human"]["email"], "ana@example.com");
+        assert_eq!(json["verdict"], "approve");
+        assert!(json.get("decidedAt").is_some());
+    }
+
+    #[test]
+    fn automatic_decision_serializes_without_approver() {
+        let view = AccessRequestDecisionView::try_from(automatic_decision()).unwrap();
+
+        let json = serde_json::to_value(&view).unwrap();
+
+        assert_eq!(json["decider"], "automatic");
+        assert_eq!(json["verdict"], "approve");
     }
 }

--- a/bitwarden_license/bitwarden-pam/src/access_requests/models.rs
+++ b/bitwarden_license/bitwarden-pam/src/access_requests/models.rs
@@ -1,5 +1,7 @@
 use bitwarden_api_api::models::{
+    AccessDecisionVerdict as ApiAccessDecisionVerdict, AccessRequestDecisionResponseModel,
     AccessRequestDetailsResponseModel, AccessRequestStatus as ApiAccessRequestStatus,
+    DeciderKind as ApiDeciderKind,
 };
 use bitwarden_collections::collection::CollectionId;
 use bitwarden_core::{OrganizationId, UserId, require};
@@ -9,7 +11,7 @@ use serde::{Deserialize, Serialize};
 #[cfg(feature = "wasm")]
 use tsify::Tsify;
 
-use crate::{AccessRequestId, AccessRuleId, error::LeasingError};
+use crate::{AccessLeaseId, AccessLeaseStatus, AccessRequestId, AccessRuleId, error::LeasingError};
 
 /// The lifecycle state of an access request.
 ///
@@ -51,6 +53,98 @@ impl From<ApiAccessRequestStatus> for AccessRequestStatus {
     }
 }
 
+/// What produced a decision on an access request.
+#[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "wasm", derive(Tsify), tsify(into_wasm_abi, from_wasm_abi))]
+#[serde(rename_all = "snake_case")]
+pub enum AccessDeciderKind {
+    /// The decision was made automatically by the governing access rule; no human approval was
+    /// required.
+    Automatic,
+    /// The decision was made by a human approver.
+    Human,
+    /// A decider kind value this SDK version does not recognize. Kept as a distinct variant so
+    /// reading a request's decision log never fails on a newer server's decider kind.
+    Unknown,
+}
+
+impl From<ApiDeciderKind> for AccessDeciderKind {
+    fn from(kind: ApiDeciderKind) -> Self {
+        match kind {
+            ApiDeciderKind::Automatic => Self::Automatic,
+            ApiDeciderKind::Human => Self::Human,
+            ApiDeciderKind::__Unknown(_) => Self::Unknown,
+        }
+    }
+}
+
+/// An approver's verdict on an access request decision.
+#[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "wasm", derive(Tsify), tsify(into_wasm_abi, from_wasm_abi))]
+#[serde(rename_all = "snake_case")]
+pub enum AccessDecisionVerdict {
+    /// The request was denied.
+    Deny,
+    /// The request was approved.
+    Approve,
+    /// A verdict value this SDK version does not recognize. Kept as a distinct variant so reading
+    /// a request's decision log never fails on a newer server's verdict.
+    Unknown,
+}
+
+impl From<ApiAccessDecisionVerdict> for AccessDecisionVerdict {
+    fn from(verdict: ApiAccessDecisionVerdict) -> Self {
+        match verdict {
+            ApiAccessDecisionVerdict::Deny => Self::Deny,
+            ApiAccessDecisionVerdict::Approve => Self::Approve,
+            ApiAccessDecisionVerdict::__Unknown(_) => Self::Unknown,
+        }
+    }
+}
+
+/// A single decision recorded on an access request's decision log.
+///
+/// For an [`Automatic`](AccessDeciderKind::Automatic) decision, `id`, `name`, and `email` are
+/// `None`; for a [`Human`](AccessDeciderKind::Human) decision they carry the approver's identity,
+/// denormalized by the server (`None` only when the user could not be resolved).
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "wasm", derive(Tsify), tsify(into_wasm_abi, from_wasm_abi))]
+#[serde(rename_all = "camelCase")]
+pub struct AccessRequestDecisionView {
+    /// Who made the decision.
+    pub decider_kind: AccessDeciderKind,
+    /// The human approver's user id; `None` for an automatic decision.
+    pub id: Option<UserId>,
+    /// The human approver's display name; `None` for an automatic decision, or when the user
+    /// could not be resolved.
+    pub name: Option<String>,
+    /// The human approver's email; `None` for an automatic decision, or when the user could not
+    /// be resolved.
+    pub email: Option<String>,
+    /// The optional note the approver left with the decision.
+    pub comment: Option<String>,
+    /// The decision's verdict.
+    pub verdict: AccessDecisionVerdict,
+    /// When the decision was recorded (UTC).
+    pub decided_at: DateTime<Utc>,
+}
+
+impl TryFrom<AccessRequestDecisionResponseModel> for AccessRequestDecisionView {
+    type Error = LeasingError;
+
+    fn try_from(response: AccessRequestDecisionResponseModel) -> Result<Self, Self::Error> {
+        Ok(Self {
+            decider_kind: AccessDeciderKind::from(require!(response.decider_kind)),
+            id: response.id.map(UserId::new),
+            name: response.name,
+            email: response.email,
+            comment: response.comment,
+            verdict: AccessDecisionVerdict::from(require!(response.verdict)),
+            decided_at: require!(response.decided_at).parse()?,
+        })
+    }
+}
+
 /// A decrypted view of an access request, as its requester sees it.
 ///
 /// An access request is a member's ask to open a PAM-gated cipher. Once approved, the requester
@@ -86,6 +180,20 @@ pub struct AccessRequestView {
     pub submitted_at: DateTime<Utc>,
     /// When the request was approved, denied, or cancelled (UTC); None while pending.
     pub resolved_at: Option<DateTime<Utc>>,
+    /// The request's decision log, oldest first. Empty only while pending.
+    pub decisions: Vec<AccessRequestDecisionView>,
+    /// The lease produced once this (approved) request was activated. None until activation.
+    pub produced_lease_id: Option<AccessLeaseId>,
+    /// The status of the produced lease at the time this view was fetched. None until activation.
+    pub produced_lease_status: Option<AccessLeaseStatus>,
+    /// The parent lease this request extends, if it is an extension request. None otherwise.
+    pub extension_of_lease_id: Option<AccessLeaseId>,
+    /// The requester's display name, denormalized by the server. None only when the user could
+    /// not be resolved.
+    pub requester_name: Option<String>,
+    /// The requester's email, denormalized by the server. None only when the user could not be
+    /// resolved.
+    pub requester_email: Option<String>,
 }
 
 impl TryFrom<AccessRequestDetailsResponseModel> for AccessRequestView {
@@ -105,6 +213,138 @@ impl TryFrom<AccessRequestDetailsResponseModel> for AccessRequestView {
             reason: response.reason,
             submitted_at: require!(response.submitted_at).parse()?,
             resolved_at: response.resolved_at.map(|d| d.parse()).transpose()?,
+            decisions: response
+                .decisions
+                .unwrap_or_default()
+                .into_iter()
+                .map(AccessRequestDecisionView::try_from)
+                .collect::<Result<Vec<_>, _>>()?,
+            produced_lease_id: response.produced_lease_id.map(AccessLeaseId::new),
+            produced_lease_status: response.produced_lease_status.map(AccessLeaseStatus::from),
+            extension_of_lease_id: response.extension_of_lease_id.map(AccessLeaseId::new),
+            requester_name: response.requester_name,
+            requester_email: response.requester_email,
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use bitwarden_api_api::models::{AccessLeaseStatus as ApiAccessLeaseStatus, DeciderKind};
+    use uuid::Uuid;
+
+    use super::*;
+
+    fn human_decision() -> AccessRequestDecisionResponseModel {
+        AccessRequestDecisionResponseModel {
+            decider_kind: Some(DeciderKind::Human),
+            id: Some(Uuid::new_v4()),
+            name: Some("Ana Approver".to_string()),
+            email: Some("ana@example.com".to_string()),
+            comment: Some("Looks fine".to_string()),
+            verdict: Some(ApiAccessDecisionVerdict::Approve),
+            decided_at: Some("2025-01-01T00:30:00Z".to_string()),
+        }
+    }
+
+    fn automatic_decision() -> AccessRequestDecisionResponseModel {
+        AccessRequestDecisionResponseModel {
+            decider_kind: Some(DeciderKind::Automatic),
+            id: None,
+            name: None,
+            email: None,
+            comment: None,
+            verdict: Some(ApiAccessDecisionVerdict::Approve),
+            decided_at: Some("2025-01-01T00:00:05Z".to_string()),
+        }
+    }
+
+    fn full_response() -> AccessRequestDetailsResponseModel {
+        AccessRequestDetailsResponseModel {
+            id: Some(Uuid::new_v4()),
+            cipher_id: Some(Uuid::new_v4()),
+            collection_id: Some(Uuid::new_v4()),
+            organization_id: Some(Uuid::new_v4()),
+            requester_id: Some(Uuid::new_v4()),
+            rule_id: Some(Uuid::new_v4()),
+            status: Some(ApiAccessRequestStatus::Activated),
+            lease_not_before: Some("2025-01-01T00:00:00Z".to_string()),
+            lease_not_after: Some("2025-01-01T01:00:00Z".to_string()),
+            reason: Some("Need to fix an incident".to_string()),
+            submitted_at: Some("2025-01-01T00:00:00Z".to_string()),
+            resolved_at: Some("2025-01-01T00:30:00Z".to_string()),
+            decisions: Some(vec![automatic_decision(), human_decision()]),
+            produced_lease_id: Some(Uuid::new_v4()),
+            produced_lease_status: Some(ApiAccessLeaseStatus::Active),
+            extension_of_lease_id: Some(Uuid::new_v4()),
+            requester_name: Some("Rea Quester".to_string()),
+            requester_email: Some("rea@example.com".to_string()),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn full_response_converts_decisions_and_lease_linkage() {
+        let response = full_response();
+        let expected_produced_lease_id = response.produced_lease_id.unwrap();
+        let expected_extension_of_lease_id = response.extension_of_lease_id.unwrap();
+
+        let view = AccessRequestView::try_from(response).unwrap();
+
+        assert_eq!(view.decisions.len(), 2);
+        assert_eq!(
+            view.produced_lease_id,
+            Some(AccessLeaseId::new(expected_produced_lease_id))
+        );
+        assert_eq!(view.produced_lease_status, Some(AccessLeaseStatus::Active));
+        assert_eq!(
+            view.extension_of_lease_id,
+            Some(AccessLeaseId::new(expected_extension_of_lease_id))
+        );
+        assert_eq!(view.requester_name, Some("Rea Quester".to_string()));
+        assert_eq!(view.requester_email, Some("rea@example.com".to_string()));
+
+        let human = &view.decisions[1];
+        assert_eq!(human.decider_kind, AccessDeciderKind::Human);
+        assert_eq!(human.name, Some("Ana Approver".to_string()));
+        assert_eq!(human.email, Some("ana@example.com".to_string()));
+        assert_eq!(human.comment, Some("Looks fine".to_string()));
+        assert_eq!(human.verdict, AccessDecisionVerdict::Approve);
+    }
+
+    #[test]
+    fn automatic_decision_has_no_approver_identity() {
+        let view = AccessRequestDecisionView::try_from(automatic_decision()).unwrap();
+
+        assert_eq!(view.decider_kind, AccessDeciderKind::Automatic);
+        assert_eq!(view.id, None);
+        assert_eq!(view.name, None);
+        assert_eq!(view.email, None);
+    }
+
+    #[test]
+    fn missing_decisions_becomes_empty_vec() {
+        let response = AccessRequestDetailsResponseModel {
+            decisions: None,
+            ..full_response()
+        };
+
+        let view = AccessRequestView::try_from(response).unwrap();
+
+        assert_eq!(view.decisions, Vec::new());
+    }
+
+    #[test]
+    fn unknown_decider_kind_and_verdict_map_to_unknown() {
+        let response = AccessRequestDecisionResponseModel {
+            decider_kind: Some(DeciderKind::__Unknown(99)),
+            verdict: Some(ApiAccessDecisionVerdict::__Unknown(99)),
+            ..human_decision()
+        };
+
+        let view = AccessRequestDecisionView::try_from(response).unwrap();
+
+        assert_eq!(view.decider_kind, AccessDeciderKind::Unknown);
+        assert_eq!(view.verdict, AccessDecisionVerdict::Unknown);
     }
 }

--- a/bitwarden_license/bitwarden-pam/src/error.rs
+++ b/bitwarden_license/bitwarden-pam/src/error.rs
@@ -15,6 +15,9 @@ pub enum LeasingError {
     /// The server response was missing a field required to build the requested type.
     #[error(transparent)]
     MissingField(#[from] MissingFieldError),
+    /// The server returned an access-request decider kind this SDK version does not recognize.
+    #[error("The server returned an unrecognized access-request decider kind")]
+    UnrecognizedDeciderKind,
     /// A date field in the server response could not be parsed.
     #[error(transparent)]
     Chrono(#[from] chrono::ParseError),

--- a/bitwarden_license/bitwarden-pam/src/error.rs
+++ b/bitwarden_license/bitwarden-pam/src/error.rs
@@ -1,0 +1,24 @@
+use bitwarden_core::{ApiError, MissingFieldError};
+use bitwarden_error::bitwarden_error;
+use thiserror::Error;
+
+/// Errors returned from the PAM leasing clients
+/// ([`AccessRequestsClient`](crate::AccessRequestsClient)
+/// and [`LeasesClient`](crate::LeasesClient)).
+///
+/// Access requests and leases are two sides of the same lifecycle - activating a request mints a
+/// lease, and extending a lease returns the updated request - so both clients share one error type
+/// rather than each defining a near-identical one.
+#[bitwarden_error(flat)]
+#[derive(Debug, Error)]
+pub enum LeasingError {
+    /// The server response was missing a field required to build the requested type.
+    #[error(transparent)]
+    MissingField(#[from] MissingFieldError),
+    /// A date field in the server response could not be parsed.
+    #[error(transparent)]
+    Chrono(#[from] chrono::ParseError),
+    /// A network or (de)serialization error occurred while calling the server.
+    #[error(transparent)]
+    Api(#[from] ApiError),
+}

--- a/bitwarden_license/bitwarden-pam/src/leases/client.rs
+++ b/bitwarden_license/bitwarden-pam/src/leases/client.rs
@@ -1,0 +1,225 @@
+use std::sync::Arc;
+
+use bitwarden_core::{ApiError, FromClient, client::ApiConfigurations};
+#[cfg(feature = "wasm")]
+use wasm_bindgen::prelude::wasm_bindgen;
+
+use super::models::{AccessLeaseExtensionRequest, AccessLeaseRevokeRequest, AccessLeaseView};
+use crate::{AccessLeaseId, access_requests::AccessRequestView, error::LeasingError};
+
+/// Client for reading and managing a requester's PAM access leases.
+///
+/// A lease is minted by [`AccessRequestsClient::activate`](crate::AccessRequestsClient::activate);
+/// this client covers the rest of a lease's life: listing the caller's leases, extending an active
+/// one, and ending one early.
+#[cfg_attr(feature = "wasm", wasm_bindgen)]
+#[derive(FromClient)]
+pub struct LeasesClient {
+    pub(crate) api_configurations: Arc<ApiConfigurations>,
+}
+
+#[cfg_attr(feature = "wasm", wasm_bindgen)]
+impl LeasesClient {
+    /// Lists the caller's currently active leases.
+    pub async fn list_active(&self) -> Result<Vec<AccessLeaseView>, LeasingError> {
+        let response = self
+            .api_configurations
+            .api_client
+            .leases_api()
+            .get_active()
+            .await
+            .map_err(ApiError::from)?;
+
+        response
+            .data
+            .unwrap_or_default()
+            .into_iter()
+            .map(AccessLeaseView::try_from)
+            .collect()
+    }
+
+    /// Lists all of the caller's leases, active or not.
+    pub async fn list_mine(&self) -> Result<Vec<AccessLeaseView>, LeasingError> {
+        let response = self
+            .api_configurations
+            .api_client
+            .leases_api()
+            .get_mine()
+            .await
+            .map_err(ApiError::from)?;
+
+        response
+            .data
+            .unwrap_or_default()
+            .into_iter()
+            .map(AccessLeaseView::try_from)
+            .collect()
+    }
+
+    /// Extends an active lease, returning the updated originating request.
+    pub async fn extend(
+        &self,
+        lease_id: AccessLeaseId,
+        request: AccessLeaseExtensionRequest,
+    ) -> Result<AccessRequestView, LeasingError> {
+        let response = self
+            .api_configurations
+            .api_client
+            .leases_api()
+            .extend(lease_id.into(), request.into())
+            .await
+            .map_err(ApiError::from)?;
+
+        AccessRequestView::try_from(response)
+    }
+
+    /// Ends a lease before it expires, re-locking the cipher.
+    pub async fn end(
+        &self,
+        lease_id: AccessLeaseId,
+        request: AccessLeaseRevokeRequest,
+    ) -> Result<(), LeasingError> {
+        self.api_configurations
+            .api_client
+            .leases_api()
+            .revoke(lease_id.into(), request.into())
+            .await
+            .map_err(ApiError::from)?;
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use bitwarden_api_api::{
+        apis::ApiClient,
+        models::{
+            AccessLeaseResponseModel, AccessLeaseResponseModelListResponseModel,
+            AccessLeaseStatus as ApiAccessLeaseStatus, AccessRequestDetailsResponseModel,
+        },
+    };
+    use chrono::{DateTime, Utc};
+    use uuid::uuid;
+
+    use super::*;
+    use crate::leases::models::AccessLeaseStatus;
+
+    fn lease_id() -> AccessLeaseId {
+        AccessLeaseId::new(uuid!("33333333-3333-3333-3333-333333333333"))
+    }
+
+    fn client(api_client: ApiClient) -> LeasesClient {
+        LeasesClient {
+            api_configurations: Arc::new(ApiConfigurations::from_api_client(api_client)),
+        }
+    }
+
+    fn sample_lease() -> AccessLeaseResponseModel {
+        AccessLeaseResponseModel {
+            id: Some(lease_id().into()),
+            request_id: Some(uuid!("44444444-4444-4444-4444-444444444444")),
+            cipher_id: Some(uuid!("55555555-5555-5555-5555-555555555555")),
+            collection_id: Some(uuid!("66666666-6666-6666-6666-666666666666")),
+            organization_id: Some(uuid!("77777777-7777-7777-7777-777777777777")),
+            requester_id: Some(uuid!("88888888-8888-8888-8888-888888888888")),
+            status: Some(ApiAccessLeaseStatus::Active),
+            not_before: Some("2025-01-01T00:00:00Z".to_string()),
+            not_after: Some("2025-01-01T01:00:00Z".to_string()),
+            ..Default::default()
+        }
+    }
+
+    #[tokio::test]
+    async fn list_active_returns_views() {
+        let api_client = ApiClient::new_mocked(move |mock| {
+            mock.leases_api
+                .expect_get_active()
+                .returning(move || {
+                    let mut list = AccessLeaseResponseModelListResponseModel::new();
+                    list.data = Some(vec![sample_lease()]);
+                    Ok(list)
+                })
+                .once();
+        });
+
+        let result = client(api_client).list_active().await.unwrap();
+
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].id, lease_id());
+        assert_eq!(result[0].status, AccessLeaseStatus::Active);
+    }
+
+    #[tokio::test]
+    async fn list_mine_surfaces_api_error() {
+        let api_client = ApiClient::new_mocked(move |mock| {
+            mock.leases_api
+                .expect_get_mine()
+                .returning(move || {
+                    Err(bitwarden_api_api::apis::Error::Response(
+                        bitwarden_api_api::apis::ResponseContent {
+                            status: reqwest::StatusCode::INTERNAL_SERVER_ERROR,
+                            message: String::new(),
+                        },
+                    ))
+                })
+                .once();
+        });
+
+        let result = client(api_client).list_mine().await;
+
+        assert!(matches!(result, Err(LeasingError::Api(_))));
+    }
+
+    #[tokio::test]
+    async fn extend_returns_updated_request() {
+        let api_client = ApiClient::new_mocked(move |mock| {
+            mock.leases_api
+                .expect_extend()
+                .returning(move |_id, _request| {
+                    Ok(AccessRequestDetailsResponseModel {
+                        id: Some(uuid!("44444444-4444-4444-4444-444444444444")),
+                        cipher_id: Some(uuid!("55555555-5555-5555-5555-555555555555")),
+                        collection_id: Some(uuid!("66666666-6666-6666-6666-666666666666")),
+                        requester_id: Some(uuid!("88888888-8888-8888-8888-888888888888")),
+                        status: Some(bitwarden_api_api::models::AccessRequestStatus::Activated),
+                        lease_not_before: Some("2025-01-01T00:00:00Z".to_string()),
+                        lease_not_after: Some("2025-01-01T02:00:00Z".to_string()),
+                        submitted_at: Some("2025-01-01T00:00:00Z".to_string()),
+                        ..Default::default()
+                    })
+                })
+                .once();
+        });
+
+        let request = AccessLeaseExtensionRequest {
+            duration_seconds: Some(3600),
+            reason: "Need more time".to_string(),
+        };
+        let result = client(api_client)
+            .extend(lease_id(), request)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            result.lease_not_after,
+            "2025-01-01T02:00:00Z".parse::<DateTime<Utc>>().unwrap()
+        );
+    }
+
+    #[tokio::test]
+    async fn end_succeeds() {
+        let api_client = ApiClient::new_mocked(move |mock| {
+            mock.leases_api
+                .expect_revoke()
+                .returning(move |_id, _request| Ok(()))
+                .once();
+        });
+
+        let result = client(api_client)
+            .end(lease_id(), AccessLeaseRevokeRequest::default())
+            .await;
+
+        assert!(result.is_ok());
+    }
+}

--- a/bitwarden_license/bitwarden-pam/src/leases/client.rs
+++ b/bitwarden_license/bitwarden-pam/src/leases/client.rs
@@ -92,6 +92,8 @@ impl LeasesClient {
 
 #[cfg(test)]
 mod tests {
+    use std::num::NonZeroU32;
+
     use bitwarden_api_api::{
         apis::ApiClient,
         models::{
@@ -193,7 +195,7 @@ mod tests {
         });
 
         let request = AccessLeaseExtensionRequest {
-            duration_seconds: Some(3600),
+            duration_seconds: NonZeroU32::new(3600),
             reason: "Need more time".to_string(),
         };
         let result = client(api_client)

--- a/bitwarden_license/bitwarden-pam/src/leases/client.rs
+++ b/bitwarden_license/bitwarden-pam/src/leases/client.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use bitwarden_core::{ApiError, FromClient, client::ApiConfigurations};
+use bitwarden_core::{FromClient, client::ApiConfigurations};
 #[cfg(feature = "wasm")]
 use wasm_bindgen::prelude::wasm_bindgen;
 
@@ -27,8 +27,7 @@ impl LeasesClient {
             .api_client
             .leases_api()
             .get_active()
-            .await
-            .map_err(ApiError::from)?;
+            .await?;
 
         response
             .data
@@ -45,8 +44,7 @@ impl LeasesClient {
             .api_client
             .leases_api()
             .get_mine()
-            .await
-            .map_err(ApiError::from)?;
+            .await?;
 
         response
             .data
@@ -67,8 +65,7 @@ impl LeasesClient {
             .api_client
             .leases_api()
             .extend(lease_id.into(), request.into())
-            .await
-            .map_err(ApiError::from)?;
+            .await?;
 
         AccessRequestView::try_from(response)
     }
@@ -83,8 +80,7 @@ impl LeasesClient {
             .api_client
             .leases_api()
             .revoke(lease_id.into(), request.into())
-            .await
-            .map_err(ApiError::from)?;
+            .await?;
 
         Ok(())
     }

--- a/bitwarden_license/bitwarden-pam/src/leases/mod.rs
+++ b/bitwarden_license/bitwarden-pam/src/leases/mod.rs
@@ -1,0 +1,21 @@
+//! PAM access lease operations.
+//!
+//! An *access lease* is the short-lived, single-use grant that a member holds after an approved
+//! [`AccessRequest`](crate::AccessRequestView) is activated. While the lease is
+//! [`Active`](AccessLeaseStatus::Active) the member may open the cipher the request was for; when
+//! it [`Expired`](AccessLeaseStatus::Expired) or is [`Revoked`](AccessLeaseStatus::Revoked) the
+//! cipher re-locks.
+//!
+//! [`LeasesClient`] is obtained from the [`PamClient`](crate::PamClient) and covers reading the
+//! caller's leases ([`list_active`](LeasesClient::list_active) /
+//! [`list_mine`](LeasesClient::list_mine)), [`extend`](LeasesClient::extend)ing an active lease,
+//! and [`end`](LeasesClient::end)ing one early. Leases are *minted* on the access-request side, by
+//! [`AccessRequestsClient::activate`](crate::AccessRequestsClient::activate).
+
+mod client;
+mod models;
+
+pub use client::LeasesClient;
+pub use models::{
+    AccessLeaseExtensionRequest, AccessLeaseRevokeRequest, AccessLeaseStatus, AccessLeaseView,
+};

--- a/bitwarden_license/bitwarden-pam/src/leases/models.rs
+++ b/bitwarden_license/bitwarden-pam/src/leases/models.rs
@@ -1,0 +1,133 @@
+use bitwarden_api_api::models::{
+    AccessLeaseExtensionRequestModel, AccessLeaseResponseModel, AccessLeaseRevokeRequestModel,
+    AccessLeaseStatus as ApiAccessLeaseStatus,
+};
+use bitwarden_collections::collection::CollectionId;
+use bitwarden_core::{OrganizationId, UserId, require};
+use bitwarden_vault::CipherId;
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+#[cfg(feature = "wasm")]
+use tsify::Tsify;
+
+use crate::{AccessLeaseId, AccessRequestId, error::LeasingError};
+
+/// The lifecycle state of an access lease.
+#[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "wasm", derive(Tsify), tsify(into_wasm_abi, from_wasm_abi))]
+#[serde(rename_all = "snake_case")]
+pub enum AccessLeaseStatus {
+    /// The lease is currently within its access window and grants access.
+    Active,
+    /// The lease's access window has closed; it no longer grants access.
+    Expired,
+    /// The lease was revoked before its window closed.
+    Revoked,
+    /// A status value this SDK version does not recognize. Kept as a distinct variant so listing
+    /// leases never fails on a newer server's status.
+    Unknown,
+}
+
+impl From<ApiAccessLeaseStatus> for AccessLeaseStatus {
+    fn from(status: ApiAccessLeaseStatus) -> Self {
+        match status {
+            ApiAccessLeaseStatus::Active => Self::Active,
+            ApiAccessLeaseStatus::Expired => Self::Expired,
+            ApiAccessLeaseStatus::Revoked => Self::Revoked,
+            ApiAccessLeaseStatus::__Unknown(_) => Self::Unknown,
+        }
+    }
+}
+
+/// A decrypted view of an access lease, as its requester sees it.
+///
+/// A lease is the single-use grant that an approved [`AccessRequest`](crate::AccessRequestView)
+/// mints when the requester activates it. While a lease is [`Active`](AccessLeaseStatus::Active)
+/// the requester may open the otherwise-gated cipher; once it
+/// [`Expired`](AccessLeaseStatus::Expired) or is [`Revoked`](AccessLeaseStatus::Revoked) the cipher
+/// re-locks.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "wasm", derive(Tsify), tsify(into_wasm_abi, from_wasm_abi))]
+#[serde(rename_all = "camelCase")]
+pub struct AccessLeaseView {
+    /// The lease's unique identifier.
+    pub id: AccessLeaseId,
+    /// The request this lease was minted from.
+    pub request_id: AccessRequestId,
+    /// The cipher the lease grants access to.
+    pub cipher_id: CipherId,
+    /// The collection the cipher belongs to.
+    pub collection_id: CollectionId,
+    /// The organization that owns the cipher. None when the server omits it.
+    pub organization_id: Option<OrganizationId>,
+    /// The user the lease was granted to (the original requester).
+    pub requester_id: UserId,
+    /// The lease's lifecycle state.
+    pub status: AccessLeaseStatus,
+    /// When the lease's access window opens (UTC).
+    pub not_before: DateTime<Utc>,
+    /// When the lease's access window closes (UTC).
+    pub not_after: DateTime<Utc>,
+    /// When the lease was revoked early (UTC); None unless it was revoked before expiry.
+    pub revoked_at: Option<DateTime<Utc>>,
+    /// The user who revoked the lease; None unless it was revoked early.
+    pub revoked_by_user_id: Option<UserId>,
+}
+
+impl TryFrom<AccessLeaseResponseModel> for AccessLeaseView {
+    type Error = LeasingError;
+
+    fn try_from(response: AccessLeaseResponseModel) -> Result<Self, Self::Error> {
+        Ok(Self {
+            id: AccessLeaseId::new(require!(response.id)),
+            request_id: AccessRequestId::new(require!(response.request_id)),
+            cipher_id: CipherId::new(require!(response.cipher_id)),
+            collection_id: CollectionId::new(require!(response.collection_id)),
+            organization_id: response.organization_id.map(OrganizationId::new),
+            requester_id: UserId::new(require!(response.requester_id)),
+            status: AccessLeaseStatus::from(require!(response.status)),
+            not_before: require!(response.not_before).parse()?,
+            not_after: require!(response.not_after).parse()?,
+            revoked_at: response.revoked_at.map(|d| d.parse()).transpose()?,
+            revoked_by_user_id: response.revoked_by_user_id.map(UserId::new),
+        })
+    }
+}
+
+/// Request to extend an active lease.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "wasm", derive(Tsify), tsify(into_wasm_abi, from_wasm_abi))]
+#[serde(rename_all = "camelCase")]
+pub struct AccessLeaseExtensionRequest {
+    /// How much further to push out the lease's end, in seconds. None asks the server to apply the
+    /// governing rule's default extension. Must be positive and within the rule's maximum.
+    pub duration_seconds: Option<i32>,
+    /// The justification recorded with the extension. Required by the server to be non-empty.
+    pub reason: String,
+}
+
+impl From<AccessLeaseExtensionRequest> for AccessLeaseExtensionRequestModel {
+    fn from(request: AccessLeaseExtensionRequest) -> Self {
+        Self {
+            duration_seconds: request.duration_seconds,
+            reason: request.reason,
+        }
+    }
+}
+
+/// Request to revoke (end) a lease before it expires.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Default)]
+#[cfg_attr(feature = "wasm", derive(Tsify), tsify(into_wasm_abi, from_wasm_abi))]
+#[serde(rename_all = "camelCase")]
+pub struct AccessLeaseRevokeRequest {
+    /// An optional note explaining the revocation. Recorded on the audit trail only.
+    pub reason: Option<String>,
+}
+
+impl From<AccessLeaseRevokeRequest> for AccessLeaseRevokeRequestModel {
+    fn from(request: AccessLeaseRevokeRequest) -> Self {
+        Self {
+            reason: request.reason,
+        }
+    }
+}

--- a/bitwarden_license/bitwarden-pam/src/leases/models.rs
+++ b/bitwarden_license/bitwarden-pam/src/leases/models.rs
@@ -1,3 +1,5 @@
+use std::num::NonZeroU32;
+
 use bitwarden_api_api::models::{
     AccessLeaseExtensionRequestModel, AccessLeaseResponseModel, AccessLeaseRevokeRequestModel,
     AccessLeaseStatus as ApiAccessLeaseStatus,
@@ -101,7 +103,7 @@ impl TryFrom<AccessLeaseResponseModel> for AccessLeaseView {
 pub struct AccessLeaseExtensionRequest {
     /// How much further to push out the lease's end, in seconds. None asks the server to apply the
     /// governing rule's default extension. Must be positive and within the rule's maximum.
-    pub duration_seconds: Option<i32>,
+    pub duration_seconds: Option<NonZeroU32>,
     /// The justification recorded with the extension. Required by the server to be non-empty.
     pub reason: String,
 }
@@ -109,7 +111,7 @@ pub struct AccessLeaseExtensionRequest {
 impl From<AccessLeaseExtensionRequest> for AccessLeaseExtensionRequestModel {
     fn from(request: AccessLeaseExtensionRequest) -> Self {
         Self {
-            duration_seconds: request.duration_seconds,
+            duration_seconds: request.duration_seconds.map(|d| d.get() as i32),
             reason: request.reason,
         }
     }
@@ -129,5 +131,25 @@ impl From<AccessLeaseRevokeRequest> for AccessLeaseRevokeRequestModel {
         Self {
             reason: request.reason,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::num::NonZeroU32;
+
+    use super::*;
+
+    #[test]
+    fn access_lease_extension_request_converts_to_model() {
+        let request = AccessLeaseExtensionRequest {
+            duration_seconds: NonZeroU32::new(3600),
+            reason: "Need more time".to_string(),
+        };
+
+        let model = AccessLeaseExtensionRequestModel::from(request);
+
+        assert_eq!(model.duration_seconds, Some(3600));
+        assert_eq!(model.reason, "Need more time".to_string());
     }
 }

--- a/bitwarden_license/bitwarden-pam/src/lib.rs
+++ b/bitwarden_license/bitwarden-pam/src/lib.rs
@@ -12,7 +12,10 @@ uuid_newtype!(pub AccessLeaseId);
 uuid_newtype!(pub AccessRequestId);
 uuid_newtype!(pub AccessRuleId);
 
-pub use access_requests::{AccessRequestStatus, AccessRequestView, AccessRequestsClient};
+pub use access_requests::{
+    AccessDeciderKind, AccessDecisionVerdict, AccessRequestDecisionView, AccessRequestStatus,
+    AccessRequestView, AccessRequestsClient,
+};
 pub use access_rules::{
     AccessCondition, AccessRuleAddEditRequest, AccessRuleError, AccessRuleValidationError,
     AccessRuleView, AccessRulesClient, is_valid_cidr,

--- a/bitwarden_license/bitwarden-pam/src/lib.rs
+++ b/bitwarden_license/bitwarden-pam/src/lib.rs
@@ -13,8 +13,8 @@ uuid_newtype!(pub AccessRequestId);
 uuid_newtype!(pub AccessRuleId);
 
 pub use access_requests::{
-    AccessDeciderKind, AccessDecisionVerdict, AccessRequestDecisionView, AccessRequestStatus,
-    AccessRequestView, AccessRequestsClient,
+    AccessApprover, AccessDecider, AccessDecisionVerdict, AccessRequestDecisionView,
+    AccessRequestStatus, AccessRequestView, AccessRequestsClient,
 };
 pub use access_rules::{
     AccessCondition, AccessRuleAddEditRequest, AccessRuleError, AccessRuleValidationError,

--- a/bitwarden_license/bitwarden-pam/src/lib.rs
+++ b/bitwarden_license/bitwarden-pam/src/lib.rs
@@ -2,13 +2,24 @@
 
 use bitwarden_uuid::uuid_newtype;
 
+mod access_requests;
 mod access_rules;
+mod error;
+mod leases;
 mod pam_client;
 
+uuid_newtype!(pub AccessLeaseId);
+uuid_newtype!(pub AccessRequestId);
 uuid_newtype!(pub AccessRuleId);
 
+pub use access_requests::{AccessRequestStatus, AccessRequestView, AccessRequestsClient};
 pub use access_rules::{
     AccessCondition, AccessRuleAddEditRequest, AccessRuleError, AccessRuleValidationError,
     AccessRuleView, AccessRulesClient, is_valid_cidr,
+};
+pub use error::LeasingError;
+pub use leases::{
+    AccessLeaseExtensionRequest, AccessLeaseRevokeRequest, AccessLeaseStatus, AccessLeaseView,
+    LeasesClient,
 };
 pub use pam_client::{PamClient, PamClientExt};

--- a/bitwarden_license/bitwarden-pam/src/pam_client.rs
+++ b/bitwarden_license/bitwarden-pam/src/pam_client.rs
@@ -4,7 +4,9 @@ use bitwarden_core::{Client, FromClient, client::ApiConfigurations};
 #[cfg(feature = "wasm")]
 use wasm_bindgen::prelude::*;
 
-use crate::access_rules::AccessRulesClient;
+use crate::{
+    access_requests::AccessRequestsClient, access_rules::AccessRulesClient, leases::LeasesClient,
+};
 
 /// Entry point for Privileged Access Management (PAM) operations.
 #[derive(Clone, FromClient)]
@@ -18,6 +20,20 @@ impl PamClient {
     /// Access rule CRUD operations.
     pub fn access_rules(&self) -> AccessRulesClient {
         AccessRulesClient {
+            api_configurations: self.api_configurations.clone(),
+        }
+    }
+
+    /// Access request operations (activate, cancel, and read the caller's requests).
+    pub fn access_requests(&self) -> AccessRequestsClient {
+        AccessRequestsClient {
+            api_configurations: self.api_configurations.clone(),
+        }
+    }
+
+    /// Access lease operations (read, extend, and end the caller's leases).
+    pub fn leases(&self) -> LeasesClient {
+        LeasesClient {
             api_configurations: self.api_configurations.clone(),
         }
     }


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-41226

## 📔 Objective

Extend the `bitwarden-pam` crate with the **request→activate** leasing surface,
copying the shape of the existing `access_rules` module (client + models + flat
error, with Tsify/`wasm_bindgen` bindings and `mockall` unit tests):

- **`access_requests`** — `AccessRequestsClient` on `PamClient::access_requests()`:
  - `activate(id) -> AccessLeaseView` — activate an approved request, minting the lease
  - `cancel(id)` — cancel the caller's own pending request
  - `get(id)` / `list_mine()` — read the caller's requests
  - `AccessRequestView`, `AccessRequestStatus`
- **`leases`** — `LeasesClient` on `PamClient::leases()`:
  - `list_active()` / `list_mine()` — read the caller's leases
  - `extend(lease_id, request)` — extend an active lease
  - `end(lease_id, request)` — end a lease early (re-lock)
  - `AccessLeaseView`, `AccessLeaseStatus`, `AccessLeaseExtensionRequest`, `AccessLeaseRevokeRequest`
- Shared flat `LeasingError`; new `AccessLeaseId` / `AccessRequestId` newtypes.

Built entirely on bindings already present in `bitwarden-api-api` on `main`
(`access_requests_api`, `leases_api`) — no binding changes in this PR.

**Deliberately not included:** request *creation* (`POST /leases/ciphers/{id}`)
and the per-cipher access-state / pre-check reads. Those depend on the
`cipher_lease_api` binding, which isn't generated into `bitwarden-api-api` yet
and, per repo convention, lands via the bindings-update workflow rather than a
feature PR. Until then, clients keep creating requests over HTTP and can derive
per-cipher state from `leases().list_active()` + `access_requests().list_mine()`.
Human-approval (`decide`) is out of scope for the automatic flow.

Verification: `cargo test -p bitwarden-pam --all-features` (74 pass, 9 new),
clippy/fmt/cargo-sort clean, wasm target compiles, and the generated commercial
`.d.ts` exposes `commercial().pam().access_requests()` / `.leases()` with the
expected view/DTO/status types.

## 🚨 Breaking Changes

None — purely additive to the commercial `bitwarden-pam` crate.