### PR TITLE
[PM-41071] Remove cipher key encryption flag

### DIFF
--- a/crates/bitwarden-core/src/client/flags.rs
+++ b/crates/bitwarden-core/src/client/flags.rs
@@ -9,10 +9,6 @@
 #[derive(Debug, Default, Clone, serde::Serialize, serde::Deserialize)]
 #[serde(default, rename_all = "kebab-case")]
 pub struct Flags {
-    /// Enable cipher key encryption.
-    #[serde(alias = "enableCipherKeyEncryption", alias = "cipher-key-encryption")]
-    pub enable_cipher_key_encryption: bool,
-
     /// Enable strict cipher field decryption (propagates errors instead of nulling fields).
     #[serde(alias = "pm-34500-strict-cipher-decryption")]
     pub strict_cipher_decryption: bool,
@@ -41,23 +37,23 @@ mod tests {
     fn test_load_empty_map() {
         let map = std::collections::HashMap::new();
         let flags = Flags::load_from_map(map);
-        assert!(!flags.enable_cipher_key_encryption);
+        assert!(!flags.strict_cipher_decryption);
     }
 
     #[test]
     fn test_load_valid_map() {
         let mut map = std::collections::HashMap::new();
-        map.insert("enableCipherKeyEncryption".into(), true);
+        map.insert("strict-cipher-decryption".into(), true);
         let flags = Flags::load_from_map(map);
-        assert!(flags.enable_cipher_key_encryption);
+        assert!(flags.strict_cipher_decryption);
     }
 
     #[test]
     fn test_load_valid_map_alias() {
         let mut map = std::collections::HashMap::new();
-        map.insert("cipher-key-encryption".into(), true);
+        map.insert("pm-34500-strict-cipher-decryption".into(), true);
         let flags = Flags::load_from_map(map);
-        assert!(flags.enable_cipher_key_encryption);
+        assert!(flags.strict_cipher_decryption);
     }
 
     #[test]
@@ -65,6 +61,6 @@ mod tests {
         let mut map = std::collections::HashMap::new();
         map.insert("thisIsNotAFlag".into(), true);
         let flags = Flags::load_from_map(map);
-        assert!(!flags.enable_cipher_key_encryption);
+        assert!(!flags.strict_cipher_decryption);
     }
 }

--- a/crates/bitwarden-core/src/client/flags_client.rs
+++ b/crates/bitwarden-core/src/client/flags_client.rs
@@ -158,18 +158,15 @@ mod tests {
 
         // With no flags loaded yet, get should return defaults.
         let initial = client.flags().get().await;
-        assert!(!initial.enable_cipher_key_encryption);
         assert!(!initial.strict_cipher_decryption);
 
         // Loading flags should persist them via the FLAGS setting.
         let mut map = HashMap::new();
-        map.insert("enableCipherKeyEncryption".to_string(), true);
         map.insert("pm-34500-strict-cipher-decryption".to_string(), true);
         client.flags().load(map).await;
 
         // get should now return the loaded values.
         let loaded = client.flags().get().await;
-        assert!(loaded.enable_cipher_key_encryption);
         assert!(loaded.strict_cipher_decryption);
 
         // The values should be readable directly from the setting too.
@@ -182,7 +179,6 @@ mod tests {
             .await
             .unwrap()
             .expect("flags should be persisted after load");
-        assert!(persisted.enable_cipher_key_encryption);
         assert!(persisted.strict_cipher_decryption);
     }
 
@@ -192,7 +188,7 @@ mod tests {
         Mock::given(method("GET"))
             .and(path("/config"))
             .respond_with(ResponseTemplate::new(200).set_body_json(json!({
-                "featureStates": { "enableCipherKeyEncryption": true }
+                "featureStates": { "pm-34500-strict-cipher-decryption": true }
             })))
             .expect(1)
             .mount(&server)
@@ -202,7 +198,7 @@ mod tests {
         let before = Utc::now();
         client.flags().fetch(true).await.unwrap();
 
-        assert!(client.flags().get().await.enable_cipher_key_encryption);
+        assert!(client.flags().get().await.strict_cipher_decryption);
         let fetched_at = read_fetched_at(&client)
             .await
             .expect("fetched_at must be set after a successful fetch");
@@ -247,7 +243,7 @@ mod tests {
         Mock::given(method("GET"))
             .and(path("/config"))
             .respond_with(ResponseTemplate::new(200).set_body_json(json!({
-                "featureStates": { "enableCipherKeyEncryption": true }
+                "featureStates": { "pm-34500-strict-cipher-decryption": true }
             })))
             .expect(1)
             .mount(&server)
@@ -259,7 +255,7 @@ mod tests {
 
         client.flags().fetch(false).await.unwrap();
 
-        assert!(client.flags().get().await.enable_cipher_key_encryption);
+        assert!(client.flags().get().await.strict_cipher_decryption);
         let fetched_at = read_fetched_at(&client).await.unwrap();
         assert!(fetched_at > stale);
     }
@@ -277,14 +273,14 @@ mod tests {
         client
             .flags()
             .load(HashMap::from([(
-                "enableCipherKeyEncryption".to_string(),
+                "pm-34500-strict-cipher-decryption".to_string(),
                 true,
             )]))
             .await;
 
         assert!(client.flags().fetch(true).await.is_err());
         assert!(
-            client.flags().get().await.enable_cipher_key_encryption,
+            client.flags().get().await.strict_cipher_decryption,
             "previously persisted flags must survive a failed fetch"
         );
     }

--- a/crates/bitwarden-core/src/client/test_accounts.rs
+++ b/crates/bitwarden-core/src/client/test_accounts.rs
@@ -61,14 +61,6 @@ impl Client {
 
     async fn init_test_account_on(client: Client, account: TestAccount) -> Self {
         client
-            .flags()
-            .load(HashMap::from([(
-                "enableCipherKeyEncryption".to_owned(),
-                true,
-            )]))
-            .await;
-
-        client
             .crypto()
             .initialize_user_crypto(account.user)
             .await

--- a/crates/bitwarden-core/src/client/test_accounts.rs
+++ b/crates/bitwarden-core/src/client/test_accounts.rs
@@ -67,14 +67,6 @@ impl Client {
 
     async fn init_test_account_on(client: Client, account: TestAccount) -> Self {
         client
-            .flags()
-            .load(HashMap::from([(
-                "enableCipherKeyEncryption".to_owned(),
-                true,
-            )]))
-            .await;
-
-        client
             .crypto()
             .initialize_user_crypto(account.user)
             .await

--- a/crates/bitwarden-importers/src/pipeline.rs
+++ b/crates/bitwarden-importers/src/pipeline.rs
@@ -453,6 +453,8 @@ mod tests {
         }));
         let cipher = encrypt_import(&mut ctx, importing("GitHub", login), None).unwrap();
 
+        // Imported ciphers carry their own cipher key
+        assert!(cipher.key.is_some());
         assert_ne!(cipher.name.unwrap().to_string(), "GitHub");
     }
 }

--- a/crates/bitwarden-importers/src/pipeline.rs
+++ b/crates/bitwarden-importers/src/pipeline.rs
@@ -454,6 +454,8 @@ mod tests {
             encrypt_import(&mut ctx, importing("GitHub", login), None, user_id).unwrap();
 
         assert_eq!(encrypted.encrypted_for, user_id);
+        // Imported ciphers carry their own cipher key
+        assert!(encrypted.cipher.key.is_some());
         assert_ne!(encrypted.cipher.name.unwrap().to_string(), "GitHub");
     }
 }

--- a/crates/bitwarden-uniffi/src/vault/ciphers.rs
+++ b/crates/bitwarden-uniffi/src/vault/ciphers.rs
@@ -2,7 +2,6 @@ use bitwarden_collections::collection::CollectionId;
 use bitwarden_core::OrganizationId;
 use bitwarden_vault::{
     Cipher, CipherListView, CipherView, DecryptCipherListResult, EncryptionContext,
-    Fido2CredentialView,
 };
 
 use crate::Result;

--- a/crates/bitwarden-user-crypto-management/src/key_rotation/data.rs
+++ b/crates/bitwarden-user-crypto-management/src/key_rotation/data.rs
@@ -379,6 +379,35 @@ mod tests {
         );
     }
 
+    /// Builds a legacy cipher whose fields are encrypted directly under `key`, with no per-cipher
+    /// key. Encrypting a `CipherView` always produces one now, so this shape — which still exists
+    /// server-side for vaults predating per-cipher keys — has to be constructed by hand.
+    fn make_keyless_legacy_cipher(
+        view: &bitwarden_vault::CipherView,
+        key: bitwarden_core::key_management::SymmetricKeySlotId,
+        ctx: &mut bitwarden_crypto::KeyStoreContext<KeySlotIds>,
+    ) -> Cipher {
+        use bitwarden_crypto::PrimitiveEncryptable;
+        use bitwarden_vault::Login;
+
+        let login = view.login.as_ref().unwrap();
+
+        Cipher {
+            name: Some(view.name.encrypt(ctx, key).unwrap()),
+            notes: view.notes.encrypt(ctx, key).unwrap(),
+            login: Some(Login {
+                username: login.username.encrypt(ctx, key).unwrap(),
+                password: login.password.encrypt(ctx, key).unwrap(),
+                password_revision_date: None,
+                uris: None,
+                totp: None,
+                autofill_on_page_load: None,
+                fido2_credentials: None,
+            }),
+            ..make_test_cipher(None)
+        }
+    }
+
     #[test]
     fn test_ciphers() {
         let store: KeyStore<KeySlotIds> = KeyStore::default();
@@ -390,9 +419,8 @@ mod tests {
             ctx.make_symmetric_key(bitwarden_crypto::SymmetricKeyAlgorithm::Aes256CbcHmac);
 
         let cipher = make_cipher_view();
-        let encrypted_cipher = EncryptMode::Legacy(cipher.clone())
-            .encrypt_composite(&mut ctx, user_key_old)
-            .unwrap();
+        let encrypted_cipher = make_keyless_legacy_cipher(&cipher, user_key_old, &mut ctx);
+        assert!(encrypted_cipher.key.is_none());
 
         // Rotate it
         let ciphers = vec![encrypted_cipher];

--- a/crates/bitwarden-user-crypto-management/src/key_rotation/data.rs
+++ b/crates/bitwarden-user-crypto-management/src/key_rotation/data.rs
@@ -370,6 +370,35 @@ mod tests {
         );
     }
 
+    /// Builds a legacy cipher whose fields are encrypted directly under `key`, with no per-cipher
+    /// key. Encrypting a `CipherView` always produces one now, so this shape — which still exists
+    /// server-side for vaults predating per-cipher keys — has to be constructed by hand.
+    fn make_keyless_legacy_cipher(
+        view: &bitwarden_vault::CipherView,
+        key: bitwarden_core::key_management::SymmetricKeySlotId,
+        ctx: &mut bitwarden_crypto::KeyStoreContext<KeySlotIds>,
+    ) -> Cipher {
+        use bitwarden_crypto::PrimitiveEncryptable;
+        use bitwarden_vault::Login;
+
+        let login = view.login.as_ref().unwrap();
+
+        Cipher {
+            name: Some(view.name.encrypt(ctx, key).unwrap()),
+            notes: view.notes.encrypt(ctx, key).unwrap(),
+            login: Some(Login {
+                username: login.username.encrypt(ctx, key).unwrap(),
+                password: login.password.encrypt(ctx, key).unwrap(),
+                password_revision_date: None,
+                uris: None,
+                totp: None,
+                autofill_on_page_load: None,
+                fido2_credentials: None,
+            }),
+            ..make_test_cipher(None)
+        }
+    }
+
     #[test]
     fn test_ciphers() {
         let store: KeyStore<KeySlotIds> = KeyStore::default();
@@ -381,9 +410,8 @@ mod tests {
             ctx.make_symmetric_key(bitwarden_crypto::SymmetricKeyAlgorithm::Aes256CbcHmac);
 
         let cipher = make_cipher_view();
-        let encrypted_cipher = EncryptMode::Legacy(cipher.clone())
-            .encrypt_composite(&mut ctx, user_key_old)
-            .unwrap();
+        let encrypted_cipher = make_keyless_legacy_cipher(&cipher, user_key_old, &mut ctx);
+        assert!(encrypted_cipher.key.is_none());
 
         // Rotate it
         let ciphers = vec![encrypted_cipher];

--- a/crates/bitwarden-user-crypto-management/src/key_rotation/data.rs
+++ b/crates/bitwarden-user-crypto-management/src/key_rotation/data.rs
@@ -436,7 +436,7 @@ mod tests {
 
         // A legacy cipher that already carries a per-item cipher key
         let mut cipher = make_cipher_view();
-        cipher.generate_cipher_key(&mut ctx).unwrap();
+        let _ = cipher.load_cipher_key_slot(&mut ctx).unwrap();
         let encrypted = EncryptMode::Legacy(cipher.clone())
             .encrypt_composite(&mut ctx, user_key_old)
             .unwrap();

--- a/crates/bitwarden-user-crypto-management/src/key_rotation/data.rs
+++ b/crates/bitwarden-user-crypto-management/src/key_rotation/data.rs
@@ -445,7 +445,7 @@ mod tests {
 
         // A legacy cipher that already carries a per-item cipher key
         let mut cipher = make_cipher_view();
-        cipher.generate_cipher_key(&mut ctx).unwrap();
+        let _ = cipher.load_cipher_key_slot(&mut ctx).unwrap();
         let encrypted = EncryptMode::Legacy(cipher.clone())
             .encrypt_composite(&mut ctx, user_key_old)
             .unwrap();

--- a/crates/bitwarden-vault/src/cipher/blob/encryption.rs
+++ b/crates/bitwarden-vault/src/cipher/blob/encryption.rs
@@ -84,9 +84,8 @@ pub(crate) fn encrypt_blob_cipher(
 
 /// Variant of [`encrypt_blob_cipher`] that accepts an explicit outer wrapping
 /// key. Used by key rotation, where the new user/org key is installed under a
-/// `Local` slot id and `view.key` has been rewrapped under that slot — calling
-/// `key_identifier()` would resolve to the original `User`/`Organization` slot
-/// and fail to unwrap the CEK.
+/// `Local` slot id — `key_identifier()` would resolve to the original
+/// `User`/`Organization` slot and wrap the cipher key under the old key.
 pub(crate) fn encrypt_blob_cipher_with_wrapping_key(
     view: &mut CipherView,
     ctx: &mut KeyStoreContext<KeySlotIds>,
@@ -109,11 +108,7 @@ pub(crate) fn encrypt_blob_cipher_with_wrapping_key(
         organization_id: view.organization_id,
         folder_id: view.folder_id,
         collection_ids: view.collection_ids.clone(),
-        key: view
-            .key
-            .as_ref()
-            .map(|_| ctx.wrap_symmetric_key(wrapping_key, cipher_key))
-            .transpose()?,
+        key: Some(ctx.wrap_symmetric_key(wrapping_key, cipher_key)?),
         r#type: view.r#type,
         favorite: view.favorite,
         reprompt: view.reprompt,

--- a/crates/bitwarden-vault/src/cipher/blob/encryption.rs
+++ b/crates/bitwarden-vault/src/cipher/blob/encryption.rs
@@ -92,11 +92,7 @@ pub(crate) fn encrypt_blob_cipher_with_wrapping_key(
     ctx: &mut KeyStoreContext<KeySlotIds>,
     wrapping_key: SymmetricKeySlotId,
 ) -> Result<Cipher, BlobEncryptionError> {
-    if view.key.is_none() {
-        view.generate_cipher_key(ctx)?;
-    }
-
-    let cipher_key = view.load_cipher_key_slot(ctx, wrapping_key)?;
+    let cipher_key = view.load_cipher_key_slot(ctx)?;
 
     let sealed_string = seal_cipher(view, ctx, cipher_key)?;
 
@@ -314,11 +310,8 @@ mod tests {
         view.secure_note = Some(SecureNoteView {
             r#type: SecureNoteType::Generic,
         });
-        view.generate_cipher_key(&mut ctx).unwrap();
+        let cipher_key = view.load_cipher_key_slot(&mut ctx).unwrap();
 
-        let cipher_key = view
-            .load_cipher_key_slot(&mut ctx, view.key_identifier())
-            .unwrap();
         let sealed_string = seal_cipher(&view, &mut ctx, cipher_key).unwrap();
 
         let mut cipher = make_test_cipher_with_data(&mut ctx, Some(sealed_string));

--- a/crates/bitwarden-vault/src/cipher/blob/encryption.rs
+++ b/crates/bitwarden-vault/src/cipher/blob/encryption.rs
@@ -91,11 +91,7 @@ pub(crate) fn encrypt_blob_cipher_with_wrapping_key(
     ctx: &mut KeyStoreContext<KeySlotIds>,
     wrapping_key: SymmetricKeySlotId,
 ) -> Result<Cipher, BlobEncryptionError> {
-    if view.key.is_none() {
-        view.generate_cipher_key(ctx)?;
-    }
-
-    let cipher_key = view.load_cipher_key_slot(ctx, wrapping_key)?;
+    let cipher_key = view.load_cipher_key_slot(ctx)?;
 
     let sealed_string = seal_cipher(view, ctx, cipher_key)?;
 
@@ -309,11 +305,8 @@ mod tests {
         view.secure_note = Some(SecureNoteView {
             r#type: SecureNoteType::Generic,
         });
-        view.generate_cipher_key(&mut ctx).unwrap();
+        let cipher_key = view.load_cipher_key_slot(&mut ctx).unwrap();
 
-        let cipher_key = view
-            .load_cipher_key_slot(&mut ctx, view.key_identifier())
-            .unwrap();
         let sealed_string = seal_cipher(&view, &mut ctx, cipher_key).unwrap();
 
         let mut cipher = make_test_cipher_with_data(&mut ctx, Some(sealed_string));

--- a/crates/bitwarden-vault/src/cipher/blob/encryption.rs
+++ b/crates/bitwarden-vault/src/cipher/blob/encryption.rs
@@ -85,9 +85,8 @@ pub(crate) fn encrypt_blob_cipher(
 
 /// Variant of [`encrypt_blob_cipher`] that accepts an explicit outer wrapping
 /// key. Used by key rotation, where the new user/org key is installed under a
-/// `Local` slot id and `view.key` has been rewrapped under that slot — calling
-/// `key_identifier()` would resolve to the original `User`/`Organization` slot
-/// and fail to unwrap the CEK.
+/// `Local` slot id — `key_identifier()` would resolve to the original
+/// `User`/`Organization` slot and wrap the cipher key under the old key.
 pub(crate) fn encrypt_blob_cipher_with_wrapping_key(
     view: &mut CipherView,
     ctx: &mut KeyStoreContext<KeySlotIds>,
@@ -113,11 +112,7 @@ pub(crate) fn encrypt_blob_cipher_with_wrapping_key(
         organization_id: view.organization_id,
         folder_id: view.folder_id,
         collection_ids: view.collection_ids.clone(),
-        key: view
-            .key
-            .as_ref()
-            .map(|_| ctx.wrap_symmetric_key(wrapping_key, cipher_key))
-            .transpose()?,
+        key: Some(ctx.wrap_symmetric_key(wrapping_key, cipher_key)?),
         r#type: view.r#type,
         favorite: view.favorite,
         reprompt: view.reprompt,

--- a/crates/bitwarden-vault/src/cipher/cipher.rs
+++ b/crates/bitwarden-vault/src/cipher/cipher.rs
@@ -630,27 +630,12 @@ impl CipherListView {
 }
 
 impl CipherView {
-    pub(crate) fn load_cipher_key_slot(
-        &self,
-        ctx: &mut KeyStoreContext<KeySlotIds>,
-        wrapping_key: SymmetricKeySlotId,
-    ) -> Result<SymmetricKeySlotId, CryptoError> {
-        match &self.key {
-            Some(key) => Ok(ctx.add_local_symmetric_key(key.clone())),
-            None => Ok(wrapping_key),
-        }
-    }
-
     fn encrypt_legacy_field_encryption(
         &mut self,
         ctx: &mut KeyStoreContext<KeySlotIds>,
         key: SymmetricKeySlotId,
     ) -> Result<Cipher, CryptoError> {
-        if self.key.is_none() {
-            self.generate_cipher_key(ctx)?;
-        }
-
-        let ciphers_key = self.load_cipher_key_slot(ctx, key)?;
+        let ciphers_key = self.load_cipher_key_slot(ctx)?;
 
         self.generate_checksums();
 
@@ -883,16 +868,21 @@ impl Cipher {
     }
 }
 impl CipherView {
-    #[allow(missing_docs)]
-    pub fn generate_cipher_key(
+    /// Returns the context slot holding the cipher's own key, generating and storing one if the
+    /// view doesn't have it yet. Every cipher the SDK encrypts carries its own key.
+    pub fn load_cipher_key_slot(
         &mut self,
         ctx: &mut KeyStoreContext<KeySlotIds>,
-    ) -> Result<(), CryptoError> {
+    ) -> Result<SymmetricKeySlotId, CryptoError> {
+        if let Some(key) = &self.key {
+            return Ok(ctx.add_local_symmetric_key(key.clone()));
+        }
+
         let new_key = ctx.generate_symmetric_key();
         #[allow(deprecated)]
         let new_key_raw = ctx.dangerous_get_symmetric_key(new_key)?.clone();
         self.key = Some(new_key_raw);
-        Ok(())
+        Ok(new_key)
     }
 
     #[allow(missing_docs)]
@@ -2367,55 +2357,7 @@ mod tests {
     }
 
     #[test]
-    fn test_generate_cipher_key() {
-        let key = SymmetricCryptoKey::make(SymmetricKeyAlgorithm::Aes256CbcHmac);
-        let key_store = create_test_crypto_with_user_key(key);
-
-        let original_cipher = generate_cipher();
-
-        // A keyless view has a cipher key generated for it at encrypt time
-        let cipher = generate_cipher();
-        let no_key_cipher_enc = key_store.encrypt(EncryptMode::Legacy(cipher)).unwrap();
-        assert!(no_key_cipher_enc.key.is_some());
-        let no_key_cipher_dec: CipherView = key_store.decrypt(&no_key_cipher_enc).unwrap();
-        assert!(no_key_cipher_dec.key.is_some());
-        assert_eq!(no_key_cipher_dec.name, original_cipher.name);
-
-        let mut cipher = generate_cipher();
-        cipher
-            .generate_cipher_key(&mut key_store.context())
-            .unwrap();
-
-        // Check that the cipher gets encrypted correctly when it's assigned it's own key
-        let key_cipher_enc = key_store.encrypt(EncryptMode::Legacy(cipher)).unwrap();
-        let key_cipher_dec: CipherView = key_store.decrypt(&key_cipher_enc).unwrap();
-        assert!(key_cipher_dec.key.is_some());
-        assert_eq!(key_cipher_dec.name, original_cipher.name);
-    }
-
-    #[test]
-    fn test_generate_cipher_key_when_a_cipher_key_already_exists() {
-        let key = SymmetricCryptoKey::make(SymmetricKeyAlgorithm::Aes256CbcHmac);
-        let key_store = create_test_crypto_with_user_key(key);
-
-        let mut original_cipher = generate_cipher();
-        {
-            let mut ctx = key_store.context();
-            let cipher_key = ctx.generate_symmetric_key();
-            #[allow(deprecated)]
-            let raw = ctx.dangerous_get_symmetric_key(cipher_key).unwrap().clone();
-            original_cipher.key = Some(raw);
-        }
-
-        original_cipher
-            .generate_cipher_key(&mut key_store.context())
-            .unwrap();
-
-        assert!(original_cipher.key.is_some());
-    }
-
-    #[test]
-    fn test_generate_cipher_key_ignores_attachments_without_key() {
+    fn test_load_cipher_key_slot_ignores_attachments_without_key() {
         let key = SymmetricCryptoKey::make(SymmetricKeyAlgorithm::Aes256CbcHmac);
         let key_store = create_test_crypto_with_user_key(key);
 
@@ -2430,35 +2372,34 @@ mod tests {
         };
         cipher.attachments = Some(vec![attachment]);
 
-        cipher
-            .generate_cipher_key(&mut key_store.context())
+        let _ = cipher
+            .load_cipher_key_slot(&mut key_store.context())
             .unwrap();
         assert!(cipher.attachments.unwrap()[0].key.is_none());
     }
 
     #[test]
-    fn test_reencrypt_cipher_key() {
+    fn test_validate_attachment_keys_with_cipher_key() {
         let old_key = SymmetricCryptoKey::make(SymmetricKeyAlgorithm::Aes256CbcHmac);
         let key_store = create_test_crypto_with_user_key(old_key);
         let mut ctx = key_store.context_mut();
 
         let mut cipher = generate_cipher();
-        cipher.generate_cipher_key(&mut ctx).unwrap();
+        let _ = cipher.load_cipher_key_slot(&mut ctx).unwrap();
 
         cipher.validate_attachment_keys().unwrap();
 
         assert!(cipher.key.is_some());
     }
 
+    /// A keyless cipher with no attachments has nothing to orphan, so it must stay rotatable.
     #[test]
-    fn test_reencrypt_cipher_key_ignores_missing_key() {
+    fn test_validate_attachment_keys_without_attachments() {
         let mut cipher = generate_cipher();
-
-        // The cipher does not have a key, so validation should pass without error
-        cipher.validate_attachment_keys().unwrap();
-
-        // Check that the cipher key is still None
         assert!(cipher.key.is_none());
+        assert!(cipher.attachments.is_none());
+
+        cipher.validate_attachment_keys().unwrap();
     }
 
     #[test]
@@ -2470,8 +2411,8 @@ mod tests {
 
         // Create a cipher with a user key
         let mut cipher = generate_cipher();
-        cipher
-            .generate_cipher_key(&mut key_store.context())
+        let _ = cipher
+            .load_cipher_key_slot(&mut key_store.context())
             .unwrap();
 
         cipher.move_to_organization(org).unwrap();
@@ -2493,8 +2434,8 @@ mod tests {
 
         // Create a cipher with a user key
         let mut cipher = generate_cipher();
-        cipher
-            .generate_cipher_key(&mut key_store.context())
+        let _ = cipher
+            .load_cipher_key_slot(&mut key_store.context())
             .unwrap();
 
         cipher.organization_id = Some(org);
@@ -2648,7 +2589,7 @@ mod tests {
         let mut ctx = key_store.context();
 
         let mut cipher_view = generate_cipher();
-        cipher_view.generate_cipher_key(&mut ctx).unwrap();
+        let _ = cipher_view.load_cipher_key_slot(&mut ctx).unwrap();
 
         let fido2_credential = generate_fido2_view();
 
@@ -4110,6 +4051,38 @@ mod tests {
             assert!(
                 lenient_decrypt_cipher_view(&cipher, &mut ctx, view.key_identifier()).is_err(),
                 "cipher key must not be wrapped under the view's own slot"
+            );
+        }
+
+        /// An already-keyed view keeps its cipher key through encryption.
+        #[test]
+        fn legacy_variant_preserves_existing_cipher_key() {
+            let key_store = make_key_store();
+            let mut view = base_login_view();
+            let mut ctx = key_store.context();
+
+            let _ = view.load_cipher_key_slot(&mut ctx).unwrap();
+            let original_key = view
+                .key
+                .clone()
+                .expect("load_cipher_key_slot stores the key");
+
+            let wrapping_key = ctx.add_local_symmetric_key(SymmetricCryptoKey::make(
+                SymmetricKeyAlgorithm::Aes256CbcHmac,
+            ));
+            let cipher = EncryptMode::Legacy(view)
+                .encrypt_composite(&mut ctx, wrapping_key)
+                .unwrap();
+
+            let unwrapped = ctx
+                .unwrap_symmetric_key(wrapping_key, &cipher.key.expect("cipher key is emitted"))
+                .unwrap();
+            #[allow(deprecated)]
+            let unwrapped_raw = ctx.dangerous_get_symmetric_key(unwrapped).unwrap().clone();
+
+            assert_eq!(
+                unwrapped_raw, original_key,
+                "encryption must wrap the view's existing cipher key, not a new one"
             );
         }
 

--- a/crates/bitwarden-vault/src/cipher/cipher.rs
+++ b/crates/bitwarden-vault/src/cipher/cipher.rs
@@ -637,27 +637,12 @@ impl CipherListView {
 }
 
 impl CipherView {
-    pub(crate) fn load_cipher_key_slot(
-        &self,
-        ctx: &mut KeyStoreContext<KeySlotIds>,
-        wrapping_key: SymmetricKeySlotId,
-    ) -> Result<SymmetricKeySlotId, CryptoError> {
-        match &self.key {
-            Some(key) => Ok(ctx.add_local_symmetric_key(key.clone())),
-            None => Ok(wrapping_key),
-        }
-    }
-
     fn encrypt_legacy_field_encryption(
         &mut self,
         ctx: &mut KeyStoreContext<KeySlotIds>,
         key: SymmetricKeySlotId,
     ) -> Result<Cipher, CryptoError> {
-        if self.key.is_none() {
-            self.generate_cipher_key(ctx)?;
-        }
-
-        let ciphers_key = self.load_cipher_key_slot(ctx, key)?;
+        let ciphers_key = self.load_cipher_key_slot(ctx)?;
 
         self.generate_checksums();
 
@@ -890,16 +875,21 @@ impl Cipher {
     }
 }
 impl CipherView {
-    #[allow(missing_docs)]
-    pub fn generate_cipher_key(
+    /// Returns the context slot holding the cipher's own key, generating and storing one if the
+    /// view doesn't have it yet. Every cipher the SDK encrypts carries its own key.
+    pub fn load_cipher_key_slot(
         &mut self,
         ctx: &mut KeyStoreContext<KeySlotIds>,
-    ) -> Result<(), CryptoError> {
+    ) -> Result<SymmetricKeySlotId, CryptoError> {
+        if let Some(key) = &self.key {
+            return Ok(ctx.add_local_symmetric_key(key.clone()));
+        }
+
         let new_key = ctx.generate_symmetric_key();
         #[allow(deprecated)]
         let new_key_raw = ctx.dangerous_get_symmetric_key(new_key)?.clone();
         self.key = Some(new_key_raw);
-        Ok(())
+        Ok(new_key)
     }
 
     #[allow(missing_docs)]
@@ -2356,7 +2346,7 @@ mod tests {
         let key_store = create_test_crypto_with_user_key(user_key);
 
         let mut view = generate_cipher();
-        view.generate_cipher_key(&mut key_store.context()).unwrap();
+        let _ = view.load_cipher_key_slot(&mut key_store.context()).unwrap();
         assert!(view.key.is_some());
 
         let actual = key_store
@@ -2465,55 +2455,7 @@ mod tests {
     }
 
     #[test]
-    fn test_generate_cipher_key() {
-        let key = SymmetricCryptoKey::make(SymmetricKeyAlgorithm::Aes256CbcHmac);
-        let key_store = create_test_crypto_with_user_key(key);
-
-        let original_cipher = generate_cipher();
-
-        // A keyless view has a cipher key generated for it at encrypt time
-        let cipher = generate_cipher();
-        let no_key_cipher_enc = key_store.encrypt(EncryptMode::Legacy(cipher)).unwrap();
-        assert!(no_key_cipher_enc.key.is_some());
-        let no_key_cipher_dec: CipherView = key_store.decrypt(&no_key_cipher_enc).unwrap();
-        assert!(no_key_cipher_dec.key.is_some());
-        assert_eq!(no_key_cipher_dec.name, original_cipher.name);
-
-        let mut cipher = generate_cipher();
-        cipher
-            .generate_cipher_key(&mut key_store.context())
-            .unwrap();
-
-        // Check that the cipher gets encrypted correctly when it's assigned it's own key
-        let key_cipher_enc = key_store.encrypt(EncryptMode::Legacy(cipher)).unwrap();
-        let key_cipher_dec: CipherView = key_store.decrypt(&key_cipher_enc).unwrap();
-        assert!(key_cipher_dec.key.is_some());
-        assert_eq!(key_cipher_dec.name, original_cipher.name);
-    }
-
-    #[test]
-    fn test_generate_cipher_key_when_a_cipher_key_already_exists() {
-        let key = SymmetricCryptoKey::make(SymmetricKeyAlgorithm::Aes256CbcHmac);
-        let key_store = create_test_crypto_with_user_key(key);
-
-        let mut original_cipher = generate_cipher();
-        {
-            let mut ctx = key_store.context();
-            let cipher_key = ctx.generate_symmetric_key();
-            #[allow(deprecated)]
-            let raw = ctx.dangerous_get_symmetric_key(cipher_key).unwrap().clone();
-            original_cipher.key = Some(raw);
-        }
-
-        original_cipher
-            .generate_cipher_key(&mut key_store.context())
-            .unwrap();
-
-        assert!(original_cipher.key.is_some());
-    }
-
-    #[test]
-    fn test_generate_cipher_key_ignores_attachments_without_key() {
+    fn test_load_cipher_key_slot_ignores_attachments_without_key() {
         let key = SymmetricCryptoKey::make(SymmetricKeyAlgorithm::Aes256CbcHmac);
         let key_store = create_test_crypto_with_user_key(key);
 
@@ -2528,35 +2470,34 @@ mod tests {
         };
         cipher.attachments = Some(vec![attachment]);
 
-        cipher
-            .generate_cipher_key(&mut key_store.context())
+        let _ = cipher
+            .load_cipher_key_slot(&mut key_store.context())
             .unwrap();
         assert!(cipher.attachments.unwrap()[0].key.is_none());
     }
 
     #[test]
-    fn test_reencrypt_cipher_key() {
+    fn test_validate_attachment_keys_with_cipher_key() {
         let old_key = SymmetricCryptoKey::make(SymmetricKeyAlgorithm::Aes256CbcHmac);
         let key_store = create_test_crypto_with_user_key(old_key);
         let mut ctx = key_store.context_mut();
 
         let mut cipher = generate_cipher();
-        cipher.generate_cipher_key(&mut ctx).unwrap();
+        let _ = cipher.load_cipher_key_slot(&mut ctx).unwrap();
 
         cipher.validate_attachment_keys().unwrap();
 
         assert!(cipher.key.is_some());
     }
 
+    /// A keyless cipher with no attachments has nothing to orphan, so it must stay rotatable.
     #[test]
-    fn test_reencrypt_cipher_key_ignores_missing_key() {
+    fn test_validate_attachment_keys_without_attachments() {
         let mut cipher = generate_cipher();
-
-        // The cipher does not have a key, so validation should pass without error
-        cipher.validate_attachment_keys().unwrap();
-
-        // Check that the cipher key is still None
         assert!(cipher.key.is_none());
+        assert!(cipher.attachments.is_none());
+
+        cipher.validate_attachment_keys().unwrap();
     }
 
     #[test]
@@ -2568,8 +2509,8 @@ mod tests {
 
         // Create a cipher with a user key
         let mut cipher = generate_cipher();
-        cipher
-            .generate_cipher_key(&mut key_store.context())
+        let _ = cipher
+            .load_cipher_key_slot(&mut key_store.context())
             .unwrap();
 
         cipher.move_to_organization(org).unwrap();
@@ -2591,8 +2532,8 @@ mod tests {
 
         // Create a cipher with a user key
         let mut cipher = generate_cipher();
-        cipher
-            .generate_cipher_key(&mut key_store.context())
+        let _ = cipher
+            .load_cipher_key_slot(&mut key_store.context())
             .unwrap();
 
         cipher.organization_id = Some(org);
@@ -4189,6 +4130,38 @@ mod tests {
             assert!(
                 lenient_decrypt_cipher_view(&cipher, &mut ctx, view.key_identifier()).is_err(),
                 "cipher key must not be wrapped under the view's own slot"
+            );
+        }
+
+        /// An already-keyed view keeps its cipher key through encryption.
+        #[test]
+        fn legacy_variant_preserves_existing_cipher_key() {
+            let key_store = make_key_store();
+            let mut view = base_login_view();
+            let mut ctx = key_store.context();
+
+            let _ = view.load_cipher_key_slot(&mut ctx).unwrap();
+            let original_key = view
+                .key
+                .clone()
+                .expect("load_cipher_key_slot stores the key");
+
+            let wrapping_key = ctx.add_local_symmetric_key(SymmetricCryptoKey::make(
+                SymmetricKeyAlgorithm::Aes256CbcHmac,
+            ));
+            let cipher = EncryptMode::Legacy(view)
+                .encrypt_composite(&mut ctx, wrapping_key)
+                .unwrap();
+
+            let unwrapped = ctx
+                .unwrap_symmetric_key(wrapping_key, &cipher.key.expect("cipher key is emitted"))
+                .unwrap();
+            #[allow(deprecated)]
+            let unwrapped_raw = ctx.dangerous_get_symmetric_key(unwrapped).unwrap().clone();
+
+            assert_eq!(
+                unwrapped_raw, original_key,
+                "encryption must wrap the view's existing cipher key, not a new one"
             );
         }
 

--- a/crates/bitwarden-vault/src/cipher/cipher.rs
+++ b/crates/bitwarden-vault/src/cipher/cipher.rs
@@ -295,8 +295,9 @@ pub struct Cipher {
     pub organization_id: Option<OrganizationId>,
     pub folder_id: Option<FolderId>,
     pub collection_ids: Vec<CollectionId>,
-    /// More recent ciphers uses individual encryption keys to encrypt the other fields of the
-    /// Cipher.
+    /// Per-cipher key, wrapped under the owning user or organization key, that protects the
+    /// cipher's fields. Always set on ciphers the SDK encrypts; `None` only on legacy
+    /// ciphers that predates per-cipher keys.
     pub key: Option<EncString>,
 
     /// Encrypted item name. `None` for blob-encrypted ciphers, where the name lives inside
@@ -648,60 +649,49 @@ impl CipherView {
     }
 
     fn encrypt_legacy_field_encryption(
-        &self,
+        &mut self,
         ctx: &mut KeyStoreContext<KeySlotIds>,
         key: SymmetricKeySlotId,
     ) -> Result<Cipher, CryptoError> {
+        if self.key.is_none() {
+            self.generate_cipher_key(ctx)?;
+        }
+
         let ciphers_key = self.load_cipher_key_slot(ctx, key)?;
 
-        let mut cipher_view = self.clone();
-        cipher_view.generate_checksums();
+        self.generate_checksums();
 
         Ok(Cipher {
-            id: cipher_view.id,
-            organization_id: cipher_view.organization_id,
-            folder_id: cipher_view.folder_id,
-            collection_ids: cipher_view.collection_ids,
-            key: cipher_view
-                .key
-                .as_ref()
-                .map(|_| ctx.wrap_symmetric_key(key, ciphers_key))
-                .transpose()?,
-            name: Some(cipher_view.name.encrypt(ctx, ciphers_key)?),
-            notes: cipher_view.notes.encrypt(ctx, ciphers_key)?,
-            r#type: cipher_view.r#type,
-            login: cipher_view.login.encrypt_composite(ctx, ciphers_key)?,
-            identity: cipher_view.identity.encrypt_composite(ctx, ciphers_key)?,
-            card: cipher_view.card.encrypt_composite(ctx, ciphers_key)?,
-            secure_note: cipher_view
-                .secure_note
-                .encrypt_composite(ctx, ciphers_key)?,
-            ssh_key: cipher_view.ssh_key.encrypt_composite(ctx, ciphers_key)?,
-            bank_account: cipher_view
-                .bank_account
-                .encrypt_composite(ctx, ciphers_key)?,
-            drivers_license: cipher_view
-                .drivers_license
-                .encrypt_composite(ctx, ciphers_key)?,
-            passport: cipher_view.passport.encrypt_composite(ctx, ciphers_key)?,
-            favorite: cipher_view.favorite,
-            reprompt: cipher_view.reprompt,
-            organization_use_totp: cipher_view.organization_use_totp,
-            edit: cipher_view.edit,
-            view_password: cipher_view.view_password,
-            local_data: cipher_view.local_data.encrypt_composite(ctx, ciphers_key)?,
-            attachments: cipher_view
-                .attachments
-                .encrypt_composite(ctx, ciphers_key)?,
-            fields: cipher_view.fields.encrypt_composite(ctx, ciphers_key)?,
-            password_history: cipher_view
-                .password_history
-                .encrypt_composite(ctx, ciphers_key)?,
-            creation_date: cipher_view.creation_date,
-            deleted_date: cipher_view.deleted_date,
-            revision_date: cipher_view.revision_date,
-            permissions: cipher_view.permissions,
-            archived_date: cipher_view.archived_date,
+            id: self.id,
+            organization_id: self.organization_id,
+            folder_id: self.folder_id,
+            collection_ids: self.collection_ids.clone(),
+            key: Some(ctx.wrap_symmetric_key(key, ciphers_key)?),
+            name: Some(self.name.encrypt(ctx, ciphers_key)?),
+            notes: self.notes.encrypt(ctx, ciphers_key)?,
+            r#type: self.r#type,
+            login: self.login.encrypt_composite(ctx, ciphers_key)?,
+            identity: self.identity.encrypt_composite(ctx, ciphers_key)?,
+            card: self.card.encrypt_composite(ctx, ciphers_key)?,
+            secure_note: self.secure_note.encrypt_composite(ctx, ciphers_key)?,
+            ssh_key: self.ssh_key.encrypt_composite(ctx, ciphers_key)?,
+            bank_account: self.bank_account.encrypt_composite(ctx, ciphers_key)?,
+            drivers_license: self.drivers_license.encrypt_composite(ctx, ciphers_key)?,
+            passport: self.passport.encrypt_composite(ctx, ciphers_key)?,
+            favorite: self.favorite,
+            reprompt: self.reprompt,
+            organization_use_totp: self.organization_use_totp,
+            edit: self.edit,
+            view_password: self.view_password,
+            local_data: self.local_data.encrypt_composite(ctx, ciphers_key)?,
+            attachments: self.attachments.encrypt_composite(ctx, ciphers_key)?,
+            fields: self.fields.encrypt_composite(ctx, ciphers_key)?,
+            password_history: self.password_history.encrypt_composite(ctx, ciphers_key)?,
+            creation_date: self.creation_date,
+            deleted_date: self.deleted_date,
+            revision_date: self.revision_date,
+            permissions: self.permissions,
+            archived_date: self.archived_date,
             data: None, // TODO: Do we need to repopulate this on this on the cipher?
         })
     }
@@ -1720,16 +1710,18 @@ impl CompositeEncryptable<KeySlotIds, SymmetricKeySlotId, Cipher> for EncryptMod
         key: SymmetricKeySlotId,
     ) -> Result<Cipher, CryptoError> {
         match self {
+            // Both paths take `&mut CipherView` to generate a cipher key when the view lacks one,
+            // so we hand them a local clone. Both wrap it under the explicit `key`, letting
+            // callers target a non-`User`/`Organization` slot (e.g. rotation's `Local` slot).
             Self::Blob(view) => {
-                // `encrypt_blob_cipher_with_wrapping_key` takes `&mut CipherView` because it may
-                // generate a cipher key; so we operate on a local clone. The explicit `key` is
-                // respected here so callers can target a non-`User`/`Organization` slot (e.g.
-                // a `Local` slot during key rotation).
                 let mut owned = view.clone();
                 encrypt_blob_cipher_with_wrapping_key(&mut owned, ctx, key)
                     .map_err(CryptoError::from)
             }
-            Self::Legacy(view) => view.encrypt_legacy_field_encryption(ctx, key),
+            Self::Legacy(view) => {
+                let mut owned = view.clone();
+                owned.encrypt_legacy_field_encryption(ctx, key)
+            }
         }
     }
 }
@@ -2479,11 +2471,12 @@ mod tests {
 
         let original_cipher = generate_cipher();
 
-        // Check that the cipher gets encrypted correctly without it's own key
+        // A keyless view has a cipher key generated for it at encrypt time
         let cipher = generate_cipher();
         let no_key_cipher_enc = key_store.encrypt(EncryptMode::Legacy(cipher)).unwrap();
+        assert!(no_key_cipher_enc.key.is_some());
         let no_key_cipher_dec: CipherView = key_store.decrypt(&no_key_cipher_enc).unwrap();
-        assert!(no_key_cipher_dec.key.is_none());
+        assert!(no_key_cipher_dec.key.is_some());
         assert_eq!(no_key_cipher_dec.name, original_cipher.name);
 
         let mut cipher = generate_cipher();
@@ -4161,6 +4154,42 @@ mod tests {
             assert!(try_parse_blob(&cipher).is_none());
             assert!(cipher.data.is_none());
             assert!(cipher.login.is_some());
+            assert!(
+                cipher.key.is_some(),
+                "legacy encrypt must always emit a cipher key"
+            );
+        }
+
+        /// Legacy encryption must wrap the generated cipher key under the wrapping key it is
+        /// handed, not the view's own `User`/`Organization` slot — key rotation passes a `Local`
+        /// slot holding the new user key.
+        #[test]
+        fn legacy_variant_wraps_cipher_key_under_explicit_key() {
+            let key_store = make_key_store();
+            let view = base_login_view();
+            let mut ctx = key_store.context();
+
+            let new_key = ctx.add_local_symmetric_key(SymmetricCryptoKey::make(
+                SymmetricKeyAlgorithm::Aes256CbcHmac,
+            ));
+            let cipher = EncryptMode::Legacy(view.clone())
+                .encrypt_composite(&mut ctx, new_key)
+                .unwrap();
+
+            // The cipher key unwraps under the explicitly supplied key, and the data it protects
+            // round-trips.
+            let decrypted = lenient_decrypt_cipher_view(&cipher, &mut ctx, new_key).unwrap();
+            assert_eq!(decrypted.name, view.name);
+            assert_eq!(
+                decrypted.login.as_ref().unwrap().password,
+                view.login.as_ref().unwrap().password
+            );
+
+            // It does not unwrap under the view's natural slot.
+            assert!(
+                lenient_decrypt_cipher_view(&cipher, &mut ctx, view.key_identifier()).is_err(),
+                "cipher key must not be wrapped under the view's own slot"
+            );
         }
 
         /// Blob variant round-trips through decryption

--- a/crates/bitwarden-vault/src/cipher/cipher.rs
+++ b/crates/bitwarden-vault/src/cipher/cipher.rs
@@ -290,8 +290,9 @@ pub struct Cipher {
     pub organization_id: Option<OrganizationId>,
     pub folder_id: Option<FolderId>,
     pub collection_ids: Vec<CollectionId>,
-    /// More recent ciphers uses individual encryption keys to encrypt the other fields of the
-    /// Cipher.
+    /// Per-cipher key, wrapped under the owning user or organization key, that protects the
+    /// cipher's fields. Always set on ciphers the SDK encrypts; `None` only on legacy
+    /// ciphers that predates per-cipher keys.
     pub key: Option<EncString>,
 
     /// Encrypted item name. `None` for blob-encrypted ciphers, where the name lives inside
@@ -641,60 +642,49 @@ impl CipherView {
     }
 
     fn encrypt_legacy_field_encryption(
-        &self,
+        &mut self,
         ctx: &mut KeyStoreContext<KeySlotIds>,
         key: SymmetricKeySlotId,
     ) -> Result<Cipher, CryptoError> {
+        if self.key.is_none() {
+            self.generate_cipher_key(ctx)?;
+        }
+
         let ciphers_key = self.load_cipher_key_slot(ctx, key)?;
 
-        let mut cipher_view = self.clone();
-        cipher_view.generate_checksums();
+        self.generate_checksums();
 
         Ok(Cipher {
-            id: cipher_view.id,
-            organization_id: cipher_view.organization_id,
-            folder_id: cipher_view.folder_id,
-            collection_ids: cipher_view.collection_ids,
-            key: cipher_view
-                .key
-                .as_ref()
-                .map(|_| ctx.wrap_symmetric_key(key, ciphers_key))
-                .transpose()?,
-            name: Some(cipher_view.name.encrypt(ctx, ciphers_key)?),
-            notes: cipher_view.notes.encrypt(ctx, ciphers_key)?,
-            r#type: cipher_view.r#type,
-            login: cipher_view.login.encrypt_composite(ctx, ciphers_key)?,
-            identity: cipher_view.identity.encrypt_composite(ctx, ciphers_key)?,
-            card: cipher_view.card.encrypt_composite(ctx, ciphers_key)?,
-            secure_note: cipher_view
-                .secure_note
-                .encrypt_composite(ctx, ciphers_key)?,
-            ssh_key: cipher_view.ssh_key.encrypt_composite(ctx, ciphers_key)?,
-            bank_account: cipher_view
-                .bank_account
-                .encrypt_composite(ctx, ciphers_key)?,
-            drivers_license: cipher_view
-                .drivers_license
-                .encrypt_composite(ctx, ciphers_key)?,
-            passport: cipher_view.passport.encrypt_composite(ctx, ciphers_key)?,
-            favorite: cipher_view.favorite,
-            reprompt: cipher_view.reprompt,
-            organization_use_totp: cipher_view.organization_use_totp,
-            edit: cipher_view.edit,
-            view_password: cipher_view.view_password,
-            local_data: cipher_view.local_data.encrypt_composite(ctx, ciphers_key)?,
-            attachments: cipher_view
-                .attachments
-                .encrypt_composite(ctx, ciphers_key)?,
-            fields: cipher_view.fields.encrypt_composite(ctx, ciphers_key)?,
-            password_history: cipher_view
-                .password_history
-                .encrypt_composite(ctx, ciphers_key)?,
-            creation_date: cipher_view.creation_date,
-            deleted_date: cipher_view.deleted_date,
-            revision_date: cipher_view.revision_date,
-            permissions: cipher_view.permissions,
-            archived_date: cipher_view.archived_date,
+            id: self.id,
+            organization_id: self.organization_id,
+            folder_id: self.folder_id,
+            collection_ids: self.collection_ids.clone(),
+            key: Some(ctx.wrap_symmetric_key(key, ciphers_key)?),
+            name: Some(self.name.encrypt(ctx, ciphers_key)?),
+            notes: self.notes.encrypt(ctx, ciphers_key)?,
+            r#type: self.r#type,
+            login: self.login.encrypt_composite(ctx, ciphers_key)?,
+            identity: self.identity.encrypt_composite(ctx, ciphers_key)?,
+            card: self.card.encrypt_composite(ctx, ciphers_key)?,
+            secure_note: self.secure_note.encrypt_composite(ctx, ciphers_key)?,
+            ssh_key: self.ssh_key.encrypt_composite(ctx, ciphers_key)?,
+            bank_account: self.bank_account.encrypt_composite(ctx, ciphers_key)?,
+            drivers_license: self.drivers_license.encrypt_composite(ctx, ciphers_key)?,
+            passport: self.passport.encrypt_composite(ctx, ciphers_key)?,
+            favorite: self.favorite,
+            reprompt: self.reprompt,
+            organization_use_totp: self.organization_use_totp,
+            edit: self.edit,
+            view_password: self.view_password,
+            local_data: self.local_data.encrypt_composite(ctx, ciphers_key)?,
+            attachments: self.attachments.encrypt_composite(ctx, ciphers_key)?,
+            fields: self.fields.encrypt_composite(ctx, ciphers_key)?,
+            password_history: self.password_history.encrypt_composite(ctx, ciphers_key)?,
+            creation_date: self.creation_date,
+            deleted_date: self.deleted_date,
+            revision_date: self.revision_date,
+            permissions: self.permissions,
+            archived_date: self.archived_date,
             data: None, // TODO: Do we need to repopulate this on this on the cipher?
         })
     }
@@ -1719,16 +1709,18 @@ impl CompositeEncryptable<KeySlotIds, SymmetricKeySlotId, Cipher> for EncryptMod
         key: SymmetricKeySlotId,
     ) -> Result<Cipher, CryptoError> {
         match self {
+            // Both paths take `&mut CipherView` to generate a cipher key when the view lacks one,
+            // so we hand them a local clone. Both wrap it under the explicit `key`, letting
+            // callers target a non-`User`/`Organization` slot (e.g. rotation's `Local` slot).
             Self::Blob(view) => {
-                // `encrypt_blob_cipher_with_wrapping_key` takes `&mut CipherView` because it may
-                // generate a cipher key; so we operate on a local clone. The explicit `key` is
-                // respected here so callers can target a non-`User`/`Organization` slot (e.g.
-                // a `Local` slot during key rotation).
                 let mut owned = view.clone();
                 encrypt_blob_cipher_with_wrapping_key(&mut owned, ctx, key)
                     .map_err(CryptoError::from)
             }
-            Self::Legacy(view) => view.encrypt_legacy_field_encryption(ctx, key),
+            Self::Legacy(view) => {
+                let mut owned = view.clone();
+                owned.encrypt_legacy_field_encryption(ctx, key)
+            }
         }
     }
 }
@@ -2381,11 +2373,12 @@ mod tests {
 
         let original_cipher = generate_cipher();
 
-        // Check that the cipher gets encrypted correctly without it's own key
+        // A keyless view has a cipher key generated for it at encrypt time
         let cipher = generate_cipher();
         let no_key_cipher_enc = key_store.encrypt(EncryptMode::Legacy(cipher)).unwrap();
+        assert!(no_key_cipher_enc.key.is_some());
         let no_key_cipher_dec: CipherView = key_store.decrypt(&no_key_cipher_enc).unwrap();
-        assert!(no_key_cipher_dec.key.is_none());
+        assert!(no_key_cipher_dec.key.is_some());
         assert_eq!(no_key_cipher_dec.name, original_cipher.name);
 
         let mut cipher = generate_cipher();
@@ -4082,6 +4075,42 @@ mod tests {
             assert!(try_parse_blob(&cipher).is_none());
             assert!(cipher.data.is_none());
             assert!(cipher.login.is_some());
+            assert!(
+                cipher.key.is_some(),
+                "legacy encrypt must always emit a cipher key"
+            );
+        }
+
+        /// Legacy encryption must wrap the generated cipher key under the wrapping key it is
+        /// handed, not the view's own `User`/`Organization` slot — key rotation passes a `Local`
+        /// slot holding the new user key.
+        #[test]
+        fn legacy_variant_wraps_cipher_key_under_explicit_key() {
+            let key_store = make_key_store();
+            let view = base_login_view();
+            let mut ctx = key_store.context();
+
+            let new_key = ctx.add_local_symmetric_key(SymmetricCryptoKey::make(
+                SymmetricKeyAlgorithm::Aes256CbcHmac,
+            ));
+            let cipher = EncryptMode::Legacy(view.clone())
+                .encrypt_composite(&mut ctx, new_key)
+                .unwrap();
+
+            // The cipher key unwraps under the explicitly supplied key, and the data it protects
+            // round-trips.
+            let decrypted = lenient_decrypt_cipher_view(&cipher, &mut ctx, new_key).unwrap();
+            assert_eq!(decrypted.name, view.name);
+            assert_eq!(
+                decrypted.login.as_ref().unwrap().password,
+                view.login.as_ref().unwrap().password
+            );
+
+            // It does not unwrap under the view's natural slot.
+            assert!(
+                lenient_decrypt_cipher_view(&cipher, &mut ctx, view.key_identifier()).is_err(),
+                "cipher key must not be wrapped under the view's own slot"
+            );
         }
 
         /// Blob variant round-trips through decryption

--- a/crates/bitwarden-vault/src/cipher/cipher_client/admin/create.rs
+++ b/crates/bitwarden-vault/src/cipher/cipher_client/admin/create.rs
@@ -104,13 +104,7 @@ impl CipherAdminClient {
             .get_user_id()
             .ok_or(NotAuthenticatedError)?;
 
-        let mut view: CipherView = convert_request_to_cipher_view(request);
-
-        // TODO: Once this flag is removed, the key generation logic should
-        // be moved directly into the CompositeEncryptable implementation.
-        if self.client.flags().get().await.enable_cipher_key_encryption {
-            view.generate_cipher_key(&mut key_store.context())?;
-        }
+        let view: CipherView = convert_request_to_cipher_view(request);
 
         let use_blob = should_use_blob_encryption(&key_store.context(), view.organization_id);
 
@@ -157,6 +151,7 @@ mod tests {
                             .and_then(|id| id.parse().ok()),
                         name: Some(request.cipher.name.clone()),
                         r#type: request.cipher.r#type,
+                        key: request.cipher.key.clone(),
                         creation_date: Some(
                             Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
                         ),
@@ -219,6 +214,7 @@ mod tests {
 
         assert_eq!(response.id, Some(TEST_CIPHER_ID.parse().unwrap()));
         assert_eq!(response.organization_id, view.organization_id);
+        assert_eq!(response.name, "Test Cipher");
         // Fields omitted from CipherMiniResponseModel must be preserved from the request.
         assert_eq!(response.collection_ids, view.collection_ids);
         assert_eq!(response.folder_id, view.folder_id);

--- a/crates/bitwarden-vault/src/cipher/cipher_client/admin/create.rs
+++ b/crates/bitwarden-vault/src/cipher/cipher_client/admin/create.rs
@@ -109,13 +109,7 @@ impl CipherAdminClient {
             .get_user_id()
             .ok_or(NotAuthenticatedError)?;
 
-        let mut view: CipherView = convert_request_to_cipher_view(request);
-
-        // TODO: Once this flag is removed, the key generation logic should
-        // be moved directly into the CompositeEncryptable implementation.
-        if self.client.flags().get().await.enable_cipher_key_encryption {
-            view.generate_cipher_key(&mut key_store.context())?;
-        }
+        let view: CipherView = convert_request_to_cipher_view(request);
 
         let use_blob = should_use_blob_encryption(&key_store.context(), view.organization_id);
 
@@ -162,6 +156,7 @@ mod tests {
                             .and_then(|id| id.parse().ok()),
                         name: request.cipher.name.clone(),
                         r#type: request.cipher.r#type,
+                        key: request.cipher.key.clone(),
                         creation_date: Some(
                             Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
                         ),
@@ -224,6 +219,7 @@ mod tests {
 
         assert_eq!(response.id, Some(TEST_CIPHER_ID.parse().unwrap()));
         assert_eq!(response.organization_id, view.organization_id);
+        assert_eq!(response.name, "Test Cipher");
         // Fields omitted from CipherMiniResponseModel must be preserved from the request.
         assert_eq!(response.collection_ids, view.collection_ids);
         assert_eq!(response.folder_id, view.folder_id);

--- a/crates/bitwarden-vault/src/cipher/cipher_client/admin/edit.rs
+++ b/crates/bitwarden-vault/src/cipher/cipher_client/admin/edit.rs
@@ -47,10 +47,6 @@ pub enum EditCipherAdminError {
     Decrypt(#[from] DecryptError),
 }
 
-// `use_strict_decryption`, `enable_cipher_key_encryption`, and `use_blob` are
-// short-lived feature-rollout flags that will be removed once their migrations
-// complete, at which point the argument count drops back under the limit.
-#[allow(clippy::too_many_arguments)]
 async fn edit_cipher(
     key_store: &KeyStore<KeySlotIds>,
     api_client: &bitwarden_api_api::apis::ApiClient,
@@ -58,7 +54,6 @@ async fn edit_cipher(
     original_cipher_view: CipherView,
     request: CipherEditRequest,
     use_strict_decryption: bool,
-    enable_cipher_key_encryption: bool,
     use_blob: bool,
 ) -> Result<CipherView, EditCipherAdminError> {
     let cipher_id = request.id;
@@ -69,12 +64,6 @@ async fn edit_cipher(
 
     let mut view: CipherView = convert_request_to_cipher_view(request);
     view.update_password_history(&original_cipher_view);
-
-    // TODO: Once this flag is removed, the key generation logic should be
-    // moved directly into the CompositeEncryptable implementation.
-    if view.key.is_none() && enable_cipher_key_encryption {
-        view.generate_cipher_key(&mut key_store.context())?;
-    }
 
     // Admin endpoints operate on organization-owned ciphers, which aren't
     // expected to use blob encryption yet — `should_use_blob_encryption`
@@ -159,9 +148,6 @@ impl CipherAdminClient {
             .get_user_id()
             .ok_or(NotAuthenticatedError)?;
 
-        let enable_cipher_key_encryption =
-            self.client.flags().get().await.enable_cipher_key_encryption;
-
         let use_blob = should_use_blob_encryption(&key_store.context(), request.organization_id);
 
         edit_cipher(
@@ -171,7 +157,6 @@ impl CipherAdminClient {
             original_cipher_view,
             request,
             self.is_strict_decrypt().await,
-            enable_cipher_key_encryption,
             use_blob,
         )
         .await
@@ -319,7 +304,6 @@ mod tests {
             request,
             false,
             false,
-            false,
         )
         .await
         .unwrap();
@@ -375,7 +359,6 @@ mod tests {
             original_cipher_view,
             request,
             false,
-            false,
             true, // use_blob
         )
         .await
@@ -409,7 +392,6 @@ mod tests {
             TEST_USER_ID.parse().unwrap(),
             orig_cipher_view,
             request,
-            false,
             false,
             false,
         )

--- a/crates/bitwarden-vault/src/cipher/cipher_client/admin/edit.rs
+++ b/crates/bitwarden-vault/src/cipher/cipher_client/admin/edit.rs
@@ -47,10 +47,6 @@ pub enum EditCipherAdminError {
     Decrypt(#[from] DecryptError),
 }
 
-// `use_strict_decryption`, `enable_cipher_key_encryption`, and `use_blob` are
-// short-lived feature-rollout flags that will be removed once their migrations
-// complete, at which point the argument count drops back under the limit.
-#[allow(clippy::too_many_arguments)]
 async fn edit_cipher(
     key_store: &KeyStore<KeySlotIds>,
     api_client: &bitwarden_api_api::apis::ApiClient,
@@ -58,7 +54,6 @@ async fn edit_cipher(
     original_cipher_view: CipherView,
     request: CipherEditRequest,
     use_strict_decryption: bool,
-    enable_cipher_key_encryption: bool,
     use_blob: bool,
 ) -> Result<CipherView, EditCipherAdminError> {
     let cipher_id = request.id;
@@ -69,12 +64,6 @@ async fn edit_cipher(
 
     let mut view: CipherView = convert_request_to_cipher_view(request);
     view.update_password_history(&original_cipher_view);
-
-    // TODO: Once this flag is removed, the key generation logic should be
-    // moved directly into the CompositeEncryptable implementation.
-    if view.key.is_none() && enable_cipher_key_encryption {
-        view.generate_cipher_key(&mut key_store.context())?;
-    }
 
     // Admin endpoints operate on organization-owned ciphers, which aren't
     // expected to use blob encryption yet — `should_use_blob_encryption`
@@ -164,9 +153,6 @@ impl CipherAdminClient {
             .get_user_id()
             .ok_or(NotAuthenticatedError)?;
 
-        let enable_cipher_key_encryption =
-            self.client.flags().get().await.enable_cipher_key_encryption;
-
         let use_blob = should_use_blob_encryption(&key_store.context(), request.organization_id);
 
         edit_cipher(
@@ -176,7 +162,6 @@ impl CipherAdminClient {
             original_cipher_view,
             request,
             self.is_strict_decrypt().await,
-            enable_cipher_key_encryption,
             use_blob,
         )
         .await
@@ -325,7 +310,6 @@ mod tests {
             request,
             false,
             false,
-            false,
         )
         .await
         .unwrap();
@@ -381,7 +365,6 @@ mod tests {
             original_cipher_view,
             request,
             false,
-            false,
             true, // use_blob
         )
         .await
@@ -415,7 +398,6 @@ mod tests {
             TEST_USER_ID.parse().unwrap(),
             orig_cipher_view,
             request,
-            false,
             false,
             false,
         )

--- a/crates/bitwarden-vault/src/cipher/cipher_client/create.rs
+++ b/crates/bitwarden-vault/src/cipher/cipher_client/create.rs
@@ -174,13 +174,7 @@ impl CiphersClient {
             .get_user_id()
             .ok_or(NotAuthenticatedError)?;
 
-        let mut view: CipherView = convert_request_to_cipher_view(request);
-
-        // TODO: Once this flag is removed, the key generation logic should
-        // be moved directly into the CompositeEncryptable implementation.
-        if self.client.flags().get().await.enable_cipher_key_encryption {
-            view.generate_cipher_key(&mut key_store.context())?;
-        }
+        let view: CipherView = convert_request_to_cipher_view(request);
 
         let use_blob = self.should_use_blob_encryption(view.organization_id);
 
@@ -388,6 +382,7 @@ mod tests {
                             .and_then(|id| id.parse().ok()),
                         name: request_body.cipher.name.clone(),
                         r#type: request_body.cipher.r#type,
+                        key: request_body.cipher.key.clone(),
                         creation_date: Some(Utc::now().to_string()),
                         revision_date: Some(Utc::now().to_string()),
                         ..Default::default()
@@ -449,6 +444,7 @@ mod tests {
 
         assert_eq!(response.id, cipher_view.id);
         assert_eq!(response.organization_id, cipher_view.organization_id);
+        assert_eq!(cipher_view.name, "Test Cipher");
 
         assert_eq!(response.id, Some(TEST_CIPHER_ID.parse().unwrap()));
         assert_eq!(response.organization_id, Some(TEST_ORG_ID.parse().unwrap()));

--- a/crates/bitwarden-vault/src/cipher/cipher_client/create.rs
+++ b/crates/bitwarden-vault/src/cipher/cipher_client/create.rs
@@ -169,13 +169,7 @@ impl CiphersClient {
             .get_user_id()
             .ok_or(NotAuthenticatedError)?;
 
-        let mut view: CipherView = convert_request_to_cipher_view(request);
-
-        // TODO: Once this flag is removed, the key generation logic should
-        // be moved directly into the CompositeEncryptable implementation.
-        if self.client.flags().get().await.enable_cipher_key_encryption {
-            view.generate_cipher_key(&mut key_store.context())?;
-        }
+        let view: CipherView = convert_request_to_cipher_view(request);
 
         let use_blob = self.should_use_blob_encryption(view.organization_id);
 
@@ -382,6 +376,7 @@ mod tests {
                             .and_then(|id| id.parse().ok()),
                         name: Some(request_body.cipher.name.clone()),
                         r#type: request_body.cipher.r#type,
+                        key: request_body.cipher.key.clone(),
                         creation_date: Some(Utc::now().to_string()),
                         revision_date: Some(Utc::now().to_string()),
                         ..Default::default()
@@ -443,6 +438,7 @@ mod tests {
 
         assert_eq!(response.id, cipher_view.id);
         assert_eq!(response.organization_id, cipher_view.organization_id);
+        assert_eq!(cipher_view.name, "Test Cipher");
 
         assert_eq!(response.id, Some(TEST_CIPHER_ID.parse().unwrap()));
         assert_eq!(response.organization_id, Some(TEST_ORG_ID.parse().unwrap()));

--- a/crates/bitwarden-vault/src/cipher/cipher_client/edit.rs
+++ b/crates/bitwarden-vault/src/cipher/cipher_client/edit.rs
@@ -160,10 +160,6 @@ pub(crate) fn convert_request_to_cipher_view(r: CipherEditRequest) -> CipherView
     }
 }
 
-// `use_strict_decryption`, `enable_cipher_key_encryption`, and `use_blob` are
-// short-lived feature-rollout flags that will be removed once their migrations
-// complete, at which point the argument count drops back under the limit.
-#[allow(clippy::too_many_arguments)]
 async fn edit_cipher<R: Repository<Cipher> + ?Sized>(
     key_store: &KeyStore<KeySlotIds>,
     api_client: &bitwarden_api_api::apis::ApiClient,
@@ -171,7 +167,6 @@ async fn edit_cipher<R: Repository<Cipher> + ?Sized>(
     encrypted_for: UserId,
     request: CipherEditRequest,
     use_strict_decryption: bool,
-    enable_cipher_key_encryption: bool,
     use_blob: bool,
 ) -> Result<CipherView, EditCipherError> {
     let cipher_id = request.id;
@@ -185,12 +180,6 @@ async fn edit_cipher<R: Repository<Cipher> + ?Sized>(
 
     let mut view: CipherView = convert_request_to_cipher_view(request);
     view.update_password_history(&original_cipher_view);
-
-    // TODO: Once this flag is removed, the key generation logic should be
-    // moved directly into the CompositeEncryptable implementation.
-    if view.key.is_none() && enable_cipher_key_encryption {
-        view.generate_cipher_key(&mut key_store.context())?;
-    }
 
     let encrypted_by_key_id = key_store
         .context()
@@ -271,9 +260,6 @@ impl CiphersClient {
             .get_user_id()
             .ok_or(NotAuthenticatedError)?;
 
-        let enable_cipher_key_encryption =
-            self.client.flags().get().await.enable_cipher_key_encryption;
-
         let use_blob = self.should_use_blob_encryption(request.organization_id);
 
         edit_cipher(
@@ -283,7 +269,6 @@ impl CiphersClient {
             user_id,
             request,
             self.is_strict_decrypt().await,
-            enable_cipher_key_encryption,
             use_blob,
         )
         .await
@@ -563,7 +548,6 @@ mod tests {
             request,
             false,
             false,
-            false,
         )
         .await
         .unwrap();
@@ -704,7 +688,6 @@ mod tests {
             request,
             false,
             false,
-            false,
         )
         .await;
 
@@ -745,7 +728,6 @@ mod tests {
             &repository,
             TEST_USER_ID.parse().unwrap(),
             request,
-            false,
             false,
             false,
         )

--- a/crates/bitwarden-vault/src/cipher/cipher_client/edit.rs
+++ b/crates/bitwarden-vault/src/cipher/cipher_client/edit.rs
@@ -160,10 +160,6 @@ pub(crate) fn convert_request_to_cipher_view(r: CipherEditRequest) -> CipherView
     }
 }
 
-// `use_strict_decryption`, `enable_cipher_key_encryption`, and `use_blob` are
-// short-lived feature-rollout flags that will be removed once their migrations
-// complete, at which point the argument count drops back under the limit.
-#[allow(clippy::too_many_arguments)]
 async fn edit_cipher<R: Repository<Cipher> + ?Sized>(
     key_store: &KeyStore<KeySlotIds>,
     api_client: &bitwarden_api_api::apis::ApiClient,
@@ -171,7 +167,6 @@ async fn edit_cipher<R: Repository<Cipher> + ?Sized>(
     encrypted_for: UserId,
     request: CipherEditRequest,
     use_strict_decryption: bool,
-    enable_cipher_key_encryption: bool,
     use_blob: bool,
 ) -> Result<CipherView, EditCipherError> {
     let cipher_id = request.id;
@@ -185,12 +180,6 @@ async fn edit_cipher<R: Repository<Cipher> + ?Sized>(
 
     let mut view: CipherView = convert_request_to_cipher_view(request);
     view.update_password_history(&original_cipher_view);
-
-    // TODO: Once this flag is removed, the key generation logic should be
-    // moved directly into the CompositeEncryptable implementation.
-    if view.key.is_none() && enable_cipher_key_encryption {
-        view.generate_cipher_key(&mut key_store.context())?;
-    }
 
     let mode = if use_blob {
         EncryptMode::Blob(view)
@@ -265,9 +254,6 @@ impl CiphersClient {
             .get_user_id()
             .ok_or(NotAuthenticatedError)?;
 
-        let enable_cipher_key_encryption =
-            self.client.flags().get().await.enable_cipher_key_encryption;
-
         let use_blob = self.should_use_blob_encryption(request.organization_id);
 
         edit_cipher(
@@ -277,7 +263,6 @@ impl CiphersClient {
             user_id,
             request,
             self.is_strict_decrypt().await,
-            enable_cipher_key_encryption,
             use_blob,
         )
         .await
@@ -556,7 +541,6 @@ mod tests {
             request,
             false,
             false,
-            false,
         )
         .await
         .unwrap();
@@ -696,7 +680,6 @@ mod tests {
             request,
             false,
             false,
-            false,
         )
         .await;
 
@@ -737,7 +720,6 @@ mod tests {
             &repository,
             TEST_USER_ID.parse().unwrap(),
             request,
-            false,
             false,
             false,
         )

--- a/crates/bitwarden-vault/src/cipher/cipher_client/mod.rs
+++ b/crates/bitwarden-vault/src/cipher/cipher_client/mod.rs
@@ -83,9 +83,11 @@ impl CiphersClient {
     }
 
     #[allow(missing_docs)]
+    // The signature is part of the UniFFI and wasm public surface; keep it `async`.
+    #[allow(clippy::unused_async)]
     pub async fn encrypt(
         &self,
-        mut cipher_view: CipherView,
+        cipher_view: CipherView,
     ) -> Result<EncryptionContext, EncryptError> {
         let user_id = self
             .client
@@ -94,18 +96,9 @@ impl CiphersClient {
             .ok_or(EncryptError::MissingUserId)?;
         let key_store = self.client.internal.get_key_store();
 
-        let wrapping_key = cipher_view.key_identifier();
-
-        // TODO: Once this flag is removed, the key generation logic should
-        // be moved directly into the KeyEncryptable implementation
-        if cipher_view.key.is_none() && self.client.flags().get().await.enable_cipher_key_encryption
-        {
-            cipher_view.generate_cipher_key(&mut key_store.context())?;
-        }
-
         let encrypted_by_key_id = key_store
             .context()
-            .get_symmetric_key_id(wrapping_key)
+            .get_symmetric_key_id(cipher_view.key_identifier())
             .map(|id| id.to_string());
 
         let mode = if self.should_use_blob_encryption(cipher_view.organization_id) {
@@ -127,11 +120,13 @@ impl CiphersClient {
     /// Until key rotation is fully implemented in the SDK, this method must be provided the new
     /// symmetric key in base64 format. See PM-23084
     ///
-    /// If the cipher has a CipherKey, it will be re-encrypted with the new key.
-    /// If the cipher does not have a CipherKey and CipherKeyEncryption is enabled, one will be
-    /// generated using the new key. Otherwise, the cipher's data will be encrypted with the new
-    /// key directly.
+    /// The cipher key is wrapped with the new key. A cipher key is generated if the cipher
+    /// does not already have one.
+    ///
+    /// Returns [`CipherError::AttachmentsWithoutKeys`] if any attachment lacks its own key.
     #[cfg(feature = "wasm")]
+    // The signature is part of the wasm public surface; keep it `async`.
+    #[allow(clippy::unused_async)]
     pub async fn encrypt_cipher_for_rotation(
         &self,
         mut cipher_view: CipherView,
@@ -144,8 +139,6 @@ impl CiphersClient {
             .internal
             .get_user_id()
             .ok_or(EncryptError::MissingUserId)?;
-        let enable_cipher_key_encryption =
-            self.client.flags().get().await.enable_cipher_key_encryption;
 
         let key_store = self.client.internal.get_key_store();
         let mut ctx = key_store.context();
@@ -153,11 +146,7 @@ impl CiphersClient {
         // Set the new key in the key store context
         let new_key_id = ctx.add_local_symmetric_key(new_key);
 
-        if cipher_view.key.is_none() && enable_cipher_key_encryption {
-            cipher_view.generate_cipher_key(&mut ctx)?;
-        } else {
-            cipher_view.validate_attachment_keys()?;
-        }
+        cipher_view.validate_attachment_keys()?;
 
         // Rotation installs the new key under a `Local` slot id (`new_key_id`), not the view's
         // natural `User`/`Organization` slot — so pass it explicitly to `encrypt_composite` rather
@@ -187,6 +176,8 @@ impl CiphersClient {
     /// This method attempts to encrypt all ciphers in the list. If any cipher
     /// fails to encrypt, the entire operation fails and an error is returned.
     #[cfg(feature = "wasm")]
+    // The signature is part of the wasm public surface; keep it `async`.
+    #[allow(clippy::unused_async)]
     pub async fn encrypt_list(
         &self,
         cipher_views: Vec<CipherView>,
@@ -197,30 +188,24 @@ impl CiphersClient {
             .get_user_id()
             .ok_or(EncryptError::MissingUserId)?;
         let key_store = self.client.internal.get_key_store();
-        let enable_cipher_key = self.client.flags().get().await.enable_cipher_key_encryption;
-
-        let mut ctx = key_store.context();
+        let ctx = key_store.context();
 
         // Each cipher may be wrapped under a different key (organization vs. user), so the key id
         // is captured per cipher and zipped back up after the batch encrypt.
         let prepared: Vec<(EncryptMode<CipherView>, Option<String>)> = cipher_views
             .into_iter()
-            .map(|mut cv| {
-                let wrapping_key = cv.key_identifier();
-                if cv.key.is_none() && enable_cipher_key {
-                    cv.generate_cipher_key(&mut ctx)?;
-                }
+            .map(|cv| {
                 let encrypted_by_key_id = ctx
-                    .get_symmetric_key_id(wrapping_key)
+                    .get_symmetric_key_id(cv.key_identifier())
                     .map(|id| id.to_string());
                 let mode = if self.should_use_blob_encryption(cv.organization_id) {
                     EncryptMode::Blob(cv)
                 } else {
                     EncryptMode::Legacy(cv)
                 };
-                Ok((mode, encrypted_by_key_id))
+                (mode, encrypted_by_key_id)
             })
-            .collect::<Result<Vec<_>, bitwarden_crypto::CryptoError>>()?;
+            .collect();
 
         let (prepared_modes, key_ids): (Vec<_>, Vec<_>) = prepared.into_iter().unzip();
 
@@ -366,10 +351,9 @@ mod tests {
     use bitwarden_crypto::{CryptoError, SymmetricKeyAlgorithm};
 
     use super::*;
-    use crate::{
-        Attachment, CipherRepromptType, CipherType, Login, VaultClientExt,
-        cipher::blob::try_parse_blob,
-    };
+    use crate::{Attachment, CipherRepromptType, CipherType, Login, VaultClientExt};
+    #[cfg(feature = "wasm")]
+    use crate::{AttachmentView, cipher::blob::try_parse_blob};
 
     fn test_cipher() -> Cipher {
         Cipher {
@@ -888,6 +872,45 @@ mod tests {
         ));
     }
 
+    /// Attachments that carry no key of their own are encrypted under the old user key, so
+    /// rotation must reject them regardless of whether the view already has a cipher key.
+    #[tokio::test]
+    #[cfg(feature = "wasm")]
+    async fn test_encrypt_cipher_for_rotation_with_keyless_attachment_fails() {
+        let client = Client::init_test_account(test_bitwarden_com_account()).await;
+
+        for generate_key in [false, true] {
+            let mut cipher_view = test_cipher_view();
+            if generate_key {
+                cipher_view
+                    .generate_cipher_key(&mut client.internal.get_key_store().context())
+                    .unwrap();
+            }
+            cipher_view.attachments = Some(vec![AttachmentView {
+                id: None,
+                url: None,
+                size: None,
+                size_name: None,
+                file_name: Some("h.txt".to_string()),
+                key: None,
+            }]);
+
+            let new_key =
+                SymmetricCryptoKey::make(SymmetricKeyAlgorithm::Aes256CbcHmac).to_base64();
+
+            let result = client
+                .vault()
+                .ciphers()
+                .encrypt_cipher_for_rotation(cipher_view, new_key)
+                .await;
+
+            assert!(matches!(
+                result.err(),
+                Some(CipherError::AttachmentsWithoutKeys)
+            ));
+        }
+    }
+
     #[cfg(feature = "wasm")]
     #[tokio::test]
     async fn test_encrypt_list() {
@@ -901,7 +924,7 @@ mod tests {
         let contexts = result.unwrap();
         assert_eq!(contexts.len(), 2);
 
-        // Verify each encrypted cipher has a key (cipher key encryption is enabled)
+        // Every encrypted cipher gets a cipher key
         for ctx in &contexts {
             assert!(ctx.cipher.key.is_some());
         }

--- a/crates/bitwarden-vault/src/cipher/cipher_client/mod.rs
+++ b/crates/bitwarden-vault/src/cipher/cipher_client/mod.rs
@@ -882,8 +882,8 @@ mod tests {
         for generate_key in [false, true] {
             let mut cipher_view = test_cipher_view();
             if generate_key {
-                cipher_view
-                    .generate_cipher_key(&mut client.internal.get_key_store().context())
+                let _ = cipher_view
+                    .load_cipher_key_slot(&mut client.internal.get_key_store().context())
                     .unwrap();
             }
             cipher_view.attachments = Some(vec![AttachmentView {

--- a/crates/bitwarden-vault/src/cipher/cipher_client/mod.rs
+++ b/crates/bitwarden-vault/src/cipher/cipher_client/mod.rs
@@ -816,8 +816,8 @@ mod tests {
         for generate_key in [false, true] {
             let mut cipher_view = test_cipher_view();
             if generate_key {
-                cipher_view
-                    .generate_cipher_key(&mut client.internal.get_key_store().context())
+                let _ = cipher_view
+                    .load_cipher_key_slot(&mut client.internal.get_key_store().context())
                     .unwrap();
             }
             cipher_view.attachments = Some(vec![AttachmentView {

--- a/crates/bitwarden-vault/src/cipher/cipher_client/mod.rs
+++ b/crates/bitwarden-vault/src/cipher/cipher_client/mod.rs
@@ -83,9 +83,11 @@ impl CiphersClient {
     }
 
     #[allow(missing_docs)]
+    // The signature is part of the UniFFI and wasm public surface; keep it `async`.
+    #[allow(clippy::unused_async)]
     pub async fn encrypt(
         &self,
-        mut cipher_view: CipherView,
+        cipher_view: CipherView,
     ) -> Result<EncryptionContext, EncryptError> {
         let user_id = self
             .client
@@ -93,13 +95,6 @@ impl CiphersClient {
             .get_user_id()
             .ok_or(EncryptError::MissingUserId)?;
         let key_store = self.client.internal.get_key_store();
-
-        // TODO: Once this flag is removed, the key generation logic should
-        // be moved directly into the KeyEncryptable implementation
-        if cipher_view.key.is_none() && self.client.flags().get().await.enable_cipher_key_encryption
-        {
-            cipher_view.generate_cipher_key(&mut key_store.context())?;
-        }
 
         let mode = if self.should_use_blob_encryption(cipher_view.organization_id) {
             EncryptMode::Blob(cipher_view)
@@ -119,11 +114,13 @@ impl CiphersClient {
     /// Until key rotation is fully implemented in the SDK, this method must be provided the new
     /// symmetric key in base64 format. See PM-23084
     ///
-    /// If the cipher has a CipherKey, it will be re-encrypted with the new key.
-    /// If the cipher does not have a CipherKey and CipherKeyEncryption is enabled, one will be
-    /// generated using the new key. Otherwise, the cipher's data will be encrypted with the new
-    /// key directly.
+    /// The cipher key is wrapped with the new key. A cipher key is generated if the cipher
+    /// does not already have one.
+    ///
+    /// Returns [`CipherError::AttachmentsWithoutKeys`] if any attachment lacks its own key.
     #[cfg(feature = "wasm")]
+    // The signature is part of the wasm public surface; keep it `async`.
+    #[allow(clippy::unused_async)]
     pub async fn encrypt_cipher_for_rotation(
         &self,
         mut cipher_view: CipherView,
@@ -136,8 +133,6 @@ impl CiphersClient {
             .internal
             .get_user_id()
             .ok_or(EncryptError::MissingUserId)?;
-        let enable_cipher_key_encryption =
-            self.client.flags().get().await.enable_cipher_key_encryption;
 
         let key_store = self.client.internal.get_key_store();
         let mut ctx = key_store.context();
@@ -145,11 +140,7 @@ impl CiphersClient {
         // Set the new key in the key store context
         let new_key_id = ctx.add_local_symmetric_key(new_key);
 
-        if cipher_view.key.is_none() && enable_cipher_key_encryption {
-            cipher_view.generate_cipher_key(&mut ctx)?;
-        } else {
-            cipher_view.validate_attachment_keys()?;
-        }
+        cipher_view.validate_attachment_keys()?;
 
         // Rotation installs the new key under a `Local` slot id (`new_key_id`), not the view's
         // natural `User`/`Organization` slot — so pass it explicitly to `encrypt_composite` rather
@@ -172,6 +163,8 @@ impl CiphersClient {
     /// This method attempts to encrypt all ciphers in the list. If any cipher
     /// fails to encrypt, the entire operation fails and an error is returned.
     #[cfg(feature = "wasm")]
+    // The signature is part of the wasm public surface; keep it `async`.
+    #[allow(clippy::unused_async)]
     pub async fn encrypt_list(
         &self,
         cipher_views: Vec<CipherView>,
@@ -182,24 +175,17 @@ impl CiphersClient {
             .get_user_id()
             .ok_or(EncryptError::MissingUserId)?;
         let key_store = self.client.internal.get_key_store();
-        let enable_cipher_key = self.client.flags().get().await.enable_cipher_key_encryption;
-
-        let mut ctx = key_store.context();
 
         let prepared_modes: Vec<EncryptMode<CipherView>> = cipher_views
             .into_iter()
-            .map(|mut cv| {
-                if cv.key.is_none() && enable_cipher_key {
-                    cv.generate_cipher_key(&mut ctx)?;
-                }
-                let mode = if self.should_use_blob_encryption(cv.organization_id) {
+            .map(|cv| {
+                if self.should_use_blob_encryption(cv.organization_id) {
                     EncryptMode::Blob(cv)
                 } else {
                     EncryptMode::Legacy(cv)
-                };
-                Ok(mode)
+                }
             })
-            .collect::<Result<Vec<_>, bitwarden_crypto::CryptoError>>()?;
+            .collect();
 
         let ciphers: Vec<Cipher> = key_store.encrypt_list(&prepared_modes)?;
 
@@ -356,10 +342,9 @@ mod tests {
     use bitwarden_crypto::{CryptoError, SymmetricKeyAlgorithm};
 
     use super::*;
-    use crate::{
-        Attachment, CipherRepromptType, CipherType, Login, VaultClientExt,
-        cipher::blob::try_parse_blob,
-    };
+    use crate::{Attachment, CipherRepromptType, CipherType, Login, VaultClientExt};
+    #[cfg(feature = "wasm")]
+    use crate::{AttachmentView, cipher::blob::try_parse_blob};
 
     fn test_cipher() -> Cipher {
         Cipher {
@@ -821,6 +806,45 @@ mod tests {
         ));
     }
 
+    /// Attachments that carry no key of their own are encrypted under the old user key, so
+    /// rotation must reject them regardless of whether the view already has a cipher key.
+    #[tokio::test]
+    #[cfg(feature = "wasm")]
+    async fn test_encrypt_cipher_for_rotation_with_keyless_attachment_fails() {
+        let client = Client::init_test_account(test_bitwarden_com_account()).await;
+
+        for generate_key in [false, true] {
+            let mut cipher_view = test_cipher_view();
+            if generate_key {
+                cipher_view
+                    .generate_cipher_key(&mut client.internal.get_key_store().context())
+                    .unwrap();
+            }
+            cipher_view.attachments = Some(vec![AttachmentView {
+                id: None,
+                url: None,
+                size: None,
+                size_name: None,
+                file_name: Some("h.txt".to_string()),
+                key: None,
+            }]);
+
+            let new_key =
+                SymmetricCryptoKey::make(SymmetricKeyAlgorithm::Aes256CbcHmac).to_base64();
+
+            let result = client
+                .vault()
+                .ciphers()
+                .encrypt_cipher_for_rotation(cipher_view, new_key)
+                .await;
+
+            assert!(matches!(
+                result.err(),
+                Some(CipherError::AttachmentsWithoutKeys)
+            ));
+        }
+    }
+
     #[cfg(feature = "wasm")]
     #[tokio::test]
     async fn test_encrypt_list() {
@@ -834,7 +858,7 @@ mod tests {
         let contexts = result.unwrap();
         assert_eq!(contexts.len(), 2);
 
-        // Verify each encrypted cipher has a key (cipher key encryption is enabled)
+        // Every encrypted cipher gets a cipher key
         for ctx in &contexts {
             assert!(ctx.cipher.key.is_some());
         }

--- a/crates/bitwarden-vault/src/cipher/cipher_client/share_cipher.rs
+++ b/crates/bitwarden-vault/src/cipher/cipher_client/share_cipher.rs
@@ -814,14 +814,6 @@ mod tests {
 
         let client = Client::new_test(Some(settings));
 
-        client
-            .flags()
-            .load(std::collections::HashMap::from([(
-                "enableCipherKeyEncryption".to_owned(),
-                true,
-            )]))
-            .await;
-
         let user_request = InitUserCryptoRequest {
             user_id: Some(UserId::new(uuid::uuid!("060000fb-0922-4dd3-b170-6e15cb5df8c8"))),
             kdf_params: Kdf::PBKDF2 {

--- a/crates/bitwarden-vault/src/cipher/cipher_client/share_cipher.rs
+++ b/crates/bitwarden-vault/src/cipher/cipher_client/share_cipher.rs
@@ -815,14 +815,6 @@ mod tests {
 
         let client = Client::new_test(Some(settings));
 
-        client
-            .flags()
-            .load(std::collections::HashMap::from([(
-                "enableCipherKeyEncryption".to_owned(),
-                true,
-            )]))
-            .await;
-
         let user_request = InitUserCryptoRequest {
             user_id: Some(UserId::new(uuid::uuid!("060000fb-0922-4dd3-b170-6e15cb5df8c8"))),
             kdf_params: Kdf::PBKDF2 {


### PR DESCRIPTION
## 🎟️ Tracking

[PM-41071](https://bitwarden.atlassian.net/browse/PM-41071)

## 📔 Objective

Remove the internal `cipher-key-encryption` feature flag from the SDK and always use cipher key encryption when encrypting ciphers.


[PM-41071]: https://bitwarden.atlassian.net/browse/PM-41071?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ