### PR TITLE
[PM-41310] feat: Add FillAssist variant to PolicyType

### DIFF
--- a/crates/bitwarden-policies/src/policy_type.rs
+++ b/crates/bitwarden-policies/src/policy_type.rs
@@ -67,4 +67,8 @@ pub enum PolicyType {
     /// Supersedes [`DisableSend`](Self::DisableSend) and [`SendOptions`](Self::SendOptions) when
     /// the `pm-31885-send-controls` feature flag is active on the server.
     SendControls = 21,
+    /// Enables the Fill Assist targeting-rules autofill engine as the default for members who
+    /// have not explicitly set their Fill Assist preference, and optionally overrides the default
+    /// rules feed URL.
+    FillAssist = 22,
 }


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[PM-41310](https://bitwarden.atlassian.net/browse/PM-41310)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Adds a `FillAssist = 22` variant to the `PolicyType` enum in `bitwarden-policies`.

This is a foundational, SDK-only change that unblocks the Fill Assist Milestone 2 Epic ([PM-39414]): the new organizational policy that lets admins turn Fill Assist ON as a default for org members who have never explicitly set their preference, and optionally supply a custom rules-feed URL.

Both server-side registration and client-side wiring depend on this variant existing here — the Bitwarden clients repo re-exports `PolicyType` directly from `@bitwarden/sdk-internal` as `SdkPolicyType`, so those workstreams cannot begin until an SDK release with this variant is published.

No policy payload schema, enforcement logic, or client-side behavior is defined in this PR — those live in the server and client repos.

## 🚨 Breaking Changes

<!-- Does this PR introduce any breaking changes? If so, please describe the impact and migration path for clients.

If you're unsure, the automated TypeScript compatibility check will run when you open/update this PR and provide feedback.

For breaking changes:
1. Describe what changed in the client interface
2. Explain why the change was necessary
3. Provide migration steps for client developers
4. Link to any paired client PRs if needed

Otherwise, you can remove this section. -->

None. This is a purely additive change: a new variant on an existing enum, appended at the end with the next sequential discriminant (FillAssist = 22). Serialization of existing variants is unchanged, no existing variants were renamed or removed, and no APIs, function signatures, or types were modified.



Ticket: [PM-41310] · Epic: [PM-39414] (Fill Assist Milestone 2: Organizational Policy and Custom Rules)


[PM-41310]: https://bitwarden.atlassian.net/browse/PM-41310?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PM-39414]: https://bitwarden.atlassian.net/browse/PM-39414?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PM-41310]: https://bitwarden.atlassian.net/browse/PM-41310?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ