### PR TITLE
feat(crypto): implement aes256-cbc-hmac-sha256-aead as a COSE compat layer for type 2 symmetric keys

### DIFF
--- a/crates/bitwarden-core/src/key_management/pin_lock_system.rs
+++ b/crates/bitwarden-core/src/key_management/pin_lock_system.rs
@@ -8,7 +8,7 @@
 //! with an unlock.
 
 use bitwarden_crypto::{
-    Decryptable, KeyStore, PrimitiveEncryptable,
+    Decryptable, KeyId, KeyStore, PrimitiveEncryptable, SymmetricKeyAlgorithm,
     safe::{PasswordProtectedKeyEnvelope, PasswordProtectedKeyEnvelopeNamespace},
 };
 use serde::{Deserialize, Serialize};
@@ -58,24 +58,66 @@ pub(crate) enum UnlockError {
     InternalError,
 }
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq)]
 pub(crate) enum MigrationFailed {
+    /// Vault is locked
+    Locked,
     /// Could not read the contained key id from the persistent envelope.
     EnvelopeMalformed,
-    /// Envelope is V2-encrypted and user key is V2, but the key ids differ.
+    /// Envelope and user key are both V2, but the key ids differ.
     /// V2 -> V2 key rotation is not currently supported here.
     V2KeyRotationUnsupported,
-    /// Envelope is V2-encrypted but the user key is V1 — inconsistent state.
-    V2EnvelopeWithV1UserKey,
+    /// The envelope holds a key that is not the current V1 user key, and no recovery path exists.
+    EnvelopeWithKeyIdWithV1UserKey,
     /// V1 -> V2 migration is required but no V2 upgrade token is stored.
     MissingV2UpgradeToken,
-    /// V1 -> V2 migration is required but no encrypted PIN is stored.
+    /// Re-enrollment is required but no encrypted PIN is stored.
     MissingEncryptedPin,
-    /// V1 -> V2 migration could not decrypt the encrypted PIN via the upgrade
-    /// token.
+    /// Re-enrollment could not decrypt the encrypted PIN.
     PinDecryption,
     /// Re-sealing the envelope under the new user key failed.
     Reenrollment,
+}
+
+/// What [`PinLockSystem::migrate_pin_envelope_if_needed`] should do with the persistent PIN
+/// envelope, decided from key ids alone.
+#[derive(Debug, PartialEq, Eq)]
+enum PinEnvelopeAction {
+    /// The envelope already holds the current user key. Nothing to do.
+    UpToDate,
+    /// The envelope holds the current V1 user key but was sealed before V1 keys had derived key
+    /// ids, so it carries none. Re-enroll under the same key so the envelope gains one. This is
+    /// not a key change and needs no upgrade token.
+    BackfillKeyId,
+    /// The envelope holds the previous V1 user key. Re-enroll under the current V2 user key. The
+    /// upgrade token is used to confirm the envelope really is V1 before anything is rewritten.
+    MigrateV1ToV2,
+    /// Terminal failure; no migration is possible.
+    Failed(MigrationFailed),
+}
+
+/// Decides what to do with the persistent PIN envelope.
+///
+/// - No key id at all means the envelope predates derived key ids, which means it was sealed under
+///   a V1 key — V2 keys have always had one.
+/// - A key id that differs from the user key's is ambiguous, and only the V2 upgrade token can
+///   resolve it.
+fn classify_pin_envelope(
+    envelope_key_id: Option<&KeyId>,
+    current_user_key_id: &KeyId,
+    user_key_is_v1: bool,
+) -> PinEnvelopeAction {
+    match envelope_key_id {
+        Some(envelope_key_id) if envelope_key_id == current_user_key_id => {
+            PinEnvelopeAction::UpToDate
+        }
+        None if user_key_is_v1 => PinEnvelopeAction::BackfillKeyId,
+        None => PinEnvelopeAction::MigrateV1ToV2,
+        Some(_) if user_key_is_v1 => {
+            PinEnvelopeAction::Failed(MigrationFailed::EnvelopeWithKeyIdWithV1UserKey)
+        }
+        Some(_) => PinEnvelopeAction::MigrateV1ToV2,
+    }
 }
 
 /// Provides PIN-based unlock functionality. This includes enrolling into PIN-based unlock,
@@ -145,9 +187,17 @@ impl PinLockSystem<'_> {
             .map_err(|_| UnlockError::InternalError)
     }
 
-    /// After a V2 upgrade, when a V2 upgrade token is present and the persistent
-    /// PIN envelope is still encrypted with the V1 user key, this function migrates
-    /// the persistent PIN enrollment to be encrypted with the current user-key.
+    /// Brings the persistent PIN envelope in line with the current user key.
+    ///
+    /// This covers two cases, both of which end in a fresh enrollment and differ only in how the
+    /// previous PIN is recovered:
+    ///
+    /// - After a V2 upgrade, when a V2 upgrade token is present and the persistent PIN envelope is
+    ///   still encrypted with the V1 user key, the enrollment is migrated to the current user key.
+    /// - When the envelope was sealed before V1 keys had derived key ids, it is re-enrolled under
+    ///   the same, unchanged key so that it gains one.
+    ///
+    /// See [`classify_pin_envelope`] for how the two are told apart.
     async fn migrate_pin_envelope_if_needed(&self) -> Result<(), MigrationFailed> {
         let Some(envelope) = self
             .client
@@ -161,53 +211,82 @@ impl PinLockSystem<'_> {
         let envelope_key_id = envelope
             .contained_key_id()
             .map_err(|_| MigrationFailed::EnvelopeMalformed)?;
-        let current_user_key_id = self
-            .key_store()
-            .context()
-            .get_symmetric_key_id(SymmetricKeySlotId::User);
-        // Detect which scenario we are in. A key id being present indicates V2 encryption.
-        // Absence of a key indicates V1 encryption. A key rotation changes the key id.
-        match (envelope_key_id, current_user_key_id) {
-            // Envelope is up-to-date, no migration needed
-            (Some(envelope_key_id), Some(current_user_key_id))
-                if envelope_key_id == current_user_key_id =>
-            {
-                return Ok(());
+        // Scoped so the context is dropped before the awaits below.
+        let (current_user_key_id, user_key_is_v1) = {
+            let ctx = self.key_store().context();
+            (
+                ctx.get_symmetric_key_id(SymmetricKeySlotId::User)
+                    .ok_or(MigrationFailed::Locked)?,
+                matches!(
+                    ctx.get_symmetric_key_algorithm(SymmetricKeySlotId::User),
+                    Ok(SymmetricKeyAlgorithm::Aes256CbcHmac)
+                ),
+            )
+        };
+
+        // Recover the previous PIN, in the way the classified action calls for.
+        let pin: String = match classify_pin_envelope(
+            envelope_key_id.as_ref(),
+            &current_user_key_id,
+            user_key_is_v1,
+        ) {
+            PinEnvelopeAction::UpToDate => return Ok(()),
+            PinEnvelopeAction::Failed(error) => return Err(error),
+
+            // The user key has not changed, so the stored PIN is still encrypted under it.
+            PinEnvelopeAction::BackfillKeyId => {
+                let encrypted_pin = self
+                    .client
+                    .km_state_bridge()
+                    .get_encrypted_pin()
+                    .await
+                    .ok_or(MigrationFailed::MissingEncryptedPin)?;
+                encrypted_pin
+                    .decrypt(
+                        &mut self.key_store().context_mut(),
+                        SymmetricKeySlotId::User,
+                    )
+                    .map_err(|_| MigrationFailed::PinDecryption)?
             }
-            // V1 -> V2 migration
-            (None, Some(_)) => {}
-            // V2 -> V2 key rotation. Not supported currently.
-            (Some(_), Some(_)) => return Err(MigrationFailed::V2KeyRotationUnsupported),
-            // V2 -> V1 migration. Not possible, something strange happened.
-            (Some(_), None) => return Err(MigrationFailed::V2EnvelopeWithV1UserKey),
-            // V1 -> V1 (unable to see whether key changed)
-            (None, None) => return Ok(()),
-        }
 
-        let token = self
-            .client
-            .km_state_bridge()
-            .get_v2_upgrade_token()
-            .await
-            .ok_or(MigrationFailed::MissingV2UpgradeToken)?;
-        let encrypted_pin = self
-            .client
-            .km_state_bridge()
-            .get_encrypted_pin()
-            .await
-            .ok_or(MigrationFailed::MissingEncryptedPin)?;
+            // The stored PIN is encrypted under the previous V1 user key, which has to be
+            // recovered from the upgrade token first.
+            PinEnvelopeAction::MigrateV1ToV2 => {
+                let token = self
+                    .client
+                    .km_state_bridge()
+                    .get_v2_upgrade_token()
+                    .await
+                    .ok_or(MigrationFailed::MissingV2UpgradeToken)?;
+                let encrypted_pin = self
+                    .client
+                    .km_state_bridge()
+                    .get_encrypted_pin()
+                    .await
+                    .ok_or(MigrationFailed::MissingEncryptedPin)?;
 
-        // Attempt to decrypt the previous PIN via the upgrade token.
-        let pin = (|| -> Result<String, ()> {
-            let mut ctx = self.key_store().context_mut();
-            let v1_slot = token
-                .unwrap_v1(SymmetricKeySlotId::User, &mut ctx)
-                .map_err(|_| ())?;
-            encrypted_pin.decrypt(&mut ctx, v1_slot).map_err(|_| ())
-        })()
-        .map_err(|_| MigrationFailed::PinDecryption)?;
+                // The unwrapped V1 key only lives in this context, so unwrapping it, identifying
+                // the envelope with it, and decrypting the PIN all have to share one context.
+                let mut ctx = self.key_store().context_mut();
+                let v1_slot = token
+                    .unwrap_v1(SymmetricKeySlotId::User, &mut ctx)
+                    .map_err(|_| MigrationFailed::PinDecryption)?;
 
-        // Do a fresh enrollment with the new user-key
+                // A V1 envelope holds the key the upgrade token unwraps. An envelope with no key id
+                // predates derived key ids and is taken to be V1; one holding any other
+                // key is a V2 -> V2 rotation.
+                if envelope_key_id.is_some() && envelope_key_id != ctx.get_symmetric_key_id(v1_slot)
+                {
+                    return Err(MigrationFailed::V2KeyRotationUnsupported);
+                }
+
+                encrypted_pin
+                    .decrypt(&mut ctx, v1_slot)
+                    .map_err(|_| MigrationFailed::PinDecryption)?
+            }
+        };
+
+        // Do a fresh enrollment with the current user-key
         self.set_pin(pin, PinLockType::BeforeFirstUnlock)
             .await
             .map_err(|_| MigrationFailed::Reenrollment)?;
@@ -423,6 +502,46 @@ mod tests {
                 SymmetricKeySlotId::User,
             )
             .expect("encrypted pin should decrypt successfully")
+    }
+
+    /// The PIN [`TESTVECTOR_LEGACY_ENVELOPE`] was sealed with.
+    const TESTVECTOR_LEGACY_ENVELOPE_PIN: &str = "1234";
+    /// A `PinUnlock` envelope sealed under an AES-CBC-HMAC (V1) key by a client predating derived
+    /// key ids, so it carries no contained key id.
+    ///
+    /// The migration never unseals this envelope — it reads the contained key id and then
+    /// re-enrolls from the key store — so the key sealed inside is arbitrary and deliberately
+    /// unrelated to the user key the tests install.
+    ///
+    /// The current seal path always writes a contained key id, so re-recording this requires
+    /// temporarily changing `set_contained_key_id(&mut header, key_to_seal.key_id())` in
+    /// `bitwarden-crypto/src/safe/password_protected_key_envelope.rs` to pass `None`, sealing a
+    /// `PinUnlock` envelope for an `Aes256CbcHmac` key with [`TESTVECTOR_LEGACY_ENVELOPE_PIN`],
+    /// printing `Vec::from(&envelope)`, and then reverting that change.
+    const TESTVECTOR_LEGACY_ENVELOPE: &[u8] = &[
+        132, 88, 52, 164, 1, 3, 3, 120, 34, 97, 112, 112, 108, 105, 99, 97, 116, 105, 111, 110, 47,
+        120, 46, 98, 105, 116, 119, 97, 114, 100, 101, 110, 46, 108, 101, 103, 97, 99, 121, 45,
+        107, 101, 121, 58, 0, 1, 56, 129, 1, 58, 0, 1, 56, 128, 1, 161, 5, 76, 148, 49, 223, 205,
+        195, 252, 91, 216, 65, 200, 121, 104, 88, 80, 89, 120, 16, 161, 14, 97, 191, 97, 138, 42,
+        102, 234, 49, 186, 2, 255, 31, 4, 232, 178, 100, 53, 37, 181, 172, 129, 193, 51, 109, 8,
+        160, 29, 254, 181, 242, 102, 73, 229, 89, 150, 227, 252, 120, 156, 71, 202, 200, 241, 74,
+        241, 206, 16, 155, 83, 49, 242, 13, 209, 10, 217, 251, 164, 244, 69, 41, 52, 9, 192, 140,
+        248, 251, 244, 84, 154, 15, 100, 222, 102, 117, 185, 129, 131, 71, 161, 1, 58, 0, 1, 21,
+        87, 165, 1, 58, 0, 1, 21, 87, 58, 0, 1, 21, 89, 3, 58, 0, 1, 21, 90, 26, 0, 1, 0, 0, 58, 0,
+        1, 21, 91, 4, 58, 0, 1, 21, 88, 80, 64, 184, 87, 20, 40, 186, 214, 56, 87, 53, 118, 100, 5,
+        21, 13, 3, 246,
+    ];
+
+    /// Parses [`TESTVECTOR_LEGACY_ENVELOPE`], asserting it really has no contained key id.
+    fn legacy_envelope() -> PasswordProtectedKeyEnvelope {
+        let envelope = PasswordProtectedKeyEnvelope::try_from(&TESTVECTOR_LEGACY_ENVELOPE.to_vec())
+            .expect("legacy envelope test vector parses");
+        assert_eq!(
+            envelope.contained_key_id().expect("readable"),
+            None,
+            "legacy envelope test vector must have no contained key id",
+        );
+        envelope
     }
 
     /// Returns the `KeyId` of the symmetric key currently in `SymmetricKeySlotId::User`.
@@ -854,77 +973,82 @@ mod tests {
         );
     }
 
+    // ------------------------------------------------------------------------------------
+    // PIN envelope migration
+    //
+    // These follow the cases in `classify_pin_envelope`: the classifier in isolation first, then
+    // each action and failure branch end to end, in the same order.
+    // ------------------------------------------------------------------------------------
+
+    fn test_key_id(byte: u8) -> KeyId {
+        KeyId::from([byte; 16])
+    }
+
+    #[test]
+    fn classify_matching_key_id_is_up_to_date() {
+        for user_key_is_v1 in [true, false] {
+            assert_eq!(
+                classify_pin_envelope(Some(&test_key_id(1)), &test_key_id(1), user_key_is_v1),
+                PinEnvelopeAction::UpToDate,
+                "user_key_is_v1 = {user_key_is_v1}",
+            );
+        }
+    }
+
+    #[test]
+    fn classify_missing_envelope_key_id_with_v1_user_key_backfills() {
+        assert_eq!(
+            classify_pin_envelope(None, &test_key_id(1), true),
+            PinEnvelopeAction::BackfillKeyId,
+        );
+    }
+
+    #[test]
+    fn classify_missing_envelope_key_id_with_v2_user_key_migrates() {
+        assert_eq!(
+            classify_pin_envelope(None, &test_key_id(1), false),
+            PinEnvelopeAction::MigrateV1ToV2,
+        );
+    }
+
+    #[test]
+    fn classify_differing_key_id_with_v1_user_key_fails() {
+        assert_eq!(
+            classify_pin_envelope(Some(&test_key_id(1)), &test_key_id(2), true),
+            PinEnvelopeAction::Failed(MigrationFailed::EnvelopeWithKeyIdWithV1UserKey),
+        );
+    }
+
+    #[test]
+    fn classify_differing_key_id_with_v2_user_key_migrates() {
+        assert_eq!(
+            classify_pin_envelope(Some(&test_key_id(1)), &test_key_id(2), false),
+            PinEnvelopeAction::MigrateV1ToV2,
+        );
+    }
+
+    /// Classification needs a user key to compare against, so a locked vault is rejected before
+    /// [`classify_pin_envelope`] is reached.
     #[tokio::test]
-    async fn migrate_v1_to_v2_reseals_envelope_with_user_key() {
-        let pin = "1234";
-        let (client, state) = fresh_v1_state_with_v2_user_key(pin);
-        let bridge = client.km_state_bridge();
-        bridge.set_persistent_pin_envelope(&state.envelope).await;
-        bridge.set_encrypted_pin(&state.encrypted_pin).await;
-        bridge.set_v2_upgrade_token(&state.token).await;
+    async fn migrate_without_user_key_fails_locked() {
+        let client = Client::new(None);
+        client
+            .km_state_bridge()
+            .register_bridge(Box::new(InMemoryStateBridge::default()));
+        client
+            .km_state_bridge()
+            .set_persistent_pin_envelope(&legacy_envelope())
+            .await;
 
-        assert_eq!(
-            state.envelope.contained_key_id().expect("readable"),
-            None,
-            "starting envelope is V1 (no key_id)",
-        );
-
-        let user_key_id = user_key_id(&client);
         let system = PinLockSystem::with_client(&client);
-
-        system
-            .migrate_pin_envelope_if_needed()
-            .await
-            .expect("migration succeeds");
-
-        let persistent = bridge
-            .get_persistent_pin_envelope()
-            .await
-            .expect("persistent envelope present after migration");
-        let ephemeral = bridge
-            .get_ephemeral_pin_envelope()
-            .await
-            .expect("ephemeral envelope present after migration");
-        let encrypted_pin = bridge
-            .get_encrypted_pin()
-            .await
-            .expect("encrypted pin present after migration");
-
-        assert_envelope_wraps_user_key(&client, &persistent, pin, &user_key_id);
-        assert_envelope_wraps_user_key(&client, &ephemeral, pin, &user_key_id);
-        assert_eq!(decrypt_encrypted_pin(&client, &encrypted_pin), pin);
         assert_eq!(
-            system.get_pin_lock_type().await,
-            Some(PinLockType::BeforeFirstUnlock),
+            system.migrate_pin_envelope_if_needed().await,
+            Err(MigrationFailed::Locked),
         );
-        assert_eq!(system.get_pin_status().await, PinUnlockStatus::Available);
-        assert!(system.unlock(pin).await.is_ok());
     }
 
     #[tokio::test]
-    async fn on_unlock_triggers_v1_to_v2_migration() {
-        let pin = "1234";
-        let (client, state) = fresh_v1_state_with_v2_user_key(pin);
-        let bridge = client.km_state_bridge();
-        bridge.set_persistent_pin_envelope(&state.envelope).await;
-        bridge.set_encrypted_pin(&state.encrypted_pin).await;
-        bridge.set_v2_upgrade_token(&state.token).await;
-
-        let user_key_id = user_key_id(&client);
-        let system = PinLockSystem::with_client(&client);
-
-        system.on_unlock().await;
-
-        let persistent = bridge
-            .get_persistent_pin_envelope()
-            .await
-            .expect("persistent envelope present after on_unlock");
-        assert_envelope_wraps_user_key(&client, &persistent, pin, &user_key_id);
-        assert!(system.unlock(pin).await.is_ok());
-    }
-
-    #[tokio::test]
-    async fn migrate_no_persistent_envelope_is_noop() {
+    async fn migrate_without_persistent_envelope_is_noop() {
         let client = client_with_user_key();
         let system = PinLockSystem::with_client(&client);
 
@@ -936,8 +1060,9 @@ mod tests {
         assert_pin_fully_unenrolled(&client).await;
     }
 
+    /// The envelope already holds the current V2 user key.
     #[tokio::test]
-    async fn migrate_v2_envelope_matching_user_key_is_noop() {
+    async fn migrate_up_to_date_v2_envelope_is_noop() {
         let client = client_with_user_key();
         let system = PinLockSystem::with_client(&client);
         system
@@ -984,8 +1109,10 @@ mod tests {
         assert_eq!(encrypted_pin_before, encrypted_pin_after);
     }
 
+    /// A V1 envelope sealed by a current client carries the V1 key's derived key id, so it
+    /// already matches the user key.
     #[tokio::test]
-    async fn migrate_v1_envelope_with_v1_user_key_is_noop() {
+    async fn migrate_up_to_date_v1_envelope_is_noop() {
         let pin = "1234";
         let client = client_with_v1_user_key();
         let envelope = seal_envelope(&client, pin);
@@ -1000,7 +1127,11 @@ mod tests {
         bridge.set_persistent_pin_envelope(&envelope).await;
         bridge.set_encrypted_pin(&encrypted_pin).await;
 
-        assert_eq!(envelope.contained_key_id().expect("readable"), None);
+        assert_eq!(
+            envelope.contained_key_id().expect("readable"),
+            Some(user_key_id(&client)),
+            "a freshly sealed V1 envelope carries the V1 key's derived key id",
+        );
 
         let persistent_before = &envelope;
         let encrypted_pin_before = encrypted_pin.to_string();
@@ -1025,40 +1156,58 @@ mod tests {
         assert!(bridge.get_ephemeral_pin_envelope().await.is_none());
     }
 
+    /// The envelope predates derived key ids and the user key is unchanged, so it is re-enrolled
+    /// under that same key purely to gain a key id. This is the state every existing V1 PIN user
+    /// is in, so it must never fail the unlock.
     #[tokio::test]
-    async fn migrate_v2_envelope_not_matching_user_key_returns_v2_key_rotation_unsupported() {
-        let client = client_with_user_key();
+    async fn migrate_legacy_envelope_with_v1_user_key_backfills_key_id() {
+        let pin = TESTVECTOR_LEGACY_ENVELOPE_PIN;
+        let client = client_with_v1_user_key();
+        let encrypted_pin = pin
+            .encrypt(
+                &mut client.internal.get_key_store().context_mut(),
+                SymmetricKeySlotId::User,
+            )
+            .expect("encrypt under v1 user key");
+
+        let bridge = client.km_state_bridge();
+        bridge.set_persistent_pin_envelope(&legacy_envelope()).await;
+        bridge.set_encrypted_pin(&encrypted_pin).await;
+
+        let user_key_id = user_key_id(&client);
         let system = PinLockSystem::with_client(&client);
         system
-            .set_pin("1234".into(), PinLockType::BeforeFirstUnlock)
+            .migrate_pin_envelope_if_needed()
             .await
-            .expect("set_pin succeeds");
+            .expect("migration succeeds");
 
-        // Replace the persistent envelope with one sealed under a *different* V2 key.
-        let mismatched_envelope = {
-            let mut ctx = client.internal.get_key_store().context_mut();
-            let other_v2 = ctx.make_symmetric_key(SymmetricKeyAlgorithm::XAes256Gcm);
-            PasswordProtectedKeyEnvelope::seal(
-                other_v2,
-                "1234",
-                PasswordProtectedKeyEnvelopeNamespace::PinUnlock,
-                &ctx,
-            )
-            .expect("seal under other v2 key")
-        };
-        client
-            .km_state_bridge()
-            .set_persistent_pin_envelope(&mismatched_envelope)
-            .await;
-
-        assert!(matches!(
-            system.migrate_pin_envelope_if_needed().await,
-            Err(MigrationFailed::V2KeyRotationUnsupported),
-        ));
+        let persistent = bridge
+            .get_persistent_pin_envelope()
+            .await
+            .expect("persistent envelope present after backfill");
+        assert_envelope_wraps_user_key(&client, &persistent, pin, &user_key_id);
+        assert!(system.unlock(pin).await.is_ok());
     }
 
+    /// A backfill with no PIN to re-enroll with.
     #[tokio::test]
-    async fn migrate_v2_envelope_with_v1_user_key_returns_v2_envelope_with_v1_user_key() {
+    async fn migrate_legacy_envelope_with_v1_user_key_without_encrypted_pin_fails() {
+        let client = client_with_v1_user_key();
+        let bridge = client.km_state_bridge();
+        bridge.set_persistent_pin_envelope(&legacy_envelope()).await;
+        // Intentionally omit set_encrypted_pin.
+
+        let system = PinLockSystem::with_client(&client);
+        assert_eq!(
+            system.migrate_pin_envelope_if_needed().await,
+            Err(MigrationFailed::MissingEncryptedPin),
+        );
+    }
+
+    /// The envelope holds some key other than the V1 user key. The upgrade token is unwrapped
+    /// with the user key, so a V1 user key leaves no way to recover the other one.
+    #[tokio::test]
+    async fn migrate_envelope_with_v1_user_key_and_other_key_id_fails() {
         let client = client_with_v1_user_key();
 
         // Build a V2-sealed envelope using a transient V2 key.
@@ -1083,14 +1232,61 @@ mod tests {
         bridge.set_persistent_pin_envelope(&v2_envelope).await;
 
         let system = PinLockSystem::with_client(&client);
-        assert!(matches!(
+        assert_eq!(
             system.migrate_pin_envelope_if_needed().await,
-            Err(MigrationFailed::V2EnvelopeWithV1UserKey),
-        ));
+            Err(MigrationFailed::EnvelopeWithKeyIdWithV1UserKey),
+        );
+    }
+
+    /// The envelope holds the V1 key the upgrade token unwraps.
+    #[tokio::test]
+    async fn migrate_v1_envelope_with_v2_user_key_reseals_with_user_key() {
+        let pin = "1234";
+        let (client, state) = fresh_v1_state_with_v2_user_key(pin);
+        let bridge = client.km_state_bridge();
+        bridge.set_persistent_pin_envelope(&state.envelope).await;
+        bridge.set_encrypted_pin(&state.encrypted_pin).await;
+        bridge.set_v2_upgrade_token(&state.token).await;
+
+        let user_key_id = user_key_id(&client);
+        assert_ne!(
+            state.envelope.contained_key_id().expect("readable"),
+            Some(user_key_id.clone()),
+            "starting envelope holds the V1 key, not the current V2 user key",
+        );
+
+        let system = PinLockSystem::with_client(&client);
+        system
+            .migrate_pin_envelope_if_needed()
+            .await
+            .expect("migration succeeds");
+
+        let persistent = bridge
+            .get_persistent_pin_envelope()
+            .await
+            .expect("persistent envelope present after migration");
+        let ephemeral = bridge
+            .get_ephemeral_pin_envelope()
+            .await
+            .expect("ephemeral envelope present after migration");
+        let encrypted_pin = bridge
+            .get_encrypted_pin()
+            .await
+            .expect("encrypted pin present after migration");
+
+        assert_envelope_wraps_user_key(&client, &persistent, pin, &user_key_id);
+        assert_envelope_wraps_user_key(&client, &ephemeral, pin, &user_key_id);
+        assert_eq!(decrypt_encrypted_pin(&client, &encrypted_pin), pin);
+        assert_eq!(
+            system.get_pin_lock_type().await,
+            Some(PinLockType::BeforeFirstUnlock),
+        );
+        assert_eq!(system.get_pin_status().await, PinUnlockStatus::Available);
+        assert!(system.unlock(pin).await.is_ok());
     }
 
     #[tokio::test]
-    async fn migrate_v1_to_v2_without_upgrade_token_returns_missing_v2_upgrade_token() {
+    async fn migrate_v1_envelope_with_v2_user_key_without_token_fails() {
         let pin = "1234";
         let (client, state) = fresh_v1_state_with_v2_user_key(pin);
         let bridge = client.km_state_bridge();
@@ -1099,14 +1295,14 @@ mod tests {
         // Intentionally omit set_v2_upgrade_token.
 
         let system = PinLockSystem::with_client(&client);
-        assert!(matches!(
+        assert_eq!(
             system.migrate_pin_envelope_if_needed().await,
             Err(MigrationFailed::MissingV2UpgradeToken),
-        ));
+        );
     }
 
     #[tokio::test]
-    async fn migrate_v1_to_v2_without_encrypted_pin_returns_missing_encrypted_pin() {
+    async fn migrate_v1_envelope_with_v2_user_key_without_encrypted_pin_fails() {
         let pin = "1234";
         let (client, state) = fresh_v1_state_with_v2_user_key(pin);
         let bridge = client.km_state_bridge();
@@ -1115,14 +1311,14 @@ mod tests {
         // Intentionally omit set_encrypted_pin.
 
         let system = PinLockSystem::with_client(&client);
-        assert!(matches!(
+        assert_eq!(
             system.migrate_pin_envelope_if_needed().await,
             Err(MigrationFailed::MissingEncryptedPin),
-        ));
+        );
     }
 
     #[tokio::test]
-    async fn migrate_v1_to_v2_with_mismatched_upgrade_token_returns_pin_decryption_failure() {
+    async fn migrate_v1_envelope_with_v2_user_key_with_mismatched_token_fails() {
         let pin = "1234";
         let (client, state) = fresh_v1_state_with_v2_user_key(pin);
 
@@ -1143,10 +1339,107 @@ mod tests {
         bridge.set_v2_upgrade_token(&unrelated_token).await;
 
         let system = PinLockSystem::with_client(&client);
-        assert!(matches!(
+        assert_eq!(
             system.migrate_pin_envelope_if_needed().await,
             Err(MigrationFailed::PinDecryption),
-        ));
+        );
+    }
+
+    /// The token unwraps, but the envelope holds neither that V1 key nor the current user key, so
+    /// the user key was rotated rather than upgraded.
+    #[tokio::test]
+    async fn migrate_v2_envelope_with_rotated_user_key_fails() {
+        let client = client_with_user_key();
+        let system = PinLockSystem::with_client(&client);
+        system
+            .set_pin("1234".into(), PinLockType::BeforeFirstUnlock)
+            .await
+            .expect("set_pin succeeds");
+
+        // Replace the persistent envelope with one sealed under a *different* V2 key, and supply
+        // an upgrade token for the current user key so the rotation check is actually reached.
+        let (mismatched_envelope, token) = {
+            let mut ctx = client.internal.get_key_store().context_mut();
+            let other_v2 = ctx.make_symmetric_key(SymmetricKeyAlgorithm::XAes256Gcm);
+            let envelope = PasswordProtectedKeyEnvelope::seal(
+                other_v2,
+                "1234",
+                PasswordProtectedKeyEnvelopeNamespace::PinUnlock,
+                &ctx,
+            )
+            .expect("seal under other v2 key");
+
+            let v1 = ctx.make_symmetric_key(SymmetricKeyAlgorithm::Aes256CbcHmac);
+            let token = V2UpgradeToken::create(v1, SymmetricKeySlotId::User, &ctx)
+                .expect("upgrade token created");
+            (envelope, token)
+        };
+
+        let bridge = client.km_state_bridge();
+        bridge
+            .set_persistent_pin_envelope(&mismatched_envelope)
+            .await;
+        bridge.set_v2_upgrade_token(&token).await;
+
+        assert_eq!(
+            system.migrate_pin_envelope_if_needed().await,
+            Err(MigrationFailed::V2KeyRotationUnsupported),
+        );
+    }
+
+    /// Without a token the rotation above cannot be distinguished from a V1 envelope, so the
+    /// missing token is reported instead.
+    #[tokio::test]
+    async fn migrate_v2_envelope_with_rotated_user_key_without_token_fails() {
+        let client = client_with_user_key();
+        let system = PinLockSystem::with_client(&client);
+        system
+            .set_pin("1234".into(), PinLockType::BeforeFirstUnlock)
+            .await
+            .expect("set_pin succeeds");
+
+        let mismatched_envelope = {
+            let mut ctx = client.internal.get_key_store().context_mut();
+            let other_v2 = ctx.make_symmetric_key(SymmetricKeyAlgorithm::XAes256Gcm);
+            PasswordProtectedKeyEnvelope::seal(
+                other_v2,
+                "1234",
+                PasswordProtectedKeyEnvelopeNamespace::PinUnlock,
+                &ctx,
+            )
+            .expect("seal under other v2 key")
+        };
+        client
+            .km_state_bridge()
+            .set_persistent_pin_envelope(&mismatched_envelope)
+            .await;
+
+        assert_eq!(
+            system.migrate_pin_envelope_if_needed().await,
+            Err(MigrationFailed::MissingV2UpgradeToken),
+        );
+    }
+
+    #[tokio::test]
+    async fn on_unlock_triggers_migration() {
+        let pin = "1234";
+        let (client, state) = fresh_v1_state_with_v2_user_key(pin);
+        let bridge = client.km_state_bridge();
+        bridge.set_persistent_pin_envelope(&state.envelope).await;
+        bridge.set_encrypted_pin(&state.encrypted_pin).await;
+        bridge.set_v2_upgrade_token(&state.token).await;
+
+        let user_key_id = user_key_id(&client);
+        let system = PinLockSystem::with_client(&client);
+
+        system.on_unlock().await;
+
+        let persistent = bridge
+            .get_persistent_pin_envelope()
+            .await
+            .expect("persistent envelope present after on_unlock");
+        assert_envelope_wraps_user_key(&client, &persistent, pin, &user_key_id);
+        assert!(system.unlock(pin).await.is_ok());
     }
 
     #[tokio::test]

--- a/crates/bitwarden-crypto/src/cose/mod.rs
+++ b/crates/bitwarden-crypto/src/cose/mod.rs
@@ -37,6 +37,12 @@ pub(crate) const XCHACHA20_POLY1305: i64 = -70000;
 /// derived key and last 96 bits of the input nonce are then used to encrypt
 /// with AES-256-GCM.
 pub(crate) const XAES_256_GCM: i64 = -70010;
+/// AES-256-CBC-HMAC-SHA256 used as an Encrypt-then-MAC AEAD. No IANA-registered COSE algorithm
+/// describes this construction: the MAC is taken over the IV, length-prefixed ciphertext, and
+/// associated data, so that the associated data required by COSE is authenticated. See
+/// [`Aes256CbcHmacSha256Aead`](crate::hazmat::symmetric_encryption::Aes256CbcHmacSha256Aead) for
+/// the exact MAC input. A private-use value is therefore allocated.
+pub(crate) const AES_256_CBC_HMAC_SHA256_AEAD: i64 = -70011;
 pub(crate) const ALG_ARGON2ID13: i64 = -71000;
 /// PBKDF2-HMAC-SHA256 KDF algorithm discriminant, used by the password protected key envelope in
 /// the FIPS cipher suite. PBKDF2 is FIPS-approved, unlike Argon2id ([`ALG_ARGON2ID13`]).

--- a/crates/bitwarden-crypto/src/cose/symmetric.rs
+++ b/crates/bitwarden-crypto/src/cose/symmetric.rs
@@ -8,13 +8,17 @@ use coset::{
     CoseEncryptBuilder, Header, HeaderBuilder, iana,
 };
 
-use super::{XAES_256_GCM, XCHACHA20_POLY1305};
+use super::{AES_256_CBC_HMAC_SHA256_AEAD, XAES_256_GCM, XCHACHA20_POLY1305};
 use crate::{
     ContentFormat, CoseEncrypt0Bytes, CryptoError, XAes256GcmKey, XChaCha20Poly1305Key,
     error::EncStringParseError,
     hazmat::symmetric_encryption::{
         Aead,
         aes_gcm::{Aes256Gcm, Aes256GcmCiphertext, Aes256GcmNonce},
+        aes256_cbc_hmac_sha256_aead::{
+            Aes256CbcHmacSha256Aead, Aes256CbcHmacSha256AeadCiphertext,
+            Aes256CbcHmacSha256AeadNonce,
+        },
         xaes_256_gcm::{XAes256Gcm, XAes256GcmCiphertext, XAes256GcmNonce},
         xchacha20::{XChaCha20Poly1305, XChaCha20Poly1305Ciphertext, XChaCha20Poly1305Nonce},
     },
@@ -39,6 +43,8 @@ pub(crate) enum CoseContentEncryptionAlgorithm {
     XAes256Gcm,
     /// XChaCha20-Poly1305 (private-use [`XCHACHA20_POLY1305`]).
     XChaCha20Poly1305,
+    /// AES-256-CBC-HMAC-SHA256 Encrypt-then-MAC (private-use [`AES_256_CBC_HMAC_SHA256_AEAD`]).
+    Aes256CbcHmacSha256,
 }
 
 /// Policy for resolving and validating a COSE message's content-encryption algorithm.
@@ -60,6 +66,7 @@ impl TryFrom<&Algorithm> for CoseContentEncryptionAlgorithm {
             Algorithm::Assigned(iana::Algorithm::A256GCM) => Ok(Self::Aes256Gcm),
             Algorithm::PrivateUse(XAES_256_GCM) => Ok(Self::XAes256Gcm),
             Algorithm::PrivateUse(XCHACHA20_POLY1305) => Ok(Self::XChaCha20Poly1305),
+            Algorithm::PrivateUse(AES_256_CBC_HMAC_SHA256_AEAD) => Ok(Self::Aes256CbcHmacSha256),
             _ => Err(CryptoError::WrongKeyType),
         }
     }
@@ -165,6 +172,16 @@ pub(crate) fn encrypt_cose(
                 cek,
             ))
         }
+        CoseContentEncryptionAlgorithm::Aes256CbcHmacSha256 => {
+            let cek: &<Aes256CbcHmacSha256Aead as Aead>::Key =
+                cek.try_into().map_err(|_| CryptoError::InvalidKeyLen)?;
+            Ok(Aes256CbcHmacSha256Aead::encrypt_cose(
+                builder,
+                protected_header,
+                &plaintext,
+                cek,
+            ))
+        }
     }
 }
 
@@ -193,6 +210,11 @@ pub(crate) fn decrypt_cose(
             let cek: &<XChaCha20Poly1305 as Aead>::Key =
                 cek.try_into().map_err(|_| CryptoError::InvalidKeyLen)?;
             XChaCha20Poly1305::decrypt_cose(cose_encrypt, cek)?
+        }
+        CoseContentEncryptionAlgorithm::Aes256CbcHmacSha256 => {
+            let cek: &<Aes256CbcHmacSha256Aead as Aead>::Key =
+                cek.try_into().map_err(|_| CryptoError::InvalidKeyLen)?;
+            Aes256CbcHmacSha256Aead::decrypt_cose(cose_encrypt, cek)?
         }
     };
     if let Ok(content_format) = ContentFormat::try_from(&cose_encrypt.protected.header)
@@ -254,6 +276,16 @@ pub(crate) fn encrypt_cose0(
                 cek,
             ))
         }
+        CoseContentEncryptionAlgorithm::Aes256CbcHmacSha256 => {
+            let cek: &<Aes256CbcHmacSha256Aead as Aead>::Key =
+                cek.try_into().map_err(|_| CryptoError::InvalidKeyLen)?;
+            Ok(Aes256CbcHmacSha256Aead::encrypt_cose0(
+                builder,
+                protected_header,
+                &plaintext,
+                cek,
+            ))
+        }
     }
 }
 
@@ -282,6 +314,11 @@ pub(crate) fn decrypt_cose0(
             let cek: &<XChaCha20Poly1305 as Aead>::Key =
                 cek.try_into().map_err(|_| CryptoError::InvalidKeyLen)?;
             XChaCha20Poly1305::decrypt_cose0(cose_encrypt0, cek)?
+        }
+        CoseContentEncryptionAlgorithm::Aes256CbcHmacSha256 => {
+            let cek: &<Aes256CbcHmacSha256Aead as Aead>::Key =
+                cek.try_into().map_err(|_| CryptoError::InvalidKeyLen)?;
+            Aes256CbcHmacSha256Aead::decrypt_cose0(cose_encrypt0, cek)?
         }
     };
     if let Ok(content_format) = ContentFormat::try_from(&cose_encrypt0.protected.header)
@@ -574,6 +611,89 @@ impl CoseEncryptCipher for XChaCha20Poly1305 {
     }
 }
 
+impl CoseEncryptCipher for Aes256CbcHmacSha256Aead {
+    const COSE_ALGORITHM: Algorithm = Algorithm::PrivateUse(AES_256_CBC_HMAC_SHA256_AEAD);
+
+    fn encrypt_cose(
+        builder: CoseEncryptBuilder,
+        mut protected_header: Header,
+        plaintext: &[u8],
+        cek: &Self::Key,
+    ) -> CoseEncrypt {
+        protected_header.alg = Some(Self::COSE_ALGORITHM);
+
+        let nonce = Aes256CbcHmacSha256AeadNonce::make();
+        builder
+            .protected(protected_header)
+            .unprotected(HeaderBuilder::new().iv(nonce.as_bytes().to_vec()).build())
+            .create_ciphertext(plaintext, &[], |data, aad| {
+                Aes256CbcHmacSha256Aead::encrypt(cek, &nonce, data, aad)
+                    .encrypted_bytes()
+                    .to_vec()
+            })
+            .build()
+    }
+
+    fn decrypt_cose(cose_encrypt: &CoseEncrypt, cek: &Self::Key) -> Result<Vec<u8>, CryptoError> {
+        ensure_algorithm_matches::<Self>(&cose_encrypt.protected.header)?;
+
+        let nonce = Aes256CbcHmacSha256AeadNonce::try_from(cose_encrypt)?;
+        cose_encrypt.decrypt_ciphertext(
+            &[],
+            || CryptoError::MissingField("ciphertext"),
+            |data, aad| {
+                Aes256CbcHmacSha256Aead::decrypt(
+                    cek,
+                    &nonce,
+                    &Aes256CbcHmacSha256AeadCiphertext::from(data.to_vec()),
+                    aad,
+                )
+            },
+        )
+    }
+
+    fn encrypt_cose0(
+        builder: CoseEncrypt0Builder,
+        mut protected_header: Header,
+        plaintext: &[u8],
+        cek: &Self::Key,
+    ) -> CoseEncrypt0 {
+        protected_header.alg = Some(Self::COSE_ALGORITHM);
+
+        let nonce = Aes256CbcHmacSha256AeadNonce::make();
+        builder
+            .protected(protected_header)
+            .unprotected(HeaderBuilder::new().iv(nonce.as_bytes().to_vec()).build())
+            .create_ciphertext(plaintext, &[], |data, aad| {
+                Aes256CbcHmacSha256Aead::encrypt(cek, &nonce, data, aad)
+                    .encrypted_bytes()
+                    .to_vec()
+            })
+            .build()
+    }
+
+    fn decrypt_cose0(
+        cose_encrypt0: &CoseEncrypt0,
+        cek: &Self::Key,
+    ) -> Result<Vec<u8>, CryptoError> {
+        ensure_algorithm_matches::<Self>(&cose_encrypt0.protected.header)?;
+
+        let nonce = Aes256CbcHmacSha256AeadNonce::try_from(cose_encrypt0)?;
+        cose_encrypt0.decrypt_ciphertext(
+            &[],
+            || CryptoError::MissingField("ciphertext"),
+            |data, aad| {
+                Aes256CbcHmacSha256Aead::decrypt(
+                    cek,
+                    &nonce,
+                    &Aes256CbcHmacSha256AeadCiphertext::from(data.to_vec()),
+                    aad,
+                )
+            },
+        )
+    }
+}
+
 /// Encrypts a plaintext message using XChaCha20Poly1305 and returns a COSE Encrypt0 message.
 pub(crate) fn encrypt_xchacha20_poly1305(
     plaintext: &[u8],
@@ -755,6 +875,8 @@ mod tests {
     use crate::keys::KeyId;
 
     const CEK: [u8; 32] = [7u8; 32];
+    /// AES-256-CBC-HMAC-SHA256 takes a 64-byte composite `enc_key || mac_key` CEK.
+    const CEK_64: [u8; 64] = [7u8; 64];
     const PLAINTEXT: &[u8] = b"content-encryption test vector";
 
     const KEY_ID: [u8; 16] = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15];
@@ -772,11 +894,14 @@ mod tests {
         13, 36, 123, 53, 12, 31, 191, 40, 13, 175,
     ];
 
-    fn algorithms() -> [CoseContentEncryptionAlgorithm; 3] {
+    /// Every supported content-encryption algorithm, each paired with a CEK of the length that
+    /// algorithm requires.
+    fn algorithms() -> [(CoseContentEncryptionAlgorithm, &'static [u8]); 4] {
         [
-            CoseContentEncryptionAlgorithm::Aes256Gcm,
-            CoseContentEncryptionAlgorithm::XAes256Gcm,
-            CoseContentEncryptionAlgorithm::XChaCha20Poly1305,
+            (CoseContentEncryptionAlgorithm::Aes256Gcm, &CEK),
+            (CoseContentEncryptionAlgorithm::XAes256Gcm, &CEK),
+            (CoseContentEncryptionAlgorithm::XChaCha20Poly1305, &CEK),
+            (CoseContentEncryptionAlgorithm::Aes256CbcHmacSha256, &CEK_64),
         ]
     }
 
@@ -808,7 +933,7 @@ mod tests {
 
     #[test]
     fn test_encrypt_decrypt_cose_roundtrip() {
-        for algorithm in algorithms() {
+        for (algorithm, cek) in algorithms() {
             let builder =
                 CoseEncryptBuilder::new().add_recipient(CoseRecipientBuilder::new().build());
             let cose_encrypt = encrypt_cose(
@@ -816,34 +941,131 @@ mod tests {
                 builder,
                 HeaderBuilder::new().build(),
                 PLAINTEXT,
-                &CEK,
+                cek,
             )
             .unwrap();
             let decrypted =
-                decrypt_cose(&cose_encrypt, CoseAlgorithmPolicy::Exactly(algorithm), &CEK).unwrap();
+                decrypt_cose(&cose_encrypt, CoseAlgorithmPolicy::Exactly(algorithm), cek).unwrap();
             assert_eq!(decrypted, PLAINTEXT);
         }
     }
 
     #[test]
     fn test_encrypt_decrypt_cose0_roundtrip() {
-        for algorithm in algorithms() {
+        for (algorithm, cek) in algorithms() {
             let cose_encrypt0 = encrypt_cose0(
                 algorithm,
                 CoseEncrypt0Builder::new(),
                 HeaderBuilder::new().build(),
                 PLAINTEXT,
-                &CEK,
+                cek,
             )
             .unwrap();
-            let decrypted = decrypt_cose0(
-                &cose_encrypt0,
-                CoseAlgorithmPolicy::Exactly(algorithm),
-                &CEK,
-            )
-            .unwrap();
+            let decrypted =
+                decrypt_cose0(&cose_encrypt0, CoseAlgorithmPolicy::Exactly(algorithm), cek)
+                    .unwrap();
             assert_eq!(decrypted, PLAINTEXT);
         }
+    }
+
+    /// The AES-256-CBC-HMAC-SHA256 CEK is a 64-byte composite; a 32-byte one must be rejected
+    /// rather than silently truncated or padded.
+    #[test]
+    fn test_aes256_cbc_hmac_rejects_wrong_length_cek() {
+        assert!(matches!(
+            encrypt_cose0(
+                CoseContentEncryptionAlgorithm::Aes256CbcHmacSha256,
+                CoseEncrypt0Builder::new(),
+                HeaderBuilder::new().build(),
+                PLAINTEXT,
+                &CEK,
+            ),
+            Err(CryptoError::InvalidKeyLen)
+        ));
+    }
+
+    #[test]
+    fn test_aes256_cbc_hmac_cose0_fails_with_wrong_key() {
+        let message = encrypt_cose0(
+            CoseContentEncryptionAlgorithm::Aes256CbcHmacSha256,
+            CoseEncrypt0Builder::new(),
+            HeaderBuilder::new().build(),
+            PLAINTEXT,
+            &CEK_64,
+        )
+        .unwrap();
+
+        let mut wrong_cek = CEK_64;
+        wrong_cek[0] ^= 1;
+        assert!(
+            decrypt_cose0(
+                &message,
+                CoseAlgorithmPolicy::Exactly(CoseContentEncryptionAlgorithm::Aes256CbcHmacSha256),
+                &wrong_cek,
+            )
+            .is_err()
+        );
+
+        // Flipping only the MAC half must fail too — it is the half that authenticates.
+        let mut wrong_mac_key = CEK_64;
+        wrong_mac_key[32] ^= 1;
+        assert!(
+            decrypt_cose0(
+                &message,
+                CoseAlgorithmPolicy::Exactly(CoseContentEncryptionAlgorithm::Aes256CbcHmacSha256),
+                &wrong_mac_key,
+            )
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn test_aes256_cbc_hmac_cose0_fails_when_ciphertext_tampered() {
+        let mut message = encrypt_cose0(
+            CoseContentEncryptionAlgorithm::Aes256CbcHmacSha256,
+            CoseEncrypt0Builder::new(),
+            HeaderBuilder::new().build(),
+            PLAINTEXT,
+            &CEK_64,
+        )
+        .unwrap();
+
+        message.ciphertext.as_mut().unwrap()[0] ^= 1;
+        assert!(
+            decrypt_cose0(
+                &message,
+                CoseAlgorithmPolicy::Exactly(CoseContentEncryptionAlgorithm::Aes256CbcHmacSha256),
+                &CEK_64,
+            )
+            .is_err()
+        );
+    }
+
+    /// The algorithm is declared in the protected header, which is authenticated as associated
+    /// data, so a mismatched policy must be rejected before decryption is attempted.
+    #[test]
+    fn test_aes256_cbc_hmac_cose0_rejects_mismatched_policy() {
+        let message = encrypt_cose0(
+            CoseContentEncryptionAlgorithm::Aes256CbcHmacSha256,
+            CoseEncrypt0Builder::new(),
+            HeaderBuilder::new().build(),
+            PLAINTEXT,
+            &CEK_64,
+        )
+        .unwrap();
+
+        assert_eq!(
+            message.protected.header.alg,
+            Some(Algorithm::PrivateUse(AES_256_CBC_HMAC_SHA256_AEAD))
+        );
+        assert!(matches!(
+            decrypt_cose0(
+                &message,
+                CoseAlgorithmPolicy::Exactly(CoseContentEncryptionAlgorithm::Aes256Gcm),
+                &CEK_64,
+            ),
+            Err(CryptoError::WrongKeyType)
+        ));
     }
 
     #[test]

--- a/crates/bitwarden-crypto/src/enc_string/symmetric.rs
+++ b/crates/bitwarden-crypto/src/enc_string/symmetric.rs
@@ -358,7 +358,7 @@ impl EncString {
     ) -> Result<EncString> {
         let mut iv = [0u8; 16];
         bitwarden_random::rng().fill(&mut iv);
-        let (mac, data) = Aes256CbcHmacSha256::encrypt(&iv, data_dec, &key.to_composite_key());
+        let (mac, data) = Aes256CbcHmacSha256::encrypt(&iv, data_dec, key.as_composite_key());
         Ok(EncString::Aes256Cbc_HmacSha256_B64 { iv, mac, data })
     }
 
@@ -439,7 +439,7 @@ impl KeyDecryptable<SymmetricCryptoKey, Vec<u8>> for EncString {
             (
                 EncString::Aes256Cbc_HmacSha256_B64 { iv, mac, data },
                 SymmetricCryptoKey::Aes256CbcHmacKey(key),
-            ) => Aes256CbcHmacSha256::decrypt(iv, data, mac, &key.to_composite_key())
+            ) => Aes256CbcHmacSha256::decrypt(iv, data, mac, key.as_composite_key())
                 .map_err(|_| CryptoError::Decrypt),
             (
                 EncString::Cose_Encrypt0_B64 { data },

--- a/crates/bitwarden-crypto/src/hazmat/symmetric_encryption/aes256_cbc_hmac_sha256_aead.rs
+++ b/crates/bitwarden-crypto/src/hazmat/symmetric_encryption/aes256_cbc_hmac_sha256_aead.rs
@@ -1,0 +1,347 @@
+//! # AES-256-CBC-HMAC-SHA256 operations
+//!
+//! An extended construction of AES-256-CBC-HMAC-SHA256. It is used when an AES256-CBC-HMAC-SHA256
+//! key is used for authenticated encryption in the context of COSE.
+
+use aes::cipher::{BlockModeDecrypt, BlockModeEncrypt, KeyIvInit, block_padding::Pkcs7};
+use hmac::{KeyInit, Mac};
+use rand::RngExt;
+use subtle::ConstantTimeEq;
+
+use super::Aead;
+use crate::CryptoError;
+
+type HmacSha256 = hmac::Hmac<sha2::Sha256>;
+
+pub(crate) const NONCE_SIZE: usize = 16;
+pub(crate) const ENC_KEY_SIZE: usize = 32;
+pub(crate) const MAC_KEY_SIZE: usize = 32;
+pub(crate) const KEY_SIZE: usize = ENC_KEY_SIZE + MAC_KEY_SIZE;
+pub(crate) const MAC_SIZE: usize = 32;
+
+/// AES-256-CBC-HMAC-SHA256 authenticated encryption with associated data.
+pub(crate) struct Aes256CbcHmacSha256Aead;
+
+impl Aead for Aes256CbcHmacSha256Aead {
+    type Key = [u8; KEY_SIZE];
+    type Ciphertext = Aes256CbcHmacSha256AeadCiphertext;
+    type Nonce = Aes256CbcHmacSha256AeadNonce;
+
+    fn encrypt(
+        key: &Self::Key,
+        nonce: &Self::Nonce,
+        plaintext: &[u8],
+        associated_data: &[u8],
+    ) -> Self::Ciphertext {
+        let (enc_key, mac_key) = split_to_subkeys(key);
+
+        let mut encrypted_bytes =
+            cbc::Encryptor::<aes::Aes256>::new(enc_key.into(), nonce.as_array().into())
+                .encrypt_padded_vec::<Pkcs7>(plaintext);
+        let mac =
+            calculate_mac_with_aad(nonce.as_array(), &encrypted_bytes, associated_data, mac_key);
+        encrypted_bytes.extend_from_slice(&mac);
+
+        Aes256CbcHmacSha256AeadCiphertext { encrypted_bytes }
+    }
+
+    fn decrypt(
+        key: &Self::Key,
+        nonce: &Self::Nonce,
+        ciphertext: &Self::Ciphertext,
+        associated_data: &[u8],
+    ) -> Result<Vec<u8>, CryptoError> {
+        let (enc_key, mac_key) = split_to_subkeys(key);
+
+        let encrypted_bytes = ciphertext.encrypted_bytes();
+        if encrypted_bytes.len() < MAC_SIZE {
+            return Err(CryptoError::KeyDecrypt);
+        }
+        let (data, received_mac) = encrypted_bytes.split_at(encrypted_bytes.len() - MAC_SIZE);
+
+        let expected_mac = calculate_mac_with_aad(nonce.as_array(), data, associated_data, mac_key);
+        if expected_mac.ct_ne(received_mac).into() {
+            return Err(CryptoError::KeyDecrypt);
+        }
+
+        let mut buf = data.to_vec();
+        cbc::Decryptor::<aes::Aes256>::new(enc_key.into(), nonce.as_array().into())
+            .decrypt_padded::<Pkcs7>(&mut buf)
+            .map(|slice| slice.to_vec())
+            .map_err(|_| CryptoError::KeyDecrypt)
+    }
+}
+
+/// Splits the 64-byte composite key into zero-copy views over its encryption and MAC halves.
+fn split_to_subkeys(key: &[u8; KEY_SIZE]) -> (&[u8; ENC_KEY_SIZE], &[u8; MAC_KEY_SIZE]) {
+    let (enc_key, mac_key) = key.split_at(ENC_KEY_SIZE);
+    let enc_key = enc_key
+        .try_into()
+        .expect("first half of a 64-byte key is always 32 bytes");
+    let mac_key = mac_key
+        .try_into()
+        .expect("second half of a 64-byte key is always 32 bytes");
+    (enc_key, mac_key)
+}
+
+/// Computes the HMAC-SHA256 MAC over `iv || len(data) || data || len(associated_data) ||
+/// associated_data`, where lengths are encoded as 4-byte big-endian `u32`s.
+///
+/// The length prefixes remove any ambiguity about where `data` ends and `associated_data` begins,
+/// since both are variable-length and directly adjacent in the MAC input.
+fn calculate_mac_with_aad(
+    iv: &[u8; NONCE_SIZE],
+    data: &[u8],
+    associated_data: &[u8],
+    mac_key: &[u8; MAC_KEY_SIZE],
+) -> [u8; MAC_SIZE] {
+    let mut hmac =
+        HmacSha256::new_from_slice(mac_key).expect("hmac new_from_slice should not fail");
+    hmac.update(iv);
+    hmac.update(&(data.len() as u32).to_be_bytes());
+    hmac.update(data);
+    hmac.update(&(associated_data.len() as u32).to_be_bytes());
+    hmac.update(associated_data);
+    (*hmac.finalize().into_bytes())
+        .try_into()
+        // This is safe because HMAC-SHA256 output size is always 32 bytes
+        .expect("HMAC output size to be correct")
+}
+
+/// A 128-bit AES-256-CBC-HMAC-SHA256 IV.
+///
+/// A fresh, cryptographically random IV must be generated for every message encrypted under a
+/// given key; use [`Aes256CbcHmacSha256AeadNonce::make`] for this.
+pub(crate) struct Aes256CbcHmacSha256AeadNonce([u8; NONCE_SIZE]);
+
+impl Aes256CbcHmacSha256AeadNonce {
+    /// Generates a fresh, cryptographically random IV.
+    pub(crate) fn make() -> Self {
+        let mut rng = bitwarden_random::rng();
+        let mut iv = [0u8; NONCE_SIZE];
+        rng.fill(&mut iv);
+        Aes256CbcHmacSha256AeadNonce(iv)
+    }
+
+    /// Returns the raw IV bytes.
+    pub(crate) fn as_bytes(&self) -> &[u8] {
+        &self.0
+    }
+
+    /// Returns the IV as a fixed-size array, as required by the underlying CBC primitives.
+    fn as_array(&self) -> &[u8; NONCE_SIZE] {
+        &self.0
+    }
+
+    /// Parses the IV from a COSE message's unprotected `iv` header bytes.
+    fn from_cose_iv(iv: &[u8]) -> Result<Self, CryptoError> {
+        let iv: [u8; NONCE_SIZE] = iv.try_into().map_err(|_| CryptoError::InvalidNonceLength)?;
+        Ok(Aes256CbcHmacSha256AeadNonce(iv))
+    }
+}
+
+/// Parses the IV from the unprotected `iv` header of a [`coset::CoseEncrypt`] message.
+impl TryFrom<&coset::CoseEncrypt> for Aes256CbcHmacSha256AeadNonce {
+    type Error = CryptoError;
+
+    fn try_from(cose_encrypt: &coset::CoseEncrypt) -> Result<Self, Self::Error> {
+        Self::from_cose_iv(cose_encrypt.unprotected.iv.as_slice())
+    }
+}
+
+/// Parses the IV from the unprotected `iv` header of a [`coset::CoseEncrypt0`] message.
+impl TryFrom<&coset::CoseEncrypt0> for Aes256CbcHmacSha256AeadNonce {
+    type Error = CryptoError;
+
+    fn try_from(cose_encrypt0: &coset::CoseEncrypt0) -> Result<Self, Self::Error> {
+        Self::from_cose_iv(cose_encrypt0.unprotected.iv.as_slice())
+    }
+}
+
+pub(crate) struct Aes256CbcHmacSha256AeadCiphertext {
+    encrypted_bytes: Vec<u8>,
+}
+
+impl Aes256CbcHmacSha256AeadCiphertext {
+    pub(crate) fn encrypted_bytes(&self) -> &[u8] {
+        &self.encrypted_bytes
+    }
+}
+
+/// Wraps already-encrypted bytes (e.g. read from a COSE message) so they can be passed to
+/// [`Aes256CbcHmacSha256Aead::decrypt`](Aead::decrypt).
+impl From<Vec<u8>> for Aes256CbcHmacSha256AeadCiphertext {
+    fn from(encrypted_bytes: Vec<u8>) -> Self {
+        Aes256CbcHmacSha256AeadCiphertext { encrypted_bytes }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const TESTVECTOR_PLAINTEXT: &[u8] = b"Bitwarden SDK test vector";
+    const TESTVECTOR_ASSOCIATED_DATA: &[u8] = b"Bitwarden SDK test vector associated data";
+    const TESTVECTOR_ENCRYPTED: &[u8] = &[
+        111, 16, 33, 143, 207, 253, 106, 89, 58, 52, 145, 240, 140, 213, 149, 83, 168, 188, 122,
+        57, 130, 28, 35, 182, 114, 227, 215, 250, 175, 182, 169, 102, 253, 109, 197, 48, 44, 61,
+        189, 243, 17, 170, 108, 228, 96, 43, 41, 31, 205, 221, 208, 241, 18, 248, 245, 125, 217,
+        130, 218, 176, 188, 244, 211, 59,
+    ];
+
+    const TESTVECTOR_KEY: [u8; KEY_SIZE] = [
+        0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24,
+        25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47,
+        48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63,
+    ];
+    const TESTVECTOR_NONCE: Aes256CbcHmacSha256AeadNonce =
+        Aes256CbcHmacSha256AeadNonce([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]);
+
+    #[test]
+    #[ignore = "Generates test vectors; run manually"]
+    fn generate_test_vectors() {
+        let encrypted = Aes256CbcHmacSha256Aead::encrypt(
+            &TESTVECTOR_KEY,
+            &TESTVECTOR_NONCE,
+            TESTVECTOR_PLAINTEXT,
+            TESTVECTOR_ASSOCIATED_DATA,
+        );
+        let decrypted = Aes256CbcHmacSha256Aead::decrypt(
+            &TESTVECTOR_KEY,
+            &TESTVECTOR_NONCE,
+            &encrypted,
+            TESTVECTOR_ASSOCIATED_DATA,
+        )
+        .unwrap();
+        assert_eq!(decrypted, TESTVECTOR_PLAINTEXT);
+
+        println!(
+            "const TESTVECTOR_ENCRYPTED: &[u8] = &{:?};",
+            encrypted.encrypted_bytes()
+        );
+    }
+
+    /// Locks in the serialized format of the AEAD ciphertext (CBC ciphertext followed by the MAC
+    /// over the length-prefixed input); must never break, or existing data will no longer
+    /// decrypt.
+    #[test]
+    fn test_decrypt_testvector() {
+        let encrypted = Aes256CbcHmacSha256AeadCiphertext::from(TESTVECTOR_ENCRYPTED.to_vec());
+
+        let decrypted = Aes256CbcHmacSha256Aead::decrypt(
+            &TESTVECTOR_KEY,
+            &TESTVECTOR_NONCE,
+            &encrypted,
+            TESTVECTOR_ASSOCIATED_DATA,
+        )
+        .unwrap();
+
+        assert_eq!(decrypted, TESTVECTOR_PLAINTEXT);
+    }
+
+    #[test]
+    fn test_encrypt_decrypt_aes256_cbc_hmac() {
+        let key = TESTVECTOR_KEY;
+        let nonce = Aes256CbcHmacSha256AeadNonce::make();
+        let plaintext_secret_data = b"My secret data";
+        let authenticated_data = b"My authenticated data";
+        let encrypted = Aes256CbcHmacSha256Aead::encrypt(
+            &key,
+            &nonce,
+            plaintext_secret_data,
+            authenticated_data,
+        );
+        let decrypted =
+            Aes256CbcHmacSha256Aead::decrypt(&key, &nonce, &encrypted, authenticated_data).unwrap();
+        assert_eq!(plaintext_secret_data, decrypted.as_slice());
+    }
+
+    #[test]
+    fn test_make_nonce_has_correct_length() {
+        let nonce = Aes256CbcHmacSha256AeadNonce::make();
+        assert_eq!(nonce.as_bytes().len(), NONCE_SIZE);
+    }
+
+    #[test]
+    fn test_fails_when_ciphertext_changed() {
+        let key = TESTVECTOR_KEY;
+        let nonce = Aes256CbcHmacSha256AeadNonce::make();
+        let plaintext_secret_data = b"My secret data";
+        let authenticated_data = b"My authenticated data";
+
+        let mut encrypted = Aes256CbcHmacSha256Aead::encrypt(
+            &key,
+            &nonce,
+            plaintext_secret_data,
+            authenticated_data,
+        );
+        encrypted.encrypted_bytes[0] = encrypted.encrypted_bytes[0].wrapping_add(1);
+        let result = Aes256CbcHmacSha256Aead::decrypt(&key, &nonce, &encrypted, authenticated_data);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_fails_when_associated_data_changed() {
+        let key = TESTVECTOR_KEY;
+        let nonce = Aes256CbcHmacSha256AeadNonce::make();
+        let plaintext_secret_data = b"My secret data";
+        let mut authenticated_data = b"My authenticated data".to_vec();
+
+        let encrypted = Aes256CbcHmacSha256Aead::encrypt(
+            &key,
+            &nonce,
+            plaintext_secret_data,
+            authenticated_data.as_slice(),
+        );
+        authenticated_data[0] = authenticated_data[0].wrapping_add(1);
+        let result = Aes256CbcHmacSha256Aead::decrypt(
+            &key,
+            &nonce,
+            &encrypted,
+            authenticated_data.as_slice(),
+        );
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_fails_when_nonce_changed() {
+        let key = TESTVECTOR_KEY;
+        let nonce = Aes256CbcHmacSha256AeadNonce::make();
+        let plaintext_secret_data = b"My secret data";
+        let authenticated_data = b"My authenticated data";
+
+        let encrypted = Aes256CbcHmacSha256Aead::encrypt(
+            &key,
+            &nonce,
+            plaintext_secret_data,
+            authenticated_data,
+        );
+        // Decrypting with a different (freshly generated) nonce must fail.
+        let other_nonce = Aes256CbcHmacSha256AeadNonce::make();
+        let result =
+            Aes256CbcHmacSha256Aead::decrypt(&key, &other_nonce, &encrypted, authenticated_data);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_fails_when_ciphertext_too_short() {
+        let key = TESTVECTOR_KEY;
+        let nonce = Aes256CbcHmacSha256AeadNonce::make();
+        let truncated = Aes256CbcHmacSha256AeadCiphertext {
+            encrypted_bytes: vec![0u8; MAC_SIZE - 1],
+        };
+        let result = Aes256CbcHmacSha256Aead::decrypt(&key, &nonce, &truncated, b"");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_length_prefixing_prevents_data_ad_boundary_confusion() {
+        // Without length-prefixing, HMAC(iv || data || ad) for ("ab", "cd") would collide with
+        // ("a", "bcd") since the concatenation is identical. Length-prefixing must prevent this.
+        let mac_key = [0u8; MAC_KEY_SIZE];
+        let iv = [0u8; NONCE_SIZE];
+        let mac1 = calculate_mac_with_aad(&iv, b"ab", b"cd", &mac_key);
+        let mac2 = calculate_mac_with_aad(&iv, b"a", b"bcd", &mac_key);
+        assert_ne!(mac1, mac2);
+    }
+}

--- a/crates/bitwarden-crypto/src/hazmat/symmetric_encryption/aes256_cbc_hmac_sha256_aead.rs
+++ b/crates/bitwarden-crypto/src/hazmat/symmetric_encryption/aes256_cbc_hmac_sha256_aead.rs
@@ -19,6 +19,12 @@ pub(crate) const MAC_KEY_SIZE: usize = 32;
 pub(crate) const KEY_SIZE: usize = ENC_KEY_SIZE + MAC_KEY_SIZE;
 pub(crate) const MAC_SIZE: usize = 32;
 
+/// Domain separation label prefixed to the MAC input. It distinguishes this construction from the
+/// legacy [`Aes256CbcHmacSha256`](super::Aes256CbcHmacSha256) Encrypt-then-MAC construction, which
+/// MACs `iv || ciphertext` under the same MAC sub-key, so that a tag produced by one construction
+/// can never be a valid tag for the other.
+const MAC_DOMAIN_SEPARATOR: &[u8] = b"bitwarden.aes256-cbc-hmac-sha256-aead.v1";
+
 /// AES-256-CBC-HMAC-SHA256 authenticated encryption with associated data.
 pub(crate) struct Aes256CbcHmacSha256Aead;
 
@@ -84,11 +90,8 @@ fn split_to_subkeys(key: &[u8; KEY_SIZE]) -> (&[u8; ENC_KEY_SIZE], &[u8; MAC_KEY
     (enc_key, mac_key)
 }
 
-/// Computes the HMAC-SHA256 MAC over `iv || len(data) || data || len(associated_data) ||
-/// associated_data`, where lengths are encoded as 4-byte big-endian `u32`s.
-///
-/// The length prefixes remove any ambiguity about where `data` ends and `associated_data` begins,
-/// since both are variable-length and directly adjacent in the MAC input.
+/// Computes the HMAC-SHA256 MAC over `MAC_DOMAIN_SEPARATOR || iv || len(data) || data ||
+/// len(associated_data) || associated_data`, where lengths are encoded as 8-byte big-endian `u64`s.
 fn calculate_mac_with_aad(
     iv: &[u8; NONCE_SIZE],
     data: &[u8],
@@ -97,10 +100,11 @@ fn calculate_mac_with_aad(
 ) -> [u8; MAC_SIZE] {
     let mut hmac =
         HmacSha256::new_from_slice(mac_key).expect("hmac new_from_slice should not fail");
+    hmac.update(MAC_DOMAIN_SEPARATOR);
     hmac.update(iv);
-    hmac.update(&(data.len() as u32).to_be_bytes());
+    hmac.update(&(data.len() as u64).to_be_bytes());
     hmac.update(data);
-    hmac.update(&(associated_data.len() as u32).to_be_bytes());
+    hmac.update(&(associated_data.len() as u64).to_be_bytes());
     hmac.update(associated_data);
     (*hmac.finalize().into_bytes())
         .try_into()
@@ -184,9 +188,9 @@ mod tests {
     const TESTVECTOR_ASSOCIATED_DATA: &[u8] = b"Bitwarden SDK test vector associated data";
     const TESTVECTOR_ENCRYPTED: &[u8] = &[
         111, 16, 33, 143, 207, 253, 106, 89, 58, 52, 145, 240, 140, 213, 149, 83, 168, 188, 122,
-        57, 130, 28, 35, 182, 114, 227, 215, 250, 175, 182, 169, 102, 253, 109, 197, 48, 44, 61,
-        189, 243, 17, 170, 108, 228, 96, 43, 41, 31, 205, 221, 208, 241, 18, 248, 245, 125, 217,
-        130, 218, 176, 188, 244, 211, 59,
+        57, 130, 28, 35, 182, 114, 227, 215, 250, 175, 182, 169, 102, 33, 159, 62, 224, 104, 214,
+        248, 153, 248, 63, 219, 206, 228, 17, 93, 110, 14, 150, 81, 139, 74, 235, 115, 206, 113,
+        115, 220, 197, 18, 206, 252, 198,
     ];
 
     const TESTVECTOR_KEY: [u8; KEY_SIZE] = [

--- a/crates/bitwarden-crypto/src/hazmat/symmetric_encryption/mod.rs
+++ b/crates/bitwarden-crypto/src/hazmat/symmetric_encryption/mod.rs
@@ -29,6 +29,8 @@ impl From<SymmetricEncryptionError> for CryptoError {
     }
 }
 pub(crate) mod aes256_cbc_hmac_sha256_ae;
+#[allow(dead_code)]
+pub(crate) mod aes256_cbc_hmac_sha256_aead;
 pub(crate) mod aes_gcm;
 pub(crate) mod xaes_256_gcm;
 pub(crate) mod xchacha20;
@@ -37,6 +39,8 @@ pub(crate) mod xchacha20;
 pub(crate) use aes_gcm::Aes256Gcm;
 pub(crate) use aes256_cbc::Aes256Cbc;
 pub(crate) use aes256_cbc_hmac_sha256_ae::Aes256CbcHmacSha256;
+#[allow(unused_imports)]
+pub(crate) use aes256_cbc_hmac_sha256_aead::Aes256CbcHmacSha256Aead;
 #[allow(unused_imports)]
 pub(crate) use xaes_256_gcm::XAes256Gcm;
 #[allow(unused_imports)]

--- a/crates/bitwarden-crypto/src/hazmat/symmetric_encryption/mod.rs
+++ b/crates/bitwarden-crypto/src/hazmat/symmetric_encryption/mod.rs
@@ -2,8 +2,8 @@
 //!
 //! Low-level ("hazmat") authenticated symmetric ciphers, exposed behind two traits:
 //! - [`Aead`]: authenticated encryption *with* associated data. Implemented by AES-256-GCM
-//!   ([`Aes256Gcm`]), XAES-256-GCM ([`XAes256Gcm`]), and XChaCha20-Poly1305
-//!   ([`XChaCha20Poly1305`]).
+//!   ([`Aes256Gcm`]), XAES-256-GCM ([`XAes256Gcm`]), XChaCha20-Poly1305 ([`XChaCha20Poly1305`]),
+//!   and AES-256-CBC-HMAC-SHA256 ([`Aes256CbcHmacSha256Aead`]).
 //!
 //! These are dangerous primitives that operate directly on raw key material. In most cases you
 //! should use the higher-level [`safe`](crate::safe) module (e.g. the password-protected key
@@ -29,7 +29,6 @@ impl From<SymmetricEncryptionError> for CryptoError {
     }
 }
 pub(crate) mod aes256_cbc_hmac_sha256_ae;
-#[allow(dead_code)]
 pub(crate) mod aes256_cbc_hmac_sha256_aead;
 pub(crate) mod aes_gcm;
 pub(crate) mod xaes_256_gcm;

--- a/crates/bitwarden-crypto/src/keys/key_connector_key.rs
+++ b/crates/bitwarden-crypto/src/keys/key_connector_key.rs
@@ -214,14 +214,14 @@ mod tests {
         };
 
         assert_eq!(
-            user_key_unwrapped.enc_key.as_slice(),
+            user_key_unwrapped.enc_key().as_slice(),
             [
                 116, 170, 187, 43, 80, 212, 193, 202, 234, 181, 57, 66, 151, 249, 59, 47, 70, 16,
                 57, 4, 170, 78, 85, 241, 152, 232, 91, 57, 9, 87, 209, 245,
             ]
         );
         assert_eq!(
-            user_key_unwrapped.mac_key.as_slice(),
+            user_key_unwrapped.mac_key().as_slice(),
             [
                 40, 245, 106, 140, 2, 225, 138, 213, 98, 223, 92, 168, 135, 208, 22, 194, 31, 21,
                 178, 252, 203, 198, 35, 174, 53, 218, 254, 151, 235, 57, 7, 98,
@@ -248,14 +248,14 @@ mod tests {
         };
 
         assert_eq!(
-            user_key_unwrapped.enc_key.as_slice(),
+            user_key_unwrapped.enc_key().as_slice(),
             [
                 62, 0, 239, 47, 137, 95, 64, 214, 127, 91, 184, 232, 31, 9, 165, 161, 44, 132, 14,
                 195, 206, 154, 127, 59, 24, 27, 225, 136, 239, 113, 26, 30
             ]
         );
         assert_eq!(
-            user_key_unwrapped.mac_key.as_slice(),
+            user_key_unwrapped.mac_key().as_slice(),
             [
                 152, 76, 225, 114, 185, 33, 111, 65, 159, 68, 83, 103, 69, 109, 86, 25, 49, 74, 66,
                 163, 218, 134, 176, 1, 56, 123, 253, 184, 14, 12, 254, 66

--- a/crates/bitwarden-crypto/src/keys/master_key.rs
+++ b/crates/bitwarden-crypto/src/keys/master_key.rs
@@ -286,14 +286,14 @@ mod tests {
         };
 
         assert_eq!(
-            user_key_unwrapped.enc_key.as_slice(),
+            user_key_unwrapped.enc_key().as_slice(),
             [
                 62, 0, 239, 47, 137, 95, 64, 214, 127, 91, 184, 232, 31, 9, 165, 161, 44, 132, 14,
                 195, 206, 154, 127, 59, 24, 27, 225, 136, 239, 113, 26, 30
             ]
         );
         assert_eq!(
-            user_key_unwrapped.mac_key.as_slice(),
+            user_key_unwrapped.mac_key().as_slice(),
             [
                 152, 76, 225, 114, 185, 33, 111, 65, 159, 68, 83, 103, 69, 109, 86, 25, 49, 74, 66,
                 163, 218, 134, 176, 1, 56, 123, 253, 184, 14, 12, 254, 66
@@ -311,7 +311,8 @@ mod tests {
 
     #[test]
     fn test_make_user_key2() {
-        let kdf_material = KdfDerivedKeyMaterial(derive_symmetric_key("test1").enc_key.clone());
+        let kdf_material =
+            KdfDerivedKeyMaterial(Box::pin((*derive_symmetric_key("test1").enc_key()).into()));
         let master_key = MasterKey::KdfKey(kdf_material);
 
         let user_key = SymmetricCryptoKey::Aes256CbcHmacKey(derive_symmetric_key("test2"));
@@ -342,14 +343,14 @@ mod tests {
         };
 
         assert_eq!(
-            decrypted.enc_key.as_slice(),
+            decrypted.enc_key().as_slice(),
             [
                 12, 95, 151, 203, 37, 4, 236, 67, 137, 97, 90, 58, 6, 127, 242, 28, 209, 168, 125,
                 29, 118, 24, 213, 44, 117, 202, 2, 115, 132, 165, 125, 148
             ]
         );
         assert_eq!(
-            decrypted.mac_key.as_slice(),
+            decrypted.mac_key().as_slice(),
             [
                 186, 215, 234, 137, 24, 169, 227, 29, 218, 57, 180, 237, 73, 91, 189, 51, 253, 26,
                 17, 52, 226, 4, 134, 75, 194, 208, 178, 133, 128, 224, 140, 167
@@ -376,14 +377,14 @@ mod tests {
         };
 
         assert_eq!(
-            decrypted.enc_key.as_slice(),
+            decrypted.enc_key().as_slice(),
             [
                 116, 170, 187, 43, 80, 212, 193, 202, 234, 181, 57, 66, 151, 249, 59, 47, 70, 16,
                 57, 4, 170, 78, 85, 241, 152, 232, 91, 57, 9, 87, 209, 245,
             ]
         );
         assert_eq!(
-            decrypted.mac_key.as_slice(),
+            decrypted.mac_key().as_slice(),
             [
                 40, 245, 106, 140, 2, 225, 138, 213, 98, 223, 92, 168, 135, 208, 22, 194, 31, 21,
                 178, 252, 203, 198, 35, 174, 53, 218, 254, 151, 235, 57, 7, 98,

--- a/crates/bitwarden-crypto/src/keys/shareable_key.rs
+++ b/crates/bitwarden-crypto/src/keys/shareable_key.rs
@@ -2,8 +2,8 @@ use std::pin::Pin;
 
 use hmac::{KeyInit, Mac};
 use hybrid_array::Array;
-use typenum::{U32, U64};
-use zeroize::{Zeroize, Zeroizing};
+use typenum::U64;
+use zeroize::Zeroizing;
 
 use super::Aes256CbcHmacKey;
 use crate::util::{PbkdfSha256Hmac, hkdf_expand};
@@ -26,11 +26,9 @@ pub fn derive_shareable_key(
             .into_bytes(),
     );
 
-    let mut key: Pin<Box<Array<u8, U64>>> = hkdf_expand(&res, info).expect("Input is a valid size");
-    let enc_key = Box::pin(Array::<u8, U32>::try_from(&key[..32]).expect("slice is 32 bytes"));
-    let mac_key = Box::pin(Array::<u8, U32>::try_from(&key[32..]).expect("slice is 32 bytes"));
-    key.zeroize();
-    Aes256CbcHmacKey { enc_key, mac_key }
+    // HKDF already produces the `enc_key || mac_key` layout the key stores internally.
+    let key: Pin<Box<Array<u8, U64>>> = hkdf_expand(&res, info).expect("Input is a valid size");
+    Aes256CbcHmacKey { key }
 }
 
 #[cfg(test)]

--- a/crates/bitwarden-crypto/src/keys/symmetric_crypto_key.rs
+++ b/crates/bitwarden-crypto/src/keys/symmetric_crypto_key.rs
@@ -16,12 +16,15 @@ use serde::{Deserialize, Serialize};
 #[cfg(test)]
 use sha2::Digest;
 use subtle::{Choice, ConstantTimeEq};
-use typenum::U32;
+use typenum::{U32, U64};
 #[cfg(feature = "wasm")]
 use wasm_bindgen::convert::{FromWasmAbi, IntoWasmAbi, OptionFromWasmAbi};
-use zeroize::{Zeroize, ZeroizeOnDrop, Zeroizing};
+use zeroize::{Zeroize, ZeroizeOnDrop};
 
-use super::{key_encryptable::CryptoKey, key_id::KeyId};
+use super::{
+    key_encryptable::CryptoKey,
+    key_id::{KEY_ID_SIZE, KeyId},
+};
 use crate::{
     BitwardenLegacyKeyBytes, ContentFormat, CoseKeyBytes, CoseKeyThumbprint, CryptoError, cose,
     cose::{
@@ -123,31 +126,108 @@ impl PartialEq for Aes256CbcKey {
     }
 }
 
+/// The size of the encryption half of an [`Aes256CbcHmacKey`].
+pub(crate) const AES256_CBC_HMAC_ENC_KEY_SIZE: usize = 32;
+/// The size of the MAC half of an [`Aes256CbcHmacKey`].
+pub(crate) const AES256_CBC_HMAC_MAC_KEY_SIZE: usize = 32;
+/// The size of the composite `enc_key || mac_key` buffer of an [`Aes256CbcHmacKey`].
+pub(crate) const AES256_CBC_HMAC_KEY_SIZE: usize =
+    AES256_CBC_HMAC_ENC_KEY_SIZE + AES256_CBC_HMAC_MAC_KEY_SIZE;
+
 /// [Aes256CbcHmacKey] is a symmetric encryption key consisting
 /// of two 256-bit keys, one for encryption and one for MAC
 #[derive(ZeroizeOnDrop, Clone)]
 pub struct Aes256CbcHmacKey {
+    /// The encryption and MAC keys, stored contiguously as `enc_key || mac_key`.
+    ///
+    /// They are kept in one buffer rather than two so that the 64-byte composite form — the layout
+    /// used by the byte serialization, by the
+    /// [`Aes256CbcHmacSha256Aead`](crate::hazmat::symmetric_encryption::Aes256CbcHmacSha256Aead)
+    /// cipher, and by this key's COSE key view — can be borrowed instead of copied. Use
+    /// [`Aes256CbcHmacKey::enc_key`] and [`Aes256CbcHmacKey::mac_key`] for zero-copy views of the
+    /// individual halves.
+    ///
     /// Uses a pinned heap data structure, as noted in [Pinned heap data][crate#pinned-heap-data]
-    pub(crate) enc_key: Pin<Box<Array<u8, U32>>>,
-    /// Uses a pinned heap data structure, as noted in [Pinned heap data][crate#pinned-heap-data]
-    pub(crate) mac_key: Pin<Box<Array<u8, U32>>>,
+    pub(crate) key: Pin<Box<Array<u8, U64>>>,
 }
 
 impl ConstantTimeEq for Aes256CbcHmacKey {
     fn ct_eq(&self, other: &Self) -> Choice {
-        self.enc_key.ct_eq(&other.enc_key) & self.mac_key.ct_eq(&other.mac_key)
+        self.key.ct_eq(&other.key)
     }
 }
 
 impl Aes256CbcHmacKey {
-    /// Returns the 64-byte composite key (`enc_key || mac_key`) in the layout expected by the
-    /// [`Aes256CbcHmacSha256`](crate::hazmat::symmetric_encryption::Aes256CbcHmacSha256) cipher.
-    pub(crate) fn to_composite_key(&self) -> Zeroizing<[u8; 64]> {
-        let mut key = Zeroizing::new([0u8; 64]);
-        key[..32].copy_from_slice(&self.enc_key);
-        key[32..].copy_from_slice(&self.mac_key);
-        key
+    /// Builds a key from its two halves.
+    pub(crate) fn new(
+        enc_key: &[u8; AES256_CBC_HMAC_ENC_KEY_SIZE],
+        mac_key: &[u8; AES256_CBC_HMAC_MAC_KEY_SIZE],
+    ) -> Self {
+        let mut key = Box::pin(Array::<u8, U64>::default());
+        let (enc, mac) = key.split_at_mut(AES256_CBC_HMAC_ENC_KEY_SIZE);
+        enc.copy_from_slice(enc_key);
+        mac.copy_from_slice(mac_key);
+        Self { key }
     }
+
+    /// Returns the 64-byte composite key (`enc_key || mac_key`), which is the layout expected by
+    /// the [`Aes256CbcHmacSha256`](crate::hazmat::symmetric_encryption::Aes256CbcHmacSha256) and
+    /// [`Aes256CbcHmacSha256Aead`](crate::hazmat::symmetric_encryption::Aes256CbcHmacSha256Aead)
+    /// ciphers.
+    pub(crate) fn as_composite_key(&self) -> &[u8; AES256_CBC_HMAC_KEY_SIZE] {
+        &self.key.0
+    }
+
+    /// Returns the composite key as a slice. This is also this key's legacy byte serialization.
+    pub(crate) fn as_slice(&self) -> &[u8] {
+        self.key.as_slice()
+    }
+
+    /// Returns a zero-copy view of the 256-bit encryption key.
+    pub(crate) fn enc_key(&self) -> &[u8; AES256_CBC_HMAC_ENC_KEY_SIZE] {
+        let (enc_key, _) = self.key.split_at(AES256_CBC_HMAC_ENC_KEY_SIZE);
+        enc_key
+            .try_into()
+            .expect("first half of a 64-byte key is always 32 bytes")
+    }
+
+    /// Returns a zero-copy view of the 256-bit MAC key.
+    pub(crate) fn mac_key(&self) -> &[u8; AES256_CBC_HMAC_MAC_KEY_SIZE] {
+        let (_, mac_key) = self.key.split_at(AES256_CBC_HMAC_ENC_KEY_SIZE);
+        mac_key
+            .try_into()
+            .expect("second half of a 64-byte key is always 32 bytes")
+    }
+
+    /// Returns the key ID of this key.
+    ///
+    /// Unlike the other COSE key types, this key has no field to store a key ID in — it is
+    /// serialized as a bare 64-byte blob with no `kid`. The ID is therefore *derived*: it is the
+    /// key's own [RFC 9679](https://www.rfc-editor.org/rfc/rfc9679) thumbprint truncated to
+    /// [`KEY_ID_SIZE`] bytes. Two keys with identical key material consequently share an ID, and a
+    /// key's ID is stable across serialization round-trips.
+    pub(crate) fn key_id(&self) -> KeyId {
+        let thumbprint = symmetric_key_thumbprint(self.as_slice());
+        let mut key_id = [0u8; KEY_ID_SIZE];
+        key_id.copy_from_slice(&thumbprint.as_bytes()[..KEY_ID_SIZE]);
+        KeyId::from(key_id)
+    }
+}
+
+/// Computes the [RFC 9679](https://www.rfc-editor.org/rfc/rfc9679) thumbprint of a COSE `Symmetric`
+/// key with the given `k` bytes. `kty` and `k` are the only required parameters for this key type,
+/// so they are the only ones hashed.
+fn symmetric_key_thumbprint(key_bytes: &[u8]) -> CoseKeyThumbprint {
+    thumbprint_from_required_params(vec![
+        (
+            KeyParameter::Kty.to_i64(),
+            Value::Integer(Integer::from(KeyType::Symmetric.to_i64())),
+        ),
+        (
+            SymmetricKeyParameter::K.to_i64(),
+            Value::Bytes(key_bytes.to_vec()),
+        ),
+    ])
 }
 
 impl PartialEq for Aes256CbcHmacKey {
@@ -295,27 +375,37 @@ impl PartialEq for XAes256GcmKey {
     }
 }
 
-/// A borrowed view over a symmetric key that is encoded as a COSE key.
+/// A borrowed view over a symmetric key that can be used as a COSE content-encryption key.
 pub(crate) enum CoseKeyView<'a> {
     Aes256Gcm(&'a Aes256GcmKey),
     XChaCha20Poly1305(&'a XChaCha20Poly1305Key),
     XAes256Gcm(&'a XAes256GcmKey),
+    Aes256CbcHmac(&'a Aes256CbcHmacKey),
 }
 
 impl CoseKeyView<'_> {
-    pub(crate) fn key_id(&self) -> &KeyId {
+    /// Returns the key ID of the viewed key.
+    ///
+    /// This is returned by value rather than by reference because
+    /// [`CoseKeyView::Aes256CbcHmac`] derives its ID from the key material instead of storing one;
+    /// see [`Aes256CbcHmacKey::key_id`].
+    pub(crate) fn key_id(&self) -> KeyId {
         match self {
-            CoseKeyView::Aes256Gcm(k) => &k.key_id,
-            CoseKeyView::XChaCha20Poly1305(k) => &k.key_id,
-            CoseKeyView::XAes256Gcm(k) => &k.key_id,
+            CoseKeyView::Aes256Gcm(k) => k.key_id.clone(),
+            CoseKeyView::XChaCha20Poly1305(k) => k.key_id.clone(),
+            CoseKeyView::XAes256Gcm(k) => k.key_id.clone(),
+            CoseKeyView::Aes256CbcHmac(k) => k.key_id(),
         }
     }
 
+    /// Returns the key material in the layout the corresponding [`algorithm`](Self::algorithm)
+    /// expects as its content-encryption key.
     pub(crate) fn key_bytes(&self) -> &[u8] {
         match self {
             CoseKeyView::Aes256Gcm(k) => k.enc_key.as_slice(),
             CoseKeyView::XChaCha20Poly1305(k) => k.enc_key.as_slice(),
             CoseKeyView::XAes256Gcm(k) => k.enc_key.as_slice(),
+            CoseKeyView::Aes256CbcHmac(k) => k.as_slice(),
         }
     }
 
@@ -324,6 +414,7 @@ impl CoseKeyView<'_> {
             CoseKeyView::Aes256Gcm(_) => CoseContentEncryptionAlgorithm::Aes256Gcm,
             CoseKeyView::XChaCha20Poly1305(_) => CoseContentEncryptionAlgorithm::XChaCha20Poly1305,
             CoseKeyView::XAes256Gcm(_) => CoseContentEncryptionAlgorithm::XAes256Gcm,
+            CoseKeyView::Aes256CbcHmac(_) => CoseContentEncryptionAlgorithm::Aes256CbcHmacSha256,
         }
     }
 }
@@ -358,13 +449,14 @@ impl SymmetricCryptoKey {
     /// have a good reason for using this function, use
     /// [SymmetricCryptoKey::make_aes256_cbc_hmac_key] instead.
     pub(crate) fn make_aes256_cbc_hmac_key_internal(mut rng: impl rand::CryptoRng) -> Self {
-        let mut enc_key = Box::pin(Array::<u8, U32>::default());
-        let mut mac_key = Box::pin(Array::<u8, U32>::default());
+        let mut key = Box::pin(Array::<u8, U64>::default());
+        // Drawn as two separate 32-byte fills, matching the order and sizes used before the two
+        // halves shared one buffer, so seeded generation stays byte-for-byte identical.
+        let (enc_key, mac_key) = key.split_at_mut(AES256_CBC_HMAC_ENC_KEY_SIZE);
+        rng.fill(enc_key);
+        rng.fill(mac_key);
 
-        rng.fill(enc_key.as_mut_slice());
-        rng.fill(mac_key.as_mut_slice());
-
-        Self::Aes256CbcHmacKey(Aes256CbcHmacKey { enc_key, mac_key })
+        Self::Aes256CbcHmacKey(Aes256CbcHmacKey { key })
     }
 
     /// Make a new [SymmetricCryptoKey] for the specified algorithm
@@ -429,13 +521,13 @@ impl SymmetricCryptoKey {
     pub fn generate_seeded_for_unit_tests(seed: &str) -> Self {
         // Keep this separate from the other generate function to not break test vectors.
         let mut seeded_rng = ChaChaRng::from_seed(sha2::Sha256::digest(seed.as_bytes()).into());
-        let mut enc_key = Box::pin(Array::<u8, U32>::default());
-        let mut mac_key = Box::pin(Array::<u8, U32>::default());
+        let mut key = Box::pin(Array::<u8, U64>::default());
+        // Two separate 32-byte fills, as above, so the generated key is unchanged.
+        let (enc_key, mac_key) = key.split_at_mut(AES256_CBC_HMAC_ENC_KEY_SIZE);
+        seeded_rng.fill(enc_key);
+        seeded_rng.fill(mac_key);
 
-        seeded_rng.fill(enc_key.as_mut_slice());
-        seeded_rng.fill(mac_key.as_mut_slice());
-
-        SymmetricCryptoKey::Aes256CbcHmacKey(Aes256CbcHmacKey { enc_key, mac_key })
+        SymmetricCryptoKey::Aes256CbcHmacKey(Aes256CbcHmacKey { key })
     }
 
     /// Creates the byte representation of the key, without any padding. This should not
@@ -456,10 +548,7 @@ impl SymmetricCryptoKey {
                 EncodedSymmetricKey::BitwardenLegacyKey(key.enc_key.to_vec().into())
             }
             Self::Aes256CbcHmacKey(key) => {
-                let mut buf = Vec::with_capacity(64);
-                buf.extend_from_slice(&key.enc_key);
-                buf.extend_from_slice(&key.mac_key);
-                EncodedSymmetricKey::BitwardenLegacyKey(buf.into())
+                EncodedSymmetricKey::BitwardenLegacyKey(key.as_slice().to_vec().into())
             }
             Self::XChaCha20Poly1305Key(key) => {
                 let builder = coset::CoseKeyBuilder::new_symmetric_key(key.enc_key.to_vec());
@@ -525,25 +614,32 @@ impl SymmetricCryptoKey {
         B64::from(self.to_encoded().as_ref())
     }
 
-    /// Returns the key ID of the key, if it has one. COSE-serialized key variants have a key ID.
+    /// Returns the key ID of the key, if it has one. Every authenticated key variant has a key ID;
+    /// only the unauthenticated [`SymmetricCryptoKey::Aes256CbcKey`] does not.
+    ///
+    /// [`SymmetricCryptoKey::Aes256CbcHmacKey`] has no field to store a key ID in, and derives one
+    /// from its key material instead: its RFC 9679 thumbprint, truncated to the key ID length. Two
+    /// such keys with identical key material therefore share an ID.
     pub fn key_id(&self) -> Option<KeyId> {
         match self {
             Self::Aes256CbcKey(_) => None,
-            Self::Aes256CbcHmacKey(_) => None,
+            Self::Aes256CbcHmacKey(key) => Some(key.key_id()),
             Self::XChaCha20Poly1305Key(key) => Some(key.key_id.clone()),
             Self::Aes256GcmKey(key) => Some(key.key_id.clone()),
             Self::XAes256GcmKey(key) => Some(key.key_id.clone()),
         }
     }
 
-    /// Returns a [`CoseKeyView`] for COSE-encoded symmetric key variants.
-    /// Legacy AES-CBC variants return `None`.
+    /// Returns a [`CoseKeyView`] for every symmetric key variant usable as a COSE
+    /// content-encryption key. Only the unauthenticated [`SymmetricCryptoKey::Aes256CbcKey`]
+    /// returns `None`.
     pub(crate) fn as_cose_key_view(&self) -> Option<CoseKeyView<'_>> {
         match self {
             Self::Aes256GcmKey(k) => Some(CoseKeyView::Aes256Gcm(k)),
             Self::XChaCha20Poly1305Key(k) => Some(CoseKeyView::XChaCha20Poly1305(k)),
             Self::XAes256GcmKey(k) => Some(CoseKeyView::XAes256Gcm(k)),
-            Self::Aes256CbcKey(_) | Self::Aes256CbcHmacKey(_) => None,
+            Self::Aes256CbcHmacKey(k) => Some(CoseKeyView::Aes256CbcHmac(k)),
+            Self::Aes256CbcKey(_) => None,
         }
     }
 }
@@ -551,25 +647,15 @@ impl SymmetricCryptoKey {
 impl CoseKeyThumbprintExt for SymmetricCryptoKey {
     /// Computes the RFC 9679 thumbprint of this symmetric key.
     ///
-    /// Returns an error for legacy AES-CBC keys, which are not currently representable as COSE
-    /// keys.
+    /// Returns an error for the unauthenticated legacy AES-CBC key, which is not representable as
+    /// a COSE key.
     fn thumbprint(&self) -> Result<CoseKeyThumbprint, CryptoError> {
         let view = self
             .as_cose_key_view()
             .ok_or(EncodingError::UnsupportedValue(
-                "legacy AES-CBC keys are not COSE keys and have no thumbprint",
+                "unauthenticated AES-CBC keys are not COSE keys and have no thumbprint",
             ))?;
-        let params = vec![
-            (
-                KeyParameter::Kty.to_i64(),
-                Value::Integer(Integer::from(KeyType::Symmetric.to_i64())),
-            ),
-            (
-                SymmetricKeyParameter::K.to_i64(),
-                Value::Bytes(view.key_bytes().to_vec()),
-            ),
-        ];
-        Ok(thumbprint_from_required_params(params))
+        Ok(symmetric_key_thumbprint(view.key_bytes()))
     }
 }
 
@@ -658,15 +744,12 @@ impl TryFrom<EncodedSymmetricKey> for SymmetricCryptoKey {
             EncodedSymmetricKey::BitwardenLegacyKey(key)
                 if key.as_ref().len() == Self::AES256_CBC_HMAC_KEY_LEN =>
             {
-                let mut enc_key = Box::pin(Array::<u8, U32>::default());
-                enc_key.copy_from_slice(&key.as_ref()[..32]);
-
-                let mut mac_key = Box::pin(Array::<u8, U32>::default());
-                mac_key.copy_from_slice(&key.as_ref()[32..]);
+                // The legacy byte serialization is defined as `enc_key || mac_key`
+                let mut composite_key = Box::pin(Array::<u8, U64>::default());
+                composite_key.copy_from_slice(key.as_ref());
 
                 Ok(Self::Aes256CbcHmacKey(Aes256CbcHmacKey {
-                    enc_key,
-                    mac_key,
+                    key: composite_key,
                 }))
             }
             EncodedSymmetricKey::CoseKey(key) => Self::try_from_cose(key.as_ref()),
@@ -704,8 +787,8 @@ impl std::fmt::Debug for Aes256CbcHmacKey {
         let mut debug_struct = f.debug_struct("SymmetricKey::Aes256CbcHmac");
         #[cfg(feature = "dangerous-crypto-debug")]
         debug_struct
-            .field("enc_key", &hex::encode(self.enc_key.as_slice()))
-            .field("mac_key", &hex::encode(self.mac_key.as_slice()));
+            .field("enc_key", &hex::encode(self.enc_key()))
+            .field("mac_key", &hex::encode(self.mac_key()));
         debug_struct.finish()
     }
 }
@@ -866,7 +949,10 @@ mod tests {
     use hybrid_array::Array;
     use typenum::U32;
 
-    use super::{EncodedSymmetricKey, SymmetricCryptoKey, derive_symmetric_key};
+    use super::{
+        AES256_CBC_HMAC_ENC_KEY_SIZE, EncodedSymmetricKey, KEY_ID_SIZE, SymmetricCryptoKey,
+        derive_symmetric_key,
+    };
     use crate::{
         Aes256CbcHmacKey, Aes256CbcKey, BitwardenLegacyKeyBytes, CoseKeyThumbprintExt,
         SymmetricKeyAlgorithm, XAes256GcmKey, XChaCha20Poly1305Key,
@@ -1034,18 +1120,9 @@ mod tests {
 
     #[test]
     fn test_eq_variant_aes256_cbc_hmac() {
-        let key1 = Aes256CbcHmacKey {
-            enc_key: Box::pin(Array::from([1u8; 32])),
-            mac_key: Box::pin(Array::from([2u8; 32])),
-        };
-        let key2 = Aes256CbcHmacKey {
-            enc_key: Box::pin(Array::from([1u8; 32])),
-            mac_key: Box::pin(Array::from([2u8; 32])),
-        };
-        let key3 = Aes256CbcHmacKey {
-            enc_key: Box::pin(Array::from([3u8; 32])),
-            mac_key: Box::pin(Array::from([4u8; 32])),
-        };
+        let key1 = Aes256CbcHmacKey::new(&[1u8; 32], &[2u8; 32]);
+        let key2 = Aes256CbcHmacKey::new(&[1u8; 32], &[2u8; 32]);
+        let key3 = Aes256CbcHmacKey::new(&[3u8; 32], &[4u8; 32]);
         assert_eq!(key1, key2);
         assert_ne!(key1, key3);
     }
@@ -1171,10 +1248,7 @@ mod tests {
             SymmetricCryptoKey::Aes256CbcKey(Aes256CbcKey {
                 enc_key: Box::pin(Array::default()),
             }),
-            SymmetricCryptoKey::Aes256CbcHmacKey(Aes256CbcHmacKey {
-                enc_key: Box::pin(Array::default()),
-                mac_key: Box::pin(Array::default()),
-            }),
+            SymmetricCryptoKey::Aes256CbcHmacKey(Aes256CbcHmacKey::new(&[0u8; 32], &[0u8; 32])),
             SymmetricCryptoKey::Aes256GcmKey(crate::Aes256GcmKey::make()),
             SymmetricCryptoKey::XChaCha20Poly1305Key(XChaCha20Poly1305Key::make()),
         ] {
@@ -1258,12 +1332,118 @@ mod tests {
         assert_eq!(key.thumbprint().unwrap(), key.thumbprint().unwrap());
     }
 
+    /// The unauthenticated AES-CBC key is the only variant with no COSE key view, and so the only
+    /// one without a thumbprint.
     #[test]
-    fn test_thumbprint_errors_for_legacy_aes_cbc() {
-        assert!(
-            SymmetricCryptoKey::make_aes256_cbc_hmac_key()
-                .thumbprint()
-                .is_err()
+    fn test_thumbprint_errors_for_unauthenticated_aes_cbc() {
+        let key = SymmetricCryptoKey::Aes256CbcKey(Aes256CbcKey {
+            enc_key: Box::pin(Array::from([1u8; 32])),
+        });
+        assert!(key.thumbprint().is_err());
+    }
+
+    const AES256_CBC_HMAC_KEY_THUMBPRINT: &str =
+        "ac4ecffb2e087a59180d1dd19950b8e9e634997f47bbfd7a2bb829edf7a9f900";
+    const AES256_CBC_HMAC_KEY_ID: &str = "ac4ecffb2e087a59180d1dd19950b8e9";
+
+    /// A fixed AES-256-CBC-HMAC key: `enc_key` is `0x00..0x1f`, `mac_key` is `0x20..0x3f`.
+    fn fixed_aes_cbc_hmac_key_inner() -> Aes256CbcHmacKey {
+        Aes256CbcHmacKey::new(
+            &std::array::from_fn(|i| i as u8),
+            &std::array::from_fn(|i| (i + 32) as u8),
+        )
+    }
+
+    fn fixed_aes_cbc_hmac_key() -> SymmetricCryptoKey {
+        SymmetricCryptoKey::Aes256CbcHmacKey(fixed_aes_cbc_hmac_key_inner())
+    }
+
+    #[test]
+    #[ignore = "Generates test vectors; run manually"]
+    fn generate_aes256_cbc_hmac_thumbprint_vectors() {
+        let key = fixed_aes_cbc_hmac_key();
+        println!(
+            "const AES256_CBC_HMAC_KEY_THUMBPRINT: &str = \"{}\";",
+            key.thumbprint().unwrap().to_hex()
         );
+        println!(
+            "const AES256_CBC_HMAC_KEY_ID: &str = \"{}\";",
+            hex::encode(key.key_id().unwrap().as_slice())
+        );
+    }
+
+    /// Locks in the thumbprint of an AES-256-CBC-HMAC key: the RFC 9679 thumbprint of a COSE
+    /// `Symmetric` key whose `k` is the 64-byte `enc_key || mac_key` composite. The derived key ID
+    /// depends on this, so it must never change.
+    #[test]
+    fn test_thumbprint_aes256_cbc_hmac_vector() {
+        assert_eq!(
+            fixed_aes_cbc_hmac_key().thumbprint().unwrap().to_hex(),
+            AES256_CBC_HMAC_KEY_THUMBPRINT
+        );
+    }
+
+    #[test]
+    fn test_key_id_aes256_cbc_hmac_vector() {
+        let key_id = fixed_aes_cbc_hmac_key().key_id().unwrap();
+        assert_eq!(hex::encode(key_id.as_slice()), AES256_CBC_HMAC_KEY_ID);
+    }
+
+    /// Locks in the derivation rule itself: the key ID is the leading `KEY_ID_SIZE` bytes of the
+    /// key's thumbprint.
+    #[test]
+    fn test_key_id_is_thumbprint_prefix() {
+        let key = fixed_aes_cbc_hmac_key();
+        let thumbprint = key.thumbprint().unwrap();
+        assert_eq!(
+            key.key_id().unwrap().as_slice(),
+            &thumbprint.as_bytes()[..KEY_ID_SIZE]
+        );
+    }
+
+    #[test]
+    fn test_key_id_aes256_cbc_hmac_is_deterministic() {
+        assert_eq!(
+            fixed_aes_cbc_hmac_key().key_id(),
+            fixed_aes_cbc_hmac_key().key_id()
+        );
+    }
+
+    /// Both halves of the key must feed the ID, or two keys differing only in their MAC key would
+    /// collide.
+    #[test]
+    fn test_key_id_aes256_cbc_hmac_covers_both_halves() {
+        let key = fixed_aes_cbc_hmac_key();
+
+        // Flip the first byte of the encryption half, then of the MAC half.
+        let mut different_enc = fixed_aes_cbc_hmac_key_inner();
+        different_enc.key[0] ^= 1;
+        assert_ne!(
+            key.key_id(),
+            SymmetricCryptoKey::Aes256CbcHmacKey(different_enc).key_id()
+        );
+
+        let mut different_mac = fixed_aes_cbc_hmac_key_inner();
+        different_mac.key[AES256_CBC_HMAC_ENC_KEY_SIZE] ^= 1;
+        assert_ne!(
+            key.key_id(),
+            SymmetricCryptoKey::Aes256CbcHmacKey(different_mac).key_id()
+        );
+    }
+
+    /// Having a COSE key view must not change how these keys are serialized: they remain the raw
+    /// 64-byte legacy encoding. Changing this would break every existing user key.
+    #[test]
+    fn test_aes256_cbc_hmac_still_encodes_as_legacy_64_bytes() {
+        let key = fixed_aes_cbc_hmac_key();
+
+        let EncodedSymmetricKey::BitwardenLegacyKey(raw) = key.to_encoded_raw() else {
+            panic!("expected legacy key encoding");
+        };
+        assert_eq!(raw.as_ref().len(), 64);
+        assert_eq!(raw.as_ref(), (0u8..64).collect::<Vec<_>>());
+
+        assert_eq!(key.to_encoded().as_ref().len(), 64);
+        assert_eq!(SymmetricCryptoKey::try_from(key.to_base64()).unwrap(), key);
     }
 }

--- a/crates/bitwarden-crypto/src/keys/utils.rs
+++ b/crates/bitwarden-crypto/src/keys/utils.rs
@@ -10,11 +10,12 @@ use crate::{CryptoError, Result, util::hkdf_expand};
 /// This can be either a kdf-derived key (PIN/Master password) or
 /// a random key from key connector
 pub(super) fn stretch_key(key: &Pin<Box<Array<u8, U32>>>) -> Aes256CbcHmacKey {
-    Aes256CbcHmacKey {
-        // this is safe because the key length is always 32 bytes
-        enc_key: hkdf_expand(key, Some("enc")).expect("HKDF expand to succeed"),
-        mac_key: hkdf_expand(key, Some("mac")).expect("HKDF expand to succeed"),
-    }
+    // this is safe because the key length is always 32 bytes
+    let enc_key: Pin<Box<Array<u8, U32>>> =
+        hkdf_expand(key, Some("enc")).expect("HKDF expand to succeed");
+    let mac_key: Pin<Box<Array<u8, U32>>> =
+        hkdf_expand(key, Some("mac")).expect("HKDF expand to succeed");
+    Aes256CbcHmacKey::new(&enc_key.0, &mac_key.0)
 }
 
 /// Pads bytes to a minimum length using PKCS7-like padding.
@@ -66,14 +67,14 @@ mod tests {
                 111, 31, 178, 45, 238, 152, 37, 114, 143, 215, 124, 83, 135, 173, 195, 23, 142,
                 134, 120, 249, 61, 132, 163, 182, 113, 197, 189, 204, 188, 21, 237, 96
             ],
-            stretched.enc_key.as_slice()
+            stretched.enc_key().as_slice()
         );
         assert_eq!(
             [
                 221, 127, 206, 234, 101, 27, 202, 38, 86, 52, 34, 28, 78, 28, 185, 16, 48, 61, 127,
                 166, 209, 247, 194, 87, 232, 26, 48, 85, 193, 249, 179, 155
             ],
-            stretched.mac_key.as_slice()
+            stretched.mac_key().as_slice()
         );
     }
 

--- a/crates/bitwarden-crypto/src/safe/data_envelope.rs
+++ b/crates/bitwarden-crypto/src/safe/data_envelope.rs
@@ -181,9 +181,14 @@ impl DataEnvelope {
         // AES-256-GCM (current), XAES-256-GCM, and XChaCha20-Poly1305 (legacy)
         // content-encryption keys are accepted. The typed key's algorithm must match the algorithm
         // in the envelope's protected header.
-        let view = cek
-            .as_cose_key_view()
-            .ok_or(DataEnvelopeError::UnsupportedContentFormat)?;
+        let view = match cek {
+            SymmetricCryptoKey::Aes256CbcKey(_) | SymmetricCryptoKey::Aes256CbcHmacKey(_) => {
+                return Err(DataEnvelopeError::UnsupportedContentFormat);
+            }
+            cek => cek
+                .as_cose_key_view()
+                .ok_or(DataEnvelopeError::UnsupportedContentFormat)?,
+        };
         self.unseal_ref(T::NAMESPACE, view)
     }
 

--- a/crates/bitwarden-crypto/src/safe/helpers.rs
+++ b/crates/bitwarden-crypto/src/safe/helpers.rs
@@ -53,6 +53,7 @@ pub(super) fn debug_fmt<C: ContentNamespace>(
             CoseContentEncryptionAlgorithm::Aes256Gcm => "AES-256-GCM",
             CoseContentEncryptionAlgorithm::XAes256Gcm => "XAES-256-GCM",
             CoseContentEncryptionAlgorithm::XChaCha20Poly1305 => "XChaCha20-Poly1305",
+            CoseContentEncryptionAlgorithm::Aes256CbcHmacSha256 => "AES-256-CBC-HMAC-SHA256-AEAD",
         };
         debug_struct.field("content_encryption_algorithm", &label);
     }

--- a/crates/bitwarden-crypto/src/safe/password_protected_key_envelope.rs
+++ b/crates/bitwarden-crypto/src/safe/password_protected_key_envelope.rs
@@ -1130,11 +1130,14 @@ mod tests {
         assert_eq!(Some(key_id), contained_key_id);
     }
 
+    /// AES-CBC-HMAC keys have no stored key ID, but derive one from their key material, so a
+    /// sealed envelope still carries a contained key ID.
     #[test]
-    fn test_no_key_id() {
+    fn test_derived_key_id_for_aes_cbc_hmac_key() {
         let key_store = KeyStore::<TestIds>::default();
         let mut ctx: KeyStoreContext<'_, TestIds> = key_store.context_mut();
         let test_key = ctx.generate_symmetric_key();
+        let key_id = ctx.get_symmetric_key(test_key).unwrap().key_id().unwrap();
 
         let password = "test_password";
 
@@ -1147,7 +1150,7 @@ mod tests {
         )
         .unwrap();
         let contained_key_id = envelope.contained_key_id().unwrap();
-        assert_eq!(None, contained_key_id);
+        assert_eq!(Some(key_id), contained_key_id);
     }
 
     /// Builds a key store configured with the given cipher suite.

--- a/crates/bitwarden-crypto/src/safe/secret_protected_key_envelope.rs
+++ b/crates/bitwarden-crypto/src/safe/secret_protected_key_envelope.rs
@@ -991,11 +991,14 @@ mod tests {
         assert_eq!(Some(key_id), contained_key_id);
     }
 
+    /// AES-CBC-HMAC keys have no stored key ID, but derive one from their key material, so a
+    /// sealed envelope still carries a contained key ID.
     #[test]
-    fn test_no_key_id() {
+    fn test_derived_key_id_for_aes_cbc_hmac_key() {
         let key_store = KeyStore::<TestIds>::default();
         let mut ctx: KeyStoreContext<'_, TestIds> = key_store.context_mut();
         let test_key = ctx.generate_symmetric_key();
+        let key_id = ctx.get_symmetric_key(test_key).unwrap().key_id().unwrap();
 
         let secret = testvector_secret();
 
@@ -1008,6 +1011,6 @@ mod tests {
         )
         .unwrap();
         let contained_key_id = envelope.contained_key_id().unwrap();
-        assert_eq!(None, contained_key_id);
+        assert_eq!(Some(key_id), contained_key_id);
     }
 }

--- a/crates/bitwarden-crypto/src/store/context.rs
+++ b/crates/bitwarden-crypto/src/store/context.rs
@@ -238,7 +238,7 @@ impl<Ids: KeySlotIds> KeyStoreContext<'_, Ids> {
                 EncString::Aes256Cbc_HmacSha256_B64 { iv, mac, data },
                 SymmetricCryptoKey::Aes256CbcHmacKey(key),
             ) => SymmetricCryptoKey::try_from(&BitwardenLegacyKeyBytes::from(
-                Aes256CbcHmacSha256::decrypt(iv, data, mac, &key.to_composite_key())
+                Aes256CbcHmacSha256::decrypt(iv, data, mac, key.as_composite_key())
                     .map_err(|_| CryptoError::Decrypt)?,
             ))?,
             (
@@ -774,7 +774,7 @@ impl<Ids: KeySlotIds> KeyStoreContext<'_, Ids> {
             (
                 EncString::Aes256Cbc_HmacSha256_B64 { iv, mac, data },
                 SymmetricCryptoKey::Aes256CbcHmacKey(key),
-            ) => Aes256CbcHmacSha256::decrypt(iv, data, mac, &key.to_composite_key())
+            ) => Aes256CbcHmacSha256::decrypt(iv, data, mac, key.as_composite_key())
                 .map_err(|_| CryptoError::Decrypt),
             (
                 EncString::Cose_Encrypt0_B64 { data },

--- a/crates/bitwarden-crypto/src/stream/aes256_cbc_hmac_legacy_stream.rs
+++ b/crates/bitwarden-crypto/src/stream/aes256_cbc_hmac_legacy_stream.rs
@@ -238,8 +238,8 @@ impl DecryptorState {
         match self {
             Self::Uninitialized { key } => {
                 *self = Self::Streaming {
-                    decryptor: Box::new(CbcDecryptor::new(&key.enc_key.0, &header.iv)),
-                    integrity_validator: HmacStreamValidator::new(&key.mac_key.0, &header.iv),
+                    decryptor: Box::new(CbcDecryptor::new(key.enc_key(), &header.iv)),
+                    integrity_validator: HmacStreamValidator::new(key.mac_key(), &header.iv),
                     expected_mac: header.mac,
                 };
                 Ok(())
@@ -509,8 +509,8 @@ impl StreamingAes256CbcHmacEncryptor {
             ciphertext_buffer: CiphertextBuffer::new(ciphertext_capacity),
             plaintext_buffer: Vec::new(),
             encryptor_state: EncryptorState::Streaming {
-                encryptor: Box::new(CbcEncryptor::new(&key.enc_key.0, &iv)),
-                integrity_validator: HmacStreamValidator::new(&key.mac_key.0, &iv),
+                encryptor: Box::new(CbcEncryptor::new(key.enc_key(), &iv)),
+                integrity_validator: HmacStreamValidator::new(key.mac_key(), &iv),
                 iv,
             },
         })
@@ -606,10 +606,7 @@ mod tests {
     ];
 
     fn test_key() -> SymmetricCryptoKey {
-        SymmetricCryptoKey::Aes256CbcHmacKey(Aes256CbcHmacKey {
-            enc_key: Box::pin(ENC_KEY.into()),
-            mac_key: Box::pin(MAC_KEY.into()),
-        })
+        SymmetricCryptoKey::Aes256CbcHmacKey(Aes256CbcHmacKey::new(&ENC_KEY, &MAC_KEY))
     }
 
     #[test]

--- a/crates/bitwarden-crypto/src/stream/streaming_attachment_cipher.rs
+++ b/crates/bitwarden-crypto/src/stream/streaming_attachment_cipher.rs
@@ -555,10 +555,7 @@ mod tests {
     }
 
     fn aes_key() -> SymmetricCryptoKey {
-        SymmetricCryptoKey::Aes256CbcHmacKey(Aes256CbcHmacKey {
-            enc_key: Box::pin([0u8; 32].into()),
-            mac_key: Box::pin([1u8; 32].into()),
-        })
+        SymmetricCryptoKey::Aes256CbcHmacKey(Aes256CbcHmacKey::new(&[0u8; 32], &[1u8; 32]))
     }
 
     /// Drive the encryptor to completion against an in-memory sink and return the produced wire.


### PR DESCRIPTION
Implements COSE for type 2 symmetric keys and AES256-CBC-HMAC-SHA256-AEAD. A few item such as PIN migration previously equated key id presence with being type 2 or not, which means we had to change how these migration paths are handled. In the `clients` repository, there is a similar migration for biometric unlock.