### PR TITLE
[PM-39406] Add global flight recorder level and write fn

### DIFF
--- a/crates/bitwarden-logging/src/global.rs
+++ b/crates/bitwarden-logging/src/global.rs
@@ -38,10 +38,10 @@ pub fn init_flight_recorder(config: FlightRecorderConfig) -> FlightRecorderLayer
 /// not been called.
 pub fn write_flight_recorder(event: FlightRecorderEvent, level: tracing::Level) {
     // Mirrors the layer's check: skip events more verbose than the configured level.
-    if let Some(floor) = FLIGHT_RECORDER_LEVEL.get() {
-        if level > *floor {
-            return;
-        }
+    if let Some(floor) = FLIGHT_RECORDER_LEVEL.get()
+        && level > *floor
+    {
+        return;
     }
     if let Some(buffer) = get_flight_recorder_buffer() {
         buffer.push(event);

--- a/crates/bitwarden-logging/src/global.rs
+++ b/crates/bitwarden-logging/src/global.rs
@@ -7,6 +7,11 @@ use crate::{CircularBuffer, FlightRecorderConfig, FlightRecorderEvent, FlightRec
 /// Global Flight Recorder buffer, initialized during `init_sdk()`.
 static FLIGHT_RECORDER_BUFFER: OnceLock<Arc<CircularBuffer<FlightRecorderEvent>>> = OnceLock::new();
 
+/// Configured level floor for the global Flight Recorder, initialized during
+/// `init_sdk()`. Mirrors [`FlightRecorderLayer`]'s level so that direct writes
+/// via [`write_flight_recorder`] honor the same filter as the tracing layer.
+static FLIGHT_RECORDER_LEVEL: OnceLock<tracing::Level> = OnceLock::new();
+
 /// Initialize the global Flight Recorder.
 ///
 /// Creates a [`FlightRecorderLayer`] and stores the buffer in a global
@@ -18,9 +23,29 @@ static FLIGHT_RECORDER_BUFFER: OnceLock<Arc<CircularBuffer<FlightRecorderEvent>>
 /// still independently functional.
 #[must_use]
 pub fn init_flight_recorder(config: FlightRecorderConfig) -> FlightRecorderLayer {
+    let _ = FLIGHT_RECORDER_LEVEL.set(config.level);
     let layer = FlightRecorderLayer::new(config);
     let _ = FLIGHT_RECORDER_BUFFER.set(layer.buffer());
     layer
+}
+
+/// Write a single externally-sourced event (e.g. from TypeScript) directly into
+/// the global buffer, honoring the configured level floor.
+///
+/// This mirrors [`FlightRecorderLayer`]'s filter so that events routed around
+/// the tracing pipeline are subject to the same level check. Events more verbose
+/// than the configured floor are dropped. No-op if [`init_flight_recorder`] has
+/// not been called.
+pub fn write_flight_recorder(event: FlightRecorderEvent, level: tracing::Level) {
+    // Mirrors the layer's check: skip events more verbose than the configured level.
+    if let Some(floor) = FLIGHT_RECORDER_LEVEL.get() {
+        if level > *floor {
+            return;
+        }
+    }
+    if let Some(buffer) = get_flight_recorder_buffer() {
+        buffer.push(event);
+    }
 }
 
 /// Get the global Flight Recorder buffer.
@@ -69,5 +94,40 @@ mod tests {
         let events = read_flight_recorder();
         // Either empty (not initialized) or non-empty (another test initialized it)
         let _ = events;
+    }
+
+    fn event(marker: &str, level: &str) -> FlightRecorderEvent {
+        FlightRecorderEvent {
+            timestamp: 0,
+            level: level.to_string(),
+            target: "test::module".to_string(),
+            message: marker.to_string(),
+            fields: std::collections::HashMap::new(),
+        }
+    }
+
+    #[test]
+    fn test_write_flight_recorder_respects_level_floor() {
+        // This is the only test in the crate that initializes the global
+        // recorder, so it controls the shared level/buffer for this binary.
+        let config = FlightRecorderConfig::new(
+            std::num::NonZeroUsize::new(100).expect("non-zero"),
+            tracing::Level::INFO,
+        );
+        let _ = init_flight_recorder(config);
+
+        // Below the floor (more verbose than INFO) is dropped.
+        write_flight_recorder(event("fr-drop-debug", "DEBUG"), tracing::Level::DEBUG);
+        // At or above the floor is captured.
+        write_flight_recorder(event("fr-keep-info", "INFO"), tracing::Level::INFO);
+        write_flight_recorder(event("fr-keep-error", "ERROR"), tracing::Level::ERROR);
+
+        let messages: Vec<String> = read_flight_recorder()
+            .into_iter()
+            .map(|e| e.message)
+            .collect();
+        assert!(messages.contains(&"fr-keep-info".to_string()));
+        assert!(messages.contains(&"fr-keep-error".to_string()));
+        assert!(!messages.contains(&"fr-drop-debug".to_string()));
     }
 }

--- a/crates/bitwarden-logging/src/lib.rs
+++ b/crates/bitwarden-logging/src/lib.rs
@@ -13,6 +13,7 @@ pub use config::FlightRecorderConfig;
 pub use event::FlightRecorderEvent;
 pub use global::{
     flight_recorder_count, get_flight_recorder_buffer, init_flight_recorder, read_flight_recorder,
+    write_flight_recorder,
 };
 pub use layer::FlightRecorderLayer;
 pub use visitor::MessageVisitor;


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-39406

## 📔 Objective

Add support for injecting external events into the flight recorder buffer.

- [global.rs](crates/bitwarden-logging/src/global.rs): a second `OnceLock<tracing::Level>` (`FLIGHT_RECORDER_LEVEL`) is set inside `init_flight_recorder` alongside the buffer.
- New `write_flight_recorder(event, level)` writes a single externally-sourced event directly into the global buffer, dropping events more verbose than the configured floor. The check `if level > *floor { return; }` mirrors `layer.rs` exactly. It no-ops when the recorder is uninitialized.
- Exported from [lib.rs](crates/bitwarden-logging/src/lib.rs).
