### PR TITLE
[PM-41576] PAM partial filtered data

### DIFF
--- a/crates/bitwarden-crypto/src/error.rs
+++ b/crates/bitwarden-crypto/src/error.rs
@@ -32,6 +32,8 @@ pub enum CryptoError {
     KeyOperationNotSupported(KeyOperation),
     #[error("Cannot encrypt a restricted (partial) view; its secret fields were never decrypted")]
     EncryptRestrictedView,
+    #[error("A restricted (partial) cipher can only be decrypted when it is organization-owned")]
+    RestrictedCipherRequiresOrganization,
 
     // Note: These variants will be moved into their own key store error in a follow up ticket,
     // since the crypto error is growing too large

--- a/crates/bitwarden-crypto/src/error.rs
+++ b/crates/bitwarden-crypto/src/error.rs
@@ -30,6 +30,8 @@ pub enum CryptoError {
     MissingKeyId(String),
     #[error("Key operation not supported by key: {0:?}")]
     KeyOperationNotSupported(KeyOperation),
+    #[error("Cannot encrypt a restricted (partial) view; its secret fields were never decrypted")]
+    EncryptRestrictedView,
 
     // Note: These variants will be moved into their own key store error in a follow up ticket,
     // since the crypto error is growing too large

--- a/crates/bitwarden-exporters/src/lib.rs
+++ b/crates/bitwarden-exporters/src/lib.rs
@@ -258,6 +258,7 @@ impl From<ImportingCipher> for CipherView {
         };
 
         Self {
+            partial: false,
             id: None,
             organization_id: None,
             folder_id: value.folder_id.map(FolderId::new),

--- a/crates/bitwarden-exporters/src/models.rs
+++ b/crates/bitwarden-exporters/src/models.rs
@@ -274,6 +274,7 @@ mod tests {
 
         let test_id: uuid::Uuid = "fd411a1a-fec8-4070-985d-0e6560860e69".parse().unwrap();
         let view = CipherView {
+            partial: false,
             r#type: CipherType::Login,
             login: Some(LoginView {
                 username: Some("test_username".to_string()),
@@ -330,6 +331,7 @@ mod tests {
 
         let test_id: uuid::Uuid = "fd411a1a-fec8-4070-985d-0e6560860e69".parse().unwrap();
         let cipher_view = CipherView {
+            partial: false,
             r#type: CipherType::Login,
             login: Some(LoginView {
                 username: Some("test_username".to_string()),

--- a/crates/bitwarden-fido/src/authenticator.rs
+++ b/crates/bitwarden-fido/src/authenticator.rs
@@ -804,6 +804,7 @@ mod tests {
         };
 
         CipherView {
+            partial: false,
             id: Some("c2c7e624-dcfd-4f23-af41-b177014ffcb5".parse().unwrap()),
             organization_id: None,
             folder_id: None,

--- a/crates/bitwarden-user-crypto-management/src/key_rotation/data.rs
+++ b/crates/bitwarden-user-crypto-management/src/key_rotation/data.rs
@@ -229,6 +229,7 @@ mod tests {
 
     fn make_test_cipher(attachments: Option<Vec<Attachment>>) -> Cipher {
         Cipher {
+            partial_data: None,
             id: None,
             organization_id: None,
             folder_id: None,
@@ -321,6 +322,7 @@ mod tests {
     fn make_cipher_view() -> bitwarden_vault::CipherView {
         use bitwarden_vault::{CipherView, LoginView};
         CipherView {
+            partial: false,
             id: None,
             organization_id: None,
             folder_id: None,

--- a/crates/bitwarden-user-crypto-management/src/key_rotation/data.rs
+++ b/crates/bitwarden-user-crypto-management/src/key_rotation/data.rs
@@ -215,6 +215,7 @@ mod tests {
 
     fn make_test_cipher(attachments: Option<Vec<Attachment>>) -> Cipher {
         Cipher {
+            partial_data: None,
             id: None,
             organization_id: None,
             folder_id: None,
@@ -307,6 +308,7 @@ mod tests {
     fn make_cipher_view() -> bitwarden_vault::CipherView {
         use bitwarden_vault::{CipherView, LoginView};
         CipherView {
+            partial: false,
             id: None,
             organization_id: None,
             folder_id: None,

--- a/crates/bitwarden-user-crypto-management/src/key_rotation/password_change_and_rotate_user_keys.rs
+++ b/crates/bitwarden-user-crypto-management/src/key_rotation/password_change_and_rotate_user_keys.rs
@@ -319,6 +319,7 @@ mod tests {
 
         // Add a cipher with an old attachment (key is None)
         sync.ciphers = vec![Cipher {
+            partial_data: None,
             id: None,
             organization_id: None,
             folder_id: None,

--- a/crates/bitwarden-user-crypto-management/src/key_rotation/password_change_and_rotate_user_keys.rs
+++ b/crates/bitwarden-user-crypto-management/src/key_rotation/password_change_and_rotate_user_keys.rs
@@ -313,6 +313,7 @@ mod tests {
 
         // Add a cipher with an old attachment (key is None)
         sync.ciphers = vec![Cipher {
+            partial_data: None,
             id: None,
             organization_id: None,
             folder_id: None,

--- a/crates/bitwarden-user-crypto-management/src/key_rotation/rotate_user_keys.rs
+++ b/crates/bitwarden-user-crypto-management/src/key_rotation/rotate_user_keys.rs
@@ -743,6 +743,7 @@ mod tests {
 
         // Add a cipher with an old attachment (key is None)
         sync.ciphers = vec![Cipher {
+            partial_data: None,
             id: None,
             organization_id: None,
             folder_id: None,

--- a/crates/bitwarden-user-crypto-management/src/key_rotation/rotate_user_keys.rs
+++ b/crates/bitwarden-user-crypto-management/src/key_rotation/rotate_user_keys.rs
@@ -714,6 +714,7 @@ mod tests {
 
         // Add a cipher with an old attachment (key is None)
         sync.ciphers = vec![Cipher {
+            partial_data: None,
             id: None,
             organization_id: None,
             folder_id: None,

--- a/crates/bitwarden-user-crypto-management/src/public_key_encryption_key_pair_regeneration/should_regenerate.rs
+++ b/crates/bitwarden-user-crypto-management/src/public_key_encryption_key_pair_regeneration/should_regenerate.rs
@@ -779,6 +779,7 @@ mod tests {
                 .encrypt(&mut ctx, cipher_key)
                 .unwrap();
             Cipher {
+                partial_data: None,
                 id: None,
                 organization_id: None,
                 folder_id: None,

--- a/crates/bitwarden-vault/src/cipher/attachment.rs
+++ b/crates/bitwarden-vault/src/cipher/attachment.rs
@@ -407,6 +407,7 @@ mod tests {
 
         let attachment_file = AttachmentFileView {
             cipher: Cipher {
+                partial_data: None,
                 id: None,
                 organization_id: None,
                 folder_id: None,
@@ -467,6 +468,7 @@ mod tests {
         };
 
         let cipher  = Cipher {
+            partial_data: None,
             id: None,
             organization_id: None,
             folder_id: None,
@@ -531,6 +533,7 @@ mod tests {
         };
 
         let cipher  = Cipher {
+            partial_data: None,
             id: None,
             organization_id: None,
             folder_id: None,

--- a/crates/bitwarden-vault/src/cipher/attachment_client/create.rs
+++ b/crates/bitwarden-vault/src/cipher/attachment_client/create.rs
@@ -273,6 +273,7 @@ mod tests {
 
     fn test_cipher() -> Cipher {
         Cipher {
+            partial_data: None,
             id: TEST_CIPHER_ID.parse().ok(),
             name: Some(TEST_CIPHER_NAME.parse().unwrap()),
             r#type: CipherType::Login,

--- a/crates/bitwarden-vault/src/cipher/attachment_client/delete.rs
+++ b/crates/bitwarden-vault/src/cipher/attachment_client/delete.rs
@@ -87,6 +87,7 @@ mod tests {
 
     fn test_cipher() -> Cipher {
         Cipher {
+            partial_data: None,
             id: TEST_CIPHER_ID.parse().ok(),
             name: Some(TEST_CIPHER_NAME.parse().unwrap()),
             r#type: CipherType::Login,

--- a/crates/bitwarden-vault/src/cipher/attachment_client/download_url.rs
+++ b/crates/bitwarden-vault/src/cipher/attachment_client/download_url.rs
@@ -144,6 +144,7 @@ mod tests {
 
     fn test_cipher() -> Cipher {
         Cipher {
+            partial_data: None,
             id: TEST_CIPHER_ID.parse().ok(),
             name: Some(TEST_CIPHER_NAME.parse().unwrap()),
             r#type: CipherType::Login,

--- a/crates/bitwarden-vault/src/cipher/attachment_client/upgrade.rs
+++ b/crates/bitwarden-vault/src/cipher/attachment_client/upgrade.rs
@@ -329,6 +329,7 @@ mod tests {
 
     fn cipher_with(name: EncString, attachments: Option<Vec<Attachment>>) -> Cipher {
         Cipher {
+            partial_data: None,
             id: TEST_CIPHER_ID.parse().ok(),
             name: Some(name),
             r#type: CipherType::Login,

--- a/crates/bitwarden-vault/src/cipher/blob/conversions/mod.rs
+++ b/crates/bitwarden-vault/src/cipher/blob/conversions/mod.rs
@@ -268,6 +268,7 @@ pub(crate) mod test_support {
 
     pub(crate) fn create_shell_cipher_view(cipher_type: CipherType) -> CipherView {
         CipherView {
+            partial: false,
             id: None,
             organization_id: None,
             folder_id: None,

--- a/crates/bitwarden-vault/src/cipher/blob/encryption.rs
+++ b/crates/bitwarden-vault/src/cipher/blob/encryption.rs
@@ -95,7 +95,9 @@ pub(crate) fn encrypt_blob_cipher_with_wrapping_key(
     // Fail closed: a restricted (partial) view has all secret fields stripped; re-encrypting it
     // would overwrite the item's secrets with empty values. See `decrypt_restricted_cipher_view`.
     if view.partial {
-        return Err(BlobEncryptionError::Crypto(CryptoError::EncryptRestrictedView));
+        return Err(BlobEncryptionError::Crypto(
+            CryptoError::EncryptRestrictedView,
+        ));
     }
 
     if view.key.is_none() {

--- a/crates/bitwarden-vault/src/cipher/blob/encryption.rs
+++ b/crates/bitwarden-vault/src/cipher/blob/encryption.rs
@@ -108,6 +108,7 @@ pub(crate) fn encrypt_blob_cipher_with_wrapping_key(
     let name = "".encrypt(ctx, cipher_key)?;
 
     Ok(Cipher {
+        partial_data: None,
         // Metadata
         id: view.id,
         organization_id: view.organization_id,
@@ -175,6 +176,7 @@ pub(crate) fn decrypt_blob_cipher(
     let local_data = cipher.local_data.decrypt(ctx, cipher_key).ok().flatten();
 
     let mut view = CipherView {
+        partial: false,
         // Metadata
         id: cipher.id,
         organization_id: cipher.organization_id,
@@ -250,6 +252,7 @@ mod tests {
             )
             .unwrap();
         Cipher {
+            partial_data: None,
             id: None,
             organization_id: None,
             folder_id: None,

--- a/crates/bitwarden-vault/src/cipher/blob/encryption.rs
+++ b/crates/bitwarden-vault/src/cipher/blob/encryption.rs
@@ -96,7 +96,9 @@ pub(crate) fn encrypt_blob_cipher_with_wrapping_key(
     // Fail closed: a restricted (partial) view has all secret fields stripped; re-encrypting it
     // would overwrite the item's secrets with empty values. See `decrypt_restricted_cipher_view`.
     if view.partial {
-        return Err(BlobEncryptionError::Crypto(CryptoError::EncryptRestrictedView));
+        return Err(BlobEncryptionError::Crypto(
+            CryptoError::EncryptRestrictedView,
+        ));
     }
 
     if view.key.is_none() {

--- a/crates/bitwarden-vault/src/cipher/blob/encryption.rs
+++ b/crates/bitwarden-vault/src/cipher/blob/encryption.rs
@@ -93,6 +93,12 @@ pub(crate) fn encrypt_blob_cipher_with_wrapping_key(
     ctx: &mut KeyStoreContext<KeySlotIds>,
     wrapping_key: SymmetricKeySlotId,
 ) -> Result<Cipher, BlobEncryptionError> {
+    // Fail closed: a restricted (partial) view has all secret fields stripped; re-encrypting it
+    // would overwrite the item's secrets with empty values. See `decrypt_restricted_cipher_view`.
+    if view.partial {
+        return Err(BlobEncryptionError::Crypto(CryptoError::EncryptRestrictedView));
+    }
+
     if view.key.is_none() {
         view.generate_cipher_key(ctx, wrapping_key)?;
     }

--- a/crates/bitwarden-vault/src/cipher/blob/encryption.rs
+++ b/crates/bitwarden-vault/src/cipher/blob/encryption.rs
@@ -92,6 +92,12 @@ pub(crate) fn encrypt_blob_cipher_with_wrapping_key(
     ctx: &mut KeyStoreContext<KeySlotIds>,
     wrapping_key: SymmetricKeySlotId,
 ) -> Result<Cipher, BlobEncryptionError> {
+    // Fail closed: a restricted (partial) view has all secret fields stripped; re-encrypting it
+    // would overwrite the item's secrets with empty values. See `decrypt_restricted_cipher_view`.
+    if view.partial {
+        return Err(BlobEncryptionError::Crypto(CryptoError::EncryptRestrictedView));
+    }
+
     if view.key.is_none() {
         view.upgrade_to_cipher_key_encryption(ctx, wrapping_key)?;
     }

--- a/crates/bitwarden-vault/src/cipher/blob/encryption.rs
+++ b/crates/bitwarden-vault/src/cipher/blob/encryption.rs
@@ -104,6 +104,7 @@ pub(crate) fn encrypt_blob_cipher_with_wrapping_key(
     let local_data = view.local_data.encrypt_composite(ctx, cipher_key)?;
 
     Ok(Cipher {
+        partial_data: None,
         // Metadata
         id: view.id,
         organization_id: view.organization_id,
@@ -170,6 +171,7 @@ pub(crate) fn decrypt_blob_cipher(
     let local_data = cipher.local_data.decrypt(ctx, cipher_key).ok().flatten();
 
     let mut view = CipherView {
+        partial: false,
         // Metadata
         id: cipher.id,
         organization_id: cipher.organization_id,
@@ -245,6 +247,7 @@ mod tests {
             )
             .unwrap();
         Cipher {
+            partial_data: None,
             id: None,
             organization_id: None,
             folder_id: None,

--- a/crates/bitwarden-vault/src/cipher/cipher.rs
+++ b/crates/bitwarden-vault/src/cipher/cipher.rs
@@ -33,7 +33,7 @@ use super::{
     cipher_permissions::CipherPermissions,
     drivers_license, field, identity,
     local_data::{LocalData, LocalDataView},
-    login::{LoginListView, LoginUri, LoginUriView, UriMatchType},
+    login::{LoginListView, LoginUri, LoginUriView},
     passport, secure_note, ssh_key,
 };
 use crate::{
@@ -1563,48 +1563,32 @@ impl IdentifyKey<SymmetricKeySlotId> for Cipher {
     }
 }
 
-/// The server's reduced payload for a restricted (PAM-gated) cipher, mirroring
-/// `PartialCipherData.Strip` on the server. Deserialized with PascalCase to match the server's
-/// wire shape. This struct is the single authoritative allowlist for what a gated view may
-/// expose: the encrypted name and, for logins, the encrypted URIs — nothing else, so an
-/// over-sharing server blob can never leak a password or TOTP onto a gated view.
+/// The server's reduced payload for a restricted (PAM-gated) cipher, produced by
+/// `PartialCipherData.Strip` on the server. The server emits a purpose-built camelCase envelope
+/// carrying the same [`LoginUri`] fields the full decrypt path uses, so the URIs deserialize
+/// straight into [`LoginUri`] with no parallel representation.
+///
+/// This struct is the single authoritative allowlist for what a gated view may expose: the
+/// encrypted name and, for logins, the encrypted URIs — nothing else. It is deliberately NOT
+/// `deny_unknown_fields`: an over-sharing server blob (e.g. a stray `password` or `totp`) is
+/// silently dropped by the allowlist rather than surfaced onto the view or failing the parse.
 #[derive(Deserialize, Default)]
-#[serde(rename_all = "PascalCase")]
+#[serde(rename_all = "camelCase")]
 struct RestrictedCipherData {
     name: Option<EncString>,
-    uris: Option<Vec<RestrictedLoginUri>>,
-}
-
-/// A single URI entry inside [`RestrictedCipherData`] (server PascalCase shape). Structurally a
-/// [`LoginUri`]; converted to one for decryption.
-#[derive(Deserialize)]
-#[serde(rename_all = "PascalCase")]
-struct RestrictedLoginUri {
-    uri: Option<EncString>,
-    r#match: Option<UriMatchType>,
-    uri_checksum: Option<EncString>,
-}
-
-impl From<RestrictedLoginUri> for LoginUri {
-    fn from(u: RestrictedLoginUri) -> Self {
-        LoginUri {
-            uri: u.uri,
-            r#match: u.r#match,
-            uri_checksum: u.uri_checksum,
-        }
-    }
+    uris: Option<Vec<LoginUri>>,
 }
 
 /// Decrypt the allowlisted URIs from a restricted envelope. A URI that fails to decrypt is
 /// dropped rather than failing the whole cipher.
 fn decrypt_restricted_uris(
-    uris: Option<Vec<RestrictedLoginUri>>,
+    uris: Option<Vec<LoginUri>>,
     ctx: &mut KeyStoreContext<KeySlotIds>,
     ciphers_key: SymmetricKeySlotId,
 ) -> Option<Vec<LoginUriView>> {
     uris.map(|list| {
         list.into_iter()
-            .filter_map(|u| LoginUri::from(u).decrypt(ctx, ciphers_key).ok())
+            .filter_map(|u| u.decrypt(ctx, ciphers_key).ok())
             .collect()
     })
 }
@@ -2572,8 +2556,8 @@ mod tests {
             .encrypt(&mut key_store.context(), SymmetricKeySlotId::User)
             .unwrap();
         let envelope = serde_json::json!({
-            "Name": enc_name,
-            "Uris": [{ "Uri": enc_uri, "UriChecksum": null, "Match": null }],
+            "name": enc_name,
+            "uris": [{ "uri": enc_uri, "uriChecksum": null, "match": null }],
         })
         .to_string();
 
@@ -2619,9 +2603,9 @@ mod tests {
             .encrypt(&mut key_store.context(), SymmetricKeySlotId::User)
             .unwrap();
         let envelope = serde_json::json!({
-            "Name": enc_name,
-            "Uris": [{ "Uri": enc_uri, "UriChecksum": null, "Match": null }],
-            "Password": enc_pw,
+            "name": enc_name,
+            "uris": [{ "uri": enc_uri, "uriChecksum": null, "match": null }],
+            "password": enc_pw,
         })
         .to_string();
 
@@ -2653,7 +2637,7 @@ mod tests {
             .to_string()
             .encrypt(&mut key_store.context(), SymmetricKeySlotId::User)
             .unwrap();
-        let envelope = serde_json::json!({ "Name": enc_name }).to_string();
+        let envelope = serde_json::json!({ "name": enc_name }).to_string();
         let cipher = restricted_cipher(CipherType::SecureNote, envelope);
 
         let list: CipherListView = key_store.decrypt(&cipher).unwrap();
@@ -2694,7 +2678,7 @@ mod tests {
             .to_string()
             .encrypt(&mut key_store.context(), SymmetricKeySlotId::User)
             .unwrap();
-        let envelope = serde_json::json!({ "Name": enc_name }).to_string();
+        let envelope = serde_json::json!({ "name": enc_name }).to_string();
         // A Card with no card payload would hit `MissingField("card")` under strict decrypt —
         // the restricted branch must short-circuit before that.
         let cipher = restricted_cipher(CipherType::Card, envelope);

--- a/crates/bitwarden-vault/src/cipher/cipher.rs
+++ b/crates/bitwarden-vault/src/cipher/cipher.rs
@@ -680,7 +680,8 @@ impl CipherView {
         key: SymmetricKeySlotId,
     ) -> Result<Cipher, CryptoError> {
         // Fail closed: a restricted (partial) view has all secret fields stripped; re-encrypting it
-        // would overwrite the item's secrets with empty values. See `decrypt_restricted_cipher_view`.
+        // would overwrite the item's secrets with empty values. See
+        // `decrypt_restricted_cipher_view`.
         if self.partial {
             return Err(CryptoError::EncryptRestrictedView);
         }

--- a/crates/bitwarden-vault/src/cipher/cipher.rs
+++ b/crates/bitwarden-vault/src/cipher/cipher.rs
@@ -33,7 +33,7 @@ use super::{
     cipher_permissions::CipherPermissions,
     drivers_license, field, identity,
     local_data::{LocalData, LocalDataView},
-    login::{LoginListView, LoginUri, LoginUriView, UriMatchType},
+    login::{LoginListView, LoginUri, LoginUriView},
     passport, secure_note, ssh_key,
 };
 use crate::{
@@ -1532,48 +1532,32 @@ impl IdentifyKey<SymmetricKeySlotId> for Cipher {
     }
 }
 
-/// The server's reduced payload for a restricted (PAM-gated) cipher, mirroring
-/// `PartialCipherData.Strip` on the server. Deserialized with PascalCase to match the server's
-/// wire shape. This struct is the single authoritative allowlist for what a gated view may
-/// expose: the encrypted name and, for logins, the encrypted URIs — nothing else, so an
-/// over-sharing server blob can never leak a password or TOTP onto a gated view.
+/// The server's reduced payload for a restricted (PAM-gated) cipher, produced by
+/// `PartialCipherData.Strip` on the server. The server emits a purpose-built camelCase envelope
+/// carrying the same [`LoginUri`] fields the full decrypt path uses, so the URIs deserialize
+/// straight into [`LoginUri`] with no parallel representation.
+///
+/// This struct is the single authoritative allowlist for what a gated view may expose: the
+/// encrypted name and, for logins, the encrypted URIs — nothing else. It is deliberately NOT
+/// `deny_unknown_fields`: an over-sharing server blob (e.g. a stray `password` or `totp`) is
+/// silently dropped by the allowlist rather than surfaced onto the view or failing the parse.
 #[derive(Deserialize, Default)]
-#[serde(rename_all = "PascalCase")]
+#[serde(rename_all = "camelCase")]
 struct RestrictedCipherData {
     name: Option<EncString>,
-    uris: Option<Vec<RestrictedLoginUri>>,
-}
-
-/// A single URI entry inside [`RestrictedCipherData`] (server PascalCase shape). Structurally a
-/// [`LoginUri`]; converted to one for decryption.
-#[derive(Deserialize)]
-#[serde(rename_all = "PascalCase")]
-struct RestrictedLoginUri {
-    uri: Option<EncString>,
-    r#match: Option<UriMatchType>,
-    uri_checksum: Option<EncString>,
-}
-
-impl From<RestrictedLoginUri> for LoginUri {
-    fn from(u: RestrictedLoginUri) -> Self {
-        LoginUri {
-            uri: u.uri,
-            r#match: u.r#match,
-            uri_checksum: u.uri_checksum,
-        }
-    }
+    uris: Option<Vec<LoginUri>>,
 }
 
 /// Decrypt the allowlisted URIs from a restricted envelope. A URI that fails to decrypt is
 /// dropped rather than failing the whole cipher.
 fn decrypt_restricted_uris(
-    uris: Option<Vec<RestrictedLoginUri>>,
+    uris: Option<Vec<LoginUri>>,
     ctx: &mut KeyStoreContext<KeySlotIds>,
     ciphers_key: SymmetricKeySlotId,
 ) -> Option<Vec<LoginUriView>> {
     uris.map(|list| {
         list.into_iter()
-            .filter_map(|u| LoginUri::from(u).decrypt(ctx, ciphers_key).ok())
+            .filter_map(|u| u.decrypt(ctx, ciphers_key).ok())
             .collect()
     })
 }
@@ -2541,8 +2525,8 @@ mod tests {
             .encrypt(&mut key_store.context(), SymmetricKeySlotId::User)
             .unwrap();
         let envelope = serde_json::json!({
-            "Name": enc_name,
-            "Uris": [{ "Uri": enc_uri, "UriChecksum": null, "Match": null }],
+            "name": enc_name,
+            "uris": [{ "uri": enc_uri, "uriChecksum": null, "match": null }],
         })
         .to_string();
 
@@ -2588,9 +2572,9 @@ mod tests {
             .encrypt(&mut key_store.context(), SymmetricKeySlotId::User)
             .unwrap();
         let envelope = serde_json::json!({
-            "Name": enc_name,
-            "Uris": [{ "Uri": enc_uri, "UriChecksum": null, "Match": null }],
-            "Password": enc_pw,
+            "name": enc_name,
+            "uris": [{ "uri": enc_uri, "uriChecksum": null, "match": null }],
+            "password": enc_pw,
         })
         .to_string();
 
@@ -2622,7 +2606,7 @@ mod tests {
             .to_string()
             .encrypt(&mut key_store.context(), SymmetricKeySlotId::User)
             .unwrap();
-        let envelope = serde_json::json!({ "Name": enc_name }).to_string();
+        let envelope = serde_json::json!({ "name": enc_name }).to_string();
         let cipher = restricted_cipher(CipherType::SecureNote, envelope);
 
         let list: CipherListView = key_store.decrypt(&cipher).unwrap();
@@ -2663,7 +2647,7 @@ mod tests {
             .to_string()
             .encrypt(&mut key_store.context(), SymmetricKeySlotId::User)
             .unwrap();
-        let envelope = serde_json::json!({ "Name": enc_name }).to_string();
+        let envelope = serde_json::json!({ "name": enc_name }).to_string();
         // A Card with no card payload would hit `MissingField("card")` under strict decrypt —
         // the restricted branch must short-circuit before that.
         let cipher = restricted_cipher(CipherType::Card, envelope);

--- a/crates/bitwarden-vault/src/cipher/cipher.rs
+++ b/crates/bitwarden-vault/src/cipher/cipher.rs
@@ -1624,9 +1624,9 @@ fn decrypt_restricted_cipher_view(
         organization_id: cipher.organization_id,
         folder_id: cipher.folder_id,
         collection_ids: cipher.collection_ids.clone(),
-        // ⚠️ pass-through of the wrapped, key-bound cipher key — see the contract-violation note
-        // in `lenient_decrypt_cipher_view`.
-        key: cipher.key.clone(),
+        // A restricted view is never re-encrypted (the encrypt paths fail closed on `partial`),
+        // so it carries no cipher key.
+        key: None,
         name,
         notes: None,
         r#type: cipher.r#type,
@@ -1658,7 +1658,7 @@ fn decrypt_restricted_cipher_view(
 
     // Drop URIs whose checksum doesn't validate — guards against a tampering server, mirroring
     // the full decrypt paths (same gate as `lenient_decrypt_cipher_view`).
-    if view.key.is_some()
+    if cipher.key.is_some()
         || ctx.get_security_state_version() >= MINIMUM_ENFORCE_ICON_URI_HASH_VERSION
     {
         view.remove_invalid_checksums();
@@ -1711,9 +1711,9 @@ fn decrypt_restricted_cipher_list_view(
         organization_id: cipher.organization_id,
         folder_id: cipher.folder_id,
         collection_ids: cipher.collection_ids.clone(),
-        // ⚠️ pass-through of the wrapped, key-bound cipher key — see the contract-violation note
-        // in `lenient_decrypt_cipher_view`.
-        key: cipher.key.clone(),
+        // A restricted view is never re-encrypted (the encrypt paths fail closed on `partial`),
+        // so it carries no cipher key.
+        key: None,
         name,
         subtitle: String::new(),
         r#type,
@@ -1749,6 +1749,12 @@ impl Decryptable<KeySlotIds, SymmetricKeySlotId, CipherView> for Cipher {
         key: SymmetricKeySlotId,
     ) -> Result<CipherView, CryptoError> {
         if let Some(raw) = &self.partial_data {
+            // Partial (PAM-gated) data is only ever produced for organization ciphers. Refuse the
+            // restricted path for a personal cipher so a user item can never be exposed through the
+            // weaker partial format. Fail closed.
+            if self.organization_id.is_none() {
+                return Err(CryptoError::RestrictedCipherRequiresOrganization);
+            }
             return decrypt_restricted_cipher_view(self, raw, ctx, key);
         }
         match try_parse_blob(self) {
@@ -1765,6 +1771,12 @@ impl Decryptable<KeySlotIds, SymmetricKeySlotId, CipherListView> for Cipher {
         key: SymmetricKeySlotId,
     ) -> Result<CipherListView, CryptoError> {
         if let Some(raw) = &self.partial_data {
+            // Partial (PAM-gated) data is only ever produced for organization ciphers. Refuse the
+            // restricted path for a personal cipher so a user item can never be exposed through the
+            // weaker partial format. Fail closed.
+            if self.organization_id.is_none() {
+                return Err(CryptoError::RestrictedCipherRequiresOrganization);
+            }
             return decrypt_restricted_cipher_list_view(self, raw, ctx, key);
         }
         match try_parse_blob(self) {
@@ -1816,6 +1828,10 @@ impl Decryptable<KeySlotIds, SymmetricKeySlotId, CipherView> for StrictDecrypt<C
         key: SymmetricKeySlotId,
     ) -> Result<CipherView, CryptoError> {
         if let Some(raw) = &self.0.partial_data {
+            // See the org-gate note in the non-strict `Decryptable for Cipher` impl.
+            if self.0.organization_id.is_none() {
+                return Err(CryptoError::RestrictedCipherRequiresOrganization);
+            }
             return decrypt_restricted_cipher_view(&self.0, raw, ctx, key);
         }
         match try_parse_blob(&self.0) {
@@ -1924,6 +1940,10 @@ impl Decryptable<KeySlotIds, SymmetricKeySlotId, CipherListView> for StrictDecry
         key: SymmetricKeySlotId,
     ) -> Result<CipherListView, CryptoError> {
         if let Some(raw) = &self.0.partial_data {
+            // See the org-gate note in the non-strict `Decryptable for Cipher` impl.
+            if self.0.organization_id.is_none() {
+                return Err(CryptoError::RestrictedCipherRequiresOrganization);
+            }
             return decrypt_restricted_cipher_list_view(&self.0, raw, ctx, key);
         }
         match try_parse_blob(&self.0) {
@@ -2155,7 +2175,11 @@ impl TryFrom<CipherDetailsResponseModel> for Cipher {
 impl PartialCipher for CipherDetailsResponseModel {
     fn merge_with_cipher(self, cipher: Option<Cipher>) -> Result<Cipher, VaultParseError> {
         Ok(Cipher {
-            local_data: cipher.and_then(|c| c.local_data),
+            local_data: cipher.as_ref().and_then(|c| c.local_data.clone()),
+            // Preserve PAM gating across a partial/full update; these merge responses never change
+            // gating. TODO: prefer the response's partialData once the generated API model carries
+            // it.
+            partial_data: cipher.and_then(|c| c.partial_data),
             ..self.try_into()?
         })
     }
@@ -2229,7 +2253,10 @@ impl From<CipherRepromptType> for bitwarden_api_api::models::CipherRepromptType 
 impl PartialCipher for CipherResponseModel {
     fn merge_with_cipher(self, cipher: Option<Cipher>) -> Result<Cipher, VaultParseError> {
         Ok(Cipher {
-            partial_data: None,
+            // Preserve PAM gating across a partial/full update; these merge responses never change
+            // gating. TODO: prefer the response's partialData once the generated API model carries
+            // it.
+            partial_data: cipher.as_ref().and_then(|c| c.partial_data.clone()),
             collection_ids: cipher
                 .as_ref()
                 .map(|c| c.collection_ids.clone())
@@ -2285,7 +2312,10 @@ impl PartialCipher for CipherMiniResponseModel {
     fn merge_with_cipher(self, cipher: Option<Cipher>) -> Result<Cipher, VaultParseError> {
         let cipher = cipher.as_ref();
         Ok(Cipher {
-            partial_data: None,
+            // Preserve PAM gating across a partial/full update; these merge responses never change
+            // gating. TODO: prefer the response's partialData once the generated API model carries
+            // it.
+            partial_data: cipher.and_then(|c| c.partial_data.clone()),
             id: self.id.map(CipherId::new),
             organization_id: self.organization_id.map(OrganizationId::new),
             key: EncString::try_from_optional(self.key)?,
@@ -2346,7 +2376,10 @@ impl PartialCipher for CipherMiniDetailsResponseModel {
     fn merge_with_cipher(self, cipher: Option<Cipher>) -> Result<Cipher, VaultParseError> {
         let cipher = cipher.as_ref();
         Ok(Cipher {
-            partial_data: None,
+            // Preserve PAM gating across a partial/full update; these merge responses never change
+            // gating. TODO: prefer the response's partialData once the generated API model carries
+            // it.
+            partial_data: cipher.and_then(|c| c.partial_data.clone()),
             id: self.id.map(CipherId::new),
             organization_id: self.organization_id.map(OrganizationId::new),
             key: EncString::try_from_optional(self.key)?,
@@ -2415,7 +2448,7 @@ mod tests {
     use bitwarden_core::key_management::{
         create_test_crypto_with_user_and_org_key, create_test_crypto_with_user_key,
     };
-    use bitwarden_crypto::{SymmetricCryptoKey, SymmetricKeyAlgorithm};
+    use bitwarden_crypto::{KeyStore, SymmetricCryptoKey, SymmetricKeyAlgorithm};
 
     use super::*;
     use crate::{Fido2Credential, PasswordHistoryView, login::Fido2CredentialListView};
@@ -2428,6 +2461,32 @@ mod tests {
     const TEST_ENC_STRING_5: &str = "2.hqdioUAc81FsKQmO1XuLQg==|oDRdsJrQjoFu9NrFVy8tcJBAFKBx95gHaXZnWdXbKpsxWnOr2sKipIG43pKKUFuq|3gKZMiboceIB5SLVOULKg2iuyu6xzos22dfJbvx0EHk=";
     const TEST_CIPHER_NAME: &str = "2.d3rzo0P8rxV9Hs1m1BmAjw==|JOwna6i0zs+K7ZghwrZRuw==|SJqKreLag1ID+g6H1OdmQr0T5zTrVWKzD6hGy3fDqB0=";
     const TEST_UUID: &str = "fd411a1a-fec8-4070-985d-0e6560860e69";
+
+    /// Fixed org id + key for the restricted-cipher test vectors (partials are always org-owned).
+    const RESTRICTED_ORG_UUID: &str = "3cf0d3ba-3ded-4bf3-a51c-b03fd9ac6e07";
+    const RESTRICTED_ORG_KEY_B64: &str =
+        "w2LO+nwV4oxwswVYCxlOfRUseXfvU03VzvKQHrqeklPgiMZrspUe6sOBToCnDn9Ay0tuCBn8ykVVRb7PWhub2Q==";
+
+    /// `partial_data` vectors: EncStrings encrypted once under [`RESTRICTED_ORG_KEY_B64`] and
+    /// pinned, so decrypt runs against fixed ciphertext and the format can't silently break.
+    const RESTRICTED_LOGIN_ENVELOPE: &str = r#"{"name":"2.qip4DSwdOzU2KwY3jgDjUg==|CsGRQgTwAzmszz+dkk5xIg==|rmW/mlnHq2MulR9uNKclD+1UBFLfOimedkq5tPRSLOc=","uris":[{"uri":"2.2na8mpfA1B1OBTUHkDz+fw==|yTWB1nEf3EHIZgsDINM8JnTYyxf7KVZvXraIGAVOiEg=|i2swsODSjEMRaYNnBHAigdphZBBUg2lkPNo763fX12w=","uriChecksum":null,"match":null}]}"#;
+    /// [`RESTRICTED_LOGIN_ENVELOPE`] plus an extra `password` field the allowlist must drop.
+    const RESTRICTED_LOGIN_ENVELOPE_WITH_PASSWORD: &str = r#"{"name":"2.qip4DSwdOzU2KwY3jgDjUg==|CsGRQgTwAzmszz+dkk5xIg==|rmW/mlnHq2MulR9uNKclD+1UBFLfOimedkq5tPRSLOc=","uris":[{"uri":"2.2na8mpfA1B1OBTUHkDz+fw==|yTWB1nEf3EHIZgsDINM8JnTYyxf7KVZvXraIGAVOiEg=|i2swsODSjEMRaYNnBHAigdphZBBUg2lkPNo763fX12w=","uriChecksum":null,"match":null}],"password":"2.cKf+VYTb7KF2ITGLDmGzig==|zC66OfcYpUB8V6jLB6GQvQ==|hnDFyYCAf6RPD4lPmXZCzEWzXwniRyFnCVrO0KZMPlc="}"#;
+    const RESTRICTED_SECURE_NOTE_ENVELOPE: &str = r#"{"name":"2.EwVjyRAgPmUvRpyT68lbjQ==|73O9id1+DZevAB3K+2fXnA==|OoJhN3p9UgjQ4yk55OUBZ4nYQMlFcf9wTHPxrOPhQVI="}"#;
+    const RESTRICTED_CARD_ENVELOPE: &str = r#"{"name":"2.HF21EOZVqF3eyeZtEgxaCg==|zuChVgXPqxipFE6zOBUBXQ==|gxyvw0+gMf5Grxk8EAhpLCBeXdA0kvea2maJmpLIUIw="}"#;
+
+    /// Key store for the restricted-cipher vectors: [`RESTRICTED_ORG_KEY_B64`] under
+    /// [`RESTRICTED_ORG_UUID`] (the user key is unused — restricted decrypt is org-keyed).
+    fn restricted_test_key_store() -> (OrganizationId, KeyStore<KeySlotIds>) {
+        let org: OrganizationId = RESTRICTED_ORG_UUID.parse().unwrap();
+        let org_key: SymmetricCryptoKey = RESTRICTED_ORG_KEY_B64.to_string().try_into().unwrap();
+        let key_store = create_test_crypto_with_user_and_org_key(
+            SymmetricCryptoKey::make(SymmetricKeyAlgorithm::Aes256CbcHmac),
+            org,
+            org_key,
+        );
+        (org, key_store)
+    }
 
     fn generate_cipher() -> CipherView {
         let test_id = "fd411a1a-fec8-4070-985d-0e6560860e69".parse().unwrap();
@@ -2497,12 +2556,16 @@ mod tests {
     }
 
     /// Builds a server-restricted (PAM-gated) cipher: no top-level secret fields, only the
-    /// `partial_data` envelope the server sends in their place.
-    fn restricted_cipher(r#type: CipherType, partial_data: String) -> Cipher {
+    /// `partial_data` envelope. Org-owned, since partials always are.
+    fn restricted_cipher(
+        organization_id: OrganizationId,
+        r#type: CipherType,
+        partial_data: String,
+    ) -> Cipher {
         Cipher {
             partial_data: Some(partial_data),
             id: Some(TEST_UUID.parse().unwrap()),
-            organization_id: None,
+            organization_id: Some(organization_id),
             folder_id: None,
             collection_ids: vec![],
             key: None,
@@ -2537,24 +2600,12 @@ mod tests {
 
     #[test]
     fn test_decrypt_restricted_cipher_list_view_login() {
-        let key_store = create_test_crypto_with_user_key(SymmetricCryptoKey::make(
-            SymmetricKeyAlgorithm::Aes256CbcHmac,
-        ));
-        let enc_name = "Restricted Name"
-            .to_string()
-            .encrypt(&mut key_store.context(), SymmetricKeySlotId::User)
-            .unwrap();
-        let enc_uri = "https://example.com"
-            .to_string()
-            .encrypt(&mut key_store.context(), SymmetricKeySlotId::User)
-            .unwrap();
-        let envelope = serde_json::json!({
-            "name": enc_name,
-            "uris": [{ "uri": enc_uri, "uriChecksum": null, "match": null }],
-        })
-        .to_string();
-
-        let cipher = restricted_cipher(CipherType::Login, envelope);
+        let (org, key_store) = restricted_test_key_store();
+        let cipher = restricted_cipher(
+            org,
+            CipherType::Login,
+            RESTRICTED_LOGIN_ENVELOPE.to_string(),
+        );
         let view: CipherListView = key_store.decrypt(&cipher).unwrap();
 
         assert!(view.partial);
@@ -2578,31 +2629,14 @@ mod tests {
 
     #[test]
     fn test_decrypt_restricted_cipher_view_login_omits_secrets() {
-        let key_store = create_test_crypto_with_user_key(SymmetricCryptoKey::make(
-            SymmetricKeyAlgorithm::Aes256CbcHmac,
-        ));
-        let enc_name = "Restricted Name"
-            .to_string()
-            .encrypt(&mut key_store.context(), SymmetricKeySlotId::User)
-            .unwrap();
-        let enc_uri = "https://example.com"
-            .to_string()
-            .encrypt(&mut key_store.context(), SymmetricKeySlotId::User)
-            .unwrap();
+        let (org, key_store) = restricted_test_key_store();
         // A rogue/over-sharing server also stuffs an encrypted password into the envelope; the
         // allowlist (`RestrictedCipherData`) must ignore anything outside name + uris.
-        let enc_pw = "s3cret"
-            .to_string()
-            .encrypt(&mut key_store.context(), SymmetricKeySlotId::User)
-            .unwrap();
-        let envelope = serde_json::json!({
-            "name": enc_name,
-            "uris": [{ "uri": enc_uri, "uriChecksum": null, "match": null }],
-            "password": enc_pw,
-        })
-        .to_string();
-
-        let cipher = restricted_cipher(CipherType::Login, envelope);
+        let cipher = restricted_cipher(
+            org,
+            CipherType::Login,
+            RESTRICTED_LOGIN_ENVELOPE_WITH_PASSWORD.to_string(),
+        );
         let view: CipherView = key_store.decrypt(&cipher).unwrap();
 
         assert!(view.partial);
@@ -2623,15 +2657,12 @@ mod tests {
 
     #[test]
     fn test_decrypt_restricted_non_login_name_only() {
-        let key_store = create_test_crypto_with_user_key(SymmetricCryptoKey::make(
-            SymmetricKeyAlgorithm::Aes256CbcHmac,
-        ));
-        let enc_name = "Gated Note"
-            .to_string()
-            .encrypt(&mut key_store.context(), SymmetricKeySlotId::User)
-            .unwrap();
-        let envelope = serde_json::json!({ "name": enc_name }).to_string();
-        let cipher = restricted_cipher(CipherType::SecureNote, envelope);
+        let (org, key_store) = restricted_test_key_store();
+        let cipher = restricted_cipher(
+            org,
+            CipherType::SecureNote,
+            RESTRICTED_SECURE_NOTE_ENVELOPE.to_string(),
+        );
 
         let list: CipherListView = key_store.decrypt(&cipher).unwrap();
         assert!(list.partial);
@@ -2647,11 +2678,9 @@ mod tests {
 
     #[test]
     fn test_decrypt_restricted_malformed_envelope_fails_closed() {
-        let key_store = create_test_crypto_with_user_key(SymmetricCryptoKey::make(
-            SymmetricKeyAlgorithm::Aes256CbcHmac,
-        ));
+        let (org, key_store) = restricted_test_key_store();
         // A malformed envelope must not un-gate the row: it stays partial, just nameless.
-        let cipher = restricted_cipher(CipherType::Login, "not valid json".to_string());
+        let cipher = restricted_cipher(org, CipherType::Login, "not valid json".to_string());
 
         let list: CipherListView = key_store.decrypt(&cipher).unwrap();
         assert!(list.partial);
@@ -2664,17 +2693,10 @@ mod tests {
 
     #[test]
     fn test_decrypt_restricted_works_in_strict_mode() {
-        let key_store = create_test_crypto_with_user_key(SymmetricCryptoKey::make(
-            SymmetricKeyAlgorithm::Aes256CbcHmac,
-        ));
-        let enc_name = "Restricted Card"
-            .to_string()
-            .encrypt(&mut key_store.context(), SymmetricKeySlotId::User)
-            .unwrap();
-        let envelope = serde_json::json!({ "name": enc_name }).to_string();
+        let (org, key_store) = restricted_test_key_store();
         // A Card with no card payload would hit `MissingField("card")` under strict decrypt —
         // the restricted branch must short-circuit before that.
-        let cipher = restricted_cipher(CipherType::Card, envelope);
+        let cipher = restricted_cipher(org, CipherType::Card, RESTRICTED_CARD_ENVELOPE.to_string());
 
         let list: CipherListView = key_store.decrypt(&StrictDecrypt(cipher.clone())).unwrap();
         assert!(list.partial);
@@ -2687,6 +2709,33 @@ mod tests {
         let view: CipherView = key_store.decrypt(&StrictDecrypt(cipher)).unwrap();
         assert!(view.partial);
         assert!(view.card.is_none());
+    }
+
+    #[test]
+    fn test_decrypt_restricted_non_org_cipher_fails_closed() {
+        // A personal cipher carrying `partial_data` must fail closed, never take the restricted
+        // path.
+        let (org, key_store) = restricted_test_key_store();
+        let cipher = Cipher {
+            organization_id: None,
+            ..restricted_cipher(
+                org,
+                CipherType::SecureNote,
+                RESTRICTED_SECURE_NOTE_ENVELOPE.to_string(),
+            )
+        };
+
+        let view_result: Result<CipherView, CryptoError> = key_store.decrypt(&cipher);
+        assert!(matches!(
+            view_result.unwrap_err(),
+            CryptoError::RestrictedCipherRequiresOrganization
+        ));
+
+        let list_result: Result<CipherListView, CryptoError> = key_store.decrypt(&cipher);
+        assert!(matches!(
+            list_result.unwrap_err(),
+            CryptoError::RestrictedCipherRequiresOrganization
+        ));
     }
 
     #[test]

--- a/crates/bitwarden-vault/src/cipher/cipher.rs
+++ b/crates/bitwarden-vault/src/cipher/cipher.rs
@@ -673,7 +673,8 @@ impl CipherView {
         key: SymmetricKeySlotId,
     ) -> Result<Cipher, CryptoError> {
         // Fail closed: a restricted (partial) view has all secret fields stripped; re-encrypting it
-        // would overwrite the item's secrets with empty values. See `decrypt_restricted_cipher_view`.
+        // would overwrite the item's secrets with empty values. See
+        // `decrypt_restricted_cipher_view`.
         if self.partial {
             return Err(CryptoError::EncryptRestrictedView);
         }

--- a/crates/bitwarden-vault/src/cipher/cipher.rs
+++ b/crates/bitwarden-vault/src/cipher/cipher.rs
@@ -33,7 +33,7 @@ use super::{
     cipher_permissions::CipherPermissions,
     drivers_license, field, identity,
     local_data::{LocalData, LocalDataView},
-    login::LoginListView,
+    login::{LoginListView, LoginUri, LoginUriView, UriMatchType},
     passport, secure_note, ssh_key,
 };
 use crate::{
@@ -331,6 +331,15 @@ pub struct Cipher {
     pub revision_date: DateTime<Utc>,
     pub archived_date: Option<DateTime<Utc>>,
     pub data: Option<String>,
+
+    /// Raw JSON envelope for a server-restricted (PAM-gated) cipher: the encrypted name and,
+    /// for logins, the encrypted URIs — every secret field is withheld by the server. Its
+    /// presence marks the cipher restricted; the decrypt path parses only these allowlisted
+    /// fields and produces a view with `partial = true`, never reading the secret payloads.
+    /// Distinct from `data` (the full sealed blob) and from the unrelated `PartialCipher`
+    /// merge trait.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub partial_data: Option<String>,
 }
 
 /// Represents the result of re-wrapping a cipher key, which can be needed when changing the
@@ -478,6 +487,12 @@ pub struct CipherView {
     pub deleted_date: Option<DateTime<Utc>>,
     pub revision_date: DateTime<Utc>,
     pub archived_date: Option<DateTime<Utc>>,
+
+    /// True when this view was produced from a server-restricted (PAM-gated) cipher: only the
+    /// name and (for logins) URIs are populated; every secret field is absent. See
+    /// [`Cipher::partial_data`].
+    #[serde(default)]
+    pub partial: bool,
 }
 
 #[allow(missing_docs)]
@@ -570,6 +585,11 @@ pub struct CipherListView {
     pub copyable_fields: Vec<CopyableCipherFields>,
 
     pub local_data: Option<LocalDataView>,
+
+    /// True when this view was produced from a server-restricted (PAM-gated) cipher: only the
+    /// name and (for logins) URIs are populated. See [`Cipher::partial_data`].
+    #[serde(default)]
+    pub partial: bool,
 
     /// Decrypted cipher notes for search indexing.
     #[cfg(feature = "wasm")]
@@ -664,6 +684,7 @@ impl CipherView {
         cipher_view.generate_checksums();
 
         Ok(Cipher {
+            partial_data: None,
             id: cipher_view.id,
             organization_id: cipher_view.organization_id,
             folder_id: cipher_view.folder_id,
@@ -732,6 +753,7 @@ pub(crate) fn lenient_decrypt_cipher_view(
         );
 
     let mut view = CipherView {
+        partial: false,
         id: cipher.id,
         organization_id: cipher.organization_id,
         folder_id: cipher.folder_id,
@@ -1177,6 +1199,7 @@ impl CipherView {
         };
 
         Ok(CipherListView {
+            partial: false,
             id: self.id,
             organization_id: self.organization_id,
             folder_id: self.folder_id,
@@ -1441,6 +1464,7 @@ pub(crate) fn lenient_decrypt_cipher_list_view(
     let ciphers_key = Cipher::decrypt_cipher_key(ctx, key, &cipher.key)?;
 
     Ok(CipherListView {
+        partial: false,
         id: cipher.id,
         organization_id: cipher.organization_id,
         folder_id: cipher.folder_id,
@@ -1539,6 +1563,207 @@ impl IdentifyKey<SymmetricKeySlotId> for Cipher {
     }
 }
 
+/// The server's reduced payload for a restricted (PAM-gated) cipher, mirroring
+/// `PartialCipherData.Strip` on the server. Deserialized with PascalCase to match the server's
+/// wire shape. This struct is the single authoritative allowlist for what a gated view may
+/// expose: the encrypted name and, for logins, the encrypted URIs — nothing else, so an
+/// over-sharing server blob can never leak a password or TOTP onto a gated view.
+#[derive(Deserialize, Default)]
+#[serde(rename_all = "PascalCase")]
+struct RestrictedCipherData {
+    name: Option<EncString>,
+    uris: Option<Vec<RestrictedLoginUri>>,
+}
+
+/// A single URI entry inside [`RestrictedCipherData`] (server PascalCase shape). Structurally a
+/// [`LoginUri`]; converted to one for decryption.
+#[derive(Deserialize)]
+#[serde(rename_all = "PascalCase")]
+struct RestrictedLoginUri {
+    uri: Option<EncString>,
+    r#match: Option<UriMatchType>,
+    uri_checksum: Option<EncString>,
+}
+
+impl From<RestrictedLoginUri> for LoginUri {
+    fn from(u: RestrictedLoginUri) -> Self {
+        LoginUri {
+            uri: u.uri,
+            r#match: u.r#match,
+            uri_checksum: u.uri_checksum,
+        }
+    }
+}
+
+/// Decrypt the allowlisted URIs from a restricted envelope. A URI that fails to decrypt is
+/// dropped rather than failing the whole cipher.
+fn decrypt_restricted_uris(
+    uris: Option<Vec<RestrictedLoginUri>>,
+    ctx: &mut KeyStoreContext<KeySlotIds>,
+    ciphers_key: SymmetricKeySlotId,
+) -> Option<Vec<LoginUriView>> {
+    uris.map(|list| {
+        list.into_iter()
+            .filter_map(|u| LoginUri::from(u).decrypt(ctx, ciphers_key).ok())
+            .collect()
+    })
+}
+
+/// Decrypt a restricted (PAM-gated) cipher into a [`CipherView`].
+///
+/// Parses `partial_data` and decrypts ONLY the allowlisted fields — the name and, for logins,
+/// the URIs. It never reads the cipher's secret payloads (`login.password`, `card`, …), which
+/// the server withholds anyway. Fail-closed: a malformed envelope or an undecryptable field
+/// degrades to empty rather than un-gating the row — the view is always `partial = true`.
+fn decrypt_restricted_cipher_view(
+    cipher: &Cipher,
+    raw: &str,
+    ctx: &mut KeyStoreContext<KeySlotIds>,
+    key: SymmetricKeySlotId,
+) -> Result<CipherView, CryptoError> {
+    let ciphers_key = Cipher::decrypt_cipher_key(ctx, key, &cipher.key)?;
+    let restricted: RestrictedCipherData = serde_json::from_str(raw).unwrap_or_default();
+
+    let name = restricted
+        .name
+        .as_ref()
+        .and_then(|n| n.decrypt(ctx, ciphers_key).ok())
+        .unwrap_or_default();
+
+    // Only logins carry URIs; expose them so the partial view can render a domain
+    // (favicon / launch). Every other login field stays absent.
+    let login = matches!(cipher.r#type, CipherType::Login).then(|| LoginView {
+        username: None,
+        password: None,
+        password_revision_date: None,
+        uris: decrypt_restricted_uris(restricted.uris, ctx, ciphers_key),
+        totp: None,
+        autofill_on_page_load: None,
+        fido2_credentials: None,
+    });
+
+    let mut view = CipherView {
+        id: cipher.id,
+        organization_id: cipher.organization_id,
+        folder_id: cipher.folder_id,
+        collection_ids: cipher.collection_ids.clone(),
+        // ⚠️ pass-through of the wrapped, key-bound cipher key — see the contract-violation note
+        // in `lenient_decrypt_cipher_view`.
+        key: cipher.key.clone(),
+        name,
+        notes: None,
+        r#type: cipher.r#type,
+        login,
+        identity: None,
+        card: None,
+        secure_note: None,
+        ssh_key: None,
+        bank_account: None,
+        drivers_license: None,
+        passport: None,
+        favorite: cipher.favorite,
+        reprompt: cipher.reprompt,
+        organization_use_totp: cipher.organization_use_totp,
+        edit: cipher.edit,
+        permissions: cipher.permissions,
+        view_password: cipher.view_password,
+        local_data: cipher.local_data.decrypt(ctx, ciphers_key).ok().flatten(),
+        attachments: None,
+        attachment_decryption_failures: None,
+        fields: None,
+        password_history: None,
+        creation_date: cipher.creation_date,
+        deleted_date: cipher.deleted_date,
+        revision_date: cipher.revision_date,
+        archived_date: cipher.archived_date,
+        partial: true,
+    };
+
+    // Drop URIs whose checksum doesn't validate — guards against a tampering server, mirroring
+    // the full decrypt paths (same gate as `lenient_decrypt_cipher_view`).
+    if view.key.is_some()
+        || ctx.get_security_state_version() >= MINIMUM_ENFORCE_ICON_URI_HASH_VERSION
+    {
+        view.remove_invalid_checksums();
+    }
+
+    Ok(view)
+}
+
+/// Decrypt a restricted (PAM-gated) cipher into a [`CipherListView`]. See
+/// [`decrypt_restricted_cipher_view`] for the allowlist and fail-closed contract. The type
+/// discriminant is preserved (so the row keeps its icon) but every type payload is empty apart
+/// from a login's URIs.
+fn decrypt_restricted_cipher_list_view(
+    cipher: &Cipher,
+    raw: &str,
+    ctx: &mut KeyStoreContext<KeySlotIds>,
+    key: SymmetricKeySlotId,
+) -> Result<CipherListView, CryptoError> {
+    let ciphers_key = Cipher::decrypt_cipher_key(ctx, key, &cipher.key)?;
+    let restricted: RestrictedCipherData = serde_json::from_str(raw).unwrap_or_default();
+
+    let name = restricted
+        .name
+        .as_ref()
+        .and_then(|n| n.decrypt(ctx, ciphers_key).ok())
+        .unwrap_or_default();
+
+    let r#type = match cipher.r#type {
+        CipherType::Login => CipherListViewType::Login(LoginListView {
+            fido2_credentials: None,
+            has_fido2: false,
+            username: None,
+            totp: None,
+            uris: decrypt_restricted_uris(restricted.uris, ctx, ciphers_key),
+        }),
+        CipherType::SecureNote => CipherListViewType::SecureNote,
+        CipherType::Card => CipherListViewType::Card(CardListView { brand: None }),
+        CipherType::Identity => CipherListViewType::Identity,
+        CipherType::SshKey => CipherListViewType::SshKey,
+        CipherType::BankAccount => CipherListViewType::BankAccount(BankAccountListView {
+            account_number: None,
+            account_type: None,
+        }),
+        CipherType::Passport => CipherListViewType::Passport,
+        CipherType::DriversLicense => CipherListViewType::DriversLicense,
+    };
+
+    Ok(CipherListView {
+        id: cipher.id,
+        organization_id: cipher.organization_id,
+        folder_id: cipher.folder_id,
+        collection_ids: cipher.collection_ids.clone(),
+        // ⚠️ pass-through of the wrapped, key-bound cipher key — see the contract-violation note
+        // in `lenient_decrypt_cipher_view`.
+        key: cipher.key.clone(),
+        name,
+        subtitle: String::new(),
+        r#type,
+        favorite: cipher.favorite,
+        reprompt: cipher.reprompt,
+        organization_use_totp: cipher.organization_use_totp,
+        edit: cipher.edit,
+        permissions: cipher.permissions,
+        view_password: cipher.view_password,
+        attachments: 0,
+        has_old_attachments: false,
+        creation_date: cipher.creation_date,
+        deleted_date: cipher.deleted_date,
+        revision_date: cipher.revision_date,
+        archived_date: cipher.archived_date,
+        copyable_fields: vec![],
+        local_data: cipher.local_data.decrypt(ctx, ciphers_key).ok().flatten(),
+        partial: true,
+        #[cfg(feature = "wasm")]
+        notes: None,
+        #[cfg(feature = "wasm")]
+        fields: None,
+        #[cfg(feature = "wasm")]
+        attachment_names: None,
+    })
+}
+
 impl Decryptable<KeySlotIds, SymmetricKeySlotId, CipherView> for Cipher {
     #[bitwarden_logging::instrument(err, fields(cipher_id = ?self.id, org_id = ?self.organization_id, kind = ?self.r#type))]
     fn decrypt(
@@ -1546,6 +1771,9 @@ impl Decryptable<KeySlotIds, SymmetricKeySlotId, CipherView> for Cipher {
         ctx: &mut KeyStoreContext<KeySlotIds>,
         key: SymmetricKeySlotId,
     ) -> Result<CipherView, CryptoError> {
+        if let Some(raw) = &self.partial_data {
+            return decrypt_restricted_cipher_view(self, raw, ctx, key);
+        }
         match try_parse_blob(self) {
             Some(sealed) => decrypt_blob_cipher(self, &sealed, ctx, key).map_err(CryptoError::from),
             None => lenient_decrypt_cipher_view(self, ctx, key),
@@ -1559,6 +1787,9 @@ impl Decryptable<KeySlotIds, SymmetricKeySlotId, CipherListView> for Cipher {
         ctx: &mut KeyStoreContext<KeySlotIds>,
         key: SymmetricKeySlotId,
     ) -> Result<CipherListView, CryptoError> {
+        if let Some(raw) = &self.partial_data {
+            return decrypt_restricted_cipher_list_view(self, raw, ctx, key);
+        }
         match try_parse_blob(self) {
             Some(sealed) => decrypt_blob_cipher(self, &sealed, ctx, key)?.to_list_view(ctx, key),
             None => lenient_decrypt_cipher_list_view(self, ctx, key),
@@ -1607,6 +1838,9 @@ impl Decryptable<KeySlotIds, SymmetricKeySlotId, CipherView> for StrictDecrypt<C
         ctx: &mut KeyStoreContext<KeySlotIds>,
         key: SymmetricKeySlotId,
     ) -> Result<CipherView, CryptoError> {
+        if let Some(raw) = &self.0.partial_data {
+            return decrypt_restricted_cipher_view(&self.0, raw, ctx, key);
+        }
         match try_parse_blob(&self.0) {
             Some(sealed) => {
                 decrypt_blob_cipher(&self.0, &sealed, ctx, key).map_err(CryptoError::from)
@@ -1634,6 +1868,7 @@ fn strict_decrypt_cipher_view(
         );
 
     let mut view = CipherView {
+        partial: false,
         id: cipher.id,
         organization_id: cipher.organization_id,
         folder_id: cipher.folder_id,
@@ -1711,6 +1946,9 @@ impl Decryptable<KeySlotIds, SymmetricKeySlotId, CipherListView> for StrictDecry
         ctx: &mut KeyStoreContext<KeySlotIds>,
         key: SymmetricKeySlotId,
     ) -> Result<CipherListView, CryptoError> {
+        if let Some(raw) = &self.0.partial_data {
+            return decrypt_restricted_cipher_list_view(&self.0, raw, ctx, key);
+        }
         match try_parse_blob(&self.0) {
             Some(sealed) => decrypt_blob_cipher(&self.0, &sealed, ctx, key)?.to_list_view(ctx, key),
             None => strict_decrypt_cipher_list_view(&self.0, ctx, key),
@@ -1728,6 +1966,7 @@ fn strict_decrypt_cipher_list_view(
     let ciphers_key = Cipher::decrypt_cipher_key(ctx, key, &cipher.key)?;
 
     Ok(CipherListView {
+        partial: false,
         id: cipher.id,
         organization_id: cipher.organization_id,
         folder_id: cipher.folder_id,
@@ -1879,6 +2118,7 @@ impl TryFrom<CipherDetailsResponseModel> for Cipher {
 
     fn try_from(cipher: CipherDetailsResponseModel) -> Result<Self, Self::Error> {
         Ok(Self {
+            partial_data: None,
             id: cipher.id.map(CipherId::new),
             organization_id: cipher.organization_id.map(OrganizationId::new),
             folder_id: cipher.folder_id.map(FolderId::new),
@@ -2012,6 +2252,7 @@ impl From<CipherRepromptType> for bitwarden_api_api::models::CipherRepromptType 
 impl PartialCipher for CipherResponseModel {
     fn merge_with_cipher(self, cipher: Option<Cipher>) -> Result<Cipher, VaultParseError> {
         Ok(Cipher {
+            partial_data: None,
             collection_ids: cipher
                 .as_ref()
                 .map(|c| c.collection_ids.clone())
@@ -2067,6 +2308,7 @@ impl PartialCipher for CipherMiniResponseModel {
     fn merge_with_cipher(self, cipher: Option<Cipher>) -> Result<Cipher, VaultParseError> {
         let cipher = cipher.as_ref();
         Ok(Cipher {
+            partial_data: None,
             id: self.id.map(CipherId::new),
             organization_id: self.organization_id.map(OrganizationId::new),
             key: EncString::try_from_optional(self.key)?,
@@ -2127,6 +2369,7 @@ impl PartialCipher for CipherMiniDetailsResponseModel {
     fn merge_with_cipher(self, cipher: Option<Cipher>) -> Result<Cipher, VaultParseError> {
         let cipher = cipher.as_ref();
         Ok(Cipher {
+            partial_data: None,
             id: self.id.map(CipherId::new),
             organization_id: self.organization_id.map(OrganizationId::new),
             key: EncString::try_from_optional(self.key)?,
@@ -2212,6 +2455,7 @@ mod tests {
     fn generate_cipher() -> CipherView {
         let test_id = "fd411a1a-fec8-4070-985d-0e6560860e69".parse().unwrap();
         CipherView {
+            partial: false,
             r#type: CipherType::Login,
             login: Some(LoginView {
                 username: Some("test_username".to_string()),
@@ -2275,12 +2519,206 @@ mod tests {
         }
     }
 
+    /// Builds a server-restricted (PAM-gated) cipher: no top-level secret fields, only the
+    /// `partial_data` envelope the server sends in their place.
+    fn restricted_cipher(r#type: CipherType, partial_data: String) -> Cipher {
+        Cipher {
+            partial_data: Some(partial_data),
+            id: Some(TEST_UUID.parse().unwrap()),
+            organization_id: None,
+            folder_id: None,
+            collection_ids: vec![],
+            key: None,
+            name: None,
+            notes: None,
+            r#type,
+            login: None,
+            identity: None,
+            card: None,
+            secure_note: None,
+            ssh_key: None,
+            bank_account: None,
+            drivers_license: None,
+            passport: None,
+            favorite: false,
+            reprompt: CipherRepromptType::None,
+            organization_use_totp: false,
+            edit: true,
+            permissions: None,
+            view_password: true,
+            local_data: None,
+            attachments: None,
+            fields: None,
+            password_history: None,
+            creation_date: "2024-01-30T17:55:36.150Z".parse().unwrap(),
+            deleted_date: None,
+            revision_date: "2024-01-30T17:55:36.150Z".parse().unwrap(),
+            archived_date: None,
+            data: None,
+        }
+    }
+
+    #[test]
+    fn test_decrypt_restricted_cipher_list_view_login() {
+        let key_store = create_test_crypto_with_user_key(SymmetricCryptoKey::make(
+            SymmetricKeyAlgorithm::Aes256CbcHmac,
+        ));
+        let enc_name = "Restricted Name"
+            .to_string()
+            .encrypt(&mut key_store.context(), SymmetricKeySlotId::User)
+            .unwrap();
+        let enc_uri = "https://example.com"
+            .to_string()
+            .encrypt(&mut key_store.context(), SymmetricKeySlotId::User)
+            .unwrap();
+        let envelope = serde_json::json!({
+            "Name": enc_name,
+            "Uris": [{ "Uri": enc_uri, "UriChecksum": null, "Match": null }],
+        })
+        .to_string();
+
+        let cipher = restricted_cipher(CipherType::Login, envelope);
+        let view: CipherListView = key_store.decrypt(&cipher).unwrap();
+
+        assert!(view.partial);
+        assert_eq!(view.name, "Restricted Name".to_string());
+        assert!(view.subtitle.is_empty());
+        assert!(view.copyable_fields.is_empty());
+        assert_eq!(view.attachments, 0);
+        match view.r#type {
+            CipherListViewType::Login(login) => {
+                assert_eq!(
+                    login.uris.unwrap()[0].uri.as_deref(),
+                    Some("https://example.com")
+                );
+                assert_eq!(login.username, None);
+                assert_eq!(login.totp, None);
+                assert!(!login.has_fido2);
+            }
+            other => panic!("expected Login list view, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_decrypt_restricted_cipher_view_login_omits_secrets() {
+        let key_store = create_test_crypto_with_user_key(SymmetricCryptoKey::make(
+            SymmetricKeyAlgorithm::Aes256CbcHmac,
+        ));
+        let enc_name = "Restricted Name"
+            .to_string()
+            .encrypt(&mut key_store.context(), SymmetricKeySlotId::User)
+            .unwrap();
+        let enc_uri = "https://example.com"
+            .to_string()
+            .encrypt(&mut key_store.context(), SymmetricKeySlotId::User)
+            .unwrap();
+        // A rogue/over-sharing server also stuffs an encrypted password into the envelope; the
+        // allowlist (`RestrictedCipherData`) must ignore anything outside name + uris.
+        let enc_pw = "s3cret"
+            .to_string()
+            .encrypt(&mut key_store.context(), SymmetricKeySlotId::User)
+            .unwrap();
+        let envelope = serde_json::json!({
+            "Name": enc_name,
+            "Uris": [{ "Uri": enc_uri, "UriChecksum": null, "Match": null }],
+            "Password": enc_pw,
+        })
+        .to_string();
+
+        let cipher = restricted_cipher(CipherType::Login, envelope);
+        let view: CipherView = key_store.decrypt(&cipher).unwrap();
+
+        assert!(view.partial);
+        assert_eq!(view.name, "Restricted Name".to_string());
+        let login = view
+            .login
+            .expect("login populated so the view can render a domain");
+        assert_eq!(
+            login.uris.unwrap()[0].uri.as_deref(),
+            Some("https://example.com")
+        );
+        assert_eq!(login.username, None);
+        assert_eq!(login.password, None);
+        assert_eq!(login.totp, None);
+        assert_eq!(view.notes, None);
+        assert!(view.card.is_none());
+    }
+
+    #[test]
+    fn test_decrypt_restricted_non_login_name_only() {
+        let key_store = create_test_crypto_with_user_key(SymmetricCryptoKey::make(
+            SymmetricKeyAlgorithm::Aes256CbcHmac,
+        ));
+        let enc_name = "Gated Note"
+            .to_string()
+            .encrypt(&mut key_store.context(), SymmetricKeySlotId::User)
+            .unwrap();
+        let envelope = serde_json::json!({ "Name": enc_name }).to_string();
+        let cipher = restricted_cipher(CipherType::SecureNote, envelope);
+
+        let list: CipherListView = key_store.decrypt(&cipher).unwrap();
+        assert!(list.partial);
+        assert_eq!(list.name, "Gated Note".to_string());
+        assert_eq!(list.r#type, CipherListViewType::SecureNote);
+
+        let view: CipherView = key_store.decrypt(&cipher).unwrap();
+        assert!(view.partial);
+        assert_eq!(view.name, "Gated Note".to_string());
+        assert!(view.login.is_none());
+        assert!(view.secure_note.is_none());
+    }
+
+    #[test]
+    fn test_decrypt_restricted_malformed_envelope_fails_closed() {
+        let key_store = create_test_crypto_with_user_key(SymmetricCryptoKey::make(
+            SymmetricKeyAlgorithm::Aes256CbcHmac,
+        ));
+        // A malformed envelope must not un-gate the row: it stays partial, just nameless.
+        let cipher = restricted_cipher(CipherType::Login, "not valid json".to_string());
+
+        let list: CipherListView = key_store.decrypt(&cipher).unwrap();
+        assert!(list.partial);
+        assert!(list.name.is_empty());
+
+        let view: CipherView = key_store.decrypt(&cipher).unwrap();
+        assert!(view.partial);
+        assert!(view.name.is_empty());
+    }
+
+    #[test]
+    fn test_decrypt_restricted_works_in_strict_mode() {
+        let key_store = create_test_crypto_with_user_key(SymmetricCryptoKey::make(
+            SymmetricKeyAlgorithm::Aes256CbcHmac,
+        ));
+        let enc_name = "Restricted Card"
+            .to_string()
+            .encrypt(&mut key_store.context(), SymmetricKeySlotId::User)
+            .unwrap();
+        let envelope = serde_json::json!({ "Name": enc_name }).to_string();
+        // A Card with no card payload would hit `MissingField("card")` under strict decrypt —
+        // the restricted branch must short-circuit before that.
+        let cipher = restricted_cipher(CipherType::Card, envelope);
+
+        let list: CipherListView = key_store.decrypt(&StrictDecrypt(cipher.clone())).unwrap();
+        assert!(list.partial);
+        assert_eq!(list.name, "Restricted Card".to_string());
+        assert_eq!(
+            list.r#type,
+            CipherListViewType::Card(CardListView { brand: None })
+        );
+
+        let view: CipherView = key_store.decrypt(&StrictDecrypt(cipher)).unwrap();
+        assert!(view.partial);
+        assert!(view.card.is_none());
+    }
+
     #[test]
     fn test_decrypt_cipher_list_view() {
         let key: SymmetricCryptoKey = "w2LO+nwV4oxwswVYCxlOfRUseXfvU03VzvKQHrqeklPgiMZrspUe6sOBToCnDn9Ay0tuCBn8ykVVRb7PWhub2Q==".to_string().try_into().unwrap();
         let key_store = create_test_crypto_with_user_key(key);
 
         let cipher = Cipher {
+            partial_data: None,
             id: Some("090c19ea-a61a-4df6-8963-262b97bc6266".parse().unwrap()),
             organization_id: None,
             folder_id: None,
@@ -2330,6 +2768,7 @@ mod tests {
         assert_eq!(
             view,
             CipherListView {
+                partial: false,
                 id: cipher.id,
                 organization_id: cipher.organization_id,
                 folder_id: cipher.folder_id,
@@ -3139,6 +3578,7 @@ mod tests {
     #[test]
     fn test_populate_cipher_types_login_with_valid_data() {
         let mut cipher = Cipher {
+            partial_data: None,
             id: Some(TEST_UUID.parse().unwrap()),
             organization_id: None,
             folder_id: None,
@@ -3188,6 +3628,7 @@ mod tests {
     #[test]
     fn test_populate_cipher_types_secure_note() {
         let mut cipher = Cipher {
+            partial_data: None,
             id: Some(TEST_UUID.parse().unwrap()),
             organization_id: None,
             folder_id: None,
@@ -3231,6 +3672,7 @@ mod tests {
     #[test]
     fn test_populate_cipher_types_card() {
         let mut cipher = Cipher {
+            partial_data: None,
             id: Some(TEST_UUID.parse().unwrap()),
             organization_id: None,
             folder_id: None,
@@ -3298,6 +3740,7 @@ mod tests {
     #[test]
     fn test_populate_cipher_types_identity() {
         let mut cipher = Cipher {
+            partial_data: None,
             id: Some(TEST_UUID.parse().unwrap()),
             organization_id: None,
             folder_id: None,
@@ -3458,6 +3901,7 @@ mod tests {
     #[test]
     fn test_populate_cipher_types_ssh_key() {
         let mut cipher = Cipher {
+            partial_data: None,
             id: Some(TEST_UUID.parse().unwrap()),
             organization_id: None,
             folder_id: None,
@@ -3508,6 +3952,7 @@ mod tests {
     #[test]
     fn test_populate_cipher_types_with_null_data() {
         let mut cipher = Cipher {
+            partial_data: None,
             id: Some(TEST_UUID.parse().unwrap()),
             organization_id: None,
             folder_id: None,
@@ -3551,6 +3996,7 @@ mod tests {
     #[test]
     fn test_populate_cipher_types_with_invalid_json() {
         let mut cipher = Cipher {
+            partial_data: None,
             id: Some(TEST_UUID.parse().unwrap()),
             organization_id: None,
             folder_id: None,
@@ -3612,6 +4058,7 @@ mod tests {
             .unwrap();
 
         let cipher = Cipher {
+            partial_data: None,
             id: Some("090c19ea-a61a-4df6-8963-262b97bc6266".parse().unwrap()),
             organization_id: None,
             folder_id: None,

--- a/crates/bitwarden-vault/src/cipher/cipher.rs
+++ b/crates/bitwarden-vault/src/cipher/cipher.rs
@@ -33,7 +33,7 @@ use super::{
     cipher_permissions::CipherPermissions,
     drivers_license, field, identity,
     local_data::{LocalData, LocalDataView},
-    login::LoginListView,
+    login::{LoginListView, LoginUri, LoginUriView, UriMatchType},
     passport, secure_note, ssh_key,
 };
 use crate::{
@@ -326,6 +326,15 @@ pub struct Cipher {
     pub revision_date: DateTime<Utc>,
     pub archived_date: Option<DateTime<Utc>>,
     pub data: Option<String>,
+
+    /// Raw JSON envelope for a server-restricted (PAM-gated) cipher: the encrypted name and,
+    /// for logins, the encrypted URIs — every secret field is withheld by the server. Its
+    /// presence marks the cipher restricted; the decrypt path parses only these allowlisted
+    /// fields and produces a view with `partial = true`, never reading the secret payloads.
+    /// Distinct from `data` (the full sealed blob) and from the unrelated `PartialCipher`
+    /// merge trait.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub partial_data: Option<String>,
 }
 
 /// Represents the result of re-wrapping a cipher key, which can be needed when changing the
@@ -471,6 +480,12 @@ pub struct CipherView {
     pub deleted_date: Option<DateTime<Utc>>,
     pub revision_date: DateTime<Utc>,
     pub archived_date: Option<DateTime<Utc>>,
+
+    /// True when this view was produced from a server-restricted (PAM-gated) cipher: only the
+    /// name and (for logins) URIs are populated; every secret field is absent. See
+    /// [`Cipher::partial_data`].
+    #[serde(default)]
+    pub partial: bool,
 }
 
 #[allow(missing_docs)]
@@ -563,6 +578,11 @@ pub struct CipherListView {
     pub copyable_fields: Vec<CopyableCipherFields>,
 
     pub local_data: Option<LocalDataView>,
+
+    /// True when this view was produced from a server-restricted (PAM-gated) cipher: only the
+    /// name and (for logins) URIs are populated. See [`Cipher::partial_data`].
+    #[serde(default)]
+    pub partial: bool,
 
     /// Decrypted cipher notes for search indexing.
     #[cfg(feature = "wasm")]
@@ -657,6 +677,7 @@ impl CipherView {
         cipher_view.generate_checksums();
 
         Ok(Cipher {
+            partial_data: None,
             id: cipher_view.id,
             organization_id: cipher_view.organization_id,
             folder_id: cipher_view.folder_id,
@@ -725,6 +746,7 @@ pub(crate) fn lenient_decrypt_cipher_view(
         );
 
     let mut view = CipherView {
+        partial: false,
         id: cipher.id,
         organization_id: cipher.organization_id,
         folder_id: cipher.folder_id,
@@ -1146,6 +1168,7 @@ impl CipherView {
         };
 
         Ok(CipherListView {
+            partial: false,
             id: self.id,
             organization_id: self.organization_id,
             folder_id: self.folder_id,
@@ -1410,6 +1433,7 @@ pub(crate) fn lenient_decrypt_cipher_list_view(
     let ciphers_key = Cipher::decrypt_cipher_key(ctx, key, &cipher.key)?;
 
     Ok(CipherListView {
+        partial: false,
         id: cipher.id,
         organization_id: cipher.organization_id,
         folder_id: cipher.folder_id,
@@ -1508,6 +1532,207 @@ impl IdentifyKey<SymmetricKeySlotId> for Cipher {
     }
 }
 
+/// The server's reduced payload for a restricted (PAM-gated) cipher, mirroring
+/// `PartialCipherData.Strip` on the server. Deserialized with PascalCase to match the server's
+/// wire shape. This struct is the single authoritative allowlist for what a gated view may
+/// expose: the encrypted name and, for logins, the encrypted URIs — nothing else, so an
+/// over-sharing server blob can never leak a password or TOTP onto a gated view.
+#[derive(Deserialize, Default)]
+#[serde(rename_all = "PascalCase")]
+struct RestrictedCipherData {
+    name: Option<EncString>,
+    uris: Option<Vec<RestrictedLoginUri>>,
+}
+
+/// A single URI entry inside [`RestrictedCipherData`] (server PascalCase shape). Structurally a
+/// [`LoginUri`]; converted to one for decryption.
+#[derive(Deserialize)]
+#[serde(rename_all = "PascalCase")]
+struct RestrictedLoginUri {
+    uri: Option<EncString>,
+    r#match: Option<UriMatchType>,
+    uri_checksum: Option<EncString>,
+}
+
+impl From<RestrictedLoginUri> for LoginUri {
+    fn from(u: RestrictedLoginUri) -> Self {
+        LoginUri {
+            uri: u.uri,
+            r#match: u.r#match,
+            uri_checksum: u.uri_checksum,
+        }
+    }
+}
+
+/// Decrypt the allowlisted URIs from a restricted envelope. A URI that fails to decrypt is
+/// dropped rather than failing the whole cipher.
+fn decrypt_restricted_uris(
+    uris: Option<Vec<RestrictedLoginUri>>,
+    ctx: &mut KeyStoreContext<KeySlotIds>,
+    ciphers_key: SymmetricKeySlotId,
+) -> Option<Vec<LoginUriView>> {
+    uris.map(|list| {
+        list.into_iter()
+            .filter_map(|u| LoginUri::from(u).decrypt(ctx, ciphers_key).ok())
+            .collect()
+    })
+}
+
+/// Decrypt a restricted (PAM-gated) cipher into a [`CipherView`].
+///
+/// Parses `partial_data` and decrypts ONLY the allowlisted fields — the name and, for logins,
+/// the URIs. It never reads the cipher's secret payloads (`login.password`, `card`, …), which
+/// the server withholds anyway. Fail-closed: a malformed envelope or an undecryptable field
+/// degrades to empty rather than un-gating the row — the view is always `partial = true`.
+fn decrypt_restricted_cipher_view(
+    cipher: &Cipher,
+    raw: &str,
+    ctx: &mut KeyStoreContext<KeySlotIds>,
+    key: SymmetricKeySlotId,
+) -> Result<CipherView, CryptoError> {
+    let ciphers_key = Cipher::decrypt_cipher_key(ctx, key, &cipher.key)?;
+    let restricted: RestrictedCipherData = serde_json::from_str(raw).unwrap_or_default();
+
+    let name = restricted
+        .name
+        .as_ref()
+        .and_then(|n| n.decrypt(ctx, ciphers_key).ok())
+        .unwrap_or_default();
+
+    // Only logins carry URIs; expose them so the partial view can render a domain
+    // (favicon / launch). Every other login field stays absent.
+    let login = matches!(cipher.r#type, CipherType::Login).then(|| LoginView {
+        username: None,
+        password: None,
+        password_revision_date: None,
+        uris: decrypt_restricted_uris(restricted.uris, ctx, ciphers_key),
+        totp: None,
+        autofill_on_page_load: None,
+        fido2_credentials: None,
+    });
+
+    let mut view = CipherView {
+        id: cipher.id,
+        organization_id: cipher.organization_id,
+        folder_id: cipher.folder_id,
+        collection_ids: cipher.collection_ids.clone(),
+        // ⚠️ pass-through of the wrapped, key-bound cipher key — see the contract-violation note
+        // in `lenient_decrypt_cipher_view`.
+        key: cipher.key.clone(),
+        name,
+        notes: None,
+        r#type: cipher.r#type,
+        login,
+        identity: None,
+        card: None,
+        secure_note: None,
+        ssh_key: None,
+        bank_account: None,
+        drivers_license: None,
+        passport: None,
+        favorite: cipher.favorite,
+        reprompt: cipher.reprompt,
+        organization_use_totp: cipher.organization_use_totp,
+        edit: cipher.edit,
+        permissions: cipher.permissions,
+        view_password: cipher.view_password,
+        local_data: cipher.local_data.decrypt(ctx, ciphers_key).ok().flatten(),
+        attachments: None,
+        attachment_decryption_failures: None,
+        fields: None,
+        password_history: None,
+        creation_date: cipher.creation_date,
+        deleted_date: cipher.deleted_date,
+        revision_date: cipher.revision_date,
+        archived_date: cipher.archived_date,
+        partial: true,
+    };
+
+    // Drop URIs whose checksum doesn't validate — guards against a tampering server, mirroring
+    // the full decrypt paths (same gate as `lenient_decrypt_cipher_view`).
+    if view.key.is_some()
+        || ctx.get_security_state_version() >= MINIMUM_ENFORCE_ICON_URI_HASH_VERSION
+    {
+        view.remove_invalid_checksums();
+    }
+
+    Ok(view)
+}
+
+/// Decrypt a restricted (PAM-gated) cipher into a [`CipherListView`]. See
+/// [`decrypt_restricted_cipher_view`] for the allowlist and fail-closed contract. The type
+/// discriminant is preserved (so the row keeps its icon) but every type payload is empty apart
+/// from a login's URIs.
+fn decrypt_restricted_cipher_list_view(
+    cipher: &Cipher,
+    raw: &str,
+    ctx: &mut KeyStoreContext<KeySlotIds>,
+    key: SymmetricKeySlotId,
+) -> Result<CipherListView, CryptoError> {
+    let ciphers_key = Cipher::decrypt_cipher_key(ctx, key, &cipher.key)?;
+    let restricted: RestrictedCipherData = serde_json::from_str(raw).unwrap_or_default();
+
+    let name = restricted
+        .name
+        .as_ref()
+        .and_then(|n| n.decrypt(ctx, ciphers_key).ok())
+        .unwrap_or_default();
+
+    let r#type = match cipher.r#type {
+        CipherType::Login => CipherListViewType::Login(LoginListView {
+            fido2_credentials: None,
+            has_fido2: false,
+            username: None,
+            totp: None,
+            uris: decrypt_restricted_uris(restricted.uris, ctx, ciphers_key),
+        }),
+        CipherType::SecureNote => CipherListViewType::SecureNote,
+        CipherType::Card => CipherListViewType::Card(CardListView { brand: None }),
+        CipherType::Identity => CipherListViewType::Identity,
+        CipherType::SshKey => CipherListViewType::SshKey,
+        CipherType::BankAccount => CipherListViewType::BankAccount(BankAccountListView {
+            account_number: None,
+            account_type: None,
+        }),
+        CipherType::Passport => CipherListViewType::Passport,
+        CipherType::DriversLicense => CipherListViewType::DriversLicense,
+    };
+
+    Ok(CipherListView {
+        id: cipher.id,
+        organization_id: cipher.organization_id,
+        folder_id: cipher.folder_id,
+        collection_ids: cipher.collection_ids.clone(),
+        // ⚠️ pass-through of the wrapped, key-bound cipher key — see the contract-violation note
+        // in `lenient_decrypt_cipher_view`.
+        key: cipher.key.clone(),
+        name,
+        subtitle: String::new(),
+        r#type,
+        favorite: cipher.favorite,
+        reprompt: cipher.reprompt,
+        organization_use_totp: cipher.organization_use_totp,
+        edit: cipher.edit,
+        permissions: cipher.permissions,
+        view_password: cipher.view_password,
+        attachments: 0,
+        has_old_attachments: false,
+        creation_date: cipher.creation_date,
+        deleted_date: cipher.deleted_date,
+        revision_date: cipher.revision_date,
+        archived_date: cipher.archived_date,
+        copyable_fields: vec![],
+        local_data: cipher.local_data.decrypt(ctx, ciphers_key).ok().flatten(),
+        partial: true,
+        #[cfg(feature = "wasm")]
+        notes: None,
+        #[cfg(feature = "wasm")]
+        fields: None,
+        #[cfg(feature = "wasm")]
+        attachment_names: None,
+    })
+}
+
 impl Decryptable<KeySlotIds, SymmetricKeySlotId, CipherView> for Cipher {
     #[bitwarden_logging::instrument(err, fields(cipher_id = ?self.id, org_id = ?self.organization_id, kind = ?self.r#type))]
     fn decrypt(
@@ -1515,6 +1740,9 @@ impl Decryptable<KeySlotIds, SymmetricKeySlotId, CipherView> for Cipher {
         ctx: &mut KeyStoreContext<KeySlotIds>,
         key: SymmetricKeySlotId,
     ) -> Result<CipherView, CryptoError> {
+        if let Some(raw) = &self.partial_data {
+            return decrypt_restricted_cipher_view(self, raw, ctx, key);
+        }
         match try_parse_blob(self) {
             Some(sealed) => decrypt_blob_cipher(self, &sealed, ctx, key).map_err(CryptoError::from),
             None => lenient_decrypt_cipher_view(self, ctx, key),
@@ -1528,6 +1756,9 @@ impl Decryptable<KeySlotIds, SymmetricKeySlotId, CipherListView> for Cipher {
         ctx: &mut KeyStoreContext<KeySlotIds>,
         key: SymmetricKeySlotId,
     ) -> Result<CipherListView, CryptoError> {
+        if let Some(raw) = &self.partial_data {
+            return decrypt_restricted_cipher_list_view(self, raw, ctx, key);
+        }
         match try_parse_blob(self) {
             Some(sealed) => decrypt_blob_cipher(self, &sealed, ctx, key)?.to_list_view(ctx, key),
             None => lenient_decrypt_cipher_list_view(self, ctx, key),
@@ -1576,6 +1807,9 @@ impl Decryptable<KeySlotIds, SymmetricKeySlotId, CipherView> for StrictDecrypt<C
         ctx: &mut KeyStoreContext<KeySlotIds>,
         key: SymmetricKeySlotId,
     ) -> Result<CipherView, CryptoError> {
+        if let Some(raw) = &self.0.partial_data {
+            return decrypt_restricted_cipher_view(&self.0, raw, ctx, key);
+        }
         match try_parse_blob(&self.0) {
             Some(sealed) => {
                 decrypt_blob_cipher(&self.0, &sealed, ctx, key).map_err(CryptoError::from)
@@ -1603,6 +1837,7 @@ fn strict_decrypt_cipher_view(
         );
 
     let mut view = CipherView {
+        partial: false,
         id: cipher.id,
         organization_id: cipher.organization_id,
         folder_id: cipher.folder_id,
@@ -1680,6 +1915,9 @@ impl Decryptable<KeySlotIds, SymmetricKeySlotId, CipherListView> for StrictDecry
         ctx: &mut KeyStoreContext<KeySlotIds>,
         key: SymmetricKeySlotId,
     ) -> Result<CipherListView, CryptoError> {
+        if let Some(raw) = &self.0.partial_data {
+            return decrypt_restricted_cipher_list_view(&self.0, raw, ctx, key);
+        }
         match try_parse_blob(&self.0) {
             Some(sealed) => decrypt_blob_cipher(&self.0, &sealed, ctx, key)?.to_list_view(ctx, key),
             None => strict_decrypt_cipher_list_view(&self.0, ctx, key),
@@ -1697,6 +1935,7 @@ fn strict_decrypt_cipher_list_view(
     let ciphers_key = Cipher::decrypt_cipher_key(ctx, key, &cipher.key)?;
 
     Ok(CipherListView {
+        partial: false,
         id: cipher.id,
         organization_id: cipher.organization_id,
         folder_id: cipher.folder_id,
@@ -1848,6 +2087,7 @@ impl TryFrom<CipherDetailsResponseModel> for Cipher {
 
     fn try_from(cipher: CipherDetailsResponseModel) -> Result<Self, Self::Error> {
         Ok(Self {
+            partial_data: None,
             id: cipher.id.map(CipherId::new),
             organization_id: cipher.organization_id.map(OrganizationId::new),
             folder_id: cipher.folder_id.map(FolderId::new),
@@ -1981,6 +2221,7 @@ impl From<CipherRepromptType> for bitwarden_api_api::models::CipherRepromptType 
 impl PartialCipher for CipherResponseModel {
     fn merge_with_cipher(self, cipher: Option<Cipher>) -> Result<Cipher, VaultParseError> {
         Ok(Cipher {
+            partial_data: None,
             collection_ids: cipher
                 .as_ref()
                 .map(|c| c.collection_ids.clone())
@@ -2036,6 +2277,7 @@ impl PartialCipher for CipherMiniResponseModel {
     fn merge_with_cipher(self, cipher: Option<Cipher>) -> Result<Cipher, VaultParseError> {
         let cipher = cipher.as_ref();
         Ok(Cipher {
+            partial_data: None,
             id: self.id.map(CipherId::new),
             organization_id: self.organization_id.map(OrganizationId::new),
             key: EncString::try_from_optional(self.key)?,
@@ -2096,6 +2338,7 @@ impl PartialCipher for CipherMiniDetailsResponseModel {
     fn merge_with_cipher(self, cipher: Option<Cipher>) -> Result<Cipher, VaultParseError> {
         let cipher = cipher.as_ref();
         Ok(Cipher {
+            partial_data: None,
             id: self.id.map(CipherId::new),
             organization_id: self.organization_id.map(OrganizationId::new),
             key: EncString::try_from_optional(self.key)?,
@@ -2181,6 +2424,7 @@ mod tests {
     fn generate_cipher() -> CipherView {
         let test_id = "fd411a1a-fec8-4070-985d-0e6560860e69".parse().unwrap();
         CipherView {
+            partial: false,
             r#type: CipherType::Login,
             login: Some(LoginView {
                 username: Some("test_username".to_string()),
@@ -2244,12 +2488,206 @@ mod tests {
         }
     }
 
+    /// Builds a server-restricted (PAM-gated) cipher: no top-level secret fields, only the
+    /// `partial_data` envelope the server sends in their place.
+    fn restricted_cipher(r#type: CipherType, partial_data: String) -> Cipher {
+        Cipher {
+            partial_data: Some(partial_data),
+            id: Some(TEST_UUID.parse().unwrap()),
+            organization_id: None,
+            folder_id: None,
+            collection_ids: vec![],
+            key: None,
+            name: None,
+            notes: None,
+            r#type,
+            login: None,
+            identity: None,
+            card: None,
+            secure_note: None,
+            ssh_key: None,
+            bank_account: None,
+            drivers_license: None,
+            passport: None,
+            favorite: false,
+            reprompt: CipherRepromptType::None,
+            organization_use_totp: false,
+            edit: true,
+            permissions: None,
+            view_password: true,
+            local_data: None,
+            attachments: None,
+            fields: None,
+            password_history: None,
+            creation_date: "2024-01-30T17:55:36.150Z".parse().unwrap(),
+            deleted_date: None,
+            revision_date: "2024-01-30T17:55:36.150Z".parse().unwrap(),
+            archived_date: None,
+            data: None,
+        }
+    }
+
+    #[test]
+    fn test_decrypt_restricted_cipher_list_view_login() {
+        let key_store = create_test_crypto_with_user_key(SymmetricCryptoKey::make(
+            SymmetricKeyAlgorithm::Aes256CbcHmac,
+        ));
+        let enc_name = "Restricted Name"
+            .to_string()
+            .encrypt(&mut key_store.context(), SymmetricKeySlotId::User)
+            .unwrap();
+        let enc_uri = "https://example.com"
+            .to_string()
+            .encrypt(&mut key_store.context(), SymmetricKeySlotId::User)
+            .unwrap();
+        let envelope = serde_json::json!({
+            "Name": enc_name,
+            "Uris": [{ "Uri": enc_uri, "UriChecksum": null, "Match": null }],
+        })
+        .to_string();
+
+        let cipher = restricted_cipher(CipherType::Login, envelope);
+        let view: CipherListView = key_store.decrypt(&cipher).unwrap();
+
+        assert!(view.partial);
+        assert_eq!(view.name, "Restricted Name".to_string());
+        assert!(view.subtitle.is_empty());
+        assert!(view.copyable_fields.is_empty());
+        assert_eq!(view.attachments, 0);
+        match view.r#type {
+            CipherListViewType::Login(login) => {
+                assert_eq!(
+                    login.uris.unwrap()[0].uri.as_deref(),
+                    Some("https://example.com")
+                );
+                assert_eq!(login.username, None);
+                assert_eq!(login.totp, None);
+                assert!(!login.has_fido2);
+            }
+            other => panic!("expected Login list view, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_decrypt_restricted_cipher_view_login_omits_secrets() {
+        let key_store = create_test_crypto_with_user_key(SymmetricCryptoKey::make(
+            SymmetricKeyAlgorithm::Aes256CbcHmac,
+        ));
+        let enc_name = "Restricted Name"
+            .to_string()
+            .encrypt(&mut key_store.context(), SymmetricKeySlotId::User)
+            .unwrap();
+        let enc_uri = "https://example.com"
+            .to_string()
+            .encrypt(&mut key_store.context(), SymmetricKeySlotId::User)
+            .unwrap();
+        // A rogue/over-sharing server also stuffs an encrypted password into the envelope; the
+        // allowlist (`RestrictedCipherData`) must ignore anything outside name + uris.
+        let enc_pw = "s3cret"
+            .to_string()
+            .encrypt(&mut key_store.context(), SymmetricKeySlotId::User)
+            .unwrap();
+        let envelope = serde_json::json!({
+            "Name": enc_name,
+            "Uris": [{ "Uri": enc_uri, "UriChecksum": null, "Match": null }],
+            "Password": enc_pw,
+        })
+        .to_string();
+
+        let cipher = restricted_cipher(CipherType::Login, envelope);
+        let view: CipherView = key_store.decrypt(&cipher).unwrap();
+
+        assert!(view.partial);
+        assert_eq!(view.name, "Restricted Name".to_string());
+        let login = view
+            .login
+            .expect("login populated so the view can render a domain");
+        assert_eq!(
+            login.uris.unwrap()[0].uri.as_deref(),
+            Some("https://example.com")
+        );
+        assert_eq!(login.username, None);
+        assert_eq!(login.password, None);
+        assert_eq!(login.totp, None);
+        assert_eq!(view.notes, None);
+        assert!(view.card.is_none());
+    }
+
+    #[test]
+    fn test_decrypt_restricted_non_login_name_only() {
+        let key_store = create_test_crypto_with_user_key(SymmetricCryptoKey::make(
+            SymmetricKeyAlgorithm::Aes256CbcHmac,
+        ));
+        let enc_name = "Gated Note"
+            .to_string()
+            .encrypt(&mut key_store.context(), SymmetricKeySlotId::User)
+            .unwrap();
+        let envelope = serde_json::json!({ "Name": enc_name }).to_string();
+        let cipher = restricted_cipher(CipherType::SecureNote, envelope);
+
+        let list: CipherListView = key_store.decrypt(&cipher).unwrap();
+        assert!(list.partial);
+        assert_eq!(list.name, "Gated Note".to_string());
+        assert_eq!(list.r#type, CipherListViewType::SecureNote);
+
+        let view: CipherView = key_store.decrypt(&cipher).unwrap();
+        assert!(view.partial);
+        assert_eq!(view.name, "Gated Note".to_string());
+        assert!(view.login.is_none());
+        assert!(view.secure_note.is_none());
+    }
+
+    #[test]
+    fn test_decrypt_restricted_malformed_envelope_fails_closed() {
+        let key_store = create_test_crypto_with_user_key(SymmetricCryptoKey::make(
+            SymmetricKeyAlgorithm::Aes256CbcHmac,
+        ));
+        // A malformed envelope must not un-gate the row: it stays partial, just nameless.
+        let cipher = restricted_cipher(CipherType::Login, "not valid json".to_string());
+
+        let list: CipherListView = key_store.decrypt(&cipher).unwrap();
+        assert!(list.partial);
+        assert!(list.name.is_empty());
+
+        let view: CipherView = key_store.decrypt(&cipher).unwrap();
+        assert!(view.partial);
+        assert!(view.name.is_empty());
+    }
+
+    #[test]
+    fn test_decrypt_restricted_works_in_strict_mode() {
+        let key_store = create_test_crypto_with_user_key(SymmetricCryptoKey::make(
+            SymmetricKeyAlgorithm::Aes256CbcHmac,
+        ));
+        let enc_name = "Restricted Card"
+            .to_string()
+            .encrypt(&mut key_store.context(), SymmetricKeySlotId::User)
+            .unwrap();
+        let envelope = serde_json::json!({ "Name": enc_name }).to_string();
+        // A Card with no card payload would hit `MissingField("card")` under strict decrypt —
+        // the restricted branch must short-circuit before that.
+        let cipher = restricted_cipher(CipherType::Card, envelope);
+
+        let list: CipherListView = key_store.decrypt(&StrictDecrypt(cipher.clone())).unwrap();
+        assert!(list.partial);
+        assert_eq!(list.name, "Restricted Card".to_string());
+        assert_eq!(
+            list.r#type,
+            CipherListViewType::Card(CardListView { brand: None })
+        );
+
+        let view: CipherView = key_store.decrypt(&StrictDecrypt(cipher)).unwrap();
+        assert!(view.partial);
+        assert!(view.card.is_none());
+    }
+
     #[test]
     fn test_decrypt_cipher_list_view() {
         let key: SymmetricCryptoKey = "w2LO+nwV4oxwswVYCxlOfRUseXfvU03VzvKQHrqeklPgiMZrspUe6sOBToCnDn9Ay0tuCBn8ykVVRb7PWhub2Q==".to_string().try_into().unwrap();
         let key_store = create_test_crypto_with_user_key(key);
 
         let cipher = Cipher {
+            partial_data: None,
             id: Some("090c19ea-a61a-4df6-8963-262b97bc6266".parse().unwrap()),
             organization_id: None,
             folder_id: None,
@@ -2299,6 +2737,7 @@ mod tests {
         assert_eq!(
             view,
             CipherListView {
+                partial: false,
                 id: cipher.id,
                 organization_id: cipher.organization_id,
                 folder_id: cipher.folder_id,
@@ -2919,6 +3358,7 @@ mod tests {
     #[test]
     fn test_populate_cipher_types_login_with_valid_data() {
         let mut cipher = Cipher {
+            partial_data: None,
             id: Some(TEST_UUID.parse().unwrap()),
             organization_id: None,
             folder_id: None,
@@ -2968,6 +3408,7 @@ mod tests {
     #[test]
     fn test_populate_cipher_types_secure_note() {
         let mut cipher = Cipher {
+            partial_data: None,
             id: Some(TEST_UUID.parse().unwrap()),
             organization_id: None,
             folder_id: None,
@@ -3011,6 +3452,7 @@ mod tests {
     #[test]
     fn test_populate_cipher_types_card() {
         let mut cipher = Cipher {
+            partial_data: None,
             id: Some(TEST_UUID.parse().unwrap()),
             organization_id: None,
             folder_id: None,
@@ -3078,6 +3520,7 @@ mod tests {
     #[test]
     fn test_populate_cipher_types_identity() {
         let mut cipher = Cipher {
+            partial_data: None,
             id: Some(TEST_UUID.parse().unwrap()),
             organization_id: None,
             folder_id: None,
@@ -3238,6 +3681,7 @@ mod tests {
     #[test]
     fn test_populate_cipher_types_ssh_key() {
         let mut cipher = Cipher {
+            partial_data: None,
             id: Some(TEST_UUID.parse().unwrap()),
             organization_id: None,
             folder_id: None,
@@ -3288,6 +3732,7 @@ mod tests {
     #[test]
     fn test_populate_cipher_types_with_null_data() {
         let mut cipher = Cipher {
+            partial_data: None,
             id: Some(TEST_UUID.parse().unwrap()),
             organization_id: None,
             folder_id: None,
@@ -3331,6 +3776,7 @@ mod tests {
     #[test]
     fn test_populate_cipher_types_with_invalid_json() {
         let mut cipher = Cipher {
+            partial_data: None,
             id: Some(TEST_UUID.parse().unwrap()),
             organization_id: None,
             folder_id: None,
@@ -3392,6 +3838,7 @@ mod tests {
             .unwrap();
 
         let cipher = Cipher {
+            partial_data: None,
             id: Some("090c19ea-a61a-4df6-8963-262b97bc6266".parse().unwrap()),
             organization_id: None,
             folder_id: None,

--- a/crates/bitwarden-vault/src/cipher/cipher.rs
+++ b/crates/bitwarden-vault/src/cipher/cipher.rs
@@ -2149,7 +2149,7 @@ impl TryFrom<CipherDetailsResponseModel> for Cipher {
 
     fn try_from(cipher: CipherDetailsResponseModel) -> Result<Self, Self::Error> {
         Ok(Self {
-            partial_data: None,
+            partial_data: cipher.partial_data,
             id: cipher.id.map(CipherId::new),
             organization_id: cipher.organization_id.map(OrganizationId::new),
             folder_id: cipher.folder_id.map(FolderId::new),
@@ -2209,11 +2209,7 @@ impl TryFrom<CipherDetailsResponseModel> for Cipher {
 impl PartialCipher for CipherDetailsResponseModel {
     fn merge_with_cipher(self, cipher: Option<Cipher>) -> Result<Cipher, VaultParseError> {
         Ok(Cipher {
-            local_data: cipher.as_ref().and_then(|c| c.local_data.clone()),
-            // Preserve PAM gating across a partial/full update; these merge responses never change
-            // gating. TODO: prefer the response's partialData once the generated API model carries
-            // it.
-            partial_data: cipher.and_then(|c| c.partial_data),
+            local_data: cipher.and_then(|c| c.local_data),
             ..self.try_into()?
         })
     }
@@ -2287,10 +2283,7 @@ impl From<CipherRepromptType> for bitwarden_api_api::models::CipherRepromptType 
 impl PartialCipher for CipherResponseModel {
     fn merge_with_cipher(self, cipher: Option<Cipher>) -> Result<Cipher, VaultParseError> {
         Ok(Cipher {
-            // Preserve PAM gating across a partial/full update; these merge responses never change
-            // gating. TODO: prefer the response's partialData once the generated API model carries
-            // it.
-            partial_data: cipher.as_ref().and_then(|c| c.partial_data.clone()),
+            partial_data: self.partial_data,
             collection_ids: cipher
                 .as_ref()
                 .map(|c| c.collection_ids.clone())
@@ -2346,10 +2339,7 @@ impl PartialCipher for CipherMiniResponseModel {
     fn merge_with_cipher(self, cipher: Option<Cipher>) -> Result<Cipher, VaultParseError> {
         let cipher = cipher.as_ref();
         Ok(Cipher {
-            // Preserve PAM gating across a partial/full update; these merge responses never change
-            // gating. TODO: prefer the response's partialData once the generated API model carries
-            // it.
-            partial_data: cipher.and_then(|c| c.partial_data.clone()),
+            partial_data: self.partial_data,
             id: self.id.map(CipherId::new),
             organization_id: self.organization_id.map(OrganizationId::new),
             key: EncString::try_from_optional(self.key)?,
@@ -2410,10 +2400,7 @@ impl PartialCipher for CipherMiniDetailsResponseModel {
     fn merge_with_cipher(self, cipher: Option<Cipher>) -> Result<Cipher, VaultParseError> {
         let cipher = cipher.as_ref();
         Ok(Cipher {
-            // Preserve PAM gating across a partial/full update; these merge responses never change
-            // gating. TODO: prefer the response's partialData once the generated API model carries
-            // it.
-            partial_data: cipher.and_then(|c| c.partial_data.clone()),
+            partial_data: self.partial_data,
             id: self.id.map(CipherId::new),
             organization_id: self.organization_id.map(OrganizationId::new),
             key: EncString::try_from_optional(self.key)?,
@@ -4448,6 +4435,68 @@ mod tests {
             cipher.view_password,
             "view_password should default to true for CipherMiniDetailsResponseModel"
         );
+    }
+
+    /// PAM gating is authoritative from the server response: `merge_with_cipher` takes
+    /// `partial_data` from the response, so it gates when the response carries the restricted
+    /// envelope and un-gates when it does not — regardless of the local cipher's prior state.
+    #[test]
+    fn test_merge_takes_partial_data_from_response() {
+        use chrono::Utc;
+
+        let org: OrganizationId = RESTRICTED_ORG_UUID.parse().unwrap();
+        // A local cipher that is currently PAM-gated; the response's gating must win over it.
+        let local_restricted = || {
+            Some(restricted_cipher(
+                org,
+                CipherType::Login,
+                RESTRICTED_LOGIN_ENVELOPE.to_string(),
+            ))
+        };
+        let now = Utc::now().to_rfc3339();
+
+        macro_rules! assert_gating_from_response {
+            ($model:ident) => {{
+                let base = $model {
+                    id: Some(TEST_UUID.parse().unwrap()),
+                    organization_id: Some(org.to_string().parse().unwrap()),
+                    r#type: Some(bitwarden_api_api::models::CipherType::Login),
+                    creation_date: Some(now.clone()),
+                    revision_date: Some(now.clone()),
+                    ..Default::default()
+                };
+
+                // A full response (no `partial_data`) un-gates a locally-restricted cipher.
+                assert_eq!(
+                    base.clone()
+                        .merge_with_cipher(local_restricted())
+                        .unwrap()
+                        .partial_data,
+                    None,
+                    concat!(stringify!($model), ": full response must un-gate"),
+                );
+
+                // A restricted response gates the row even when the local cipher was full.
+                let restricted = $model {
+                    partial_data: Some(RESTRICTED_LOGIN_ENVELOPE.to_string()),
+                    ..base
+                };
+                assert_eq!(
+                    restricted
+                        .merge_with_cipher(None)
+                        .unwrap()
+                        .partial_data
+                        .as_deref(),
+                    Some(RESTRICTED_LOGIN_ENVELOPE),
+                    concat!(stringify!($model), ": restricted response must gate"),
+                );
+            }};
+        }
+
+        assert_gating_from_response!(CipherResponseModel);
+        assert_gating_from_response!(CipherDetailsResponseModel);
+        assert_gating_from_response!(CipherMiniResponseModel);
+        assert_gating_from_response!(CipherMiniDetailsResponseModel);
     }
 
     // ---------- Cipher Decryptable dispatch + CipherView::to_list_view ----------

--- a/crates/bitwarden-vault/src/cipher/cipher.rs
+++ b/crates/bitwarden-vault/src/cipher/cipher.rs
@@ -33,7 +33,7 @@ use super::{
     cipher_permissions::CipherPermissions,
     drivers_license, field, identity,
     local_data::{LocalData, LocalDataView},
-    login::{LoginListView, LoginUri},
+    login::{LoginListView, LoginUri, LoginUriView},
     passport, secure_note, ssh_key,
 };
 use crate::{
@@ -1586,38 +1586,75 @@ struct RestrictedCipherData {
     uris: Option<Vec<LoginUri>>,
 }
 
+/// Decrypt the restricted `name`. An absent field is legitimate and stays empty in both modes; a
+/// field that is present but fails to decrypt is a real decryption failure (wrong key / corruption
+/// / tampering) — it propagates in strict mode and degrades to empty in lenient mode.
+fn decrypt_restricted_name(
+    restricted: &RestrictedCipherData,
+    ctx: &mut KeyStoreContext<KeySlotIds>,
+    ciphers_key: SymmetricKeySlotId,
+    strict: bool,
+) -> Result<String, CryptoError> {
+    let Some(name) = restricted.name.as_ref() else {
+        return Ok(String::new());
+    };
+    if strict {
+        name.decrypt(ctx, ciphers_key)
+    } else {
+        Ok(name.decrypt(ctx, ciphers_key).ok().unwrap_or_default())
+    }
+}
+
+/// Decrypt the restricted login `uris`. Absent → `None` in both modes; present-but-undecryptable →
+/// error in strict mode, `None` in lenient mode. See [`decrypt_restricted_name`].
+fn decrypt_restricted_uris(
+    restricted: &RestrictedCipherData,
+    ctx: &mut KeyStoreContext<KeySlotIds>,
+    ciphers_key: SymmetricKeySlotId,
+    strict: bool,
+) -> Result<Option<Vec<LoginUriView>>, CryptoError> {
+    if strict {
+        restricted.uris.decrypt(ctx, ciphers_key)
+    } else {
+        Ok(restricted.uris.decrypt(ctx, ciphers_key).ok().flatten())
+    }
+}
+
 /// Decrypt a restricted (PAM-gated) cipher into a [`CipherView`].
 ///
 /// Parses `partial_data` and decrypts ONLY the allowlisted fields — the name and, for logins,
 /// the URIs. It never reads the cipher's secret payloads (`login.password`, `card`, …), which
-/// the server withholds anyway. Fail-closed: a malformed envelope or an undecryptable field
-/// degrades to empty rather than un-gating the row — the view is always `partial = true`.
+/// the server withholds anyway. Fail-closed: a malformed envelope always degrades to empty
+/// rather than un-gating the row (the view is always `partial = true`). A field that is present
+/// but fails to decrypt degrades to empty in lenient mode, but propagates as an error under
+/// strict decryption (`strict = true`).
 fn decrypt_restricted_cipher_view(
     cipher: &Cipher,
     raw: &str,
     ctx: &mut KeyStoreContext<KeySlotIds>,
     key: SymmetricKeySlotId,
+    strict: bool,
 ) -> Result<CipherView, CryptoError> {
     let ciphers_key = Cipher::decrypt_cipher_key(ctx, key, &cipher.key)?;
     let restricted: RestrictedCipherData = serde_json::from_str(raw).unwrap_or_default();
 
-    let name = restricted
-        .name
-        .as_ref()
-        .and_then(|n| n.decrypt(ctx, ciphers_key).ok())
-        .unwrap_or_default();
+    let name = decrypt_restricted_name(&restricted, ctx, ciphers_key, strict)?;
 
     // Only logins carry URIs; expose them so the partial view can render a domain
     // (favicon / launch). Every other login field stays absent.
-    let login = matches!(cipher.r#type, CipherType::Login).then(|| LoginView {
-        username: None,
-        password: None,
-        password_revision_date: None,
-        uris: restricted.uris.decrypt(ctx, ciphers_key).ok().flatten(),
-        totp: None,
-        autofill_on_page_load: None,
-        fido2_credentials: None,
-    });
+    let login = if matches!(cipher.r#type, CipherType::Login) {
+        Some(LoginView {
+            username: None,
+            password: None,
+            password_revision_date: None,
+            uris: decrypt_restricted_uris(&restricted, ctx, ciphers_key, strict)?,
+            totp: None,
+            autofill_on_page_load: None,
+            fido2_credentials: None,
+        })
+    } else {
+        None
+    };
 
     let mut view = CipherView {
         id: cipher.id,
@@ -1676,15 +1713,12 @@ fn decrypt_restricted_cipher_list_view(
     raw: &str,
     ctx: &mut KeyStoreContext<KeySlotIds>,
     key: SymmetricKeySlotId,
+    strict: bool,
 ) -> Result<CipherListView, CryptoError> {
     let ciphers_key = Cipher::decrypt_cipher_key(ctx, key, &cipher.key)?;
     let restricted: RestrictedCipherData = serde_json::from_str(raw).unwrap_or_default();
 
-    let name = restricted
-        .name
-        .as_ref()
-        .and_then(|n| n.decrypt(ctx, ciphers_key).ok())
-        .unwrap_or_default();
+    let name = decrypt_restricted_name(&restricted, ctx, ciphers_key, strict)?;
 
     let r#type = match cipher.r#type {
         CipherType::Login => CipherListViewType::Login(LoginListView {
@@ -1692,7 +1726,7 @@ fn decrypt_restricted_cipher_list_view(
             has_fido2: false,
             username: None,
             totp: None,
-            uris: restricted.uris.decrypt(ctx, ciphers_key).ok().flatten(),
+            uris: decrypt_restricted_uris(&restricted, ctx, ciphers_key, strict)?,
         }),
         CipherType::SecureNote => CipherListViewType::SecureNote,
         CipherType::Card => CipherListViewType::Card(CardListView { brand: None }),
@@ -1755,7 +1789,7 @@ impl Decryptable<KeySlotIds, SymmetricKeySlotId, CipherView> for Cipher {
             if self.organization_id.is_none() {
                 return Err(CryptoError::RestrictedCipherRequiresOrganization);
             }
-            return decrypt_restricted_cipher_view(self, raw, ctx, key);
+            return decrypt_restricted_cipher_view(self, raw, ctx, key, false);
         }
         match try_parse_blob(self) {
             Some(sealed) => decrypt_blob_cipher(self, &sealed, ctx, key).map_err(CryptoError::from),
@@ -1777,7 +1811,7 @@ impl Decryptable<KeySlotIds, SymmetricKeySlotId, CipherListView> for Cipher {
             if self.organization_id.is_none() {
                 return Err(CryptoError::RestrictedCipherRequiresOrganization);
             }
-            return decrypt_restricted_cipher_list_view(self, raw, ctx, key);
+            return decrypt_restricted_cipher_list_view(self, raw, ctx, key, false);
         }
         match try_parse_blob(self) {
             Some(sealed) => decrypt_blob_cipher(self, &sealed, ctx, key)?.to_list_view(ctx, key),
@@ -1832,7 +1866,7 @@ impl Decryptable<KeySlotIds, SymmetricKeySlotId, CipherView> for StrictDecrypt<C
             if self.0.organization_id.is_none() {
                 return Err(CryptoError::RestrictedCipherRequiresOrganization);
             }
-            return decrypt_restricted_cipher_view(&self.0, raw, ctx, key);
+            return decrypt_restricted_cipher_view(&self.0, raw, ctx, key, true);
         }
         match try_parse_blob(&self.0) {
             Some(sealed) => {
@@ -1944,7 +1978,7 @@ impl Decryptable<KeySlotIds, SymmetricKeySlotId, CipherListView> for StrictDecry
             if self.0.organization_id.is_none() {
                 return Err(CryptoError::RestrictedCipherRequiresOrganization);
             }
-            return decrypt_restricted_cipher_list_view(&self.0, raw, ctx, key);
+            return decrypt_restricted_cipher_list_view(&self.0, raw, ctx, key, true);
         }
         match try_parse_blob(&self.0) {
             Some(sealed) => decrypt_blob_cipher(&self.0, &sealed, ctx, key)?.to_list_view(ctx, key),
@@ -2689,6 +2723,12 @@ mod tests {
         let view: CipherView = key_store.decrypt(&cipher).unwrap();
         assert!(view.partial);
         assert!(view.name.is_empty());
+
+        // A malformed envelope is a wire-shape problem, not a crypto failure: lenient even in
+        // strict mode.
+        let strict_view: CipherView = key_store.decrypt(&StrictDecrypt(cipher.clone())).unwrap();
+        assert!(strict_view.partial);
+        assert!(strict_view.name.is_empty());
     }
 
     #[test]
@@ -2709,6 +2749,35 @@ mod tests {
         let view: CipherView = key_store.decrypt(&StrictDecrypt(cipher)).unwrap();
         assert!(view.partial);
         assert!(view.card.is_none());
+    }
+
+    #[test]
+    fn test_decrypt_restricted_strict_propagates_field_decrypt_error() {
+        let (org, key_store) = restricted_test_key_store();
+        // Encrypt a name under an UNRELATED key so it is present in the envelope but cannot be
+        // decrypted with the organization key.
+        let wrong_key_store = create_test_crypto_with_user_key(SymmetricCryptoKey::make(
+            SymmetricKeyAlgorithm::Aes256CbcHmac,
+        ));
+        let bad_name = "boom"
+            .to_string()
+            .encrypt(&mut wrong_key_store.context(), SymmetricKeySlotId::User)
+            .unwrap();
+        let envelope = serde_json::json!({ "name": bad_name }).to_string();
+        let cipher = restricted_cipher(org, CipherType::Login, envelope);
+
+        // Lenient degrades to an empty name, still gated.
+        let view: CipherView = key_store.decrypt(&cipher).unwrap();
+        assert!(view.partial);
+        assert!(view.name.is_empty());
+
+        // Strict surfaces the present-but-undecryptable field as an error (both view and list).
+        let view_result: Result<CipherView, CryptoError> =
+            key_store.decrypt(&StrictDecrypt(cipher.clone()));
+        assert!(view_result.is_err());
+        let list_result: Result<CipherListView, CryptoError> =
+            key_store.decrypt(&StrictDecrypt(cipher));
+        assert!(list_result.is_err());
     }
 
     #[test]

--- a/crates/bitwarden-vault/src/cipher/cipher.rs
+++ b/crates/bitwarden-vault/src/cipher/cipher.rs
@@ -482,6 +482,9 @@ pub struct CipherView {
     /// True when this view was produced from a server-restricted (PAM-gated) cipher. Only a
     /// sub-set of fields are populated; every secret field is absent. See
     /// [`Cipher::partial_data`].
+    /// Such a view is fail-closed against re-encryption: passing it to any encrypt path returns
+    /// [`bitwarden_crypto::CryptoError::EncryptRestrictedView`] rather than silently stripping
+    /// secrets.
     #[serde(default)]
     pub partial: bool,
 }
@@ -669,6 +672,12 @@ impl CipherView {
         ctx: &mut KeyStoreContext<KeySlotIds>,
         key: SymmetricKeySlotId,
     ) -> Result<Cipher, CryptoError> {
+        // Fail closed: a restricted (partial) view has all secret fields stripped; re-encrypting it
+        // would overwrite the item's secrets with empty values. See `decrypt_restricted_cipher_view`.
+        if self.partial {
+            return Err(CryptoError::EncryptRestrictedView);
+        }
+
         let ciphers_key = Cipher::decrypt_cipher_key(ctx, key, &self.key)?;
 
         let mut cipher_view = self.clone();
@@ -2869,6 +2878,48 @@ mod tests {
             strict_result.is_err(),
             "Strict decryption should fail when login username is encrypted with a different key"
         );
+    }
+
+    #[test]
+    fn test_encrypt_legacy_fails_closed_for_partial_view() {
+        let key_store = create_test_crypto_with_user_key(SymmetricCryptoKey::make(
+            SymmetricKeyAlgorithm::Aes256CbcHmac,
+        ));
+
+        let mut view = generate_cipher();
+        view.partial = true;
+
+        let result = key_store.encrypt(EncryptMode::Legacy(view));
+        assert!(matches!(result, Err(CryptoError::EncryptRestrictedView)));
+    }
+
+    #[test]
+    fn test_encrypt_blob_fails_closed_for_partial_view() {
+        let key_store = create_test_crypto_with_user_key(SymmetricCryptoKey::make(
+            SymmetricKeyAlgorithm::Aes256CbcHmac,
+        ));
+
+        let mut view = generate_cipher();
+        view.partial = true;
+
+        let result = key_store.encrypt(EncryptMode::Blob(view));
+        assert!(matches!(result, Err(CryptoError::EncryptRestrictedView)));
+    }
+
+    #[test]
+    fn test_encrypt_succeeds_for_non_partial_view() {
+        let key_store = create_test_crypto_with_user_key(SymmetricCryptoKey::make(
+            SymmetricKeyAlgorithm::Aes256CbcHmac,
+        ));
+
+        // Control: the same shape of view, but with `partial: false`, must still encrypt
+        // successfully — proving the guard is specific to `partial` rather than some other
+        // difference between test fixtures.
+        let view = generate_cipher();
+        assert!(!view.partial);
+
+        let result = key_store.encrypt(EncryptMode::Legacy(view));
+        assert!(result.is_ok());
     }
 
     #[test]

--- a/crates/bitwarden-vault/src/cipher/cipher.rs
+++ b/crates/bitwarden-vault/src/cipher/cipher.rs
@@ -33,7 +33,7 @@ use super::{
     cipher_permissions::CipherPermissions,
     drivers_license, field, identity,
     local_data::{LocalData, LocalDataView},
-    login::{LoginListView, LoginUri, LoginUriView},
+    login::{LoginListView, LoginUri},
     passport, secure_note, ssh_key,
 };
 use crate::{
@@ -327,12 +327,10 @@ pub struct Cipher {
     pub archived_date: Option<DateTime<Utc>>,
     pub data: Option<String>,
 
-    /// Raw JSON envelope for a server-restricted (PAM-gated) cipher: the encrypted name and,
-    /// for logins, the encrypted URIs — every secret field is withheld by the server. Its
-    /// presence marks the cipher restricted; the decrypt path parses only these allowlisted
-    /// fields and produces a view with `partial = true`, never reading the secret payloads.
-    /// Distinct from `data` (the full sealed blob) and from the unrelated `PartialCipher`
-    /// merge trait.
+    /// Raw JSON envelope for a server-restricted (PAM-gated) cipher: only contains a sub-set of
+    /// non sensitive fields, all other fields are withheld by the server. Its presence marks the
+    /// cipher restricted; the decrypt path parses only these allowlisted fields and produces a
+    /// view with `partial = true`, never reading the secret payloads.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub partial_data: Option<String>,
 }
@@ -481,8 +479,8 @@ pub struct CipherView {
     pub revision_date: DateTime<Utc>,
     pub archived_date: Option<DateTime<Utc>>,
 
-    /// True when this view was produced from a server-restricted (PAM-gated) cipher: only the
-    /// name and (for logins) URIs are populated; every secret field is absent. See
+    /// True when this view was produced from a server-restricted (PAM-gated) cipher. Only a
+    /// sub-set of fields are populated; every secret field is absent. See
     /// [`Cipher::partial_data`].
     #[serde(default)]
     pub partial: bool,
@@ -579,8 +577,8 @@ pub struct CipherListView {
 
     pub local_data: Option<LocalDataView>,
 
-    /// True when this view was produced from a server-restricted (PAM-gated) cipher: only the
-    /// name and (for logins) URIs are populated. See [`Cipher::partial_data`].
+    /// True when this view was produced from a server-restricted (PAM-gated) cipher. Only a
+    /// sub-set of fields are populated. See [`Cipher::partial_data`].
     #[serde(default)]
     pub partial: bool,
 
@@ -1533,33 +1531,18 @@ impl IdentifyKey<SymmetricKeySlotId> for Cipher {
 }
 
 /// The server's reduced payload for a restricted (PAM-gated) cipher, produced by
-/// `PartialCipherData.Strip` on the server. The server emits a purpose-built camelCase envelope
-/// carrying the same [`LoginUri`] fields the full decrypt path uses, so the URIs deserialize
-/// straight into [`LoginUri`] with no parallel representation.
+/// `PartialCipherData.Strip` on the server.
 ///
 /// This struct is the single authoritative allowlist for what a gated view may expose: the
 /// encrypted name and, for logins, the encrypted URIs — nothing else. It is deliberately NOT
-/// `deny_unknown_fields`: an over-sharing server blob (e.g. a stray `password` or `totp`) is
-/// silently dropped by the allowlist rather than surfaced onto the view or failing the parse.
+/// `deny_unknown_fields`: the server may decide to include additional non sensitive fields in the
+/// future; these are silently dropped by the allowlist rather than surfaced onto the view or
+/// failing the parse.
 #[derive(Deserialize, Default)]
 #[serde(rename_all = "camelCase")]
 struct RestrictedCipherData {
     name: Option<EncString>,
     uris: Option<Vec<LoginUri>>,
-}
-
-/// Decrypt the allowlisted URIs from a restricted envelope. A URI that fails to decrypt is
-/// dropped rather than failing the whole cipher.
-fn decrypt_restricted_uris(
-    uris: Option<Vec<LoginUri>>,
-    ctx: &mut KeyStoreContext<KeySlotIds>,
-    ciphers_key: SymmetricKeySlotId,
-) -> Option<Vec<LoginUriView>> {
-    uris.map(|list| {
-        list.into_iter()
-            .filter_map(|u| u.decrypt(ctx, ciphers_key).ok())
-            .collect()
-    })
 }
 
 /// Decrypt a restricted (PAM-gated) cipher into a [`CipherView`].
@@ -1589,7 +1572,7 @@ fn decrypt_restricted_cipher_view(
         username: None,
         password: None,
         password_revision_date: None,
-        uris: decrypt_restricted_uris(restricted.uris, ctx, ciphers_key),
+        uris: restricted.uris.decrypt(ctx, ciphers_key).ok().flatten(),
         totp: None,
         autofill_on_page_load: None,
         fido2_credentials: None,
@@ -1668,7 +1651,7 @@ fn decrypt_restricted_cipher_list_view(
             has_fido2: false,
             username: None,
             totp: None,
-            uris: decrypt_restricted_uris(restricted.uris, ctx, ciphers_key),
+            uris: restricted.uris.decrypt(ctx, ciphers_key).ok().flatten(),
         }),
         CipherType::SecureNote => CipherListViewType::SecureNote,
         CipherType::Card => CipherListViewType::Card(CardListView { brand: None }),

--- a/crates/bitwarden-vault/src/cipher/cipher.rs
+++ b/crates/bitwarden-vault/src/cipher/cipher.rs
@@ -489,6 +489,9 @@ pub struct CipherView {
     /// True when this view was produced from a server-restricted (PAM-gated) cipher. Only a
     /// sub-set of fields are populated; every secret field is absent. See
     /// [`Cipher::partial_data`].
+    /// Such a view is fail-closed against re-encryption: passing it to any encrypt path returns
+    /// [`bitwarden_crypto::CryptoError::EncryptRestrictedView`] rather than silently stripping
+    /// secrets.
     #[serde(default)]
     pub partial: bool,
 }
@@ -676,6 +679,12 @@ impl CipherView {
         ctx: &mut KeyStoreContext<KeySlotIds>,
         key: SymmetricKeySlotId,
     ) -> Result<Cipher, CryptoError> {
+        // Fail closed: a restricted (partial) view has all secret fields stripped; re-encrypting it
+        // would overwrite the item's secrets with empty values. See `decrypt_restricted_cipher_view`.
+        if self.partial {
+            return Err(CryptoError::EncryptRestrictedView);
+        }
+
         let ciphers_key = Cipher::decrypt_cipher_key(ctx, key, &self.key)?;
 
         let mut cipher_view = self.clone();
@@ -2998,6 +3007,48 @@ mod tests {
             strict_result.is_err(),
             "Strict decryption should fail when login username is encrypted with a different key"
         );
+    }
+
+    #[test]
+    fn test_encrypt_legacy_fails_closed_for_partial_view() {
+        let key_store = create_test_crypto_with_user_key(SymmetricCryptoKey::make(
+            SymmetricKeyAlgorithm::Aes256CbcHmac,
+        ));
+
+        let mut view = generate_cipher();
+        view.partial = true;
+
+        let result = key_store.encrypt(EncryptMode::Legacy(view));
+        assert!(matches!(result, Err(CryptoError::EncryptRestrictedView)));
+    }
+
+    #[test]
+    fn test_encrypt_blob_fails_closed_for_partial_view() {
+        let key_store = create_test_crypto_with_user_key(SymmetricCryptoKey::make(
+            SymmetricKeyAlgorithm::Aes256CbcHmac,
+        ));
+
+        let mut view = generate_cipher();
+        view.partial = true;
+
+        let result = key_store.encrypt(EncryptMode::Blob(view));
+        assert!(matches!(result, Err(CryptoError::EncryptRestrictedView)));
+    }
+
+    #[test]
+    fn test_encrypt_succeeds_for_non_partial_view() {
+        let key_store = create_test_crypto_with_user_key(SymmetricCryptoKey::make(
+            SymmetricKeyAlgorithm::Aes256CbcHmac,
+        ));
+
+        // Control: the same shape of view, but with `partial: false`, must still encrypt
+        // successfully — proving the guard is specific to `partial` rather than some other
+        // difference between test fixtures.
+        let view = generate_cipher();
+        assert!(!view.partial);
+
+        let result = key_store.encrypt(EncryptMode::Legacy(view));
+        assert!(result.is_ok());
     }
 
     #[test]

--- a/crates/bitwarden-vault/src/cipher/cipher.rs
+++ b/crates/bitwarden-vault/src/cipher/cipher.rs
@@ -33,7 +33,7 @@ use super::{
     cipher_permissions::CipherPermissions,
     drivers_license, field, identity,
     local_data::{LocalData, LocalDataView},
-    login::{LoginListView, LoginUri, LoginUriView},
+    login::{LoginListView, LoginUri},
     passport, secure_note, ssh_key,
 };
 use crate::{
@@ -332,12 +332,10 @@ pub struct Cipher {
     pub archived_date: Option<DateTime<Utc>>,
     pub data: Option<String>,
 
-    /// Raw JSON envelope for a server-restricted (PAM-gated) cipher: the encrypted name and,
-    /// for logins, the encrypted URIs — every secret field is withheld by the server. Its
-    /// presence marks the cipher restricted; the decrypt path parses only these allowlisted
-    /// fields and produces a view with `partial = true`, never reading the secret payloads.
-    /// Distinct from `data` (the full sealed blob) and from the unrelated `PartialCipher`
-    /// merge trait.
+    /// Raw JSON envelope for a server-restricted (PAM-gated) cipher: only contains a sub-set of
+    /// non sensitive fields, all other fields are withheld by the server. Its presence marks the
+    /// cipher restricted; the decrypt path parses only these allowlisted fields and produces a
+    /// view with `partial = true`, never reading the secret payloads.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub partial_data: Option<String>,
 }
@@ -488,8 +486,8 @@ pub struct CipherView {
     pub revision_date: DateTime<Utc>,
     pub archived_date: Option<DateTime<Utc>>,
 
-    /// True when this view was produced from a server-restricted (PAM-gated) cipher: only the
-    /// name and (for logins) URIs are populated; every secret field is absent. See
+    /// True when this view was produced from a server-restricted (PAM-gated) cipher. Only a
+    /// sub-set of fields are populated; every secret field is absent. See
     /// [`Cipher::partial_data`].
     #[serde(default)]
     pub partial: bool,
@@ -586,8 +584,8 @@ pub struct CipherListView {
 
     pub local_data: Option<LocalDataView>,
 
-    /// True when this view was produced from a server-restricted (PAM-gated) cipher: only the
-    /// name and (for logins) URIs are populated. See [`Cipher::partial_data`].
+    /// True when this view was produced from a server-restricted (PAM-gated) cipher. Only a
+    /// sub-set of fields are populated. See [`Cipher::partial_data`].
     #[serde(default)]
     pub partial: bool,
 
@@ -1564,33 +1562,18 @@ impl IdentifyKey<SymmetricKeySlotId> for Cipher {
 }
 
 /// The server's reduced payload for a restricted (PAM-gated) cipher, produced by
-/// `PartialCipherData.Strip` on the server. The server emits a purpose-built camelCase envelope
-/// carrying the same [`LoginUri`] fields the full decrypt path uses, so the URIs deserialize
-/// straight into [`LoginUri`] with no parallel representation.
+/// `PartialCipherData.Strip` on the server.
 ///
 /// This struct is the single authoritative allowlist for what a gated view may expose: the
 /// encrypted name and, for logins, the encrypted URIs — nothing else. It is deliberately NOT
-/// `deny_unknown_fields`: an over-sharing server blob (e.g. a stray `password` or `totp`) is
-/// silently dropped by the allowlist rather than surfaced onto the view or failing the parse.
+/// `deny_unknown_fields`: the server may decide to include additional non sensitive fields in the
+/// future; these are silently dropped by the allowlist rather than surfaced onto the view or
+/// failing the parse.
 #[derive(Deserialize, Default)]
 #[serde(rename_all = "camelCase")]
 struct RestrictedCipherData {
     name: Option<EncString>,
     uris: Option<Vec<LoginUri>>,
-}
-
-/// Decrypt the allowlisted URIs from a restricted envelope. A URI that fails to decrypt is
-/// dropped rather than failing the whole cipher.
-fn decrypt_restricted_uris(
-    uris: Option<Vec<LoginUri>>,
-    ctx: &mut KeyStoreContext<KeySlotIds>,
-    ciphers_key: SymmetricKeySlotId,
-) -> Option<Vec<LoginUriView>> {
-    uris.map(|list| {
-        list.into_iter()
-            .filter_map(|u| u.decrypt(ctx, ciphers_key).ok())
-            .collect()
-    })
 }
 
 /// Decrypt a restricted (PAM-gated) cipher into a [`CipherView`].
@@ -1620,7 +1603,7 @@ fn decrypt_restricted_cipher_view(
         username: None,
         password: None,
         password_revision_date: None,
-        uris: decrypt_restricted_uris(restricted.uris, ctx, ciphers_key),
+        uris: restricted.uris.decrypt(ctx, ciphers_key).ok().flatten(),
         totp: None,
         autofill_on_page_load: None,
         fido2_credentials: None,
@@ -1699,7 +1682,7 @@ fn decrypt_restricted_cipher_list_view(
             has_fido2: false,
             username: None,
             totp: None,
-            uris: decrypt_restricted_uris(restricted.uris, ctx, ciphers_key),
+            uris: restricted.uris.decrypt(ctx, ciphers_key).ok().flatten(),
         }),
         CipherType::SecureNote => CipherListViewType::SecureNote,
         CipherType::Card => CipherListViewType::Card(CardListView { brand: None }),

--- a/crates/bitwarden-vault/src/cipher/cipher_client/admin/edit.rs
+++ b/crates/bitwarden-vault/src/cipher/cipher_client/admin/edit.rs
@@ -214,6 +214,7 @@ mod tests {
 
     fn generate_test_cipher() -> CipherView {
         CipherView {
+            partial: false,
             id: Some(TEST_CIPHER_ID.parse().unwrap()),
             organization_id: None,
             folder_id: None,

--- a/crates/bitwarden-vault/src/cipher/cipher_client/admin/edit.rs
+++ b/crates/bitwarden-vault/src/cipher/cipher_client/admin/edit.rs
@@ -45,6 +45,9 @@ pub enum EditCipherAdminError {
     Uuid(#[from] uuid::Error),
     #[error(transparent)]
     Decrypt(#[from] DecryptError),
+    /// `edit` was handed a partial view as the original.
+    #[error("Editing a PAM-gated cipher requires a full original; the supplied view is partial")]
+    PartialOriginal,
 }
 
 // `use_strict_decryption`, `enable_cipher_key_encryption`, and `use_blob` are
@@ -66,6 +69,13 @@ async fn edit_cipher(
     // request before it is consumed so they can be applied to the merged result.
     let folder_id = request.folder_id;
     let favorite = request.favorite;
+
+    // A partial original has every secret field stripped: password history diffed against it
+    // would drop the item's real history. The encrypt of the merge original below would also
+    // refuse it (EncryptRestrictedView), but only incidentally — fail clearly and first.
+    if original_cipher_view.partial {
+        return Err(EditCipherAdminError::PartialOriginal);
+    }
 
     let mut view: CipherView = convert_request_to_cipher_view(request);
     view.update_password_history(&original_cipher_view);
@@ -392,6 +402,41 @@ mod tests {
         // The edited name lives inside the blob, so recovering it proves the
         // echoed blob was used rather than the stale original.
         assert_eq!(result.name, "New Cipher Name");
+    }
+
+    /// A partial original has every secret field stripped, so building on it would drop the
+    /// item's real password history. The guard must fire before any request is built.
+    #[tokio::test]
+    async fn test_edit_refuses_a_partial_original() {
+        let store: KeyStore<KeySlotIds> = KeyStore::default();
+        #[allow(deprecated)]
+        let _ = store.context_mut().set_symmetric_key(
+            SymmetricKeySlotId::User,
+            SymmetricCryptoKey::make(SymmetricKeyAlgorithm::Aes256CbcHmac),
+        );
+
+        // Deliberately no `expect_put_admin`: the guard has to fire before any request is built.
+        let api_client = ApiClient::new_mocked(|_mock| {});
+
+        let mut original_cipher_view = generate_test_cipher();
+        original_cipher_view.partial = true;
+        let cipher_view = original_cipher_view.clone();
+        // `CipherEditRequest` carries no `partial` field, so only the original view can gate.
+        let request: CipherEditRequest = cipher_view.try_into().unwrap();
+
+        let result = edit_cipher(
+            &store,
+            &api_client,
+            TEST_USER_ID.parse().unwrap(),
+            original_cipher_view,
+            request,
+            false,
+            false,
+            false,
+        )
+        .await;
+
+        assert!(matches!(result, Err(EditCipherAdminError::PartialOriginal)));
     }
 
     #[tokio::test]

--- a/crates/bitwarden-vault/src/cipher/cipher_client/admin/edit.rs
+++ b/crates/bitwarden-vault/src/cipher/cipher_client/admin/edit.rs
@@ -209,6 +209,7 @@ mod tests {
 
     fn generate_test_cipher() -> CipherView {
         CipherView {
+            partial: false,
             id: Some(TEST_CIPHER_ID.parse().unwrap()),
             organization_id: None,
             folder_id: None,

--- a/crates/bitwarden-vault/src/cipher/cipher_client/admin/get.rs
+++ b/crates/bitwarden-vault/src/cipher/cipher_client/admin/get.rs
@@ -183,6 +183,7 @@ mod tests {
 
     fn generate_test_cipher() -> Cipher {
         Cipher {
+            partial_data: None,
             id: TEST_CIPHER_ID_1.parse().ok(),
             name: Some("2.pMS6/icTQABtulw52pq2lg==|XXbxKxDTh+mWiN1HjH2N1w==|Q6PkuT+KX/axrgN9ubD5Ajk2YNwxQkgs3WJM0S0wtG8=".parse().unwrap()),
             r#type: CipherType::Login,

--- a/crates/bitwarden-vault/src/cipher/cipher_client/admin/restore.rs
+++ b/crates/bitwarden-vault/src/cipher/cipher_client/admin/restore.rs
@@ -140,6 +140,7 @@ mod tests {
 
     fn generate_test_cipher() -> Cipher {
         Cipher {
+            partial_data: None,
             id: TEST_CIPHER_ID.parse().ok(),
             name: Some("2.pMS6/icTQABtulw52pq2lg==|XXbxKxDTh+mWiN1HjH2N1w==|Q6PkuT+KX/axrgN9ubD5Ajk2YNwxQkgs3WJM0S0wtG8=".parse().unwrap()),
             r#type: crate::CipherType::Login,

--- a/crates/bitwarden-vault/src/cipher/cipher_client/bulk_update_collections.rs
+++ b/crates/bitwarden-vault/src/cipher/cipher_client/bulk_update_collections.rs
@@ -101,6 +101,7 @@ mod tests {
 
     fn generate_test_cipher() -> Cipher {
         Cipher {
+            partial_data: None,
             id: TEST_CIPHER_ID.parse().ok(),
             name: Some("2.pMS6/icTQABtulw52pq2lg==|XXbxKxDTh+mWiN1HjH2N1w==|Q6PkuT+KX/axrgN9ubD5Ajk2YNwxQkgs3WJM0S0wtG8=".parse().unwrap()),
             r#type: crate::CipherType::Login,

--- a/crates/bitwarden-vault/src/cipher/cipher_client/create.rs
+++ b/crates/bitwarden-vault/src/cipher/cipher_client/create.rs
@@ -70,6 +70,7 @@ pub(crate) fn convert_request_to_cipher_view(r: CipherCreateRequest) -> CipherVi
     // merge; `Utc::now()` is a safe placeholder.
     let now = chrono::Utc::now();
     CipherView {
+        partial: false,
         id: None,
         organization_id: r.organization_id,
         folder_id: r.folder_id,

--- a/crates/bitwarden-vault/src/cipher/cipher_client/delete.rs
+++ b/crates/bitwarden-vault/src/cipher/cipher_client/delete.rs
@@ -155,6 +155,7 @@ mod tests {
 
     fn generate_test_cipher() -> Cipher {
         Cipher {
+            partial_data: None,
             id: TEST_CIPHER_ID.parse().ok(),
             name: Some("2.pMS6/icTQABtulw52pq2lg==|XXbxKxDTh+mWiN1HjH2N1w==|Q6PkuT+KX/axrgN9ubD5Ajk2YNwxQkgs3WJM0S0wtG8=".parse().unwrap()),
             r#type: crate::CipherType::Login,

--- a/crates/bitwarden-vault/src/cipher/cipher_client/edit.rs
+++ b/crates/bitwarden-vault/src/cipher/cipher_client/edit.rs
@@ -123,6 +123,7 @@ pub struct CipherPartialEditRequest {
 /// as the `CipherView` produced will not have all fields populated (e.g. `collection_ids`).
 pub(crate) fn convert_request_to_cipher_view(r: CipherEditRequest) -> CipherView {
     CipherView {
+        partial: false,
         id: Some(r.id),
         organization_id: r.organization_id,
         folder_id: r.folder_id,
@@ -365,6 +366,7 @@ mod tests {
 
     fn generate_test_cipher() -> CipherView {
         CipherView {
+            partial: false,
             id: Some(TEST_CIPHER_ID.parse().unwrap()),
             organization_id: None,
             folder_id: None,
@@ -425,6 +427,7 @@ mod tests {
             let mut ctx = store.context();
 
             Cipher {
+                partial_data: None,
                 id: Some(cipher_id),
                 organization_id: None,
                 folder_id: None,

--- a/crates/bitwarden-vault/src/cipher/cipher_client/edit.rs
+++ b/crates/bitwarden-vault/src/cipher/cipher_client/edit.rs
@@ -45,6 +45,16 @@ pub enum EditCipherError {
     Repository(#[from] RepositoryError),
     #[error(transparent)]
     Uuid(#[from] uuid::Error),
+    /// The stored cipher is PAM-gated, so local state holds only its partial copy and an edit
+    /// built on it would drop the item's password history and mis-stamp its revision date.
+    #[error(
+        "Cannot edit a PAM-gated cipher from local state; use `edit_gated` with a full original \
+         obtained under an active lease"
+    )]
+    GatedCipher,
+    /// `edit_gated` was handed a partial view as the original.
+    #[error("Editing a PAM-gated cipher requires a full original; the supplied view is partial")]
+    PartialOriginal,
 }
 
 /// Request to edit a cipher.
@@ -177,14 +187,66 @@ async fn edit_cipher<R: Repository<Cipher> + ?Sized>(
     let cipher_id = request.id;
 
     let original_cipher = repository.get(cipher_id).await?.ok_or(ItemNotFoundError)?;
+
+    // A PAM-gated cipher is only ever stored partial — the server withholds its secrets from
+    // every bulk read and from write-returns alike — so the original below would carry blanks
+    // where the withheld fields belong. `update_password_history` would then drop the item's
+    // whole history (a partial view has none to chain) and stamp a fresh `password_revision_date`,
+    // and the PUT would persist both. Refuse rather than corrupt; `edit_gated` takes the full
+    // original from a lease-authorised read.
+    if original_cipher.partial_data.is_some() {
+        return Err(EditCipherError::GatedCipher);
+    }
+
     let original_cipher_view: CipherView = if use_strict_decryption {
         key_store.decrypt(&StrictDecrypt(original_cipher.clone()))?
     } else {
         key_store.decrypt(&original_cipher)?
     };
 
+    submit_cipher_edit(
+        key_store,
+        api_client,
+        repository,
+        encrypted_for,
+        request,
+        &original_cipher_view,
+        original_cipher,
+        use_strict_decryption,
+        enable_cipher_key_encryption,
+        use_blob,
+    )
+    .await
+}
+
+/// The body both edit paths share: request → view, fold in password history against
+/// `original_cipher_view`, encrypt, PUT, and merge the write-return over `stored_cipher` before
+/// persisting it.
+///
+/// The paths differ only in where the original comes from — local state for [`edit_cipher`], the
+/// caller for [`edit_gated_cipher`], because a gated cipher has no full copy in state — so that is
+/// all either one is left holding.
+// `use_strict_decryption`, `enable_cipher_key_encryption`, and `use_blob` are
+// short-lived feature-rollout flags that will be removed once their migrations
+// complete, at which point the argument count drops back under the limit.
+#[allow(clippy::too_many_arguments)]
+async fn submit_cipher_edit<R: Repository<Cipher> + ?Sized>(
+    key_store: &KeyStore<KeySlotIds>,
+    api_client: &bitwarden_api_api::apis::ApiClient,
+    repository: &R,
+    encrypted_for: UserId,
+    request: CipherEditRequest,
+    original_cipher_view: &CipherView,
+    stored_cipher: Cipher,
+    use_strict_decryption: bool,
+    enable_cipher_key_encryption: bool,
+    use_blob: bool,
+) -> Result<CipherView, EditCipherError> {
+    let cipher_id = request.id;
+    let stored_gated = stored_cipher.partial_data.is_some();
+
     let mut view: CipherView = convert_request_to_cipher_view(request);
-    view.update_password_history(&original_cipher_view);
+    view.update_password_history(original_cipher_view);
 
     // TODO: Once this flag is removed, the key generation logic should be
     // moved directly into the CompositeEncryptable implementation.
@@ -213,15 +275,75 @@ async fn edit_cipher<R: Repository<Cipher> + ?Sized>(
         .ciphers_api()
         .put(cipher_id.into(), Some(cipher_request))
         .await?
-        .merge_with_cipher(Some(original_cipher))?;
+        .merge_with_cipher(Some(stored_cipher))?;
     debug_assert!(cipher.id.unwrap_or_default() == cipher_id);
-    repository.set(cipher_id, cipher.clone()).await?;
+
+    // Never let a write-return un-gate the stored copy. The server withholds secrets from a gated
+    // write-return, so a full response here should be impossible — but persisting one would put
+    // lease-scoped secrets into durable state, outliving the lease that justified them. Skip the
+    // write and let the next sync reconcile: the server already applied the change, so reporting
+    // a failure would be the worse lie.
+    //
+    // A no-op for [`edit_cipher`], which refuses a gated cipher outright, so nothing it stores is
+    // ever gated to begin with.
+    if !stored_gated || cipher.partial_data.is_some() {
+        repository.set(cipher_id, cipher.clone()).await?;
+    }
 
     Ok(if use_strict_decryption {
         key_store.decrypt(&StrictDecrypt(cipher))?
     } else {
         key_store.decrypt(&cipher)?
     })
+}
+
+/// Edit a PAM-gated cipher against a full original supplied by the caller.
+///
+/// [`edit_cipher`] reads its original out of the repository, which for a gated cipher only ever
+/// holds the partial copy. This path takes the full view the caller obtained from a
+/// lease-authorised single-cipher read instead, so password history carries forward correctly.
+/// It mirrors the admin edit path, which takes its original as an argument for the same reason:
+/// no usable copy exists in local state.
+// `use_strict_decryption`, `enable_cipher_key_encryption`, and `use_blob` are
+// short-lived feature-rollout flags that will be removed once their migrations
+// complete, at which point the argument count drops back under the limit.
+#[allow(clippy::too_many_arguments)]
+async fn edit_gated_cipher<R: Repository<Cipher> + ?Sized>(
+    key_store: &KeyStore<KeySlotIds>,
+    api_client: &bitwarden_api_api::apis::ApiClient,
+    repository: &R,
+    encrypted_for: UserId,
+    request: CipherEditRequest,
+    original_cipher_view: CipherView,
+    use_strict_decryption: bool,
+    enable_cipher_key_encryption: bool,
+    use_blob: bool,
+) -> Result<CipherView, EditCipherError> {
+    let cipher_id = request.id;
+
+    // The point of this path is the full original. A partial one lands us back in exactly the
+    // case `edit_cipher` refuses, only with the blanks handed in by the caller.
+    if original_cipher_view.partial {
+        return Err(EditCipherError::PartialOriginal);
+    }
+
+    // Read for `local_data`, which the response model does not carry, and for the gating the
+    // shared body checks before it persists the write-return.
+    let stored_cipher = repository.get(cipher_id).await?.ok_or(ItemNotFoundError)?;
+
+    submit_cipher_edit(
+        key_store,
+        api_client,
+        repository,
+        encrypted_for,
+        request,
+        &original_cipher_view,
+        stored_cipher,
+        use_strict_decryption,
+        enable_cipher_key_encryption,
+        use_blob,
+    )
+    .await
 }
 
 /// Update only the cipher fields available to users without edit permissions
@@ -283,6 +405,49 @@ impl CiphersClient {
             repository.as_ref(),
             user_id,
             request,
+            self.is_strict_decrypt().await,
+            enable_cipher_key_encryption,
+            use_blob,
+        )
+        .await
+    }
+
+    /// Edit a PAM-gated [`Cipher`] whose secrets were revealed under an active lease.
+    ///
+    /// [`CiphersClient::edit`] builds its original from local state, which for a gated cipher only
+    /// ever holds the partial copy, and so refuses. Pass the full view obtained from the
+    /// lease-authorised read as `original_cipher_view` — it is what password history is diffed
+    /// against.
+    ///
+    /// The returned view reflects what was persisted, so it is partial: the server withholds
+    /// secrets from a gated write-return. The caller keeps its own full copy in memory.
+    pub async fn edit_gated(
+        &self,
+        request: CipherEditRequest,
+        original_cipher_view: CipherView,
+    ) -> Result<CipherView, EditCipherError> {
+        let key_store = self.client.internal.get_key_store();
+        let config = self.client.internal.get_api_configurations();
+        let repository = self.get_repository()?;
+
+        let user_id = self
+            .client
+            .internal
+            .get_user_id()
+            .ok_or(NotAuthenticatedError)?;
+
+        let enable_cipher_key_encryption =
+            self.client.flags().get().await.enable_cipher_key_encryption;
+
+        let use_blob = self.should_use_blob_encryption(request.organization_id);
+
+        edit_gated_cipher(
+            key_store,
+            &config.api_client,
+            repository.as_ref(),
+            user_id,
+            request,
+            original_cipher_view,
             self.is_strict_decrypt().await,
             enable_cipher_key_encryption,
             use_blob,
@@ -356,8 +521,12 @@ impl CiphersClient {
 #[cfg(test)]
 mod tests {
     use bitwarden_api_api::{apis::ApiClient, models::CipherResponseModel};
-    use bitwarden_core::key_management::SymmetricKeySlotId;
-    use bitwarden_crypto::{KeyStore, PrimitiveEncryptable, SymmetricKeyAlgorithm};
+    use bitwarden_core::key_management::{
+        SymmetricKeySlotId, create_test_crypto_with_user_and_org_key,
+    };
+    use bitwarden_crypto::{
+        KeyStore, PrimitiveEncryptable, SymmetricCryptoKey, SymmetricKeyAlgorithm,
+    };
     use bitwarden_test::MemoryRepository;
     use chrono::TimeZone;
 
@@ -575,6 +744,294 @@ mod tests {
         assert_eq!(result.name, "Test Login");
         // collection_ids must be preserved even though CipherResponseModel omits them.
         assert_eq!(result.collection_ids, vec![collection_id]);
+    }
+
+    /// Fixed org id + key for the PAM-gated fixtures — a partial is always org-owned — with a
+    /// `partial_data` envelope encrypted under that key. Same vectors as the ones pinned in
+    /// `cipher.rs`, so both sides exercise identical ciphertext.
+    const GATED_ORG_UUID: &str = "3cf0d3ba-3ded-4bf3-a51c-b03fd9ac6e07";
+    const GATED_ORG_KEY_B64: &str =
+        "w2LO+nwV4oxwswVYCxlOfRUseXfvU03VzvKQHrqeklPgiMZrspUe6sOBToCnDn9Ay0tuCBn8ykVVRb7PWhub2Q==";
+    const GATED_LOGIN_ENVELOPE: &str = r#"{"name":"2.qip4DSwdOzU2KwY3jgDjUg==|CsGRQgTwAzmszz+dkk5xIg==|rmW/mlnHq2MulR9uNKclD+1UBFLfOimedkq5tPRSLOc=","uris":[{"uri":"2.2na8mpfA1B1OBTUHkDz+fw==|yTWB1nEf3EHIZgsDINM8JnTYyxf7KVZvXraIGAVOiEg=|i2swsODSjEMRaYNnBHAigdphZBBUg2lkPNo763fX12w=","uriChecksum":null,"match":null}]}"#;
+
+    fn gated_key_store() -> (OrganizationId, KeyStore<KeySlotIds>) {
+        let org: OrganizationId = GATED_ORG_UUID.parse().unwrap();
+        let org_key: SymmetricCryptoKey = GATED_ORG_KEY_B64.to_string().try_into().unwrap();
+        let key_store = create_test_crypto_with_user_and_org_key(
+            SymmetricCryptoKey::make(SymmetricKeyAlgorithm::Aes256CbcHmac),
+            org,
+            org_key,
+        );
+        (org, key_store)
+    }
+
+    /// The copy local state holds for a gated cipher: the reduced envelope and nothing else.
+    fn gated_stored_cipher(cipher_id: CipherId, organization_id: OrganizationId) -> Cipher {
+        Cipher {
+            partial_data: Some(GATED_LOGIN_ENVELOPE.to_string()),
+            id: Some(cipher_id),
+            organization_id: Some(organization_id),
+            folder_id: None,
+            collection_ids: vec![],
+            key: None,
+            name: None,
+            notes: None,
+            r#type: CipherType::Login,
+            login: None,
+            identity: None,
+            card: None,
+            secure_note: None,
+            ssh_key: None,
+            bank_account: None,
+            drivers_license: None,
+            passport: None,
+            favorite: false,
+            reprompt: CipherRepromptType::None,
+            organization_use_totp: false,
+            edit: true,
+            permissions: None,
+            view_password: true,
+            local_data: None,
+            attachments: None,
+            fields: None,
+            password_history: None,
+            creation_date: "2024-01-01T00:00:00Z".parse().unwrap(),
+            deleted_date: None,
+            revision_date: "2024-01-01T00:00:00Z".parse().unwrap(),
+            archived_date: None,
+            data: None,
+        }
+    }
+
+    /// The full original a caller obtains from a lease-authorised read: one prior history entry
+    /// and the password this edit replaces.
+    fn gated_original_view(organization_id: OrganizationId) -> CipherView {
+        let mut view = create_test_login_cipher("old_password");
+        view.organization_id = Some(organization_id);
+        view.password_history = Some(vec![PasswordHistoryView {
+            password: "older_password".to_string(),
+            last_used_date: Utc.with_ymd_and_hms(2025, 1, 1, 0, 0, 0).unwrap(),
+        }]);
+        view
+    }
+
+    /// The regular edit path builds its original from local state, which for a gated cipher only
+    /// ever holds the partial copy. Editing on that would blank every withheld field and drop the
+    /// item's password history, so it must refuse — before it reaches the server.
+    #[tokio::test]
+    async fn test_edit_refuses_a_gated_stored_cipher() {
+        let (org, store) = gated_key_store();
+        let cipher_id: CipherId = TEST_CIPHER_ID.parse().unwrap();
+
+        // Deliberately no `expect_put`: the guard has to fire before any request is built.
+        let api_client = ApiClient::new_mocked(|_mock| {});
+
+        let repository = MemoryRepository::<Cipher>::default();
+        repository
+            .set(cipher_id, gated_stored_cipher(cipher_id, org))
+            .await
+            .unwrap();
+
+        let mut cipher_view = generate_test_cipher();
+        cipher_view.organization_id = Some(org);
+
+        let result = edit_cipher(
+            &store,
+            &api_client,
+            &repository,
+            TEST_USER_ID.parse().unwrap(),
+            cipher_view.try_into().unwrap(),
+            false,
+            false,
+            false,
+        )
+        .await;
+
+        assert!(matches!(result, Err(EditCipherError::GatedCipher)));
+    }
+
+    /// Handing the gated path the partial view the caller already had puts us back in exactly the
+    /// case the regular path refuses, with the blanks supplied by the caller instead of by state.
+    #[tokio::test]
+    async fn test_edit_gated_refuses_a_partial_original() {
+        let (org, store) = gated_key_store();
+        let cipher_id: CipherId = TEST_CIPHER_ID.parse().unwrap();
+        let api_client = ApiClient::new_mocked(|_mock| {});
+
+        let repository = MemoryRepository::<Cipher>::default();
+        repository
+            .set(cipher_id, gated_stored_cipher(cipher_id, org))
+            .await
+            .unwrap();
+
+        let mut cipher_view = generate_test_cipher();
+        cipher_view.organization_id = Some(org);
+        let mut original = cipher_view.clone();
+        original.partial = true;
+
+        let result = edit_gated_cipher(
+            &store,
+            &api_client,
+            &repository,
+            TEST_USER_ID.parse().unwrap(),
+            cipher_view.try_into().unwrap(),
+            original,
+            false,
+            false,
+            false,
+        )
+        .await;
+
+        assert!(matches!(result, Err(EditCipherError::PartialOriginal)));
+    }
+
+    /// The whole reason this path exists: password history is diffed against the caller's full
+    /// original, not against the partial copy in state. The partial has no history at all, so a
+    /// wrong original shows up as a short array in the request body.
+    #[tokio::test]
+    async fn test_edit_gated_carries_history_from_the_supplied_original() {
+        let (org, store) = gated_key_store();
+        let cipher_id: CipherId = TEST_CIPHER_ID.parse().unwrap();
+
+        let api_client = ApiClient::new_mocked(move |mock| {
+            mock.ciphers_api
+                .expect_put()
+                .returning(move |_id, body| {
+                    let body = body.unwrap();
+                    // The original's one prior entry, plus the entry for the password this edit
+                    // replaces. Building on the partial copy would have sent none of either.
+                    assert_eq!(body.password_history.as_ref().map(|h| h.len()), Some(2));
+                    Ok(gated_response_model(cipher_id, org, body.r#type))
+                })
+                .once();
+        });
+
+        let repository = MemoryRepository::<Cipher>::default();
+        repository
+            .set(cipher_id, gated_stored_cipher(cipher_id, org))
+            .await
+            .unwrap();
+
+        let mut cipher_view = create_test_login_cipher("new_password");
+        cipher_view.organization_id = Some(org);
+
+        let result = edit_gated_cipher(
+            &store,
+            &api_client,
+            &repository,
+            TEST_USER_ID.parse().unwrap(),
+            cipher_view.try_into().unwrap(),
+            gated_original_view(org),
+            false,
+            false,
+            false,
+        )
+        .await
+        .unwrap();
+
+        // The server withholds secrets from a gated write-return, so what comes back — and what
+        // is persisted — is still the reduced shape.
+        assert!(result.partial);
+        let stored = repository.get(cipher_id).await.unwrap().unwrap();
+        assert!(stored.partial_data.is_some());
+    }
+
+    /// Defence in depth for the durable-state property: the server strips a gated write-return, so
+    /// a full one should be unreachable — but were it ever to arrive, persisting it would put
+    /// lease-scoped secrets on disk, outliving the lease that justified them.
+    #[tokio::test]
+    async fn test_edit_gated_does_not_persist_a_full_write_return() {
+        let (org, store) = gated_key_store();
+        let cipher_id: CipherId = TEST_CIPHER_ID.parse().unwrap();
+
+        let api_client = ApiClient::new_mocked(move |mock| {
+            mock.ciphers_api
+                .expect_put()
+                .returning(move |_id, body| {
+                    let body = body.unwrap();
+                    // A server that has not been taught to strip write-returns.
+                    Ok(CipherResponseModel {
+                        partial_data: None,
+                        name: Some(body.name),
+                        login: body.login,
+                        ..gated_response_model(cipher_id, org, body.r#type)
+                    })
+                })
+                .once();
+        });
+
+        let repository = MemoryRepository::<Cipher>::default();
+        repository
+            .set(cipher_id, gated_stored_cipher(cipher_id, org))
+            .await
+            .unwrap();
+
+        let mut cipher_view = create_test_login_cipher("new_password");
+        cipher_view.organization_id = Some(org);
+
+        let result = edit_gated_cipher(
+            &store,
+            &api_client,
+            &repository,
+            TEST_USER_ID.parse().unwrap(),
+            cipher_view.try_into().unwrap(),
+            gated_original_view(org),
+            false,
+            false,
+            false,
+        )
+        .await
+        .unwrap();
+
+        // The caller still gets the full view in memory — it is the write to disk that is refused.
+        assert!(!result.partial);
+        let stored = repository.get(cipher_id).await.unwrap().unwrap();
+        assert!(stored.partial_data.is_some(), "local state must stay gated");
+        assert!(
+            stored.login.is_none(),
+            "no secret field may reach local state"
+        );
+    }
+
+    /// A gated write-return: metadata and the reduced envelope, every secret field withheld.
+    fn gated_response_model(
+        cipher_id: CipherId,
+        organization_id: OrganizationId,
+        r#type: Option<bitwarden_api_api::models::CipherType>,
+    ) -> CipherResponseModel {
+        CipherResponseModel {
+            object: Some("cipher".to_string()),
+            id: Some(cipher_id.into()),
+            organization_id: Some(organization_id.into()),
+            r#type,
+            partial_data: Some(GATED_LOGIN_ENVELOPE.to_string()),
+            name: None,
+            notes: None,
+            login: None,
+            card: None,
+            identity: None,
+            secure_note: None,
+            ssh_key: None,
+            bank_account: None,
+            drivers_license: None,
+            passport: None,
+            fields: None,
+            password_history: None,
+            attachments: None,
+            permissions: None,
+            data: None,
+            folder_id: None,
+            favorite: Some(false),
+            reprompt: None,
+            key: None,
+            view_password: Some(true),
+            edit: Some(true),
+            organization_use_totp: Some(false),
+            revision_date: Some("2025-01-01T00:00:00Z".to_string()),
+            creation_date: Some("2025-01-01T00:00:00Z".to_string()),
+            deleted_date: None,
+            archived_date: None,
+        }
     }
 
     #[tokio::test]

--- a/crates/bitwarden-vault/src/cipher/cipher_client/edit.rs
+++ b/crates/bitwarden-vault/src/cipher/cipher_client/edit.rs
@@ -123,6 +123,7 @@ pub struct CipherPartialEditRequest {
 /// as the `CipherView` produced will not have all fields populated (e.g. `collection_ids`).
 pub(crate) fn convert_request_to_cipher_view(r: CipherEditRequest) -> CipherView {
     CipherView {
+        partial: false,
         id: Some(r.id),
         organization_id: r.organization_id,
         folder_id: r.folder_id,
@@ -371,6 +372,7 @@ mod tests {
 
     fn generate_test_cipher() -> CipherView {
         CipherView {
+            partial: false,
             id: Some(TEST_CIPHER_ID.parse().unwrap()),
             organization_id: None,
             folder_id: None,
@@ -431,6 +433,7 @@ mod tests {
             let mut ctx = store.context();
 
             Cipher {
+                partial_data: None,
                 id: Some(cipher_id),
                 organization_id: None,
                 folder_id: None,

--- a/crates/bitwarden-vault/src/cipher/cipher_client/edit.rs
+++ b/crates/bitwarden-vault/src/cipher/cipher_client/edit.rs
@@ -952,7 +952,7 @@ mod tests {
                     // A server that has not been taught to strip write-returns.
                     Ok(CipherResponseModel {
                         partial_data: None,
-                        name: Some(body.name),
+                        name: body.name,
                         login: body.login,
                         ..gated_response_model(cipher_id, org, body.r#type)
                     })

--- a/crates/bitwarden-vault/src/cipher/cipher_client/mod.rs
+++ b/crates/bitwarden-vault/src/cipher/cipher_client/mod.rs
@@ -397,6 +397,7 @@ mod tests {
 
     fn test_cipher() -> Cipher {
         Cipher {
+            partial_data: None,
             id: Some("358f2b2b-9326-4e5e-94a8-b18100bb0908".parse().unwrap()),
             organization_id: None,
             folder_id: None,
@@ -443,6 +444,7 @@ mod tests {
     fn test_cipher_view() -> CipherView {
         let test_id = "fd411a1a-fec8-4070-985d-0e6560860e69".parse().unwrap();
         CipherView {
+            partial: false,
             r#type: CipherType::Login,
             login: Some(crate::LoginView {
                 username: Some("test_username".to_string()),
@@ -515,6 +517,7 @@ mod tests {
             .vault()
             .ciphers()
             .decrypt_list(vec![Cipher {
+                partial_data: None,
                 id: Some("a1569f46-0797-4d3f-b859-b181009e2e49".parse().unwrap()),
                 organization_id: Some("1bc9ac1e-f5aa-45f2-94bf-b181009709b8".parse().unwrap()),
                 folder_id: None,

--- a/crates/bitwarden-vault/src/cipher/cipher_client/mod.rs
+++ b/crates/bitwarden-vault/src/cipher/cipher_client/mod.rs
@@ -371,6 +371,7 @@ mod tests {
 
     fn test_cipher() -> Cipher {
         Cipher {
+            partial_data: None,
             id: Some("358f2b2b-9326-4e5e-94a8-b18100bb0908".parse().unwrap()),
             organization_id: None,
             folder_id: None,
@@ -417,6 +418,7 @@ mod tests {
     fn test_cipher_view() -> CipherView {
         let test_id = "fd411a1a-fec8-4070-985d-0e6560860e69".parse().unwrap();
         CipherView {
+            partial: false,
             r#type: CipherType::Login,
             login: Some(crate::LoginView {
                 username: Some("test_username".to_string()),
@@ -489,6 +491,7 @@ mod tests {
             .vault()
             .ciphers()
             .decrypt_list(vec![Cipher {
+                partial_data: None,
                 id: Some("a1569f46-0797-4d3f-b859-b181009e2e49".parse().unwrap()),
                 organization_id: Some("1bc9ac1e-f5aa-45f2-94bf-b181009709b8".parse().unwrap()),
                 folder_id: None,

--- a/crates/bitwarden-vault/src/cipher/cipher_client/move_many.rs
+++ b/crates/bitwarden-vault/src/cipher/cipher_client/move_many.rs
@@ -70,6 +70,7 @@ mod tests {
 
     fn generate_test_cipher() -> Cipher {
         Cipher {
+            partial_data: None,
             id: TEST_CIPHER_ID.parse().ok(),
             name: Some("2.pMS6/icTQABtulw52pq2lg==|XXbxKxDTh+mWiN1HjH2N1w==|Q6PkuT+KX/axrgN9ubD5Ajk2YNwxQkgs3WJM0S0wtG8=".parse().unwrap()),
             r#type: crate::CipherType::Login,

--- a/crates/bitwarden-vault/src/cipher/cipher_client/restore.rs
+++ b/crates/bitwarden-vault/src/cipher/cipher_client/restore.rs
@@ -174,6 +174,7 @@ mod tests {
 
     fn generate_test_cipher() -> Cipher {
         Cipher {
+            partial_data: None,
             id: TEST_CIPHER_ID.parse().ok(),
             name: Some("2.pMS6/icTQABtulw52pq2lg==|XXbxKxDTh+mWiN1HjH2N1w==|Q6PkuT+KX/axrgN9ubD5Ajk2YNwxQkgs3WJM0S0wtG8=".parse().unwrap()),
             r#type: crate::CipherType::Login,

--- a/crates/bitwarden-vault/src/cipher/cipher_client/share_cipher.rs
+++ b/crates/bitwarden-vault/src/cipher/cipher_client/share_cipher.rs
@@ -50,6 +50,13 @@ async fn share_ciphers_bulk(
     encrypted_ciphers: Vec<EncryptionContext>,
     collection_ids: Vec<CollectionId>,
 ) -> Result<Vec<Cipher>, CipherError> {
+    // `require!` expands to a `return` from the enclosing function, so it must run in a plain
+    // loop rather than inside a closure passed to `.map`.
+    let mut shared_ids = Vec::with_capacity(encrypted_ciphers.len());
+    for ec in &encrypted_ciphers {
+        shared_ids.push(require!(ec.cipher.id));
+    }
+
     let request = CipherBulkShareRequestModel::new(
         collection_ids
             .iter()
@@ -65,21 +72,33 @@ async fn share_ciphers_bulk(
 
     let cipher_minis = response.data.unwrap_or_default();
     let mut results = Vec::new();
+    let mut returned_ids = std::collections::HashSet::with_capacity(cipher_minis.len());
 
     for cipher_mini in cipher_minis {
         // The server does not return the full Cipher object, so we pull the details from the
         // current local version to fill in those missing values.
-        let orig_cipher = repository
-            .get(CipherId::new(
-                cipher_mini.id.ok_or(MissingFieldError("id"))?,
-            ))
-            .await?;
+        let cipher_id = CipherId::new(cipher_mini.id.ok_or(MissingFieldError("id"))?);
+        let orig_cipher = repository.get(cipher_id).await?;
 
         let mut cipher: Cipher = cipher_mini.merge_with_cipher(orig_cipher)?;
         cipher.collection_ids = collection_ids.clone();
 
         repository.set(require!(cipher.id), cipher.clone()).await?;
+        returned_ids.insert(cipher_id);
         results.push(cipher)
+    }
+
+    // The server applies the share, then withholds a now-gated cipher from the write-return when
+    // the calling client can't render the partial shape — so a requested id can legitimately be
+    // missing from `cipher_minis` even though the share succeeded. The local pre-share copy is
+    // stale (still personal-owned, full secrets), so evict it rather than let it linger until the
+    // next sync restores the cipher in its gated shape.
+    let evicted_ids = shared_ids
+        .into_iter()
+        .filter(|id| !returned_ids.contains(id))
+        .collect::<Vec<_>>();
+    if !evicted_ids.is_empty() {
+        repository.remove_bulk(evicted_ids).await?;
     }
 
     Ok(results)
@@ -831,6 +850,99 @@ mod tests {
             "local-only fields must survive the merge"
         );
         assert_eq!(stored_cipher.folder_id, original_folder_id);
+    }
+
+    /// The write-return can omit a cipher the share nonetheless applied to: the server strips a
+    /// now-gated cipher from the response when the caller can't render the partial shape. The
+    /// stale pre-share copy (personal-owned, full secrets) must not outlive a share the server
+    /// confirmed — it has to be evicted, not left for the next sync to (maybe) clean up.
+    #[tokio::test]
+    async fn test_share_ciphers_bulk_evicts_a_stripped_write_return() {
+        let returned_id: CipherId = TEST_CIPHER_ID.parse().unwrap();
+        let stripped_id: CipherId = "11111111-2222-3333-4444-555555555555".parse().unwrap();
+        let org_id: OrganizationId = TEST_ORG_ID.parse().unwrap();
+
+        let api_client = ApiClient::new_mocked(move |mock| {
+            mock.ciphers_api
+                .expect_put_share_many()
+                .returning(move |_body| {
+                    // Only the non-gated cipher comes back; the stripped one is omitted entirely,
+                    // as the server does for a now-gated cipher the caller can't render.
+                    Ok(CipherMiniResponseModelListResponseModel {
+                        object: Some("list".to_string()),
+                        data: Some(vec![bitwarden_api_api::models::CipherMiniResponseModel {
+                            object: Some("cipherMini".to_string()),
+                            id: Some(returned_id.into()),
+                            organization_id: Some(org_id.into()),
+                            r#type: Some(bitwarden_api_api::models::CipherType::Login),
+                            name: Some("2.EI9Km5BfrIqBa1W+WCccfA==|laWxNnx+9H3MZww4zm7cBSLisjpi81zreaQntRhegVI=|x42+qKFf5ga6DIL0OW5pxCdLrC/gm8CXJvf3UASGteI=".to_string()),
+                            revision_date: Some("2024-01-30T17:55:36.150Z".to_string()),
+                            creation_date: Some("2024-01-30T17:55:36.150Z".to_string()),
+                            ..Default::default()
+                        }]),
+                        continuation_token: None,
+                    })
+                });
+        });
+
+        let repository = MemoryRepository::<Cipher>::default();
+
+        // Pre-populate the repository with pre-share originals for both ciphers: personal-owned,
+        // full secrets, no org id.
+        let mut original_returned = create_encryption_context().cipher;
+        original_returned.organization_id = None;
+        original_returned.collection_ids = vec![];
+        repository
+            .set(returned_id, original_returned)
+            .await
+            .unwrap();
+
+        let mut original_stripped = create_encryption_context().cipher;
+        original_stripped.id = Some(stripped_id);
+        original_stripped.organization_id = None;
+        original_stripped.collection_ids = vec![];
+        repository
+            .set(stripped_id, original_stripped)
+            .await
+            .unwrap();
+
+        let mut encryption_context_returned = create_encryption_context();
+        encryption_context_returned.cipher.id = Some(returned_id);
+        let mut encryption_context_stripped = create_encryption_context();
+        encryption_context_stripped.cipher.id = Some(stripped_id);
+
+        let collection_ids: Vec<CollectionId> = vec![TEST_COLLECTION_ID_1.parse().unwrap()];
+
+        let result = share_ciphers_bulk(
+            api_client.ciphers_api(),
+            &repository,
+            vec![encryption_context_returned, encryption_context_stripped],
+            collection_ids,
+        )
+        .await;
+
+        assert!(result.is_ok());
+        let shared_ciphers = result.unwrap();
+        assert_eq!(
+            shared_ciphers.len(),
+            1,
+            "only the ciphers the server returned are reported back to the caller"
+        );
+
+        let stored_returned = repository.get(returned_id).await.unwrap();
+        assert!(
+            stored_returned
+                .and_then(|c| c.organization_id)
+                .is_some_and(|id| id == org_id),
+            "the cipher the server returned must be merged and persisted with its new org id"
+        );
+
+        let stored_stripped = repository.get(stripped_id).await.unwrap();
+        assert!(
+            stored_stripped.is_none(),
+            "a cipher omitted from the write-return must be evicted, not left as a stale \
+             pre-share copy"
+        );
     }
 
     #[tokio::test]

--- a/crates/bitwarden-vault/src/cipher/cipher_client/share_cipher.rs
+++ b/crates/bitwarden-vault/src/cipher/cipher_client/share_cipher.rs
@@ -1,3 +1,5 @@
+use std::collections::HashSet;
+
 use bitwarden_api_api::{
     apis::ciphers_api::CiphersApi,
     models::{CipherBulkShareRequestModel, CipherShareRequestModel},
@@ -50,12 +52,12 @@ async fn share_ciphers_bulk(
     encrypted_ciphers: Vec<EncryptionContext>,
     collection_ids: Vec<CollectionId>,
 ) -> Result<Vec<Cipher>, CipherError> {
-    // `require!` expands to a `return` from the enclosing function, so it must run in a plain
-    // loop rather than inside a closure passed to `.map`.
-    let mut shared_ids = Vec::with_capacity(encrypted_ciphers.len());
-    for ec in &encrypted_ciphers {
-        shared_ids.push(require!(ec.cipher.id));
-    }
+    // Everything we asked the server to share; the merge loop below removes each id the
+    // write-return acknowledges, leaving the ones the server withheld.
+    let mut withheld_ids: HashSet<CipherId> = encrypted_ciphers
+        .iter()
+        .map(|ec| ec.cipher.id.ok_or(MissingFieldError("id")))
+        .collect::<Result<_, _>>()?;
 
     let request = CipherBulkShareRequestModel::new(
         collection_ids
@@ -72,7 +74,6 @@ async fn share_ciphers_bulk(
 
     let cipher_minis = response.data.unwrap_or_default();
     let mut results = Vec::new();
-    let mut returned_ids = std::collections::HashSet::with_capacity(cipher_minis.len());
 
     for cipher_mini in cipher_minis {
         // The server does not return the full Cipher object, so we pull the details from the
@@ -84,7 +85,7 @@ async fn share_ciphers_bulk(
         cipher.collection_ids = collection_ids.clone();
 
         repository.set(require!(cipher.id), cipher.clone()).await?;
-        returned_ids.insert(cipher_id);
+        withheld_ids.remove(&cipher_id);
         results.push(cipher)
     }
 
@@ -93,12 +94,10 @@ async fn share_ciphers_bulk(
     // missing from `cipher_minis` even though the share succeeded. The local pre-share copy is
     // stale (still personal-owned, full secrets), so evict it rather than let it linger until the
     // next sync restores the cipher in its gated shape.
-    let evicted_ids = shared_ids
-        .into_iter()
-        .filter(|id| !returned_ids.contains(id))
-        .collect::<Vec<_>>();
-    if !evicted_ids.is_empty() {
-        repository.remove_bulk(evicted_ids).await?;
+    if !withheld_ids.is_empty() {
+        repository
+            .remove_bulk(withheld_ids.into_iter().collect())
+            .await?;
     }
 
     Ok(results)

--- a/crates/bitwarden-vault/src/cipher/cipher_client/share_cipher.rs
+++ b/crates/bitwarden-vault/src/cipher/cipher_client/share_cipher.rs
@@ -77,6 +77,7 @@ async fn share_ciphers_bulk(
             .await?;
 
         let cipher: Cipher = Cipher {
+            partial_data: None,
             id: cipher_mini.id.map(CipherId::new),
             organization_id: cipher_mini.organization_id.map(OrganizationId::new),
             key: EncString::try_from_optional(cipher_mini.key)?,
@@ -321,6 +322,7 @@ mod tests {
 
     fn test_cipher_view_without_org() -> CipherView {
         CipherView {
+            partial: false,
             r#type: CipherType::Login,
             login: Some(LoginView {
                 username: Some("test@example.com".to_string()),
@@ -521,6 +523,7 @@ mod tests {
 
         // Create a minimal encrypted cipher for testing the API logic
         let cipher = Cipher {
+                partial_data: None,
                 r#type: CipherType::Login,
                 login: Some(Login {
                     username: Some("2.EI9Km5BfrIqBa1W+WCccfA==|laWxNnx+9H3MZww4zm7cBSLisjpi81zreaQntRhegVI=|x42+qKFf5ga6DIL0OW5pxCdLrC/gm8CXJvf3UASGteI=".parse().unwrap()),
@@ -687,6 +690,7 @@ mod tests {
 
         // Pre-populate repository with original cipher data that will be used for missing fields
         let original_cipher = Cipher {
+                partial_data: None,
                 r#type: CipherType::Login,
                 login: Some(crate::cipher::Login {
                     username: Some("2.EI9Km5BfrIqBa1W+WCccfA==|laWxNnx+9H3MZww4zm7cBSLisjpi81zreaQntRhegVI=|x42+qKFf5ga6DIL0OW5pxCdLrC/gm8CXJvf3UASGteI=".parse().unwrap()),

--- a/crates/bitwarden-vault/src/cipher/cipher_client/share_cipher.rs
+++ b/crates/bitwarden-vault/src/cipher/cipher_client/share_cipher.rs
@@ -4,14 +4,13 @@ use bitwarden_api_api::{
 };
 use bitwarden_collections::collection::CollectionId;
 use bitwarden_core::{MissingFieldError, OrganizationId, require};
-use bitwarden_crypto::EncString;
 use bitwarden_state::repository::Repository;
 #[cfg(feature = "wasm")]
 use wasm_bindgen::prelude::wasm_bindgen;
 
 use crate::{
-    Cipher, CipherError, CipherId, CipherRepromptType, CipherView, CiphersClient,
-    EncryptionContext, VaultParseError, cipher::cipher::PartialCipher,
+    Cipher, CipherError, CipherId, CipherView, CiphersClient, EncryptionContext,
+    cipher::cipher::PartialCipher,
 };
 
 /// Standalone function that shares a cipher to an organization via API call.
@@ -76,82 +75,8 @@ async fn share_ciphers_bulk(
             ))
             .await?;
 
-        let cipher: Cipher = Cipher {
-            partial_data: None,
-            id: cipher_mini.id.map(CipherId::new),
-            organization_id: cipher_mini.organization_id.map(OrganizationId::new),
-            key: EncString::try_from_optional(cipher_mini.key)?,
-            name: EncString::try_from_optional(cipher_mini.name)?,
-            notes: EncString::try_from_optional(cipher_mini.notes)?,
-            r#type: require!(cipher_mini.r#type).try_into()?,
-            login: cipher_mini.login.map(|l| (*l).try_into()).transpose()?,
-            identity: cipher_mini.identity.map(|i| (*i).try_into()).transpose()?,
-            card: cipher_mini.card.map(|c| (*c).try_into()).transpose()?,
-            secure_note: cipher_mini
-                .secure_note
-                .map(|s| (*s).try_into())
-                .transpose()?,
-            ssh_key: cipher_mini.ssh_key.map(|s| (*s).try_into()).transpose()?,
-            bank_account: cipher_mini
-                .bank_account
-                .map(|b| (*b).try_into())
-                .transpose()?,
-            drivers_license: cipher_mini
-                .drivers_license
-                .map(|d| (*d).try_into())
-                .transpose()?,
-            passport: cipher_mini.passport.map(|p| (*p).try_into()).transpose()?,
-            reprompt: cipher_mini
-                .reprompt
-                .map(|r| r.try_into())
-                .transpose()?
-                .unwrap_or(CipherRepromptType::None),
-            organization_use_totp: cipher_mini.organization_use_totp.unwrap_or(true),
-            attachments: cipher_mini
-                .attachments
-                .map(|a| a.into_iter().map(|a| a.try_into()).collect())
-                .transpose()?,
-            fields: cipher_mini
-                .fields
-                .map(|f| f.into_iter().map(|f| f.try_into()).collect())
-                .transpose()?,
-            password_history: cipher_mini
-                .password_history
-                .map(|p| p.into_iter().map(|p| p.try_into()).collect())
-                .transpose()?,
-            creation_date: require!(cipher_mini.creation_date)
-                .parse()
-                .map_err(Into::<VaultParseError>::into)?,
-            deleted_date: cipher_mini
-                .deleted_date
-                .map(|d| d.parse())
-                .transpose()
-                .map_err(Into::<VaultParseError>::into)?,
-            revision_date: require!(cipher_mini.revision_date)
-                .parse()
-                .map_err(Into::<VaultParseError>::into)?,
-            archived_date: orig_cipher
-                .as_ref()
-                .map(|c| c.archived_date)
-                .unwrap_or_default(),
-            edit: orig_cipher.as_ref().map(|c| c.edit).unwrap_or_default(),
-            favorite: orig_cipher.as_ref().map(|c| c.favorite).unwrap_or_default(),
-            folder_id: orig_cipher
-                .as_ref()
-                .map(|c| c.folder_id)
-                .unwrap_or_default(),
-            permissions: orig_cipher
-                .as_ref()
-                .map(|c| c.permissions)
-                .unwrap_or_default(),
-            view_password: orig_cipher
-                .as_ref()
-                .map(|c| c.view_password)
-                .unwrap_or_default(),
-            local_data: orig_cipher.map(|c| c.local_data).unwrap_or_default(),
-            collection_ids: collection_ids.clone(),
-            data: None,
-        };
+        let mut cipher: Cipher = cipher_mini.merge_with_cipher(orig_cipher)?;
+        cipher.collection_ids = collection_ids.clone();
 
         repository.set(require!(cipher.id), cipher.clone()).await?;
         results.push(cipher)
@@ -775,6 +700,137 @@ mod tests {
 
         assert_eq!(stored_cipher.id, shared_cipher.id);
         assert!(stored_cipher.favorite); // Should preserve from original
+    }
+
+    /// A bulk-share write-return can be PAM-gated the same as any other write: secrets withheld,
+    /// `partial_data` set. Persisting the response must keep that gate — dropping `partial_data`
+    /// on merge would leave a husk in the repository that looks like an ungated, secret-free
+    /// cipher.
+    #[tokio::test]
+    async fn test_share_ciphers_bulk_persists_a_gated_write_return() {
+        let cipher_id: CipherId = TEST_CIPHER_ID.parse().unwrap();
+        let org_id: OrganizationId = TEST_ORG_ID.parse().unwrap();
+
+        let api_client = ApiClient::new_mocked(move |mock| {
+            mock.ciphers_api
+                .expect_put_share_many()
+                .returning(move |_body| {
+                    Ok(CipherMiniResponseModelListResponseModel {
+                        object: Some("list".to_string()),
+                        data: Some(vec![bitwarden_api_api::models::CipherMiniResponseModel {
+                            object: Some("cipherMini".to_string()),
+                            id: Some(cipher_id.into()),
+                            organization_id: Some(org_id.into()),
+                            r#type: Some(bitwarden_api_api::models::CipherType::Login),
+                            partial_data: Some(
+                                r#"{"strippedFields":["login","name","notes"]}"#.to_string(),
+                            ),
+                            name: None,
+                            notes: None,
+                            login: None,
+                            revision_date: Some("2024-01-30T17:55:36.150Z".to_string()),
+                            creation_date: Some("2024-01-30T17:55:36.150Z".to_string()),
+                            ..Default::default()
+                        }]),
+                        continuation_token: None,
+                    })
+                });
+        });
+
+        let repository = MemoryRepository::<Cipher>::default();
+
+        // Pre-populate the repository with an ordinary (non-partial) original cipher, so the
+        // merge has local-only fields (favorite, folder_id, ...) to pull forward.
+        let original_cipher = Cipher {
+            partial_data: None,
+            r#type: CipherType::Login,
+            login: Some(crate::cipher::Login {
+                username: Some("2.EI9Km5BfrIqBa1W+WCccfA==|laWxNnx+9H3MZww4zm7cBSLisjpi81zreaQntRhegVI=|x42+qKFf5ga6DIL0OW5pxCdLrC/gm8CXJvf3UASGteI=".parse().unwrap()),
+                password: Some("2.EI9Km5BfrIqBa1W+WCccfA==|laWxNnx+9H3MZww4zm7cBSLisjpi81zreaQntRhegVI=|x42+qKFf5ga6DIL0OW5pxCdLrC/gm8CXJvf3UASGteI=".parse().unwrap()),
+                password_revision_date: None,
+                uris: None,
+                totp: None,
+                autofill_on_page_load: None,
+                fido2_credentials: None,
+            }),
+            id: Some(TEST_CIPHER_ID.parse().unwrap()),
+            organization_id: None,
+            folder_id: Some(crate::FolderId::new(uuid::uuid!(
+                "b1111111-1111-1111-1111-111111111111"
+            ))),
+            collection_ids: vec![],
+            key: None,
+            name: Some("2.EI9Km5BfrIqBa1W+WCccfA==|laWxNnx+9H3MZww4zm7cBSLisjpi81zreaQntRhegVI=|x42+qKFf5ga6DIL0OW5pxCdLrC/gm8CXJvf3UASGteI=".parse().unwrap()),
+            notes: Some("2.EI9Km5BfrIqBa1W+WCccfA==|laWxNnx+9H3MZww4zm7cBSLisjpi81zreaQntRhegVI=|x42+qKFf5ga6DIL0OW5pxCdLrC/gm8CXJvf3UASGteI=".parse().unwrap()),
+            identity: None,
+            card: None,
+            secure_note: None,
+            ssh_key: None,
+            bank_account: None,
+            drivers_license: None,
+            passport: None,
+            favorite: true,
+            reprompt: CipherRepromptType::None,
+            organization_use_totp: true,
+            edit: true,
+            permissions: None,
+            view_password: true,
+            local_data: None,
+            attachments: None,
+            fields: None,
+            password_history: None,
+            creation_date: "2024-01-30T17:55:36.150Z".parse().unwrap(),
+            deleted_date: None,
+            revision_date: "2024-01-30T17:55:36.150Z".parse().unwrap(),
+            archived_date: None,
+            data: None,
+        };
+        let original_folder_id = original_cipher.folder_id;
+
+        repository
+            .set(TEST_CIPHER_ID.parse().unwrap(), original_cipher)
+            .await
+            .unwrap();
+
+        let encryption_context = create_encryption_context();
+        let collection_ids: Vec<CollectionId> = vec![
+            TEST_COLLECTION_ID_1.parse().unwrap(),
+            TEST_COLLECTION_ID_2.parse().unwrap(),
+        ];
+
+        let result = share_ciphers_bulk(
+            api_client.ciphers_api(),
+            &repository,
+            vec![encryption_context],
+            collection_ids.clone(),
+        )
+        .await;
+
+        assert!(result.is_ok());
+        let shared_ciphers = result.unwrap();
+        assert_eq!(shared_ciphers.len(), 1);
+
+        let stored_cipher = repository
+            .get(TEST_CIPHER_ID.parse().unwrap())
+            .await
+            .unwrap()
+            .expect("Cipher should be stored");
+
+        assert!(
+            stored_cipher.partial_data.is_some(),
+            "gated write-return must stay gated in the repository"
+        );
+        assert!(
+            stored_cipher.login.is_none(),
+            "no secret field may reach local state"
+        );
+        assert!(stored_cipher.name.is_none());
+        assert_eq!(stored_cipher.collection_ids, collection_ids);
+        assert!(
+            stored_cipher.favorite,
+            "local-only fields must survive the merge"
+        );
+        assert_eq!(stored_cipher.folder_id, original_folder_id);
     }
 
     #[tokio::test]

--- a/crates/bitwarden-vault/src/cipher/cipher_client/share_cipher.rs
+++ b/crates/bitwarden-vault/src/cipher/cipher_client/share_cipher.rs
@@ -77,6 +77,7 @@ async fn share_ciphers_bulk(
             .await?;
 
         let cipher: Cipher = Cipher {
+            partial_data: None,
             id: cipher_mini.id.map(CipherId::new),
             organization_id: cipher_mini.organization_id.map(OrganizationId::new),
             key: EncString::try_from_optional(cipher_mini.key)?,
@@ -321,6 +322,7 @@ mod tests {
 
     fn test_cipher_view_without_org() -> CipherView {
         CipherView {
+            partial: false,
             r#type: CipherType::Login,
             login: Some(LoginView {
                 username: Some("test@example.com".to_string()),
@@ -521,6 +523,7 @@ mod tests {
 
         // Create a minimal encrypted cipher for testing the API logic
         let cipher = Cipher {
+                partial_data: None,
                 r#type: CipherType::Login,
                 login: Some(Login {
                     username: Some("2.EI9Km5BfrIqBa1W+WCccfA==|laWxNnx+9H3MZww4zm7cBSLisjpi81zreaQntRhegVI=|x42+qKFf5ga6DIL0OW5pxCdLrC/gm8CXJvf3UASGteI=".parse().unwrap()),
@@ -688,6 +691,7 @@ mod tests {
 
         // Pre-populate repository with original cipher data that will be used for missing fields
         let original_cipher = Cipher {
+                partial_data: None,
                 r#type: CipherType::Login,
                 login: Some(crate::cipher::Login {
                     username: Some("2.EI9Km5BfrIqBa1W+WCccfA==|laWxNnx+9H3MZww4zm7cBSLisjpi81zreaQntRhegVI=|x42+qKFf5ga6DIL0OW5pxCdLrC/gm8CXJvf3UASGteI=".parse().unwrap()),

--- a/crates/bitwarden-vault/src/cipher/secure_note.rs
+++ b/crates/bitwarden-vault/src/cipher/secure_note.rs
@@ -152,6 +152,7 @@ mod tests {
 
     fn create_cipher_for_note(note: SecureNote) -> Cipher {
         Cipher {
+            partial_data: None,
             id: Some("090c19ea-a61a-4df6-8963-262b97bc6266".parse().unwrap()),
             organization_id: None,
             folder_id: None,

--- a/crates/bitwarden-vault/src/totp.rs
+++ b/crates/bitwarden-vault/src/totp.rs
@@ -731,6 +731,7 @@ mod tests {
     #[test]
     fn test_generate_totp_cipher_view() {
         let view = CipherListView {
+            partial: false,
             id: Some("090c19ea-a61a-4df6-8963-262b97bc6266".parse().unwrap()),
             organization_id: None,
             folder_id: None,


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-41576

## 📔 Objective

When a cipher is PAM-gated, the server withholds its secret fields and returns a reduced **`partial_data`** envelope in their place — the encrypted name and, for logins, the encrypted URIs. This PR adds support to for this field in the SDK.

- **`Cipher.partial_data: Option<String>`** — the raw JSON envelope (defaulted + skip-if-none, so existing ciphers round-trip byte-identically).
- **`CipherView.partial` / `CipherListView.partial: bool`** — the flag clients read instead of inferring gating from a string.
- **`RestrictedCipherData`** — a private deserialize struct mirroring the server's `PartialCipherData.Strip` output (a purpose-built **camelCase** envelope). This is the single authoritative allowlist for what a gated view may expose: **name + login URIs, nothing else**.
- **Restricted decrypt branch** (`decrypt_restricted_cipher_view` / `_list_view`) — short-circuits ahead of `try_parse_blob` in **both** the lenient and `StrictDecrypt` impls, decrypts only the allowlisted fields, marks the view `partial = true`, and **never reads** `login`/`card`/… So a gated `Login`/`Card`/`BankAccount` no longer fails with `MissingField`, in either decrypt mode.

### Wire shape

`partial_data` is delivered in camelCase carrying the same `LoginUri` fields (`uri`/`uriChecksum`/`match`) the SDK already consumes on a full login, so the restricted path reuses `LoginUri` directly. Paired with the server change in bitwarden/server#8115, which emits a purpose-built camelCase envelope (rather than round-tripping the legacy PascalCase storage DTO). Clients pass `partialData` through as an opaque string, so this is a two-party server↔SDK contract with no clients impact.

In the future this can be replaced by a client encrypted blob of the partial fields.

### Fail-closed

A malformed envelope or an undecryptable field degrades to empty rather than un-gating — the view is always returned `partial = true`. The `CipherView` path still runs `remove_invalid_checksums`, mirroring the full paths' guard against a tampering server changing URIs.

## ⏰ Reminders before review

Most of the diff outside `cipher.rs` is the mechanical one-line `partial_data: None` / `partial: false` added to existing `Cipher`/`CipherView`/`CipherListView` construction sites (the two new fields). The substance is in `crates/bitwarden-vault/src/cipher/cipher.rs`.
