### PR TITLE
Auth / SealedOpenOrgInviteData - Fix TS2552 in WASM bindings by colocating custom section

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -47,6 +47,12 @@ Generated code:
   or the "Update API Bindings" GitHub workflow.
 - WASM npm packages (`@bitwarden/sdk-internal`, `@bitwarden/commercial-sdk-internal`) build via
   `crates/bitwarden-wasm-internal/build.sh` (`-r` release, `-b` commercial).
+- WASM TS aliases via `#[wasm_bindgen(typescript_custom_section)]` only reliably survive `wasm-ld`
+  in debug builds when colocated in the same source file as an externally-referenced struct/fn.
+  Debug uses many codegen units and can drop the whole unit containing the section; release masks
+  this via `codegen-units = 1` + `lto = true`. CI runs release (`-r`) — CI-green does not prove the
+  local debug build passes; run `build.sh` without `-r` when adding one. For types with no
+  downstream Rust consumer, declare the alias in `bitwarden-wasm-internal/src/custom_types.rs`.
 
 ## Architecture
 

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -47,12 +47,11 @@ Generated code:
   or the "Update API Bindings" GitHub workflow.
 - WASM npm packages (`@bitwarden/sdk-internal`, `@bitwarden/commercial-sdk-internal`) build via
   `crates/bitwarden-wasm-internal/build.sh` (`-r` release, `-b` commercial).
-- WASM TS aliases via `#[wasm_bindgen(typescript_custom_section)]` only reliably survive `wasm-ld`
-  in debug builds when colocated in the same source file as an externally-referenced struct/fn.
-  Debug uses many codegen units and can drop the whole unit containing the section; release masks
-  this via `codegen-units = 1` + `lto = true`. CI runs release (`-r`) — CI-green does not prove the
-  local debug build passes; run `build.sh` without `-r` when adding one. For types with no
-  downstream Rust consumer, declare the alias in `bitwarden-wasm-internal/src/custom_types.rs`.
+- WASM TS aliases via `#[wasm_bindgen(typescript_custom_section)]` are dropped by `wasm-ld` in debug
+  unless colocated with a non-generic fn reachable from a `#[wasm_bindgen]` export. Release masks
+  this via `codegen-units = 1`, so CI-green != local-green — run `build.sh` without `-r` when adding
+  one. For types with no such reachable fn, declare the alias in
+  `bitwarden-wasm-internal/src/custom_types.rs`.
 
 ## Architecture
 

--- a/crates/bitwarden-auth/src/registration/open_org_invite_crypto/open_org_invite.rs
+++ b/crates/bitwarden-auth/src/registration/open_org_invite_crypto/open_org_invite.rs
@@ -45,6 +45,13 @@ pub struct SealedOpenOrgInviteData {
     pub(super) key_envelope: SecretProtectedKeyEnvelope,
 }
 
+// WASM ABI: `SealedOpenOrgInviteData` marshals as its wire string, matching the JSON wire form.
+#[cfg(feature = "wasm")]
+#[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
+const TS_CUSTOM_TYPES: &'static str = r#"
+export type SealedOpenOrgInviteData = Tagged<string, "SealedOpenOrgInviteData">;
+"#;
+
 impl SealedOpenOrgInviteData {
     /// Seals an [`OpenOrgInvite`] into a [`SealedOpenOrgInviteData`] plus a freshly generated
     /// [`HighEntropySecret`]. The caller must keep the secret client-side and place the sealed

--- a/crates/bitwarden-auth/src/registration/open_org_invite_crypto/serialization.rs
+++ b/crates/bitwarden-auth/src/registration/open_org_invite_crypto/serialization.rs
@@ -89,13 +89,6 @@ impl<'de> Deserialize<'de> for SealedOpenOrgInviteData {
     }
 }
 
-// WASM ABI: `SealedOpenOrgInviteData` marshals as its wire string, matching the JSON wire form.
-#[cfg(feature = "wasm")]
-#[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
-const TS_CUSTOM_TYPES: &'static str = r#"
-export type SealedOpenOrgInviteData = Tagged<string, "SealedOpenOrgInviteData">;
-"#;
-
 #[cfg(feature = "wasm")]
 impl wasm_bindgen::describe::WasmDescribe for SealedOpenOrgInviteData {
     fn describe() {


### PR DESCRIPTION
## 🎟️ Tracking
<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
n/a

## 📔 Objective
<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

**Claude Summary**

Local WASM debug builds were failing with `TS2552: Cannot find name 'SealedOpenOrgInviteData'` in the generated `.d.ts`.

**Root cause.** The `#[wasm_bindgen(typescript_custom_section)]` declaring the `SealedOpenOrgInviteData` TS alias lived in `serialization.rs`, which contains only trait impls — no non-generic function reachable from a `#[wasm_bindgen]` export. Debug builds use many codegen units, so `wasm-ld` treats the unit as unreachable and drops it, taking the section's `#[used] static` with it. `wasm-bindgen` never sees the alias, so the generated `.d.ts` references a type it never declares.

**Why CI missed it.** The workspace `[profile.release]` sets `codegen-units = 1`, which merges every crate symbol into a single unit and eliminates the per-CU DCE that was dropping the section. CI runs `./build.sh -r` (release), so the bug was invisible in CI while breaking every local debug build.

**Fix.** Moved the `typescript_custom_section` block next to the `SealedOpenOrgInviteData` struct in `open_org_invite.rs`. The non-generic methods `SealedOpenOrgInviteData::seal`/`unseal` are called from `RegistrationClient::seal_open_org_invite_data` — a `#[wasm_bindgen]` export — so their codegen unit stays reachable in both profiles. Added a brief note to `.claude/CLAUDE.md` documenting the rule and the debug-vs-release trap so future contributors don't re-introduce the same shape of bug.

**Verified.** All four `build.sh` combinations pass (debug/release × OSS/commercial); `SealedOpenOrgInviteData` is declared and the reference resolves in every generated `.d.ts`. Also empirically isolated the mechanism: reverting the section to `serialization.rs` reproduces the debug failure; setting only `codegen-units = 1` on `[profile.dev]` (LTO still off) makes the section survive even in that broken placement — confirming `codegen-units = 1` alone is the mask, not LTO.


