### PR TITLE
Push bindings updates with GH App token so CI re-runs

### DIFF
--- a/.github/workflows/update-api-bindings.yml
+++ b/.github/workflows/update-api-bindings.yml
@@ -79,6 +79,9 @@ jobs:
         with:
           app-id: ${{ steps.get-kv-secrets.outputs.BW-GHAPP-ID }}
           private-key: ${{ steps.get-kv-secrets.outputs.BW-GHAPP-KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: sdk-internal
+          permission-contents: write
           permission-pull-requests: write
 
       - name: Download json artifacts from server for updated bindings
@@ -224,11 +227,16 @@ jobs:
         env:
           _HASH: ${{ steps.commit-info.outputs.HASH }}
           _BRANCH_NAME: ${{ steps.switch-api-branch.outputs.branch_name }}
+          _APP_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           echo "👀 Committing API bindings update..."
           git add crates/bitwarden-api-api
           git commit -m "Update API bindings to $_HASH" --no-verify || echo "No changes to commit for API"
-          git push --force-with-lease origin $_BRANCH_NAME
+          # Push via the GH App token so pull_request synchronize cascades to CI —
+          # GITHUB_TOKEN pushes are silently ignored by the recursion guard.
+          git push --force-with-lease \
+            "https://x-access-token:${_APP_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" \
+            "$_BRANCH_NAME"
 
       - name: Create or Update API Pull Request
         if: ${{ inputs.binding_type == 'api' || inputs.binding_type == 'both' || !inputs.binding_type }}
@@ -335,11 +343,16 @@ jobs:
         env:
           _HASH: ${{ steps.commit-info.outputs.HASH }}
           _BRANCH_NAME: ${{ steps.switch-identity-branch.outputs.branch_name }}
+          _APP_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           echo "👀 Committing Identity bindings update..."
           git add crates/bitwarden-api-identity
           git commit -m "Update Identity bindings to $_HASH" --no-verify || echo "No changes to commit for Identity"
-          git push --force-with-lease origin $_BRANCH_NAME
+          # Push via the GH App token so pull_request synchronize cascades to CI —
+          # GITHUB_TOKEN pushes are silently ignored by the recursion guard.
+          git push --force-with-lease \
+            "https://x-access-token:${_APP_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" \
+            "$_BRANCH_NAME"
 
       - name: Create or Update Identity Pull Request
         if: ${{ inputs.binding_type == 'identity' || inputs.binding_type == 'both' || !inputs.binding_type }}

--- a/.github/workflows/update-api-bindings.yml
+++ b/.github/workflows/update-api-bindings.yml
@@ -232,10 +232,12 @@ jobs:
           echo "👀 Committing API bindings update..."
           git add crates/bitwarden-api-api
           git commit -m "Update API bindings to $_HASH" --no-verify || echo "No changes to commit for API"
-          # Push via the GH App token so pull_request synchronize cascades to CI —
-          # GITHUB_TOKEN pushes are silently ignored by the recursion guard.
-          git remote set-url origin "https://x-access-token:${_APP_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
-          git push --force-with-lease origin "$_BRANCH_NAME"
+          # Push authenticated as the GH App so pull_request synchronize on the
+          # bindings PR isn't gated as action_required. Overrides actions/checkout's
+          # persisted GITHUB_TOKEN extraheader for just this git invocation.
+          AUTH_HEADER="AUTHORIZATION: basic $(printf 'x-access-token:%s' "${_APP_TOKEN}" | base64 -w0)"
+          git -c "http.https://github.com/.extraheader=${AUTH_HEADER}" \
+            push --force-with-lease origin "$_BRANCH_NAME"
 
       - name: Create or Update API Pull Request
         if: ${{ inputs.binding_type == 'api' || inputs.binding_type == 'both' || !inputs.binding_type }}
@@ -347,10 +349,11 @@ jobs:
           echo "👀 Committing Identity bindings update..."
           git add crates/bitwarden-api-identity
           git commit -m "Update Identity bindings to $_HASH" --no-verify || echo "No changes to commit for Identity"
-          # Push via the GH App token so pull_request synchronize cascades to CI —
-          # GITHUB_TOKEN pushes are silently ignored by the recursion guard.
-          git remote set-url origin "https://x-access-token:${_APP_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
-          git push --force-with-lease origin "$_BRANCH_NAME"
+          # Push authenticated as the GH App so pull_request synchronize on the
+          # bindings PR isn't gated as action_required.
+          AUTH_HEADER="AUTHORIZATION: basic $(printf 'x-access-token:%s' "${_APP_TOKEN}" | base64 -w0)"
+          git -c "http.https://github.com/.extraheader=${AUTH_HEADER}" \
+            push --force-with-lease origin "$_BRANCH_NAME"
 
       - name: Create or Update Identity Pull Request
         if: ${{ inputs.binding_type == 'identity' || inputs.binding_type == 'both' || !inputs.binding_type }}

--- a/.github/workflows/update-api-bindings.yml
+++ b/.github/workflows/update-api-bindings.yml
@@ -232,12 +232,13 @@ jobs:
           echo "👀 Committing API bindings update..."
           git add crates/bitwarden-api-api
           git commit -m "Update API bindings to $_HASH" --no-verify || echo "No changes to commit for API"
-          # Push authenticated as the GH App so pull_request synchronize on the
-          # bindings PR isn't gated as action_required. Overrides actions/checkout's
-          # persisted GITHUB_TOKEN extraheader for just this git invocation.
-          AUTH_HEADER="AUTHORIZATION: basic $(printf 'x-access-token:%s' "${_APP_TOKEN}" | base64 -w0)"
-          git -c "http.https://github.com/.extraheader=${AUTH_HEADER}" \
-            push --force-with-lease origin "$_BRANCH_NAME"
+          # Push authenticated as the GH App (not GITHUB_TOKEN) so pull_request
+          # synchronize on the bindings PR isn't gated as action_required.
+          # actions/checkout persists a GITHUB_TOKEN extraheader — drop it first
+          # so the app-token URL isn't sent alongside a duplicate Authorization.
+          git config --local --unset-all http.https://github.com/.extraheader
+          git remote set-url origin "https://x-access-token:${_APP_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+          git push --force-with-lease origin "$_BRANCH_NAME"
 
       - name: Create or Update API Pull Request
         if: ${{ inputs.binding_type == 'api' || inputs.binding_type == 'both' || !inputs.binding_type }}
@@ -349,11 +350,12 @@ jobs:
           echo "👀 Committing Identity bindings update..."
           git add crates/bitwarden-api-identity
           git commit -m "Update Identity bindings to $_HASH" --no-verify || echo "No changes to commit for Identity"
-          # Push authenticated as the GH App so pull_request synchronize on the
-          # bindings PR isn't gated as action_required.
-          AUTH_HEADER="AUTHORIZATION: basic $(printf 'x-access-token:%s' "${_APP_TOKEN}" | base64 -w0)"
-          git -c "http.https://github.com/.extraheader=${AUTH_HEADER}" \
-            push --force-with-lease origin "$_BRANCH_NAME"
+          # Push authenticated as the GH App. Idempotent with the API step above —
+          # if API ran, the extraheader is already unset and origin URL already
+          # rewritten; if only identity runs, this step does it.
+          git config --local --unset-all http.https://github.com/.extraheader 2>/dev/null || true
+          git remote set-url origin "https://x-access-token:${_APP_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+          git push --force-with-lease origin "$_BRANCH_NAME"
 
       - name: Create or Update Identity Pull Request
         if: ${{ inputs.binding_type == 'identity' || inputs.binding_type == 'both' || !inputs.binding_type }}

--- a/.github/workflows/update-api-bindings.yml
+++ b/.github/workflows/update-api-bindings.yml
@@ -43,19 +43,6 @@ jobs:
           exit 0
           fi
 
-      - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          fetch-depth: 0
-          persist-credentials: true
-
-      - name: Capture base commit
-        id: base-commit
-        run: |
-          BASE_SHA=$(git rev-parse HEAD)
-          echo "sha=$BASE_SHA" >> $GITHUB_OUTPUT
-          echo "📌 Base commit: $BASE_SHA"
-
       - name: Log in to Azure
         uses: bitwarden/gh-actions/azure-login@main
         with:
@@ -83,6 +70,24 @@ jobs:
           repositories: sdk-internal
           permission-contents: write
           permission-pull-requests: write
+
+      # Check out with the GH App token so subsequent pushes are attributed to
+      # bw-ghapp[bot], which lets pull_request synchronize on the bindings PR
+      # cascade into CI without an action_required approval gate. Using
+      # GITHUB_TOKEN here would gate the downstream WASM/Android builds.
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          persist-credentials: true
+          token: ${{ steps.app-token.outputs.token }}
+
+      - name: Capture base commit
+        id: base-commit
+        run: |
+          BASE_SHA=$(git rev-parse HEAD)
+          echo "sha=$BASE_SHA" >> $GITHUB_OUTPUT
+          echo "📌 Base commit: $BASE_SHA"
 
       - name: Download json artifacts from server for updated bindings
         uses: bitwarden/gh-actions/download-artifacts@main
@@ -227,18 +232,11 @@ jobs:
         env:
           _HASH: ${{ steps.commit-info.outputs.HASH }}
           _BRANCH_NAME: ${{ steps.switch-api-branch.outputs.branch_name }}
-          _APP_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           echo "👀 Committing API bindings update..."
           git add crates/bitwarden-api-api
           git commit -m "Update API bindings to $_HASH" --no-verify || echo "No changes to commit for API"
-          # Push authenticated as the GH App (not GITHUB_TOKEN) so pull_request
-          # synchronize on the bindings PR isn't gated as action_required.
-          # actions/checkout persists a GITHUB_TOKEN extraheader — drop it first
-          # so the app-token URL isn't sent alongside a duplicate Authorization.
-          git config --local --unset-all http.https://github.com/.extraheader
-          git remote set-url origin "https://x-access-token:${_APP_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
-          git push --force-with-lease origin "$_BRANCH_NAME"
+          git push --force-with-lease origin $_BRANCH_NAME
 
       - name: Create or Update API Pull Request
         if: ${{ inputs.binding_type == 'api' || inputs.binding_type == 'both' || !inputs.binding_type }}
@@ -345,17 +343,11 @@ jobs:
         env:
           _HASH: ${{ steps.commit-info.outputs.HASH }}
           _BRANCH_NAME: ${{ steps.switch-identity-branch.outputs.branch_name }}
-          _APP_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           echo "👀 Committing Identity bindings update..."
           git add crates/bitwarden-api-identity
           git commit -m "Update Identity bindings to $_HASH" --no-verify || echo "No changes to commit for Identity"
-          # Push authenticated as the GH App. Idempotent with the API step above —
-          # if API ran, the extraheader is already unset and origin URL already
-          # rewritten; if only identity runs, this step does it.
-          git config --local --unset-all http.https://github.com/.extraheader 2>/dev/null || true
-          git remote set-url origin "https://x-access-token:${_APP_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
-          git push --force-with-lease origin "$_BRANCH_NAME"
+          git push --force-with-lease origin $_BRANCH_NAME
 
       - name: Create or Update Identity Pull Request
         if: ${{ inputs.binding_type == 'identity' || inputs.binding_type == 'both' || !inputs.binding_type }}

--- a/.github/workflows/update-api-bindings.yml
+++ b/.github/workflows/update-api-bindings.yml
@@ -234,9 +234,8 @@ jobs:
           git commit -m "Update API bindings to $_HASH" --no-verify || echo "No changes to commit for API"
           # Push via the GH App token so pull_request synchronize cascades to CI —
           # GITHUB_TOKEN pushes are silently ignored by the recursion guard.
-          git push --force-with-lease \
-            "https://x-access-token:${_APP_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" \
-            "$_BRANCH_NAME"
+          git remote set-url origin "https://x-access-token:${_APP_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+          git push --force-with-lease origin "$_BRANCH_NAME"
 
       - name: Create or Update API Pull Request
         if: ${{ inputs.binding_type == 'api' || inputs.binding_type == 'both' || !inputs.binding_type }}
@@ -350,9 +349,8 @@ jobs:
           git commit -m "Update Identity bindings to $_HASH" --no-verify || echo "No changes to commit for Identity"
           # Push via the GH App token so pull_request synchronize cascades to CI —
           # GITHUB_TOKEN pushes are silently ignored by the recursion guard.
-          git push --force-with-lease \
-            "https://x-access-token:${_APP_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" \
-            "$_BRANCH_NAME"
+          git remote set-url origin "https://x-access-token:${_APP_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+          git push --force-with-lease origin "$_BRANCH_NAME"
 
       - name: Create or Update Identity Pull Request
         if: ${{ inputs.binding_type == 'identity' || inputs.binding_type == 'both' || !inputs.binding_type }}


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-41826

## 📔 Objective

The **Update Bindings** workflow force-pushes `api-bindings-update` / `identity-bindings-update` whenever it re-runs. Because `actions/checkout` was called with the default `GITHUB_TOKEN`, those pushes were attributed to `github-actions[bot]`.  Github does not run downstream `pull_request synchronize` runs when the workflow is executed by the default bot, to avoid workflow circular execution loops. Symptoms:

- WASM / Android builds on the bindings PR queued as `action_required` and sat there until someone approved.
- The `<!-- SDK-BREAKING-CHANGE-CHECK -->` sticky comment stayed frozen on whatever SHA was current at `pull_request opened`, since `synchronize` events never ran to update it.
- Only fix was closing the PR and letting the workflow open a fresh one — which was exactly the manual step done to unstick the identity bindings PR earlier today (#1299 closed → #1372 opened fresh).

Root cause: pushes need to be attributed to a distinct bot identity (`bw-ghapp[bot]`) so downstream `pull_request synchronize` runs auto-approve.

## Changes

Same pattern already used by `.github/workflows/version-bump.yml` in this repo:

1. **Reorder steps**: `Azure login → KV secrets → generate GH App token → Checkout`. Previously the checkout ran first with default `GITHUB_TOKEN` credentials.
2. **`Checkout` uses the app token**: `token: ${{ steps.app-token.outputs.token }}`. Every git operation in the workflow — fetch, reset, push — now uses the same `bw-ghapp[bot]` identity.
3. **Scope the app token to this repo**: add `owner`, `repositories: sdk-internal`, and `permission-contents: write`. Previously the token was minted for the whole `bw-ghapp` installation with only `pull-requests: write`.

The two commit/push steps themselves are **unchanged** — plain `git push --force-with-lease origin $_BRANCH_NAME`. No URL rewriting, no header override, no mid-flow credential swap. The identity switch happens once at checkout.

## Security notes

- **No new capability at the job level.** The job already declared `contents: write` at line 33-34; this PR just adopts it under `bw-ghapp[bot]` instead of `github-actions[bot]`.
- **App-token scope tightened** to just `sdk-internal` (was: the whole installation). Least-privilege improvement over the prior state.
- **Recursion-guard bypass is scoped and safe.** The `pull_request synchronize` runs on `api-bindings-update` / `identity-bindings-update` are WASM build, Android build, and the breaking-change checker — none push back to this repo, so no loop is possible.
- **`action_required` approval gate is removed.** That gate was shallow — approvers weren't reviewing bindings correctness, and `main` still requires human review before merge.
- **Bot-identity guard preserved.** `git config user.email` on line 158-159 is unchanged, so the "last committer must be `bw-ghapp[bot]`" gate at lines 187 and 298 still works.

## Verified end-to-end pre-merge

Dispatched **Update Bindings** from this branch against `binding_type=api`. Result:

- Workflow completed green: [run 31419282388](https://github.com/bitwarden/sdk-internal/actions/runs/31419282388).
- Force-push to `api-bindings-update` landed as commit `36220f235a`, authored by `bw-ghapp[bot]`.
- Downstream WASM / Android / lint runs on the new head SHA started **automatically with `triggering_actor: bw-ghapp[bot]`, status `in_progress`, no `action_required` gate**. That's the whole fix, working.

Confirms the `bw-ghapp` installation already has `contents: write` on `sdk-internal` (else `create-github-app-token` would have failed at mint time).

## 🚨 Breaking Changes

None.

## Test plan

- [x] `Update Bindings` workflow runs green end-to-end when dispatched from this branch.
- [x] Push to `api-bindings-update` is attributed to `bw-ghapp[bot]`.
- [x] Downstream `pull_request synchronize` runs on the bindings PR execute automatically (no `action_required`).
- [x] After merge, next cron run (Monday 04:00 UTC on even weeks) exercises the same path on both `api` and `identity`.