### PR TITLE
Add cipher-lease actions (pre-check, access state, request) to access_requests

### DIFF
--- a/bitwarden_license/bitwarden-pam/src/access_requests/client.rs
+++ b/bitwarden_license/bitwarden-pam/src/access_requests/client.rs
@@ -1,20 +1,24 @@
 use std::sync::Arc;
 
 use bitwarden_core::{FromClient, client::ApiConfigurations};
+use bitwarden_vault::CipherId;
 #[cfg(feature = "wasm")]
 use wasm_bindgen::prelude::wasm_bindgen;
 
-use super::models::AccessRequestView;
+use super::models::{
+    AccessPreCheckView, AccessRequestCreateRequest, AccessRequestResultView, AccessRequestView,
+    CipherAccessStateView,
+};
 use crate::{AccessRequestId, error::LeasingError, leases::AccessLeaseView};
 
 /// Client for a requester's PAM access requests.
 ///
-/// Covers the requester side of the request lifecycle: listing and reading the caller's own
-/// requests, [`activate`](AccessRequestsClient::activate)ing an approved request to mint a lease,
-/// and [`cancel`](AccessRequestsClient::cancel)ling a request that is still pending.
-///
-/// Creating a request (`POST /leases/ciphers/{id}`) is not yet exposed here - its binding lives on
-/// the not-yet-generated `cipher_lease_api` surface and lands with a later change.
+/// Covers the requester side of the request lifecycle: reading a cipher's access state and
+/// approval outcome ([`pre_check`](AccessRequestsClient::pre_check),
+/// [`cipher_access_state`](AccessRequestsClient::cipher_access_state)), opening a request
+/// ([`request`](AccessRequestsClient::request)), listing and reading the caller's own requests,
+/// [`activate`](AccessRequestsClient::activate)ing an approved request to mint a lease, and
+/// [`cancel`](AccessRequestsClient::cancel)ling a request that is still pending.
 #[cfg_attr(feature = "wasm", wasm_bindgen)]
 #[derive(FromClient)]
 pub struct AccessRequestsClient {
@@ -23,6 +27,53 @@ pub struct AccessRequestsClient {
 
 #[cfg_attr(feature = "wasm", wasm_bindgen)]
 impl AccessRequestsClient {
+    /// Resolves the approval outcome for a cipher without submitting a request, so the client can
+    /// present the right workflow (pick a duration vs. pick a window and justify) before the
+    /// requester commits.
+    pub async fn pre_check(&self, cipher_id: CipherId) -> Result<AccessPreCheckView, LeasingError> {
+        let response = self
+            .api_configurations
+            .api_client
+            .cipher_lease_api()
+            .pre_check(cipher_id.into())
+            .await?;
+
+        AccessPreCheckView::try_from(response)
+    }
+
+    /// Reads the caller's current access state for a cipher - powers the cipher-view banner and
+    /// the vault-row badge.
+    pub async fn cipher_access_state(
+        &self,
+        cipher_id: CipherId,
+    ) -> Result<CipherAccessStateView, LeasingError> {
+        let response = self
+            .api_configurations
+            .api_client
+            .cipher_lease_api()
+            .state(cipher_id.into())
+            .await?;
+
+        CipherAccessStateView::try_from(response)
+    }
+
+    /// Opens an access request for a cipher. Run [`pre_check`](Self::pre_check) first to know
+    /// which fields [`AccessRequestCreateRequest`] expects.
+    pub async fn request(
+        &self,
+        cipher_id: CipherId,
+        request: AccessRequestCreateRequest,
+    ) -> Result<AccessRequestResultView, LeasingError> {
+        let response = self
+            .api_configurations
+            .api_client
+            .cipher_lease_api()
+            .post(cipher_id.into(), request.into())
+            .await?;
+
+        AccessRequestResultView::try_from(response)
+    }
+
     /// Lists the caller's own access requests.
     pub async fn list_mine(&self) -> Result<Vec<AccessRequestView>, LeasingError> {
         let response = self
@@ -85,18 +136,24 @@ mod tests {
     use bitwarden_api_api::{
         apis::ApiClient,
         models::{
-            AccessLeaseResponseModel, AccessLeaseStatus as ApiAccessLeaseStatus,
+            AccessApprovalMode as ApiAccessApprovalMode, AccessLeaseResponseModel,
+            AccessLeaseStatus as ApiAccessLeaseStatus, AccessPreCheckResponseModel,
             AccessRequestDetailsResponseModel, AccessRequestDetailsResponseModelListResponseModel,
-            AccessRequestStatus as ApiAccessRequestStatus,
+            AccessRequestResultResponseModel, AccessRequestStatus as ApiAccessRequestStatus,
+            CipherAccessStateResponseModel,
         },
     };
     use uuid::uuid;
 
     use super::*;
-    use crate::{AccessLeaseStatus, AccessRequestStatus};
+    use crate::{AccessApprovalMode, AccessLeaseStatus, AccessRequestStatus};
 
     fn request_id() -> AccessRequestId {
         AccessRequestId::new(uuid!("44444444-4444-4444-4444-444444444444"))
+    }
+
+    fn cipher_id() -> CipherId {
+        CipherId::new(uuid!("55555555-5555-5555-5555-555555555555"))
     }
 
     fn client(api_client: ApiClient) -> AccessRequestsClient {
@@ -215,5 +272,138 @@ mod tests {
         let result = client(api_client).cancel(request_id()).await;
 
         assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn pre_check_returns_view() {
+        let api_client = ApiClient::new_mocked(move |mock| {
+            mock.cipher_lease_api
+                .expect_pre_check()
+                .returning(move |_id| {
+                    Ok(AccessPreCheckResponseModel {
+                        cipher_id: Some(cipher_id().into()),
+                        approval_mode: Some(ApiAccessApprovalMode::Automatic),
+                        has_active_lease: Some(false),
+                        ..Default::default()
+                    })
+                })
+                .once();
+        });
+
+        let result = client(api_client).pre_check(cipher_id()).await.unwrap();
+
+        assert_eq!(result.approval_mode, AccessApprovalMode::Automatic);
+        assert!(!result.has_active_lease);
+    }
+
+    #[tokio::test]
+    async fn pre_check_surfaces_api_error() {
+        let api_client = ApiClient::new_mocked(move |mock| {
+            mock.cipher_lease_api
+                .expect_pre_check()
+                .returning(move |_id| {
+                    Err(bitwarden_api_api::apis::Error::Response(
+                        bitwarden_api_api::apis::ResponseContent {
+                            status: reqwest::StatusCode::NOT_FOUND,
+                            message: "Not found".to_string(),
+                        },
+                    ))
+                })
+                .once();
+        });
+
+        let result = client(api_client).pre_check(cipher_id()).await;
+
+        assert!(matches!(result, Err(LeasingError::Api(_))));
+    }
+
+    #[tokio::test]
+    async fn cipher_access_state_returns_view() {
+        let api_client = ApiClient::new_mocked(move |mock| {
+            mock.cipher_lease_api
+                .expect_state()
+                .returning(move |_id| {
+                    Ok(CipherAccessStateResponseModel {
+                        cipher_id: Some(cipher_id().into()),
+                        active_lease: None,
+                        pending_request: None,
+                        approved_request: None,
+                        extensions_allowed: Some(true),
+                        max_extension_duration_seconds: Some(1800),
+                        ..Default::default()
+                    })
+                })
+                .once();
+        });
+
+        let result = client(api_client)
+            .cipher_access_state(cipher_id())
+            .await
+            .unwrap();
+
+        assert_eq!(result.active_lease, None);
+        assert!(result.extensions_allowed);
+        assert_eq!(result.max_extension_duration_seconds, Some(1800));
+    }
+
+    #[tokio::test]
+    async fn request_submits_and_returns_result() {
+        let api_client = ApiClient::new_mocked(move |mock| {
+            mock.cipher_lease_api
+                .expect_post()
+                .returning(move |_id, _request| {
+                    Ok(AccessRequestResultResponseModel {
+                        approval_mode: Some(ApiAccessApprovalMode::Automatic),
+                        request: Some(Box::new(AccessRequestDetailsResponseModel {
+                            id: Some(request_id().into()),
+                            cipher_id: Some(cipher_id().into()),
+                            collection_id: Some(uuid!("66666666-6666-6666-6666-666666666666")),
+                            status: Some(ApiAccessRequestStatus::Approved),
+                            lease_not_before: Some("2025-01-01T00:00:00Z".to_string()),
+                            lease_not_after: Some("2025-01-01T01:00:00Z".to_string()),
+                            submitted_at: Some("2025-01-01T00:00:00Z".to_string()),
+                            ..Default::default()
+                        })),
+                        ..Default::default()
+                    })
+                })
+                .once();
+        });
+
+        let request = AccessRequestCreateRequest {
+            duration_seconds: Some(3600),
+            ..Default::default()
+        };
+
+        let result = client(api_client)
+            .request(cipher_id(), request)
+            .await
+            .unwrap();
+
+        assert_eq!(result.approval_mode, AccessApprovalMode::Automatic);
+        assert_eq!(result.request.id, request_id());
+    }
+
+    #[tokio::test]
+    async fn request_surfaces_api_error() {
+        let api_client = ApiClient::new_mocked(move |mock| {
+            mock.cipher_lease_api
+                .expect_post()
+                .returning(move |_id, _request| {
+                    Err(bitwarden_api_api::apis::Error::Response(
+                        bitwarden_api_api::apis::ResponseContent {
+                            status: reqwest::StatusCode::BAD_REQUEST,
+                            message: "Invalid window".to_string(),
+                        },
+                    ))
+                })
+                .once();
+        });
+
+        let result = client(api_client)
+            .request(cipher_id(), AccessRequestCreateRequest::default())
+            .await;
+
+        assert!(matches!(result, Err(LeasingError::Api(_))));
     }
 }

--- a/bitwarden_license/bitwarden-pam/src/access_requests/client.rs
+++ b/bitwarden_license/bitwarden-pam/src/access_requests/client.rs
@@ -133,6 +133,8 @@ impl AccessRequestsClient {
 
 #[cfg(test)]
 mod tests {
+    use std::num::NonZeroU32;
+
     use bitwarden_api_api::{
         apis::ApiClient,
         models::{
@@ -371,7 +373,7 @@ mod tests {
         });
 
         let request = AccessRequestCreateRequest {
-            duration_seconds: Some(3600),
+            duration_seconds: NonZeroU32::new(3600),
             ..Default::default()
         };
 

--- a/bitwarden_license/bitwarden-pam/src/access_requests/mod.rs
+++ b/bitwarden_license/bitwarden-pam/src/access_requests/mod.rs
@@ -1,27 +1,22 @@
 //! PAM access request operations.
 //!
-//! An *access request* is a member's ask to open a PAM-gated cipher. On the automatic (no human
-//! approval) path the server auto-approves it, and the requester
+//! An *access request* is a member's ask to open a PAM-gated cipher. A requester
+//! [`pre_check`](AccessRequestsClient::pre_check)s a cipher to learn whether a request would be
+//! auto-approved, then [`request`](AccessRequestsClient::request)s access. On the automatic (no
+//! human approval) path the server auto-approves it, and the requester
 //! [`activate`](AccessRequestsClient::activate)s the approved request to mint a short-lived
 //! [`AccessLease`](crate::AccessLeaseView) over the cipher.
 //!
-//! [`AccessRequestsClient`] is obtained from the [`PamClient`](crate::PamClient) and covers reading
-//! the caller's requests, activating an approved one, and cancelling a pending one.
-//!
-//! # Not yet exposed
-//!
-//! *Creating* a request (`POST /leases/ciphers/{id}`) and the per-cipher access-state / pre-check
-//! reads depend on the `cipher_lease_api` binding, which is not yet generated into
-//! `bitwarden-api-api`. Until it is, request creation stays on the clients' existing HTTP path and
-//! per-cipher state can be derived from
-//! [`LeasesClient::list_active`](crate::LeasesClient::list_active)
-//! plus [`AccessRequestsClient::list_mine`].
+//! [`AccessRequestsClient`] is obtained from the [`PamClient`](crate::PamClient) and covers
+//! per-cipher access-state reads, opening a request, listing/reading the caller's requests,
+//! activating an approved one, and cancelling a pending one.
 
 mod client;
 mod models;
 
 pub use client::AccessRequestsClient;
 pub use models::{
-    AccessApprover, AccessDecider, AccessDecisionVerdict, AccessRequestDecisionView,
-    AccessRequestStatus, AccessRequestView,
+    AccessApprovalMode, AccessApprover, AccessDecider, AccessDecisionVerdict, AccessPreCheckView,
+    AccessRequestCreateRequest, AccessRequestDecisionView, AccessRequestResultView,
+    AccessRequestStatus, AccessRequestSummaryView, AccessRequestView, CipherAccessStateView,
 };

--- a/bitwarden_license/bitwarden-pam/src/access_requests/models.rs
+++ b/bitwarden_license/bitwarden-pam/src/access_requests/models.rs
@@ -1,7 +1,9 @@
 use bitwarden_api_api::models::{
-    AccessDecisionVerdict as ApiAccessDecisionVerdict, AccessRequestDecisionResponseModel,
-    AccessRequestDetailsResponseModel, AccessRequestStatus as ApiAccessRequestStatus,
-    DeciderKind as ApiDeciderKind,
+    AccessApprovalMode as ApiAccessApprovalMode, AccessDecisionVerdict as ApiAccessDecisionVerdict,
+    AccessPreCheckResponseModel, AccessRequestCreateRequestModel,
+    AccessRequestDecisionResponseModel, AccessRequestDetailsResponseModel,
+    AccessRequestResultResponseModel, AccessRequestStatus as ApiAccessRequestStatus,
+    CipherAccessStateResponseModel, DeciderKind as ApiDeciderKind,
 };
 use bitwarden_collections::collection::CollectionId;
 use bitwarden_core::{OrganizationId, UserId, require};
@@ -11,7 +13,10 @@ use serde::{Deserialize, Serialize};
 #[cfg(feature = "wasm")]
 use tsify::Tsify;
 
-use crate::{AccessLeaseId, AccessLeaseStatus, AccessRequestId, AccessRuleId, error::LeasingError};
+use crate::{
+    AccessLeaseId, AccessLeaseStatus, AccessRequestId, AccessRuleId, error::LeasingError,
+    leases::AccessLeaseView,
+};
 
 /// The lifecycle state of an access request.
 ///
@@ -228,10 +233,221 @@ impl TryFrom<AccessRequestDetailsResponseModel> for AccessRequestView {
     }
 }
 
+/// The approval path a lease request will take, surfaced by
+/// [`pre_check`](crate::AccessRequestsClient::pre_check) so the client can present the right
+/// workflow before the requester commits.
+#[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "wasm", derive(Tsify), tsify(into_wasm_abi, from_wasm_abi))]
+#[serde(rename_all = "snake_case")]
+pub enum AccessApprovalMode {
+    /// A request would be approved immediately - the client should let the requester pick a
+    /// duration.
+    Automatic,
+    /// A request would need an approver - the client should let the requester pick a window and
+    /// justify it.
+    Human,
+    /// An approval mode value this SDK version does not recognize.
+    Unknown,
+}
+
+impl From<ApiAccessApprovalMode> for AccessApprovalMode {
+    fn from(mode: ApiAccessApprovalMode) -> Self {
+        match mode {
+            ApiAccessApprovalMode::Automatic => Self::Automatic,
+            ApiAccessApprovalMode::Human => Self::Human,
+            ApiAccessApprovalMode::__Unknown(_) => Self::Unknown,
+        }
+    }
+}
+
+/// The resolved approval outcome for a cipher, read without submitting a request.
+#[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "wasm", derive(Tsify), tsify(into_wasm_abi, from_wasm_abi))]
+#[serde(rename_all = "camelCase")]
+pub struct AccessPreCheckView {
+    /// The cipher this pre-check was resolved for.
+    pub cipher_id: CipherId,
+    /// The approval path a request for this cipher would take.
+    pub approval_mode: AccessApprovalMode,
+    /// True when the caller already holds an active lease: reveal the credential, no request
+    /// needed.
+    pub has_active_lease: bool,
+}
+
+impl TryFrom<AccessPreCheckResponseModel> for AccessPreCheckView {
+    type Error = LeasingError;
+
+    fn try_from(response: AccessPreCheckResponseModel) -> Result<Self, Self::Error> {
+        Ok(Self {
+            cipher_id: CipherId::new(require!(response.cipher_id)),
+            approval_mode: AccessApprovalMode::from(require!(response.approval_mode)),
+            has_active_lease: require!(response.has_active_lease),
+        })
+    }
+}
+
+/// A decrypted view of an access request as its requester sees it right after submitting it.
+///
+/// A lighter sibling of [`AccessRequestView`]: the create response doesn't carry a decision log,
+/// pinned rule, produced-lease linkage, or denormalized requester identity, since none of those
+/// exist yet for a request that was just opened.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "wasm", derive(Tsify), tsify(into_wasm_abi, from_wasm_abi))]
+#[serde(rename_all = "camelCase")]
+pub struct AccessRequestSummaryView {
+    /// The request's unique identifier.
+    pub id: AccessRequestId,
+    /// The cipher access was requested for.
+    pub cipher_id: CipherId,
+    /// The collection the cipher belongs to, through which the request is governed.
+    pub collection_id: CollectionId,
+    /// The organization that owns the cipher. None when the server omits it.
+    pub organization_id: Option<OrganizationId>,
+    /// The request's lifecycle state.
+    pub status: AccessRequestStatus,
+    /// The start of the activation window resolved at submit (UTC).
+    pub lease_not_before: DateTime<Utc>,
+    /// The end of the activation window resolved at submit (UTC).
+    pub lease_not_after: DateTime<Utc>,
+    /// The optional justification the requester supplied when opening the request.
+    pub reason: Option<String>,
+    /// When the request was opened (UTC).
+    pub submitted_at: DateTime<Utc>,
+}
+
+impl TryFrom<AccessRequestDetailsResponseModel> for AccessRequestSummaryView {
+    type Error = LeasingError;
+
+    fn try_from(response: AccessRequestDetailsResponseModel) -> Result<Self, Self::Error> {
+        Ok(Self {
+            id: AccessRequestId::new(require!(response.id)),
+            cipher_id: CipherId::new(require!(response.cipher_id)),
+            collection_id: CollectionId::new(require!(response.collection_id)),
+            organization_id: response.organization_id.map(OrganizationId::new),
+            status: AccessRequestStatus::from(require!(response.status)),
+            lease_not_before: require!(response.lease_not_before).parse()?,
+            lease_not_after: require!(response.lease_not_after).parse()?,
+            reason: response.reason,
+            submitted_at: require!(response.submitted_at).parse()?,
+        })
+    }
+}
+
+/// The result of submitting a cipher-lease request.
+///
+/// No lease is minted at submit on either path - the requester
+/// [`activate`](crate::AccessRequestsClient::activate)s the request to start the lease.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "wasm", derive(Tsify), tsify(into_wasm_abi, from_wasm_abi))]
+#[serde(rename_all = "camelCase")]
+pub struct AccessRequestResultView {
+    /// [`Automatic`](AccessApprovalMode::Automatic) when [`request`](Self::request) was approved
+    /// on submit and is ready to activate, [`Human`](AccessApprovalMode::Human) when it is
+    /// pending an approver.
+    pub approval_mode: AccessApprovalMode,
+    /// The request that was just submitted.
+    pub request: AccessRequestSummaryView,
+}
+
+impl TryFrom<AccessRequestResultResponseModel> for AccessRequestResultView {
+    type Error = LeasingError;
+
+    fn try_from(response: AccessRequestResultResponseModel) -> Result<Self, Self::Error> {
+        Ok(Self {
+            approval_mode: AccessApprovalMode::from(require!(response.approval_mode)),
+            request: AccessRequestSummaryView::try_from(*require!(response.request))?,
+        })
+    }
+}
+
+/// A single-snapshot read of the caller's access state for one cipher, powering the cipher-view
+/// banner and the vault-row badge.
+///
+/// At most one of [`active_lease`](Self::active_lease), [`pending_request`](Self::pending_request),
+/// and [`approved_request`](Self::approved_request) is meaningfully "next": an active lease
+/// authorizes access, a pending request awaits a decision, and an approved request awaits
+/// activation by the caller.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "wasm", derive(Tsify), tsify(into_wasm_abi, from_wasm_abi))]
+#[serde(rename_all = "camelCase")]
+pub struct CipherAccessStateView {
+    /// The cipher this state was resolved for.
+    pub cipher_id: CipherId,
+    /// The caller's active lease over this cipher, if any.
+    pub active_lease: Option<AccessLeaseView>,
+    /// The caller's request awaiting a decision on this cipher, if any.
+    pub pending_request: Option<AccessRequestView>,
+    /// The caller's approved-but-not-yet-activated request on this cipher, if any. Lapsed
+    /// approvals are never surfaced here.
+    pub approved_request: Option<AccessRequestView>,
+    /// Whether the active lease can still be extended.
+    pub extensions_allowed: bool,
+    /// The longest a single extension of the active lease may run, in seconds; None when there is
+    /// no cap or no active lease.
+    pub max_extension_duration_seconds: Option<i32>,
+}
+
+impl TryFrom<CipherAccessStateResponseModel> for CipherAccessStateView {
+    type Error = LeasingError;
+
+    fn try_from(response: CipherAccessStateResponseModel) -> Result<Self, Self::Error> {
+        Ok(Self {
+            cipher_id: CipherId::new(require!(response.cipher_id)),
+            active_lease: response
+                .active_lease
+                .map(|lease| AccessLeaseView::try_from(*lease))
+                .transpose()?,
+            pending_request: response
+                .pending_request
+                .map(|request| AccessRequestView::try_from(*request))
+                .transpose()?,
+            approved_request: response
+                .approved_request
+                .map(|request| AccessRequestView::try_from(*request))
+                .transpose()?,
+            extensions_allowed: require!(response.extensions_allowed),
+            max_extension_duration_seconds: response.max_extension_duration_seconds,
+        })
+    }
+}
+
+/// Request to lease a cipher.
+///
+/// Supply [`duration_seconds`](Self::duration_seconds) for the automatic path, or
+/// [`start`](Self::start)/[`end`](Self::end) + [`reason`](Self::reason) for the human path. Run a
+/// [`pre_check`](crate::AccessRequestsClient::pre_check) first to know which shape the server
+/// expects.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Default)]
+#[cfg_attr(feature = "wasm", derive(Tsify), tsify(into_wasm_abi, from_wasm_abi))]
+#[serde(rename_all = "camelCase")]
+pub struct AccessRequestCreateRequest {
+    /// How long the automatic path's lease should run, in seconds. None on the human path.
+    pub duration_seconds: Option<i32>,
+    /// The start of the requested window (UTC). Required on the human path.
+    pub start: Option<DateTime<Utc>>,
+    /// The end of the requested window (UTC). Required on the human path.
+    pub end: Option<DateTime<Utc>>,
+    /// The justification recorded with the request. Required on the human path.
+    pub reason: Option<String>,
+}
+
+impl From<AccessRequestCreateRequest> for AccessRequestCreateRequestModel {
+    fn from(request: AccessRequestCreateRequest) -> Self {
+        Self {
+            duration_seconds: request.duration_seconds,
+            start: request.start.map(|d| d.to_rfc3339()),
+            end: request.end.map(|d| d.to_rfc3339()),
+            reason: request.reason,
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
-    use bitwarden_api_api::models::{AccessLeaseStatus as ApiAccessLeaseStatus, DeciderKind};
-    use uuid::Uuid;
+    use bitwarden_api_api::models::{
+        AccessLeaseResponseModel, AccessLeaseStatus as ApiAccessLeaseStatus, DeciderKind,
+    };
+    use uuid::{Uuid, uuid};
 
     use super::*;
 
@@ -380,5 +596,154 @@ mod tests {
 
         assert_eq!(json["decider"], "automatic");
         assert_eq!(json["verdict"], "approve");
+    }
+
+    fn request_id() -> AccessRequestId {
+        AccessRequestId::new(uuid!("44444444-4444-4444-4444-444444444444"))
+    }
+
+    fn cipher_id() -> uuid::Uuid {
+        uuid!("55555555-5555-5555-5555-555555555555")
+    }
+
+    #[test]
+    fn pre_check_view_converts() {
+        let response = AccessPreCheckResponseModel {
+            cipher_id: Some(cipher_id()),
+            approval_mode: Some(ApiAccessApprovalMode::Automatic),
+            has_active_lease: Some(true),
+            ..Default::default()
+        };
+
+        let view = AccessPreCheckView::try_from(response).unwrap();
+
+        assert_eq!(view.cipher_id, CipherId::new(cipher_id()));
+        assert_eq!(view.approval_mode, AccessApprovalMode::Automatic);
+        assert!(view.has_active_lease);
+    }
+
+    #[test]
+    fn pre_check_view_maps_unknown_approval_mode() {
+        let response = AccessPreCheckResponseModel {
+            approval_mode: Some(ApiAccessApprovalMode::__Unknown(99)),
+            ..AccessPreCheckResponseModel {
+                cipher_id: Some(cipher_id()),
+                has_active_lease: Some(false),
+                ..Default::default()
+            }
+        };
+
+        let view = AccessPreCheckView::try_from(response).unwrap();
+
+        assert_eq!(view.approval_mode, AccessApprovalMode::Unknown);
+    }
+
+    fn sample_created_request() -> AccessRequestDetailsResponseModel {
+        AccessRequestDetailsResponseModel {
+            id: Some(request_id().into()),
+            cipher_id: Some(cipher_id()),
+            collection_id: Some(uuid!("66666666-6666-6666-6666-666666666666")),
+            organization_id: Some(uuid!("77777777-7777-7777-7777-777777777777")),
+            status: Some(ApiAccessRequestStatus::Pending),
+            lease_not_before: Some("2025-01-01T00:00:00Z".to_string()),
+            lease_not_after: Some("2025-01-01T01:00:00Z".to_string()),
+            reason: Some("Need to fix an incident".to_string()),
+            submitted_at: Some("2025-01-01T00:00:00Z".to_string()),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn access_request_summary_view_converts() {
+        let view = AccessRequestSummaryView::try_from(sample_created_request()).unwrap();
+
+        assert_eq!(view.id, request_id());
+        assert_eq!(view.cipher_id, CipherId::new(cipher_id()));
+        assert_eq!(view.status, AccessRequestStatus::Pending);
+        assert_eq!(view.reason, Some("Need to fix an incident".to_string()));
+    }
+
+    #[test]
+    fn access_request_result_view_converts() {
+        let response = AccessRequestResultResponseModel {
+            approval_mode: Some(ApiAccessApprovalMode::Human),
+            request: Some(Box::new(sample_created_request())),
+            ..Default::default()
+        };
+
+        let view = AccessRequestResultView::try_from(response).unwrap();
+
+        assert_eq!(view.approval_mode, AccessApprovalMode::Human);
+        assert_eq!(view.request.id, request_id());
+    }
+
+    #[test]
+    fn cipher_access_state_view_converts_when_nothing_active() {
+        let response = CipherAccessStateResponseModel {
+            cipher_id: Some(cipher_id()),
+            active_lease: None,
+            pending_request: None,
+            approved_request: None,
+            extensions_allowed: Some(false),
+            max_extension_duration_seconds: None,
+            ..Default::default()
+        };
+
+        let view = CipherAccessStateView::try_from(response).unwrap();
+
+        assert_eq!(view.cipher_id, CipherId::new(cipher_id()));
+        assert_eq!(view.active_lease, None);
+        assert_eq!(view.pending_request, None);
+        assert_eq!(view.approved_request, None);
+        assert!(!view.extensions_allowed);
+        assert_eq!(view.max_extension_duration_seconds, None);
+    }
+
+    #[test]
+    fn cipher_access_state_view_converts_when_all_branches_populated() {
+        let response = CipherAccessStateResponseModel {
+            cipher_id: Some(cipher_id()),
+            active_lease: Some(Box::new(AccessLeaseResponseModel {
+                id: Some(uuid!("33333333-3333-3333-3333-333333333333")),
+                request_id: Some(request_id().into()),
+                cipher_id: Some(cipher_id()),
+                collection_id: Some(uuid!("66666666-6666-6666-6666-666666666666")),
+                requester_id: Some(uuid!("88888888-8888-8888-8888-888888888888")),
+                status: Some(ApiAccessLeaseStatus::Active),
+                not_before: Some("2025-01-01T00:00:00Z".to_string()),
+                not_after: Some("2025-01-01T01:00:00Z".to_string()),
+                ..Default::default()
+            })),
+            pending_request: Some(Box::new(full_response())),
+            approved_request: Some(Box::new(full_response())),
+            extensions_allowed: Some(true),
+            max_extension_duration_seconds: Some(3600),
+            ..Default::default()
+        };
+
+        let view = CipherAccessStateView::try_from(response).unwrap();
+
+        assert!(view.active_lease.is_some());
+        assert!(view.pending_request.is_some());
+        assert!(view.approved_request.is_some());
+        assert!(view.extensions_allowed);
+        assert_eq!(view.max_extension_duration_seconds, Some(3600));
+    }
+
+    #[test]
+    fn access_request_create_request_converts_to_model() {
+        let request = AccessRequestCreateRequest {
+            duration_seconds: Some(3600),
+            start: Some("2025-01-01T00:00:00Z".parse().unwrap()),
+            end: Some("2025-01-01T01:00:00Z".parse().unwrap()),
+            reason: Some("Need access".to_string()),
+        };
+
+        let model = AccessRequestCreateRequestModel::from(request);
+
+        assert_eq!(model.duration_seconds, Some(3600));
+        assert_eq!(model.start, Some("2025-01-01T00:00:00+00:00".to_string()));
+        assert_eq!(model.end, Some("2025-01-01T01:00:00+00:00".to_string()));
+        assert_eq!(model.reason, Some("Need access".to_string()));
     }
 }

--- a/bitwarden_license/bitwarden-pam/src/access_requests/models.rs
+++ b/bitwarden_license/bitwarden-pam/src/access_requests/models.rs
@@ -1,3 +1,5 @@
+use std::num::NonZeroU32;
+
 use bitwarden_api_api::models::{
     AccessApprovalMode as ApiAccessApprovalMode, AccessDecisionVerdict as ApiAccessDecisionVerdict,
     AccessPreCheckResponseModel, AccessRequestCreateRequestModel,
@@ -422,7 +424,7 @@ impl TryFrom<CipherAccessStateResponseModel> for CipherAccessStateView {
 #[serde(rename_all = "camelCase")]
 pub struct AccessRequestCreateRequest {
     /// How long the automatic path's lease should run, in seconds. None on the human path.
-    pub duration_seconds: Option<i32>,
+    pub duration_seconds: Option<NonZeroU32>,
     /// The start of the requested window (UTC). Required on the human path.
     pub start: Option<DateTime<Utc>>,
     /// The end of the requested window (UTC). Required on the human path.
@@ -434,7 +436,7 @@ pub struct AccessRequestCreateRequest {
 impl From<AccessRequestCreateRequest> for AccessRequestCreateRequestModel {
     fn from(request: AccessRequestCreateRequest) -> Self {
         Self {
-            duration_seconds: request.duration_seconds,
+            duration_seconds: request.duration_seconds.map(|d| d.get() as i32),
             start: request.start.map(|d| d.to_rfc3339()),
             end: request.end.map(|d| d.to_rfc3339()),
             reason: request.reason,
@@ -733,7 +735,7 @@ mod tests {
     #[test]
     fn access_request_create_request_converts_to_model() {
         let request = AccessRequestCreateRequest {
-            duration_seconds: Some(3600),
+            duration_seconds: NonZeroU32::new(3600),
             start: Some("2025-01-01T00:00:00Z".parse().unwrap()),
             end: Some("2025-01-01T01:00:00Z".parse().unwrap()),
             reason: Some("Need access".to_string()),

--- a/bitwarden_license/bitwarden-pam/src/lib.rs
+++ b/bitwarden_license/bitwarden-pam/src/lib.rs
@@ -13,8 +13,10 @@ uuid_newtype!(pub AccessRequestId);
 uuid_newtype!(pub AccessRuleId);
 
 pub use access_requests::{
-    AccessApprover, AccessDecider, AccessDecisionVerdict, AccessRequestDecisionView,
-    AccessRequestStatus, AccessRequestView, AccessRequestsClient,
+    AccessApprovalMode, AccessApprover, AccessDecider, AccessDecisionVerdict, AccessPreCheckView,
+    AccessRequestCreateRequest, AccessRequestDecisionView, AccessRequestResultView,
+    AccessRequestStatus, AccessRequestSummaryView, AccessRequestView, AccessRequestsClient,
+    CipherAccessStateView,
 };
 pub use access_rules::{
     AccessCondition, AccessRuleAddEditRequest, AccessRuleError, AccessRuleValidationError,


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-41259

## 📔 Objective

Second PR in the PAM leasing SDK-first stack (on top of #1310). Adds the per-cipher
leasing surface that #1310 deliberately deferred, now that the `cipher_lease_api`
binding exists:

- **`pre_check(cipher_id)`** → `AccessPreCheckView` — the resolved approval outcome for
  a cipher without submitting a request, so the client can present the right workflow
  before the requester commits.
- **`cipher_access_state(cipher_id)`** → `CipherAccessStateView` — a single-snapshot
  read (active lease / pending request / approved request) powering the cipher-view
  banner and vault-row badge.
- **`request(cipher_id, AccessRequestCreateRequest)`** → `AccessRequestResultView` —
  opens a request. Introduces `AccessRequestSummaryView` as a lighter sibling of
  `AccessRequestView`, since the create response carries no decision log, pinned rule,
  produced-lease linkage, or denormalized requester identity.

All three mirror the existing `activate`/`cancel`/`AccessRequestView` conversion
pattern in `access_requests`.

### Commit 1 — bindings regen

Regenerated `bitwarden-api-api` against `server`#8105 (`pam/scaffold-cipher-lease`),
which scaffolds the `/leases/ciphers/{id}` contract (routes, request/response models,
status codes; handlers are still `NotImplementedException` — real behavior is a later
server PR, same as the rest of the automatic-flow scaffolds). Reverted unrelated Send
"Item type" model changes (server PM-39978) that the full regen also picked up and
that broke `bitwarden-send` (not updated for that change yet), to keep this commit
scoped to PAM.

This commit is expected to be **superseded once #8105 merges to `server` main** and
the "Update API Bindings" automation regenerates for real — this branch will rebase
to drop it in favor of the automated one.

### Commit 2 — feature

The `AccessRequestsClient` additions described above, plus `mockall`-backed unit tests
(happy path + error-surfacing per method) and model-conversion tests for the new view
types.

Verification: `cargo test -p bitwarden-pam --all-features` (90 pass), clippy clean,
`bitwarden-wasm-internal` commercial build confirms `preCheck`/`cipherAccessState`/
`request` and the new view/DTO types surface under
`commercial().pam().access_requests()`.

## 🚨 Breaking Changes

None — purely additive to the commercial `bitwarden-pam` crate.