### PR TITLE
[PM-39455] Defer account recovery rotation to organizatio on a V1 to V2 user key rotation

### DIFF
--- a/crates/bitwarden-user-crypto-management/src/key_rotation/password_change_and_rotate_user_keys.rs
+++ b/crates/bitwarden-user-crypto-management/src/key_rotation/password_change_and_rotate_user_keys.rs
@@ -18,6 +18,7 @@ use crate::{
         RotateUserKeysError,
         crypto::rotate_account_cryptographic_state_to_request_model,
         data::{check_for_old_attachments, reencrypt_data},
+        rotate_user_keys::UpgradeTokenAction,
         rotation_context::make_rotation_context,
         sync::{SyncedAccountData, sync_current_account_data},
         unlock::{
@@ -92,6 +93,7 @@ async fn internal_password_change_and_rotate_user_keys(
             &sync,
             request.trusted_organization_public_keys.as_slice(),
             request.trusted_emergency_access_public_keys.as_slice(),
+            UpgradeTokenAction::Skip,
             &mut ctx,
         )?;
 

--- a/crates/bitwarden-user-crypto-management/src/key_rotation/rotate_user_keys.rs
+++ b/crates/bitwarden-user-crypto-management/src/key_rotation/rotate_user_keys.rs
@@ -55,6 +55,8 @@ pub enum UpgradeTokenAction {
 pub struct RotateUserKeysRequest {
     pub key_rotation_method: KeyRotationMethod,
     pub trusted_emergency_access_public_keys: Vec<PublicKey>,
+    /// Organization public keys the user confirmed as trusted. Only needed when the rotation
+    /// shares the new user key for account recovery.
     pub trusted_organization_public_keys: Vec<PublicKey>,
     pub upgrade_token_action: UpgradeTokenAction,
 }
@@ -155,6 +157,7 @@ async fn internal_rotate_user_keys(
             &sync,
             request.trusted_organization_public_keys.as_slice(),
             request.trusted_emergency_access_public_keys.as_slice(),
+            request.upgrade_token_action.clone(),
             &mut ctx,
         )?;
 
@@ -208,7 +211,7 @@ async fn internal_rotate_user_keys(
             },
             rotation_context.current_user_key_id,
             rotation_context.new_user_key_id,
-            request.upgrade_token_action,
+            rotation_context.creates_v2_upgrade_token,
             &mut ctx,
         )
         .map_err(|_| RotateUserKeysError::Crypto)?;
@@ -284,7 +287,9 @@ mod tests {
     use chrono::DateTime;
 
     use super::*;
-    use crate::key_rotation::partial_rotateable_keyset::PartialRotateableKeyset;
+    use crate::key_rotation::{
+        partial_rotateable_keyset::PartialRotateableKeyset, unlock::V1OrganizationMembership,
+    };
 
     fn make_state_bridge() -> StateBridgeClient {
         let client = Client::new(None);
@@ -322,6 +327,26 @@ mod tests {
                 "test_salt".to_string(),
             )),
         };
+
+        (store, sync)
+    }
+
+    /// Builds a V1 account that is enrolled in account recovery for a single organization.
+    fn make_test_key_store_and_synced_data_with_organization()
+    -> (KeyStore<KeySlotIds>, SyncedAccountData) {
+        let (store, mut sync) = make_test_key_store_and_synced_data();
+        {
+            let mut ctx = store.context_mut();
+            let organization_private_key =
+                ctx.make_private_key(PublicKeyEncryptionAlgorithm::RsaOaepSha1);
+            sync.organization_memberships = vec![V1OrganizationMembership {
+                organization_id: uuid::Uuid::new_v4(),
+                name: "Test Org".to_string(),
+                public_key: ctx
+                    .get_public_key(organization_private_key)
+                    .expect("public key should exist"),
+            }];
+        }
 
         (store, sync)
     }
@@ -911,6 +936,148 @@ mod tests {
             key_connector_api_client
         {
             mock.user_keys_api.checkpoint();
+        }
+    }
+
+    #[tokio::test]
+    async fn test_rotate_user_keys_v1_to_v2_upgrade_defers_organization_account_recovery() {
+        let (key_store, sync) = make_test_key_store_and_synced_data_with_organization();
+        let organization_id = sync.organization_memberships[0].organization_id;
+
+        let api_client = ApiClient::new_mocked(|mock| {
+            mock.accounts_key_management_api
+                .expect_rotate_user_keys()
+                .once()
+                .returning(move |req| {
+                    let req = req.expect("request body should be present");
+                    assert!(
+                        req.unlock_data.v2_upgrade_token.is_some(),
+                        "without the token, admins cannot update account recovery"
+                    );
+
+                    let account_recovery = req
+                        .unlock_data
+                        .organization_account_recovery_unlock_data
+                        .as_ref()
+                        .expect("account recovery data should be present");
+                    assert_eq!(account_recovery.len(), 1);
+                    assert_eq!(account_recovery[0].organization_id, organization_id);
+                    assert!(
+                        account_recovery[0].reset_password_key.is_none(),
+                        "account recovery is left for organization admins to update"
+                    );
+                    Ok(())
+                });
+        });
+
+        let state_bridge = make_state_bridge();
+        let result = internal_rotate_user_keys(
+            &key_store,
+            &api_client,
+            &state_bridge,
+            None,
+            RotateUserKeysRequest {
+                key_rotation_method: KeyRotationMethod::Password {
+                    password: "test_password".to_string(),
+                },
+                trusted_organization_public_keys: vec![],
+                trusted_emergency_access_public_keys: vec![],
+                upgrade_token_action: UpgradeTokenAction::CreateIfNeeded,
+            },
+            sync.wrapped_account_cryptographic_state.clone(),
+            sync,
+        )
+        .await;
+
+        assert!(result.is_ok());
+        if let ApiClient::Mock(mut mock) = api_client {
+            mock.accounts_key_management_api.checkpoint();
+        }
+    }
+
+    #[tokio::test]
+    async fn test_rotate_user_keys_v1_to_v2_upgrade_ignores_trusted_organization_public_keys() {
+        let (key_store, sync) = make_test_key_store_and_synced_data_with_organization();
+        let organization_public_key = sync.organization_memberships[0].public_key.clone();
+
+        let api_client = ApiClient::new_mocked(|mock| {
+            mock.accounts_key_management_api
+                .expect_rotate_user_keys()
+                .once()
+                .returning(move |req| {
+                    let req = req.expect("request body should be present");
+                    let account_recovery = req
+                        .unlock_data
+                        .organization_account_recovery_unlock_data
+                        .as_ref()
+                        .expect("account recovery data should be present");
+                    assert_eq!(account_recovery.len(), 1);
+                    assert!(
+                        account_recovery[0].reset_password_key.is_none(),
+                        "trusting a key does not change who updates account recovery"
+                    );
+                    Ok(())
+                });
+        });
+
+        let state_bridge = make_state_bridge();
+        let result = internal_rotate_user_keys(
+            &key_store,
+            &api_client,
+            &state_bridge,
+            None,
+            RotateUserKeysRequest {
+                key_rotation_method: KeyRotationMethod::Password {
+                    password: "test_password".to_string(),
+                },
+                // Older callers may still send organization keys. That must keep working.
+                trusted_organization_public_keys: vec![organization_public_key],
+                trusted_emergency_access_public_keys: vec![],
+                upgrade_token_action: UpgradeTokenAction::CreateIfNeeded,
+            },
+            sync.wrapped_account_cryptographic_state.clone(),
+            sync,
+        )
+        .await;
+
+        assert!(result.is_ok());
+        if let ApiClient::Mock(mut mock) = api_client {
+            mock.accounts_key_management_api.checkpoint();
+        }
+    }
+
+    #[tokio::test]
+    async fn test_rotate_user_keys_untrusted_organization_without_upgrade_token_returns_error() {
+        let (key_store, sync) = make_test_key_store_and_synced_data_with_organization();
+
+        let api_client = ApiClient::new_mocked(|mock| {
+            mock.accounts_key_management_api
+                .expect_rotate_user_keys()
+                .never();
+        });
+
+        let state_bridge = make_state_bridge();
+        let result = internal_rotate_user_keys(
+            &key_store,
+            &api_client,
+            &state_bridge,
+            None,
+            RotateUserKeysRequest {
+                key_rotation_method: KeyRotationMethod::Password {
+                    password: "test_password".to_string(),
+                },
+                trusted_organization_public_keys: vec![],
+                trusted_emergency_access_public_keys: vec![],
+                upgrade_token_action: UpgradeTokenAction::Skip,
+            },
+            sync.wrapped_account_cryptographic_state.clone(),
+            sync,
+        )
+        .await;
+
+        assert!(matches!(result, Err(RotateUserKeysError::UntrustedKey)));
+        if let ApiClient::Mock(mut mock) = api_client {
+            mock.accounts_key_management_api.checkpoint();
         }
     }
 }

--- a/crates/bitwarden-user-crypto-management/src/key_rotation/rotation_context.rs
+++ b/crates/bitwarden-user-crypto-management/src/key_rotation/rotation_context.rs
@@ -4,12 +4,40 @@ use tracing::{debug, info, warn};
 
 use super::{
     RotateUserKeysError,
+    rotate_user_keys::UpgradeTokenAction,
     sync::SyncedAccountData,
     unlock::{V1EmergencyAccessMembership, V1OrganizationMembership},
 };
 
 #[derive(Debug)]
 struct UntrustedKeyError;
+
+/// Whether the rotation creates a V2 upgrade token.
+///
+/// A token only makes sense when the user moves from a V1 to a V2 user key. Every other rotation
+/// logs the user out of their other sessions.
+fn creates_v2_upgrade_token(
+    current_user_key_id: SymmetricKeySlotId,
+    new_user_key_id: SymmetricKeySlotId,
+    upgrade_token_action: UpgradeTokenAction,
+    ctx: &KeyStoreContext<KeySlotIds>,
+) -> bool {
+    if matches!(upgrade_token_action, UpgradeTokenAction::Skip) {
+        debug!("UpgradeTokenAction::Skip, no upgrade token is created for this rotation");
+        return false;
+    }
+
+    matches!(
+        (
+            ctx.get_symmetric_key_algorithm(current_user_key_id),
+            ctx.get_symmetric_key_algorithm(new_user_key_id),
+        ),
+        (
+            Ok(SymmetricKeyAlgorithm::Aes256CbcHmac),
+            Ok(SymmetricKeyAlgorithm::XAes256Gcm)
+        )
+    )
+}
 
 fn filter_trusted_organization(
     org: &[V1OrganizationMembership],
@@ -58,26 +86,20 @@ pub(super) struct RotationContext {
     pub(super) v1_emergency_access_memberships: Vec<V1EmergencyAccessMembership>,
     pub(super) current_user_key_id: SymmetricKeySlotId,
     pub(super) new_user_key_id: SymmetricKeySlotId,
+    pub(super) creates_v2_upgrade_token: bool,
 }
 
+/// Generates the new user key and collects the memberships that get a copy of it.
+///
+/// Returns [`RotateUserKeysError::UntrustedKey`] if the rotation needs a public key the user has
+/// not confirmed. A public key does not show who owns it, so the user has to confirm it first.
 pub(super) fn make_rotation_context(
     sync: &SyncedAccountData,
     trusted_organization_public_keys: &[PublicKey],
     trusted_emergency_access_public_keys: &[PublicKey],
+    upgrade_token_action: UpgradeTokenAction,
     ctx: &mut KeyStoreContext<KeySlotIds>,
 ) -> Result<RotationContext, RotateUserKeysError> {
-    let v1_organization_memberships = filter_trusted_organization(
-        sync.organization_memberships.as_slice(),
-        trusted_organization_public_keys,
-    )
-    .map_err(|_| RotateUserKeysError::UntrustedKey)?;
-
-    let v1_emergency_access_memberships = filter_trusted_emergency_access(
-        sync.emergency_access_memberships.as_slice(),
-        trusted_emergency_access_public_keys,
-    )
-    .map_err(|_| RotateUserKeysError::UntrustedKey)?;
-
     info!(
         "Existing user cryptographic version {:?}",
         sync.wrapped_account_cryptographic_state
@@ -87,11 +109,41 @@ pub(super) fn make_rotation_context(
     debug!("Generating new XAES-256-GCM user key for key rotation");
     let new_user_key_id = ctx.make_symmetric_key(SymmetricKeyAlgorithm::XAes256Gcm);
 
+    let creates_v2_upgrade_token = creates_v2_upgrade_token(
+        current_user_key_id,
+        new_user_key_id,
+        upgrade_token_action,
+        ctx,
+    );
+
+    let v1_organization_memberships = if creates_v2_upgrade_token {
+        // Organization admins update account recovery from the token. The user is never asked to
+        // trust these keys.
+        info!(
+            "Skipping the trust check for {} organization public key(s), the rotation does not use them",
+            sync.organization_memberships.len()
+        );
+        sync.organization_memberships.clone()
+    } else {
+        filter_trusted_organization(
+            sync.organization_memberships.as_slice(),
+            trusted_organization_public_keys,
+        )
+        .map_err(|_| RotateUserKeysError::UntrustedKey)?
+    };
+
+    let v1_emergency_access_memberships = filter_trusted_emergency_access(
+        sync.emergency_access_memberships.as_slice(),
+        trusted_emergency_access_public_keys,
+    )
+    .map_err(|_| RotateUserKeysError::UntrustedKey)?;
+
     Ok(RotationContext {
         v1_organization_memberships,
         v1_emergency_access_memberships,
         current_user_key_id,
         new_user_key_id,
+        creates_v2_upgrade_token,
     })
 }
 
@@ -111,9 +163,75 @@ mod tests {
             sync::SyncedAccountData,
             unlock::{V1EmergencyAccessMembership, V1OrganizationMembership},
         },
-        RotateUserKeysError, filter_trusted_emergency_access, filter_trusted_organization,
-        make_rotation_context,
+        RotateUserKeysError, UpgradeTokenAction, creates_v2_upgrade_token,
+        filter_trusted_emergency_access, filter_trusted_organization, make_rotation_context,
     };
+
+    #[test]
+    fn test_creates_v2_upgrade_token_v1_to_v2_with_create_if_needed() {
+        let store: KeyStore<KeySlotIds> = KeyStore::default();
+        let mut ctx = store.context_mut();
+
+        let current_user_key_id = ctx.make_symmetric_key(SymmetricKeyAlgorithm::Aes256CbcHmac);
+        let new_user_key_id = ctx.make_symmetric_key(SymmetricKeyAlgorithm::XAes256Gcm);
+
+        assert!(creates_v2_upgrade_token(
+            current_user_key_id,
+            new_user_key_id,
+            UpgradeTokenAction::CreateIfNeeded,
+            &ctx,
+        ));
+    }
+
+    #[test]
+    fn test_creates_v2_upgrade_token_v1_to_v2_with_skip() {
+        let store: KeyStore<KeySlotIds> = KeyStore::default();
+        let mut ctx = store.context_mut();
+
+        let current_user_key_id = ctx.make_symmetric_key(SymmetricKeyAlgorithm::Aes256CbcHmac);
+        let new_user_key_id = ctx.make_symmetric_key(SymmetricKeyAlgorithm::XAes256Gcm);
+
+        assert!(!creates_v2_upgrade_token(
+            current_user_key_id,
+            new_user_key_id,
+            UpgradeTokenAction::Skip,
+            &ctx,
+        ));
+    }
+
+    #[test]
+    fn test_creates_v2_upgrade_token_v2_to_v2_with_create_if_needed() {
+        let store: KeyStore<KeySlotIds> = KeyStore::default();
+        let mut ctx = store.context_mut();
+
+        let current_user_key_id = ctx.make_symmetric_key(SymmetricKeyAlgorithm::XAes256Gcm);
+        let new_user_key_id = ctx.make_symmetric_key(SymmetricKeyAlgorithm::XAes256Gcm);
+
+        assert!(!creates_v2_upgrade_token(
+            current_user_key_id,
+            new_user_key_id,
+            UpgradeTokenAction::CreateIfNeeded,
+            &ctx,
+        ));
+    }
+
+    #[test]
+    fn test_creates_v2_upgrade_token_missing_current_user_key() {
+        let store: KeyStore<KeySlotIds> = KeyStore::default();
+        let mut ctx = store.context_mut();
+
+        let new_user_key_id = ctx.make_symmetric_key(SymmetricKeyAlgorithm::XAes256Gcm);
+
+        assert!(
+            !creates_v2_upgrade_token(
+                SymmetricKeySlotId::User,
+                new_user_key_id,
+                UpgradeTokenAction::CreateIfNeeded,
+                &ctx,
+            ),
+            "a user key that cannot be read must not be treated as V1"
+        );
+    }
 
     fn make_org_membership(
         ctx: &mut KeyStoreContext<KeySlotIds>,
@@ -304,7 +422,7 @@ mod tests {
         let mut ctx = store.context_mut();
         let sync = make_test_sync(vec![], vec![], &mut ctx);
 
-        let result = make_rotation_context(&sync, &[], &[], &mut ctx);
+        let result = make_rotation_context(&sync, &[], &[], UpgradeTokenAction::Skip, &mut ctx);
 
         let rotation_ctx = result.expect("should succeed");
         assert!(rotation_ctx.v1_organization_memberships.is_empty());
@@ -314,6 +432,74 @@ mod tests {
             rotation_ctx.new_user_key_id,
             rotation_ctx.current_user_key_id
         );
+        assert!(!rotation_ctx.creates_v2_upgrade_token);
+    }
+
+    #[test]
+    fn test_make_rotation_context_untrusted_org_with_upgrade_token_is_accepted() {
+        let store: KeyStore<KeySlotIds> = KeyStore::default();
+        let mut ctx = store.context_mut();
+        let user_key = ctx.make_symmetric_key(SymmetricKeyAlgorithm::Aes256CbcHmac);
+        ctx.persist_symmetric_key(user_key, SymmetricKeySlotId::User)
+            .expect("persisting the user key should work");
+        let (org, _) = make_org_membership(&mut ctx);
+        let expected_org = org.clone();
+        let sync = make_test_sync(vec![org], vec![], &mut ctx);
+
+        let result = make_rotation_context(
+            &sync,
+            &[],
+            &[],
+            UpgradeTokenAction::CreateIfNeeded,
+            &mut ctx,
+        );
+
+        let rotation_ctx = result.expect("should succeed");
+        assert!(rotation_ctx.creates_v2_upgrade_token);
+        assert_eq!(rotation_ctx.v1_organization_memberships.len(), 1);
+        assert_org_membership_eq(&rotation_ctx.v1_organization_memberships[0], &expected_org);
+    }
+
+    #[test]
+    fn test_make_rotation_context_untrusted_org_v2_user_returns_error() {
+        let store: KeyStore<KeySlotIds> = KeyStore::default();
+        let mut ctx = store.context_mut();
+        let user_key = ctx.make_symmetric_key(SymmetricKeyAlgorithm::XAes256Gcm);
+        ctx.persist_symmetric_key(user_key, SymmetricKeySlotId::User)
+            .expect("persisting the user key should work");
+        let (org, _) = make_org_membership(&mut ctx);
+        let sync = make_test_sync(vec![org], vec![], &mut ctx);
+
+        let result = make_rotation_context(
+            &sync,
+            &[],
+            &[],
+            UpgradeTokenAction::CreateIfNeeded,
+            &mut ctx,
+        );
+
+        assert!(matches!(result, Err(RotateUserKeysError::UntrustedKey)));
+    }
+
+    #[test]
+    fn test_make_rotation_context_untrusted_emergency_access_with_upgrade_token_returns_error() {
+        let store: KeyStore<KeySlotIds> = KeyStore::default();
+        let mut ctx = store.context_mut();
+        let user_key = ctx.make_symmetric_key(SymmetricKeyAlgorithm::Aes256CbcHmac);
+        ctx.persist_symmetric_key(user_key, SymmetricKeySlotId::User)
+            .expect("persisting the user key should work");
+        let (ea, _) = make_ea_membership(&mut ctx);
+        let sync = make_test_sync(vec![], vec![ea], &mut ctx);
+
+        let result = make_rotation_context(
+            &sync,
+            &[],
+            &[],
+            UpgradeTokenAction::CreateIfNeeded,
+            &mut ctx,
+        );
+
+        assert!(matches!(result, Err(RotateUserKeysError::UntrustedKey)));
     }
 
     #[test]
@@ -328,7 +514,13 @@ mod tests {
         let expected_ea = ea.clone();
         let sync = make_test_sync(vec![org], vec![ea], &mut ctx);
 
-        let result = make_rotation_context(&sync, &trusted_orgs, &trusted_eas, &mut ctx);
+        let result = make_rotation_context(
+            &sync,
+            &trusted_orgs,
+            &trusted_eas,
+            UpgradeTokenAction::Skip,
+            &mut ctx,
+        );
 
         let rotation_ctx = result.expect("should succeed");
         assert_eq!(rotation_ctx.v1_organization_memberships.len(), 1);
@@ -352,7 +544,7 @@ mod tests {
         let (org, _) = make_org_membership(&mut ctx);
         let sync = make_test_sync(vec![org], vec![], &mut ctx);
 
-        let result = make_rotation_context(&sync, &[], &[], &mut ctx);
+        let result = make_rotation_context(&sync, &[], &[], UpgradeTokenAction::Skip, &mut ctx);
 
         assert!(matches!(result, Err(RotateUserKeysError::UntrustedKey)));
     }
@@ -364,7 +556,7 @@ mod tests {
         let (ea, _) = make_ea_membership(&mut ctx);
         let sync = make_test_sync(vec![], vec![ea], &mut ctx);
 
-        let result = make_rotation_context(&sync, &[], &[], &mut ctx);
+        let result = make_rotation_context(&sync, &[], &[], UpgradeTokenAction::Skip, &mut ctx);
 
         assert!(matches!(result, Err(RotateUserKeysError::UntrustedKey)));
     }

--- a/crates/bitwarden-user-crypto-management/src/key_rotation/unlock.rs
+++ b/crates/bitwarden-user-crypto-management/src/key_rotation/unlock.rs
@@ -17,9 +17,7 @@ use bitwarden_core::{
     },
     require,
 };
-use bitwarden_crypto::{
-    Kdf, KeyStoreContext, PublicKey, SpkiPublicKeyBytes, SymmetricKeyAlgorithm, UnsignedSharedKey,
-};
+use bitwarden_crypto::{Kdf, KeyStoreContext, PublicKey, SpkiPublicKeyBytes, UnsignedSharedKey};
 use bitwarden_encoding::B64;
 use serde::{Deserialize, Serialize};
 use tracing::{debug, debug_span, error, info};
@@ -28,7 +26,6 @@ use tsify::Tsify;
 
 use crate::key_rotation::{
     KeyRotationDataParseError, partial_rotateable_keyset::PartialRotateableKeyset,
-    rotate_user_keys::UpgradeTokenAction,
 };
 
 /// The data necessary to re-share the user-key to a V1 emergency access membership. Note: The
@@ -142,7 +139,7 @@ pub(super) fn reencrypt_master_password_change_unlock_data(
         input.common_unlock_data,
         current_user_key_id,
         new_user_key_id,
-        UpgradeTokenAction::Skip,
+        false,
         ctx,
     )?;
 
@@ -159,11 +156,12 @@ pub(super) fn reencrypt_master_password_change_unlock_data(
     })
 }
 
+/// Re-encrypts the unlock methods that every key rotation flow shares.
 pub(super) fn reencrypt_common_unlock_data(
     input: ReencryptCommonUnlockDataInput,
     current_user_key_id: SymmetricKeySlotId,
     new_user_key_id: SymmetricKeySlotId,
-    upgrade_token_action: UpgradeTokenAction,
+    creates_v2_upgrade_token: bool,
     ctx: &mut KeyStoreContext<KeySlotIds>,
 ) -> Result<CommonUnlockDataRequestModel, ReencryptError> {
     let tde_device_unlock_data = reencrypt_tde_devices(
@@ -180,13 +178,16 @@ pub(super) fn reencrypt_common_unlock_data(
     )?;
     let emergency_accesses =
         reencrypt_emergency_access_keys(input.trusted_emergency_access_keys, new_user_key_id, ctx)?;
-    let organizations_memberships =
-        reencrypt_organization_memberships(input.trusted_organization_keys, new_user_key_id, ctx)?;
+    let organizations_memberships = if creates_v2_upgrade_token {
+        defer_organization_account_recovery_to_admins(input.trusted_organization_keys)
+    } else {
+        reencrypt_organization_memberships(input.trusted_organization_keys, new_user_key_id, ctx)?
+    };
 
     let upgrade_token = make_upgrade_token_if_needed(
         current_user_key_id,
         new_user_key_id,
-        upgrade_token_action,
+        creates_v2_upgrade_token,
         ctx,
     )?;
 
@@ -291,6 +292,29 @@ fn reencrypt_organization_memberships(
         .collect()
 }
 
+/// Leaves account recovery for organization admins to update, so the user is not involved.
+///
+/// Sending no key keeps the one the organization already holds. The organizations are still listed.
+/// Leaving them out would look like the user is no longer enrolled.
+fn defer_organization_account_recovery_to_admins(
+    organization_memberships: Vec<V1OrganizationMembership>,
+) -> Vec<ResetPasswordWithOrgIdRequestModel> {
+    organization_memberships
+        .into_iter()
+        .map(|org_membership| {
+            debug!(
+                organization = ?org_membership.organization_id,
+                "Leaving account recovery for organization admins to update",
+            );
+            ResetPasswordWithOrgIdRequestModel {
+                reset_password_key: None,
+                master_password_hash: None,
+                organization_id: org_membership.organization_id,
+            }
+        })
+        .collect()
+}
+
 fn reencrypt_userkey_for_masterpassword_unlock(
     password: String,
     hint: Option<String>,
@@ -361,29 +385,19 @@ fn to_authentication_and_unlock_data(
 fn make_upgrade_token_if_needed(
     current_user_key_id: SymmetricKeySlotId,
     new_user_key_id: SymmetricKeySlotId,
-    upgrade_token_action: UpgradeTokenAction,
+    creates_v2_upgrade_token: bool,
     ctx: &mut KeyStoreContext<KeySlotIds>,
 ) -> Result<Option<Box<V2UpgradeTokenRequestModel>>, ReencryptError> {
-    if matches!(upgrade_token_action, UpgradeTokenAction::Skip) {
-        debug!("UpgradeTokenAction::Skip, skipping upgrade token creation");
+    if !creates_v2_upgrade_token {
         return Ok(None);
     }
 
-    match (
-        ctx.get_symmetric_key_algorithm(current_user_key_id),
-        ctx.get_symmetric_key_algorithm(new_user_key_id),
-    ) {
-        (Ok(SymmetricKeyAlgorithm::Aes256CbcHmac), Ok(SymmetricKeyAlgorithm::XAes256Gcm)) => {
-            let token =
-                V2UpgradeToken::create(current_user_key_id, new_user_key_id, ctx).map_err(|e| {
-                    error!("Failed to create V2 upgrade token: {e}");
-                    ReencryptError::UpgradeTokenCreation
-                })?;
-            info!("Upgrade token created for the key rotation");
-            Ok(Some(Box::new(token.into())))
-        }
-        _ => Ok(None),
-    }
+    let token = V2UpgradeToken::create(current_user_key_id, new_user_key_id, ctx).map_err(|e| {
+        error!("Failed to create V2 upgrade token: {e}");
+        ReencryptError::UpgradeTokenCreation
+    })?;
+    info!("Upgrade token created for the key rotation");
+    Ok(Some(Box::new(token.into())))
 }
 
 #[cfg(test)]
@@ -392,7 +406,9 @@ mod tests {
 
     use bitwarden_api_api::models::KdfType;
     use bitwarden_core::key_management::KeySlotIds;
-    use bitwarden_crypto::{Kdf, KeyStore, PublicKeyEncryptionAlgorithm, UnsignedSharedKey};
+    use bitwarden_crypto::{
+        Kdf, KeyStore, PublicKeyEncryptionAlgorithm, SymmetricKeyAlgorithm, UnsignedSharedKey,
+    };
     use uuid::Uuid;
 
     use super::*;
@@ -557,7 +573,7 @@ mod tests {
             },
             current_user_key_id,
             new_user_key_id,
-            UpgradeTokenAction::CreateIfNeeded,
+            false,
             &mut ctx,
         );
 
@@ -598,7 +614,7 @@ mod tests {
             },
             current_user_key_id,
             new_user_key_id,
-            UpgradeTokenAction::CreateIfNeeded,
+            false,
             &mut ctx,
         );
 
@@ -648,7 +664,7 @@ mod tests {
             },
             current_user_key_id,
             new_user_key_id,
-            UpgradeTokenAction::CreateIfNeeded,
+            false,
             &mut ctx,
         );
 
@@ -696,7 +712,7 @@ mod tests {
             },
             current_user_key_id,
             new_user_key_id,
-            UpgradeTokenAction::CreateIfNeeded,
+            false,
             &mut ctx,
         );
 
@@ -720,6 +736,50 @@ mod tests {
     }
 
     #[test]
+    fn test_reencrypt_unlock_organization_membership_data_with_upgrade_token_sends_no_key() {
+        let store: KeyStore<KeySlotIds> = KeyStore::default();
+        let mut ctx = store.context_mut();
+
+        let current_user_key_id = ctx.make_symmetric_key(SymmetricKeyAlgorithm::Aes256CbcHmac);
+        let new_user_key_id = ctx.make_symmetric_key(SymmetricKeyAlgorithm::XAes256Gcm);
+
+        let org_key = ctx.make_private_key(PublicKeyEncryptionAlgorithm::RsaOaepSha1);
+        let organization_id = Uuid::new_v4();
+        let org_membership = V1OrganizationMembership {
+            organization_id,
+            name: "Test Org".to_string(),
+            public_key: ctx.get_public_key(org_key).expect("key exists"),
+        };
+
+        let result = reencrypt_common_unlock_data(
+            ReencryptCommonUnlockDataInput {
+                trusted_devices: vec![],
+                webauthn_credentials: vec![],
+                trusted_organization_keys: vec![org_membership],
+                trusted_emergency_access_keys: vec![],
+            },
+            current_user_key_id,
+            new_user_key_id,
+            true,
+            &mut ctx,
+        );
+
+        let unlock_data = result.expect("should be ok");
+
+        let org_membership_unlock = unlock_data
+            .organization_account_recovery_unlock_data
+            .as_ref()
+            .expect("should be present");
+        assert_eq!(org_membership_unlock.len(), 1);
+        assert_eq!(org_membership_unlock[0].organization_id, organization_id);
+        assert!(
+            org_membership_unlock[0].reset_password_key.is_none(),
+            "account recovery is left for organization admins to update"
+        );
+        assert!(org_membership_unlock[0].master_password_hash.is_none());
+    }
+
+    #[test]
     fn test_reencrypt_common_unlock_data_v1_to_v2_creates_upgrade_token() {
         let store: KeyStore<KeySlotIds> = KeyStore::default();
         let mut ctx = store.context_mut();
@@ -731,7 +791,7 @@ mod tests {
             empty_common_unlock_input(),
             current_user_key_id,
             new_user_key_id,
-            UpgradeTokenAction::CreateIfNeeded,
+            true,
             &mut ctx,
         );
 
@@ -753,7 +813,7 @@ mod tests {
     }
 
     #[test]
-    fn test_reencrypt_common_unlock_data_v1_to_v2_upgrade_token_action_skip_returns_none() {
+    fn test_reencrypt_common_unlock_data_without_upgrade_token_returns_none() {
         let store: KeyStore<KeySlotIds> = KeyStore::default();
         let mut ctx = store.context_mut();
 
@@ -764,39 +824,12 @@ mod tests {
             empty_common_unlock_input(),
             current_user_key_id,
             new_user_key_id,
-            UpgradeTokenAction::Skip,
+            false,
             &mut ctx,
         );
 
         let unlock_data = result.expect("should be ok");
-        assert!(
-            unlock_data.v2_upgrade_token.is_none(),
-            "UpgradeTokenAction::Skip skips the creation of the upgrade token"
-        );
-    }
-
-    #[test]
-    fn test_reencrypt_common_unlock_data_v2_to_v2_upgrade_token_action_create_if_needed_returns_none()
-     {
-        let store: KeyStore<KeySlotIds> = KeyStore::default();
-        let mut ctx = store.context_mut();
-
-        let current_user_key_id = ctx.make_symmetric_key(SymmetricKeyAlgorithm::XAes256Gcm);
-        let new_user_key_id = ctx.make_symmetric_key(SymmetricKeyAlgorithm::XAes256Gcm);
-
-        let result = reencrypt_common_unlock_data(
-            empty_common_unlock_input(),
-            current_user_key_id,
-            new_user_key_id,
-            UpgradeTokenAction::CreateIfNeeded,
-            &mut ctx,
-        );
-
-        let unlock_data = result.expect("should be ok");
-        assert!(
-            unlock_data.v2_upgrade_token.is_none(),
-            "UpgradeTokenAction::CreateIfNeeded should not create a v2_upgrade_token for V2 -> V2 rotation"
-        );
+        assert!(unlock_data.v2_upgrade_token.is_none());
     }
 
     fn make_valid_public_key_b64() -> String {


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-39455

## 📔 Objective

When forced user key rotation creates a V2 upgrade token, the client sends no new account recovery key. It sends one entry per enrolled organization with an empty key, so the server keeps the key the organization already holds. Later, organization admins update that key from the token.
This prevents showing a trust prompt to the user and prevents sharing it's new user key with server (who provides public key of the organization, hence could be swapped by malicious server).

Requires https://github.com/bitwarden/server/pull/8174, since at the moment server will reject a request with null account recovery key (also known as reset password key).

Note for reviewers:
- Should the v2 upgrade token creation (and request creation) still live in `unlock.rs` module ? It is no longer just unlock.
- ~~The org trust dialog shows first in clients, before the SDK key rotation. To my understanding this change is part of https://bitwarden.atlassian.net/browse/PM-30160 (there are mobile tickets too), but as a result all clients will need to know whether user is part of org and whether that org member have account recover enabled for that user. This is already known as part of sync / profile response from server. This fragments many clients, but could instead be lifted into SDK.~~ This is already part of SDK and in use by clients.

## 🚨 Breaking Changes

None expected, V2 key rotation is behind a feature flag in clients, none exists in prod at this moment.
The https://github.com/bitwarden/server/pull/8174 introduces a change to forced user key rotation request, which changes the `ResetPasswordWithOrgIdRequestModel` into `OrganizationUserAccountRecoveryRequestModel` (identical in payload). A compilation error is expected once the server change is merged and automated api models are updated in SDK, but since it's trivial to fix (just change the struct), it will be addressed immediately / as part of this PR later.

<!-- Does this PR introduce any breaking changes? If so, please describe the impact and migration path for clients.

If you're unsure, the automated TypeScript compatibility check will run when you open/update this PR and provide feedback.

For breaking changes:
1. Describe what changed in the client interface
2. Explain why the change was necessary
3. Provide migration steps for client developers
4. Link to any paired client PRs if needed

Otherwise, you can remove this section. -->
