### PR TITLE
[PM-41512] Update dylint toolchain

### DIFF
--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -121,11 +121,18 @@ run_dylint() {
   cargo bin cargo-dylint --help >/dev/null
   cargo bin dylint-link --help >/dev/null 2>&1 || true
 
-  local cargo_dylint dylint_link
-  cargo_dylint="$(find "$REPO_ROOT/.bin" -type f -name cargo-dylint -not -path '*/.shims/*' -print -quit)"
-  dylint_link="$(find "$REPO_ROOT/.bin" -type f -name dylint-link -not -path '*/.shims/*' -print -quit)"
+  # Grab the exact version from the manifest. The directory gets cached and can contain older versions.
+  local dylint_version dylint_link_version cargo_dylint dylint_link
+  dylint_version="$(awk -F'"' '/^cargo-dylint *=/ {print $2}' "$REPO_ROOT/Cargo.toml")"
+  dylint_link_version="$(awk -F'"' '/^dylint-link *=/ {print $2}' "$REPO_ROOT/Cargo.toml")"
+  if [[ -z "$dylint_version" || -z "$dylint_link_version" ]]; then
+    echo "Could not read cargo-dylint/dylint-link versions from Cargo.toml" >&2
+    exit 1
+  fi
+  cargo_dylint="$(find "$REPO_ROOT/.bin" -type f -name cargo-dylint -path "*/cargo-dylint/$dylint_version/*" -print -quit)"
+  dylint_link="$(find "$REPO_ROOT/.bin" -type f -name dylint-link -path "*/dylint-link/$dylint_link_version/*" -print -quit)"
   if [[ -z "$cargo_dylint" || -z "$dylint_link" ]]; then
-    echo "Could not find cargo-dylint/dylint-link under .bin (build failed?)" >&2
+    echo "Could not find cargo-dylint $dylint_version / dylint-link $dylint_link_version under .bin (build failed?)" >&2
     exit 1
   fi
   PATH="$(dirname "$dylint_link"):$PATH" "$cargo_dylint" dylint --all -- --all-features --all-targets

--- a/support/lints/Cargo.lock
+++ b/support/lints/Cargo.lock
@@ -221,8 +221,8 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "clippy_utils"
-version = "0.1.91"
-source = "git+https://github.com/rust-lang/rust-clippy?rev=334fb906aef13d20050987b13448f37391bb97a2#334fb906aef13d20050987b13448f37391bb97a2"
+version = "0.1.98"
+source = "git+https://github.com/rust-lang/rust-clippy?rev=9fca3bc9fc2bc83c60bde26d18ed68f11564b228#9fca3bc9fc2bc83c60bde26d18ed68f11564b228"
 dependencies = [
  "arrayvec",
  "itertools",

--- a/support/lints/Cargo.toml
+++ b/support/lints/Cargo.toml
@@ -25,6 +25,6 @@ members = ["*"]
 exclude = [".cargo", "src", "target"]
 
 [workspace.dependencies]
-clippy_utils = { git = "https://github.com/rust-lang/rust-clippy", rev = "334fb906aef13d20050987b13448f37391bb97a2" }
+clippy_utils = { git = "https://github.com/rust-lang/rust-clippy", rev = "9fca3bc9fc2bc83c60bde26d18ed68f11564b228" }
 dylint_linting = "6.0.0"
 dylint_testing = "6.0.0"

--- a/support/lints/error_enum/src/lib.rs
+++ b/support/lints/error_enum/src/lib.rs
@@ -3,13 +3,11 @@
 
 extern crate rustc_errors;
 extern crate rustc_hir;
-extern crate rustc_span;
 
-use clippy_utils::{diagnostics::span_lint_and_sugg, ty::implements_trait};
+use clippy_utils::{diagnostics::span_lint_and_sugg, sym, ty::implements_trait};
 use rustc_errors::Applicability;
 use rustc_hir::{Item, ItemKind};
 use rustc_lint::LateLintPass;
-use rustc_span::symbol::sym;
 
 dylint_linting::declare_late_lint! {
     /// ### What it does
@@ -47,7 +45,11 @@ dylint_linting::declare_late_lint! {
 impl<'tcx> LateLintPass<'tcx> for EnumVariantEndsWithError {
     fn check_item(&mut self, cx: &rustc_lint::LateContext<'tcx>, item: &'tcx Item<'tcx>) {
         if let ItemKind::Enum(_, _, enum_def) = &item.kind {
-            let ty = cx.tcx.type_of(item.owner_id.def_id).instantiate_identity();
+            let ty = cx
+                .tcx
+                .type_of(item.owner_id.def_id)
+                .instantiate_identity()
+                .skip_norm_wip();
             let implements_error = cx
                 .tcx
                 .get_diagnostic_item(sym::Error)

--- a/support/lints/error_suffix/src/lib.rs
+++ b/support/lints/error_suffix/src/lib.rs
@@ -3,13 +3,11 @@
 
 extern crate rustc_errors;
 extern crate rustc_hir;
-extern crate rustc_span;
 
-use clippy_utils::{diagnostics::span_lint_and_sugg, ty::implements_trait};
+use clippy_utils::{diagnostics::span_lint_and_sugg, sym, ty::implements_trait};
 use rustc_errors::Applicability;
 use rustc_hir::{Item, ItemKind};
 use rustc_lint::LateLintPass;
-use rustc_span::symbol::sym;
 
 dylint_linting::declare_late_lint! {
     pub ERROR_SUFFIX,
@@ -28,7 +26,11 @@ impl<'tcx> LateLintPass<'tcx> for ErrorSuffix {
 
         match &item.kind {
             ItemKind::Enum(..) | ItemKind::Struct(..) => {
-                let ty = cx.tcx.type_of(item.owner_id.def_id).instantiate_identity();
+                let ty = cx
+                    .tcx
+                    .type_of(item.owner_id.def_id)
+                    .instantiate_identity()
+                    .skip_norm_wip();
                 let implements_error = cx
                     .tcx
                     .get_diagnostic_item(sym::Error)

--- a/support/lints/rust-toolchain.toml
+++ b/support/lints/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "nightly-2025-08-07"
+channel = "nightly-2026-05-28"
 components = ["llvm-tools-preview", "rustc-dev"]

--- a/support/lints/uniffi_async_export/src/lib.rs
+++ b/support/lints/uniffi_async_export/src/lib.rs
@@ -6,7 +6,8 @@ extern crate rustc_errors;
 
 use clippy_utils::diagnostics::{span_lint_and_help, span_lint_and_sugg};
 use rustc_ast::ast::{
-    AssocItemKind, AttrArgs, AttrKind, Attribute, CoroutineKind, FnSig, Item, ItemKind,
+    AssocItemKind, AttrArgs, AttrItemKind, AttrKind, Attribute, CoroutineKind, FnSig, Item,
+    ItemKind,
 };
 use rustc_ast::token::{LitKind, TokenKind};
 use rustc_ast::tokenstream::TokenTree;
@@ -100,7 +101,7 @@ fn has_async_runtime_tokio(attr: &Attribute) -> bool {
     let AttrKind::Normal(normal) = &attr.kind else {
         return false;
     };
-    let AttrArgs::Delimited(delim) = &normal.item.args else {
+    let AttrItemKind::Unparsed(AttrArgs::Delimited(delim)) = &normal.item.args else {
         return false;
     };
 
@@ -129,7 +130,7 @@ fn emit_lint(cx: &EarlyContext<'_>, attr: &Attribute) {
     let msg =
         "`#[uniffi::export]` on `async fn`s must specify `async_runtime = \"tokio\"`";
 
-    if matches!(normal.item.args, AttrArgs::Empty) {
+    if matches!(normal.item.args, AttrItemKind::Unparsed(AttrArgs::Empty)) {
         span_lint_and_sugg(
             cx,
             UNIFFI_ASYNC_EXPORT,


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-41512

## 📔 Objective

Update the referenced toolchain and clippy utils for dylint. This is required for bumping the MSRV to 1.95 for rusqlite: https://github.com/bitwarden/sdk-internal/pull/1171

The versions used are from the dylint templates:
https://github.com/trailofbits/dylint/blob/c98f542f6ddea7208ba8d76ed773fecf96c01113/internal/template/Cargo.toml#L13
https://github.com/trailofbits/dylint/blob/c98f542f6ddea7208ba8d76ed773fecf96c01113/internal/template/rust-toolchain.toml#L2

Also fixes `scripts/lint.sh` picking up a stale `cargo-dylint` from the cached `.bin` directory, it now matches the version pinned in `[workspace.metadata.bin]`, rather than taking whatever `find` returned first. On CI that was resolving to 5.0.0, which builds a `dylint_driver` too old to compile against the new nightly.

## 🚨 Breaking Changes

<!-- Does this PR introduce any breaking changes? If so, please describe the impact and migration path for clients.

If you're unsure, the automated TypeScript compatibility check will run when you open/update this PR and provide feedback.

For breaking changes:
1. Describe what changed in the client interface
2. Explain why the change was necessary
3. Provide migration steps for client developers
4. Link to any paired client PRs if needed

Otherwise, you can remove this section. -->
