### PR TITLE
[PM-39407] feat: Add FlightRecorderClient.write WASM method

### DIFF
--- a/crates/bitwarden-wasm-internal/src/flight_recorder.rs
+++ b/crates/bitwarden-wasm-internal/src/flight_recorder.rs
@@ -1,7 +1,11 @@
 //! WASM bindings for the Flight Recorder.
 
-use bitwarden_logging::{FlightRecorderEvent, flight_recorder_count, read_flight_recorder};
+use bitwarden_logging::{
+    FlightRecorderEvent, flight_recorder_count, read_flight_recorder, write_flight_recorder,
+};
 use wasm_bindgen::prelude::*;
+
+use crate::init::{LogLevel, convert_level};
 
 /// WASM client for reading Flight Recorder logs.
 ///
@@ -26,6 +30,20 @@ impl FlightRecorderClient {
     /// Get the current event count without reading event contents.
     pub fn count(&self) -> usize {
         flight_recorder_count()
+    }
+
+    /// Ingest a single TypeScript-originated log event into the global buffer,
+    /// honoring the configured level floor.
+    pub fn write(&self, timestamp: i64, level: LogLevel, target: String, message: String) {
+        let level = convert_level(level);
+        let event = FlightRecorderEvent {
+            timestamp,
+            level: level.to_string(),
+            target,
+            message,
+            fields: Default::default(),
+        };
+        write_flight_recorder(event, level);
     }
 }
 

--- a/crates/bitwarden-wasm-internal/src/flight_recorder.rs
+++ b/crates/bitwarden-wasm-internal/src/flight_recorder.rs
@@ -34,10 +34,13 @@ impl FlightRecorderClient {
 
     /// Ingest a single TypeScript-originated log event into the global buffer,
     /// honoring the configured level floor.
-    pub fn write(&self, timestamp: i64, level: LogLevel, target: String, message: String) {
+    ///
+    /// `timestamp` is milliseconds since the Unix epoch, supplied by the caller
+    /// (`Date.now()`).
+    pub fn write(&self, timestamp: f64, level: LogLevel, target: String, message: String) {
         let level = convert_level(level);
         let event = FlightRecorderEvent {
-            timestamp,
+            timestamp: timestamp as i64,
             level: level.to_string(),
             target,
             message,

--- a/crates/bitwarden-wasm-internal/src/init.rs
+++ b/crates/bitwarden-wasm-internal/src/init.rs
@@ -15,7 +15,7 @@ pub enum LogLevel {
     Error,
 }
 
-fn convert_level(level: LogLevel) -> Level {
+pub(crate) fn convert_level(level: LogLevel) -> Level {
     match level {
         LogLevel::Trace => Level::TRACE,
         LogLevel::Debug => Level::DEBUG,


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-39407

## 📔 Objective

Task [2] of Flight Recorder Phase 2. The WASM `FlightRecorderClient` was read-only (`read`/`count`); this adds a `write(timestamp, level, target, message)` method so TypeScript can ingest a single log event directly into the SDK's global flight-recorder buffer (the direct-write path, not the tracing pipeline).

Note that we take timestamp as f64 as opposed to i64, because wasm-bindgen generates `bigint` for i64, while f64 just gets the normal `number` type.