### PR TITLE
[PM-41514] Add Fill Assist policy override

### DIFF
--- a/crates/bitwarden-policies/src/policy_client.rs
+++ b/crates/bitwarden-policies/src/policy_client.rs
@@ -19,6 +19,7 @@ fn build_policy_registry() -> PolicyRegistry {
         .register(RestrictedItemTypesPolicy)
         .register(AutomaticUserConfirmationPolicy)
         .register(OrganizationUserNotificationPolicy)
+        .register(FillAssistPolicy)
         .build()
 }
 

--- a/crates/bitwarden-policies/src/policy_overrides.rs
+++ b/crates/bitwarden-policies/src/policy_overrides.rs
@@ -124,6 +124,21 @@ impl Policy for OrganizationUserNotificationPolicy {
     }
 }
 
+/// Fill Assist policy.
+///
+/// Applies to **everyone**, including Owners and Admins.
+pub struct FillAssistPolicy;
+
+impl Policy for FillAssistPolicy {
+    fn policy_type(&self) -> PolicyType {
+        PolicyType::FillAssist
+    }
+
+    fn exempt_roles(&self) -> &[OrganizationUserType] {
+        &[]
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use bitwarden_organizations::{OrganizationUserStatusType, OrganizationUserType};
@@ -300,5 +315,23 @@ mod tests {
                 .len(),
             1
         );
+    }
+
+    // --- FillAssistPolicy ---
+
+    #[test]
+    fn fill_assist_applies_to_owner() {
+        let org_id = Uuid::new_v4();
+        let policies = [policy_view(org_id, PolicyType::FillAssist)];
+        let orgs = [org(org_id, OrganizationUserType::Owner)];
+        assert_eq!(FillAssistPolicy.filter(&policies, &orgs).len(), 1);
+    }
+
+    #[test]
+    fn fill_assist_applies_to_admin() {
+        let org_id = Uuid::new_v4();
+        let policies = [policy_view(org_id, PolicyType::FillAssist)];
+        let orgs = [org(org_id, OrganizationUserType::Admin)];
+        assert_eq!(FillAssistPolicy.filter(&policies, &orgs).len(), 1);
     }
 }


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[PM-41514](https://bitwarden.atlassian.net/browse/PM-41514)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Registers a `FillAssistPolicy` override in the SDK's `PolicyRegistry` so the Fill Assist organizational policy is correctly filtered for all org members, including Owners and Admins.

Follow-up to [#1321] ([PM-41310](https://bitwarden.atlassian.net/browse/PM-41310)), which added the `PolicyType::FillAssist = 22` enum variant. That change alone left `FillAssist` unregistered in `build_policy_registry()`, so the SDK fell back to `DefaultPolicy` — whose defaults exempt Owners and Admins. Downstream, `policyService` in the Bitwarden clients would have silently reported Fill Assist as inactive for those roles even when the org had the policy enabled. This PR fixes that gap.

Configuration mirrors the peer user-experience policies (`MasterPassword`, `PasswordGenerator`, `RemoveUnlockWithPin`, `RestrictedItemTypes`, `FreeFamiliesSponsorship`, `OrganizationUserNotification`, `AutomaticUserConfirmation`):

- `exempt_roles = &[]` — applies to everyone
- Default `exempt_providers` (`true`) and `applicable_statuses` (`Accepted`, `Confirmed`)

No changes to `PolicyType`, wire format, or policy payload schema.

## 🚨 Breaking Changes

<!-- Does this PR introduce any breaking changes? If so, please describe the impact and migration path for clients.

If you're unsure, the automated TypeScript compatibility check will run when you open/update this PR and provide feedback.

For breaking changes:
1. Describe what changed in the client interface
2. Explain why the change was necessary
3. Provide migration steps for client developers
4. Link to any paired client PRs if needed

Otherwise, you can remove this section. -->

None. This PR only adds an internal registration in `build_policy_registry()` and a new unit struct (`FillAssistPolicy`) alongside the existing overrides in `policy_overrides.rs`. No public types, function signatures, enum variants, or serialization formats change.

The observable effect for clients is a behavioral correction, not a breaking change: `policyService` will now correctly report Fill Assist as active for Owners and Admins in orgs where the policy is enabled, rather than silently exempting them via `DefaultPolicy`. Since the enum variant itself only shipped in `0.2.0-main.945` and no released client is consuming Fill Assist policy filtering yet, no migration is required.

[PM-41514]: https://bitwarden.atlassian.net/browse/PM-41514?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PM-41310]: https://bitwarden.atlassian.net/browse/PM-41310?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ