### PR TITLE
tests: add test vectors

### DIFF
--- a/.aikido
+++ b/.aikido
@@ -1,0 +1,3 @@
+exclude:
+  paths:
+    - test-vectors

--- a/.prettierignore
+++ b/.prettierignore
@@ -9,6 +9,10 @@ crates/bitwarden-uniffi/swift/*
 
 # Test fixtures
 crates/bitwarden-exporters/resources/*
+# Committed test vectors. Ignored so prettier cannot reformat them, which would change bytes that
+# the Rust and TypeScript suites both read as fixed input.
+test-vectors/*.json
+test-vectors/**/*.json
 
 # CI output
 clippy_result.sarif

--- a/test-vectors/README.md
+++ b/test-vectors/README.md
@@ -1,0 +1,3 @@
+# Test vectors
+
+Committed, fixed bitwarden cryptographic test vectors.

--- a/test-vectors/emergency-access/v1-grants-v2.json
+++ b/test-vectors/emergency-access/v1-grants-v2.json
@@ -1,0 +1,10 @@
+{
+  "description": "A V1 account grants emergency access to a V2 account.",
+  "granteePublicKey": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAvDb29I3cRYNk2CfhnjNfP6vPFxurlKeYohbyYU8YQwpTETqoMnXlJ6oUokJcXmPD7H/9Zkwdhr1/4GkGmT2h10qY6RnMPXV+BkZ3YdvnYRhU58bcMUMBsLJDbrAiAajK03xaDfYKts1+czPdt6hvkz3IWdzGjbqzO87/GRQ86IbOCcFyXCdv+veIRtwRnaDBT7lc/qH+vh2R7Pqy0p32KmI12WXsiWkcQaXVMCGHiFE70ZyTfN527XK56IhkR+3S5Oo4E+asdSrbgPJE9C5OirbXKRCM0s6SEAVNwLu5fq6W6CkCxeDj2Rs1Dk0q2a4myJspviipV2i0PkS9zQ3eoQIDAQAB",
+  "granteeVector": "v2-argon2id-blob",
+  "grantorUserKeySealedToGrantee": "4.UWTeWeSrT6m2tkx8D+q/ho+VwvWu8T+XRLrWodztGmSPE8dR2RogS1BP610B7zxrHpaTrr1nr6+f7/qX9QTWe91JKb0i6kIJZzNtSVuQ374lhILTVNUQv5qZRtz+xUnrndTMwbx8+LONNfVz1DaYadFOHZ4zjpwbMCTq77nGvY3+riVoFm6QacuezFHEauIvtwS4P5wxhP6qbnbwQ9zmgWF+Zow7dM0eYo/5+LjAKchxlv0BU7WDVqpVyx1p/KFa5fHuq+isqS6Fo3N60QLH+9KwOfILRMC8xCLJDXQ0JyQD1syp0Lezy7TZ4/RyekJK4veqkXIUIl/nxPbQsXCf/A==",
+  "grantorVector": "v1-pbkdf2-password",
+  "id": "bc066e00-0000-4000-8000-000000000000",
+  "name": "v1-grants-v2",
+  "schemaVersion": 1
+}

--- a/test-vectors/emergency-access/v2-grants-v1.json
+++ b/test-vectors/emergency-access/v2-grants-v1.json
@@ -1,0 +1,10 @@
+{
+  "description": "A V2 account grants emergency access to a V1 account.",
+  "granteePublicKey": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAwrnE6Z385RQaNYYN2HKcgkSkwBzjwZpcThc0U+4T5fi3MamsEWb3rkhPkTkHf5k+NCG/JlDfULediRKsOjSJZ49i76EUKg1N0AQv/e5wfohnlUb4SL6RYEQSyFCtp1tQoqjkbF5SMyPx3jS+b1K0/AmoF2UKebFXDIPkdeJaPy8PaE0XyQleTD6j1KHIWn8bIsPUyRPgvJBfewqwFwcsY3XZldqeOExd0TsXJXBKtK3XvWGLSHjKBmAl7VODM0eV+q3XDVK7hmUgYdNiS7IukZ8fqQ8PlgbUA9keNebK1t5jwDczoZiHGzAMiSqZ8GYSOPDioo4kZqMIUjTKkF2KHwIDAQAB",
+  "granteeVector": "v1-pbkdf2-password",
+  "grantorUserKeySealedToGrantee": "4.jiOPDUCZgCIFEvyGrK91zD+3oj019rzi/+1A8Os7cvS8wZ1MeBZMx1LRDcq+eZdbsZatN9qx9K2sDwMQI95DaNnp0VCBkn4cTi/pggGQGRllY0ME5yejM0vYBhjMzF1j0GpTxotmr1PhOGCqtHCtiTRZZB+1cK+mhAobRl/xzaGz18mXQLFybfM9RhxBNp4jZ9stlp8hBo88IWjvm1woB8PzBP0NPYURqMBwzcEZYbqu0V03EaRgR66ZYChmh73gdeoMSojXjXL6K9B6RWlVs/j9eOq2jjbKyItmy+pyqMF6Li1QkgUchWpoH9ZN7KtHsoNjPfm6hkpjYsmPUxkAkA==",
+  "grantorVector": "v2-argon2id-blob",
+  "id": "bc066e01-0000-4000-8000-000000000000",
+  "name": "v2-grants-v1",
+  "schemaVersion": 1
+}

--- a/test-vectors/organizations/example-org.json
+++ b/test-vectors/organizations/example-org.json
@@ -1,0 +1,288 @@
+{
+  "description": "A regular organization with three members across both account generations. Two are enrolled in account recovery. Its ciphers stay legacy field-encrypted, because organization ciphers are never blob-encrypted.",
+  "members": [
+    {
+      "accountRecoveryKey": "4.i13WwUOOdlUi9Fp/JgJ9c2K32PbX1PfJzUvEmeYUh7gKCdrdSTZMiELCjUaGf1/yK27LJdiGQ8+qUvqxfSyxRqnDI2vI+AYpCcuibUVM66bkXtI/BHlOdPYfbISJo7PpI6++npoy4ENXGC2Rf7REZ6TAzR+WNIoJVX/ChXZ4jLt4hYZQjjGO6/fG9Qu+JumTU3H4JmJMaqti/OqKtwtBXQJoGhsL9ei6LfYy8sq3iGLOeA2ZB1wtr6v3+k6y5l7WEuTWU73SBy5VwDHqDniF+XN/Rw7pbzcFTQhSrvbnjP/AeKanaQVjEEUwN/yiJEPnwrD8/fVk+b3MQ1JnIZwpvg==",
+      "organizationKeySealedToMember": "4.vhbzMrSczyG4acviiclbnUnBYZGhn0GScTSV7CHy6LO9zONAeG091MP+6IOXfthw6HNY2YV+YI6TVaN1C8KbAh1q4gQRTMkM0vFF9iP0a2yGwh9aTa80Mx4ZN03/Ztzv5uM2qoSpi6a1HGuD99L5ykJOuFXYjmZ+IoByOiGHxuhUvc/qafLkCpvrpZP/uFpSmU8r+qrYBj0mtruqVvYPqn2zEZo8ddTPyF9jYWfMkug+pSQtKOakfiwtSok+IifWIVbfVVU0Lwi41hw5ZY8Sut7qrrooFeKCV6DUfT93tqdn2ScY+lBzZmARt/jXNNrGtZk2NvLYEhqRLI4NCs4k5w==",
+      "userVector": "v1-pbkdf2-password"
+    },
+    {
+      "organizationKeySealedToMember": "4.gSKekfA+ue8pQjsxXe8BXKA/VGKr2ggvxbcBzSLW58HVPTmQJdp1MPvk8UhuxNPvgsUC0FRMqmXUjci+gLz3eGNMadoVjjr4LLrg6T9VDs6rsQzMufXDheldAzQKvPMH+GRnhai/b1tC/YzNgFlDoTbHCic1PY8KTf/26rDkdnaWr1/AaBZnDHBvEFUIpEXvP5+GAijTP86yi6FGm0lvSAQM24xbkK8lnRtAHO5szsmnk4uxTwWHyLz6Zs2EvA3eOxrAUD9qQiq0Yllzs8fXGZ/qrdoNWhf/Fjnhov1aXVct+gnrjaQExMxn5wM1URJcd35we2oTVV5La8WdLZlH1Q==",
+      "userVector": "v1-argon2id-password"
+    },
+    {
+      "accountRecoveryKey": "4.Rph8feAE413i1LQ32BZisbRfF5/3uJLx6UsaR+rtmAvzJmlYRUfnHcyAqepDwesuigOr2gvc/hi+JWyIISQD2PKLBQXwjbV4cUQwBm+s+SpoaUb/NFZGxUvbvwYycr6GUR00+VZgYhVeEFmxxLyD/w/34PU42VkguX8ED46RXVoLjBcmbW5+N8JBt2OvZSmg7x48F0OT7J7vFgRBo+9jxI+0eGZlN7NOuKsR5sumQFBuRZU/EtE9O4Wp7KntFdSiOu1BZIWpLJtzyadx6Kqz+zA2fgMARh8VQuo6ouXxSOLPvAo0LBYQQyVoxdI/+2DjkU6EqizWEQO3Yf31xZK2Bg==",
+      "organizationKeySealedToMember": "4.nwJeFaMJm+k4Np9q8l2dUu9R0HPJu7D/yo1r2pabNJlP5s7qh5BgP2xwvUx57w2DH2QsJklXTPkT31IjbJXo9qmzXN9xGLlDfrqZAKGcOcPA54n6TQqvZP1Jg/U65epG99n0WZbH+FKXxtLvmZPv0jhPzmr3fScTwzzvwpV8Cp1f7pmr+fqg9KKElzYqaKBxRiRUgpvjTcnx54MrL55bQENsYCUj3vZhKDyGMGQcGEzegl2eL66AVv3YDtnvUf/MKL32lnJeiU3kKzTwADVeZXbQVJUIDWvwfmg4gKE44TRS6iTSOymi2G1d/6qfgkWwux/q6v38TdcE1eRfAeE1Ag==",
+      "userVector": "v2-argon2id-blob"
+    }
+  ],
+  "name": "example-org",
+  "organizationId": "bc056400-0000-4000-8000-000000000000",
+  "organizationKey": "yo9L6okm7Ppbpy/Qw9ptAemaoZgNgS8jVCpTJdMUdpfJot0B2znl6rpxA8PK3W75/So+AEIOKi3zVCi4AH/jHQ==",
+  "organizationKeyId": null,
+  "publicKey": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAxtOncn1Jrp2AC5lx4tWeVL2FpKBWwTmQIifstWOm6CmmEpf5SBBYdFKfb8l4+mQ6x2nf6d9IIi/mOOyNqbO7JfO+YU2ghsdEKRczPJSJ0t+VzvvtMbg5QYJgtKvi+2/EUr4M2kxVEu29JbqF38a2qUPdshFJjawQDCb3GavCjx1OVl8ee9Z9TMKgbMJNLwN5owhIzRJN0qQr7v8PBC8ZXF7sdFhGe3NACoJfgPAGb0pNZxnVW52y/HP5JVBGmKJSAeHyOUymzQzbhrFy6JLbKxTCkd/LmCjq7Lp3Lr0p8EuzuX9lTEihKyr31IhKxaZYL2PERP02kCp7VrZbUhphhQIDAQAB",
+  "schemaVersion": 1,
+  "vault": {
+    "ciphers": [
+      {
+        "blobEncrypted": false,
+        "decrypted": {
+          "archivedDate": null,
+          "attachmentDecryptionFailures": [],
+          "attachments": [],
+          "bankAccount": null,
+          "card": null,
+          "collectionIds": [],
+          "creationDate": "2024-01-08T00:00:00Z",
+          "deletedDate": null,
+          "driversLicense": null,
+          "edit": true,
+          "favorite": false,
+          "fields": null,
+          "folderId": null,
+          "id": "bc026400-0000-4000-8000-000000000000",
+          "identity": null,
+          "key": "2.gO29xLWUBYdBnHCrCOPy/Q==|i6S7Etb3bzRCC4ubtmoGr5D949saof14CzMm0awUvaI0GrOCwWMYY9wvQFwJMHUaJXUwnv6/UFD539dDLzPsUnj0r08KVHM0/rn7VySi9Ew=|w3MDnALg9Ni9B2U1u8UFdaIVxSzmzs5hBYypAosRdsQ=",
+          "localData": null,
+          "login": {
+            "autofillOnPageLoad": null,
+            "fido2Credentials": null,
+            "password": "shared-password",
+            "passwordRevisionDate": null,
+            "totp": null,
+            "uris": null,
+            "username": "shared@example.com"
+          },
+          "name": "Shared Login",
+          "notes": "Owned by the organization, legacy field-encrypted",
+          "organizationId": "bc056400-0000-4000-8000-000000000000",
+          "organizationUseTotp": false,
+          "passport": null,
+          "passwordHistory": null,
+          "permissions": null,
+          "reprompt": 0,
+          "revisionDate": "2024-06-15T12:30:00Z",
+          "secureNote": null,
+          "sshKey": null,
+          "type": 1,
+          "viewPassword": true
+        },
+        "encrypted": {
+          "archivedDate": null,
+          "attachments": null,
+          "bankAccount": null,
+          "card": null,
+          "collectionIds": [],
+          "creationDate": "2024-01-08T00:00:00Z",
+          "data": null,
+          "deletedDate": null,
+          "driversLicense": null,
+          "edit": true,
+          "favorite": false,
+          "fields": null,
+          "folderId": null,
+          "id": "bc026400-0000-4000-8000-000000000000",
+          "identity": null,
+          "key": "2.gO29xLWUBYdBnHCrCOPy/Q==|i6S7Etb3bzRCC4ubtmoGr5D949saof14CzMm0awUvaI0GrOCwWMYY9wvQFwJMHUaJXUwnv6/UFD539dDLzPsUnj0r08KVHM0/rn7VySi9Ew=|w3MDnALg9Ni9B2U1u8UFdaIVxSzmzs5hBYypAosRdsQ=",
+          "localData": null,
+          "login": {
+            "autofillOnPageLoad": null,
+            "fido2Credentials": null,
+            "password": "2.fBR3C5OESBRrUcM2CSeIkA==|PVs1OayjGCe8sgJ172eWeA==|k6WHbc+U8w7yrDuCkkN/1ZMBktK81QrthWLnP3+JAiA=",
+            "passwordRevisionDate": null,
+            "totp": null,
+            "uris": null,
+            "username": "2.n/yoJ+ifFW4940i1xNvpfA==|hO5hBxtjsrk3ka4Jpkd+QrbWg/kBKmGjq8VXkLnGYWU=|ljPO90/wOgZfBBoKgxwMrrDiLG3mYcWYjwylhfUVB3A="
+          },
+          "name": "2.a5ORHMNN6mI3Ek8DULxSaw==|FDyErE1vVYC9t1uneDioYg==|XSORImsYnnb55FFZ67rZ+5HQ7AJbAY5/RYrCqwbmPLI=",
+          "notes": "2.J1gEkQBzAsMeIu9BMuoMvw==|SDomLe/qzmC2k2vFHWn3McFEb1hrhZp73EiMTlwrDDUPKtyLExzycfZIl9sygq6TUDqFTSiKv0BntEb061/nJw==|oHX58Ky7l54mSlxpqeZNe7KfmSS5W1B73kylupUj8lQ=",
+          "organizationId": "bc056400-0000-4000-8000-000000000000",
+          "organizationUseTotp": false,
+          "passport": null,
+          "passwordHistory": null,
+          "permissions": null,
+          "reprompt": 0,
+          "revisionDate": "2024-06-15T12:30:00Z",
+          "secureNote": null,
+          "sshKey": null,
+          "type": 1,
+          "viewPassword": true
+        },
+        "id": "bc026400-0000-4000-8000-000000000000",
+        "keys": {
+          "attachments": {},
+          "cipherKey": "TP6eMrQjWofeAN0nR6asY12rWZ+/ijH8IgjdPBohyZ2qVm9OAS30qdeBpLcNrR7abqEu/XDylMuTEPLpvo10Og==",
+          "cipherKeyId": null
+        }
+      },
+      {
+        "blobEncrypted": false,
+        "decrypted": {
+          "archivedDate": null,
+          "attachmentDecryptionFailures": [],
+          "attachments": [],
+          "bankAccount": null,
+          "card": null,
+          "collectionIds": [],
+          "creationDate": "2024-01-08T00:00:00Z",
+          "deletedDate": null,
+          "driversLicense": null,
+          "edit": true,
+          "favorite": false,
+          "fields": null,
+          "folderId": null,
+          "id": "bc026401-0000-4000-8000-000000000000",
+          "identity": null,
+          "key": null,
+          "localData": null,
+          "login": {
+            "autofillOnPageLoad": null,
+            "fido2Credentials": null,
+            "password": "shared-keyless-password",
+            "passwordRevisionDate": null,
+            "totp": null,
+            "uris": null,
+            "username": "shared-keyless@example.com"
+          },
+          "name": "Shared Keyless Login",
+          "notes": null,
+          "organizationId": "bc056400-0000-4000-8000-000000000000",
+          "organizationUseTotp": false,
+          "passport": null,
+          "passwordHistory": null,
+          "permissions": null,
+          "reprompt": 0,
+          "revisionDate": "2024-06-15T12:30:00Z",
+          "secureNote": null,
+          "sshKey": null,
+          "type": 1,
+          "viewPassword": true
+        },
+        "encrypted": {
+          "archivedDate": null,
+          "attachments": null,
+          "bankAccount": null,
+          "card": null,
+          "collectionIds": [],
+          "creationDate": "2024-01-08T00:00:00Z",
+          "data": null,
+          "deletedDate": null,
+          "driversLicense": null,
+          "edit": true,
+          "favorite": false,
+          "fields": null,
+          "folderId": null,
+          "id": "bc026401-0000-4000-8000-000000000000",
+          "identity": null,
+          "key": null,
+          "localData": null,
+          "login": {
+            "autofillOnPageLoad": null,
+            "fido2Credentials": null,
+            "password": "2.7qJMvu8SSrAOGgjbt0WiVw==|GP3B4hWmHLTbjuZnXYK7UpiRtKwj2No6xV1oic4GWfU=|gqZJxBNqSxLCZxjUzjd1b5JzyI3/j2tUS0txdkzOTpc=",
+            "passwordRevisionDate": null,
+            "totp": null,
+            "uris": null,
+            "username": "2.TwW1HBcKPvF1KXtF5ZeDWA==|ASeqFZ2bDegHUVyAo2rk8m9/+D0s/XZXSIcGZP93E64=|ZU+vnZrKGqTSuZlEtqIZ6XIx+oXawCV4gHS6BxAndw0="
+          },
+          "name": "2.z5Xxpd7t6vZKOL4n1x1yOg==|h5G+WM1B01rK3JhnztXOg9+5Mfizc7OxPwxv3MWAEZE=|p+i/gks711D6u3XV9o+hfOIaWxr4aHXMCZXXVF5d1es=",
+          "notes": null,
+          "organizationId": "bc056400-0000-4000-8000-000000000000",
+          "organizationUseTotp": false,
+          "passport": null,
+          "passwordHistory": null,
+          "permissions": null,
+          "reprompt": 0,
+          "revisionDate": "2024-06-15T12:30:00Z",
+          "secureNote": null,
+          "sshKey": null,
+          "type": 1,
+          "viewPassword": true
+        },
+        "id": "bc026401-0000-4000-8000-000000000000",
+        "keys": {
+          "attachments": {},
+          "cipherKey": null,
+          "cipherKeyId": null
+        }
+      }
+    ],
+    "collections": [
+      {
+        "decrypted": {
+          "externalId": "ext-shared-collection",
+          "hidePasswords": false,
+          "id": "bc076400-0000-4000-8000-000000000000",
+          "manage": true,
+          "name": "Shared Collection",
+          "organizationId": "bc056400-0000-4000-8000-000000000000",
+          "readOnly": false,
+          "type": 0
+        },
+        "encrypted": {
+          "defaultUserCollectionEmail": null,
+          "externalId": "ext-shared-collection",
+          "hidePasswords": false,
+          "id": "bc076400-0000-4000-8000-000000000000",
+          "manage": true,
+          "name": "2.1gqtJ8jaFgfn6IKeB4Ccmw==|tE1Bd16OzoMQ/7NthuiGBG0pmfK2KaSEpToukvtgOyM=|p7jRxAB8XitKyB37O0yyA2DbNA2CzZe9xJHTpgcyC+Y=",
+          "organizationId": "bc056400-0000-4000-8000-000000000000",
+          "readOnly": false,
+          "type": 0
+        },
+        "id": "bc076400-0000-4000-8000-000000000000"
+      },
+      {
+        "decrypted": {
+          "externalId": null,
+          "hidePasswords": true,
+          "id": "bc076401-0000-4000-8000-000000000000",
+          "manage": false,
+          "name": "Read Only Collection",
+          "organizationId": "bc056400-0000-4000-8000-000000000000",
+          "readOnly": true,
+          "type": 0
+        },
+        "encrypted": {
+          "defaultUserCollectionEmail": null,
+          "externalId": null,
+          "hidePasswords": true,
+          "id": "bc076401-0000-4000-8000-000000000000",
+          "manage": false,
+          "name": "2.glQbixYJRdgqrdRlkkVxXQ==|O3mgACF3HDZEjvpnhtuaJ4fjl3u9tkurmonGhoGuMI4=|RKeaxdOnrpJcMUVeEzQjE1nuW88S9e4W5dKIb9K2o2o=",
+          "organizationId": "bc056400-0000-4000-8000-000000000000",
+          "readOnly": true,
+          "type": 0
+        },
+        "id": "bc076401-0000-4000-8000-000000000000"
+      },
+      {
+        "decrypted": {
+          "externalId": null,
+          "hidePasswords": false,
+          "id": "bc076402-0000-4000-8000-000000000000",
+          "manage": true,
+          "name": "v1-pbkdf2-password@test.bitwarden.com",
+          "organizationId": "bc056400-0000-4000-8000-000000000000",
+          "readOnly": false,
+          "type": 1
+        },
+        "encrypted": {
+          "defaultUserCollectionEmail": "v1-pbkdf2-password@test.bitwarden.com",
+          "externalId": null,
+          "hidePasswords": false,
+          "id": "bc076402-0000-4000-8000-000000000000",
+          "manage": true,
+          "name": "2.+Tcz5Oi4CwTwqhpUjvwizA==|ulD0Aqs8p+NVIXkFTTejeUv1VPdhIYoRjDBdKl/59cs=|Ny1DIlDidxbspzEOj1AkmAbu7m5wmW8OD8ODUZTjYjA=",
+          "organizationId": "bc056400-0000-4000-8000-000000000000",
+          "readOnly": false,
+          "type": 1
+        },
+        "id": "bc076402-0000-4000-8000-000000000000"
+      }
+    ],
+    "folders": [],
+    "sends": []
+  },
+  "wrappedPrivateKey": "2.kZC1GqDyhnwhqY2iUHIwmQ==|t6ZN9mqdQik9uOAwkfHIjxxFCi2jRPXfUd1LqhxV42w9nJgI0WaTPSuo0KAH43uTTN6wjq940ZA3eHqX+B/R/uE/RDg6aTBsk84ArdPV/xDt0VDAPMisZpoXJXVUt64exuPZ7WB/abwsJHb1oJ/z+pZNAHlPKuu5hTSSZ5GPVVsbqS1PDtJWwtiOuWODjG8XvYl/cJAIGOYcdXL3T/JlAkHIiTuCiX57DeGPcvfXKufdSjTVqy+nMVbLmJeXidMhpr7VT6XbMIQvxqlUXe2BntkyTJLHLgya16WzH1/CB2kStlRyIZYTzvMr2xmgZK1DBwX/9Q6m4yRLTQdSEWtLMCrm1RXXpA6OAglje1lxN9AVo2IjSe71RNVTJJlNNVvQpJl8ayIjS6yC4vLa4ODkN17gc3gb/ci+R8saitiBh/iUR7Fu3rZ55/XVAYDIvfqnnaq+ZjjCpm5dGjbSERXdvs5u8SfLH/GRD4XG6CyxRDBWFCVTItBTp4ycGNEmnpNJIwCfYzO3zehu/ZRMqdVdHHTyFxs5m7fMkSpQERd32SD0HE1qvztZqxo+yzLl5tDv0MJuNEfNK+5gSRI5pTvCJG8keQImE17RgB1TlPQQN2OwTNQYbtaoNgTMALjfEEGHjeAUzagVPaUrRD/bk7fxD8nb7jxXbs3+b4wGcGMzeeoOZUVRocxYtJ5RxzwvhiWxhOXRvmXErH0Y2ylVQbB6MpuAJUShg+wB8jwleMSgH/NdYczRC3aeRAJCkFbvUeHkblSo5ioymZ7zRUMMtpohJTYo70sYjlC48Sz3ngWUbx9mXfE5mGcXXRREzHEEF9fn56fxVQEG6XIZfodVBU6+mR+4mmeO4+X5FFaExsnPjRsl5X7PY0WF/4mJKVHDO/AdM6Osih5ixKlx8CdYKruDvci52StYPfNGEcpoXvWcw2PkQdODpsAxQimf0LKYRU7P83fosMTTGFhnp3CK/7Q58VcrNSxtcZ5e6dnt9x4IgnBXn/w25wBgmA70N/X4M+3PDvZuEeFg/3hNNzzOQGzKgBme48decSgCWMCKkWAUW0FWT/phhkaYQBAIFLhmihmelHZL91dn6MyvANry4cY+V8w1UUj3rX0OaPjMOx/G23C/0jTXnbCutH5S8sNjDHNE5CSmGmSiKWxJh0hT3IZO5hqp2pegkfjT/aNLtbaKdD/Dw6KFIUNOI2vkjKkNdrvJh7b9wp2opg2QQfRn/dcxxXkWAWOTdtwhHKaUuwFN/Nk77dgiIw4zOnajmXJ8q751/i++TPacSQBlgHEK+2tJN7bUJxxwymEXT2t3kE+3UitTyDCh9XMP6Qs7D7EyHNi7u2P/6sLptxdH2LI4guvWx7SfqIDzvUERM7gHYngW0aNu+pfNhmpQw8EAMeaUtGn/q6k5NmoiejgFhU7MB7aPZHfxSP1GPkI4QWPWZbe7ejcwjsl41PTF0c9inUI4Yr6BomayOjNXBcCQFj4XbERhVJXV6UEhsLS/0YhRoCe206/On453h+X9Xa5E5f5CmDjcJQX6vhtS3j+1oBKpxaL3Hq0q4oaHGSS9XMNaiGPQSuekDI7Svt18dD5iEKwnWFJStjT1DJJoQaud8M2EthrSRW4sYnIzs7erz+psCvM35gM=|oNzzAUu9iqWzGzDX8271w3BAeszDAkn8zYUoPzrgkU8="
+}

--- a/test-vectors/users/v1-argon2id-password.json
+++ b/test-vectors/users/v1-argon2id-password.json
@@ -1,0 +1,317 @@
+{
+  "account": {
+    "accountCryptographicState": {
+      "V1": {
+        "private_key": "2.6EJSGORU4JaD/IbTL1J6eg==|oO1Kd3vsyMvcpVKi2rknaIrt4lU7pBZSaw6uWMft5N6uDO2VE1exYS0S1d8Upu8NA2qiWyfWa+19sfZfLNqVyFAA0osvKZcVj7ArewydvQC6J1Nhqt7cbCosw397Hs3sOnDnkRYmwQ1SHaKDzunnVR3hxqPhmDyEGIRdxPjA3fCznI40EdVyT4R22t1euFlj1z6aKCdWyEllc8LeTRXihc+xucNEvL2oB+S7Eyh1N77ophYeEa2Zv51klEP3rH0G4K8FDJvRaUIVIbNsli1vFZUepn61ajyx+MeW1aqwAIFnmVBMu9IP9OBnuowbTp65P0ebW8zwVK9eeSZUomXGUP4Sdmvg7zfw24ogYZEdSzCVcuLA73uwUXdE0+Iz+wXBGzy+1DYeebu7yD1VlewIwL1bvxhdg6r7LRL2ufvlmiK+ZlNJ33rhlsQfPmfA04ctoRxHKO42hrbZ29u5ZWhIzHvktX80mdbvvyZcsRJ6AuQsZt0/Nu7+J9zP6MQwkoLtZckYzFLyGhWVAC0stNyEVXqKhYKmPE09GM/wPEC7zLOsjATCcQHE5yZUlitRmnyYhv7UbxEqEti+lqhxCXWXpOmk2yv7B+6gnorh0kBn+JVbMxAloRFDmJ4xg8gtGn7qoJoqsKq9gig+NcEnVY8izKyZyl/dB1uv5110WkYEQ8KUwstkOkDhxPPgLYBTEi/e+8feHgm3JP/t6lyMQK0Rpj5o0Az9Vw5ndEmY794JohkYPkuI/xM5tG7p5lB4IFfUbhgdyxPPB7M61m+MAas3h7MCZD9XBeCqwOj7KhCOj319WLAppXjmPEvGWgw6C3j/6aj9lOlVYithmI9sT8iZ0WrA7hUtFaPE9VONWgMDs5AjKD4alX+qIZ3U0yovnkchodS6Iecb0+B95tY1JhCeV6kSJ2KB6LAl+pJ62+8E53mzKJOWKP9XTIL5YOPm7fn7F+dq5be02OYQt/+YYn9Mlry1RIZofxgpIsrqwVAWlrCa3ooIghAoA4jpYyShdyLMxZIBwd/7H487fGkkaQoEteBAvapBg1pz5IJBrsGvm8lT0k4M44uI1sV3MQnCfxfBCXD9nYFQYeClHUN/WCPMxAaEo81DuNU2BO4vPujDMS9iEDHtEw8c5O86zFmGKrd2XUZuYNg2O4EqzPmewntwVouo4pBPRcjLiJxnPAKAOfxzQSQT+pRko+//dBBUa5WF2HLTf7KE1eEma+DQiwmvD0Wn4QJOL15j//EeDWUx6Tm7PStSd1/y3g6aPkCWE0KhXk3d+i9v88SjAvttK9j4CIhbYGREbizcjoOTY+oJnPWNZtySXebdXCv5qQ/fABtyN2uOkX8eWudEnDtVTgMzt9brkURxoNhQfOgQ3n9SXFRQf8w2ci82CfPk1NDY4lQFZ+xSG5y+hmGcmttCCEuPcvhignUKu3zTMcpgu1TCkwYBhezs0CUMmYdbUTVnfRd9OX/SFJfNbvxUig7NtOpvv4ZxXGxBF28naq2Cav3qiPgbwZa1GatC3aW3OUKQS76vv0AsC9ZeiDy5C0z+Mite9tTr6Yhk0sqynKwijTYSBdFwZm+ajbQ5lQv0KbI7dgVzhuBKNzjVc5zLNsIn8puUScEjDNGDUNyb+ke4kFimLFE=|p7LzeERUdSKhIp66Bfo2J5UEvkLHZpVzC+Srm46UUns="
+      }
+    },
+    "email": "v1-argon2id-password@test.bitwarden.com",
+    "kdf": {
+      "argon2id": {
+        "iterations": 6,
+        "memory": 32,
+        "parallelism": 4
+      }
+    },
+    "organizationKeys": {
+      "bc056400-0000-4000-8000-000000000000": "4.gSKekfA+ue8pQjsxXe8BXKA/VGKr2ggvxbcBzSLW58HVPTmQJdp1MPvk8UhuxNPvgsUC0FRMqmXUjci+gLz3eGNMadoVjjr4LLrg6T9VDs6rsQzMufXDheldAzQKvPMH+GRnhai/b1tC/YzNgFlDoTbHCic1PY8KTf/26rDkdnaWr1/AaBZnDHBvEFUIpEXvP5+GAijTP86yi6FGm0lvSAQM24xbkK8lnRtAHO5szsmnk4uxTwWHyLz6Zs2EvA3eOxrAUD9qQiq0Yllzs8fXGZ/qrdoNWhf/Fjnhov1aXVct+gnrjaQExMxn5wM1URJcd35we2oTVV5La8WdLZlH1Q=="
+    },
+    "password": "password-v1-argon2id-password",
+    "securityVersion": 1,
+    "userId": "bc010300-0000-4000-8000-000000000000"
+  },
+  "description": "V1 account, Argon2id. Mixed vault, folder and send. Unlocks by master password or directly with the user key.",
+  "name": "v1-argon2id-password",
+  "rawCryptographicState": {
+    "fingerprint": "unshipped-consoling-stable-snowflake-escapade",
+    "keyPairThumbprint": "9a505dd174059ef98109419b5d632f1a545e679cc56fc4ada403c1c2e0505608",
+    "masterKey": "pMaIyNQaIaSXYgqqnZDbUD6hy3i+CSv9PcAbF84GkgU=",
+    "privateKey": "MIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQDKE/fGY6GQv0gl8+Mju/ZLdwoJ+yNbGmBdKe+tpU/UqdSOWKpnMdCFkEAWJa1ckmHS8TV4L1TkO0rCrtiYuV5Bga2rwNvEMuQzvsOA21PnsEP+KYsFL1BkUs+noAGE2wkILGq06A2AibMM2JOX6TX2HpIcRucSmwBgoizoJqWfTxgG/2C8OKwLGohxHQphQ8MwP5z8Ko43qslahjdfVsiBDIhzmH2pcyxIvh521S/WKkhoQgP0HkklRQKV03XQN+2vbqulCm0LCoM1pnVA4EJZs4Syq6F1MR3Bj/mCVqkmjkW+3A6lfMar4l8uRqkE1Sd/Pu36C6+tuAQkOlj/If6zAgMBAAECggEAH7msz7+6kNAHErZMdcK/sy9YKyL7dQUaFeZMk7V9aATVsxdmgVcHxsBT32ZA5mSw6P4nh9vedwp7/T6YELoheyVRz8IyfoYC38DWTregX6KDujZpdgHsnCOIKGftdR8yNs9KXWaFICX+L0kdOt9JMn+wLrJO+tPM5l7vr+7JV846oCeg/PlodiLURr5Ug+Q6+UMpTwYz4hvLhX3Vwk3GBbeyQSJZS1t6R/2nttXZI/nk9txD4X//ibEjnmt1xeY2BFZ1GbG5sZR9WEQeX8QgDXagYz/EGvozBpgXFr03AeoqVsoy/yscCbK6pLo3XWPPSW1/r6qhD3Kw2OTHzqJXiQKBgQDrqVMH/edlUjSBz+r0gcf490FinCOuHPd3tsm9Jb8Vy/8SSeWpk24fSZK4qNwm78ds7pXZteC2gB+uvtAXJH2yySeJnx9pFEbAfPxUjpTvTx6S8FNSVGJ970r9IEDw+GfwQ3RHS3jjYreAy9L93UqUwCgpPF3TFTNuOK+BbBIlXQKBgQDbhKfD10NhwRodx5Jko/mERSGxrLJ7R2tlth1Ib0waBotvOa6WibJnwDKLvF4zhn6AZGsh9q+Z6wT/2lIDf4OxcYywabhGCkRMJRWMNbpSoOuiHk0UN2qT9VLm9wO8oXf2Q4jGshDx+GjjbI6WY4ABwmDpL/lukgFbL8AR4pPjTwKBgGF5CLnegC49YTBsMk9tuqu0gVvrHyruGkFu3mSYzz+Rv+/tlsucCklwofo1BdIpDUB2Mo75FngF6JTbobBgzIj9gJgAs/o/g8AsMiY7T0joXcoDE0OTWaWjK04lYBcLd9o93EN86QSMGUBxjdSpCicaj8H2kQw00a/+TEFo1NyVAoGBAI1WN/4sF0JVZk9OM7+ApCK5sBwJqVEehtOSEgCVSFZpaFVQukxKlAehA+pcefqK2eAox6GyhxV+8FUbaDrAWzZgeckMCI1wBtFP/zOrVC/nVE+pWs9tbr2c8qeq20kUXXy9ts7Xz3k8C6yCNLw3jC+Vy3fYX60FbMIdWHkrfTSZAoGAcYCVrK0n/NfOPVJbUVEZyStd9Etj9cSuTKM2BNjLqfAIJeR890tXnvsZg2D72GXrc9X4JhSwnZvx7qIOMdOJvzQw1ondgMhWOF5T/lWqEIEcfZLGqk6y94TS/hzQkb3bkcUSZIoMgGB5xpWsloC3Yah9cSSb9SmcFw8Q9teL31I=",
+    "publicKey": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAyhP3xmOhkL9IJfPjI7v2S3cKCfsjWxpgXSnvraVP1KnUjliqZzHQhZBAFiWtXJJh0vE1eC9U5DtKwq7YmLleQYGtq8DbxDLkM77DgNtT57BD/imLBS9QZFLPp6ABhNsJCCxqtOgNgImzDNiTl+k19h6SHEbnEpsAYKIs6Caln08YBv9gvDisCxqIcR0KYUPDMD+c/CqON6rJWoY3X1bIgQyIc5h9qXMsSL4edtUv1ipIaEID9B5JJUUCldN10Dftr26rpQptCwqDNaZ1QOBCWbOEsquhdTEdwY/5glapJo5FvtwOpXzGq+JfLkapBNUnfz7t+guvrbgEJDpY/yH+swIDAQAB",
+    "signingKey": null,
+    "signingKeyId": null,
+    "signingKeyThumbprint": null,
+    "userKey": "9xUXgxWOaG9aaVtu4b9ofESFT5sM2ooHbnRml/C53E3SqEWOz3Rj24qyjHoM6XukPjV37CnRrmS2WqrhiN+s2A==",
+    "userKeyId": null,
+    "verifyingKey": null
+  },
+  "rngSeed": "NDU2Nzg5Ojs8PT4/QEFCQ0RFRkdISUpLTE1OT1BRUlM=",
+  "schemaVersion": 1,
+  "unlockMethods": [
+    {
+      "masterPasswordUnlock": {
+        "master_password_unlock": {
+          "kdf": {
+            "argon2id": {
+              "iterations": 6,
+              "memory": 32,
+              "parallelism": 4
+            }
+          },
+          "masterKeyWrappedUserKey": "2.MPL6BBBdy3/fSu+JNE84cQ==|Y8MdDhkjTo0yucd2rvYY7ZiTSxsxENLCq/UpfL4jTjTNumHlYlVWJGkbjqPJ6l9pZTQrJnCbbhFiNek89mCrVefNBKLInlUB1Wva6n1HJ24=|Jfyl8dZbLxZGcvP312b8CTUugaAfVG7A/pTfz6+u2xQ=",
+          "salt": "v1-argon2id-password@test.bitwarden.com"
+        },
+        "password": "password-v1-argon2id-password"
+      }
+    },
+    {
+      "decryptedKey": {
+        "decrypted_user_key": "9xUXgxWOaG9aaVtu4b9ofESFT5sM2ooHbnRml/C53E3SqEWOz3Rj24qyjHoM6XukPjV37CnRrmS2WqrhiN+s2A=="
+      }
+    }
+  ],
+  "vault": {
+    "ciphers": [
+      {
+        "blobEncrypted": false,
+        "decrypted": {
+          "archivedDate": null,
+          "attachmentDecryptionFailures": [],
+          "attachments": [],
+          "bankAccount": null,
+          "card": null,
+          "collectionIds": [],
+          "creationDate": "2024-01-08T00:00:00Z",
+          "deletedDate": null,
+          "driversLicense": null,
+          "edit": true,
+          "favorite": false,
+          "fields": null,
+          "folderId": null,
+          "id": "bc020300-0000-4000-8000-000000000000",
+          "identity": null,
+          "key": null,
+          "localData": null,
+          "login": {
+            "autofillOnPageLoad": null,
+            "fido2Credentials": null,
+            "password": "keyless-password",
+            "passwordRevisionDate": null,
+            "totp": null,
+            "uris": null,
+            "username": "keyless@example.com"
+          },
+          "name": "Keyless Login",
+          "notes": "Encrypted directly under the user key",
+          "organizationId": null,
+          "organizationUseTotp": false,
+          "passport": null,
+          "passwordHistory": null,
+          "permissions": null,
+          "reprompt": 0,
+          "revisionDate": "2024-06-15T12:30:00Z",
+          "secureNote": null,
+          "sshKey": null,
+          "type": 1,
+          "viewPassword": true
+        },
+        "encrypted": {
+          "archivedDate": null,
+          "attachments": null,
+          "bankAccount": null,
+          "card": null,
+          "collectionIds": [],
+          "creationDate": "2024-01-08T00:00:00Z",
+          "data": null,
+          "deletedDate": null,
+          "driversLicense": null,
+          "edit": true,
+          "favorite": false,
+          "fields": null,
+          "folderId": null,
+          "id": "bc020300-0000-4000-8000-000000000000",
+          "identity": null,
+          "key": null,
+          "localData": null,
+          "login": {
+            "autofillOnPageLoad": null,
+            "fido2Credentials": null,
+            "password": "2.iRDs5Y4uWI0WY9ElNX4p8g==|oSlCO1y5zgPdQkRPaP3Q6OZHoaBULHGAiLWKYwZ8z9c=|6R+T5VMvj/EzCIYqA3x1MfgW7yUIOKre8MH/iISKXWo=",
+            "passwordRevisionDate": null,
+            "totp": null,
+            "uris": null,
+            "username": "2.5AlA6ufQauZCE64KpG5LkA==|xPT8445J4bmi6IiH5JToLzTlMqP6QFs8Nl1YqYvYrkY=|dQk7UR1vhd/q00ADU9GSrouKyoeHYb0oGJjxpoYCmmg="
+          },
+          "name": "2.kxvDB3y9qksfX1IpMBidWQ==|5FRYq5Hr4xD83PVif6TxFQ==|VEEz/4XyS6P1zBHfdZn+rijSOCoUbEqogi+Vyp+iudI=",
+          "notes": "2.0hH9TxkCdkAHIBe6IKNdZQ==|II6TpBqcTQxB6JupWd/slMasQPei6XJUKWnxpQaPzmOOEyJPsqLScGmLk5t6ccKf|NMsAXiXL+LQC1gtAgHq63rTDh757Cvqdx9h42cI2xMY=",
+          "organizationId": null,
+          "organizationUseTotp": false,
+          "passport": null,
+          "passwordHistory": null,
+          "permissions": null,
+          "reprompt": 0,
+          "revisionDate": "2024-06-15T12:30:00Z",
+          "secureNote": null,
+          "sshKey": null,
+          "type": 1,
+          "viewPassword": true
+        },
+        "id": "bc020300-0000-4000-8000-000000000000",
+        "keys": {
+          "attachments": {},
+          "cipherKey": null,
+          "cipherKeyId": null
+        }
+      },
+      {
+        "blobEncrypted": false,
+        "decrypted": {
+          "archivedDate": null,
+          "attachmentDecryptionFailures": [],
+          "attachments": [],
+          "bankAccount": null,
+          "card": null,
+          "collectionIds": [],
+          "creationDate": "2024-01-08T00:00:00Z",
+          "deletedDate": null,
+          "driversLicense": null,
+          "edit": true,
+          "favorite": false,
+          "fields": null,
+          "folderId": null,
+          "id": "bc020301-0000-4000-8000-000000000000",
+          "identity": null,
+          "key": "2.qXqDexMCj7jt9BXhighIUQ==|1Gu8U/5c2JuGN2zTsDIr2QSDR6fgS5Z0P0QRcWxjYPUzZUq60iLcPtTt2DjjFA1HRZeEfOYZ2wlnq+IzWksSX14aXFOHV5dbnmeqBRQ0Whc=|q8JtzKpcFNdYn761Xr5spK6CPaoGY7TglWSb8YR8Z88=",
+          "localData": null,
+          "login": {
+            "autofillOnPageLoad": null,
+            "fido2Credentials": null,
+            "password": "keyed-password",
+            "passwordRevisionDate": null,
+            "totp": null,
+            "uris": null,
+            "username": "keyed@example.com"
+          },
+          "name": "Keyed Login",
+          "notes": "Encrypted under a per-item cipher key",
+          "organizationId": null,
+          "organizationUseTotp": false,
+          "passport": null,
+          "passwordHistory": null,
+          "permissions": null,
+          "reprompt": 0,
+          "revisionDate": "2024-06-15T12:30:00Z",
+          "secureNote": null,
+          "sshKey": null,
+          "type": 1,
+          "viewPassword": true
+        },
+        "encrypted": {
+          "archivedDate": null,
+          "attachments": null,
+          "bankAccount": null,
+          "card": null,
+          "collectionIds": [],
+          "creationDate": "2024-01-08T00:00:00Z",
+          "data": null,
+          "deletedDate": null,
+          "driversLicense": null,
+          "edit": true,
+          "favorite": false,
+          "fields": null,
+          "folderId": null,
+          "id": "bc020301-0000-4000-8000-000000000000",
+          "identity": null,
+          "key": "2.qXqDexMCj7jt9BXhighIUQ==|1Gu8U/5c2JuGN2zTsDIr2QSDR6fgS5Z0P0QRcWxjYPUzZUq60iLcPtTt2DjjFA1HRZeEfOYZ2wlnq+IzWksSX14aXFOHV5dbnmeqBRQ0Whc=|q8JtzKpcFNdYn761Xr5spK6CPaoGY7TglWSb8YR8Z88=",
+          "localData": null,
+          "login": {
+            "autofillOnPageLoad": null,
+            "fido2Credentials": null,
+            "password": "2.xBzqq0f7LkOlfjjszHqJpA==|JzLDzgSto3HX2etEdOa/UA==|QToHMpFWeY24Pr5Dee0HlzOYV9nskImwyxhkW7KS83Y=",
+            "passwordRevisionDate": null,
+            "totp": null,
+            "uris": null,
+            "username": "2.0QgTWlgPBPq6CkBjfucg4w==|zc3rJrybtrBdxgHoCrThPwJhRSrqsjpOW9gng42KUEU=|L6k14vr1uEQbe7Od66IiMNuO9JzMOEI4bbkktXrQ7KU="
+          },
+          "name": "2.d08ML5fC2EjBxPcoF1nW9Q==|m2pqCV7X0JG6vfRjdJGdaw==|RAqb0HHOa5EOLcXaFbDqE0IWsJAtgbY/Hps7hrE1kog=",
+          "notes": "2.RoMl+Sder60YdkCNaoJfxw==|zTEg9prKs01V5OP2Rw+Pj8bJlshcz6aZDy6JJR0slAT5tAM72uzrjU5YfU3EV/cQ|UWA07FKn5hAK3+Tl+0HE9FYbnlqAYS/S1OFq73sCC7o=",
+          "organizationId": null,
+          "organizationUseTotp": false,
+          "passport": null,
+          "passwordHistory": null,
+          "permissions": null,
+          "reprompt": 0,
+          "revisionDate": "2024-06-15T12:30:00Z",
+          "secureNote": null,
+          "sshKey": null,
+          "type": 1,
+          "viewPassword": true
+        },
+        "id": "bc020301-0000-4000-8000-000000000000",
+        "keys": {
+          "attachments": {},
+          "cipherKey": "ZaQ6rs6U8HZJmKBK9Sph+VEq3Lh2XVHOkDkEn4PQO4BpKm6lvzpIrh0e2yZ9MGci/rXa/AWwxOEVkUg+66NOxw==",
+          "cipherKeyId": null
+        }
+      }
+    ],
+    "collections": [],
+    "folders": [
+      {
+        "decrypted": {
+          "id": "bc030300-0000-4000-8000-000000000000",
+          "name": "Test Folder",
+          "revisionDate": "2024-06-15T12:30:00Z"
+        },
+        "encrypted": {
+          "id": "bc030300-0000-4000-8000-000000000000",
+          "name": "2.6yWkVI2SJgLSs+jETu2bsA==|Dld7OZR+o6jXRg+ZMdpe+A==|+WLJMcy9W068Srs1T/yL2gwfqvaWIz21N88jt0VLZCE=",
+          "revisionDate": "2024-06-15T12:30:00Z"
+        },
+        "id": "bc030300-0000-4000-8000-000000000000"
+      }
+    ],
+    "sends": [
+      {
+        "decrypted": {
+          "accessCount": 0,
+          "accessId": null,
+          "authType": 2,
+          "deletionDate": "2034-06-15T12:30:00Z",
+          "disabled": false,
+          "emails": [],
+          "expirationDate": null,
+          "file": null,
+          "hasPassword": false,
+          "hideEmail": false,
+          "id": "bc040300-0000-4000-8000-000000000000",
+          "key": "Pgui0FK85cNhBGWHAlBHBw",
+          "maxAccessCount": null,
+          "name": "Test Send",
+          "newPassword": null,
+          "notes": "Send notes",
+          "revisionDate": "2024-06-15T12:30:00Z",
+          "text": {
+            "hidden": false,
+            "text": "This is a test send"
+          },
+          "type": 0
+        },
+        "encrypted": {
+          "accessCount": 0,
+          "accessId": null,
+          "authType": 2,
+          "deletionDate": "2034-06-15T12:30:00Z",
+          "disabled": false,
+          "emails": null,
+          "expirationDate": null,
+          "file": null,
+          "hideEmail": false,
+          "id": "bc040300-0000-4000-8000-000000000000",
+          "key": "2.BZC3ApOoszY/9vhYRHPlwQ==|EXmG7VMJ8G1z1jZHz3sCdFqTPUBnPMA0/GqY8MSYqfo=|QaJjg+m5Fun5V6EwFnkrRQm+Xv8lZ9bWSm/CUDjQksE=",
+          "maxAccessCount": null,
+          "name": "2.e71Ym1vZmb4ug8LlWwLpLg==|OdxfCxiHgImSZLco/chUvA==|t0KaN5f88G72urUnNlVM+ZOQYTEEAsFNvhGFc2Hvamg=",
+          "notes": "2.+X382iWveTVchhZNxAN7ag==|1Ay2tAU1swRzbAXRK/PBhg==|yLgexnZK2Eti9P7mEg1s06NZWTooGZo/akoRfdbPIuM=",
+          "password": null,
+          "revisionDate": "2024-06-15T12:30:00Z",
+          "text": {
+            "hidden": false,
+            "text": "2.ofsCHOn7Qgi/o407XeClZg==|uu3Bpa7FxlzL9FADQec0FLQhoOmbera1yP5OPMIXbvw=|h8h25CalYQ1vu8Znll7gQGO3TncuSSEmFih9nbUv11E="
+          },
+          "type": 0
+        },
+        "id": "bc040300-0000-4000-8000-000000000000"
+      }
+    ]
+  }
+}

--- a/test-vectors/users/v1-argon2id-tde.json
+++ b/test-vectors/users/v1-argon2id-tde.json
@@ -1,0 +1,154 @@
+{
+  "account": {
+    "accountCryptographicState": {
+      "V1": {
+        "private_key": "2.lQHA86LoWROOG4KGToXXaQ==|U2iTrSKcJ/yKhJ6ff1+nhwzMTxh2NzI+MMv66MctP4LYGUgihpYeygcflEvJU7kYQfhh6xSqm6i60xiYzBfH4dMe+7FhSKRDQ6iqBu5JNP+GkjRvmXJ0L0KwfkF0U2yHGPYVXX0zylh6HiIU6ORLHMVSsQtdNTjczk0RfJz+OiwY1NIthY/s9h7p67qf+F9sU3uPOWow2g7LSmn0RYSgmFStasyWDRI1bVSdZoUKdEGt9r2pZvUezc1XeCEudXEfn+V2bTVgH0+R3I4ZjrNk5bCDP+fd6wT4Ey2nyCSypTHMbXgOv6Js/JpoTPoJSD0u2rA77G15Pdh3CNrC5QUVk2y8BYKEpqNuMe5wI+i5C6BbyPEr1gSDDo8tgBuy/MKmvOGjR+WIzgM1iz1jYQGN9RuRXV+bQQferJdXQVHA9P4wYOzVGi64n6Mdpur6Opktmy2wSKowy/6/kIni9LpUQ9d1pS2Vieaszti2BgFV5ABCr0fteKQEadbd2UBaEEfIXnx2H7Cb9gvLc6ICdHfdTYk4MB5Z6GJEmot0p1sHgVGpFy9WunDLc8NWTJdpPNc6bLghPJgwGBa5ZtuKf6yrIOKkTayWBbEXMP32GC5momkHz8ktsjEtX6CSWo4bn+W8B5FyNUVOpDXKdRxWkRppsqnz/nSTCagEjlkoKFM1WadTdJO55GW4FqON3rtdjZn7faSzm2FSKTy/Gcf2OtCjQRaERFj5BT6tL2hbVBReuf7yT86v5rfYGz1M19LiRusZqi+3HM08cSkMRA4HhrqSRuz9Tap3XYt0rlkh90DqU1xuKdVzvp4OHXaSkbRjW7Gm6c199Q25ZatX3eriYyyCbxJb4ssesa1Ox1uEwv1gj5jT0zuZRoGouK6Ug5MS2NQbYldJFpGC8Gj+A45JMDkliGdX/x3zkcodCLWVf3PMX9a4zyOyS6o7Kd//UvZOiixVqXhkFSo5B2Fwn6oSO64HPAaIXxNx4DGP61TaDX3PALRAJ5D6R8hKWvqvzNID0NibYcFQKECpyobp+HYyIXStNMdqnZk4dI0UNSLpbIi1K9rrmOo4xACr5ATm7Mjo/rk5HpqHzZW/T8J7VO8rpDgSxISRwpNasgplprKBy+nQNwGLUERTNkV4jewXQ2+TegpU5A/5dZYdlQM1I+5rVyFFyqZaxLc+HxepeVb/NZducRvhQjQWG/q0/mzZy5XZSOD0Dc1IHr1K4eEarb5l2M0jnmlRCSkk0tL4PO7pKbmQvtuiHRQAGjF3AFnLfW+wPfJSxqjWIKWQ6rXr084QlgiOKxDFzv9TKQt6MNau0/yFEMGEiCOv+lN5T++PAlr64+odCwrrq4TOQifgHtHvwLqdRZ7PqBevcxJ1hgwZd9mgpqW9tV5GFXOvys3TlHrBSo0RyZdywLwAWdOxvhnBnm5DvFVbKxaNC43IP2oOfYTRSWY15/JKcSbXncZDPljfrGjZS9bl7+zss3m5pyGrXyKqcUWCsPlYR0qbFsK3pjsz3r1AFG9O5Ygl+ARmgzNwQ1JKjHy1Q3Ck/nenex7TrRQeLzeuHhAfwYbEK9FXBu/gAWns0es9L/kw1tz6EPtmDzYekVYwKkbWKNz6FlHq0e5oPf9EBNZuI0WtGVeSHs/ObLQ=|Kkq0+PFtXw8nt2ZO8aN3lGFtpTd4IFQ0TO8YBewxCFI="
+      }
+    },
+    "email": "v1-argon2id-tde@test.bitwarden.com",
+    "kdf": {
+      "argon2id": {
+        "iterations": 6,
+        "memory": 32,
+        "parallelism": 4
+      }
+    },
+    "password": "password-v1-argon2id-tde",
+    "securityVersion": 1,
+    "userId": "bc010500-0000-4000-8000-000000000000"
+  },
+  "description": "V1 trusted-device account with no master password. Unlocks by device key or auth request.",
+  "name": "v1-argon2id-tde",
+  "rawCryptographicState": {
+    "fingerprint": "banknote-crafty-reanalyze-approve-faculty",
+    "keyPairThumbprint": "5bffc4658d9cd7b584c0a3c00c53799cd292144c9c124d981b68dc7e870be322",
+    "masterKey": null,
+    "privateKey": "MIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQDqaRJcjYdZVuJe20U2Mp6jkrl24DwcsGCMH+dTLS+KD+6lruL+q8P1DnA4M+GvQAqqJCmzv1oN0PH4wnUCWIW/4bqSZng9mlslQJnd6GNKMiFJhhxy5uT60IhuJnt5Cw+YUl4z3acEnRtKBsoAmxcx3jEooen5AoydHJB7SGd7QPdKlUvfjOClsbvHPNc/LeBXsUOaOwemgX4BBwqiBGng2SGdWGI7gszyI1s98T33LE2gDhmEjGk0L32GxsbiUeBmY5cajjh6XpkGpP6c65+hJA9LnFCi0d9UaYh/SmlwWAEJe0vBfTKFKWLlcIqkDg+dpht76RCnv0ti8KqxCb8bAgMBAAECggEAA9znaI8Mg/Rilp2WbmY3Jwrr84GOfAqMDMMZ1M0R03yfuis/omLCP++U+dghB/pOMq+V4Fhu63teAXNy6i77RUY7BN6bbKh2iA6gen+x4y8gTU3geiRD8b4uAWKw9jWwdBonY0Nr1S+hm36xJYFoyHGY7cp9SJU6K/ykhOOUkPthBHYcs7kzzYtFcpx4w+UZCRYJm/BV9DqPCVMplDO8xv/Nd58WVmBwR0aqG/RkZPOtZwzB5WajsvLRYyOlgCbnDQ6DJACT9uIY4/HMWdP1NhPSVR4P6A5hRl/a4xtP/LPm7NzaD5ekQicxiiqv37WEbp++eTMn1BkNnOBw/Jw7QQKBgQDvmj+QfQPhMwWQOM0xcJGOrCcRgrZZoGpdU/p2t6lmLGcLaSHOF5wldDOk64NXyqA46kozkNtdDW7aFt67wCNeLJ+iy9vYXFx8bvNZHbi5W2zGz3aTCB0wsFpgjClHQw3U1PJUuEciEQ6GJsoCnJVCBUVVza61mugyppW2gR93TwKBgQD6c9wX3kqIR0b1ENNZ3kmcDl3xJjpGirWkfwRN5zL1yDgjnVOBx0XJsWMO07uQhaf3nn9oSOXiDnPCQxkyDizNI5ZlfTkFOQQPyFw+PMFZdsZbOa76u1lYLjiTVinhswFA4hlWsZP3YFLgNwL3V7wWkbMAPfXYYfbtnJRZY8ZIdQKBgC25tyXA5eulTAuA+4/S1sRukCokUt554bKb4zGizT5FfQjNcHkfQlpXeb+gfnlTnw4dkDmVDHgOpzgRo0IbYeSICZMM6pC416Gbnu9D38vn6bNrRkq7Aq8XCLhiJ0KFRm92kCSg4lpa/PWXE3g6H7XwwZGlZhEcVfHMnsesjq+7AoGAQ5WCPfqhWDcLwdPhhK3EZVVHKmzrat/BdntEGRWbndGCvLGWuD2i6nNwzK58PdqjYeGmdei+CAtoV3Kt2OEUW+MPkaGCApPJMc0afzz72/1+N13Qhx6JVI9cev3UXXBllTGuLsPKrwWSN6kApuhI/Doi+Jy/u71r2eDX82tGNYUCgYEA4fvRP/jwGKaD7XLmLZfu1Zu0ttq8vWZTiaL/btwY5tZUu4Cvb5KedVoNJHb2KIsmp1pDdns381+11EnocLo+lu0O7ycvZrDEG0NOpTDPR7UaQeOioIH6AIyTEv178dg+ZCnATPGWsKUc95nxLiYH6O1lInAMn/0KK6rRuuLkSWk=",
+    "publicKey": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA6mkSXI2HWVbiXttFNjKeo5K5duA8HLBgjB/nUy0vig/upa7i/qvD9Q5wODPhr0AKqiQps79aDdDx+MJ1AliFv+G6kmZ4PZpbJUCZ3ehjSjIhSYYccubk+tCIbiZ7eQsPmFJeM92nBJ0bSgbKAJsXMd4xKKHp+QKMnRyQe0hne0D3SpVL34zgpbG7xzzXPy3gV7FDmjsHpoF+AQcKogRp4NkhnVhiO4LM8iNbPfE99yxNoA4ZhIxpNC99hsbG4lHgZmOXGo44el6ZBqT+nOufoSQPS5xQotHfVGmIf0ppcFgBCXtLwX0yhSli5XCKpA4PnaYbe+kQp79LYvCqsQm/GwIDAQAB",
+    "signingKey": null,
+    "signingKeyId": null,
+    "signingKeyThumbprint": null,
+    "userKey": "OELlBDhSPq3/os1PGNL6WfIlC3rrOwb8lrffKnigj+kqCkTJIRb8clv/HqABj5r3btYYnkcW4CF+GooJNlPhaA==",
+    "userKeyId": null,
+    "verifyingKey": null
+  },
+  "rngSeed": "VldYWVpbXF1eX2BhYmNkZWZnaGlqa2xtbm9wcXJzdHU=",
+  "schemaVersion": 1,
+  "unlockMethods": [
+    {
+      "deviceKey": {
+        "device_key": "zmS/JUu/wYmDi4Fd50A+Zy0zuRZUKYo60MS3n51IKGyElBbVtNg+Wn6rTC/XCxJkZpl1KF5R31BQu0U94HYDkQ==",
+        "device_protected_user_key": "4.vWLYGcKiyY88Mp8R+KRhmp043/9Ca9T4coYtjm/WxqweKZo7FnImskKjJ04SRrPM+ML+LeUWF9Mib4c+5TuDQqaQgnXL0so4f6dnTtoUaC555kTbAkEXujzc8lBkemS2BZHOVB83+Er8+dZzVtYxSjYXcnwaMoJ92+AEUDtpK7ltT8/D+L1cOu3K1H5w/vhHcpnRVOmRCzGDgaOHfRimJe9wF8Rhes0FB5NA64bihCRnsborer+kZaEsE7RWqtrjDOjxnq5FoDlvpAW/PCPtQhbIGeCheg7zwocof8OXZydUaeo5YTv+oyfqP4eN97Jd93Jk8RDAdS2S1mWn9OuJug==",
+        "protected_device_private_key": "2.+rSwfUfEu6k9tgw8LwTRWA==|pxnHAPGiS/dC4Gx6AjS0Eb5oclLln0l1FsxcVHuVg9KMrHMuUoDN9z5tu8hCovh8ZBSoceLjcHl+mpXw4bP3BwHxWAqDNpKTH7H1lycASQGpHZWwXl5+LUXQqYMNA41CZ2pNmX+fcP3YQy/nzixXBkxdahVXoeGVIK4qWLTJIoPxLLC3yEBCfAKlnWiPK9cxqqxsXCdJNf4VRatGSmHb+Ixr62wzkNzkZ6CnCch/owiKeA6gppuNuqICc6jFa2Wg4xdWkYZtbD7QhAgyKLgjwL7N6ZdkJAiedpBlE1YWXqpiNYs7ksCgnUuD72t/Rjwu28CTUQqfzfenciWU2pWSR4q/pqFwPKIQmvz6f0BYCDoQ9CpYcpO6z8TFdQAGgrblv5pEoxgcYLFfkoLuolQxqBI62DLTHzrfL08zBeTFUNEYPZuryI2bECljE0CuCx9M34E5tXBn4h+Ht9XdM2nnN4gtd9CdxCt7VuLils0OMWH0sJ7eqXAArrB990BPDIY6TQ2Gjh27TRRO/C2hvV1rZYwCFFrf/PLnudHT2NEtBFN/64tQgFuzvOT/XEtVdD3re1KhCIdX6NwkCvPaOanzguU5wy5VLvos1cXx2dOBbyZgAZWeaA1tqVBexdjQGCApEDQnZMbBrzXYy5gYdxNlriUZeE+/UVsN+IhIi8vgWT12IcUvT330iF9mpO6Gnd/g5PvNPvDHXum6oKIePYthapN7gxOfc9G9+G7YAYXAc0z5bFZq2D054C4bqa2DK2tyK7DZtkdnatzNmQoysU4oIjM3s+G5qQ/ikyia5CcSPj7L9wSdFGL3NtDhnhSXC428o2PCATG20Hw2MHUxDOr2UsUkT+TU5CJfyTc77OAHFeFf2p3bjCIVH2qLVF2Ctf1qmI3dCOFxm3z2+NMix1G6PMXK+axlZcHUIoujzYSaQTQ98FG0snXuuPxs0rfWiyILBqrlVrU5LaYy7hiNkqE1h4cifWS9DzE1FrDjSXdiPIYloHgbSpb0hFtLEqMLbBSNDV0/+GGfisLOoz7v8YX1Ijm139kV/TyH4YqvY9JqrhKAV69QQ9mHTHlAysFRH4cehpbBcBTmi+q+y3aa7FVB65ciFssjaqfBBeGjgiDffYR9rtEbvJpXWMGv0QY10Q5wLE9PkxtcPhluDRbVJTNqRc8MDwryeHXH6+GUgKl8xZbA3kp6q7I9tOlJTvpDViUGR2sF+risHsHYkWoxw+W1RTLdAoHmvWXN9kmbT0uVaaMhcsIzFqWbnK3vTvXvU2v9kh45HJDoSE3BMzWSiOEIaIaku9Iud7bzdWI4FIJY9TR7d1jRCXRom8RA8tBkFw4vcVrtvhdj4VqSJssWp718o8dPUFwvVU/HNi8JpF+USBcL2XrQcShqwZOcL45S2TxTV9UHE0c+GfdyyvSXmoqK++jBBmr7KFWIwxvS1sv+0SGBEFS7/n8LdfJunqnZkaGExRGIVaZmb7YSka0ojWfAdCBZJGlvxV27Pm3JJfbGyAmISr4NzstFWlG1Qvo47HlldfN8mQr72P4TQB3mB3lZ6bGB6/Z1O/uuTKuuL9K0c+OsaCLdzuvYAIKTWmPEOXNsI/fAbQRS/Wj3l39LZtN36kfV5vAXtqciCJprQgPN8TI=|5zBC+FGPzwYN0qhPfwP0KX8usSpkJTEOIHO6F5HPeXw="
+      }
+    },
+    {
+      "authRequest": {
+        "method": {
+          "userKey": {
+            "protected_user_key": "4.YgJi9Svzadwk4nhXW2XCnWXKurM5dTBfBBNbopWgNZZKeh1SsXsx/XB5wraUkNhOauKKojrj62tkRHyciA6yKtAmeI1Kt+mUZP/hq3+YdHYfQ8FomptSKsm0ueNCTVjsPNvhYe8PHWADCXBUK10+Cg1pttRb4fgEFG0fkD+RfEqZ/khNHUJ/ePNxRP3nil80Nm3c6h13tz0DaFVEmuIjKv0rx/P3GQV7tEpAdc2NtWLV1zbg2+4WX0jELhX+dtdJuyAHAclHARFQ6w1OlEztdpzGwamfX7XGUh6QeAw0j0P7OE9s8WDiKWDK7uOLiN96NR2Pq+GVy+DfUiKtFNmCRQ=="
+          }
+        },
+        "request_private_key": "MIIEvAIBADANBgkqhkiG9w0BAQEFAASCBKYwggSiAgEAAoIBAQCsiGmY5NOIHb3k1VXFOJtf15EKiGVv1JUtuq0iS6vT37MA3RjualAQ57bOG31C3mhmIsSjo4ok26ED9U3rUy+U0V2SxvuOZR7Oq9g2GwRWrKTfIXffree3Tj28Ikr51RJvD/6i99KzCE9hM09PNQBQdMFi85qgHmROaqKVRN+y81eQlNIeXK4CdfAd9+uNyl5EqxnKc+ix1RMCWgCI3wLDl64+kLT77trqTtYaabzgtQ4ySEMaVD2IzqGZOGbasdj8Mrd6kWIpnCOGDEiZZcd7KTpX4JHt97/AIgZNYO19UxzO+N6arGRLDpkw0rNwQwUzrva/E3Vh4RA4WXu9O5EvAgMBAAECggEATeCtOZRgXxp9sqMROhqZF6PoFkcG8nmUdLXEnKxnfRWGaSdjr4pRZbAR9eq2mc5mdWPQOsUBAC4a+fxqFYTQ/22ZvT0QI3BFfahXyeRcCvuW2Bj1UQPgif9JInigOzEQRw2DNPCELMfdfNR6Qhh8cdShzhaDfy74u+SqSpJyHwW10qc7MR2FjKPcyUel/0gnhQu6/75mpMMq9ZQhktVATFb+JIDfeVIH7XBW24+YKQMiZkzWKtHzOWNDn1suBEqEbMP8JQ7keSY/3EBKR53ZZW9fyawZ4qmWoUEclgcMOB4A8OjREswE3jCbhxDTsM1JQ9LwO0e70LkzflEjiqsMoQKBgQDAZbp1OSV5qDdVcaudF6IqLcr6bHkasdIQA8/65vUhpsvN7rOWugoWAg2iHb4sNbnzZQfpKEtIwWtnOv+y0f8KJC5PTkyBSkKJf3bvVughlBZYdLM6DeQCdXc90hw5iGvYHlW2hoqQO0fWN30uvl/2EUlSWCPupr7N3r1HGQFftwKBgQDlkZVFeZJ2gGnTqGZptpwtHwixEaPdOIpuNbUBMX39ahCMqulSBf7byvNDbSrHryh9qz+EOz79pWzpYR9NAU2sFB+tGdg05s2tLl9uIj7G++xK62Y4eOjkMT6BvA4CEvcUGVoMaCKGCUGC2e9B1oTna601pb78VWycmOHRpHbqSQKBgAEFiUPuFcDbn8+YVuzyny3SKG3D/bCimRb0rjoK1+ph1Fs3lUSLoFoVkLT3q3bYojAkrTITwLKWNFfL/GeardwD7SsGo2lcV5YbUypaL8ld2/CETh9Uy40nyoZNg1Da5Je1MYdSl5HEftEoYkXJRQEtflItnaM6x3CYajDidRtpAoGAZUsAV0BWLK1qhHa4gYqOjKY12pNS/0h0ZD6UWCtzUP6cwMSk4Ik+s9Jv1d90Udlqf1CxXPIbUCXO0YcGHZ8mm3fhpipSKL1yISjl+J1pn7kGwOPvHZnUAOPtlabZc3bUyGyLPBAys3ugCVGJ7T3vNIFhUtuIUqSKoOogMbVktukCgYB/7OO5+czDxPH/Aigk8J57OAjcj0WyyYu37+PT038rI59PbkBccgIhK+6v1+2SveZhPE1I1H/X/JHdJ29WgVsfR0fJ/fx9gtocPLDIze7rCAJmi590A8Zsw92NP22ubC+BssFCxQwnxhYxxwer+piOqO52fknclbsHOzCMGlq2yg=="
+      }
+    }
+  ],
+  "vault": {
+    "ciphers": [
+      {
+        "blobEncrypted": false,
+        "decrypted": {
+          "archivedDate": null,
+          "attachmentDecryptionFailures": [],
+          "attachments": [],
+          "bankAccount": null,
+          "card": null,
+          "collectionIds": [],
+          "creationDate": "2024-01-08T00:00:00Z",
+          "deletedDate": null,
+          "driversLicense": null,
+          "edit": true,
+          "favorite": false,
+          "fields": null,
+          "folderId": null,
+          "id": "bc020500-0000-4000-8000-000000000000",
+          "identity": null,
+          "key": "2.od5MYBDPxb3l1eYKSaBOvg==|dcrjF9juBBjFZyXb4CsJBwNua3QCznzJRSHsR5R0tTfQpPQa7P+svsmSQM//2GvX+7flO5mnhlnv9tcaK2PoSVCjB1wMrVGStKuot4mIwds=|09bNsGdcGjbdPtvt6fIgFic0pPYx+W7ftiYCEQ7mPGo=",
+          "localData": null,
+          "login": {
+            "autofillOnPageLoad": null,
+            "fido2Credentials": null,
+            "password": "keyed-password",
+            "passwordRevisionDate": null,
+            "totp": null,
+            "uris": null,
+            "username": "keyed@example.com"
+          },
+          "name": "Keyed Login",
+          "notes": "Encrypted under a per-item cipher key",
+          "organizationId": null,
+          "organizationUseTotp": false,
+          "passport": null,
+          "passwordHistory": null,
+          "permissions": null,
+          "reprompt": 0,
+          "revisionDate": "2024-06-15T12:30:00Z",
+          "secureNote": null,
+          "sshKey": null,
+          "type": 1,
+          "viewPassword": true
+        },
+        "encrypted": {
+          "archivedDate": null,
+          "attachments": null,
+          "bankAccount": null,
+          "card": null,
+          "collectionIds": [],
+          "creationDate": "2024-01-08T00:00:00Z",
+          "data": null,
+          "deletedDate": null,
+          "driversLicense": null,
+          "edit": true,
+          "favorite": false,
+          "fields": null,
+          "folderId": null,
+          "id": "bc020500-0000-4000-8000-000000000000",
+          "identity": null,
+          "key": "2.od5MYBDPxb3l1eYKSaBOvg==|dcrjF9juBBjFZyXb4CsJBwNua3QCznzJRSHsR5R0tTfQpPQa7P+svsmSQM//2GvX+7flO5mnhlnv9tcaK2PoSVCjB1wMrVGStKuot4mIwds=|09bNsGdcGjbdPtvt6fIgFic0pPYx+W7ftiYCEQ7mPGo=",
+          "localData": null,
+          "login": {
+            "autofillOnPageLoad": null,
+            "fido2Credentials": null,
+            "password": "2.RWrDS2WsfBQvpOdSRrARXA==|nsJ3BVXaQy5PseC40LHnKA==|72uZPhh0HBKpJmqCtCHP20jgRUqYco1LczTySVAJBRY=",
+            "passwordRevisionDate": null,
+            "totp": null,
+            "uris": null,
+            "username": "2.Q49yhIFGyaNeqrvbZ/SVtQ==|Wi5zNkGtpv3ioiCfwJ4eD/EA8kAdpH4MzXOEukLknL0=|8QTpnYTYabIhzJWzsnawFw8u4/NIdMre/bxKOHDYmdU="
+          },
+          "name": "2.Ua+pAa00pKNp/N0lgbObOw==|WBHKkItaRWLHLthQr2AzTQ==|SATXFju+PfzBYMwpPs+pSl2Rspm05zd3b18wh5tPBBE=",
+          "notes": "2.lof9RLaIE+3FaACmSgCKbQ==|mvuTNLHUYrLeRVSb2bmudhXiKqcZrzOPJqv4LhSdk6Z+hAR3M9ZrHo/B5xh3uvPg|1jVgwJWcslNazqwLjgmLX0G+xRQaN16f5DgpwvJprRg=",
+          "organizationId": null,
+          "organizationUseTotp": false,
+          "passport": null,
+          "passwordHistory": null,
+          "permissions": null,
+          "reprompt": 0,
+          "revisionDate": "2024-06-15T12:30:00Z",
+          "secureNote": null,
+          "sshKey": null,
+          "type": 1,
+          "viewPassword": true
+        },
+        "id": "bc020500-0000-4000-8000-000000000000",
+        "keys": {
+          "attachments": {},
+          "cipherKey": "6jZWlkPvOu8s+DXp5F5Rw55a5fiUTGRle7iIfK10YlyHkkmgiAKlLun39nwK8ySJVTNA+hvxp0JgzPiBePHzFg==",
+          "cipherKeyId": null
+        }
+      }
+    ],
+    "collections": [],
+    "folders": [],
+    "sends": []
+  }
+}

--- a/test-vectors/users/v1-pbkdf2-key-connector.json
+++ b/test-vectors/users/v1-pbkdf2-key-connector.json
@@ -1,0 +1,232 @@
+{
+  "account": {
+    "accountCryptographicState": {
+      "V1": {
+        "private_key": "2.5ViWCwTVpqLHnAJaATTNTw==|l5O/hwsjAhgOGA6/IsKpGS4DhAh8j3+MV+86zZPAlL8eFq9IswJZDgbeYWOmNtFrTLyWnZ2aVApkdSgUsVLUCvVwc6FqGPG58jKovIO0d27Va/mZPkRIPSat+PzHi4ETzi1AveONM6lzNkui2L+niLANvtmpCfsbHyIXTYX4WJmdVTf0JKcBAZ07qjsqOzBDCT/0YBjaXKL6BPs6eg0dUm0BM5DtbaEP0b2In/9aVyo/8ilQAaxtVZTl2qHZo4V6jFptdmnCJV1BnUttWC1ocWhqb8myKxH1nSjloZSDMLw7zRhd3fsz1Etgads+vfOikf2pX2XWbBoIB5cN69oUjLjDuA4GaU5fkzCvuLY07DiOSyTNjukTCEKzeobdyWermrrdhmQuGxVvGmlBOvkY58FXHJb7VIJv63IQN+hJ1lsG+03gLRhtnC9WSoYdle2UC/35QZWL+3WnfF1PBn/kqMn+INCMWKhHNtSs6tL8LWwKpwVrq0CX8CUvhbvY1yN934+NiEtgwW4MjADrXWK0U0xCcXk/wvUa1iMUwfLw1Mjhi/V16fmvY0WRhQHi0wtRwFychIkQZofBKqCjZgpj9XnT24xny7wPvsMnrMYgbKWSW+GNo3bmOfWE3Nx2W6TqVnBkuFpl4E1+Pi487RwlSa11DZzXc+SrSIpfMzn01PRh8a1jLxOez1R0nDeTwlMcwUbABRVjn8GBfmQtAT2HJ16TNb1z50vptU4T0DIM59GuGqYzwisPWTF8UdZLSLha8Z0PS64vAxWBEqp0zJT8LlGO8a/2KnKqzJs1aNsDsFLMX/tl8XfXFOFoC9aeuMj5U4FjoL4TK4/z9Ea5NipTuhqigCQSTd+Yi26lKuQj6ywyiaIMxkoP0bPVRlq9l6nO6k5FWF+3SOt6TE6fn76Z707rfSSmXlvioWS/vYk7sQz9pLH0xWpTdAJiqUnJZM5uXSLaHOP6XgWqMbLJX8idlzhyAXSRcUTz3CK3U53GCKy1PAEaXVjm16VLFx8annWjGcKrrs+WbP+stenvuzncy2189KF4ghkhURoRjTpDfsw/uwR8AYJR64jg/Uh2MaD3sZBMhTDekgTt52Ps5BjbgSA4NRKF5DcFdnTF9ljdTyqxkLA5mFC54rlDHtzE9BeaO0UQTNJq4q1eqH9C0M8Pbts9dZPxIvtD6SfCO+nV0fj9oWJecw3nYzLd+XARBPOjHUMTvCQcWCGq2TRgo89jdOKywySs6Liez68LMeRVkagYwBojMdbObv288ZJ10BmESmEfQ/v2pHSIFCzFlv7s2r54K5gRiHCGq+7L0telDpiPkDhhr/8n06XH1g1jMdvFtxNHVvEVYZj6dlYKo19XkjYRjc9iDl0rKZUFW0XeTUaAwgooJeCI/GvRJWSJT/ZfTQepD2YVV9TMA4M5PA11ocwGKWS/c632I4fCDRfeebzNsN0Piwf/flaZo4wQ0nNjMODIswetK6xLEO6nQlkdWi4tW5H9ffg3Xhw8xuQs/4GUYb09nuOgYJQI56pFWLSHANBlRAwkl6M3STu3Uyt8x9FkiLI7+JuS6FXSttivABDSs6/ZCPM5sdLGMESgeM55v9K1V3g7pHuEc8Z2H9/jb/FBrs6SRVACKoQM7pnSpVU=|dDtNmPz+PSNxOad5JbwoTQmWqCTisZRiBvmNghhJz7Y="
+      }
+    },
+    "email": "v1-pbkdf2-key-connector@test.bitwarden.com",
+    "kdf": {
+      "pBKDF2": {
+        "iterations": 600000
+      }
+    },
+    "password": "password-v1-pbkdf2-key-connector",
+    "securityVersion": 1,
+    "userId": "bc010400-0000-4000-8000-000000000000"
+  },
+  "description": "V1 account unlocked through a key connector, with no master password. Mixed vault.",
+  "name": "v1-pbkdf2-key-connector",
+  "rawCryptographicState": {
+    "fingerprint": "engine-gallows-lustiness-uneaten-chooser",
+    "keyPairThumbprint": "da60a67aede90fdd9bc4a51fd957ddeb546268a0f707a02432ad155273d9c3eb",
+    "masterKey": null,
+    "privateKey": "MIIEvwIBADANBgkqhkiG9w0BAQEFAASCBKkwggSlAgEAAoIBAQDOpepOiqcfUOrC2XD0Qaykp6MMtvfvvI7ibwd7pXqlnHbXKJY54pOwY9nVzElk8APGLNn9UMql+S36q3vq/K6xfuopqe3+FJv5IJjXJzZSzlNRYEszMXNQPC5hGHgiuWaLSZ95OoUuh0ozgLTjymFZteLQ9XTmth22jtOWiNRzljqaEWW45IF7vG+CmgnUz9BSVfb1oZ61j4AmiL+bAsh07SuVm7Cj/8VqEpkjiM3FBrgrw9xq9hR1dcRCVEXCW4SfWCTbA6Tw6aj+znwslSYTrm9ZxjtMiPVFrKOfINTdBI5ZayjAf8uFWl7+LeK3kEgjbj73ttsRiJZmviMZT85LAgMBAAECggEBAIpsYXOTNTepAFjdRuiXRYpWMMZHmfWhHSVYsm6E/o8JLCIcMeU8fSne+QBaA5/1ltGdIbip8dUUAVS0oiFaebq0BS87gQx9ya0rxLX6skztoKoWEsmMCm5oobiwp2i7QJF1E7olFSmBvpaZVJJx8pwhVnoaseAJhgXPzrQ7m/SALNK8VPcTtXMuspBSFNXS0K7BMW0FO+eHBXekZ5p3XLupXIKx5YMVUQeEt8OqRYXZLLZ9oFKx8kiwNPch13TFQkcniKZWIVhKPPlE2ZTim1/df0CvxADNBEKv2yKvB5EBOFVDAUNkMxyrzTEY8S+vg7aW861Ct5WLAhP+QRGgjKECgYEA8rb9PV1nSkw3yCW3mWL1ZZ3VDqEik5s0j+8QbdZePtwVFu2O6hVrclpaTz9jR7cksOfeqxOPVay9ILsmiQ8awKbCW5Q8HaZOfFYAehTNyfsL4+I8pj2UbHQ/krzDGLy/oFTWUk/LS9M82eciY3sYf70UefZ/W/0HJ+j5rBSkyFUCgYEA2fWLxhboUwUKiIgsYAYjD9eZDHLfywvIbG8dQpb0ISxj9tKPBnyyBHjctE0Ny2Csbyj2t6A2CQ+p4yQk/4lbFR5upZPC72dGonUOvmov/1yryXQ7HEZBLTg4zkBJSdRozASP2sPOYDNwhnv8fDk4tqj0FFWYaPFEw3kHxtzpXB8CgYAZEZ9sZCZT/TVRvduNwzPXcArefPQmTMSMDUQkJB0N3wtql9TIBrhXUk+7ma92a8slXn2YK+gFEFdkdxAO3fmEZnTyoofnBBNdMkDQWy+6Kezbd7WN8hRPc15RmJ+KAYzFUZ3lWIqF5WaGlyHtJnysTOo9gqE67hJ8I8sN4//1FQKBgQCvXqVPBkF6AvVds4tY27c8WPGZFZjBa8KglKrLWGAnjOsFvpc71fr6JDEYlWMC/87eRex1BOBVXBgKXZuzS9ZQYMMQUJqpO8SWlG7/gLsL0YmbNv0Um+Z3NuRl903ArLqBZS5GDAQyXVEts/cMEJJ0Te7Nqa1OysnUKb67ICZXawKBgQDXV/jGtSQx0V3pvcZWSX8cEJIehQVuxfH4T7cogyjND7WGgztjUf1hfjmXxkAMb/VOKFBUikxg7T2GxDEqV89zcZxG8RBzNHYw+DBn7wAaBLf1Ha52qCAo/df8hL4hhwaDGpspUkcXNdxNlrdIsHJtbVWW7npFaNjnKhwLXhaLLw==",
+    "publicKey": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAzqXqToqnH1Dqwtlw9EGspKejDLb377yO4m8He6V6pZx21yiWOeKTsGPZ1cxJZPADxizZ/VDKpfkt+qt76vyusX7qKant/hSb+SCY1yc2Us5TUWBLMzFzUDwuYRh4Irlmi0mfeTqFLodKM4C048phWbXi0PV05rYdto7TlojUc5Y6mhFluOSBe7xvgpoJ1M/QUlX29aGetY+AJoi/mwLIdO0rlZuwo//FahKZI4jNxQa4K8PcavYUdXXEQlRFwluEn1gk2wOk8Omo/s58LJUmE65vWcY7TIj1RayjnyDU3QSOWWsowH/LhVpe/i3it5BII24+97bbEYiWZr4jGU/OSwIDAQAB",
+    "signingKey": null,
+    "signingKeyId": null,
+    "signingKeyThumbprint": null,
+    "userKey": "rZoUG2DJh4alp9/e9+ZpBv43VffmPXvxDghdD/7KFyfWva4sxxm5Uf4eAUZhgfFPDnigMPh2gkdg5Hiuwqy/4w==",
+    "userKeyId": null,
+    "verifyingKey": null
+  },
+  "rngSeed": "RUZHSElKS0xNTk9QUVJTVFVWV1hZWltcXV5fYGFiY2Q=",
+  "schemaVersion": 1,
+  "unlockMethods": [
+    {
+      "keyConnector": {
+        "master_key": "L+QqBeb0EnesNKFS0k0wDdORo+aULRzmcLf6Rdia3Ls=",
+        "user_key": "2.SM1hsRSj6lKJ5gKLDf1w7w==|KTepdrkGHgzrSEXFf/UozDxNpKMRtTz4d4ZpeO/CAJoG2bhhA16kEy3FnJcTR8EOHmviDE5GJk8T8xT8HiIfC/9KPFogQUDZHwZR8GRb1n8=|YYf6blckdLm50ZHOlmYKlJpb/K3p+D3Dt/70J8tG/k0="
+      }
+    }
+  ],
+  "vault": {
+    "ciphers": [
+      {
+        "blobEncrypted": false,
+        "decrypted": {
+          "archivedDate": null,
+          "attachmentDecryptionFailures": [],
+          "attachments": [],
+          "bankAccount": null,
+          "card": null,
+          "collectionIds": [],
+          "creationDate": "2024-01-08T00:00:00Z",
+          "deletedDate": null,
+          "driversLicense": null,
+          "edit": true,
+          "favorite": false,
+          "fields": null,
+          "folderId": null,
+          "id": "bc020400-0000-4000-8000-000000000000",
+          "identity": null,
+          "key": null,
+          "localData": null,
+          "login": {
+            "autofillOnPageLoad": null,
+            "fido2Credentials": null,
+            "password": "keyless-password",
+            "passwordRevisionDate": null,
+            "totp": null,
+            "uris": null,
+            "username": "keyless@example.com"
+          },
+          "name": "Keyless Login",
+          "notes": "Encrypted directly under the user key",
+          "organizationId": null,
+          "organizationUseTotp": false,
+          "passport": null,
+          "passwordHistory": null,
+          "permissions": null,
+          "reprompt": 0,
+          "revisionDate": "2024-06-15T12:30:00Z",
+          "secureNote": null,
+          "sshKey": null,
+          "type": 1,
+          "viewPassword": true
+        },
+        "encrypted": {
+          "archivedDate": null,
+          "attachments": null,
+          "bankAccount": null,
+          "card": null,
+          "collectionIds": [],
+          "creationDate": "2024-01-08T00:00:00Z",
+          "data": null,
+          "deletedDate": null,
+          "driversLicense": null,
+          "edit": true,
+          "favorite": false,
+          "fields": null,
+          "folderId": null,
+          "id": "bc020400-0000-4000-8000-000000000000",
+          "identity": null,
+          "key": null,
+          "localData": null,
+          "login": {
+            "autofillOnPageLoad": null,
+            "fido2Credentials": null,
+            "password": "2.N7+GeIxVzr3hf6nU5WNRzA==|wuTSscK87/rBfGYtShZe5DmIWvmwpMcKsxDXEbzdmDA=|OhDQOts+X+niL6xQXf0mgw1MkwRTsqVvsFDy2Fk1dIs=",
+            "passwordRevisionDate": null,
+            "totp": null,
+            "uris": null,
+            "username": "2.zmb4Ta5d/qPZSVCo4SOSzg==|KsylIBvQPZ9afJ5HhB4I/+SQ/k+qhXQmn6U1X1k1g3Q=|TV0lVdLh/d25dt8qXLX4O9cYSkvGTeZQFpZY6VH6o0s="
+          },
+          "name": "2.4OlHgQwmkmqZgHU2U0veMw==|QRSU0MWfqrR2qB02wbYm9w==|dpusZS7SnFmJWmPJJQModSx1OxogI+uXjcatmFE79eQ=",
+          "notes": "2.tLFqvWmDjxR6Anr6IhCl7Q==|sXztAbjULtC0T637YknM0IPHJibdsjjIa1Yk/KHKwbShR1CZYWVXFqaYJaSKcgra|5FGY5Mh+SPLgKklH6ZrIao+U54etJKHk998B3sCIGFY=",
+          "organizationId": null,
+          "organizationUseTotp": false,
+          "passport": null,
+          "passwordHistory": null,
+          "permissions": null,
+          "reprompt": 0,
+          "revisionDate": "2024-06-15T12:30:00Z",
+          "secureNote": null,
+          "sshKey": null,
+          "type": 1,
+          "viewPassword": true
+        },
+        "id": "bc020400-0000-4000-8000-000000000000",
+        "keys": {
+          "attachments": {},
+          "cipherKey": null,
+          "cipherKeyId": null
+        }
+      },
+      {
+        "blobEncrypted": false,
+        "decrypted": {
+          "archivedDate": null,
+          "attachmentDecryptionFailures": [],
+          "attachments": [],
+          "bankAccount": null,
+          "card": null,
+          "collectionIds": [],
+          "creationDate": "2024-01-08T00:00:00Z",
+          "deletedDate": null,
+          "driversLicense": null,
+          "edit": true,
+          "favorite": false,
+          "fields": null,
+          "folderId": null,
+          "id": "bc020401-0000-4000-8000-000000000000",
+          "identity": null,
+          "key": "2.x5M0ZTHdnp+rZKyCy0vmrQ==|ZqtYluIDpYAwd0p0HmTdn3a+oe7m/uss38ePodytZl3l6UQ75jSLL0De61hJugaxEo/L/Qc8Qo8ZcCOABMr+UtFBfim+gLWQVlAUe1XqxOI=|Yd0D7u2IeY/hOZHXDtPNTmTZvFTBr0CY6DzSlYKG/ms=",
+          "localData": null,
+          "login": {
+            "autofillOnPageLoad": null,
+            "fido2Credentials": null,
+            "password": "keyed-password",
+            "passwordRevisionDate": null,
+            "totp": null,
+            "uris": null,
+            "username": "keyed@example.com"
+          },
+          "name": "Keyed Login",
+          "notes": "Encrypted under a per-item cipher key",
+          "organizationId": null,
+          "organizationUseTotp": false,
+          "passport": null,
+          "passwordHistory": null,
+          "permissions": null,
+          "reprompt": 0,
+          "revisionDate": "2024-06-15T12:30:00Z",
+          "secureNote": null,
+          "sshKey": null,
+          "type": 1,
+          "viewPassword": true
+        },
+        "encrypted": {
+          "archivedDate": null,
+          "attachments": null,
+          "bankAccount": null,
+          "card": null,
+          "collectionIds": [],
+          "creationDate": "2024-01-08T00:00:00Z",
+          "data": null,
+          "deletedDate": null,
+          "driversLicense": null,
+          "edit": true,
+          "favorite": false,
+          "fields": null,
+          "folderId": null,
+          "id": "bc020401-0000-4000-8000-000000000000",
+          "identity": null,
+          "key": "2.x5M0ZTHdnp+rZKyCy0vmrQ==|ZqtYluIDpYAwd0p0HmTdn3a+oe7m/uss38ePodytZl3l6UQ75jSLL0De61hJugaxEo/L/Qc8Qo8ZcCOABMr+UtFBfim+gLWQVlAUe1XqxOI=|Yd0D7u2IeY/hOZHXDtPNTmTZvFTBr0CY6DzSlYKG/ms=",
+          "localData": null,
+          "login": {
+            "autofillOnPageLoad": null,
+            "fido2Credentials": null,
+            "password": "2.KbXQtKc47zDNm/lpd0v14A==|AfkQfIqirZrambSh74MSmg==|nkzgrGegdvnLfSx0Hwg+U/I9n0PAYC00SnEZ8Z0ml4U=",
+            "passwordRevisionDate": null,
+            "totp": null,
+            "uris": null,
+            "username": "2.hTShVTMkkWJOZ4VL1yWG/A==|JupAsAOYfwhDGeigzgNJUKzZHmbEb+FnS6JHvqwc158=|f9ifPMfIPCeDoUiDVgG80vSKJkfmx3wvTOIX52jcohc="
+          },
+          "name": "2.gG9rew7pQo65+kN/K8JE3g==|3RVR4LZE7oQsPE+t7QI5Nw==|CAg4+u1K8fQgRVjydebzcEhixFoWX+J1VA0ce41q5CA=",
+          "notes": "2.5rPrL9qgG8MZtLe2E5VmLg==|ywftyeAtkWnQja8jSQ39wfrMNBkH5Yx/dth72ZEGn4AOvu+pMAEWOko53Ilj8HiY|sLR/TwmBsPsm1Fgm2CzIqGeUmJiaki6QSN0Vrz8w6U0=",
+          "organizationId": null,
+          "organizationUseTotp": false,
+          "passport": null,
+          "passwordHistory": null,
+          "permissions": null,
+          "reprompt": 0,
+          "revisionDate": "2024-06-15T12:30:00Z",
+          "secureNote": null,
+          "sshKey": null,
+          "type": 1,
+          "viewPassword": true
+        },
+        "id": "bc020401-0000-4000-8000-000000000000",
+        "keys": {
+          "attachments": {},
+          "cipherKey": "LKu0xKfx4toq0NhtaWdD4wVZcs+ihXMCG9SmNWeofNUNlIw6tp3xlhqyeDiU8q73LInv63ek04ySWHMmLjrDPw==",
+          "cipherKeyId": null
+        }
+      }
+    ],
+    "collections": [],
+    "folders": [],
+    "sends": []
+  }
+}

--- a/test-vectors/users/v1-pbkdf2-min-iterations.json
+++ b/test-vectors/users/v1-pbkdf2-min-iterations.json
@@ -1,0 +1,149 @@
+{
+  "account": {
+    "accountCryptographicState": {
+      "V1": {
+        "private_key": "2.0ANhcyn2dgW3HeE8fpUaAA==|ok/xEVzDJm8rzlPek+CUMDwpe3QOXlsoU/qRK1tNwBthtQqg12JDMW1wcpoyj6iY5U2psjDrH8dFaG7kFY0mP7W7Ll0VPpch9f0qrcvJsImi4wtzbZiRX8hMNBrUMBgTEiV5Y74jfvrD4XgaA0CWstBipViuD9jHdx8fIQJa/MEJmMXhq5tUFBD6g6sPaaZT50hxEARW1KWW2J1qvkfibwJJoIgLTYi4vMpfB/aH3P+S1XNorg8NR7uTrRPePxEk0YoNXb+QrGXihhZmOTjwQWy3dyeUk2j8Ju2Y54PkY4IUQsKFtpj6EgDJ5sV3cUQin3ixShA/QCyQZ4y3p9onpqOsqWqVEPp41i+eGPhfX7h7QgZiLhH3ixqqySxXdn1ifyM82A8RuZrataZXeuiX0DsApWbFBR4km5X/aJ27OiZwg90vn4CPetVaqsAqthcz7PgBu0mRiuHaVY2KTliJTT6YWSKdPxrEhgxruDbdyxf/I46whXutOlGMUHtSiDzmkkFsR9ffNNzkJJiiE8n7fuGEchjnl1HqoQ+Hy/928vxGfnsDdwFsDZnKByvUgFTZRUItCLdM+7+j+4vFJnqT6QPSGYHbV6RF/ZXOex06alPscHPh7CU/l+d5jqrR0IYWU6s1t4Hf8DdBxr3EdbDMJRGOC0h8l14Ew48wZk4aIALsHLG1CXsMBr9y9k6v8KLVkLZCq95l2DzX8ZW+xSIOpFN/aPPKmTfHi/uvKhHc0uW5ghy2VfCIIl8raISbBLGNonc+IcbLIYdDbCCV8pEzkAgR3gAYV7lAv0NXAxqwzYWej7UKCbv1k2AdetUWxpmmLDK76o7KCchOVfj/knkexcZ+sUpcUzxtYubDMWybfmr50b9cy5X/J3TWRGT76zK36i7ywFS3J2oC98u5gaS7H4bOrueGm/K/4BTf/ND6vRpEYAO0lAvxuVfxVzbLFYmsfVScisKGgfV8VMik2y9xU3hz4rHBAD7HNRgDkejbBcfy3T1ip8JXNlZbL/1h5fR2ojVqoDy209z9DpzEfiO6an0GIaTI2zzCSqByjWJlECEFQ98MoxDfvLd8FaSl8vMkw3KzVBBO30Iwq6C925CJw0iAqcWnuHKqhDLhMpQ+eoxlmdW6cDIdFEI3EQlQnazCDswozCeRt6Dz50j7J4gLZ26YlDIW6ap2FnH2oGc75PXuuvUC8zsWQXrhc7dqKWg6gmvhaxrCxQG+a+GL0LT+XV+Ooo1ZcE0gEkikpayR6+CV4dGA3HAhmg05XSfWiRaItUcEcecHoEBe9bQKnnAI6D16iEfIB8AVzPw9k7tlU+0qdMI2P7tQ268qGnbH9c3aQzecFcszzLA+HtFug0n03ELyL28CsAuVESMFO8/l5T9+v6fDnMRXGvUbJaFnlhoCzkNGdLOzuYGNuRwbYz57vYqr+6IQvi+NRsDs1k5XlDompOwbwxYWI1dVnpkvyUOm0bTkDXlcc7nEObUv7JfeWFotHCUO3knD6iBrU5VgPTfMNiRbSGDrlcGzO6JdA763M2/8mEkeKahLnr5+Iy1tatx4GvQ06keJjSCu7wilQLLteVZoVvgHJC3du+yTiN0dhMTUT/GTA+ZXplSZNAbNRvczkFQkbaTjg3y0ttV7EUY=|1xOPDlk2Vjdf78N/UDfSr8LkYZWt93ZXmOHnuXXuWuI="
+      }
+    },
+    "email": "v1-pbkdf2-min-iterations@test.bitwarden.com",
+    "kdf": {
+      "pBKDF2": {
+        "iterations": 5000
+      }
+    },
+    "password": "password-v1-pbkdf2-min-iterations",
+    "securityVersion": 1,
+    "userId": "bc010200-0000-4000-8000-000000000000"
+  },
+  "description": "V1 account at the minimum allowed PBKDF2 iteration count, guarding the KDF bounds check. Single keyless cipher.",
+  "name": "v1-pbkdf2-min-iterations",
+  "rawCryptographicState": {
+    "fingerprint": "spiritism-vending-stellar-marsupial-trouble",
+    "keyPairThumbprint": "c9788da93359e1a502873b554fd76b63f97a3f693496605cd06d267651d9832e",
+    "masterKey": "UatIiUqaRRrvWopmr0qGyaKkXlanYKFJCHajYo7h0Ys=",
+    "privateKey": "MIIEvwIBADANBgkqhkiG9w0BAQEFAASCBKkwggSlAgEAAoIBAQDnmB8eCvfd12QNBnBaGY/KvZ+BZQmDRIBGHZrQkcOzcPmLdOl/EC50HfEZsaRg4OoYYG+GAaX5bPcdksYQvoZKwOAmp7qqtWDDiPHcvvZQ0QQ/DHDqUfvLnswP+LF3HpEuR7+vLvF+jShgfutjqTOLJe63WuMZbkUnncI4J2RD+qcCtQezT8u+Au5kavZdKb4dszMr3Tc4AHbkWqJVyDmNMgTKRkIxuv532PgxttHES1wRrq3NxyxOArxJ4codGv+R/lNaRG5HeiQ6tWTFnnlfgVU7qmywMRQZ59LQ/2UiPyGKguA7hBVc3YcHXixnsiVjSY4fy+GB5c3xaoYQjcqdAgMBAAECggEBAJ8YTIAZ7s6x8aRVAQeUOch/3TxJiXBotWn1Wm3fRL5XZMZdiS3lktPn4cHR2+dFeutGDDbVmQwww83ID1JfX+eoehNz8/LjaNbKk8QeVx2LiMw7IrKFoWDu9KYgJOF82SUe2tpgeDuEgvFPHys2iBcV9th0kj/dFZqycEKdJO7gygXLOBsBsafPDNp5ZqzqiD+khF1leZEXUDzQ0TOaSw3Z7ij0PFXXvPC5FGfBjAFokErb9iUk2tqEriRBIKsoa1W2EjG19g/uE4STtOIXs/tDQ7PSnNJ8GsWThlFuD7N3oKJuSKjdRUECLMMA+zy0lCNoRtyJsuptRIwRfW011u0CgYEA+cyIRMh/Wbv3gN/vtd8IACnn7owSz31JJG1rk/feCdnkcMVdZOqx6bl9CJQs+kKwQBHm/FyrZS6rrQnK+GNvRUJIScfUFJr7tBswIRSh3pDbFqo9o0WNLO9if8LJEQTgZpHlkDkvuQdzrm9thJvMaw4zdzowPPOzLcls4jS6C+cCgYEA7VfmBnONYkEW8ExFhZcMNoWyzktLSiQCQONAJzI932MfHDdvbW85saK09ApLLNh1vEZPiBXSWfqMDqXh8YEHm93UnlYogBRKJoc1MaT2c6heRh/kS+GIvnufM/3rQ4rCjTgonQi0RoIfNEQXoKaRe0K+7eZzuQxFnLJzTXJaBNsCgYEAnPu+v4tJDTmlZ2ZUHPXW71NmoHGC+MaBitUBAHKLJaG7gGtoMB2WRY3+V7/XLEdwwDL/+KS8SdA0r4AyADttGBd5mnRsga6MdDmJ26A9wcNDDFFcfxkciZq/Sg89kOaBp7QUkrh9l0hpmLwKFYZbxwObsFfvLL7yYdnuBZKhQQ0CgYEAyK7H6rCN3YRX1vtG1XwwcXF/DPuRP7FOznrYZcwPkPEI/xzIdOnVCKQhCTAi/FpSws1YtiJtaHN3NXOBpmiJfHuHKhKD0DhXslgk3EM1t/mnLPgOWzLqItX4eUe8Q7HyauIPRSh09iFULSdeKxJsdKKtOg7fzpnXynUBFX0ZLH0CgYAEjLaFGFY+GEjzuwUzyhQ1ZaFJshRrVdhKijZoxYtXmJYMvoZ5QuislG0POY3aYrozhuIH7WirYHwuD+5f3szm58CTnKhXAp1PVDpKxlVDNYgbgA7uhvV4esjyL6febGFez4DzuBvdUEh07ID3oE19tg71bPBpZYKf3OJ4Zh0BiQ==",
+    "publicKey": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA55gfHgr33ddkDQZwWhmPyr2fgWUJg0SARh2a0JHDs3D5i3TpfxAudB3xGbGkYODqGGBvhgGl+Wz3HZLGEL6GSsDgJqe6qrVgw4jx3L72UNEEPwxw6lH7y57MD/ixdx6RLke/ry7xfo0oYH7rY6kziyXut1rjGW5FJ53COCdkQ/qnArUHs0/LvgLuZGr2XSm+HbMzK903OAB25FqiVcg5jTIEykZCMbr+d9j4MbbRxEtcEa6tzccsTgK8SeHKHRr/kf5TWkRuR3okOrVkxZ55X4FVO6pssDEUGefS0P9lIj8hioLgO4QVXN2HB14sZ7IlY0mOH8vhgeXN8WqGEI3KnQIDAQAB",
+    "signingKey": null,
+    "signingKeyId": null,
+    "signingKeyThumbprint": null,
+    "userKey": "49LghK4AVIybWSZFikb4nAn/BofxxBIoXv83EJWOP4taVMbR5XCfrbF2m/eUmfZdeFW7VybPYSGT/bmv5eeMBg==",
+    "userKeyId": null,
+    "verifyingKey": null
+  },
+  "rngSeed": "IyQlJicoKSorLC0uLzAxMjM0NTY3ODk6Ozw9Pj9AQUI=",
+  "schemaVersion": 1,
+  "unlockMethods": [
+    {
+      "masterPasswordUnlock": {
+        "master_password_unlock": {
+          "kdf": {
+            "pBKDF2": {
+              "iterations": 5000
+            }
+          },
+          "masterKeyWrappedUserKey": "2.tl+DrZdn+fVyBVu+0c/Gvg==|9ivOLNtKbvirNaUnkGsEtysp9de53ibTSu88HLkDOGLig3t8nhvK5JIqxSY1/ukcr2Y/Ly9OJ12tXUGjIlJ/PtIEIdYj3gZDwhAflPUwtW8=|FD5WuIvviib3yWYcI3slmqBSqMf38Z0CMwttPG1w5DY=",
+          "salt": "v1-pbkdf2-min-iterations@test.bitwarden.com"
+        },
+        "password": "password-v1-pbkdf2-min-iterations"
+      }
+    }
+  ],
+  "vault": {
+    "ciphers": [
+      {
+        "blobEncrypted": false,
+        "decrypted": {
+          "archivedDate": null,
+          "attachmentDecryptionFailures": [],
+          "attachments": [],
+          "bankAccount": null,
+          "card": null,
+          "collectionIds": [],
+          "creationDate": "2024-01-08T00:00:00Z",
+          "deletedDate": null,
+          "driversLicense": null,
+          "edit": true,
+          "favorite": false,
+          "fields": null,
+          "folderId": null,
+          "id": "bc020200-0000-4000-8000-000000000000",
+          "identity": null,
+          "key": null,
+          "localData": null,
+          "login": {
+            "autofillOnPageLoad": null,
+            "fido2Credentials": null,
+            "password": "keyless-password",
+            "passwordRevisionDate": null,
+            "totp": null,
+            "uris": null,
+            "username": "keyless@example.com"
+          },
+          "name": "Keyless Login",
+          "notes": "Encrypted directly under the user key",
+          "organizationId": null,
+          "organizationUseTotp": false,
+          "passport": null,
+          "passwordHistory": null,
+          "permissions": null,
+          "reprompt": 0,
+          "revisionDate": "2024-06-15T12:30:00Z",
+          "secureNote": null,
+          "sshKey": null,
+          "type": 1,
+          "viewPassword": true
+        },
+        "encrypted": {
+          "archivedDate": null,
+          "attachments": null,
+          "bankAccount": null,
+          "card": null,
+          "collectionIds": [],
+          "creationDate": "2024-01-08T00:00:00Z",
+          "data": null,
+          "deletedDate": null,
+          "driversLicense": null,
+          "edit": true,
+          "favorite": false,
+          "fields": null,
+          "folderId": null,
+          "id": "bc020200-0000-4000-8000-000000000000",
+          "identity": null,
+          "key": null,
+          "localData": null,
+          "login": {
+            "autofillOnPageLoad": null,
+            "fido2Credentials": null,
+            "password": "2.IFEcuiyU7YF5cKjHInZofQ==|ckG4/YAvWrD4UAlz7a6zknim1Pbz45a3q75RBZPPgPU=|v/FBD5NIDH9VNqoTB+gL/vKJ058JH0JQYHASCPPl8/w=",
+            "passwordRevisionDate": null,
+            "totp": null,
+            "uris": null,
+            "username": "2.N7tWl4oiypcYCgwnW3H/yQ==|XKhqk2dcoGi6Ig9yII1MpK2riOdLU+aXOEqrNxi1Z18=|lDtLkeRcbiri6IMQ8sQJ6tYmn0vIWuCDNU1anGpT87c="
+          },
+          "name": "2.MTL3lCwKtsx96jWfSXA6xg==|mNk9U7tXuvcGucSPLexoGw==|ARDxQW7rhVdD601OLz3E5quxkr384yNVnhq4S4pQGZM=",
+          "notes": "2.wK6f2/Cb/3yOVeVl3L3hiQ==|8qg0SI4DbyoJjMeppSR51I95/ULMB+RfVTBHZGYwAh+ojgRz9BqYUCo7WGgE0usU|UTvqywCB1adsvvYIO2bJLkAoRWHsWfU3i7OW7jk9OHw=",
+          "organizationId": null,
+          "organizationUseTotp": false,
+          "passport": null,
+          "passwordHistory": null,
+          "permissions": null,
+          "reprompt": 0,
+          "revisionDate": "2024-06-15T12:30:00Z",
+          "secureNote": null,
+          "sshKey": null,
+          "type": 1,
+          "viewPassword": true
+        },
+        "id": "bc020200-0000-4000-8000-000000000000",
+        "keys": {
+          "attachments": {},
+          "cipherKey": null,
+          "cipherKeyId": null
+        }
+      }
+    ],
+    "collections": [],
+    "folders": [],
+    "sends": []
+  }
+}

--- a/test-vectors/users/v1-pbkdf2-password.json
+++ b/test-vectors/users/v1-pbkdf2-password.json
@@ -1,0 +1,659 @@
+{
+  "account": {
+    "accountCryptographicState": {
+      "V1": {
+        "private_key": "2.FJpf5wu41fhZAtdNh+nC/w==|jZb58ehWYa/Gf40TbT3DtJ0IJJx2MC018IFpvP1OyXyr0O1DSaoWP7/W7mPaFopNckkhHJD2Wo+24ZQFzpq4i5IqLDIy2XVp7hVRsEf8H9Q9OacG/0OD8J/c6Awo8a5pVk/kjaHVd/NUix0unUTix8df3TroiMmjDy085hvKYgremgVuinnE1XVJlhXrNm2j4NXrJtEhdV7kmzgJ4L1cSs/S05s/ZI4/s+amTXHrW3RowEmMkurqGhOSq0NGqbzc7ox8gn0W3E1CtmJxLL6wJKQCWI2ZJ48cBaWickqqPdr9C4XVBSvcgsjGsCbWTCNA6cO5xqTT4AHIwtzrZcagLIjzCigypxalbUsflgBuHwxKXnfgB9byFNCEyI+/UFDv7W2WPaUJ9SG2NMkkzyAJdWRatTRPKpT9wp2EYdXFWFzHD+Jhy1xC5JDiUDDOqoK/zUAMml1zFh/VUwBCZh+rq0IawvJd5vxeIEwQcfW5NnOzqJMHQNa/vvKvezWKQg7O0KeZIb2zBpzixT5Ln4Wcq40joBqb9l8RdaN6NdNpN2eCvg6Wn5wg9/HhhFYSrqYXT8pshT/4jgwtjd7k4bqOMTtOMJXC4sZMyvZwqHj4DT4BeAbgdSLA9LrY/ankw+YmMgQsGc58xbh4EzvAlZjERgHIh/fMmxPisqBSoMRQP7bsXypx7f8NZkaauHcpNijxwRf3QeAXo9CFboLRMpcXVMVPE0palFD7ellOQ92aJf1OHdmL1UHku/DlIoHoKk5ECuFbSzaGbgdSDAVxNh2cFX2f8XY/m7Js5yfB7Ueu+IGM+CRwwcCfMLlugGjZtZTH/XMt+RO5lAF1REEw9wESzCeCduoLHffx8fp8+BURWMtYyXd9JZg87EP1YG07h49JmXGBZbfjbfKDTv1+evRfbNR389I75Tb4gfBCUlZ0D2gUriYwjesV6rtp8SchFYrlkZRmJlesMyC+lNf0vtCkK5mV6p7Hp/tIZLEFS98Rnc+F4V0r31uBELRQpHc1CEHeC3nlF0HU4H7X5of4Y5bPzDIa6Ou7g9+lhhro0jOwvaGhlU5cIcIcZATI5ClNpM9DCM4HDUtgpQsCEqlm3LDjMCA8x3nufebJIhffWGyKtgd07JQt4m3H2kKNt73cLHxSn2Fr0+UoJWEBmvoS/HSLBDmtgRtK7roplo1o5Kfogghj/KzBDiCFnYClN0AYiVxYPzDlNgO31lS1mzMiCQnF7g72WWLKIUdz51WH1xklTOwJBHRuvu3mO0vzsJFxvBvLTd5Cm7fPTvpEgFs6Ov0UZalfl7YbMwN2l80A2dGAVqjTXqmlD5YObjRnM4feyWoIaX2DoINclu9zeOzojykUUiSpOQ6bmsKu+RKwIkqWd8I/uGKfHpA/tjDm/KhIT2mHAQ6T2tD+W119blU3xH2YEZkkwR3XHYtqIotd8RTLXSk88tdCUfLi+Hyw6R/LSmiPG2KyJa1QUqYi4nYZE6nnMrtvdsHMRleM7YH7qbIUt0ykYt1R96NKB3fwwfiC8Lm8walzVpzD7ObgUXAr3UV8+RndbbPq2uvUs0PIAMfLGrkcnRNGPybJwtMd+sfq6POn0tZ1vcvO8QhYkm0G5vcGKqoQSVL+dkxLTaWvv8ApJMY=|Drt0Rlny5FRukDwjYzhdQNkenEmCLIPWTWr0FiKA70s="
+      }
+    },
+    "email": "v1-pbkdf2-password@test.bitwarden.com",
+    "kdf": {
+      "pBKDF2": {
+        "iterations": 600000
+      }
+    },
+    "organizationKeys": {
+      "bc056400-0000-4000-8000-000000000000": "4.vhbzMrSczyG4acviiclbnUnBYZGhn0GScTSV7CHy6LO9zONAeG091MP+6IOXfthw6HNY2YV+YI6TVaN1C8KbAh1q4gQRTMkM0vFF9iP0a2yGwh9aTa80Mx4ZN03/Ztzv5uM2qoSpi6a1HGuD99L5ykJOuFXYjmZ+IoByOiGHxuhUvc/qafLkCpvrpZP/uFpSmU8r+qrYBj0mtruqVvYPqn2zEZo8ddTPyF9jYWfMkug+pSQtKOakfiwtSok+IifWIVbfVVU0Lwi41hw5ZY8Sut7qrrooFeKCV6DUfT93tqdn2ScY+lBzZmARt/jXNNrGtZk2NvLYEhqRLI4NCs4k5w=="
+    },
+    "password": "password-v1-pbkdf2-password",
+    "securityVersion": 1,
+    "userId": "bc010100-0000-4000-8000-000000000000"
+  },
+  "description": "V1 account, PBKDF2 600k. Mixed vault covering all three attachment layouts. Unlocks by master password or PIN.",
+  "name": "v1-pbkdf2-password",
+  "rawCryptographicState": {
+    "fingerprint": "banner-footage-bristle-footpath-zigzagged",
+    "keyPairThumbprint": "db7be39d047b30429b5a1c38857f128b1c285cdfa4d7c0835c352729ede96880",
+    "masterKey": "OHRSVddB56kYH8unf/H43Dx1dSIwmWLMY9fFm0rzTY4=",
+    "privateKey": "MIIEwAIBADANBgkqhkiG9w0BAQEFAASCBKowggSmAgEAAoIBAQDCucTpnfzlFBo1hg3YcpyCRKTAHOPBmlxOFzRT7hPl+LcxqawRZveuSE+ROQd/mT40Ib8mUN9Qt52JEqw6NIlnj2LvoRQqDU3QBC/97nB+iGeVRvhIvpFgRBLIUK2nW1CiqORsXlIzI/HeNL5vUrT8CagXZQp5sVcMg+R14lo/Lw9oTRfJCV5MPqPUochafxsiw9TJE+C8kF97CrAXByxjddmV2p44TF3ROxclcEq0rde9YYtIeMoGYCXtU4MzR5X6rdcNUruGZSBh02JLsi6Rnx+pDw+WBtQD2R415srW3mPANzOhmIcbMAyJKpnwZhI48OKijiRmowhSNMqQXYofAgMBAAECggEBAIuHcYG0ozHCZcVUeTdPaLYvWZ4PFWP0p4+NMQGy5q8yuJHtck5F6dQIHHuC0cyskdXpGH7sFBhSeZ9usdpDKvH53Hq4gSpgvhD/7yOVZyZDt3VPlTkK1ECWhp7isIvq8qybOJIuQ9hBOV5vjMVYDjdK9BdPX2IzoJxnJZ0SxHfgkDUH7tgfupSwh73MqDLHpjPuMrl7Fqe3LwiK44of6Iczqg2IjbyJLuBAZxXv8aCbgp33mRYGnwqFvy9AivjuPK206O5kbhRxQyNToPp6MAViQIBxInqtKtgw3MjUG2Zyp3yVlmIljeJSm1YSqQUSDe0VHo9tO8zzTqGLzyH8JIECgYEA7LnqtL2lIePHLSXhg1soll/KO7jrShED85ffsZsTItESChNIXE4fDgBoxgoFigNcQdSaJcEDLsAvn+Omcg3PQGS02d6MR4q3ioAvdP7rfuL0uwuQhj/yNe6Ykm9u8qpxDypTXnZC66pSeHckLVvgFlmYg2MYqc0nspw8Y0fs8q0CgYEA0pRvRlkHJ3NPGUaVJglIQJPDZWKYq2n37kmZ4EcTxaxnNJhc5xZy2olNb5nD2oH43K7OmQD2fqijbkktDgq6xI5JzwYObnCPihTNrvIXItG3iBmw739WyjBQkWRWU+K77gPk805rllbIe7AVmx19mBgGDqD/UUmXGIp57Rhn1XsCgYEA12WTmkG1L9ECOqJtQAiCNdGTQiRQc2RoJA3dDM3964Aw2doRzWuH9kWJECmuQJYuK/g3CoNFUhStQN7zZHQMUJtRs6w8GBywROW+SMZroVkBNfCf4Ifu7APd7+BVI5jSpunsUddprOWdhN9jm6ItlCiSDXrtxhNWO77Nc8jOYUECgYEArET+W0CN17o/ZWAWuA0z7JB1c0Wbu+9vAqN3nMDI7hfCPoa+ydXVk+5rSPc0AFf/rRncrdLZ1HhFav22PByO+imlPBWqTLMM2lt2gL5QKw4B5PePhf5YlAO+hZLeBLYiI+9Pp7Pp1A2e6YD9y+3uRzSwD9upw2g+kbcHU+15VG0CgYEA360mrk5NCZDbs/i0aiQ4gXCyusMFUZLdk3qcSRMyjuk9qo+40YEw9i6SeBLTsh2gKiDaln+7YSpPKbKih7FxbMCsa6zWSueXK6hk3u9sE7if/UcMPPzOe9CrJSEiwUo3g1u1ZEFvbCGSuD91TC0BaA3Id0qMJznXSntnjWWIgi4=",
+    "publicKey": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAwrnE6Z385RQaNYYN2HKcgkSkwBzjwZpcThc0U+4T5fi3MamsEWb3rkhPkTkHf5k+NCG/JlDfULediRKsOjSJZ49i76EUKg1N0AQv/e5wfohnlUb4SL6RYEQSyFCtp1tQoqjkbF5SMyPx3jS+b1K0/AmoF2UKebFXDIPkdeJaPy8PaE0XyQleTD6j1KHIWn8bIsPUyRPgvJBfewqwFwcsY3XZldqeOExd0TsXJXBKtK3XvWGLSHjKBmAl7VODM0eV+q3XDVK7hmUgYdNiS7IukZ8fqQ8PlgbUA9keNebK1t5jwDczoZiHGzAMiSqZ8GYSOPDioo4kZqMIUjTKkF2KHwIDAQAB",
+    "signingKey": null,
+    "signingKeyId": null,
+    "signingKeyThumbprint": null,
+    "userKey": "60r67SAmSFAuswHEInmk4S8E8BA3LYMOUEe/5xLW/y5OKrTOJ6jdlnayEpBsyX8JaA3CKcJS/wW73nHyLzwXLw==",
+    "userKeyId": null,
+    "verifyingKey": null
+  },
+  "rngSeed": "EhMUFRYXGBkaGxwdHh8gISIjJCUmJygpKissLS4vMDE=",
+  "schemaVersion": 1,
+  "unlockMethods": [
+    {
+      "masterPasswordUnlock": {
+        "master_password_unlock": {
+          "kdf": {
+            "pBKDF2": {
+              "iterations": 600000
+            }
+          },
+          "masterKeyWrappedUserKey": "2.DUbpuHm+UdosIH3aXnnqkg==|tIDzXuufud/ZKX9uk8auLeRQIEqclrLp3KZFo7kEuYVO898BaJSfQDyD7iiA3rbnyz11SYqccJWz+0VLNYAJRCoiTbAbYjYRIf0uorPGSU8=|2r5OU2VKJ4Dg/kRq4EeIhtW1Jm0wvoUFpvuD18S56V4=",
+          "salt": "v1-pbkdf2-password@test.bitwarden.com"
+        },
+        "password": "password-v1-pbkdf2-password"
+      }
+    },
+    {
+      "pinEnvelope": {
+        "pin": "1234",
+        "pin_protected_user_key_envelope": "hFg0pAEDA3giYXBwbGljYXRpb24veC5iaXR3YXJkZW4ubGVnYWN5LWtleToAATiBAToAATiAAaEFTLq33FyYJQAEf3++blhQYHMQFks206rf4aYGk+tr8At3jsQwlhRd8rOyHBcnAKpSzAkr8eV8TOtpQM0Za8fP8SnFZbSLojZ+4fcspqbthScQA48TycK9Gg5+91y8fEiBg0ehAToAARVXpQE6AAEVVzoAARVZAzoAARVaGgABAAA6AAEVWwQ6AAEVWFDgVz3Sl8lIj7TqOLtaDeMU9g=="
+      }
+    }
+  ],
+  "vault": {
+    "ciphers": [
+      {
+        "blobEncrypted": false,
+        "decrypted": {
+          "archivedDate": null,
+          "attachmentDecryptionFailures": [],
+          "attachments": [],
+          "bankAccount": null,
+          "card": null,
+          "collectionIds": [],
+          "creationDate": "2024-01-08T00:00:00Z",
+          "deletedDate": null,
+          "driversLicense": null,
+          "edit": true,
+          "favorite": false,
+          "fields": null,
+          "folderId": null,
+          "id": "bc020100-0000-4000-8000-000000000000",
+          "identity": null,
+          "key": null,
+          "localData": null,
+          "login": {
+            "autofillOnPageLoad": null,
+            "fido2Credentials": null,
+            "password": "keyless-password",
+            "passwordRevisionDate": null,
+            "totp": null,
+            "uris": null,
+            "username": "keyless@example.com"
+          },
+          "name": "Keyless Login",
+          "notes": "Encrypted directly under the user key",
+          "organizationId": null,
+          "organizationUseTotp": false,
+          "passport": null,
+          "passwordHistory": null,
+          "permissions": null,
+          "reprompt": 0,
+          "revisionDate": "2024-06-15T12:30:00Z",
+          "secureNote": null,
+          "sshKey": null,
+          "type": 1,
+          "viewPassword": true
+        },
+        "encrypted": {
+          "archivedDate": null,
+          "attachments": null,
+          "bankAccount": null,
+          "card": null,
+          "collectionIds": [],
+          "creationDate": "2024-01-08T00:00:00Z",
+          "data": null,
+          "deletedDate": null,
+          "driversLicense": null,
+          "edit": true,
+          "favorite": false,
+          "fields": null,
+          "folderId": null,
+          "id": "bc020100-0000-4000-8000-000000000000",
+          "identity": null,
+          "key": null,
+          "localData": null,
+          "login": {
+            "autofillOnPageLoad": null,
+            "fido2Credentials": null,
+            "password": "2.FcDpZcmb7zBfzKejxUoWtQ==|UPsGmGcYgcjKGWfMKlx587hZSmxEZZEu5qOiPypvmg8=|9cJwUHIPV9LIys73rii0T/XytmXx/pAL7mM4tPiP9S8=",
+            "passwordRevisionDate": null,
+            "totp": null,
+            "uris": null,
+            "username": "2.4FE09tNavEV19DyS60a1bA==|4A8MssjZr5t1CU+7Xdm9PefWPBvYzufsnimr5REyRIc=|yf1J8Hkp/FmP+UG/tnmzXbW9A5Ye6JCV031aHg/Px0Q="
+          },
+          "name": "2.rqGZfnowg+jVNJny5ivT3A==|e/dCxuQ7IZEd0MqTsFJGfg==|1VsJts9AxdA/CuULF1rKPk22AfMoFNO5t1QuRqd5CaY=",
+          "notes": "2.G38E40PZXnzRtRGSFCMm7w==|RL+xXMpIsydqOiSAteVHQN2qvVYmYxGawFs00cjJg4MmtmSk2CHnMBWb83n56VKl|g8e0iKVPsKDeqqTP3q7++JLE4XoXPhO/waj1B6w5XfU=",
+          "organizationId": null,
+          "organizationUseTotp": false,
+          "passport": null,
+          "passwordHistory": null,
+          "permissions": null,
+          "reprompt": 0,
+          "revisionDate": "2024-06-15T12:30:00Z",
+          "secureNote": null,
+          "sshKey": null,
+          "type": 1,
+          "viewPassword": true
+        },
+        "id": "bc020100-0000-4000-8000-000000000000",
+        "keys": {
+          "attachments": {},
+          "cipherKey": null,
+          "cipherKeyId": null
+        }
+      },
+      {
+        "blobEncrypted": false,
+        "decrypted": {
+          "archivedDate": null,
+          "attachmentDecryptionFailures": [],
+          "attachments": [],
+          "bankAccount": null,
+          "card": null,
+          "collectionIds": [],
+          "creationDate": "2024-01-08T00:00:00Z",
+          "deletedDate": null,
+          "driversLicense": null,
+          "edit": true,
+          "favorite": false,
+          "fields": null,
+          "folderId": null,
+          "id": "bc020101-0000-4000-8000-000000000000",
+          "identity": null,
+          "key": "2.j+FlWOH5ujbD/DvIMYL+RQ==|cD3ZqoP8EbXAzcZ0qcKq4PunHuU5a0xNIj3Lzg9IMJwNMJaEeIYqM/RnCuq3mHKmqfSr8hFNhbR7f8BUyVaCwxB8Priohh3l4TqJLembj0o=|Mk4KF3O0FxPKQmLQBEup4jP5HNkerETdJX34uVFyN/Y=",
+          "localData": null,
+          "login": {
+            "autofillOnPageLoad": null,
+            "fido2Credentials": null,
+            "password": "keyed-password",
+            "passwordRevisionDate": null,
+            "totp": null,
+            "uris": null,
+            "username": "keyed@example.com"
+          },
+          "name": "Keyed Login",
+          "notes": "Encrypted under a per-item cipher key",
+          "organizationId": null,
+          "organizationUseTotp": false,
+          "passport": null,
+          "passwordHistory": null,
+          "permissions": null,
+          "reprompt": 0,
+          "revisionDate": "2024-06-15T12:30:00Z",
+          "secureNote": null,
+          "sshKey": null,
+          "type": 1,
+          "viewPassword": true
+        },
+        "encrypted": {
+          "archivedDate": null,
+          "attachments": null,
+          "bankAccount": null,
+          "card": null,
+          "collectionIds": [],
+          "creationDate": "2024-01-08T00:00:00Z",
+          "data": null,
+          "deletedDate": null,
+          "driversLicense": null,
+          "edit": true,
+          "favorite": false,
+          "fields": null,
+          "folderId": null,
+          "id": "bc020101-0000-4000-8000-000000000000",
+          "identity": null,
+          "key": "2.j+FlWOH5ujbD/DvIMYL+RQ==|cD3ZqoP8EbXAzcZ0qcKq4PunHuU5a0xNIj3Lzg9IMJwNMJaEeIYqM/RnCuq3mHKmqfSr8hFNhbR7f8BUyVaCwxB8Priohh3l4TqJLembj0o=|Mk4KF3O0FxPKQmLQBEup4jP5HNkerETdJX34uVFyN/Y=",
+          "localData": null,
+          "login": {
+            "autofillOnPageLoad": null,
+            "fido2Credentials": null,
+            "password": "2.GT2vT6aAdQM0KVzMoeXZyA==|bNPunS9RqyQkieEGSPZmRg==|xFmFRmTwszOFqCOHRDGsEtcUXCAVhvRaE12cSCU6bi4=",
+            "passwordRevisionDate": null,
+            "totp": null,
+            "uris": null,
+            "username": "2.AeRmP0PkmySMgIJUIPD4tA==|BitKY+ERv6WQLLvx/Ww8/a61SewV8OLoR5qbmq3fYOw=|1HOqf+yZRLfjoDacrQNPKbtI7PrUHFEcC9l3lJgRKgM="
+          },
+          "name": "2.SQGPUlaZUSfolNel/4HxLg==|sm/qjTp6jq2NahYmBeMf+A==|ZQnpK30wZcKsS6nF1q9oGtZa6vyewFAL7cUF1yTiWGk=",
+          "notes": "2.k1L59xwq4sfN1Lr2BGjwdw==|iOXv3ftLkZR7syVYXsAtB5sXnMMNF13ZywdMtqoPMn/svrQThklJU/a16jfSiIgW|ZDienpAa8I8zTD48Jm8LX3hOCogK0tzgfRTK2h74p1M=",
+          "organizationId": null,
+          "organizationUseTotp": false,
+          "passport": null,
+          "passwordHistory": null,
+          "permissions": null,
+          "reprompt": 0,
+          "revisionDate": "2024-06-15T12:30:00Z",
+          "secureNote": null,
+          "sshKey": null,
+          "type": 1,
+          "viewPassword": true
+        },
+        "id": "bc020101-0000-4000-8000-000000000000",
+        "keys": {
+          "attachments": {},
+          "cipherKey": "/o4qdqUl4+ZPTuTV2r4vzwRxJFnd6oNH+en+5ruI5kvRGddR6EktWa0AeAIZ6kvvzP6HTOtq4URnA1Zv5gEFGA==",
+          "cipherKeyId": null
+        }
+      },
+      {
+        "blobEncrypted": false,
+        "decrypted": {
+          "archivedDate": null,
+          "attachmentDecryptionFailures": [],
+          "attachments": [
+            {
+              "fileName": "secret.txt",
+              "id": "attachment-1-2",
+              "key": null,
+              "size": "512",
+              "sizeName": "512 Bytes",
+              "url": null
+            }
+          ],
+          "bankAccount": null,
+          "card": null,
+          "collectionIds": [],
+          "creationDate": "2024-01-08T00:00:00Z",
+          "deletedDate": null,
+          "driversLicense": null,
+          "edit": true,
+          "favorite": false,
+          "fields": null,
+          "folderId": null,
+          "id": "bc020102-0000-4000-8000-000000000000",
+          "identity": null,
+          "key": null,
+          "localData": null,
+          "login": {
+            "autofillOnPageLoad": null,
+            "fido2Credentials": null,
+            "password": "v0-password",
+            "passwordRevisionDate": null,
+            "totp": null,
+            "uris": null,
+            "username": "v0@example.com"
+          },
+          "name": "Attachment v0",
+          "notes": null,
+          "organizationId": null,
+          "organizationUseTotp": false,
+          "passport": null,
+          "passwordHistory": null,
+          "permissions": null,
+          "reprompt": 0,
+          "revisionDate": "2024-06-15T12:30:00Z",
+          "secureNote": null,
+          "sshKey": null,
+          "type": 1,
+          "viewPassword": true
+        },
+        "encrypted": {
+          "archivedDate": null,
+          "attachments": [
+            {
+              "fileName": "2.bACRvXep5Dh0sBhWSTIp2Q==|+Ncslde1BDDZJ8wiroW+7w==|7BsQ/V0YqXibaOQBrDO5XiweglzcyQU0F5vIu7ohues=",
+              "id": "attachment-1-2",
+              "key": null,
+              "size": "512",
+              "sizeName": "512 Bytes",
+              "url": null
+            }
+          ],
+          "bankAccount": null,
+          "card": null,
+          "collectionIds": [],
+          "creationDate": "2024-01-08T00:00:00Z",
+          "data": null,
+          "deletedDate": null,
+          "driversLicense": null,
+          "edit": true,
+          "favorite": false,
+          "fields": null,
+          "folderId": null,
+          "id": "bc020102-0000-4000-8000-000000000000",
+          "identity": null,
+          "key": null,
+          "localData": null,
+          "login": {
+            "autofillOnPageLoad": null,
+            "fido2Credentials": null,
+            "password": "2.j6hQn3D/st6FvXKFzd7ggA==|+ZUDaxt2mzhq2ZWR2m5SuQ==|lsl2kzhp3eofWjW0gohgLxrpf5LXVNbcYBDEPshb+mY=",
+            "passwordRevisionDate": null,
+            "totp": null,
+            "uris": null,
+            "username": "2.P9tzOtt7wnOKOjy5qfs2xQ==|o14DiN+Uqsoy8mdGBS3I3A==|xPvBMlN+J47siBkCNRjmoNRvoIrs6wmr132rYH1mCY0="
+          },
+          "name": "2.cL5bUXAX2iKGs+k3V5STQA==|QrAqs+HonFU5MfJDBNxdbA==|L2tkZRTLX2mDYIJvKkzDg78UrEBSg+g4qi3M150HH64=",
+          "notes": null,
+          "organizationId": null,
+          "organizationUseTotp": false,
+          "passport": null,
+          "passwordHistory": null,
+          "permissions": null,
+          "reprompt": 0,
+          "revisionDate": "2024-06-15T12:30:00Z",
+          "secureNote": null,
+          "sshKey": null,
+          "type": 1,
+          "viewPassword": true
+        },
+        "id": "bc020102-0000-4000-8000-000000000000",
+        "keys": {
+          "attachments": {
+            "attachment-1-2": {
+              "key": null,
+              "keyId": null,
+              "version": "V0"
+            }
+          },
+          "cipherKey": null,
+          "cipherKeyId": null
+        }
+      },
+      {
+        "blobEncrypted": false,
+        "decrypted": {
+          "archivedDate": null,
+          "attachmentDecryptionFailures": [],
+          "attachments": [
+            {
+              "fileName": "secret.txt",
+              "id": "attachment-1-3",
+              "key": null,
+              "size": "512",
+              "sizeName": "512 Bytes",
+              "url": null
+            }
+          ],
+          "bankAccount": null,
+          "card": null,
+          "collectionIds": [],
+          "creationDate": "2024-01-08T00:00:00Z",
+          "deletedDate": null,
+          "driversLicense": null,
+          "edit": true,
+          "favorite": false,
+          "fields": null,
+          "folderId": null,
+          "id": "bc020103-0000-4000-8000-000000000000",
+          "identity": null,
+          "key": "2.lVoTVR5wNRcS56eNEiOv4g==|RFB7X+ncaDn27j+piCqW9PWpGR7UPl8p1FZKwdV8gT5flvS3f36gWpnuN+qMoFXwVAMSomvjEUewA+77T1j1PiSFuBVDY4Q3toKFaxpKYB8=|L6ChbBe2kO3hn5rL/g4LLN/M6Lfg59rczzDWw9wPjQY=",
+          "localData": null,
+          "login": {
+            "autofillOnPageLoad": null,
+            "fido2Credentials": null,
+            "password": "v1-password",
+            "passwordRevisionDate": null,
+            "totp": null,
+            "uris": null,
+            "username": "v1@example.com"
+          },
+          "name": "Attachment v1",
+          "notes": null,
+          "organizationId": null,
+          "organizationUseTotp": false,
+          "passport": null,
+          "passwordHistory": null,
+          "permissions": null,
+          "reprompt": 0,
+          "revisionDate": "2024-06-15T12:30:00Z",
+          "secureNote": null,
+          "sshKey": null,
+          "type": 1,
+          "viewPassword": true
+        },
+        "encrypted": {
+          "archivedDate": null,
+          "attachments": [
+            {
+              "fileName": "2.GDk5984D6x8S5h3LaGzjeA==|gr63AfmPyXzg5syFsJd9oQ==|mNpIx7d9JpYG5YX2b8+MhkKtvdT+D/pJNNKd6MvPCkA=",
+              "id": "attachment-1-3",
+              "key": null,
+              "size": "512",
+              "sizeName": "512 Bytes",
+              "url": null
+            }
+          ],
+          "bankAccount": null,
+          "card": null,
+          "collectionIds": [],
+          "creationDate": "2024-01-08T00:00:00Z",
+          "data": null,
+          "deletedDate": null,
+          "driversLicense": null,
+          "edit": true,
+          "favorite": false,
+          "fields": null,
+          "folderId": null,
+          "id": "bc020103-0000-4000-8000-000000000000",
+          "identity": null,
+          "key": "2.lVoTVR5wNRcS56eNEiOv4g==|RFB7X+ncaDn27j+piCqW9PWpGR7UPl8p1FZKwdV8gT5flvS3f36gWpnuN+qMoFXwVAMSomvjEUewA+77T1j1PiSFuBVDY4Q3toKFaxpKYB8=|L6ChbBe2kO3hn5rL/g4LLN/M6Lfg59rczzDWw9wPjQY=",
+          "localData": null,
+          "login": {
+            "autofillOnPageLoad": null,
+            "fido2Credentials": null,
+            "password": "2.Z0f63SwLsvaIMmAp9CcfMg==|K3sEum4N325QMna0ylcwEg==|fGHBnrDqzlWTCJ8TEQ5OBvIheICQWh0q8AmAqataKmM=",
+            "passwordRevisionDate": null,
+            "totp": null,
+            "uris": null,
+            "username": "2.Ga/sQplrJp9jse8StYaT0w==|4a6Rd3WQSH4jACJUFKJMtg==|uzCZdz5e3PIr6TCBma0w/r0HASqXdsGfz419eSLEuKQ="
+          },
+          "name": "2.r51hCNfkA73gbjkg+zFg9w==|G7AcUo2iNdsUjmlRBHiIwA==|FGSxySpnhBxnBeoMCaT9D+YciP03S1tbsMry4RBgXMM=",
+          "notes": null,
+          "organizationId": null,
+          "organizationUseTotp": false,
+          "passport": null,
+          "passwordHistory": null,
+          "permissions": null,
+          "reprompt": 0,
+          "revisionDate": "2024-06-15T12:30:00Z",
+          "secureNote": null,
+          "sshKey": null,
+          "type": 1,
+          "viewPassword": true
+        },
+        "id": "bc020103-0000-4000-8000-000000000000",
+        "keys": {
+          "attachments": {
+            "attachment-1-3": {
+              "key": null,
+              "keyId": null,
+              "version": "V1"
+            }
+          },
+          "cipherKey": "ln59h6lPudPR6XCjuJr0BZEHu+L47iDhVNrl2KfnBHrXOn1mgGatN3pbNhgJ9gT8hl0PzsqveL6YgfvzTx5EAQ==",
+          "cipherKeyId": null
+        }
+      },
+      {
+        "blobEncrypted": false,
+        "decrypted": {
+          "archivedDate": null,
+          "attachmentDecryptionFailures": [],
+          "attachments": [
+            {
+              "fileName": "secret.txt",
+              "id": "attachment-1-4",
+              "key": "2.n2V2gnPpURBZJ6DRnzRUBg==|iN2UoVZ7iFIWajxVUAb/x5In7CQwE17CdT2p1QkiVqp3CnHSMWgsMnAao++B2tY7Zm7yaSLCL7170iunxNvxdQAC1ajdBwdwK53jXth2rrw=|NYH51oO46k6Mnsct9JvndXL8NbwOMPxBJAbSlCWoDsk=",
+              "size": "512",
+              "sizeName": "512 Bytes",
+              "url": null
+            }
+          ],
+          "bankAccount": null,
+          "card": null,
+          "collectionIds": [],
+          "creationDate": "2024-01-08T00:00:00Z",
+          "deletedDate": null,
+          "driversLicense": null,
+          "edit": true,
+          "favorite": false,
+          "fields": null,
+          "folderId": null,
+          "id": "bc020104-0000-4000-8000-000000000000",
+          "identity": null,
+          "key": "2.MBwN4/wADR+41KG+LJWGVA==|CSLrFQK1Y8A54xnsn69YrtQrRiq01Ucis9wAsfk+1x9PXhFJKH7FB7ebQ+z7N6kDgEBt14zUVZIbi7nLV4HF7lBIIpsyPYqH5gXSWUSoO+0=|CAcyFNzyLG9m2LkiVGQK3yz97RDeDv1xckbQgCU41eI=",
+          "localData": null,
+          "login": {
+            "autofillOnPageLoad": null,
+            "fido2Credentials": null,
+            "password": "v2-password",
+            "passwordRevisionDate": null,
+            "totp": null,
+            "uris": null,
+            "username": "v2@example.com"
+          },
+          "name": "Attachment v2",
+          "notes": null,
+          "organizationId": null,
+          "organizationUseTotp": false,
+          "passport": null,
+          "passwordHistory": null,
+          "permissions": null,
+          "reprompt": 0,
+          "revisionDate": "2024-06-15T12:30:00Z",
+          "secureNote": null,
+          "sshKey": null,
+          "type": 1,
+          "viewPassword": true
+        },
+        "encrypted": {
+          "archivedDate": null,
+          "attachments": [
+            {
+              "fileName": "2.Uc+X+7FkuLNpJ5xJ8jMGRw==|1odjtapEqwPIxmjlH9kvUw==|eXPVQJn4BEikLFiNCEiJ4dCNnbFGzmv5W1L+Ti39sYI=",
+              "id": "attachment-1-4",
+              "key": "2.n2V2gnPpURBZJ6DRnzRUBg==|iN2UoVZ7iFIWajxVUAb/x5In7CQwE17CdT2p1QkiVqp3CnHSMWgsMnAao++B2tY7Zm7yaSLCL7170iunxNvxdQAC1ajdBwdwK53jXth2rrw=|NYH51oO46k6Mnsct9JvndXL8NbwOMPxBJAbSlCWoDsk=",
+              "size": "512",
+              "sizeName": "512 Bytes",
+              "url": null
+            }
+          ],
+          "bankAccount": null,
+          "card": null,
+          "collectionIds": [],
+          "creationDate": "2024-01-08T00:00:00Z",
+          "data": null,
+          "deletedDate": null,
+          "driversLicense": null,
+          "edit": true,
+          "favorite": false,
+          "fields": null,
+          "folderId": null,
+          "id": "bc020104-0000-4000-8000-000000000000",
+          "identity": null,
+          "key": "2.MBwN4/wADR+41KG+LJWGVA==|CSLrFQK1Y8A54xnsn69YrtQrRiq01Ucis9wAsfk+1x9PXhFJKH7FB7ebQ+z7N6kDgEBt14zUVZIbi7nLV4HF7lBIIpsyPYqH5gXSWUSoO+0=|CAcyFNzyLG9m2LkiVGQK3yz97RDeDv1xckbQgCU41eI=",
+          "localData": null,
+          "login": {
+            "autofillOnPageLoad": null,
+            "fido2Credentials": null,
+            "password": "2.z4ApL6x/eBOFws4R4Aap4Q==|GMMYOSrOtJDtCORwcXe+sQ==|6E2Dk3qCzH57GHCshChlar9oj1ciP5LG0WlnJMvH7lk=",
+            "passwordRevisionDate": null,
+            "totp": null,
+            "uris": null,
+            "username": "2.LZYM0D4czDt1jHRqfqeuxA==|NLm99zrXBFnPIGI6tJhfSg==|+2ZYHjVdl+RXFgouY4S74BRSnUlLM8Uk5U+yeadg5Pg="
+          },
+          "name": "2.HGSll/35Qzy0+OpXLXs4aA==|wBqBZJe/QlzTb3wBdEe+0w==|ZSK3WWkiNmXncYMh3xXvtUKN2sGPlehbjFJCi3jocqE=",
+          "notes": null,
+          "organizationId": null,
+          "organizationUseTotp": false,
+          "passport": null,
+          "passwordHistory": null,
+          "permissions": null,
+          "reprompt": 0,
+          "revisionDate": "2024-06-15T12:30:00Z",
+          "secureNote": null,
+          "sshKey": null,
+          "type": 1,
+          "viewPassword": true
+        },
+        "id": "bc020104-0000-4000-8000-000000000000",
+        "keys": {
+          "attachments": {
+            "attachment-1-4": {
+              "key": "199//yz5uorJZqsUpmRTx+DwNNy8SMF6PsnGABAWBYt8NAuKaOUKfKM25fNtLOPqo95cYopl7vWeiq0eBmJiuw==",
+              "keyId": null,
+              "version": "V2"
+            }
+          },
+          "cipherKey": "6/XIh5cCJI8sEoTpdh3Vp5cVCpyx8npOOg8Jsct/bqcQoopriCSJ3lB1T+74uFlva+IR7Lt5ziwRd0AQeU2now==",
+          "cipherKeyId": null
+        }
+      }
+    ],
+    "collections": [],
+    "folders": [
+      {
+        "decrypted": {
+          "id": "bc030100-0000-4000-8000-000000000000",
+          "name": "Test Folder",
+          "revisionDate": "2024-06-15T12:30:00Z"
+        },
+        "encrypted": {
+          "id": "bc030100-0000-4000-8000-000000000000",
+          "name": "2.FUnX+Ejbk37F1Q0lYwmw6A==|oDt3EeBNnEUgiEYDA7o8RQ==|i0JK/Y6Z+4e6XQ0oR7xDWkkkfvmoGuKoch8MdXAjs5M=",
+          "revisionDate": "2024-06-15T12:30:00Z"
+        },
+        "id": "bc030100-0000-4000-8000-000000000000"
+      }
+    ],
+    "sends": [
+      {
+        "decrypted": {
+          "accessCount": 0,
+          "accessId": null,
+          "authType": 2,
+          "deletionDate": "2034-06-15T12:30:00Z",
+          "disabled": false,
+          "emails": [],
+          "expirationDate": null,
+          "file": null,
+          "hasPassword": false,
+          "hideEmail": false,
+          "id": "bc040100-0000-4000-8000-000000000000",
+          "key": "Pgui0FK85cNhBGWHAlBHBw",
+          "maxAccessCount": null,
+          "name": "Test Send",
+          "newPassword": null,
+          "notes": "Send notes",
+          "revisionDate": "2024-06-15T12:30:00Z",
+          "text": {
+            "hidden": false,
+            "text": "This is a test send"
+          },
+          "type": 0
+        },
+        "encrypted": {
+          "accessCount": 0,
+          "accessId": null,
+          "authType": 2,
+          "deletionDate": "2034-06-15T12:30:00Z",
+          "disabled": false,
+          "emails": null,
+          "expirationDate": null,
+          "file": null,
+          "hideEmail": false,
+          "id": "bc040100-0000-4000-8000-000000000000",
+          "key": "2.I9P4iegsvvdi7S/nh7Qarg==|OQppCnsUpBMfX+1vlhF+jflOPUrlXqYV64PfWTLcfGE=|mNbsbjhOGj7SSBdW+wzwSMTpxvddJ5/oPdfRLgn57bs=",
+          "maxAccessCount": null,
+          "name": "2.15U+yQMktWxvKb6ufpY0PQ==|xhaH/kJ5UKIbOVrCt8xKEQ==|1M/Jex0ZvYI/AhceIZDPCr5GDwkgL+SHa1sZSo8Zd/Y=",
+          "notes": "2.dbot8YF+KTbQp0w7Lwht7Q==|D+UueUNi0pxY6oerIO450Q==|MtIXTQmHlJJjYFwRyqLone3g9/4YuSobPsoRBy90It4=",
+          "password": null,
+          "revisionDate": "2024-06-15T12:30:00Z",
+          "text": {
+            "hidden": false,
+            "text": "2.HyAsWNQreEtKhgZdfCufYA==|V9YOQtrxh0ljhMQW5dKJSTJczTqxa7O1WRZUUnhd5sM=|Hk2TffS4LH3sAVQnVTERq0AI+8z+Ylr0u+4hAo+fB8s="
+          },
+          "type": 0
+        },
+        "id": "bc040100-0000-4000-8000-000000000000"
+      }
+    ]
+  }
+}

--- a/test-vectors/users/v2-argon2id-blob.json
+++ b/test-vectors/users/v2-argon2id-blob.json
@@ -1,0 +1,329 @@
+{
+  "account": {
+    "accountCryptographicState": {
+      "V2": {
+        "private_key": "7.g1gdowE6AAEReQMZARwEUFws7vguPq/Tb6+OazHUgA+hBVgYTzokruSbUtKgQ64gKFm844odxdh/RfauWQTRvb7z2UsryJmj383jR0j8YUgs7n94RKUi7Q1cGMMqanmfYQdm/kGdZRbAe4tiJS+nTSDwn7eYYmrukFxkz8kii5sSv3Rdwf4TWwBm/DIqI6MuSIoULtmtyp1iyEWLHygigTh6Z3kBBY6lVp8+GQv9yTWr1aOVB8aRPzLCcc31eX0IGxj9bT03CTBHGdKGnbNG/G1WkFNDw/B/x4a8B5jJwqWVwFNQUXpCy9+nrqW6ClcCNsS7sQHYTwMwm2cOnRlPg3WV5dxUR0rkR029cSC5iDctXg0U8d9CJZQm8e4Stbjlz5tgAFVKWKmUwb6pZVDcMWEsqFfUqYYULBI1E8eJMOFQ+o0+nv+YUbxi/NmVfAFitWlNOBByIb9E8qvvxz+ad/AQB6VB1H47cAyPB7+woOKPxL0fF+3fqB92QY7UsdxAHON0KiqYWGDKlsLHhLzejX2Tv+pgQqvIGqGy1MyynXilVEHke8T6NuuxrywUlsl16gXKd4wvS0FOaZMvRnRAP0ThmAcgaF2rx1tgkjjsE7JupmY/dFzj9l+qAWD8+4HKQhreehYBvMdqhZW9jF9F8zr3/Q4It5i4iPl5D8bnO3t2mP4py+N5xDAL5ShWHAN6jKSMw8YmRSrOcCr6jQNjBFrt9ry5+RpFleiRoD/4pYxm9gMpOzSI0ttb6YnFN+RDJlkcTiNjtEhtkbUsk1VD6l8GX0dvcFWyel8iTVlkeL5bo7CZLHJfrEAzE+vUOUqxUwy6OnZ3cRVDTD5jMQ+IRQdDaUVEcChGVIrRRIqmsTLM1Gf56oT7WwQdypQiXYrZVSjqPO9yof1zVKouV58Wi8oDZ/Xuj+vdlEwxB07q/9ikdeTEBN5eZvH2MtpXvC7jPJboHHabR20I4yQEMlKq+rhdmQwcVbhqo1Lt6qTDp+a77IocRt6UevriW9QJem6jLWUAYu+hYOWWnotwm8+Znc/kPJuEGqh1dOansXXxDjEoeFFJF+ei8RR71FEV89ajnu4QKG3UWndDRCNdf8XDp7GR3giHCUWpBzMhbOhA6Iogdmc84t5WeFB93VcYPIxhqW2dK+WabEUsdFUF99CJzIp2XqewrSSWLn8WODne/7tc9Hz15mq359tugH1uHBL1HHXCY/tm7XdJ8TwWzpC0PvEfMxG9clbHzH1x8qgiE3XU/oU+6sLQVFGVhvWCc+Hl/D5Dfv0FU9bMiclecnYh/LGJIyjRj+/2EG9zsaGjIM9pAvNgL7TZC+gRDfwY26E2JfDS9CiKYyMZhqxFwv69CAkDKw5dKlD+fRY0sc8HZYhw73dM199zxQ1ODlzgMy1udk8owoNMOKrkY5WwGzUAutlnH/CSuJ3jDI2iQVZTwDeId4kDrRhzyQevmDXME6joLtqexjHRlo54qvGeIJMh4IfqUVxYXcotk2iarDAXxHYVqXAJxjLcE6jOYA3Q/DmRE+wGt78Mixmk5wvcPPGKqEwdl7o/H2SDBjEWkNvPzL1/yeojCbiYK+1xg7bTsBAy9R50FGNIoDEylY/jB/th44y1AV9dki3oSix2DC2VAZ1mzb9QKOnC6wMQxk6f4xqL8JFhPArE3q2MUgnqs1b9uwPkRYY2HnJ1gZ7lgpAacQEJKgTTI5oa1vev3swjO14E",
+        "security_state": "hFgfpAE4LwMYPARQdPCQkeska4wsmAuUyYHUvToAATh/AqBKoWd2ZXJzaW9uAlkJdAKuLPvFeYLr75bbTR9dtVKipQ/s2WpqRS28gHyjOX3eTTWy7cbssi8EtEU9jX7pp6Evtf+Vkhqc1FEIpuV5MhNfL2Ibj1+F4ELcztYNri20NCrnEIlP6ju/SiaOKZm7hoyb9w7FvjPQrYbI6wIo+pHwMctgHkDx2++KHnge4Wmjz0ndWfCB/vmAVj2iAlQebt6ms9Zy3PwmCNtYDMqNV7Ve/Be+W4RxSa+fZgr9m7A902tR4n3C1FhzF8NaiTdelESibtk0ZIii1PET3TJ9hhDMsE3moSFFa0xmwj/QbqMoitShrbrDjnXKwS/mHcr/g3aeVmJvi21f0aqXQGHjt0VO8IJuTX9Hp6GIyVeHzg15OfX5Dphmj+JSsva/RDo353jWgzM6TM1vCUv4BjXlYk8ja9J6GfsaQ2DDue99TDIMpLYgeXDmJoCCxmkXLuywylCkFDhma9sceW0XsVzm12Ss4VFA81MY6/o5jcFVasUV7aT1fxBmzMxkzV9WLmDETpce4FXtgaCZpwRaKkttKQLZEpWihh8b0puMX4iFBT5EOyFUaeSooiVf6WdEp472Yk6+YpKkK9tB1trAn4fyUsBhMthaEyGFyV2ykMBkY9OIXdoJ8Rr6ZwNZaCpLEpjN/m0ZIDlWGVtySEtaExVWjMTmsyxY6a4UoRfydEEuH58OeiIhQqnyv91mExvLXhLLQhwoYS+cvZvwNaBD1A1Bp4CSWQfC5YxLH6E4nABl0H1vkVGSIOQvEBONAhD5VZQec31OooT9WYn07Z+hgBOcHIwfE8b0yJk0T5+UkA2ZYLzVOuJHotAn5S28Fi6m8QDeTziQ6KLrMDSxlqJdTSVak+L7KaenjH7TYlK47FznDffrdxaTIyjNWmvX/LKsCCvPmmexrUviwsI2+SfTLAG9rRo1psvSmZiBmx9fV1rm3FahbFitCDx37dFdJXzb2vWVOmzhJHksSO2UKiF6jlqQJpVlNlOufttspMWDfPMbRy3ZoH5vUuV/cp6I9+bW7CV49zVbvyJVJ2yAS7P62GDiTHoi+Hk4g5RyF7tzUvxQ29+Awu6gZUyNYlW9A3AmSOupesJfRugyztQhy03SRXOAnlcKk2/D1LX28RgOmjJvZKqv/g8H9T9NqrTw67MIGZ/zsTuEUqdLWMyNAq/guIslskAFta3dEJrDlavGASQFAx0G/kRwYdc0HYPJ4CyHTAyPZmOXg3HLkzMPwGZ+qUPNbHQNHtonhsdgHXhtr6KwBqC7fLXsfjTQi2q28XeCQRvguhY+Au6TC6jDnscqggxvMt4uClEX+5x43+ByBT9rpTSOBR7BUkkKmllT3kMe3llIDT9uqa/ndKd2a5sOdREGu/bepU3wUytH5POH1f5sGwcukpaUJ+RhR4BoljxRmOLTGry8/q1i10+gViKWo/7KmpmqGKMnRxc6sBfmSLbtiykHfr/PtpuXOyvs57HyKPWy2+/K9W1S11q/su2why0awKfPWJVMW4yTRTD4h5i6hCs4hZdncSgtIIiilje7WD+gv21qS5bEKcl0TWDtbPuYmQ5LO13y4MAHXauUymageMDNRSsNddMA+cJ/EMB8+77Nb8Gk7+5Nt9wkw4EMNOLwu28RF2QAwaMkXSJsAfkNVz7cOMTJgSJfU1vOpp3PWhhr53ZxWqBunrG9qQj0kj5ztkmFA7ucaPSoMNbRryeKhnJjOWk6WtENd80Hm6HNpJLrh8roE5KCAKhB0KXCP4kV60X4KGZEYwK8ve7r1OkInDgxr8XMJiy4bQTVK3+VKcIvyyVEUjIWkeRqSDiq9J0UR4mPBK4wtef1IzUguXINn7GLU9PIfBsl7TQj906s6cHVFVxWgBORujwjS5jzMsrbhcRRgIkOxeCuzoy46eXmL+CtrGl9kCPv+vDiv3o+nwsVe9UbqPtIGQq6nDq0dNCUpR4TRDQm7fCQfl2f7BSBP/VFgHJZ3p1isseiXGqMmJ37xf5NHuVJ7qWrGY3UfMgfcYKAuY2PyBogLfj2YOwgRJSkj9FqN3uvz00GI+tyf5SOothscQdNdNIjh8aq6PRrkwMJjzfxPEvWMsVWLRSH3XKxQx5AmuVCRHoAs9nvwhFOK53wtkmNzMUCQ6cUYbMcMlbUt0RMQZ325QhkbbkwuvdY68wULGCUkKas0YeK/f5ajv3wz6hMZJatH7JbUzVYQpykRRN3ZglxjcCKUYMI5tXru6Shbq5xvf+OyGfufJQgzqJlKSyO139yo9ODMWw04C0x6gSz77lGeEu61C2um/ieTQHDEP63k9xc59EQxLkSi6xn5xGGOnGzjQN64WmJItZYplGL8swqRenlsgNF3VkdMuoEKC7QcFtogCNoiG9ATZM8owOe94hEuCHenOdF2lWpm46IzN3uulD+c8p7eDwXgssG+LRq+mESEcQITX9CHoizjw/Gt+T6cGCBkV7JJ/J/ptWxcw3LlASODszMTsEsQEBH/ADp0Sqg2dnclcwV6V6jUQZ0Zc0N5ZLe8CQ6KijjBtr3PZ2PmOFMyfKiiWNkfLUDvmeY4bae2B+0ffI5MyzoE1m3DQuMwdJ1yNXLsZsrsRjUaBd6bpPuiuwNNRKqGfJhe6QaMRAvo+Mdod4U6lJBrdzAj1k4v98BwxfonWe0H68Sx5JAMRJlXenMf33w4rZdLRQQjf6Ka7N9AT8bJPJZkmwc/iq8bUb9DajJs1iycqXPbQPy46ZSUYm8pTi5mfbfQwKxaCdmqEuy+zh+g1wW7ASVWOUg4hbOR1WefwNCwx7bPse2Mq/8QjtAXHa0Rc9mKQhY55/KjuaYafSNxdBfLlxbN8j6HMDv6EhOsjj2Pwhj6cCI9su8rhBDfqvwn+pfnNUssTdOnDj+2rNxBzwzvwvaPOZmLJy4LwcMXW2UtU913gx66Mwl2caNwzsZSGuiULSgpXogo2r/04tXo/ao4ifEwDh7gft7exDX639DUDinu9YZQzjNtj3ZKERGla7HQ1qW+6c1lQSQkfypLwdzN1mmiEh2lv51d/80nwsrDp+Iopun0KoLkyFvpS5fzv16DTymqhtC2gD84S/XX4p1Ke+PtZk/HLtPfU/A6ONKc4SWD1jU+R6Lwf4arqtcDSkxP05efYacn6uy1vL1/wMaHDg6Q1BvfH2GkKas3+/z/Bs1NklKcpreABsvMDlDSFJecZuyu98AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQIio4",
+        "signed_public_key": "hFgfpAE4LwMYPARQdPCQkeska4wsmAuUyYHUvToAATh/AaBZAU6jaWFsZ29yaXRobQBtY29udGVudEZvcm1hdABpcHVibGljS2V5WQEmMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAvDb29I3cRYNk2CfhnjNfP6vPFxurlKeYohbyYU8YQwpTETqoMnXlJ6oUokJcXmPD7H/9Zkwdhr1/4GkGmT2h10qY6RnMPXV+BkZ3YdvnYRhU58bcMUMBsLJDbrAiAajK03xaDfYKts1+czPdt6hvkz3IWdzGjbqzO87/GRQ86IbOCcFyXCdv+veIRtwRnaDBT7lc/qH+vh2R7Pqy0p32KmI12WXsiWkcQaXVMCGHiFE70ZyTfN527XK56IhkR+3S5Oo4E+asdSrbgPJE9C5OirbXKRCM0s6SEAVNwLu5fq6W6CkCxeDj2Rs1Dk0q2a4myJspviipV2i0PkS9zQ3eoQIDAQABWQl0togDxv0sDrB2yG24QqnTZMjOur1JTBj5dgGXncP4f0j2pOizYkkJf/tl8qnoR3t4OJ0s1vC3WqhAm3T7DJZII1eO/EUb/f7zlBEx1mVC6BtuYimL4UhT6TH9EuQvkQGRLBBpoICCKbrxzvPeExbvBTcJyO747NezxATafyi0VyrUrxMn52BHovb1Lnis9XKiruhuwGqFb+UJJ4G/Ss57sHsVIA+/hLIke2g6YGOJA5dVRvndFTujKB7fy1KrLz6jfODB1/OuEULOqulJVl668IIaYroScE/XfHbkFlywRo5/L70Vnr5x4CoqigET1jEXrY8h2sPZCcZ6k5JqURRNhdDdGBlyW6LzRF4rGr+ccNfJNyUZ8TEC8I25ZFrIejG1IBiHLPCF7oTAfeJmwftad3gdAeTnPfMqQxLC/is+9WfQnGWsmKEbH4mn1VEYT6YKsJEcdT8b+td/ehWpS+2nZ4iLkK4tITpjk5sIzAsaw4d1LMuiopMYvLkrN4/2CahuII/Djq4X7oqFgvVuEAQqaBWMq9JlvNuKrdNusVS7UhByPl3Ynu8Dge0zt3JBTahR2IeW9uAqCjv9lVfdfHdjQZmo/ukz6x1ptaQZ8fXMMmwy5LaemANt9amfNTMEo4absLRD7Azq5ig8Zkyo1W95FSTwDr5eRQrbTbyupzRsimDBMJvO3TYHU11YjK9yoJD5K0nuT93PHQC2rQd3BqWmGaQhrtTnAaY3nJ8F8TCkh37LoUN0IhDRjvh+Vc03AGqHlnesarxhr1SVQE5E3WGEOu86sy+tQERwLTDWKThPsdG8ZKvFvpHpolwrdKcXS38zKnrrSzQJLB5WPtTSnA2VJoTKbz1uQa6F3WAcKrcnYprGblNZ8LTllB3lswAsKkTJh160aVKJMC2dqXQm5MIwNRFGbsbXqFBmgtv89JNpGE2r0/sGB/i+CUEtMoEPpzK6Kd6mL2PJBWDJ+G66jTGxsbJ0659LxFDVjgkHMSQLWqp5bvCJMhGrz/TmwFTlK64CtHtnCPVXNICB2aeoJeXgIXcIAOWqwBWpuRqRRjAdHJO2iwHihDcxFmlhN/86u/Dp6u483ogRAFrzywKGenjYNuBW9MeF9EBJ6sL4UaT5fAgtem26slO45pI9+OkfqFVBS0fGQqqeT7OiU6maz50Oe1qu9ozlrjIh3J981XAnr55R85CHGy1Bp4ds7+zgGrshwxAKk8uqvnAk4hyOzOsNWbBSvmYu63p0Cl8t38WaqkQRO+Ix71MnelFpyUGUA5G0ff1XzbqwxCY9ZZHLbs37nx6XLrLYETdGokkUa9EI5kI2yh7Vj/j30eKs97Qg7L8HtB2Iak1mOr0+b5eGflyPBY8S/Hi6QxzjZuIhXj0cDJ7QddJBV0J6rVkIxyvhK1d+KgjTbRnhm3K7Hy+CibKU8ZdtOzVi0dHxoFG2W3dqGEvltSHt2D7rsOdiQJgusIkct9l05+yzoKkZITJi2pt1Whmad9uVNqhBQPZnCzDiBPti2QHI34d7KxtbAomNZ41aOPdziJbeHiofGdNuonrliWCt3SsS7/nudpy81NM02lFEdjbaCDrnzDp4Jxtxjuk9kT51bmQ0Z1nEEwLiNsGmdtedeysKWz+3GopCp215lMrx8aVxH4SQojKswzThMFYO+o4t3oY3dztpfax9wcWVZngd0nfBFcSIRsxh51GayeWh4Ng9KgwJM7vBJj7C1gXlAxDmjivu4kFha+YI4ylDm4SeSeCkAahDlv6BPF0HXbUDoQKF8z+0hTeov3QKvtzIaQr+0dh3tQ/wPZNs237TZogKEr/KypovBO/TRPiw06Wqi8BEyOzOLn5Vj04eef00+0Q1fuR6WQMWK76zetGOhx9DiN2mIL9/Ji34uDkr7AGwhZUykbBwmB1F70nt+UcK+VY1Rtf69DTxklkGRgZ4PbOXUQvOLN5N7F7V0Wq8qKKBiGekUt2qRPEreU9leXj8UWLnYCbjSzd68ooUL8IdvSjNwiqwaGYdYHWmPUEzYWs/WyAfxcVzAUgY5iTmjHgF5HwFuNP9VFMbK5m9fG9F+f0iZlW/7QT5Txq4Z2y+XHSvwp7YbPGV6ShacDEl/X5BYNpflbhkqsMobq8YwsR0x7UKNKH2334M3MRw4n+WhhprjtXyz+9OgeHMHdvUr8Epz4Edy/+awD4YAETtmjkyGN44aIkxtXDGUIlJQkmttXTUuKTqgjp01mL0D/CIaOrOKPhnSBWzXO7G3ajEV3JOaSnKH0/P2j/aNDFpUSlBqbmwEKKtrK23pkRLlq17GXkhpIVAZhVtAF5K6CJm/rI6ATMfA7BAWD76p1llfAuMotVyjfGtvXRVnM6iPcm8pCdy1Ax0ASwohIeZCRBfFhQbBgbk5eoHIF0SPeRtKhW6jFVnNRsi+EqJ7GxhjXCtJyNtdkWs35slLfyxK/jrrv0ACJshyUBFroZF8cpbGiddNOXdWJTdvjuXRNpIdLHBpIiGPoMuSRffaM8AaqiouYxLYd4oMp2FsjWhlYGyJjlnodxtj99B0NCgTOe6BCtXRf1P29Le70y7LksZUXyRYFkHLNrG3tJVFN9QJ5WK1wGwVcNiEZOe3UI2qvLN+Ob/KsFjsQrnPYKQtpdPGEuKqWzmYfmm56TEYBjEdYIScucMm06Hec4st8PMH8D1q/keIx2YRWX0FTF6cQrG9II1EQUa3Hz8zNbVdYqfbUC2IlJdHUBKvdniWgyh9DVLL4srnS6ZEoQzWHbdsGf7FGwukKbiFtpp/SbMmVCItv3nfpFfmB0i2S56DxTqX6EyuhXMh0+adGmCS5G4o+NDPK0VL2sRBufhVtUkfUQ7uR9+MUFUe456uclZyb8HE1N0TjkJCckEkbMqfEjpQegP37KMz3tinwPcmH+fJ4yjSylQ8suAVw/T4yAcZAkT//JWmJpu4zVcIqtkdcuCnUZuNr2DIYcxae+kWOf3jkOcE8wNoFcKm0mN+z1wR/9JZ/ZA9XC/i2nMWIzxz+uu9CrJukwjIHg+VyfsbXv9hkNnEif4c+aJMMNtU4sheTo43fxlHo8ETnWfVLjofr2I0Fw277Jo+W5A09Sxqh08KwiWyYKQeL/VsGgMLURSVlxreoyPmJmbnKGttrrE2/X+AQUGCRQcHzFSXmmVt8bT4vYCCCcxSmB5tb/EyM/b8vb3Gx9DSVxja3J1fqWpwMrX4AAAAAAAAAAAABYnN0c=",
+        "signing_key": "7.g1gcowE6AAEReQMYZQRQXCzu+C4+r9Nvr45rMdSAD6EFWBhrYOL91DGZrHWK+JMDyOKLthehldyHFZJZBXKf3ZMrIg9Wy6AgXJGOp1Z89WndxMOB1GIsFPKCVaZVJeH0ozIt3WHHo4K+HBV5wUigx/Y3eq1b8ZkOK0wxuGAlpWsBOBJeuyM8y2wlUfbaWyU3qdetOQWD9fGEt3/G+lLWwMjgrNXxuF+ZbxT81dgStA29c5EMtw9Sq6sk/IXDzMw3UaSTGM0QHQQi4mo8jumpAeCSw6pTX6T+tfKqeiMDx6XGh4qIRGcqX4Ji/+CaHCQapN/p7YCWcPSOhwhMgUS2/npWvY2L0qSicVc8ck6fm1We3uRXx7vnto8fUfv55Q+GobCRJ/8ytP5DeT3djQWYOj+z4FaAH70Yfifl92/Zz2kgeL/4bDNS7zjneq4qIzqD1wToVxaCC+G7P0ClRuPf3bItqOZHticHt4VwZVkSiFgotSSofl3H47ufTkX/QLi4Ve5HHbw0LSHhlgboolbg08uG464rrHxXLCl6e7vQqPaltyszQjyWOAwvQoBfjHlaRpHhMDDvOnaRWeBRzpWVaVTAiX6dHMgciIUl721DAXn7iQ6Z7rxQrj4sBKPC2NwsNRzLx/6xhI4W35YDYqJkKJr123/JNXQKrFeUKRhLNxGwgtRNsMTzIjg4p2+2Td1Ttb8PZcXoP68UjtFYTAyQ5cnAg9kk9b9Kk7/AdxjX0xX0GzaMicYSpXdcKk5J9k/L09mKGhhfcQ2qdp6fp2XfiAgfvN5D9cCtqPVJOSoDYQVwQuvHmz3ntIOqDu2clYyVtq5r36MwC39/C7fayabJFiUuDvoxPaWx9sEBq/jgMrHq4ACBD4XRv1thJ+FehhtrycJpDJ5Dhh66HbAAhs85k2FaTQfOtcM4PCnFiMC81xSp4PO7mOnI1OjznR+kkkY1thbRr3RkJzkMa2ksiFPN/75smXxkmDWtvRpJ3JQsuXhgUavir39TuyJYEiG2MSItUgzzSn5PqdcFD6pWcekc3PgFB+0a7UCdsT2Jq+Yv8wj2IODfDmRDAlUKPu875xyNBl9W3kowNzGAkPSD5IszIw2myulIDho8GIf3hVFLBmaES1nhxzSsVSD7WyNXKGWiRAbHPgAHPqjTJkonuRUWqy4ZDBHcozKBkiPFk+kYKEgeV3jA/u/AIACouvWacye73iZ9qz8rpUR/CHFUtgL/JGkW9jIJ48ytBWl7Kls50vr5GEIXqREUDZ14Jo9AWZ56LeJic3pYuqC+6mci+An5wdssEzLXlf3tjGenfj3HFXbt7ehB315HWObsX9AtWZVrD8KzLu+1HUfzE2WhVDoUuAlf3qSaXJDsISUX1qU65hDhHD2P4YtBHZ/udBz+Msv07a2yCZK/qUubcGKNkSAdM7B7EHPf9aH19AGzdowLYMZtPs6nSc81hEQqQKbsPLGVW5OBbDmePKJAIZ2FzS1w8sDnT9qGUEd38/uzh/nTdyPzYBvkHDccnWZYFuAr4BaGJfPyF0V/F0uspQoP0UG5K3RKNxnacjexNoY67MxgULAXhsyWCINfRWvsGjeSYmqipyS+o8skbct2EC1umy1Mrhv3wNe9UhdLVsB4YfQIGiqJLZ4+Le2ZKAN/GjcN/Rhixz3t8LrH0CCS+sEt1FSWN0PKUMf+GDzuuMpd5VJ2UuTWaevw/GmAOmpTsadHGNXCj+t2n5h3HV7wSIz2Ws7UZe6WOBWjZeNcj38eKmT5iHD0TZenQZgOHc9AuzAw54k4ayzAWlCmjo4h/tsD6aRmN2AvATzgRONoTIaC3dUFSVmpGfxq2U8VApcGTgl3sf5bYsMmcmpcFFDO6zZnGFP3Zyhg5iZL1MPyM09dJSv9JJItos1YpVC8RCCZEmoBeygWBNxkblKsfqxAB63LCOVLbA=="
+      }
+    },
+    "email": "v2-argon2id-blob@test.bitwarden.com",
+    "kdf": {
+      "argon2id": {
+        "iterations": 6,
+        "memory": 32,
+        "parallelism": 4
+      }
+    },
+    "organizationKeys": {
+      "bc056400-0000-4000-8000-000000000000": "4.nwJeFaMJm+k4Np9q8l2dUu9R0HPJu7D/yo1r2pabNJlP5s7qh5BgP2xwvUx57w2DH2QsJklXTPkT31IjbJXo9qmzXN9xGLlDfrqZAKGcOcPA54n6TQqvZP1Jg/U65epG99n0WZbH+FKXxtLvmZPv0jhPzmr3fScTwzzvwpV8Cp1f7pmr+fqg9KKElzYqaKBxRiRUgpvjTcnx54MrL55bQENsYCUj3vZhKDyGMGQcGEzegl2eL66AVv3YDtnvUf/MKL32lnJeiU3kKzTwADVeZXbQVJUIDWvwfmg4gKE44TRS6iTSOymi2G1d/6qfgkWwux/q6v38TdcE1eRfAeE1Ag=="
+    },
+    "password": "password-v2-argon2id-blob",
+    "securityVersion": 2,
+    "userId": "bc010600-0000-4000-8000-000000000000"
+  },
+  "description": "V2 account, Argon2id. Blob-encrypted vault with a v2 attachment, folder and send. Unlocks by master password or PIN.",
+  "name": "v2-argon2id-blob",
+  "rawCryptographicState": {
+    "fingerprint": "unnerve-semifinal-doozy-kinship-equinox",
+    "keyPairThumbprint": "18acda5a8d720f7d6dbb4512fea13165809e8081ecf26a637539f78e3a0cb66e",
+    "masterKey": "+5EoKbgbOZIApDWA0JW45fV5eAVqyFFKiTZAsVGQaI8=",
+    "privateKey": "MIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQC8Nvb0jdxFg2TYJ+GeM18/q88XG6uUp5iiFvJhTxhDClMROqgydeUnqhSiQlxeY8Psf/1mTB2GvX/gaQaZPaHXSpjpGcw9dX4GRndh2+dhGFTnxtwxQwGwskNusCIBqMrTfFoN9gq2zX5zM923qG+TPchZ3MaNurM7zv8ZFDzohs4JwXJcJ2/694hG3BGdoMFPuVz+of6+HZHs+rLSnfYqYjXZZeyJaRxBpdUwIYeIUTvRnJN83nbtcrnoiGRH7dLk6jgT5qx1KtuA8kT0Lk6KttcpEIzSzpIQBU3Au7l+rpboKQLF4OPZGzUOTSrZribImym+KKlXaLQ+RL3NDd6hAgMBAAECggEBAJ38OTEwPrwuvaBfYZfsoUAN1GgeNtkyEQHF5zBdNw1XBkEJDpREt9SihG1q7KPidFv5V1fd/k7SlBtnrT1GKapQmKfZmsHf9KgJ0D3ZW4/535MqLjw/dZS/HbE0sWbZK194GxNq+rVVKpZC7BI0lWtvydP8aMIg/D/w0dpYTYQT6lSzkVlqjcNua56aQr6q00uqPr/9tZEcTWQtEvRe43HhTS+y06bwV5vvyC6TDE5nSpIIcS1fv1PMy4nzQM2P+RyTg4VeEL0B3UbIWqDYaEibP+KvEK2ws8wpLTdcpxzjFAxAGMzmsDM5RyniKGE+aPjovYNIt/K5/eOghxODLkECgYEAzRJ/Tb4RDkvLO9CCrtXj29hSvUwj1WMULWNONlnSH9cYb0t4DURFrIqOZf0U9O7IhLHFktMc/YpDaZXJTnWrF8d9Df+1Bpy8Xu58RQmDar4JPAl5FNSkCTu1IvSSioyHXa3a+ozL9oTe15SAH1OclX/r6T1ptRuXKNVuqGWj4zkCgYEA6vS+8rZVTWFwLkPPvCc6NrYqk4gWQfgr11JV4cBFlzDaRSDJs98eBFwTBt9+DTYJd43y7/BZ+EjIx3KYw40KCGUcyWQrES90vpERCtCDmUko7KjiAjYDLTWpiI+IwKEkZ1y2hP21anJQhdX5PmsdqUf4IVjLJmu7gI8envItzqkCgYBaDXRfxEYjG/98Hb01X3G2+dCjlcrqip6yq7gNv/W4y7DMNrzaPo/GC/YqLS/FuxHMy2/yYMiLQesGc6M51Aw03gI5Yn+xDqTdnyZs/pd6CUdu2M4V6qa580FAv1uWgc1zwsO1YJy0fXaJ/okguIu7Trhe7Pv9bsc7RDZatn94aQKBgD9UoxeHAC0wY22FB7x+kllm9sj3eJBllWOfpNiJ2/gpyduyP8wFCvE/5D0JBtAGzbx0/ZOhJI8hB0WDZRvoq1ih8IV0Q4uJUB2BuqdAlwg9SROpXeocpvSLr1vI3KKXjNlzixsDy9+aWowIpfsmIkOby40pgvCjP1Iiwa00OBapAoGAfQ+Y7+1tN3Ac9BpEKl4qoIwCPAhJlASzETFcgmtCr9h6BIF8XGMdQ1yDUM63RR3Tj0mJyK5Hov/nqMVXxGWlxxvsFtrSD1sWJuvZMl8Jr79fK8oNPgmfD56/NDHTLA9MMjG31ZOq6i7xrW89lFrOX5rEujkDrc0ZuQl4pBntH4k=",
+    "publicKey": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAvDb29I3cRYNk2CfhnjNfP6vPFxurlKeYohbyYU8YQwpTETqoMnXlJ6oUokJcXmPD7H/9Zkwdhr1/4GkGmT2h10qY6RnMPXV+BkZ3YdvnYRhU58bcMUMBsLJDbrAiAajK03xaDfYKts1+czPdt6hvkz3IWdzGjbqzO87/GRQ86IbOCcFyXCdv+veIRtwRnaDBT7lc/qH+vh2R7Pqy0p32KmI12WXsiWkcQaXVMCGHiFE70ZyTfN527XK56IhkR+3S5Oo4E+asdSrbgPJE9C5OirbXKRCM0s6SEAVNwLu5fq6W6CkCxeDj2Rs1Dk0q2a4myJspviipV2i0PkS9zQ3eoQIDAQAB",
+    "signingKey": "pgEHAlB08JCR6yRrjCyYC5TJgdS9AzgvBIEBIFkFIPK3qbZy9RyE7Z+DqlGyYtQ3+7hH0RKyHSKgxuOuzGDxIkuAVRWkFQ47Rd0315bqVdEurSJNJAimCAFHJ+u2jGjOIN2rBeRvVhoRas1ElGxYP4+9mHp20I+/LchvsOwFwvh+btQWorpmVzyIDEtVOkXI4zFjteZZQ2ykuIDc9a5mU33DRRgAcSMtqc/tiNxxqgBzwUilDZ43pMbwPhc0NJqSMnjfISdVwdsZgIa/GipZNzrrB1xxyHbbYD44EJGRVez5RZYHzxKvgpKOfheY2TXo/yqcVHmiHi05ODKayAzIDnRwftfLCTvPKMs0Xsezafq6kkqBd+FjyhbqLwI1ZM7dlJWR1EK8S1W/zNs+BVlMRx5isSTaC7ioVzXZTL3OZ3jwLmCCvtc6mXbHQ9swzkdFjk9j+p1IbqAVCceaTxvIazn7dUE+Ekc0zDljXpqAeYcUPsYexTWSraFvKuqfEZ3+HukqFXuKyPPGV/EjMlwN53wdpTEIqLzn5lwF/p174NwrnY1J6qjaTF9mQL/d3r9ZIgs2Plmdb8rI1V+CG4pDld0oavX7HCASJaY2YLutxe6OSAGxZOSbBSKGiXGk/JN06NbJVPVJGhjKFIakGI2VVVptbDjDsHBUoJeVzqN+adTDn4+UXlMAk39iFN8TMXMFExoSDz9VYqUNe0nqrnbkO0fhrQGO+f1myYHrOiRlWHwZdWNpPkv8wvN6cQWMmgVuXzw7MNzyGoksGGZaSXd359iGwp2Te7QNVAoJoVXNKBZdKoUZPmBZQK6EVch9xhLdtLBZFWFRmdivduLDysrSZJ8aUgrZJ1+qo6uIQfUq9Q79ybkE9HFKkto0XK0nXCLgh5Bj4mpynByBgQ9SB9SXJYhnVG4HLvUtoucJ3RkHSVtY3aQL5xU9Z+moNVoC1ytQSAcDlmuFQt4dxSMX7YDpbcTS9W8Eo0C2pK8DuOvpj92wQMLxHKJLCIuWkWa+L7ElV5KAMWVeMLJkgZWvBvuYZhuCR017B0V/acolbEjYptSB1ReccQbKsPySOFFQUq8TY/MJoUyNxOoILSglEKw1YwFqoisIc95NrWZbQpWPPpLii9QtGFQ6TEX2iOIVyZEnDZZrc39YsmgI0M57xrWl+yaRca3ZRT70avH74/mS7+wUe4fdPMN86whmRLl/bHultk2r0E2+R/XwWICliGgSXeW69H5Q8gb+tOsp4/XeRtqnqC1riSsR/yA7/MUGNm/6D1n6iV5Fw5ZoQF595O8hJhFHJm3d2nMfnf9ZqyJwvinEeEL0y0DY7+DxdVOt4utmcPIqJTWLvpx8UosTNI/MGLrpi+wocQie4OJjp7MmFXe2kIpgQcx9eM9Pdg/63PG3Ah/mLXKLehs48Zy78q+RhA2THZNzmbpKphciKNjvaU8fDyAPwNqNNE7Zk9/40mH6WH3jMLYDo9/GJYMWWp7m9JjeFVzsys9UUnunwoxVnp51tDVeJ3592E1g2h/fW3hYCqGSKHUgQt26sI4kEhER7vgBx9QcifM+xKYX7qxCWHz3dMkf8357rlLDhH/+0xZ0VeQJ7cRuf2fl20OPdRg5PyY93UJIZkkJQo47UCBThSJh/AmnobOsY9v5w+HsGWxfEioxOU4R+8EQOqmaLoKRjJN3qsBYs796h7crruJ1PFHfy/LoXou0TcBjMtHsWtrtygD2BmzQlKcUCmZwgmMIX80zfBVoDabofcjbCdz1P5O5vV3YFjFTIe6t3wCAoYkhWCC/4n28pu9UpkCQyZad7l9Vd9pPrdGULumxTPAyOfOkNw==",
+    "signingKeyId": "74f09091eb246b8c2c980b94c981d4bd",
+    "signingKeyThumbprint": "9d60ba792db9ec2cec5667860219d2cc65a535a310dc8ed402d0bbd2f351b6b5",
+    "userKey": "pQEEAlBcLO74Lj6v02+vjmsx1IAPAzoAARF5BIQDBAUGIFggeDlEntPLFFRHT/PS5U+YWWkRRFZEyYCDvBc2+o25PMAB",
+    "userKeyId": "5c2ceef82e3eafd36faf8e6b31d4800f",
+    "verifyingKey": "pQEHAlB08JCR6yRrjCyYC5TJgdS9AzgvBIECIFkFIPK3qbZy9RyE7Z+DqlGyYtQ3+7hH0RKyHSKgxuOuzGDxIkuAVRWkFQ47Rd0315bqVdEurSJNJAimCAFHJ+u2jGjOIN2rBeRvVhoRas1ElGxYP4+9mHp20I+/LchvsOwFwvh+btQWorpmVzyIDEtVOkXI4zFjteZZQ2ykuIDc9a5mU33DRRgAcSMtqc/tiNxxqgBzwUilDZ43pMbwPhc0NJqSMnjfISdVwdsZgIa/GipZNzrrB1xxyHbbYD44EJGRVez5RZYHzxKvgpKOfheY2TXo/yqcVHmiHi05ODKayAzIDnRwftfLCTvPKMs0Xsezafq6kkqBd+FjyhbqLwI1ZM7dlJWR1EK8S1W/zNs+BVlMRx5isSTaC7ioVzXZTL3OZ3jwLmCCvtc6mXbHQ9swzkdFjk9j+p1IbqAVCceaTxvIazn7dUE+Ekc0zDljXpqAeYcUPsYexTWSraFvKuqfEZ3+HukqFXuKyPPGV/EjMlwN53wdpTEIqLzn5lwF/p174NwrnY1J6qjaTF9mQL/d3r9ZIgs2Plmdb8rI1V+CG4pDld0oavX7HCASJaY2YLutxe6OSAGxZOSbBSKGiXGk/JN06NbJVPVJGhjKFIakGI2VVVptbDjDsHBUoJeVzqN+adTDn4+UXlMAk39iFN8TMXMFExoSDz9VYqUNe0nqrnbkO0fhrQGO+f1myYHrOiRlWHwZdWNpPkv8wvN6cQWMmgVuXzw7MNzyGoksGGZaSXd359iGwp2Te7QNVAoJoVXNKBZdKoUZPmBZQK6EVch9xhLdtLBZFWFRmdivduLDysrSZJ8aUgrZJ1+qo6uIQfUq9Q79ybkE9HFKkto0XK0nXCLgh5Bj4mpynByBgQ9SB9SXJYhnVG4HLvUtoucJ3RkHSVtY3aQL5xU9Z+moNVoC1ytQSAcDlmuFQt4dxSMX7YDpbcTS9W8Eo0C2pK8DuOvpj92wQMLxHKJLCIuWkWa+L7ElV5KAMWVeMLJkgZWvBvuYZhuCR017B0V/acolbEjYptSB1ReccQbKsPySOFFQUq8TY/MJoUyNxOoILSglEKw1YwFqoisIc95NrWZbQpWPPpLii9QtGFQ6TEX2iOIVyZEnDZZrc39YsmgI0M57xrWl+yaRca3ZRT70avH74/mS7+wUe4fdPMN86whmRLl/bHultk2r0E2+R/XwWICliGgSXeW69H5Q8gb+tOsp4/XeRtqnqC1riSsR/yA7/MUGNm/6D1n6iV5Fw5ZoQF595O8hJhFHJm3d2nMfnf9ZqyJwvinEeEL0y0DY7+DxdVOt4utmcPIqJTWLvpx8UosTNI/MGLrpi+wocQie4OJjp7MmFXe2kIpgQcx9eM9Pdg/63PG3Ah/mLXKLehs48Zy78q+RhA2THZNzmbpKphciKNjvaU8fDyAPwNqNNE7Zk9/40mH6WH3jMLYDo9/GJYMWWp7m9JjeFVzsys9UUnunwoxVnp51tDVeJ3592E1g2h/fW3hYCqGSKHUgQt26sI4kEhER7vgBx9QcifM+xKYX7qxCWHz3dMkf8357rlLDhH/+0xZ0VeQJ7cRuf2fl20OPdRg5PyY93UJIZkkJQo47UCBThSJh/AmnobOsY9v5w+HsGWxfEioxOU4R+8EQOqmaLoKRjJN3qsBYs796h7crruJ1PFHfy/LoXou0TcBjMtHsWtrtygD2BmzQlKcUCmZwgmMIX80zfBVoDabofcjbCdz1P5O5vV3YFjFTIe6t3wCAoYk="
+  },
+  "rngSeed": "Z2hpamtsbW5vcHFyc3R1dnd4eXp7fH1+f4CBgoOEhYY=",
+  "schemaVersion": 1,
+  "unlockMethods": [
+    {
+      "masterPasswordUnlock": {
+        "master_password_unlock": {
+          "kdf": {
+            "argon2id": {
+              "iterations": 6,
+              "memory": 32,
+              "parallelism": 4
+            }
+          },
+          "masterKeyWrappedUserKey": "2.Kam7nyMFNO1umF4eqCeMGA==|4lt0Sq80ikEzc+wMQC4E9ZoQhUc1ehdiDz/yvO/9diT3AZvpv6ZX8aBWoenHB4j9OXGvY2nkpAu8V0UoJ4DJaBZg8FbnFkr1WfwBwJp1tQo=|XIIiQy3Y3ds8iqQFnuAA2gLt5fkuYbtB6Kf4ZNdhdr4=",
+          "salt": "v2-argon2id-blob@test.bitwarden.com"
+        },
+        "password": "password-v2-argon2id-blob"
+      }
+    },
+    {
+      "pinEnvelope": {
+        "pin": "1234",
+        "pin_protected_user_key_envelope": "hFgopQEDAxhlOgABFVxQXCzu+C4+r9Nvr45rMdSADzoAATiBAToAATiAAaEFTIoFVvoA1x1HPtuCTVhU88FUr7FcCHiZQFd88fQUQRofq7niKbfSU3AIekqMG7F/eQryilEJtcfwW0FV3OFBh9eA8EzxM4jK3k+4VMFT5S7dWCs4nycbZmzR/dkpfVQ8y5BlgYNHoQE6AAEVV6UBOgABFVc6AAEVWQM6AAEVWhoAAQAAOgABFVsEOgABFVhQeCXmqAAXOqZ3Fj/b4xXU8fY="
+      }
+    }
+  ],
+  "vault": {
+    "ciphers": [
+      {
+        "blobEncrypted": true,
+        "decrypted": {
+          "archivedDate": null,
+          "attachmentDecryptionFailures": [],
+          "attachments": [],
+          "bankAccount": null,
+          "card": null,
+          "collectionIds": [],
+          "creationDate": "2024-01-08T00:00:00Z",
+          "deletedDate": null,
+          "driversLicense": null,
+          "edit": true,
+          "favorite": false,
+          "fields": null,
+          "folderId": null,
+          "id": "bc020600-0000-4000-8000-000000000000",
+          "identity": null,
+          "key": "7.g1g+owE6AAEReQN4ImFwcGxpY2F0aW9uL3guYml0d2FyZGVuLmxlZ2FjeS1rZXkEUFws7vguPq/Tb6+OazHUgA+hBVgYJWjHNUkTqmryOruVTi5nlKq+Q182I3MoWFDw5m+RnQ/HtXlFOpLmO73AUSw2pxN5cy4F/d9hh8hoxOvnhmkWdVZvCcrz36LuhHIQ1/CstbUmwYUp4ToP3hRytkGHc5BYp9blhAfgzAr5Tg==",
+          "localData": null,
+          "login": {
+            "autofillOnPageLoad": null,
+            "fido2Credentials": null,
+            "password": "keyed-password",
+            "passwordRevisionDate": null,
+            "totp": null,
+            "uris": null,
+            "username": "keyed@example.com"
+          },
+          "name": "Keyed Login",
+          "notes": "Encrypted under a per-item cipher key",
+          "organizationId": null,
+          "organizationUseTotp": false,
+          "passport": null,
+          "passwordHistory": null,
+          "permissions": null,
+          "reprompt": 0,
+          "revisionDate": "2024-06-15T12:30:00Z",
+          "secureNote": null,
+          "sshKey": null,
+          "type": 1,
+          "viewPassword": true
+        },
+        "encrypted": {
+          "archivedDate": null,
+          "attachments": null,
+          "bankAccount": null,
+          "card": null,
+          "collectionIds": [],
+          "creationDate": "2024-01-08T00:00:00Z",
+          "data": "{\"format_version\":1,\"wrapped_cek\":\"2.8YXq5HtxoT/FrFlIS8KHXQ==|EG2S7vYD5RPKIAWjJaGWR9H8+Dzjo2saiuiDucwfQL9g8I45KQ8M3xrqW4ni2sTfkIi5Ry5zJYegY9AMXDX/0HUkr2iHMR3lm7tFGbTyn6o=|aU26UHtdmNnOZkFuWiuhQlDflfJ/odaI8fIIHY3AGWE=\",\"envelope\":\"g1hHpQEDA3gjYXBwbGljYXRpb24veC5iaXR3YXJkZW4uY2Jvci1wYWRkZWQEUH81AkTPpwFiJLUZVtvCRWU6AAE4gQI6AAE4gAGhBUyJPVd1LLjDXwrXc5RY25O68B9oOzDu1pqeBAByglnmdukvicoJ50TWB5DIv6+VYd5fnmP+HoWHJJwUqrs7FnYrGo3s5cDpqcaNmHNYParQetLz6G8AlMqJ7RV47E0KAXq/1tP/STW0sQcia2/mSM09e0hLfMnw4BnYmkXGf+FyH4AxsYyaDSrNVqkhHpt5L3d6g0oPB1Sn5ty/IRcLmHuUHZAo5Ig0OeEJB/KD6tqsK2SpQZtERx5C3p+QmmOC/lKmvcGgQWzttvKjT8hka2pI8eq2sVjJo6xXiAcFvO5LuMJCTniej+dbfg==\"}",
+          "deletedDate": null,
+          "driversLicense": null,
+          "edit": true,
+          "favorite": false,
+          "fields": null,
+          "folderId": null,
+          "id": "bc020600-0000-4000-8000-000000000000",
+          "identity": null,
+          "key": "7.g1g+owE6AAEReQN4ImFwcGxpY2F0aW9uL3guYml0d2FyZGVuLmxlZ2FjeS1rZXkEUFws7vguPq/Tb6+OazHUgA+hBVgYJWjHNUkTqmryOruVTi5nlKq+Q182I3MoWFDw5m+RnQ/HtXlFOpLmO73AUSw2pxN5cy4F/d9hh8hoxOvnhmkWdVZvCcrz36LuhHIQ1/CstbUmwYUp4ToP3hRytkGHc5BYp9blhAfgzAr5Tg==",
+          "localData": null,
+          "login": null,
+          "name": "2.7dgg8uDRqLf5uYqQK+1KzA==|ToYTjb/hsjWWSmpMTKfnEg==|S2ihk6vZA7hmxX3ecsiTAcb74ge3LmPRQEmNzFqsCY4=",
+          "notes": null,
+          "organizationId": null,
+          "organizationUseTotp": false,
+          "passport": null,
+          "passwordHistory": null,
+          "permissions": null,
+          "reprompt": 0,
+          "revisionDate": "2024-06-15T12:30:00Z",
+          "secureNote": null,
+          "sshKey": null,
+          "type": 1,
+          "viewPassword": true
+        },
+        "id": "bc020600-0000-4000-8000-000000000000",
+        "keys": {
+          "attachments": {},
+          "cipherKey": "unS1nVxwwwKMeia7KBixrt3CCIxNIAJWHgX2w9AU+amJY0FtKLevFMA5g1umoGq34dx6YWZ0vlTBCmubKha6gA==",
+          "cipherKeyId": null
+        }
+      },
+      {
+        "blobEncrypted": true,
+        "decrypted": {
+          "archivedDate": null,
+          "attachmentDecryptionFailures": [],
+          "attachments": [
+            {
+              "fileName": "secret.txt",
+              "id": "attachment-6-1",
+              "key": "2.2U5doSfIXbUjv++sdkJq7Q==|Mo8ulv+syICT3WuBugmNlF7x5dC09ZEq6CCy2+LYZ4nuz03dCdpyq+yLOdI0pN0E5WsITpj+o03rw3pEhS7NPkF/JDWRE15feDbuJyaVet0=|Mr60MWH8laclmlYx3oI7aKSqm+j/XvDdEB62bh74K90=",
+              "size": "512",
+              "sizeName": "512 Bytes",
+              "url": null
+            }
+          ],
+          "bankAccount": null,
+          "card": null,
+          "collectionIds": [],
+          "creationDate": "2024-01-08T00:00:00Z",
+          "deletedDate": null,
+          "driversLicense": null,
+          "edit": true,
+          "favorite": false,
+          "fields": null,
+          "folderId": null,
+          "id": "bc020601-0000-4000-8000-000000000000",
+          "identity": null,
+          "key": "7.g1g+owE6AAEReQN4ImFwcGxpY2F0aW9uL3guYml0d2FyZGVuLmxlZ2FjeS1rZXkEUFws7vguPq/Tb6+OazHUgA+hBVgYQu9GY2kSKVZHVS1U1zhV/j6b43/iwJevWFCr8MzbIC+TdZ9t7XZcFnbTAAzDnO5srMwV0Erf0HVqw4MbPDiHHR4eg06+W5F5rJl/2NVeudYTt+OzjcXB0MyXW76qEjeJPOJWyXc9z+efxQ==",
+          "localData": null,
+          "login": {
+            "autofillOnPageLoad": null,
+            "fido2Credentials": null,
+            "password": "v2-password",
+            "passwordRevisionDate": null,
+            "totp": null,
+            "uris": null,
+            "username": "v2@example.com"
+          },
+          "name": "Attachment v2",
+          "notes": null,
+          "organizationId": null,
+          "organizationUseTotp": false,
+          "passport": null,
+          "passwordHistory": null,
+          "permissions": null,
+          "reprompt": 0,
+          "revisionDate": "2024-06-15T12:30:00Z",
+          "secureNote": null,
+          "sshKey": null,
+          "type": 1,
+          "viewPassword": true
+        },
+        "encrypted": {
+          "archivedDate": null,
+          "attachments": [
+            {
+              "fileName": "2.anEXe+A9lKoZVNytbcjocQ==|gJWELnNrgYk4AbCWNXertw==|Vrjtbyg4Sy+PYwdrkma0wveZOweAryuQ3a5GB1XPD90=",
+              "id": "attachment-6-1",
+              "key": "2.2U5doSfIXbUjv++sdkJq7Q==|Mo8ulv+syICT3WuBugmNlF7x5dC09ZEq6CCy2+LYZ4nuz03dCdpyq+yLOdI0pN0E5WsITpj+o03rw3pEhS7NPkF/JDWRE15feDbuJyaVet0=|Mr60MWH8laclmlYx3oI7aKSqm+j/XvDdEB62bh74K90=",
+              "size": "512",
+              "sizeName": "512 Bytes",
+              "url": null
+            }
+          ],
+          "bankAccount": null,
+          "card": null,
+          "collectionIds": [],
+          "creationDate": "2024-01-08T00:00:00Z",
+          "data": "{\"format_version\":1,\"wrapped_cek\":\"2./ZzTRWQgE9OP1W4eNKMQhg==|aVDDMMc2cC+jxYQPgPvfnLvoVkb/lcuTgLctFGdnu0csnqVCYqhqz5YQQ0or5Umr0fS0jkoXzCc91UdLFwwJsKA99+kfnRl/KDnJ7qIi2+E=|XD59uQTdxFK/QrgEty9lZ7sXrVxGFbKRI0AISJ786+I=\",\"envelope\":\"g1hHpQEDA3gjYXBwbGljYXRpb24veC5iaXR3YXJkZW4uY2Jvci1wYWRkZWQEUN5r92Mbk6m3fStRjawNuGw6AAE4gQI6AAE4gAGhBUwSeQC7lhHYO8uDbalYsfVNdNHtj7tuti51LcnH7ui46tYddPLtGAZ9Dm3EiA4igIeGqm1/FCr3HtJ1t4EhwbuvqqgGs42C4qqXLaOzhNqJj8CTreLtLepjszKR/R9yLL3TtyFKu8jMh4o9dXyEpyziFKth6Ixx+eQD8WnE17CHkjVpUlEQnkynt4lLcf/ZpONQQePyY3hTakhpyBnRAgBs2RZmgeHDyYrpOMYREpqvwoTuGpN7i3a2ueuQ4pctkA==\"}",
+          "deletedDate": null,
+          "driversLicense": null,
+          "edit": true,
+          "favorite": false,
+          "fields": null,
+          "folderId": null,
+          "id": "bc020601-0000-4000-8000-000000000000",
+          "identity": null,
+          "key": "7.g1g+owE6AAEReQN4ImFwcGxpY2F0aW9uL3guYml0d2FyZGVuLmxlZ2FjeS1rZXkEUFws7vguPq/Tb6+OazHUgA+hBVgYQu9GY2kSKVZHVS1U1zhV/j6b43/iwJevWFCr8MzbIC+TdZ9t7XZcFnbTAAzDnO5srMwV0Erf0HVqw4MbPDiHHR4eg06+W5F5rJl/2NVeudYTt+OzjcXB0MyXW76qEjeJPOJWyXc9z+efxQ==",
+          "localData": null,
+          "login": null,
+          "name": "2.O0fVnrR8rGdthD2lJ0P5Ew==|RDiZb6LVyPY5op77Gy9UOg==|b4Pfi7QN+uOwLnNPCV37bxND6V7AveP3tW4nNB+VS4o=",
+          "notes": null,
+          "organizationId": null,
+          "organizationUseTotp": false,
+          "passport": null,
+          "passwordHistory": null,
+          "permissions": null,
+          "reprompt": 0,
+          "revisionDate": "2024-06-15T12:30:00Z",
+          "secureNote": null,
+          "sshKey": null,
+          "type": 1,
+          "viewPassword": true
+        },
+        "id": "bc020601-0000-4000-8000-000000000000",
+        "keys": {
+          "attachments": {
+            "attachment-6-1": {
+              "key": "XkuIG5W2e+kPZxgBFJnJeG4UgtjS+StW55flgoy2qQvT8bjtTnILp5J/gUVdPQEMfr4RE5H6IyBPAH2PL0ZPVw==",
+              "keyId": null,
+              "version": "V2"
+            }
+          },
+          "cipherKey": "+KCDQ9sY511XLuarw9MTvPWlNruKh7TQIaOJaxZ8580Mrjjs5ydU+XfYZUT4EII8WHhAla0Lp9mC+VdmDN5SGA==",
+          "cipherKeyId": null
+        }
+      }
+    ],
+    "collections": [],
+    "folders": [
+      {
+        "decrypted": {
+          "id": "bc030600-0000-4000-8000-000000000000",
+          "name": "Test Folder",
+          "revisionDate": "2024-06-15T12:30:00Z"
+        },
+        "encrypted": {
+          "id": "bc030600-0000-4000-8000-000000000000",
+          "name": "7.g1g/owE6AAEReQN4I2FwcGxpY2F0aW9uL3guYml0d2FyZGVuLnV0ZjgtcGFkZGVkBFBcLO74Lj6v02+vjmsx1IAPoQVYGFGCKYUxI4eoMnqW3caCKPjTMvUUIh9KKFgwBYvyTCLOPV3oPEvu/8qwLDf8qR6TNoRy1efuusQAMCdT5AGFLIUQo8i7qoXUX2KC",
+          "revisionDate": "2024-06-15T12:30:00Z"
+        },
+        "id": "bc030600-0000-4000-8000-000000000000"
+      }
+    ],
+    "sends": [
+      {
+        "decrypted": {
+          "accessCount": 0,
+          "accessId": null,
+          "authType": 2,
+          "deletionDate": "2034-06-15T12:30:00Z",
+          "disabled": false,
+          "emails": [],
+          "expirationDate": null,
+          "file": null,
+          "hasPassword": false,
+          "hideEmail": false,
+          "id": "bc040600-0000-4000-8000-000000000000",
+          "key": "Pgui0FK85cNhBGWHAlBHBw",
+          "maxAccessCount": null,
+          "name": "Test Send",
+          "newPassword": null,
+          "notes": "Send notes",
+          "revisionDate": "2024-06-15T12:30:00Z",
+          "text": {
+            "hidden": false,
+            "text": "This is a test send"
+          },
+          "type": 0
+        },
+        "encrypted": {
+          "accessCount": 0,
+          "accessId": null,
+          "authType": 2,
+          "deletionDate": "2034-06-15T12:30:00Z",
+          "disabled": false,
+          "emails": null,
+          "expirationDate": null,
+          "file": null,
+          "hideEmail": false,
+          "id": "bc040600-0000-4000-8000-000000000000",
+          "key": "7.g1gcowE6AAEReQMYKgRQXCzu+C4+r9Nvr45rMdSAD6EFWBh7JacVltG4HL3XQUPG+GpmhpoVrGtV3EVYIFmzV1kqz6EmEbIsUylaUbcWuu2k1nFq2+W3taA7dWfn",
+          "maxAccessCount": null,
+          "name": "2.kVA0RniptKjDvUZ6Vp2kaA==|HthndUsKQYjKk493b870wg==|FkHtzNouuuFdX73XydaxGI6zDnBcHtqiSVL9ncdd+KI=",
+          "notes": "2.0vvHP+kZV1MZZfhq+q4vnA==|2IsOCxkOSGu1tkRHEBZH1A==|q2lWY/gl0+tFvSGkKbJnSNv/W1a/iRWhxRvD44dZ7jA=",
+          "password": null,
+          "revisionDate": "2024-06-15T12:30:00Z",
+          "text": {
+            "hidden": false,
+            "text": "2.yRyITYtSf67RkhPsHp59Aw==|qpO+ER5ANtR2JDSVQPZ8ddrVIfwBbOcU53NGCpYmka8=|t1cTkdiYtcMmi1uMs4V054VafHV5DN+DhBQlv/0S5+c="
+          },
+          "type": 0
+        },
+        "id": "bc040600-0000-4000-8000-000000000000"
+      }
+    ]
+  }
+}

--- a/test-vectors/users/v2-argon2id-tde.json
+++ b/test-vectors/users/v2-argon2id-tde.json
@@ -1,0 +1,246 @@
+{
+  "account": {
+    "accountCryptographicState": {
+      "V2": {
+        "private_key": "7.g1gdowE6AAEReQMZARwEUC5Ly+270uev743nYoR44nmhBVgYbaBvWD2Bx9HzpNgoFO1B+7ysVvNWb6SAWQTTlHtgBs6Z9RI6tVOxfnHGpWvG0Z9gbEpi8FjxkpDJdNhqvznWVcqAbgUgNBo3BJ8d7qNbF3SuFvlTlzRTo7VjiBLfbboVVwos2QnllDSzGh4cCgHRSobVYHZ8eqToEbHcAV2zCjLNjglQ/8aQdJ3rXDQzdEO/H4J6hwypJbmpSXqR7vX1V3fkphWXsxBcul6JqV2IXQ2oEQ29LPNhEfcVMQ7qe4h0z/aREL3TYZ33eQ8/g4rwIzHlg8gMPwbPmmFEk71BxP1qOR/oocNswlJpABqp0FV9G53T0IRv+dBk+oz0xWwga5n4tITHM1jNkfqyWgdSOa0k7wauKtndzbxpkGQICb62tM5ZaQ0eWTZhIvsijPUJ9+AOPw3AtC3sXIkyhIfzC9NOxPisJcz4kP3IXN2xHU64i7tYNlq96tFlXKdQxLl3d9jDjVyy082kCUsTP5+B6AXRhn/kW67Oaeg9nHhQVDv5mN0jC5o176B79ULdghvM7u9/MB9EBl11VeT+VVBd55Y5rIP53XiM6A27UaCQV12o7nuss9TPAm6JXkxJRkHM80Jh+fxU/FnU0RAzPZD9PYCOfYIH1WIA/O5URjUQbwld5H1XcWlHRvASDtfaLsY+mQQpXmXKyAqyibwtbCsuD08x14rAD6fnbaN84+2r+t2Pgd3HuvPtjeCt1r65e+DOvOD+qvDd+e/fgmiplpDZ/d/RWjpmlag8a4FZvSIondiXBY24yYZSHXNtVX8fUFotdV1v1/oVAaK09UedAlK9y6Q+3Ga+RCuJOcqCwPM1KCV5TsPWsSAH3pJQ4a+2fhmWw+Lqo98Yfi0HMka2xgcs/iT+oe5rq3q88FigUEWlogcaMuc5xWdKkH6h7SCI08Wd9cU+KttvOscmg7pRvTeGUbQ09jg4cbSzljmYSg1DMLkhSY7YYvFJdARZujHve3fh7vS/0tKTM0SPpsglmr1wmPJW8+m4vFgFYV6Hiyw4h/aK50SH7Ltz97MmhCTcogr5MhjDdMnk84scaww5/zlN5PhjpL6ALnoV4BwRJTowImojvu06WUNQPIc4vkJ012SQZCj7V/HH69PK4NqlmSyWfLE0jn/bK2puDbastPRQKL5azZ+jNkOFVZGfGkqr7z4rS8SjTLNwQhwBy1RsRxVCL1SWYAQOKdtS90x5ltoVlLkE4q/b7U2ZiD/Q7J2ougCviqrXVzJ/XHFqAVBBkdi3FLmJHBLE3WQio3qE9PLnlqp357miUOS4sWtgDRBoPGhtcWIVoSxiT1oVtbnRg9o1SXW3JMVdxmpsrtPkVm6bOWM8AAgAekgIF65M3wHTCOqy/E2GVhxaMFlgavUNLSy2BzHKxoD/F7dtjTRscsuks/EOoYIZSotBlAbWMzZEyPQZTYGLaWQQBcqxkKAXH/aB+/pm3+vacRaIkXZSQ/teARWxMAhR0llkh2ZOjHDnn9TiG6w5as9RbkJxqkVFaEM8YMti5otucc9XOmhZqlX/5zDxeFcKmV09h/Zw1oq5b76JorStoBeXSq8aLtZ9AAI2NtCMs89tvZf+TAzjuqgvpb5z3cTq4SzQvEeR1OWLwdgihtYQ4ALJSn1lWDXW1R8XaDqzcCypYfqTB8qU2jG4WaPz8ks7ItfY8ZNZmk/rVPw=",
+        "security_state": "hFgfpAE4LwMYPARQIgUP7zpLNotuKwZfj/fB4joAATh/AqBKoWd2ZXJzaW9uAlkJdKONKzwbg3fPxcgcdcu2B9ElLWcdGFxQiu39q43otp+9bdTOixVM2h96SYHFZa9iFWdZBaRdPtuh3CdbDg7XWnIKNnbtgUBJTPK8lJKgTZGc6tAOmVt85YURVgI4J8AimdbRrIj9K5Nlo2pL+0mn3Q0cnl3l+Q8WnIhlrRQBEIUoKd8vwxdlhrH0/9RCEopKGK3ZMIAce4p/kzq2tQUx0vjfiqR9e2A5xkreYPNLmwJ7pKM8MfJDR3mY9S0UCxZHZQN5doqpn/OCqpmUM+ft4ffrm0HWEblU2xCpU+zYm1FH6kQlyike4dVM1gPWruDFWTqgdSB890lB1o1oZ9lkK/naOJ6TkPF54hQLH9f7Vx3hwMrpwVaHtKGSObQCDFuHaF9vnAqI2FgAfHPnFjlQF2w1mL/BGX9F+VwP5/PIHY11YvGa162cXPCO/UUeXOfnLuATBfIPK3xVQIgjOoqA5bMqHgfMym4RS1ZlH7T18NOheENPAyXqGoqZ3ZU8skdXLEyUVAK1pb9OSBcN/avq1H1BWGJDhVnysUsRTLZJPKETeb2AsndFa0EGqGTEurrreXlLpSqQi6N0FnDScKfJPpQFD53F4Az0LehQ8/D0CNIP7U96F8Jr8sfSIw6pQgU9B6XGYElME1en0vZ4eeWtf1LBVObIZvV5B+YTukXtxYl3PndNLePsvC57JDMozZYritaYbRgUm4PbfsX5Q6g/lp9Oo3+usUxgBvZZbU9ciGUl+4QsEyJFUnIa/g7JRU2+XgLTZ5ifDfTIO3crnHGXbSxxvS0+4wRGTfYBQ0cOrbpLxlxDD5/Qy75s36DfsffEL2CNO8VZvzTuihQ3wXTEHErzSkblFTgfE5Z7gjKfdPAycNNi+3CfiNr/358Rix9Gmthvq4WjNjdhCCPVCO9q0NjCEzFSYCG6702Q2PVnZuCuHxM0VYv9TyEb0X6zLYXJRef+ZpD+Z5Wt547lB3kgtAjDipX/5tOC4JnmJfZlg12i/S4LroKDvqfygXiWr6BhpneRj4hpKfqyLT1LE3CrZaCa/IQOwfzcTwfWQUZ0GlRiNOfsrIwvBq419yitt+fh/r5dGDqp+8PbNv4yfmuV4Ht+PvNaLC0DMrIYwZq/p62t8lsCtAz/syrM+SQ6dnO68OyDeEySnlD701a5gYHHDlawOXloteVsLpkKSiT/g7RYox02jb9zc5YJTaefjd2/gbSrFybt4CowNGR8hdn+ypCIkpVWj3fAo0GMjvhCjnGCBQCVDHoQ3axox5FixJSEacC4fWJte5uocIUNCHPq88HwIuJa5tqqpQpuKmfObYGsn6aQf+hgKKZovHL3kuqVXQ/Aj9YYxlaxIK4B1wdmU67jngrL6UyPXeM5ZEz5MQu3MCM4cTSD3cPTREdwEesGHBNQv2iO5lz573+LyfTNnvbwvoDB7rHbSLVA9yQu1TXx7Dg7/2bhFe8/pPYGIpE9b8dYfHCispkWEDZNKw64x+dPS8aV2uxsS+WyYXLPRx6LZUR7WPKD7zwZV++72cOGEc2+v+ldFef5dA7xqlGIPvjk6OSByax8i4shnO3sI7dISX4/dypiV+CFRlUoOd4UCh+myUZ3u7xSAehr/CFVDbH3NGyIPMbLpSHdkaoKcLij8rw0toxD5d7hyBBc+eUw5LDGhqGiLo9E68LeR7QMeoMnqwvnJfk0ajODo11l9paCFpsuGYEsaTzMXSlk+FcmOEgChxV9ZU9Eg7y98HOj5VcCZOyaa0lqTTzr4YPCieb8tRssXGXB0xe0BBXu/Vl2ycZZQskLkTH5PXRYqTZlQvkSshyFCOoWNEcreUlg4GmKNdpkfAU4iqxOrUUYq9FB8ECIaer4fxx+MU+i6t+tdUF3i6VMu4fDhUTmty7nrO9P2qcF4hS9Lo1s5L9nfcPSjAx8SkWjHjdQ2IR6DJK2YWoLE5iYDqY8+F6/15BPYO4o76Xo8TvYmjabSWBJrbCdTUDTq7ObRTUXIjBQqIuBRAKWFcbU62lOMpARXLzmI+Adp+i9bjqA3tG8MT8DyD95mysgq702SncGpzhcPIiHWyVeahpTOinR/DZCoH5Q9MgAoJdFT0n+rNbTKshrQarrQbEuUFDknm16rrSHK1l6apwD0zNpcNaVmV5zc8xlVwudc0GFJsj+kwe+na5kQ2NPw0eV2aKwRiy2IGkc7xaR3LFAgrosIBvwb0EVB/uiwf6wtwjCuqj52ctLXZuOUuq6p8+bPce9IvALNTiBjZpYKp8IbPQ8sDlr7vgit2CtLyoi8xCRs75akIhO3eruhybkBLyiDVlGmyHC8hirkgalN4xR+TuiGQz/1XnoT2aYiUcY4GoECORN29OaBLdsksguW5DieJWX2CbBkN2EgSDWSkUwXZfWWczIIHEQFUNAaBoXifoFaTKAxWhOwFgA7KHoqY5L9Fefk7O9GTwqO25gFQPlunVjlSC6XjA+g7/4RrL6SyM2FzAqGfcjRJ6ZN4o31hZbQIfC+4/+7iGakT6ByalEdV+Fv46zhbeWVMz/Dx1qparrEe0jF9ysPngwHq1epYai+roN/872oeOoa/LV4RqkW9G1E1NJMZINW/Cc9GPR2BS1onxQ1OU75z7YKX8sLUAkiljEOnP5yB79PPx+HTvv6q++lRux2rjmgAs6lMOhFQ13Fdf29DB0xbA+LBAzhsAOT7vxXcQ38i2Rg1JSl4fGzj/nUeaMVXofYto+LFa9Y7Upa02rgF1ici10VTY1E3PPMFEQmesBytHcy08gMrnyUocvWzinBHpCE7bCLAxW4crSAcB6gmDrRAqrtt5UbsxkU/IO/zm5+9aTBZzHqEtzBsZp77eqUbsb2ZzuXSFcyV7XImQV3topZT1UPFbcT4DXnqBBiWU5lEJPaPu8yLkPunGlNQlHNLuwwitE4OYkM1wcwH3GL6YwytUZJyO7x5EEPgvtJqr+7RpqW89x/oKE8bQyPJtMCTQiSBQDEgjAh7i5nj7U+6BWc7tb1twkOjrCWQUI4a3xtg2y8K35Bdsg22aqc2t+gBIxKi/Og0vu1NqCM21RCO05j6DKXY67B8/SBgrwUfofIZfIWwZBSr1IjvYRnSh14l8RSEZwwuRAEDRNcoKxtLjU3ezv9iQrPElgdHWGl7fCxcbJzNbb5u7z+xkeN05QZ2tyo6qsrrC5w9zj+QELECssTmRrb3mtv8LK0Nfd5/4AAAAAAAAAAAANIjRH",
+        "signed_public_key": "hFgfpAE4LwMYPARQIgUP7zpLNotuKwZfj/fB4joAATh/AaBZAU6jaWFsZ29yaXRobQBtY29udGVudEZvcm1hdABpcHVibGljS2V5WQEmMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA1gDy+pRylcSIYmZ7wBiW16mYMgXxE/72N0p0VRmKqo5BgfaXLSMlWDEpxgsfaPY8rwv80UKsv+zIvB5kK7RvV0VmiKwQWmbKTjmFka59+/XjjbQaoh7QXE2NWfCFk7fsPeLB05DjxX7yw4DsY85j9XJ2T1tZSBMud7bnFL7kf2y4C8tlbx6OepS0Kvd3Nmg0tNC10jZiVeFD8dZ28VTAgsGFbZgDgfdKQ+Ji0KPraHkkjI6ISaHzc4K0ya4yuPde2Z++EndlI53UBXZyVcE3r6qC7CmoMg8Q7r0qjSvCJZ04pSRafYuL2w5G4fyRs4eWF0aC0a8bZyTSNVEuBDPpnQIDAQABWQl0UClBQRV6ZySZC1Bw4DVK28NgdUrK7Bfi9kzn8Zx/fvNZVViBwevZOAYzy2dmQtpmRFBzbC2qTDcomQPjWwKGZUptQf/dyhnu1SCpZaMET2HhWGscQmtI2uLxFA2+9k9R8vv9maTNqsjgTuvapmL4yjgDVQ2NaBoSUs9K38pneWCnQ3rniWOVDrn4TnKYBgX+vOA4cNqOpPO+8XO0osVlshAL/L9ds2hzsA4xw1xClt8ycEu4HArTWzg7IKceoVd2eqqQZaImeED8KRFiH44dvdwraTvN5tKX96Pgks2Q8Qrd0iWkDnq0FKui6Hff4vVDpfPD1TjDAYP/iu+jqWPqQFElpRbaG4Q8lBy2zZ4NxUDLx+1HUBYdAxcIpyd1lKB0/wqPJXyD1eAw4nG71wievy6NN23AX9hsc5cemp20DNdxIeOykd86zvzRBH0TSmteeELXqcEXf+8a1K0JWSHMXY0nJ1XmHHs4vb2d24+bN7OmPpDzrwA/fPvOM/ymq8XvofeaH5EU6mfTmwv+TO5R4EagjRqCC8jESKhrISYsmSc8krNyHEl05wH13d9KXXDUgAWVksOjWA1YJYw7OSLXSXtTDo8fabdtoTRG/Gz7O6lg6qaqfWmxLblwqINFdbpRhYRw/OKtw+20Tp4koyQ3chRB+iET+VI2WRtwZ0C0FIHetU82HZflDssc3GbiqJexd3TwnUNw9In6HWpjV+rloifAI5TJC/BWlFE5qIALsoLaGzUIBFaanL79AMAc0a8iCd7KI5prV0Rbj68kqkse2nUpq8J2zB8UbU/8yU0MPMXsqgig8EcYwqk+uTiYqyEiFC/F+YMY5nQ6iDr7BpSyimPtQc09L42GbIcWBDdZM3jJrMza5/57Lmj5+6/MVyV5FLwgHvE7A0GV0trGpcLV2CKMu+lBh/mdvWlrGv3Wo5Nz/wKHAqBa+D51EX13l7tEd4milvUVcoVe+1m1T8kbUPRFY2TrS0hB3A1eMC5pPWd+rwo6l0ArMja/oQx8pbuykE77WtLEeARrrkDFUNmBNwzTQbIOeikFxTBwm1afp7mJuNpQvVC2+RkA57uDd5oi2ilVYWoRizkg/Q20wl1Tr3Y9FzJQYPzpBjjhAL/Q8+KoaWGoQB6sspyNDOvQSWh+LuMbIkOgXTSJgTw0Ev8TXtPbW6OizESU00Z/DgYymkYFvYLNiZXtXf+WqPu5Czuayve7ooNiiLivvFWjTBvD+jlO+fOGAGsMewyA8wAlM2mW6wty1tnBwEhSuzS/K7oIlZrRG5CCv2k7v2hqqJC4LpcK9O/tqjvToHN2wgF4MPGCdU43vNUHPp+AyTG4CK/1cng1na/jsFlpBcvGexRPolk0g3aNvZEnmKGs16jZU0kqSUQVwA2B8hg5Pu9J/GYJy3CXbmFEhkRYDDIRq3JIYq0lFTkNRIxBF0YAkt49EN1TAIP4HMDii3sDjmD3ACxAhHj2Ycube9oXBInhUI1FuFoptua01+5x/CeezlKtOFs5l/LWemg4Jx419F4dWyXQGacMfGk3yDro4xVCrqw17InmfoZCTA4CLABrUosLOz4BYt/fERX25QVdCJQDV4pwUizcXzzh7Oe8LaEcFy4+49s2YbrNl6IfNkEmyqhtDAfepvXG9DT5zKWKUglKQhK3i097+AWQwOKuaXBgwA3zesyYUV874Wq6+gYGnttF3XWmCT73PFUOAXPT4iiU1/0b9Kxv0WWUIZXFFVCudWdKmUFA8qGe56GQUoGoDAg8dpKJhim2B28+ohRjgoG7zxg+67qHIXP+Y8Kmsw/e3GXAT5FPlOdcN+PkK6XbI6rgi0S1RrZy7OJ3vpYec1S+nII5tAtfZnecP152y/pYO+JzC3tH/qhR2lucil0zzA36RX1pXMqUgdeSZERpt3hfxwpsn8kYZ845p6OugxXu5y7RuziOQMrjZ1Sr6mnf4L7/rCKnk//jDucBgt8o7EwXa1FG6IvE+2F/w+ONSVY+T4klZ4JicM9YQYPBnaarvbgpYfhI4LkAmn9eNb4ZPTUJjl/punqldLQ5ccsT+2Ilj3AbbEs0w0P7/mPvyqiMCQ5ndcr3BtWcF2muVXChViCQsy7NxCzlPs6Cmxkgu/x92Lkx4+i/5Y/lalUuFgcPyUsvI/+9XP9/gz22e6GVrbyemb3CNxMO6Un/BO2GO2cRrkNyjMtuvqCGWEOccTYuOMo9VQ8cOYXsyxzBKjTaXDey0QGhMYcU2chyrPOL6YDQBNisj0XfSrkIN+ghdA8MpfO1uq9B44VA/yJSxYiyV5oOBTvbjblvuqjZE0JOUjpd2A6P19kvbCs6Eib1HN3cBMqyF21Wm4c3sCNPNJIruyEf6cF/D0CpqoUNavc4dLZkgo7XoCP5beh4KqznHcb7oZ+c2OsCok8l7Ih6BY69TUaszmZ8/7v9mfQo0zs4mP0j5TlUHX0dexr15IgOQRYmiJjkQdMAW28P80NirsUautZ2PaYmS4QFbwd8W2R/zPve1bWhf22F6mu1dcJB8XdrYn4dvblOdqNBFfBKPFa5FWWgCDS85Ss90JMVBRCcQqIZ50xctrZRHj5ckspgIeyU8zkmNpsrfwhV91NNjsv3AWisnwkJsn06FErJ9Gqrwhb9jvuEaEGyMYvTouQMLxY/vOeS8JswK8gvLbr6QQhE6qBPnbqy2lpQacj3Ys63Z36VMWrIHctlccARchRAR3BalEnTc8Uc//3Ex1+ss/hKQ1HErga3/xW5oJaS01uQFNeR7ljGmxQg0xYCmnmuTQimK0HCsAb4TVA4RqNiZSZpzwBwtD/o8yVDkSu1wKADxWPR9dfsHekurjR6H04+ts1a1iz+hpsVKf3NmeCDIg17SHeXrb4O838up8ZmxtlJp9VDaDTbSYUAP9h3DUnqIjIGDmLFG+aiv/BNU5rKr8HpiFvUlnqpd026M1VNp2r51NX6K2ueu5DX0x3BLtQFhrRySheG6f1+kD7ZM5xR0pk/Gytz7j+iTstorEzGgPfHlSvwud+vNOvZH7paPgBcsKG2FuXI3u4nng5Zi9Gc/RXBjxknJmBDlWdvEiURV40be4yKRB4v25ct18PjmYf9m2ME4uPFR/IBDhYhKEV5ipW3uMfM3eEYGSQ5Q1pnaG1xc4S4vu/5AQUxPF1gf4mq9wEEMDtDSGqGl5idqsXI1/MAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA8fKTk=",
+        "signing_key": "7.g1gcowE6AAEReQMYZQRQLkvL7bvS56/vjedihHjieaEFWBi7k5yoQOh+Wf+73tMbknRgl6QdxtvjB7BZBXKbYy93y+st7MbCT2qCD1CNmO0MxFzjUWjhhQfDFnGp06boOOz1PWkQ9PpfEm1TvAMOWNqJh9UtBsECmCtOd7coHoayWVfXnbDU+7JvdYPI5FTCbeAFW1qApmrXQNUuTEMIursDC/568xR1Wkk5SgskHFnkRmQTktLAEFcaGI/HscAAUHBdjUkGMu2JLk6PphyXnQ6LDln6ymRceDUuAq13XocbUZM/sdsE3nQsJOu6RlcgG3AwiUREC0UO/ARVsJobA0wnsizuWzZhkXgHF1RW9N9qzRlKY1MeKSSkoJhpuIfamzZgaYP+l7YbVXt/iTvjCUw1GP46aQWRNcl5k06VmTkVZOEMmzY9gNwPTMaKVyWfTpx5M2YWnMnoTsnyIDmZqndsCyMW99jkCVefeR9uyYGREuSYfq6qA1nlMlU4peBZNmw2htGYF/7bjlWGVrBiin4Ajc/2cY17zQFnOqoJ8zrEWQMwLrWSeMCOzCpH8RpEj6bOL31gSuChFVvVJ0Vzvab/FfusubqSVLmWB/OSJW3TsHGNzEVSjgPqF1k1lZIcMnwTOu+eIy/7bDpYdjFWGLNYki1MPplhuonbvS6SeecuUpeivW2jdDhGXqusSyM4yNW/ylCjeWiWavf8dmCVZiigdxopCt36dR3dMk19YtYetNmI8vWVJPe+ehZk4F/yYdf4ModrtuFlzAkeyGWt8cr+cGzTY++YjwMULcaRxFcuQUI4Dy3303LU4ZVUwJBGhHF4UZb2gStnsYdDdiAo64LSIJcfWj0wBZC54QVoaIhFpYQhXG5iHBsJsmuXj1cbrItwp5EdxDwDO0CkZkoG1ZjW7HCHdEFzkDDIZNKqE1KL7PMwyI5kdFuJUiYymK23OXNEf74SfE/R8M97vv5vyudqlQ6LZyT1pYeqEhK3hSvSbSWnHq5o3D3XYKg+ks5eTaMEfKXOJYs7e96CMWXBPJTHaKBY3v6anSQlIIW/HG2RzJy8rMavsp5d9vd6L1zlg4TVQA6+FdDAAxRE0mtgXK7Nxa+s3GPA2fMUabXOIb9KHXqTDHTo+rlkNnDf2N9UfwT+YDP4a1FgmXpIYDtK7Bar4lrQNp7ZoEMhXIPeZ76niiHxvS75lvtwJy8Z+ZIxS8tiBPyJ6/xzplrZCz1bHhxIoVREvhE+5BPiviwy8CvNfNa4E/krzUC6vjZ8N85lPy/rBea01Hejm+aycgP4Km1fE6bxZwg3NbPNI4dw9blYCrem8zeIkbGBPPAptK0xyQHoxNlwo9Nli/vMI76jrExJRPFCj9Znh+y+hjysO3L8MCxy84rjdGrIyA8dp9/M1ouzn07AmzZW2olAzG8JfSMz7f7fz2Vkt1+dRGaPVH9qCqnjrVhz9I5Fqs6w/Sj5TQJc/zR/SRePpmLc9PASHwzrD4KU6OYMZFR1H4XQh0bzUZIbqbJveZ0BT6XqAsJ+8FdSr2iFZhAVpEiVgzC4zpJ5u7ZOo+gnLdFVSFP8pIkrLXLH7ZaghyrswOQPfiExn7KgPhHndHr9mna06H3SX+I6XPwuPsVaRjALqNk/HbPVh2JtNg0zxqNpG4SFD5Ven2W/luqEP77+YDyiv/anIb4yxdgB3oq7tLBEFA5VEeGO1hEfQj/ZeJLHVFvgUeg81sqUDCDokkosIb88RanZdVXNZ4lIG9My/m88/n7tWaCIDXZ40ZO0BQw/CUilw1tcWtfuF+TZ+YgLC9bycJWtavx/MW7KvaMOLBrRnO4a2leHFLSmuIm+2xRsE9jSRuWsj9MBsHgl9XoZXLVHs3049ewcxXD9mJvcwtt20CcwYgoaL5odXZnsmeKMwhTp+eSTWpCBsv696CJdNkVB0/0f3A=="
+      }
+    },
+    "email": "v2-argon2id-tde@test.bitwarden.com",
+    "kdf": {
+      "argon2id": {
+        "iterations": 6,
+        "memory": 32,
+        "parallelism": 4
+      }
+    },
+    "password": "password-v2-argon2id-tde",
+    "securityVersion": 2,
+    "userId": "bc010900-0000-4000-8000-000000000000"
+  },
+  "description": "V2 trusted-device account with no master password. Blob-encrypted vault.",
+  "name": "v2-argon2id-tde",
+  "rawCryptographicState": {
+    "fingerprint": "theft-dynasty-animating-debrief-glancing",
+    "keyPairThumbprint": "8adb6cfd081b178e1cca835ba54bc1f77285613eb18c5c1f45b4f58bf5fc886e",
+    "masterKey": null,
+    "privateKey": "MIIEvwIBADANBgkqhkiG9w0BAQEFAASCBKkwggSlAgEAAoIBAQDWAPL6lHKVxIhiZnvAGJbXqZgyBfET/vY3SnRVGYqqjkGB9pctIyVYMSnGCx9o9jyvC/zRQqy/7Mi8HmQrtG9XRWaIrBBaZspOOYWRrn379eONtBqiHtBcTY1Z8IWTt+w94sHTkOPFfvLDgOxjzmP1cnZPW1lIEy53tucUvuR/bLgLy2VvHo56lLQq93c2aDS00LXSNmJV4UPx1nbxVMCCwYVtmAOB90pD4mLQo+toeSSMjohJofNzgrTJrjK4917Zn74Sd2UjndQFdnJVwTevqoLsKagyDxDuvSqNK8IlnTilJFp9i4vbDkbh/JGzh5YXRoLRrxtnJNI1US4EM+mdAgMBAAECggEBAK8h7bcVv0RDpx1oI0QMm314pD3j0Ov9Tn/nJZbzJSD49DEonYVp6sjmyvnw5k6enQDf/ZE/UGJso8YX1QBTVH8GI6gbr/JbhppHxsB3HVESZJv11YnxT7EKInCFPrup2+K1bMv4Gf7pKkDGhC4VnIYkmx/McR9j2zZLb4bxxctkrXwa8V1NQtdOzixn7XKDhWdcDI1Bm5568v+F5Vn8Cp1xBxMeFOinaWDNM77/5DbTYa8aVykHpLS4S/b1+PeLQqP2f+DFTreFtTSSRS8fVTf1/xyN5qo4nanqcb8Px0GWH2ltyFgVRTVCv8XwHlT2XAd+vAlD1mTE81UZhLpenH0CgYEA5eRgp6P+d3bUhsvMptpz+MPiME8tk5nTMjRKyyR9liDdhuHhWBgg1rt8aValo76fCBMAeFdK8lIW3ICoG2DdZjdFMlrHqTqayuEhZQig3AXPg1bbBruiLp0CBHGD2BG+DO2C1kAqD/8p7Pp9xpITozuW/2SEEVW5ca1Z5tQZOO8CgYEA7k6mhLlhZVg39TlL3TYVckKweuswcJtnWDbT7Zgg3Ylhfjt/35N1U5NJuC2vqOxUe81vFUWQ49mh80uikOGVEN8QKBEI5QvZajU/AXxb/N8aolJ7iSb3AFl94cXTrGHs/6m5yNS9fYIIROsIYQ5PJcFZKzVhOeID7Wz1wZn3jjMCgYEAyzf3zRll35r2wfW0AicH73bRIt1LL7gB/tZE65BlR+njidFxDxu9I7T2hHOo1reyA0Qw3TBlOxIfzWoZsKIO9MWU8K9Y4hrBLOiYSaS39edZCgQkd64z7rqyRtVFtCHy+6CVUOnFhQCNwkOoHXmRzHDnyPnE2UILPRb9atRBO5cCgYEAk6rE4IWG5qettRTV/7Ndwrm0ZdaK45xIg48l75pO8zgH45K3ADF9iFZCXhBhQwl+qGB6LvI2gBoBkqMRjzlZh2TRvCIiItwe0wM/kYof7ifJd0ApMKmmcN8Dc/2D1tOvahUf/GRnLvh+a0ZAoPOe88RFntKq9pUo3dygxGDF16UCgYAQVzJ1Ur/fgF64RqdLpQPhANIyo9hWM4d7q42xxquioKAaEHDOzqtEwl2iHNfzkFx9V8c+zWrYXZVq5MyVkvnCJ8MCIIEXG4qhHFSHt5LjfiruaerxDin1OCVR+PqmgnBDvcd788Jr9axM9qNwn3qpD8+PQA3sg1or73GAg/oU4A==",
+    "publicKey": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA1gDy+pRylcSIYmZ7wBiW16mYMgXxE/72N0p0VRmKqo5BgfaXLSMlWDEpxgsfaPY8rwv80UKsv+zIvB5kK7RvV0VmiKwQWmbKTjmFka59+/XjjbQaoh7QXE2NWfCFk7fsPeLB05DjxX7yw4DsY85j9XJ2T1tZSBMud7bnFL7kf2y4C8tlbx6OepS0Kvd3Nmg0tNC10jZiVeFD8dZ28VTAgsGFbZgDgfdKQ+Ji0KPraHkkjI6ISaHzc4K0ya4yuPde2Z++EndlI53UBXZyVcE3r6qC7CmoMg8Q7r0qjSvCJZ04pSRafYuL2w5G4fyRs4eWF0aC0a8bZyTSNVEuBDPpnQIDAQAB",
+    "signingKey": "pgEHAlAiBQ/vOks2i24rBl+P98HiAzgvBIEBIFkFIKUMC+ptJb9QiOAynkafTzxL+lUDENG/DH5mJWaORLH0MJ5tT2zksKQxgT9uMBFsW84MY+akubbT6AqmLzeE1gLNHMYTnVs+EqshBfee2PNZH1txrUEpD4iRXcWhnvxEYr/ktj38900TXEnuRz+He43pn/34RSdZXBMUX0TRXKmNciZVviF6Ya+M80awhCCUAh9EFJHTScbLMpj8NV/ZIqvwc6H1rypeFQz5TsE+9QX0Hvs4vQbx+YSMhFBFfnmXNXF0awOvH2EdkT50EybJWECnugTqNUKSOJZUyzMieU4GCg3NtaObxSruGjnGi4r9JiSY1+UJQVZM87mJLhXCNfk4tTvvT7YNi9Fnx7sK8yVtAUSdTcBCQSD/EsilKfkjjjCECWhqrvGEH0J4LgAuyDho3hK9A3Snei4Tb3nsFyrCg0QOOqKXf5cvlwPMG6q8GghiMELAgWJ61VncOufLj67QgPEUsRepIy7P5jxLi8GnVizic1oz1VajSo0NJdWfoi5Cmf1+O5qfxoyuQyw7z7RLvf3ak/Tb8Mo3uuF3nLQCiXjM+7xsUjwImm3vGwjQLCDjS1WXmwaUL3V2uiMdBE7OJtYbIxPv8HiT2MPYpLBRIor/k+SWxcJnGR1hRjGoVEmYG9pZO+o/DtYVZd0BtsdLDRi2nDjowLJFUOW0yzkZ4rmwoLTxpoeBfgFALqi/bjGEWKSnJrpRjmYfR6Ck0Jf55I1PX3SvD4fXKpxYvOy25hSLnfg6cecUu/gEjQcKv/LA22IgKymy+gpNDrCGjkK7PLAY1qOyFYnq0RRAuIaJUKppVoQN6fJNH+K/6vdvLNFo5hDIh4SqsujYou70K2tqvTKx6Y7ukO7KAnsLLC3+alJ2bZcOo2S+9jQcWHMC9NduTZc3W4uGHKWOyw8FG+3WzoeJcDyll4VRxuFs5lw3V8Xyzk/+ARfh+RwOkWfuODGiWxOY/Z2LlW+aPmtTwqK88QIBN/GeJa7JRQ4UJwGOxR2g4t1haCfNsPxs9sn6fBU3GCm05cKigS3UI+rnpOSnEnd70bFpMUN8g2YID0ZDI4UEoeZYaCUYstXspHP0d9etLSAJP5p6/rpHCqcPc3/FJpqNQtwAbMXl7flLciXGnH27FWlY3CtYUzdY7xYHqE9F0rVWXhcepJgNzWXRH5+4az1FB6TfkC86mIXlhggew7uL5jUFQdrLqMuIgmjANW+jYY5V0rdehvAdi8q/9yk5TK+77ed3B+bmuIpBhh++N1Aa+tgjuPgKn9BuV8YOEYvBPSuFh0G3eSahiJVAnMkuHwbu9DK7Yw4nH3fld+vs2sLZu2K5oHL2f1/VIUSoHu5e3nAXoVTSDyVEASUJ0BhK94XMr+iopSs57Z4H7H5vN5WmwtdLEvQraru9mVTcUsccmFUTE0ARGfLLUgG/jgXHIdLOFEO+Y8f7mrt1qWsqD/lc187SXbLGByfdXgvCZvb96xdEtNMM+OOcPzApexK/LlPGR9FPPZ3Ou9RiH7gEaYmsbzU6XwK9O5Czp/RjYswliP2nIDs760j8d3udHE9X2LjlaxevmFukrfXO6D9G5MYkLNiXvoQLZZ5KoKc7JEn6VbxLbtMODyq6r4bvJwyspYxBVG6ls84Iyvdo3/WkQKZAByo+kqvlGIo/uTpstVig/Ja1XQYCPxY+CcLjcq2w/7ZLFQMaY0/5V1vlGu4H48J2tHW+Pwu2TBjbJmT7/590YNArHONwEMQDrogZBeAhWCDi2nxDp5aTP5+WL2Vq/E+CV/G4Vn8EuPDNd716tDdOiA==",
+    "signingKeyId": "22050fef3a4b368b6e2b065f8ff7c1e2",
+    "signingKeyThumbprint": "a511aca5fd0475153ea965afcc733c40a9a362ce47ff3a71f23a27ec91940cea",
+    "userKey": "pQEEAlAuS8vtu9Lnr++N52KEeOJ5AzoAARF5BIQDBAUGIFgghaZQSAVKOCX6peWhHnWnKn0lKxiU4d8jPZszuvT/AMoB",
+    "userKeyId": "2e4bcbedbbd2e7afef8de7628478e279",
+    "verifyingKey": "pQEHAlAiBQ/vOks2i24rBl+P98HiAzgvBIECIFkFIKUMC+ptJb9QiOAynkafTzxL+lUDENG/DH5mJWaORLH0MJ5tT2zksKQxgT9uMBFsW84MY+akubbT6AqmLzeE1gLNHMYTnVs+EqshBfee2PNZH1txrUEpD4iRXcWhnvxEYr/ktj38900TXEnuRz+He43pn/34RSdZXBMUX0TRXKmNciZVviF6Ya+M80awhCCUAh9EFJHTScbLMpj8NV/ZIqvwc6H1rypeFQz5TsE+9QX0Hvs4vQbx+YSMhFBFfnmXNXF0awOvH2EdkT50EybJWECnugTqNUKSOJZUyzMieU4GCg3NtaObxSruGjnGi4r9JiSY1+UJQVZM87mJLhXCNfk4tTvvT7YNi9Fnx7sK8yVtAUSdTcBCQSD/EsilKfkjjjCECWhqrvGEH0J4LgAuyDho3hK9A3Snei4Tb3nsFyrCg0QOOqKXf5cvlwPMG6q8GghiMELAgWJ61VncOufLj67QgPEUsRepIy7P5jxLi8GnVizic1oz1VajSo0NJdWfoi5Cmf1+O5qfxoyuQyw7z7RLvf3ak/Tb8Mo3uuF3nLQCiXjM+7xsUjwImm3vGwjQLCDjS1WXmwaUL3V2uiMdBE7OJtYbIxPv8HiT2MPYpLBRIor/k+SWxcJnGR1hRjGoVEmYG9pZO+o/DtYVZd0BtsdLDRi2nDjowLJFUOW0yzkZ4rmwoLTxpoeBfgFALqi/bjGEWKSnJrpRjmYfR6Ck0Jf55I1PX3SvD4fXKpxYvOy25hSLnfg6cecUu/gEjQcKv/LA22IgKymy+gpNDrCGjkK7PLAY1qOyFYnq0RRAuIaJUKppVoQN6fJNH+K/6vdvLNFo5hDIh4SqsujYou70K2tqvTKx6Y7ukO7KAnsLLC3+alJ2bZcOo2S+9jQcWHMC9NduTZc3W4uGHKWOyw8FG+3WzoeJcDyll4VRxuFs5lw3V8Xyzk/+ARfh+RwOkWfuODGiWxOY/Z2LlW+aPmtTwqK88QIBN/GeJa7JRQ4UJwGOxR2g4t1haCfNsPxs9sn6fBU3GCm05cKigS3UI+rnpOSnEnd70bFpMUN8g2YID0ZDI4UEoeZYaCUYstXspHP0d9etLSAJP5p6/rpHCqcPc3/FJpqNQtwAbMXl7flLciXGnH27FWlY3CtYUzdY7xYHqE9F0rVWXhcepJgNzWXRH5+4az1FB6TfkC86mIXlhggew7uL5jUFQdrLqMuIgmjANW+jYY5V0rdehvAdi8q/9yk5TK+77ed3B+bmuIpBhh++N1Aa+tgjuPgKn9BuV8YOEYvBPSuFh0G3eSahiJVAnMkuHwbu9DK7Yw4nH3fld+vs2sLZu2K5oHL2f1/VIUSoHu5e3nAXoVTSDyVEASUJ0BhK94XMr+iopSs57Z4H7H5vN5WmwtdLEvQraru9mVTcUsccmFUTE0ARGfLLUgG/jgXHIdLOFEO+Y8f7mrt1qWsqD/lc187SXbLGByfdXgvCZvb96xdEtNMM+OOcPzApexK/LlPGR9FPPZ3Ou9RiH7gEaYmsbzU6XwK9O5Czp/RjYswliP2nIDs760j8d3udHE9X2LjlaxevmFukrfXO6D9G5MYkLNiXvoQLZZ5KoKc7JEn6VbxLbtMODyq6r4bvJwyspYxBVG6ls84Iyvdo3/WkQKZAByo+kqvlGIo/uTpstVig/Ja1XQYCPxY+CcLjcq2w/7ZLFQMaY0/5V1vlGu4H48J2tHW+Pwu2TBjbJmT7/590YNArHONwEMQDrogZBeA="
+  },
+  "rngSeed": "mpucnZ6foKGio6SlpqeoqaqrrK2ur7CxsrO0tba3uLk=",
+  "schemaVersion": 1,
+  "unlockMethods": [
+    {
+      "deviceKey": {
+        "device_key": "qqCzbKl9YUl+2TOQ1V+ndZye4wqEioIT9SgKVV0vytXBpa/PGsRByrOBGWcaiyrlZWOFP6EeqX2Yy175iekb8w==",
+        "device_protected_user_key": "4.JZi90GXEstLmTo3U3nTZ18Lp2JOhbmiaooCs1eqae56m79Mq58BRgbUncm0jlpm1FAFWGV/xT2+XqDAs4siWXZCDgX4e1nRd1kiIX2h52JFjH+8t9u3sUlodknI1rl/23nGbPh9UD0ht7eATpv3NaB3qMoTrvh8ZDvmid5pKUaPsH8Jb1kNy/l1+2OkYrGmPFuRAV2ZPFcdIYPfEd/o63T7+UgPU5PAF4n/cfEQ4yZkKQA5uGA5XCGX9ILDA8fkrjS7cFOlkxt3hO1cdTmv/C8/wht/DDjgIYFbkjSLPiwZekBUX88s7ToJaVKJ4MBHdY3OckxGw0DQeF27XRwOVBg==",
+        "protected_device_private_key": "2.0RdgdCwQR3MfHFuLY8vQMA==|5mCKUQXEUX3hRpaAcU+kJ/SekDHyN2p9+3YYiqkLaXhegBAbQxAfLkjozZIvZCFeb1+VnXoXSLJK6P7YpeZMu8ScKtQY12ERM/N5lIZB9WtLR7OIBH/rVkqYMNqtnn1wsmc7sRttHXl2452T2dJlXZAv11Hj2pDSsvIIfgLKz0zUK/lwEIK0gySDA/5DUvU82dY8GbHMeYln7JC+jmDiDp7BQG+a63MF32KVvpcBt4p1CMQAkhSj1OqTv8dSaQywKQ3XbDnluvJzbP3yZJlWrjtNmP4vSuB2lyBmsDzbaOWZB/fHMEI1CuReY1JlcM+zwvBmu0GJa4oKklUGEAI7QPdwiiMAFleBDzekOQxT+Cy8tHVFjYmJ+Iic8CE4jkVIsnDhox7nXOn3+XviAGIgntMWBtlwDixpS1ERuOetktRz86Pffn6PRNiarS+onFaStjS2w3VMKjkxJi0mSKhZSKNcxMsUlxeM+b3ai0k5RJvU8NgpIcQfjevQ0+1j9Ej1WvWr4W1O0Y53ttCqsGMOKV3XqWRWfbluSXOBkj+ancTKIi31y8rlce54u+N0MG1uyi18F2PyPKdupr6QG4fdEE6wMnDvxySsuWfE0yLU4v3s5DDbds5bho3xA68ytq6MzVS76dXV80hSUCSmDPoUtqAwZPEv5/fdobG+cSjDFT2QitVc2+2WmM+WP8cfLFvKHKX6AszKk6LP9FVqZWZ/C+5d7Kr0rVooZcWRPcT2I2hiCeeHY0k4VAE0mLjquoOK8ClEaHlrKiHPg3QcsTHEw+so5sn7EL5dbCD0YkhwjY/9wcyJKTW243sakzCfOiPZUjr4JQo0FToKjsxTB5mzroYx1a7vec8zxHSanptDW1JsQ0LG+eyBtdgDabOSfSrFvg9altm6bXCuh/VviRDIB+Dd6jvhTqqdpxrOovhLw5tIsfup9tnx26+jSrORrhxRu/iMxRlNJdSSfomkyes/mxpAHOEU+kgXANrCjWSpj1kv63qgPGhABC83mThEkh9eJYuCYFt+w04vNYNsbMlzOXkWrh7MeARdZXg88TfmGyteUdP/bgBM9GFWe/VZOt780c5p+7Remk8nJVighEM6Em9U02eN5EQKA8Jae8HCsg0JgnOLB2aKNr4N80eoG+Y46yikCujpJYd0tHaeY7nw9P8K433MoFbiDCxy/4B0JZ2ov6sh9BkqYU2P4TJ4jcRrIjnJU320Xs18Plrn/TC0ReEJ11qFA/KeY6UTc+Ups4tK/pg4nUT2fNv0hGTHzAFrcEmuBDI2OwBcqLtmPHN1JU3X/o1/aNU5Gv3rs+CXF6gc6s7RllQ1C/vGkZd04vWoSbno4vmE9gi0mqyr2H7FWfdecEr9mk/jbiV7aFTfNr3chfCax9KUj1wBYAs7tKesMDBk7y6XWFtrUsp8HSGio92KL/khkkTrj/7i7IsbKIa6k1yh8p3U5tVPc13dXGUY9tRIjef5/oKoFZfZWncX8TSodxdxP1r/ryqrm94uFPGSHpgfogDnmU0SMGLrliX9lYUSnL8B2y71P2IK/hNvcheWECtNqXf7i/K3QGmlgiprgiI52McIrwSeKb+DeTFpIuas5pcKV+zZsL82oMoScWr5morhshaBTjwvNu9PsKA=|Vagjd71AdY5HQm1+MLuMH3pSMrgtQNgem8utYYtPrT0="
+      }
+    }
+  ],
+  "vault": {
+    "ciphers": [
+      {
+        "blobEncrypted": true,
+        "decrypted": {
+          "archivedDate": null,
+          "attachmentDecryptionFailures": [],
+          "attachments": [],
+          "bankAccount": null,
+          "card": null,
+          "collectionIds": [],
+          "creationDate": "2024-01-08T00:00:00Z",
+          "deletedDate": null,
+          "driversLicense": null,
+          "edit": true,
+          "favorite": false,
+          "fields": null,
+          "folderId": null,
+          "id": "bc020900-0000-4000-8000-000000000000",
+          "identity": null,
+          "key": "7.g1g+owE6AAEReQN4ImFwcGxpY2F0aW9uL3guYml0d2FyZGVuLmxlZ2FjeS1rZXkEUC5Ly+270uev743nYoR44nmhBVgYY3Pa37WqjeRyPR4yzNDsrjoaQH3lH72GWFDX+fL78WhcFyQmapLhkAAHcs8uCQ5224jr4vDbQeWHjdCrKKJcKVo6aAm/r4RsERfL+8hNSGiOSmsQk+Jh2cBqA3OAR3faaoGjb1qa6guS7w==",
+          "localData": null,
+          "login": {
+            "autofillOnPageLoad": null,
+            "fido2Credentials": null,
+            "password": "keyed-password",
+            "passwordRevisionDate": null,
+            "totp": null,
+            "uris": null,
+            "username": "keyed@example.com"
+          },
+          "name": "Keyed Login",
+          "notes": "Encrypted under a per-item cipher key",
+          "organizationId": null,
+          "organizationUseTotp": false,
+          "passport": null,
+          "passwordHistory": null,
+          "permissions": null,
+          "reprompt": 0,
+          "revisionDate": "2024-06-15T12:30:00Z",
+          "secureNote": null,
+          "sshKey": null,
+          "type": 1,
+          "viewPassword": true
+        },
+        "encrypted": {
+          "archivedDate": null,
+          "attachments": null,
+          "bankAccount": null,
+          "card": null,
+          "collectionIds": [],
+          "creationDate": "2024-01-08T00:00:00Z",
+          "data": "{\"format_version\":1,\"wrapped_cek\":\"2.y7E59Jmcc4PbVwm2i/NJsw==|dWeRrV4ve/PQWztfzq3ChiEaeefS/v6bLO9TWwvjM5HbeFV7W0nVSOxRLAgeF1AVytLdTWfRf2K6ZsOIoLGRCAup1FIdDq+pU7SBW7X4ijU=|tiCfCe94WelhxCfTgH1AeFQ3jt2/ke/MPZRtHBYJ9fg=\",\"envelope\":\"g1hHpQEDA3gjYXBwbGljYXRpb24veC5iaXR3YXJkZW4uY2Jvci1wYWRkZWQEUId7KGTTSP4AgTMoV3yQvjo6AAE4gQI6AAE4gAGhBUyYUNFVhU5JcLbtv5NY26NiYxgoFPm2D0Bwh4FLZzbKxt7ITrd83bUg6E7jSQyrCwm1gxVaethK3Ae86LZSXvSSqezZeh7SjzXB57tkKxvOzkT8zEf6keZMOrno627VoRXB6Vo3/DV1scA4ywDYSomk+h0r7aqUEuUvmhIzPR8W14RGWYQ19URJdLH8rklBeyvjqII1KihzGGM7PWKhzOSd50eVFGhmEqBqOjcVjXVqoMiZmXQFKH4kPEkwAzqdTaQOS8tfuCj1aLUutfA5gpHwTc5EVYiQtGjhfmwX3l3pO3fCtqRcVAiwmQ==\"}",
+          "deletedDate": null,
+          "driversLicense": null,
+          "edit": true,
+          "favorite": false,
+          "fields": null,
+          "folderId": null,
+          "id": "bc020900-0000-4000-8000-000000000000",
+          "identity": null,
+          "key": "7.g1g+owE6AAEReQN4ImFwcGxpY2F0aW9uL3guYml0d2FyZGVuLmxlZ2FjeS1rZXkEUC5Ly+270uev743nYoR44nmhBVgYY3Pa37WqjeRyPR4yzNDsrjoaQH3lH72GWFDX+fL78WhcFyQmapLhkAAHcs8uCQ5224jr4vDbQeWHjdCrKKJcKVo6aAm/r4RsERfL+8hNSGiOSmsQk+Jh2cBqA3OAR3faaoGjb1qa6guS7w==",
+          "localData": null,
+          "login": null,
+          "name": "2.AGhETpc2GE35K13sSz9Cng==|/aWCfjfgh4DG/V7R1er1yA==|9whVdcguT5eqRbn2KBajEbTn0XiB1QAR+G67ppfeNTw=",
+          "notes": null,
+          "organizationId": null,
+          "organizationUseTotp": false,
+          "passport": null,
+          "passwordHistory": null,
+          "permissions": null,
+          "reprompt": 0,
+          "revisionDate": "2024-06-15T12:30:00Z",
+          "secureNote": null,
+          "sshKey": null,
+          "type": 1,
+          "viewPassword": true
+        },
+        "id": "bc020900-0000-4000-8000-000000000000",
+        "keys": {
+          "attachments": {},
+          "cipherKey": "kx9oICIFxEeX7U3bxLhqP0Bn7/Z/VrmL/ds4aYA1KTx3gGcO6i14b/uFP9onE7CK+FoMWQ6NRpSWPIusvEAyLw==",
+          "cipherKeyId": null
+        }
+      },
+      {
+        "blobEncrypted": true,
+        "decrypted": {
+          "archivedDate": null,
+          "attachmentDecryptionFailures": [],
+          "attachments": [
+            {
+              "fileName": "secret.txt",
+              "id": "attachment-9-1",
+              "key": "2.F+hsOlcuqbTvMumm3ZoHUg==|u6Wv+tP9KEjouNesfy1o4nq5Vlq+4+k9oYvXdvoJ9kmeZCjhSfDjOfvJ7hJFhc9M0tkL4KffO7ps9pbzc12fr82ZVm0T1O265qbKc96H0Qg=|rvk/geg3pFHhBXQuD4prwxQW/prX6A/xsG8nHasYcNE=",
+              "size": "512",
+              "sizeName": "512 Bytes",
+              "url": null
+            }
+          ],
+          "bankAccount": null,
+          "card": null,
+          "collectionIds": [],
+          "creationDate": "2024-01-08T00:00:00Z",
+          "deletedDate": null,
+          "driversLicense": null,
+          "edit": true,
+          "favorite": false,
+          "fields": null,
+          "folderId": null,
+          "id": "bc020901-0000-4000-8000-000000000000",
+          "identity": null,
+          "key": "7.g1g+owE6AAEReQN4ImFwcGxpY2F0aW9uL3guYml0d2FyZGVuLmxlZ2FjeS1rZXkEUC5Ly+270uev743nYoR44nmhBVgY9IzMug8t1jNISoVko2jwn0VLIFA5i5V0WFDlsmw6SZp6ZwR+6c8xhIYhqBEqX+5xOFVPZ9+EBIUADyhrczF9Q5WN94+U+BxPyUBZDhxsOmfwmhxhnhodb4WiWVhPtb4j44WKzt9s/RCU0Q==",
+          "localData": null,
+          "login": {
+            "autofillOnPageLoad": null,
+            "fido2Credentials": null,
+            "password": "v2-password",
+            "passwordRevisionDate": null,
+            "totp": null,
+            "uris": null,
+            "username": "v2@example.com"
+          },
+          "name": "Attachment v2",
+          "notes": null,
+          "organizationId": null,
+          "organizationUseTotp": false,
+          "passport": null,
+          "passwordHistory": null,
+          "permissions": null,
+          "reprompt": 0,
+          "revisionDate": "2024-06-15T12:30:00Z",
+          "secureNote": null,
+          "sshKey": null,
+          "type": 1,
+          "viewPassword": true
+        },
+        "encrypted": {
+          "archivedDate": null,
+          "attachments": [
+            {
+              "fileName": "2.ul2/V7M49yyOOhTyC/kCmA==|zbW2l3Flb/PuNmOSTFACkw==|rQOVNFSe1dZ7e/CeoDkBcAcDgS3kc038qNJxqSDmQmM=",
+              "id": "attachment-9-1",
+              "key": "2.F+hsOlcuqbTvMumm3ZoHUg==|u6Wv+tP9KEjouNesfy1o4nq5Vlq+4+k9oYvXdvoJ9kmeZCjhSfDjOfvJ7hJFhc9M0tkL4KffO7ps9pbzc12fr82ZVm0T1O265qbKc96H0Qg=|rvk/geg3pFHhBXQuD4prwxQW/prX6A/xsG8nHasYcNE=",
+              "size": "512",
+              "sizeName": "512 Bytes",
+              "url": null
+            }
+          ],
+          "bankAccount": null,
+          "card": null,
+          "collectionIds": [],
+          "creationDate": "2024-01-08T00:00:00Z",
+          "data": "{\"format_version\":1,\"wrapped_cek\":\"2.PO7NMb00+Jo8DZQyzInC7w==|uL3JZHGw6lm3EQY/tRa+T3eKOYnccyPGnPi6jjD1H/Fv651/Xwm/YlElbX+AwQubwXAgGge7Ar4XZ29W5/7/I3o6Foiva7ikfHTzZM5AsfM=|y7VXcZqqSEBVMnEkR8AI4du7rbRtT1sgWlF5p9ZmVsI=\",\"envelope\":\"g1hHpQEDA3gjYXBwbGljYXRpb24veC5iaXR3YXJkZW4uY2Jvci1wYWRkZWQEULYLvnGcubHo/2AAvpC5Xig6AAE4gQI6AAE4gAGhBUzqoOLiqt95GDUsUrxYsUfWZ2CzD1t/GsTT6BClGG4VKHMZCHJe0ylvOEWf0lwyP6slHqVbnkxepBSm0bSnuz7FYVDL1BIZXtSCj4qdkny3j6V3ybcvZrX0FSJ3+x6wjSUf5aw7vKddQM5o1dNlEmTTADgD7uJDYdNmZEeuUoZy/3+yAam1cpVR6cOVh4NhSw9VG0K9nkLgD5uOiPWrm8tk2rwHPjATP/zS3EWho2pPw6UIqKQ/KlcsBn9F+ul1SA==\"}",
+          "deletedDate": null,
+          "driversLicense": null,
+          "edit": true,
+          "favorite": false,
+          "fields": null,
+          "folderId": null,
+          "id": "bc020901-0000-4000-8000-000000000000",
+          "identity": null,
+          "key": "7.g1g+owE6AAEReQN4ImFwcGxpY2F0aW9uL3guYml0d2FyZGVuLmxlZ2FjeS1rZXkEUC5Ly+270uev743nYoR44nmhBVgY9IzMug8t1jNISoVko2jwn0VLIFA5i5V0WFDlsmw6SZp6ZwR+6c8xhIYhqBEqX+5xOFVPZ9+EBIUADyhrczF9Q5WN94+U+BxPyUBZDhxsOmfwmhxhnhodb4WiWVhPtb4j44WKzt9s/RCU0Q==",
+          "localData": null,
+          "login": null,
+          "name": "2.EPHlAkUziOhOtyakLtjNBQ==|K/yWIF9J/pq20mnGXq4xpQ==|A3O8mx0M5h2wIpGT65npmWptN2VjtPueQvKEgRjxxi0=",
+          "notes": null,
+          "organizationId": null,
+          "organizationUseTotp": false,
+          "passport": null,
+          "passwordHistory": null,
+          "permissions": null,
+          "reprompt": 0,
+          "revisionDate": "2024-06-15T12:30:00Z",
+          "secureNote": null,
+          "sshKey": null,
+          "type": 1,
+          "viewPassword": true
+        },
+        "id": "bc020901-0000-4000-8000-000000000000",
+        "keys": {
+          "attachments": {
+            "attachment-9-1": {
+              "key": "wUhjsdt09o90cvyNkbcX7cY7i9WayrJ7eNOSPdJLMdS1QR5U48N4h2+vIbRNYrJvLkVa+8P4wxtbmClbOc0v+w==",
+              "keyId": null,
+              "version": "V2"
+            }
+          },
+          "cipherKey": "5veGn2x1jUjGEjtP2sb5an1OuHM8uEAkum2Cp/goYBPVIrrmXoy9tYD0Zjm9xQbgKbyPDXgEI6Fnl/on8SQJhw==",
+          "cipherKeyId": null
+        }
+      }
+    ],
+    "collections": [],
+    "folders": [],
+    "sends": []
+  }
+}

--- a/test-vectors/users/v2-argon2id-upgrade-token.json
+++ b/test-vectors/users/v2-argon2id-upgrade-token.json
@@ -1,0 +1,279 @@
+{
+  "account": {
+    "accountCryptographicState": {
+      "V2": {
+        "private_key": "7.g1gdowE6AAEReQMZARwEUGWxVqe2osydi34PnbpIlOehBVgYBhZ6nY3xw0krrfD958KpQ7VU7U4k2aWqWQTSuQzNUgWimKZ2E2WH3CdV+byLizHgdTsloXIYi9pcPoGey/FDvGwGqyShrUEaM1J8NDokeIU5ot2MWwSniAhnL96YC92j4MQg10axBWF4g6cHTzx39nUM6oX5fduWRG/YMyWgHkHLiAr1izJz/p5LiSx1gQHQ5rSrh8S1AZ6SWPBfDBSLq3fu4uyPH9zLl759l1H3RvT23VETDCABUwS7br2uBjulRBGLx7w/THj/QRgzAmafDjENHclOzlngsIT/xs/I7weh4yVe+0fllabPqfCcPPtsCWLJXyd2qKkvvZ9YDBnn1BNvSsbQb5H0fKR2nRo5aQu0+lt6MZxtwm3lhpkitQUjpuQD/HjpLup+LquUJ5l2hMS4rn16Wy9exHXaiZTjCtKOI5p9hnEZXPaXRCBeNGyVAJDJYIEbtPM+h6PfG/J96SP1A06niSbeevs6NAvpgkWXXYxuCEbuRICR/+/vYn4HD/uu7LpEu/yNqyGxPjp5EQofyJOnHzLVF167sonuVCWtnqEAuMEOO8P3+dytxzNDYGHwYlO+jw+N0v3UjiGDyBAE5Dg/6ogk+hREeCWYba0iDbWpkrYW+ehS09qdPAh05VuY+SX3BuKxixcJ9rz95JCRt3lBqGDIj0OZdVf/MeNXhN0Yz3dGBiLLcHNgoJYBd7ZmZ5hKBBWphJvsyuSIz0WI0HfZAUS0XxcYjw5xj+oKWFZWyA8/NqorU2fDpBI64eBsxRIqSs2JcdmTbFq3uo/Zsfj+3fxVzKx4HzpVG189ddwYDSbKaWoMBELb75vqfRNdiFk3kZB5vktjDmc8Psn9FP7q8D6dcfMcfj+7MngxaV3p4CpVKYO14lxc1CSuR7e+dKIj+NYzarMNqxnNTwwy0rDmpKMPOQurnxZo8POl6eYDuz5wnaF2nAcVTT4DFXlepsU7/342k6IzN+EHPaHlWe//a1e7WPhbYL8Hxl6iGudlGVxPIj/ArwUy64ksQzmnxac7vq+KzXAlpu+OiUGfUmd29dcOOlkb/OoEP4pM1/hcHtREnzo4M2QQPsQ+XLa9yO/MgGVNCeI4vr0Jr9vAwqnD3XJOY6l+a+wJhy+iOy+OTacNIkfjHYiJUwNqvWQKlxw5kxtemouxMXks5uFzjeJSxGxSVYIqipQt0HPgUxHJwoWiU3zb/9FDyuSLUb3KOqT7awJE+8FUDenlA5i5UkBkm56QEJdk8GZC9A0wOJ5OutiJM1H12xc2BlTXmqWJNpvy9ZiiHXMq26/oiIbC533+qF59Voi81ljvKlcKcPxcWJEp5/f8A/A8VNptPNB1lLBqvcgkQ42VsZInXBr0aFnwAp1ra3j/gLbU0u2iVMqbQtYnVX/rqzmFMD4FCe3w83tgHoalNYDtjp/eufLVdWbdablMLpjdbyBCtjX8/NufyGgBAgADjo2y7BtjhzfC2KE3miI4CLenwnetZ8fKOJGAKJzQj3SZLHZH1AgXo2yAmFGXHt1pG5mgR3ZeJgsc+B/0gUa9f8qBDbym25eDTi2PS/cgPpZOnJ2ctntDWNnf8nxN38pP6epvWUu+sXr4vwm2BtHbvKh9Um86oHbAvSibrZeErDhFIfGOjh3iQGvlUYGlBv/BIXw30p0vICFvk02UQVrs30eroQ==",
+        "security_state": "hFgfpAE4LwMYPARQ0qHZvW6AyR6XjF0VGiNPkToAATh/AqBKoWd2ZXJzaW9uAlkJdPVs1wcGX6prp5EpVsZWgGBHajEl7MnVAhlrGXmvXfkbQi45IqlNVtw/cTdrOrVTge6X1X5JrusG9jLFWCcI6voMpnwShizaVbDNCcdZoD34WQIwnraCRvODbQ5CGN9AfoF2SlNWetladJJDbSSoAJ3mAKnDsE+zkDAAJVgt2oPxWTU43YxzaabhxhOgL44XiWlwq2YdmfWCpDs7Q9P8J2+W3oK2FpSb1HtyAH4tjQcXuv5ZNxmvdFDW5kZTGWzdkPYqIIZkSsEg3UsmLHTqiUOeLEsgxfc0UAdJZT0euPqEAW1T7pL6fgz4S9HjOHfrUY5cxaGUspuH/u67ULtuXmDqizw8ad5erTzG3tDIHE62hGT9Vy7uWqi1Fo7zAZO7XciUUZRUl+vVWTbkTCoHjNCHs7n8L1NWYtKFjWDdF8L/6wIYe3TyLhOxIO/7VkecBorOz3V83aB2/2UvvLsiX91+3ufoigHtDbjMDpBrWjv1Wyl+c3NUpTwtGEGKlxTOHzCi9ajN0+7W6CY6APkxCkoBQOYc09etTXpV+wtsZE7fGI7W6VFDTm16wKbA4C64ohFc4TFPHbdazWnrxvac/fQecvA4HX9Xy0gho8n7VYUEviWh2cQuaCpGOrWVF7qW3TcrYpyyFckg5ZCIw64xR0UMJ2bvISHZZkdBQ5m4NriNrrLSk25eZTD9nWVm3EPJMQ2QGCcKi0ktnBYBiWGUcHG8pJNMcD+Ia2OJK3Z5qRUq7l+wTI7aRs0esJ4YpOvQzizAzIrd18VpqLAzXsuafNicTpSqltMy2v1CBztBvzmMO4ypjyZYD7/lbAMhSyBZUnri7ehuqwcc4/yZ98fks/Qlo+P0+fVkdIaIgrmJ56XcMyT+vUfJ8rVwGinsYO4cCA+eObcw92BkggwCCo/IJ6qnHPLGBgvckW5776Aum7O8y9dimX9px9Pwcwf2ktXaivUpjaT+eGDCA94mxBX4DRVhng0jZNmTf2aPcr6B3FJBGpiCUS/PIKqEdA70cprdnyT0zuqN2yUWuOAZxMjzMEf2jS1LEXBee7aHJ3hetCrSWX7E+a5NVMI4L5RZdVY9adJUbR697evf3kUawOOWM5BbeNprne893Y8Tbf6S3TFAEoUjlLbhi8YV7ZKVdP2hyKirepv5aW18LG/Yh2qJPrgCtv2Iq6ycY8IDHs+K0z3CJQ1Bvkl438dax1vf3lwHfUhlrFmHG4mcbA8ERcpS7wlwx39YDn1L7A3rCypCOSqDnq/8r0b9/scs6T470YNPmEDsakQl/BFMN2a1cQDxmCZJL0TvCVud12geBpWN33mD/TVM7Lc6e0ZMCz97jkO6eRy5agIlD2aY/F2GyINuQwJTyuKFQwtd45AtVhXbHufMzfX5iyslWHLXuIzVg1Ay3QRVDiqshF7gZ39EQa+3z8Z6HP9ByeGB5Uu0J3osBR6Slwxq8oVUQwxbOp+NuKrsSvCOPrRmAf3P4JG4RvYRi4/Xvrvzh+cKyy1u/lT9r4b7Fd8deWljHXpe+rdm2pg1HlwHmHComneW6D47YsubGvslW9lyPzYTogxu0rUFmwmuEb7aWJABYfF8b6X9lUZO1bpGS0DKTsNpobyYGT7Dcu882pGfNGmcBGZ18ZgVR9cR7jhBkC6zvZrtorK3OUCfsI71yzUSuPmXLxvUjKMrxlioNCVbybB2RrYAh5INgpoRV2q/Z+Par5vKuINo5BD+8GyH7k3Aj75d+0sglt3UGW0GnF2VBuBzsYyopH+LEHLz8PNWBfsGyq92FP+kKSfjZKIlgKoXFgA+KCQAer7ZAwKZ99SqBhQzrOmabUfr/UPCw5zFFWu7ekQcVOglk+mXK8mEiVb2lEIU+SlfbNZKgYgq0B+bUeVSDCNcWJH8fpsUq6ymJ8eKiO7q28kHiFc8fjxVp2NK7mXtaoNNGdWrO66nlx8RPW7EkK+OEi1JAFvOgUvVmLIXR3GeGlHRn0MoMYGEq9qfFKkSm0Gp9sewUWIf8V1tC6gpI9gKqYZd9onVHQbhdW+tgrQSaRqZw+VOpas1iTSjQptXtotyxywnckjEt9nhL7bpyV6ltsPxQieHPrCZkBPk8Nj9iYvl61Sp8zU/QBS/7ctdJ/as/Wt9roe+FRHxDdyHDlI0PzFdGQMqmrQ70jrcZqhACPMbG1rq4TGCiSeLq5H06EqRjZEpIpdx3N4xmgawX1btWZuuTauUeKId/2hzSzhAS/m8Ri0TNJBHjdAVTCPPM7LWh5oKiJPOsNIEka7kRhzHlwborgSJ8fjkbDKLmzRn+18kznQkzVLH+iRUomi/uizS/ZoMWWmOaCkIftT3s5TV06eyE7ykq4MPOS4LM194dS0hrDy9jNR+wG/Tac2OYXBByT8NsFLJWYDk+8Qi/eOt4MPG93pK5Zz6JLbx80j87FiHM326J74+8QRqWlJbtHCyjbb4H4kk6eapHs5U+ek9z7e58P6GMJDTzJXIFix19lpvQI2nNt4V8upmfXxY0dLg8HYuym4tGGdAsUZ/Wn4+iuSw4au+FqsC3t1YLo4rNuf+eRAydLbkVK2Y0iW3KHSACIZiyfjjROIqEeX5eWsge7Aw19EI6nRJQqFxjeIW690H1ksdZe9h79XavAcu8vSoLKqERAu5jyebb2aXihb4WVNovvyHR0h+K7p8IvCQITGorqdKOoBg2r99qNwjS62I1P8+1OxKM2xwIACuLV6/SkuRQIQ9GMLsKXeUfwCIm6dv94R2hxj0zDqcU3cN0T8r6jsHk2sDoPLEzqlAbr5GLIB/FK0+OULOYN5ofhoT+dLiRm9CCqJiMmWzbJTWqDXqPbmdvZr83anuN+RvsUmM6UUmDP/0tjGQtNnfolJ6pOBSm1ZAHWT1/Qv5r2mEwj89Ufi5oLBCiJNkCqEQkUe3kcfoasOzUYLuSd5SNP4c4BqRyYexKs45Zm6rhVwrAq1alIilK+b06Azf5zI19k7SFhB0f7u7yf8zMDAfsRV0MBfqkMltVGnEkS4MjTU/JnyUtSay3Es9KEerGMGAW24Oa6EyjOoi8n0nJLirrwqTaL1d29JjRwvo55m3iIrlyhDQXinVMchgBtxFDzkETt81h2EEBDk6EDRVWmZoiZ2hpb3DzdDh/f8DETVCRkxphq3O4fYIFiFYYGx4fY7N1eLzIyw+WGKizdLg8AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAARHSo0",
+        "signed_public_key": "hFgfpAE4LwMYPARQ0qHZvW6AyR6XjF0VGiNPkToAATh/AaBZAU6jaWFsZ29yaXRobQBtY29udGVudEZvcm1hdABpcHVibGljS2V5WQEmMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAw6ScvXdtZ/L2i86lH64849wbNrRWBQPeAMzFBSHQ1eafqZtm0XtIK6jpWpYAub4dJuV7zf29Nw0V5E+aDnI/sEChClkS3Qvp11U4GZjZcfzuduioVrINH+mjt2r0KVXNrBcGpcwv27+6ybzUXY2y3//hoofRU4haU/tT+0pMZJS62xH/3oJvpxLUVXCLQEDmfsCjP8e7pZeR9nl1lXoxEiaxHJv4ZcLTRD7r2tKPImCACMe5ZP51rzHbVWBZ4VGIWesux0L3vgqLWSxpCRiyAeIav+iz8+yRT10LGxZsuPqV/BCh/+gnggdxuipH/1Q+RnClBEZHa2eSavWYPRcR0wIDAQABWQl0vvjDoH6Si1ZjDT+R/AQOEnE20UpTdVL5fzLp2VkRuAAr1hIMMDkIso8zKmtJiM6TUzPhkhYg6n5Hp4OrUPK4Wz29ei5wWJ69+zwz1kbRav+aUdGnQ0JnP+oBnRisarWcl6xWoEKDzxM/I5Oog8N7QwNOFm0Ank2IIjW21+T+d2OSdDiegWQu3kNKNRVFLHsUZjmTFzqbxhGgXlv0LcPkEzPc3NdiYkmsYDRoG43GfrsW/+33+cWKRiuTFDOcGRhk+wbOfFQ4h00wsFzOmx4Yu/ebycjYRtOD1Kxa2oiDsPYVOE87GArQS2JyPZEOiEkfKMoysVDj5zno0LfoI7rxpYhGpU1ezLT9oHUPbIV7mASNQzDiI9+OK3hGiVEAPeW6qt9dneTZQBPPOifgOdEE214tAgUS8ZSWj7pXoQIv/fl1Iu78Dme7tGIAKVUmHZGfkiZcZQAevCRlCStSqQUOGby/nWKht0qz1lZF8N2pM0F7iHbvyr7Fs1uY+fCDGlGVbImI0FDYyJq0sRmuTPvwrL5xTatVb2R+1yenAaiwHxc80taCqkvODPDxc8sKzaDbYF7GPPyBrbpls/cC7dYyG04gymx4s5dyzlKdiWHW+l0GH+Uyq5C0i3qpW6FUqVU4KRfjePLMkrP3OpRsqnKuEB6bljotG9xdQeNkrtXpot3MKiy/KZPcgWVLocBhp7HAiUxpuE/BJKmfgcZK0caY44BSP5LqBjW6iyXF5bnWIvdC3ZoPRtgvosIwzC4WYVsUxT9hdEoNjEd03DNY9V4/S7O52Imx9L1jA3aNPxOJEx5/qNZk3luLYpVnJ4rPUkO/LtpGCk2U3y9UM+usW9z53dbiMp2goIM/Ti4JtIWK5EU71IAxwY5oa2KLpmxbIT27d/qOKj3IPnZgwYyPyXu/RDPhDp0doJs0C/b/B0juseiHBsiMaZKcJoA8xNEZLmi1iQ83OssvyPwFmZxRFYR5hqtv/zGs2xVexxkv1tgEojgk5MzVqp67BpsVGvunwbI0gy21zaflBNYKiAz5zNgCEH7NqvUk2RKdyPzdwqbo+i1Enex0UcMpk0/A9wXHQxM/rdP7jMC1EeqpCxT+D0Zw1RiI00iUb8ZsSBgsHWl/OkFRMtgD2s1Yjtkb++5PjjmIlepimjjRVB1i5A1gwn+ywy6RnCe5yhke3kozmEmKqGUWbVUTo3Z7QuTOrnDS6UmHoeaz6m/+bsbkL8rsEbsLcxbhcMiS5l9quw5wbfEogVIBhts2FZFrnrpRqAJGZRH/GjLbj1BS26lgBCWPqfC4UgGcjHgE5SxiV7pqAoHVdSM00CeaJ4Q6rvIUaxSh1LCwqVV24dpi5T2S7cPE7yHNQnx2xyvZEChPApu/NtPAu4FuAnGjqzv0skexXsLCCiRgSQH2d/O8LWAaIWCdhcumF7p0Gy1SXFWFF9kcIc7OkkBKyvbojaOuIKvXan3tlaVqpVWMrueTMAz2nXqGmufN/eheFkN9w9SjqLyiCq3R8dsNaxTNnoYt7U6bY6Wgfng8tBmpvrmqrGSOsdTpenEnZMw1OHHK6UZi7v0D7wnNLls5OUcqIemKmU3cI6w0YTWsvq0HxFT+3bmqGLG7xNVyz16q3YW+w4E7PtkeBZJdygJBrol1knY3Ub6mmXadV3djLW/kVOpaADwmU1u7E6nZw8HM9VR5ysaYvezUqn7COx2GDQW+B1LHofeDMTUkotlWIB66Jhs6EiTk0Dyf1Z9cmYdRtNmT2jGkO0fJ7rlY9OTTrmKRJmrPAYXts2rAM5Bm6qAMHXMsgO1p2eRQc0Dkd64rZRGknJQvbDHuZyzCEJRdxCWmo3/7QV2gqXvK9vTeHkWeqzt2zZ54TEDxCUxV+rPFdqkAIyRZrF30jnUkPIhU7LI6w8FFYtM4jR8PBoORXqVdzVTIyH2+jE2TXggjcrSqkn9D8mlPUv2yMA3KDhGk4qJnHAv2oF8W8zgprcPrUtMcXp1OGbdBVWxaQAJ1XquJYnbioLzZZH8SVc+d8TERTho9GdBxGCvSmbl7KuMfyYr4f53wcyhFvPO4GBGVnXqadUEU/BhzUMxxutLr0u4IZhUY6rBbhZuz5odl2fXDzJ1LJfCVjgPtk+YjEbjWXVWkqT5Q9jZZsA+xwNpuINoJJcqfwK6n9of6PcVf968IG7ErovbQhMbem0RpmFpJnybiQRa+Aa5FKv71ig0PriqoJzRvPIAypdb+s2LFO7UgDG4cEPAKVfy4o8Ocoft8uJebPNORJwnlZtZwxOVzw0+ccOe1hF45st3Bjq9a8z2iafRQ7e+tUJxeCO9kofZo0qhqPXWs0w5xEPYEoLoBUPwRF/vlB6r4CaHY7Yrd8ADngtJ+DfNueX+YqH2zL3nZvy6MGI/9xwNB/ywgmtVEXS7rM09Nwn5eQPb7V1q2arrlrqWK0BguSG/hC4EdiGe8QOeQoWxCw7g7RADZOUyzmEJ8D/7N9PpR8XcoV8Ue0fFpdvquQiVsy52/iVnfPnJOOd2wfGDgy6gok1yiBBx9PxCVhttDq4A40WEFKTn+tn+25DPoNFXC4/jLNVFSePFn/+kYCqMYLYjqPf7I42f8gj3oFchyCw9TQTyvL2J2wGddd4+Tai7oJlRJ/Te8DE2CdZibJbZ0U+MHI6Zjk33YD9kYXWKz5kv8KRMDIVeVAiWh07TVIJ3qvxFdvge4N9gEbON1NYrk/9n7ApThHBK4WhnHvCMA76qrbhV52S/wZuBZO9e7hFGHp1dN9jIO++8zhoW8U2iiXeOmdusZ5CRx7x4l5TnxqXeWyDf9rtKkvp+PV4RBXGV/3NHsYdq2DfHo+UvJQj1JpOmqbCVTPLcaXmqJC3MOiKDUXMAuRO8NBb35wreWOQWaaKlgIaq6m139aqHY+zPii+jQGnvizSMuZOd/31cc3skKMIWO/DxD1Sv7O0cHjwWWgR3+0xz0dmKKcXnvmTVKdAHUNTX5dJvx/HNlgKrq7FD3Y7wbsXpwpZa3P9cIsivscyqL9arTQzzJnTl9EUKyXeTi94W2NglhRSLTMKeSGvX9M6lYor2aBPeREQkT9eJKxpCbXK4lO22CRUFSPH2GqWeS7+qcweCxsbcGDyQmUFtgdoGOtcfT3N7v9iEjRFFucnyKjpmmtsfl/w0QMUmAl7G+yNj3Aktco7K0u9Tk7gAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABEgKzU=",
+        "signing_key": "7.g1gcowE6AAEReQMYZQRQZbFWp7aizJ2Lfg+dukiU56EFWBjeRCvP+aG3cjgkV1/fybwi2ftUW9wSk/JZBXJHzxPCdIP/gUE4OIJtVOT7+uc9lbbbEwb0HYf0TxF3DztvXY3zieNL8/nmcQhATsYKYTd3Vft0XAhDSIPqgZnrulm5BBrv6EBd42Dt7HMAbabSb24Lh96GxHiuEe33t+mZcs7Vx/k7QMtkju7sGWNdOnMvOZh9pzO55T8rO8zkpoygVOJQjKl3fg5nyuyZD8k59D+X9oNXeVMKyGMRkeWrdgY1+z5Zg7e58Kn286QjTniKxq9trIqriuuwAA6PT6oAXoCe5Rsal7QF8AjOGTKjlG3dE1kjCgrW9m9Zq7N3wBCj6zs4OlQMNGerO95KgJHlGECebfjgYBLGCbRUg/kmsjGhW5h+jP6+XStyDUXLiVzIIhFYrtrHehkb3onZWn6tcPBQGhHjt0oowGDRfm/3G+JgbURNHQDHHWcJ1kX25OcDWdi1dMJOLB50b/eWx/gxk9zjOD0i2udd0BIkloxtlGHyDiohi7A0g/+v9FQ9D7zIpImbGcnGxJCcAcShUy/6sc+DJ4dTPvrOgRoVX1G+r6pR6E5hvUC1hfZYZCuGgptrIouhq+UOqlLXR4f2H0f8to5/XIqESb6gpGBLSMFI8wJ03D9JY5H/inJ7W4oyUiG9JrFNrrZsNK8QUf2Tfj5esyktU9MZZj1BNeKqKdvFgFUtsJx6s68PdApqdnUgP69jwD/4f1tPabolg4dFiieo0ZrHFISUCVWV9kXozuzArqFN4dhp9iD2R3u8zeHYPkwAXxotuqcNmL8dRRBhtjl8HpKozXR3cCtDLy1j/IayaBYJCxWMn42wij6/Q4AZX7fYuv7OfOIJV4uXg2EpL9yXBTa+Hv0/22qeSZ5wxwT2KA4XL9idK+Ln+KJknJtAwOV7WVHzqDo4tYmb/++fjPzedjigHocwDbHimx9Fjn/Kdff0t8QRYBXbVK6EgPFp8NpJkIMBTkYoXKLi4PyDRCmyZCyaMSkV6IJ6aBeh8G0tkFRvMNB76CRJkUwq2EFc2xVevbwEqNV31J+OAjqwX5l2klPTsk61uGON9IUugLrVbFfV06vr9/bZV3mMwbtZdIfgeNJbE8cbRnUpxD58oocWCnHW5o12cwctX2D4Byzd0lgIEYcC32IfJWgbIkYb2O3htTBG8YMkisulRxTgfZSLC7ykarZhWNhIJcBsTm2dPGOMZuja5OzE2RDs3xyIK5axMU899BOaspV7OB5KUFsixEc4f8Cb2/C8ZodoWh29POpUl7kPk1aeKU5+rJ8JL+BF4spWhTyy1RGXLj1zdFO33P2BTUnH6V1QMrpkCjnZAo0IEtsoeRb9KfWoKv3tacIH7iHjn2Va454ROwCZ9Nx1OBoP9NGb6/TCVGVmbdGPSfXHklysETVc2Hr0LXIcgTfhDRcAISO/6R8Ob468EAdE4II/LZuGQDp5deggsrFscrkiU7vUYsIxyQDaWOLdsVDZUGda1gZH/Nxg/vOWPx0DafoljqnoPZvZDQaZbrBCBMxQshQrUYAy5+Ik+6ShsRC2sd25yhWVvKzJlVPfm94laU6Physqfabc9c9XG4ZY2ijck58ooN/wDh0CCTVZgAgSKCt5K/XqZSgG4/9LdLqFUiYitAz/ifcbCQmmDn7vJB5fKM3JQAYHOkr9hklnOTC5G6qrHkSO7QgXaCQk1qErhB2wHlxu9q4qcb37LbmUVPLn9GcCWch1Z1MNyhX1v+vwzJEEk409l+ufb+wekPsNaXs9qioO8LzNh+rM5Wn2weFv24tLwq0+nqZKwRJ+H9MIvSVEkT5sbXqcSAycJIUtovZDG2nMgFxzr1hbktF2duDswdPslBfYPQROc0gk5mWkw/j/M9aC7QUzIRsJKOmIWg=="
+      }
+    },
+    "email": "v2-argon2id-upgrade-token@test.bitwarden.com",
+    "kdf": {
+      "argon2id": {
+        "iterations": 6,
+        "memory": 32,
+        "parallelism": 4
+      }
+    },
+    "password": "password-v2-argon2id-upgrade-token",
+    "securityVersion": 2,
+    "upgradeToken": {
+      "wrapped_user_key_1": "7.g1g+owE6AAEReQN4ImFwcGxpY2F0aW9uL3guYml0d2FyZGVuLmxlZ2FjeS1rZXkEUGWxVqe2osydi34PnbpIlOehBVgYDHmZUIK0oHA37FLM1AHCmBsc9mfyw5uPWFCJ6RL5HLlI4HeGglvFA1ZJfzR4xocqURZ0P7fSpMoywPcLJevn01dr828NQc44crqrKybrwd8MURcQxHOIxLEwvMf5AnqOxnrMXqnXN4Z/DA==",
+      "wrapped_user_key_2": "2.BI5wj6Czi9WqMXidoihmhg==|MqlJk4DNqX+vwCWumdsM2ewrjRow9KjVAYLxLTVcBcqfsLMW0vwdwRM223NklwhifYW1ktTRfmW/WB9fd8ba5VFMk/j5fd94DMAWocXQuZE=|nyWYPnumTZcQ0XSfH0zXeOU13Ga9CK0lotpmLUl11rU="
+    },
+    "userId": "bc010a00-0000-4000-8000-000000000000"
+  },
+  "description": "An account mid-way through the V1 to V2 upgrade: a V2 cryptographic state and a V2-sealed blob vault, but unlock methods that still yield the V1 user key. The V2 upgrade token bridges them, so unlocking with the master password still reaches the V2 vault.",
+  "name": "v2-argon2id-upgrade-token",
+  "rawCryptographicState": {
+    "fingerprint": "comma-scabby-require-refuse-pointy",
+    "keyPairThumbprint": "bf2ee1c745c1037c234bf0f7a29a400c342a7873b7418d9dab7d9a26f7b2e721",
+    "masterKey": "stAgueFHq0NIxlQQxmPXm/Vp+9RaFRzecsY8Fw4Vrj4=",
+    "privateKey": "MIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKgwggSkAgEAAoIBAQDDpJy9d21n8vaLzqUfrjzj3Bs2tFYFA94AzMUFIdDV5p+pm2bRe0grqOlalgC5vh0m5XvN/b03DRXkT5oOcj+wQKEKWRLdC+nXVTgZmNlx/O526KhWsg0f6aO3avQpVc2sFwalzC/bv7rJvNRdjbLf/+Gih9FTiFpT+1P7SkxklLrbEf/egm+nEtRVcItAQOZ+wKM/x7ull5H2eXWVejESJrEcm/hlwtNEPuva0o8iYIAIx7lk/nWvMdtVYFnhUYhZ6y7HQve+CotZLGkJGLIB4hq/6LPz7JFPXQsbFmy4+pX8EKH/6CeCB3G6Kkf/VD5GcKUERkdrZ5Jq9Zg9FxHTAgMBAAECggEBAImkmpHCIDrt+P9Ll2i+kSBOjubh4VMN8XbmmgaOT/rtko8lQiVHcvMkl2if+Eq1spTXB09ZoXHFxw0l4+EeCCjcj3BUUq0p4I8a6ak4nGNR7APElArKoek9220D1lvufhEA8jBbg6A7OBMOwuo+8wYdZIWQwHjgiYxkWiWFlFF+Br+QRLXv15J6yut6rhViVkBWoLCnKhziTwP4ttRWYDl4kdQh+5zU4f4WLjPj6VJfmvnDU9gkZTX4TyGsUF1DNO9ngl+quR4m9mEO7msI3kQDaaei7Mi+ca1DNovS5hN/yQN0xtEG+RYljByh9Y7gmTslxQynCk8qOQa0DB+o6iECgYEA7NcWnRzT76a30VmaiyVOF8eNhDk84KovgNKvAVxn316nVUthu7X1YRP2Y1ujMx/p7zz05UKhkRKTWwWlf18DVBfK1zCtBkRsw3kTx5AUDzXQvC0Kcx+Ma+USMSESElkXBhs/o5y0JWw3rmhL2ojlGyQVsUy16yE3cvWbf+rxAycCgYEA03hWxe2yPrHhAueM7M43COM8FnqsMpKwpUgU1nJAmVjtB3yir6VLiBHmnQGVOV+fpO6RQnKrFRo+15SrOsC8kb4XzdqxnGkowpE/egqT/G06LgfcS+ngvlLsgoYlY5mfC5XDXfxu9eiaKSgr7IOdOEGQaEb3FOYRbeqst82q93UCgYBXGN5LFv/loPT2ezI3O5fVbOBhIL9/i3Z+tHwBTx8v6No2psshQdAkTDgO3/NLaNAZ19vjt7Y86IziK1hqV+GcekdxDYiDxoQM+qjIefa2hT7nBNVT8uUsBIjFInlH4BV0fG7R1130aTCs5dQHYNKIQaPsmN5JwuRmVWZDC35ofwKBgARfSZQADR5kuR1BQlWnEdY6NITWdnb5N3PDYMLqS9Gf2A6+kfKFvWEL1bPLU5WDF57mW9R+4HCoQUJdzYiCcaOlxYI5ElEEj5YuQJy6WULv0zMecHyVUlM9DazJLz6272Xi684mqPimnYFaVkYmlnqSSHUPeo5RD20xW+7U7sL9AoGBAKXY6bpqAKrgMyUm4nLs5whE6AgzrJHaAKewbh5p1rnRye2ZE6Fhg3R/Uu/2FKkN4tyumbKR73iTwz2GWlpVQo1Uw+Zt8EvX+uVy+o1DQTRivyRS9Z9h07bu6KogvOc4HY88f4verRrxWpIgpELMJj5XeY1BMKuroUthDslLTAYR",
+    "publicKey": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAw6ScvXdtZ/L2i86lH64849wbNrRWBQPeAMzFBSHQ1eafqZtm0XtIK6jpWpYAub4dJuV7zf29Nw0V5E+aDnI/sEChClkS3Qvp11U4GZjZcfzuduioVrINH+mjt2r0KVXNrBcGpcwv27+6ybzUXY2y3//hoofRU4haU/tT+0pMZJS62xH/3oJvpxLUVXCLQEDmfsCjP8e7pZeR9nl1lXoxEiaxHJv4ZcLTRD7r2tKPImCACMe5ZP51rzHbVWBZ4VGIWesux0L3vgqLWSxpCRiyAeIav+iz8+yRT10LGxZsuPqV/BCh/+gnggdxuipH/1Q+RnClBEZHa2eSavWYPRcR0wIDAQAB",
+    "signingKey": "pgEHAlDSodm9boDJHpeMXRUaI0+RAzgvBIEBIFkFIJlN6H97zY5kugW8OIpqJM9m6sp6CWARbJnlyTA2M/S32tydwro1VdMUM0mhZ4lKaLaEkKBg12kuH5B3xUR6LNdA6MXQi+6pbb1iyXqF0T4TgHtK7NZE3KNdyyNjJCiYSm+z4G0txXEY+9/PzVXnFwhfOMmvAu05LwNK2rVHn5cDH/PT9zir7D019xJMpn9TmOD1EiLvp7CxgLcE9UTmSWWnh6NaL26HNL+jp3AvHlfyzCWbLl6bUdf3rbpfCzQTCYt14RprLAcXiPjgRvIZD10f6NsAupuF8mXPWqW6IYPBO6EGn9kYnMo9NSFuyb+P6donasbIxiG+dkNpAkBAKlkbdyy5eYhFrFv9uxHHBVZsvhdu2nX7nUxZPNITHEXAUwPfk03AaEUEpzgm0lpkJ0iFOv8nc9x1PqQuLVVJwT6e8qisSDQbnVSvyhTInaZ7O9N5wtzkR0niNDvpj13ZYlKmdXdtNXO5FuJEsQt/2TTkBQvR+py+NBUxCCUVm4aG5frc/pcPrE9fYWFeM1v6i4ghDDMxlBm80wfZsW9c5hVYS6G9O6dyByVXHwo94mOlhcaSjnyLU0IRx8U9WKEXj1Ce/05jKRuFfrXMD6SgKdJKzKIv+OIPh0si6cDZYeNO9NckTKB4hvCFNfTvPBSNwBTSXV6b1ZHwti1snRqxfB9syM93y7ZBmnjdiTThtUiXQvkn72aZaoqmmKS9vlq66tAzsfCUcZypl7pTCGKgKvBIeSYo+akOIV72aUc0e3O3XFalILjKkJnHqv4QTIsmG5VpH4mPNkWSxQL5P9bVFiB0PKVvktod7ltj6KXjP3GNcP/vTegX0QNMfmcS3EjMSO9uwxhH7KmGM41YbH/uf6sicOJRkJcT/EX4a4BzW4UoDxuD6kH0xVw3TVyhIrEUeMWkXXMykDv6pOjpnB6ETbtsiSVynSZHM4tsyT8XurBtVZu8ypY8okTN32rV2c5N/SGOodIEDEMhwBsLWKfdGPsaEAKTVmdmV1u2ACvXy3d4eMXDNl5QHNe4lUJXlnwLaBAxY8ZGydH0ObXrzhBx1fmhici+py7s/qK8cOIkjaTnMR+nL95mKHVgTmVXfUpZ7Mc7GTFSCOF4ZCNmbK4Bb3BFeMeoKCPRpRNYT3hoh8+rLe7jyhiM4voeLMjXK0Eh7hScaPcKHnq559s5TjW/Xs4WS8iI9C47ilfPLvTE6fxJj8y+iLblS4Sh2GUAv1o7OmsCrE1Y8fMft9GWIRdOzhEbh07WD+khVo0lxVfYCcs3fT2CKoQW8hICHZ0H/ZtJ6wJXmebQYb5bRE2lG4zMlta7CsUnL5zlvZfWuVVa6slOjVeAsN9i907v/xce18VfkGayKCJIZLUD6a8Dkm4n6CcPTg4t1Bt3F1AAjkAba07lV+ixQi1efxG0Olw0CO2BcsdG9LJrXkazmpvlsbjRU2VQG+1psuYfzw0VxT4z3zoKlLoen64bgVFWuAUMUIUy+rlfqwYMi95UoZQI3CVdeGyMYlZYA7BTZjAka4OGhwWpYIZk9E8AL6rXiM0mjBdrsTBhdSgbuAWLE2Ngx9Fhrx2U2qddg714Peq8nDPQwWmtVG/eUimST3X+Kdg7VIvVwo9wAQKAkeDMH7/E0sSaYypLh238uQzo/mwXHc7fTzujU43fEP16KtzqP8wmW1TjDELZpR17JtqhbAKtob5j39EYSF8S2eIeQXez716Jt+mmkHVt4kryfs8YzafmzgTOJY4hWCDN+Ro+tCRQ25KWiNXw5gcQkSClV3GhaNhdrk0Uwisa1g==",
+    "signingKeyId": "d2a1d9bd6e80c91e978c5d151a234f91",
+    "signingKeyThumbprint": "8f9fbd6afd2731d9839f22a17183de5a6f24dba1b8524eb3d015d20d6b7f9989",
+    "userKey": "pQEEAlBlsVantqLMnYt+D526SJTnAzoAARF5BIQDBAUGIFggXQ2sy2zxBDi8x8vjUz1yWzbg5co1Lyhmr2UYqwnKewoB",
+    "userKeyId": "65b156a7b6a2cc9d8b7e0f9dba4894e7",
+    "verifyingKey": "pQEHAlDSodm9boDJHpeMXRUaI0+RAzgvBIECIFkFIJlN6H97zY5kugW8OIpqJM9m6sp6CWARbJnlyTA2M/S32tydwro1VdMUM0mhZ4lKaLaEkKBg12kuH5B3xUR6LNdA6MXQi+6pbb1iyXqF0T4TgHtK7NZE3KNdyyNjJCiYSm+z4G0txXEY+9/PzVXnFwhfOMmvAu05LwNK2rVHn5cDH/PT9zir7D019xJMpn9TmOD1EiLvp7CxgLcE9UTmSWWnh6NaL26HNL+jp3AvHlfyzCWbLl6bUdf3rbpfCzQTCYt14RprLAcXiPjgRvIZD10f6NsAupuF8mXPWqW6IYPBO6EGn9kYnMo9NSFuyb+P6donasbIxiG+dkNpAkBAKlkbdyy5eYhFrFv9uxHHBVZsvhdu2nX7nUxZPNITHEXAUwPfk03AaEUEpzgm0lpkJ0iFOv8nc9x1PqQuLVVJwT6e8qisSDQbnVSvyhTInaZ7O9N5wtzkR0niNDvpj13ZYlKmdXdtNXO5FuJEsQt/2TTkBQvR+py+NBUxCCUVm4aG5frc/pcPrE9fYWFeM1v6i4ghDDMxlBm80wfZsW9c5hVYS6G9O6dyByVXHwo94mOlhcaSjnyLU0IRx8U9WKEXj1Ce/05jKRuFfrXMD6SgKdJKzKIv+OIPh0si6cDZYeNO9NckTKB4hvCFNfTvPBSNwBTSXV6b1ZHwti1snRqxfB9syM93y7ZBmnjdiTThtUiXQvkn72aZaoqmmKS9vlq66tAzsfCUcZypl7pTCGKgKvBIeSYo+akOIV72aUc0e3O3XFalILjKkJnHqv4QTIsmG5VpH4mPNkWSxQL5P9bVFiB0PKVvktod7ltj6KXjP3GNcP/vTegX0QNMfmcS3EjMSO9uwxhH7KmGM41YbH/uf6sicOJRkJcT/EX4a4BzW4UoDxuD6kH0xVw3TVyhIrEUeMWkXXMykDv6pOjpnB6ETbtsiSVynSZHM4tsyT8XurBtVZu8ypY8okTN32rV2c5N/SGOodIEDEMhwBsLWKfdGPsaEAKTVmdmV1u2ACvXy3d4eMXDNl5QHNe4lUJXlnwLaBAxY8ZGydH0ObXrzhBx1fmhici+py7s/qK8cOIkjaTnMR+nL95mKHVgTmVXfUpZ7Mc7GTFSCOF4ZCNmbK4Bb3BFeMeoKCPRpRNYT3hoh8+rLe7jyhiM4voeLMjXK0Eh7hScaPcKHnq559s5TjW/Xs4WS8iI9C47ilfPLvTE6fxJj8y+iLblS4Sh2GUAv1o7OmsCrE1Y8fMft9GWIRdOzhEbh07WD+khVo0lxVfYCcs3fT2CKoQW8hICHZ0H/ZtJ6wJXmebQYb5bRE2lG4zMlta7CsUnL5zlvZfWuVVa6slOjVeAsN9i907v/xce18VfkGayKCJIZLUD6a8Dkm4n6CcPTg4t1Bt3F1AAjkAba07lV+ixQi1efxG0Olw0CO2BcsdG9LJrXkazmpvlsbjRU2VQG+1psuYfzw0VxT4z3zoKlLoen64bgVFWuAUMUIUy+rlfqwYMi95UoZQI3CVdeGyMYlZYA7BTZjAka4OGhwWpYIZk9E8AL6rXiM0mjBdrsTBhdSgbuAWLE2Ngx9Fhrx2U2qddg714Peq8nDPQwWmtVG/eUimST3X+Kdg7VIvVwo9wAQKAkeDMH7/E0sSaYypLh238uQzo/mwXHc7fTzujU43fEP16KtzqP8wmW1TjDELZpR17JtqhbAKtob5j39EYSF8S2eIeQXez716Jt+mmkHVt4kryfs8YzafmzgTOJY4="
+  },
+  "rngSeed": "q6ytrq+wsbKztLW2t7i5uru8vb6/wMHCw8TFxsfIyco=",
+  "schemaVersion": 1,
+  "unlockMethods": [
+    {
+      "masterPasswordUnlock": {
+        "master_password_unlock": {
+          "kdf": {
+            "argon2id": {
+              "iterations": 6,
+              "memory": 32,
+              "parallelism": 4
+            }
+          },
+          "masterKeyWrappedUserKey": "2.9ZNidaJdL0xBm3eY+3PzxA==|/vzcZzovBKk+tlbq/n8hgmAgB7OcIexwzXOvD/N/hJrI/hPZO66dDgMP+k5Ov0lxapxocuLYWIDBjMBM0w+DRQJ2mFA1nqK5RGhwIAMYKp0=|6QlnqO97RzjxkAl1sP8x5xJTyhdRRClVNFoOA29m/zE=",
+          "salt": "v2-argon2id-upgrade-token@test.bitwarden.com"
+        },
+        "password": "password-v2-argon2id-upgrade-token"
+      }
+    },
+    {
+      "pinEnvelope": {
+        "pin": "1234",
+        "pin_protected_user_key_envelope": "hFg0pAEDA3giYXBwbGljYXRpb24veC5iaXR3YXJkZW4ubGVnYWN5LWtleToAATiBAToAATiAAaEFTLVplvF7vB9+eIyUPFhQIGOPZ/CiRyotrrQi5iefpQbHN8Mb3mKLNcpkyMQW9/G2I6iyKRvYmtIzLm8ie1Sta7S0gzwd4B5x4vLEnlr0ibFuM8A2CVDxOuf4KgwzQ/iBg0ehAToAARVXpQE6AAEVVzoAARVZAzoAARVaGgABAAA6AAEVWwQ6AAEVWFDN8NLMYhOwdMyLxPoruq5C9g=="
+      }
+    }
+  ],
+  "vault": {
+    "ciphers": [
+      {
+        "blobEncrypted": true,
+        "decrypted": {
+          "archivedDate": null,
+          "attachmentDecryptionFailures": [],
+          "attachments": [],
+          "bankAccount": null,
+          "card": null,
+          "collectionIds": [],
+          "creationDate": "2024-01-08T00:00:00Z",
+          "deletedDate": null,
+          "driversLicense": null,
+          "edit": true,
+          "favorite": false,
+          "fields": null,
+          "folderId": null,
+          "id": "bc020a00-0000-4000-8000-000000000000",
+          "identity": null,
+          "key": "7.g1g+owE6AAEReQN4ImFwcGxpY2F0aW9uL3guYml0d2FyZGVuLmxlZ2FjeS1rZXkEUGWxVqe2osydi34PnbpIlOehBVgYXJUcKt5Gx5M6SSn1WYpz6uPWqRNgKWvNWFC0v1SLujv5UMktVoYSTra8zU87ekqmc4IrJmSUWu5Iepef8HTR7dGJbABKrxAVp6yUhboMHQGG81/RPpQEkCaaki9SRLsPMiK9pc6AfwZBug==",
+          "localData": null,
+          "login": {
+            "autofillOnPageLoad": null,
+            "fido2Credentials": null,
+            "password": "keyed-password",
+            "passwordRevisionDate": null,
+            "totp": null,
+            "uris": null,
+            "username": "keyed@example.com"
+          },
+          "name": "Keyed Login",
+          "notes": "Encrypted under a per-item cipher key",
+          "organizationId": null,
+          "organizationUseTotp": false,
+          "passport": null,
+          "passwordHistory": null,
+          "permissions": null,
+          "reprompt": 0,
+          "revisionDate": "2024-06-15T12:30:00Z",
+          "secureNote": null,
+          "sshKey": null,
+          "type": 1,
+          "viewPassword": true
+        },
+        "encrypted": {
+          "archivedDate": null,
+          "attachments": null,
+          "bankAccount": null,
+          "card": null,
+          "collectionIds": [],
+          "creationDate": "2024-01-08T00:00:00Z",
+          "data": "{\"format_version\":1,\"wrapped_cek\":\"2.wx/2IsEET/e3Z26a1H7wKQ==|x58R7RfQT3T9K1iBCUc2Nj6o+gnlUXcFWaVENqWfWKSdCvA2N7CIFRPoIEkvA9BcuI3rUvtkzVuqcngfwQjTQ8CxShNwbCKBlsrS4egqNQ8=|CEO+/bW4Zp5/WjUW0nlRdH8cANKG1SQ4FusAfJeO4HE=\",\"envelope\":\"g1hHpQEDA3gjYXBwbGljYXRpb24veC5iaXR3YXJkZW4uY2Jvci1wYWRkZWQEUJM8J0CK/dvjCuJOjxp8IJ06AAE4gQI6AAE4gAGhBUxQ6vtzVHcDXxQgn8FY260tgkwslkL1lTkddCdhuo/bu/fh96fptLFd4cH2vlsJHzAxmdjZRRN+mArSd+Wxo9q5sqY4p7EuiYQ98UeiPcjHMMu8VaTYHWbWvDYK534asojBBnkQ5r+N0hPtd2Uvjqe+AK+eMB+itondujp9SdYUiMm8E5lz4qp7PALWLTdmL418W86mgbhlV42P8oB/8wELPrrYL5ypRPBLxLJarQLVLDkNGr24ntk7PH/1ChvPDWSAAiiE8vX+AyjZRHkePZPe1thbmeY+x+wb++6M7qwygCAORMBBTAU+CA==\"}",
+          "deletedDate": null,
+          "driversLicense": null,
+          "edit": true,
+          "favorite": false,
+          "fields": null,
+          "folderId": null,
+          "id": "bc020a00-0000-4000-8000-000000000000",
+          "identity": null,
+          "key": "7.g1g+owE6AAEReQN4ImFwcGxpY2F0aW9uL3guYml0d2FyZGVuLmxlZ2FjeS1rZXkEUGWxVqe2osydi34PnbpIlOehBVgYXJUcKt5Gx5M6SSn1WYpz6uPWqRNgKWvNWFC0v1SLujv5UMktVoYSTra8zU87ekqmc4IrJmSUWu5Iepef8HTR7dGJbABKrxAVp6yUhboMHQGG81/RPpQEkCaaki9SRLsPMiK9pc6AfwZBug==",
+          "localData": null,
+          "login": null,
+          "name": "2.XBrDup44DouMRGp2cF+YDg==|BeLJpETysq2Ghs4Bn1MC5w==|x9ccxVrBLH4uFZz4ATayPvemL/Xml0AeSEaLhdSRxXw=",
+          "notes": null,
+          "organizationId": null,
+          "organizationUseTotp": false,
+          "passport": null,
+          "passwordHistory": null,
+          "permissions": null,
+          "reprompt": 0,
+          "revisionDate": "2024-06-15T12:30:00Z",
+          "secureNote": null,
+          "sshKey": null,
+          "type": 1,
+          "viewPassword": true
+        },
+        "id": "bc020a00-0000-4000-8000-000000000000",
+        "keys": {
+          "attachments": {},
+          "cipherKey": "BMxQC5BjL12xpd6cNrhZ5BvgWoVYw+ObNMQlw9ZVq3T2ASW1tO2074ku7sgwdq/K1JutLY+JNISJd4wjegucfQ==",
+          "cipherKeyId": null
+        }
+      },
+      {
+        "blobEncrypted": true,
+        "decrypted": {
+          "archivedDate": null,
+          "attachmentDecryptionFailures": [],
+          "attachments": [
+            {
+              "fileName": "secret.txt",
+              "id": "attachment-10-1",
+              "key": "2.13s9hHQ1b3c6yRks9HIxYA==|CfsO9w4p2WMQ10BQV4ecQPrN1x+KKMZ2NavR4OVleo9T0kJKyrOfxkxicLvswBAOG70bPNCYdew4xD8RuPpi7Stv+/o9DB3ZH30gp12S71g=|k2VKfenA5UPDgmhrduffigIEDHOHf8uNFjfiA5V38cU=",
+              "size": "512",
+              "sizeName": "512 Bytes",
+              "url": null
+            }
+          ],
+          "bankAccount": null,
+          "card": null,
+          "collectionIds": [],
+          "creationDate": "2024-01-08T00:00:00Z",
+          "deletedDate": null,
+          "driversLicense": null,
+          "edit": true,
+          "favorite": false,
+          "fields": null,
+          "folderId": null,
+          "id": "bc020a01-0000-4000-8000-000000000000",
+          "identity": null,
+          "key": "7.g1g+owE6AAEReQN4ImFwcGxpY2F0aW9uL3guYml0d2FyZGVuLmxlZ2FjeS1rZXkEUGWxVqe2osydi34PnbpIlOehBVgYbhhXI8VlGsLu1Jo1V77pzuNc8V4MdsWMWFDh48SQ9wq5E3rAKEJx5BYoXRv9EEcx3Im1XjjmtR/c2PQdYdALGJ0tO6VGLXn1OItqg2S+4i3LqBbQz4VIuJdKtgOJoR+ljemTOvakoFSLqQ==",
+          "localData": null,
+          "login": {
+            "autofillOnPageLoad": null,
+            "fido2Credentials": null,
+            "password": "v2-password",
+            "passwordRevisionDate": null,
+            "totp": null,
+            "uris": null,
+            "username": "v2@example.com"
+          },
+          "name": "Attachment v2",
+          "notes": null,
+          "organizationId": null,
+          "organizationUseTotp": false,
+          "passport": null,
+          "passwordHistory": null,
+          "permissions": null,
+          "reprompt": 0,
+          "revisionDate": "2024-06-15T12:30:00Z",
+          "secureNote": null,
+          "sshKey": null,
+          "type": 1,
+          "viewPassword": true
+        },
+        "encrypted": {
+          "archivedDate": null,
+          "attachments": [
+            {
+              "fileName": "2.mrhHrxoVij1LLEbzCxzSwg==|HfOI4PHJGwFAFrvQHV0AuQ==|YdhfSHW+oO0geMwI5Ki7P9t3c53e6sfcZog4yDw/ufo=",
+              "id": "attachment-10-1",
+              "key": "2.13s9hHQ1b3c6yRks9HIxYA==|CfsO9w4p2WMQ10BQV4ecQPrN1x+KKMZ2NavR4OVleo9T0kJKyrOfxkxicLvswBAOG70bPNCYdew4xD8RuPpi7Stv+/o9DB3ZH30gp12S71g=|k2VKfenA5UPDgmhrduffigIEDHOHf8uNFjfiA5V38cU=",
+              "size": "512",
+              "sizeName": "512 Bytes",
+              "url": null
+            }
+          ],
+          "bankAccount": null,
+          "card": null,
+          "collectionIds": [],
+          "creationDate": "2024-01-08T00:00:00Z",
+          "data": "{\"format_version\":1,\"wrapped_cek\":\"2.7ekqXCD1r42o+9fxkG8GgA==|GqVNj8eqyoqFhGNjiwMnWz0THvN3oriCRXzOeNmlCCtX0cghb3xKs0xIq13KtiamdWQE6MLdwgTxnHrf2N0AUpjxFQGTKub590nRTojFx9A=|zIqGAajlVuO+o1RbVbSU/AJL1lUcjrXSrA23aa6Sq2E=\",\"envelope\":\"g1hHpQEDA3gjYXBwbGljYXRpb24veC5iaXR3YXJkZW4uY2Jvci1wYWRkZWQEUCgoPuNAjsrS9bqFVMHNqXE6AAE4gQI6AAE4gAGhBUyGdKOZ2ATly/zn7AdYsdhtcAKvx1KCWTI749zaIMtln+Wm2NRMzKEBVPs/nqsfmyq4c3VGwVKRw9dREF0kwbfNfurHZ709fnuURAMmRLt1nYjzLymaqEE4cj2l4Btk9jAjhBmeqwmMbR1Nbkb65oJD+4CdeX85upnbwUApAoyaCTMBnD6iNJSCoIH8YzWdMO/n3gSttEX4LwQjr3Eax7e30w798YL1ZjyhqmMW+AVbSwh/V0ez5jealpIJpQ1grQ==\"}",
+          "deletedDate": null,
+          "driversLicense": null,
+          "edit": true,
+          "favorite": false,
+          "fields": null,
+          "folderId": null,
+          "id": "bc020a01-0000-4000-8000-000000000000",
+          "identity": null,
+          "key": "7.g1g+owE6AAEReQN4ImFwcGxpY2F0aW9uL3guYml0d2FyZGVuLmxlZ2FjeS1rZXkEUGWxVqe2osydi34PnbpIlOehBVgYbhhXI8VlGsLu1Jo1V77pzuNc8V4MdsWMWFDh48SQ9wq5E3rAKEJx5BYoXRv9EEcx3Im1XjjmtR/c2PQdYdALGJ0tO6VGLXn1OItqg2S+4i3LqBbQz4VIuJdKtgOJoR+ljemTOvakoFSLqQ==",
+          "localData": null,
+          "login": null,
+          "name": "2.sUd62dJAuj3hNgJCuwFCOA==|A5r02m0QQtAP3KJnjrjC6w==|4dtjPw5b5JSx1bwN14DwXS5jYfUMZiesx9hWa/0io6M=",
+          "notes": null,
+          "organizationId": null,
+          "organizationUseTotp": false,
+          "passport": null,
+          "passwordHistory": null,
+          "permissions": null,
+          "reprompt": 0,
+          "revisionDate": "2024-06-15T12:30:00Z",
+          "secureNote": null,
+          "sshKey": null,
+          "type": 1,
+          "viewPassword": true
+        },
+        "id": "bc020a01-0000-4000-8000-000000000000",
+        "keys": {
+          "attachments": {
+            "attachment-10-1": {
+              "key": "YVH51tJREfrKjGDe2vSc2aygLMXrK4nWHJf1GntkgZGpRHh1LrLoD//5MwnWJDQL4x8UTz5wh/atSHKUCoaRow==",
+              "keyId": null,
+              "version": "V2"
+            }
+          },
+          "cipherKey": "2cFjzAhLjEsVt9jJ+vKJVbKdp1xvkgjBj66iDA4tjH5PM3K8tKd9LaGbURcsglmZs/KIScb335NJn8D1wH9RnA==",
+          "cipherKeyId": null
+        }
+      }
+    ],
+    "collections": [],
+    "folders": [
+      {
+        "decrypted": {
+          "id": "bc030a00-0000-4000-8000-000000000000",
+          "name": "Test Folder",
+          "revisionDate": "2024-06-15T12:30:00Z"
+        },
+        "encrypted": {
+          "id": "bc030a00-0000-4000-8000-000000000000",
+          "name": "7.g1g/owE6AAEReQN4I2FwcGxpY2F0aW9uL3guYml0d2FyZGVuLnV0ZjgtcGFkZGVkBFBlsVantqLMnYt+D526SJTnoQVYGA/x4OGenNxUp927k84JCttQFtIleTEC6VgwnNEBNinh5LwpHRiVOtOVzPthLXUS0ArWQLIj55m1gQ1RbOHYhRJsgeKWjIL8lOsf",
+          "revisionDate": "2024-06-15T12:30:00Z"
+        },
+        "id": "bc030a00-0000-4000-8000-000000000000"
+      }
+    ],
+    "sends": []
+  }
+}

--- a/test-vectors/users/v2-pbkdf2-blob.json
+++ b/test-vectors/users/v2-pbkdf2-blob.json
@@ -1,0 +1,270 @@
+{
+  "account": {
+    "accountCryptographicState": {
+      "V2": {
+        "private_key": "7.g1gdowE6AAEReQMZARwEUP2Rq2ROzDUc0qhPXiVn4m6hBVgYGEx/vFQz/YhPOEzmpJ7l24VPrCHlBAFJWQTSp0N5UY6CTJ67CCvEu1ht5V10fA0QOtrkmS39CowF4kyI+ykOqlCOVkWt/lgviopBhDDxfZX9DQ+dZ97uNjUWWHO5CfQFKDj0ziEWJLLoSY4UoD+rm7TI9EMdHGrxrRNUnJh83zoFacPwSfiUEkEoBV5idR8QyGe+QNx4ONRNJGcM9MvZxq4+GAhVijrELPe3GXdQRTmKcKamHmF8mvnGLtNKX1Fxp7f1W2DrBCIc96lYCy2y4oe8ScbNAuv5fZNgwxLBX1eg/TzvMDsTbpasYZ74juufIderMT5/uoDNMEsXQm8EWIRCcSKMaE24W0ZSGTMEmeiPU5Lyd/xVlQPH4FTLkOTDghJw9zdtsQpDUzwYsv8blol125nhuChpnul+1HrBrux4VVOvX9VJh7L/jrjvmh8wvhe/NG51YSct6K7ZYU1BarMou7B5sapLlLyryOGN4xzUSLBGx/9RB+S4/cqU8A/iROzl3YQtW4dywi9BFQz+ToBW/hMEmb8VADhsXCBUojKNU5PronzRuqXB+NrduviuGsEOCcfBlmSNmrkhqFeZYkZ/R59RPEJb6YI02YscwAbiK3175pPJKSaz+3OdBRz/vnrFRUthjCQRnQPREfBBRDC8MXXTGO2cndT6MxhaC+yM/MjigFt5aCrtratFygQRu9XQc6Cu2k5SR/JnkkQ307vnpX6m6Hhpuvbu59IXhqrx0Nw2mg/NHa7gkmxB0anJ1chGEQfHFegpbyVPq39ie5SHklxvDxdbdikPFYRQk/dp7kc9gAuADzQbarprLaVSgx+chISNahOQZScPdbhu2jS5z8mxZYmMREh2zrVph7NQr7ga1J/eM4t2PwgaXA3X9AhZ3oTnsMa9pzwS6DYBIOTg1EKTsEVgxh1V++VApNsLi65gfcDdOpeqUPbqSBmNWqt97ClqGEGe3pRxZVHUiXx/FT6J9D9u1FM5XUKxZ5M+RXwdDphmApqVyCoY6uCkmmHgeMHCn6q73hyrVeGUGIhYgZ/3QRjruvKDtlgsoJxWo5RB84UWym6pyazN0aFNIZdX/rvhYWEDENFSwwV0YpuhpGSsA8BVs+sV+7Y2wzZdgteRSjgVERhPmnwEybKwb/iv9Wj31eN7FTPHPNEcrdAju+VBAS12K9X0vuV7vLyv9180OA5vJ7KqYRGrKvKcS31xIvxcAUgVo6DVWc0M0vJ7XMy7KBPDiteqa/LGvyFNcew+6YaNUmCZbXVVrCFBlIsNS7PJEoh9YOfd8TvipG+Lhb/klauO/k+w1RDTQhBrJgMUwRL+xSXK7r9Qv39I66Zri+rR9qg+1e+e+GAT3SDR5cR2ovi23V9FlP6Y/EoD1zrkXzqKfUC8xrg+05C8Y8ztEtmO6JkfoY9XC9NCZIv3QjSsZNnSXR8Eo1a1xWJnKnZ+cXH2oN8TK26QIWqJRtCdQ4UVPiNd6WehRU9y6vhYcpYpql/e9b16bUEFbZVkGNW/R39LZ9NBmkL9ahXgTxtgKYL1h9dHUgqn368BQrtALWulGNZnjKtKmEJbiell3iDtXb3kEI309KV+LhNCF7B75sldwjs2GBAFrnaAXW3rgjRC2keWyfgRKnVyVEnY3/68lJie1QiuEWeq3cUn3hcHmGfqDb7TQSLy2g==",
+        "security_state": "hFgfpAE4LwMYPARQXE9lm1z3BeU665m+YlqI7joAATh/AqBKoWd2ZXJzaW9uAlkJdKT6dDcA+WSFHo9yqurM0Tq3m8lHZJcQq0Q8gSgch1B4l6FO3J9LvOMYIxvIGD0Ln6GOG1YlEaToBbVLwewvv9vvJTY3qA7Jjve3i8cpBGcmYIu1pbwtc36fM+8DdUXqRjyUnxS8dNAaKNXaT7UkKWEGuXVpkMldvnAUvfpJseD3XMCUPVDtkkZazGNnx217FVqTbnVIEYWmK59aG6TsIskAIdEO2IXaYoKWW8TObCwXD1twoCd+C2+AoYB91YiQRJTl+OT+lmgldNkAOlwF1hc7CB2nuTav4q561/zb1+b7qTmQ4/aojN9snGSYix4nt9fTwyw5F6p6/jDmVgIqKwVh3FLNHNaYg5L4goR5WlNuLzOo1Mwzy66Jq46LA8ZijUDQPj9crylTA1F/lNvbVoK16afczytd4kJQp9AzgzrqJU+pKfY7ctgQrcvH60jgMe6zTaW6JuuTmh3Z8YqV+MlPnaMO3iZP/X8fUJo1ua52XwVoKTKPs9rK9tGv0t2J+SPMlwPs7qynVnw8NjoRx9h72bKLDgSna+hU4CO+3huzzkLQtwk5Pi5Oo+QWZHWjJ2qwO76Q5FYeN7tVD6L12LRsj8du7bxcLuumSXtQZAsy7QrWYm3yu6roHbKFUKQmDmO0S8GR90kDmgo36ry6QVFVbABmUmZidfUN14xcyMjLCmIWFlszBvNz0fKxv+FrOrFVNTRW8rO40dBg/CsotVSSrIEZ5O2hkcBVjbdcgFnWo8v+8A5VaSzVGTML/C0noo9U5xf999KiSKngGfCectLWVS5VwSwusMUSzdRMBIL06BZ2O7RuDPTLS9otS/2FIS2Ggym3HpGj2IHNEeWMA1pY9ClQ5ThZl76WYwWlcK54SPeGPoA2CLpJDZ+h8fWvjhQJoqzS7o6W0XCLfvBNW9Rq5wi59mxg+cjxM4RysyJSRNjssu3Re2nHcdhHOQP3s5h0j/FNIdD3YsB9XwnOJSvZT7tjn+nLi5vDNI7jOwQXjL4zVwDF0rgfx6TPijMcZDiFBCkMfkZR61qx/4z8MG086El51A7HFj5EqKC+PVKx0+LD9SCeJtNpeu3YO4HY6yLwPeaigJlRJP9C/jPJV/kv7I82w51zL/G++sQPdc0ykMWzdCgpC2y0VRH3RVrgc+5D3R1NurzAlC4fU+O6c/9F83Tj36ATY5xlOaKDyHQIsf372oRr76FczqtOsz1Lr8+4LYIdayjrFLwJo4slENau3qSpSGmSsFIltGVK7BU9vid7Zi7NRS1bqQRy0ThJDHoxevIT45dc4R3M9OrhI4le2q8QFJiGi0p7NLKcaQYUUEEVWNO/EIn9+5tthLrAeD6+VoJuCyZ+SstdEvRJlld6G6m5W7yhopzBvvAMLMsM4OxMdokXfPL4EeEY+rw+BjuRzZYgOm5J1LbaJLUyHp/SyldZF+y/7NvPRE6LNeaNG9q7crNkJlwC16pDfiH1vMmXCIS1B3sbFklnVlIH5TxU6JonSZf4g+JLGQ8w/FIi+wt5GcSoZSy8d7ss/R5AeXvz/o6jG/1oje16R5KcbMZgOL+4CZpmBPqZPA/AT39d4CjsG4RQ4xI3KOGFH0MQvsYNLnhXoBQZiMIH26A6fmsIX09WZwdLoqDQp8I8/55clEJfzGmg/rtBkFypBJSFv91++QeS20R2goh48rnPoIhIvcSu2xgLn2eiX7lUk6wKn+Cdn6y/L98fLoAcnV9cBuGW5RMDRuxTYoeEgATtunXa8Vw2D6Zeyt2jGIInlCK6Dhp9fV+x0cJkst/vfZr61DQecZHdZhWuoqgfZRIba9MCwRCSyZhi3bpB9HHFT3FepBfHen2jWvdduGO8V7D4SZvTHl2/27YjYa6qnseYZ9MBOwaxjNDKd6OaFaJ4rpueufdFiGUKDuqIhB9XKvHJNkeyt5Auwnnxdfs4sp2A2wacIR0eIkh3MhnpHHCWHmldFuK5DEHxsYWeLVdWP1e+M9YcsN4WSoZGYHyQLYZQecphLctU+rCTgc5gwxFfwpWVK2z/t0FMIM77sK9yJdKX8KEtoDGDvHbaT2uIuQiONdwYiss/eJepmXnj7/1ORs276wgGdNUYEquUG8eWOm8Xb4+jtxx1WmZgDbCAeDequntuCymLvyAnmopr4mWyf0bKaY0u6F+0Nl/1cB1nsFGQB87gKmgjcUVKy3JxQdETUfdF8B93fwRuImA4K8ywbCcG9v2RmFkUWFBi79RV8rSos/4pA6nabErB8bDgnquhLsGfk9KkTvemGoFYViggic9Q6sldiCwGSQtJoiJKnePxadNkDNwPmp+8/Yr6xKwtuhSxuAFFsHarTMYxIvyrTuNQlX3v2YB9YcyNpjvoGLcOeCuAQMY3Iff2OobNNm6te8RiDMtIyq4tfMmQS9zHnqOZQlTmiGvXZ9h6bpl9dm0LncIWYlUwfTsSpDJv3SeslkJciSepNTdGP+v4cfSZ47WDi5q/jd5FbCCb9poXZlJ4ciKUZrjeTphItGVCe/bcTGivEGiZSF+WgoXhOcVOx+qGeh2W6q4nf/AJl2DZ9q8dYET5M2VQ2izWWFpAvr8HqSHlvvBFT60VEgadCzyX6WR6Ag0vSCderDhYzLFzOIPEgjt8XPw9+W8hE9Fmu5uaH3yl++5+waaaLloZRWDBeumohLdCjTv9GVhE2MmlkMpDh0rmHxvVu2199MF+cu7iwj9r12/zWNtEthMdwqDUD+YJCAa4zysinSTSl7h5Z5d+SX4XlOyDc4l2C7ZsB6iNF9hniEv0OaT+6Iy1AJgDCQKOkgMInEIaVdPWCEmK/OclA5znyXO27Uz7qdilNyHMQlL9l6bPu5hbr395PDwbg/nvs16RU7X/Y2pcvr+JbqsDzlfyoMO1fAhdCFSW3OgFIFIx+pxAjtJJRyAv8ASmf+25moX9CquLi9bDgQ9iMPPHn8u2E8uTawKTt6ZUOhh/IBULOAoZr7JuiUMawBcCSnFLrvDSxZZnkk7Uyk261bVigwJjpfZ3kGlnDQQeAKZ7qB4+Q29LAfW46qFFrijO47uaE6TV92WgC4lU0CndP5ni5n5b5R85ovAJbKFt0WtPLIVmMIv5IUIFgQ1aQZsOXHnGGSElLVRYZnCGmZqosLa6xdbg7g0eNEJESFeOl52fq8HT8/b7AyUoSGt0eYiOnbjB1QYICRcnM0BTW16Ynaquu+AAAAAAAAAAAAAAAAAAAAATJDFB",
+        "signed_public_key": "hFgfpAE4LwMYPARQXE9lm1z3BeU665m+YlqI7joAATh/AaBZAU6jaWFsZ29yaXRobQBtY29udGVudEZvcm1hdABpcHVibGljS2V5WQEmMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA13Ig9cLVkdvhupo/hGFiVevsGupO2GE9/76M8ZpNTNZsDuLt64yiRgIJj0AQIk2gmG+jN4gM+FpkwFkuFlIQ2OffKD51g13OpAiBqn+ihWL9UNN6uRiGIfxtUFtOiFrpH2LyrW9kqh4K7dgvTDIVCQixZ87kYNCQWRbK64mFSa/sK0uhTypTgA+3HqtzNQrM7Lq4Z3MWQ9v3kGUh9pDZMVJl/hRUVa6RdD6uj7c9ETsJ7sy5d/RaoS7wATL1RYPdhsyZpFzOYryXFXsdlHqGaepOkvv+SpI78S6WhjCXli1zLURVp2tkXuoETAz1jYlXmEta/9ycku3wjL51psRlmwIDAQABWQl0WLFOM5IJWDpea/ufQm1Wl+BYvD8QsWpexTX1AA6EhWzKS+1aGkt7gPahQeUaLGQkXm0oyoWAiLKDWYTcp3f5LA8LRlRrLNxUGLAZoGh2satz+uzF8V/84nhrNmlMlEKOwyeyx8EU7n2qioQbJuhez2S/5MgbSrpu0RSZjXgGxqYzd6mY4WpnNkatNSNASNTlc2Q0eBgoQcX5mUNzuefbquetP7H1Nkhe/2EDVK2JFlmqfsZb64aLF1e2NU4WC1Bb7T61SG3cadAWvGi1pyyRepseL6SUPQWkHsIxHwLT3KrY5KI1SW5Hpc3sSnv1dy6YIp5qISRnBYitpVL9JTrZAOd4fXSl0Jz3d1ZSDCDLbX/Miw86vu5SJZjdmU3l+qs1ePBH+2Wyz0BDX7PofbBM4uUtG+SL9cb+tJoQUesISTPM2od2PsNa79uc0PVA5FZ5UPexr6EcwZX9yn5cr4+fUcfD5Np3n/ba4M8r9Y0Z+EcXPEcneLeYSqCCPDozyBd/tgddwKoqu4e4R2L6mvGmR5zhraYNBdjcdWKkLYbGkpjzpbTqTJAwSE2hlWDbDVEtChUc9vRSaMK880f6Sf642P7o7uJrtvCaqytDHxOPe7aDtwPumXK7IvmIYn1/iH2gQb7/5s5uYtL22oEJGHFWnJRMc2ZGdC72iOVFWc8RyPVnUzBBD5ApwhrgUKdP9TEkz6zEd7C//QJpEuw/5w8TLw8e7V6ZwXX72UvEYzGQUCHyEWKI+meJvM/luPJFptNf76z4G/tbNSb0DYN2wG5mcy4WZ8E3kFhUdHgP1OATkNrUTs0jBuZLW2sgRlampIt0/xMEUd0KKifN6SyK1wvH2jAovH721iMzPyvjZ9kza1TxKooTk0g2j062C06T6vin9Ik56YOfpvMyoilbc4gkFXEGIcyTbhqvTkUb+fl//6XPRyq9It9zjYKusyYQg76H6yuAiWw7A8kFyQrmPWp7lUyOfKrIWE+Rpa4QJmFwCvPlqHghJsBB7cu7fXQ9nvWY6C2Y+Td2ElaxhFcNmGM8/YzHit92Zk1Rf7lFWYkeyp5FERk+tWkO+mrdcIQDD0MfRoxgL0lBHs5h17fzWoVU5uvlA+kFdcIr5UTxcOCbddwrxsbL6C1UUhjH0zYqQaUylZTwMEGpK9vHnx8Y60RmdLJZwU3jCsR7yCRCVCiLBxzInhLdchRJkLQvxFdHIYgubjDbncazcfdFhO+S5yghZvOdpPl/9QmLjnTkzp2QIVwgAy91pGKPeqRvM8osb4lNju3vVq/V/NWRMuBCWImwu8TrYgLE/raonXesc9brKONywr/CzR2WRPCTz1wydQgxJEXZTZ1h3jpX7dLuxEafnjNcEdvAvXFUS0eEGssh4MEiHpVBv/XkOFviABA1HPVe6E2m12KP9Nl2sjAoMx5eNvmjGhRu6DzTIUBdIAmciuMATLL1AFZE2VzfZbLEDLv/a3ecy2rOMS1BagbLWkxBWOxE02UOP14Tv8prNgFOabiU45K/olHTAZiY6XdNLoFlMYbDtqZ4wB/Mh7CP0HaKxLd1eDrJuNEnR4OCBURKEbGcM4+a1pAhkYMEvRiD3tUEUTxvciVKtzMJ6GZxxEdCV1oYo1YrScfJ1sEC6V8qyeUgT10saYKaQITN2WKim+ldgB109zAJEZGkRf+16f8s2xHhuJGcnS7zz4lmlmLxwyErpgjd3EtiKEMrfodDjZmHV8BbshVMbIxG/nVaTrUYoPGASjbaQYgt8MXjxCuZXyEnlJxCwtj0VJnn/nh9I+PTxfI2xtfbBCAwVvbqII6VEL2wHgzKgXibm88n014u/Bbhk0pZy1DQuGD7iWr/hHMCfAnDPWH4KJItR9bd0Jj7P4Ua6eyg/M8+fyGz25JumTWv01YHVcxsjAkmZKTqiA/XDwCGfZDtMW82NlnVQ8BRGQskUp9bDpbS4U3jZ6X1wJBaYs9eycxVi3fSS3i1sqYXMAKC2X+nnDb1AaUq8JMhV2tm87+m4U3V6NPaCoC2ppH4W/7msVjFb6twSv3of/PacFsbXgK7zuBN7zaa3TRaPhn9hsd7RKpOxrieZFVLHSM1Z2j+NfCypO9SGDLXPlWguQzDW2V6FKMSd/RhtBkivhJegBXUCEutNtJG6j2HUfmty+mcAM3SGRGhs/Q+d54swnLPpKuTCkbdYkcZ+/e6qPmz9acXBDeqgiW0dGDsoLIifBl91Ka+cw5WwVNMI/TtT5dWLblcIp8hrOyNwszvAF6fa0DmGWyofUhnAr8yqVhMiMcfsEOx+p8g2XiUvxQlCc1IQ+vlDgjwFsHTdhz/ymWtOm0U6QUNy4jo5+kqqOd1yd0VAvTK1H/wTkLLFn/oDwSAL8Ev+UeisSVuzyuc/Dn2eAzJ73MBmf18nVU0S5P6gIX6PruYePgtvxobH3gUHWPdL06McvUummju22lE4Npgywd3whXnsDdzUV8QXa/l2Tz6nqARwopBmV1PC/nE7xJbBjEfVkxjsrOsb6CjabA5CgzinLK5K+YyC4wQ5WZzRmqlJOHR2JBaM35vxcSsLTJbaTihk8sBZLjR8t5Uu79HckEL2T/NDiayAbI8xn/D+81oIW/2V+/aX7smjGm2blC5s+LQ/ECMC04kyLh5RAfT57oV6GAMi9hjfjatjmE7yXtf7oJK+pUrrPKwHshF1Gk95AZUrVnTsQuF0nm74elEBD26D9W5lUbjCx2iJM3qwCXEHAcKRWFuFDYzqU9H3Hdn4dkUeyTP+QSykzkRG6nAYXbiYL1s+yoGGY1dsRr2ehB2dICR6+gxqyuv0xaJ2XczfZCWYTFUg3wRYeXow2jV0hyJEhqkpUgy45SwPo1RHR/7FBWHoxMchJcDw8Xm+vc7s3zRst3Vwxfepd5pqZAENEiTIQQ/B87UkpNp0uEquUelQMSDR/nSDPr7SsU4jTB+AJ1Nwp8rGOIt7Wq68rZkcPDL9AevQUyHhx2jwdqyZ4ljrHnnd1ZBX9wAP0E90Zzk8CCiUZQCiRI6X2N6Hcgg4s1DTZqVKOchw57R+fVx+0AYcHDxjgd9VcNLWNJqdLxzWzrmD5yhDRvv47ga6nwNh4C+krvbqyjMsHjxzQMLFRkbLnZ+iJ+70tfmQHB1gI6PkJugudDW5v0YKj5CQ1FtcIK91+MeMDI1TE9eZIO5w9HW6vkAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA0bJzY=",
+        "signing_key": "7.g1gcowE6AAEReQMYZQRQ/ZGrZE7MNRzSqE9eJWfibqEFWBgxkIiXyaMJ7MIUqFk/AvFZZhYe/pLvCUFZBXLaBq4Q5+vv0jul6g7yLXGnNttxjHxiHCsV2T4MZYwZ12/JPiiBFM7k+OoPeUuLrBOc7W5dgVFijcOAHei1wDlbEOEKh8xXMp79EWStSX7a/1Zvho8bwSwf4sdsCsyIBSVHF9E+qGYUPAjRiTG1eb9ikvQmcbumJ8JOz7LHn0mlBO2Vs97fCVKRnZyp4BbgmgJH076zl2JbxoWFE1dsTK9uEpEpvKHMnRJrfC3f8pNmetACo171z7nDiikD2P0LitgLHw9IJxfLMaizksiaF3ALqeLaI3GpEm8ArZaoMiF1T3ktsN/HqleGuVr9LvQqeAFJ0/btOuhzuhE1vFCSGclqAZ6m/swbwU6JLXqtYO5AKxRVMRAQvfWuXLVJQ7+iDUY9kCP2pumki2PSFGznf/y/PwY886lPT04MWNqP1VyvQHV8ksqGV4DhIsgOtYLTcn0Dr41hMu8qxkvYyJjJFF8NEoA2ITPgCbh0lETzw8dy+lcA8NS3XBXqO8ocGJ1Iu96kl03Qp0EQ+JVwwsqi3AdsOI3GHETOmCGtkLwCAvx6gG4xmEHqwl9jteM3Y0G4w11fQJNdKmZlNd4jOHoduLpIsz1bMsvFrWre9I3uW08JvhqJCcZ0iBwf+ZIlTNqqtHpOHBbLTWCl23uzSE9gyR/M0VMkwbxUetIjJnTEok6msBBe8d5oxhvemrNhGvJe4cb37HPQxsLY3tb899+DMchwnMufIIa8/DMxjZd+/fHPUg6P2gVvEA/StlrcupDwI9M1Jq8KalrwjShDwt2SItu8XAI6iQOakdiKJMtExaMpUefMqP6ObehGZ9Ie2fRqixLge/GZ0nd1YzNv9NVK8HCfUApUOmiaUJMn2kmlbf/2eKsbruvEdiMi0eIUctfCy7B7b6+ITF9ZZJuh/GMizldahXKHEvXy0SvO0bRQ7C8fSUq+xBAfH4OE+enKHZCjAU+0GXgWRhy8rYf0iGck2g6SrACROiq+XhcYj1aVR6jiOkmp5R77MspElwIckrF5pPWCxL16pdmiuors/K5vJasj3Ig7mHdrhryMBuJGjtfaOiGwCSgq9O60RfVhXLE4JQp1d5J+l8gAz68lvA4gLpmzv5P+yV6JiFuu+JLJTCFCVn9iQ1yPG+QSZnCMFMXtWHY6ksudB7kRWLjKxY2h+aK39Iflia+kQvmyBJqWGQujKWrMInpwx3IM46ACx3TH4LdERv8+vVmbkWAQAtKhZs/P8dm2zV+rbbLxKam1LhIg3tXyyv2huwAfdOZRD1849sVM+Mt3NNZXkLqbwtiVTZwasrpiChqYXskrUhRHOfq4g79HTJLVcy1tpou7IekLw3J4dYrjbcQqK02BUyl2o0363Svru8Rc8T+FOGa3SGJMCEeiGkFeH1mGOEeRMx6tmvFw72v5MDcw9El7VR5Dz0qgaZzAeoXf208mnvSJI+s5qUh5gfJ+Lul1z5aVMzWaq+VxAWvynRkfoCO9/ATWDjk3YdSmOls1P/vCiNVvzfP2Ipr6AxOxWp6nKOyjpoO2YTaBZirEMbOIacKiv1S9t7bPhTicENHJGHWMT9PTx2K6D2rawZlev0wHcaRPEHAkvpZslFV4EcNl165o+9nbKvozXDwiT9CMsSyN+18umdSyGr+n684omVWDnL833WyGOtxE1HoqIIftEhuXjGEKVZOzgB+u26P6jX6+fGBjYnxSE3HxpWy+RCi8nqhK1veLejMnsKM64kaJStI9LMsZzfoMzKJuT2giDtZXAkaZ3cAJoU9Fx5mnAfXmxiRBMmQJRqb7EdmqOgJUUoPrZMibHSAa+sf9UHT64edDcqVjxDAkIpHQ97KwUcfFL9802CdEL/GVrg=="
+      }
+    },
+    "email": "v2-pbkdf2-blob@test.bitwarden.com",
+    "kdf": {
+      "pBKDF2": {
+        "iterations": 600000
+      }
+    },
+    "password": "password-v2-pbkdf2-blob",
+    "securityVersion": 2,
+    "userId": "bc010700-0000-4000-8000-000000000000"
+  },
+  "description": "V2 account on PBKDF2 rather than Argon2id, so the V2 unlock path is covered for both KDFs. Blob-encrypted vault.",
+  "name": "v2-pbkdf2-blob",
+  "rawCryptographicState": {
+    "fingerprint": "setting-rebirth-primp-endanger-antennae",
+    "keyPairThumbprint": "d1d53d934e8caf75b602d7889489f26769e957cbc93e1526bae9338b2112a11b",
+    "masterKey": "hzhGJLOufWOGazhRzXLknCbsMyjLJom1uFwqxRKfU44=",
+    "privateKey": "MIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKgwggSkAgEAAoIBAQDXciD1wtWR2+G6mj+EYWJV6+wa6k7YYT3/vozxmk1M1mwO4u3rjKJGAgmPQBAiTaCYb6M3iAz4WmTAWS4WUhDY598oPnWDXc6kCIGqf6KFYv1Q03q5GIYh/G1QW06IWukfYvKtb2SqHgrt2C9MMhUJCLFnzuRg0JBZFsrriYVJr+wrS6FPKlOAD7ceq3M1CszsurhncxZD2/eQZSH2kNkxUmX+FFRVrpF0Pq6Ptz0ROwnuzLl39FqhLvABMvVFg92GzJmkXM5ivJcVex2UeoZp6k6S+/5KkjvxLpaGMJeWLXMtRFWna2Re6gRMDPWNiVeYS1r/3JyS7fCMvnWmxGWbAgMBAAECggEAOIiFJ5gJjK2jDOEe27DmKd+vY9yp9dOGfk5VE6zGrevyDPH1NoL/rdkpAwLveODfzEA3FwJHTQADQgnkswyzyQcHIrtJAMCj0Z090SyOy+uOxx/HKzzJLa/cS2K6N8OLOqYvQd1iD9W0TncU6iyWInm6e5/pg5IW3pnBg47hf9UDkZ6prrzSs/jBqvKronuF/I07/SuvoxhEglJQKEDlNPxbxC+nyJqguIbz8iJs9hZLq8Clpo6bXOc6dfO95AtU0/m/G+MBW242g8fp/o9VXT/98CCAZ9qPhmMg/ub0SyuCj8EcevZKpz/eS0H2RCF6zFTT/tBn+nK+GYrhMpueyQKBgQDidpsY9GDKgWYVQkpyF4DIFDZU7/pO4kTKId9BHM57Z5GkPnhL5Hf49LqbIEYYvMzdzw1Z3bLcph04IXG+dhn+g0eh//pP4l3Zc36fj2ew15fNZWA3eBWE/KtIJlMpO0pPw075M1x+pO9zdVJiWgTcxLtjjiZVdl080hceFRQIXQKBgQDzi6jRKFwZaPV/kTKvMZax8Vgfm9vZopXrA916KAfdHM9onbEzp0JlTT/rWFzV5qtyswct1aX9pzDeseMRY6Ig4ZHunJFWdzTdyYw5FtAsqaiiUDZwA8qI4fwO6eRCz4oT1sClLAMGGJ5DNGtjCulSHXp+4p5nOTm+MKDH9BrmVwKBgQDVTgP+eEgm1cTyZzM5zZt2WVtnm3X4ETXb8hWX/esa302WF2U1jqfWLaUKclaz/Dk2/0xDBgfvvuMsuIuraxBG4x54n2QFFGFzbU6qOeff8OHCDCeZd5lFXrxyQ+72mir/gCYFoXQQsYf9B1em3cVQsFkUh5Lh0pA1tmkh45av3QKBgQCk9cXE1dd8BpGydECmVapCoLwVvNXu1adB5f5PzWl2JRt/OsBZwkLAptBSsik/YNxj9ks4imvCIUqCrG6mypt4NhFIU5hFvrx6NRfbW05p0gi82CPnP0oh6R93YokPj89wnJcjyWnK6UXZM1pBXZSn3/umkgzE0ggAgKOGjBrkRQKBgFe3oooFav4w5vedtL7aAZ6vnrci6kWxivugdckLmKTNyp1FqEwzqVSAychdAVI8aDbePN0sUjUoiGoofSSiBHAsa7SGfFbl50kXxoT9UEvnBCK6MRGp8b4QCQ8iXy6i2s+8A65JN+oJYZMqp1jhhVeiES0QMEL2HfQ/OIIY3Omi",
+    "publicKey": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA13Ig9cLVkdvhupo/hGFiVevsGupO2GE9/76M8ZpNTNZsDuLt64yiRgIJj0AQIk2gmG+jN4gM+FpkwFkuFlIQ2OffKD51g13OpAiBqn+ihWL9UNN6uRiGIfxtUFtOiFrpH2LyrW9kqh4K7dgvTDIVCQixZ87kYNCQWRbK64mFSa/sK0uhTypTgA+3HqtzNQrM7Lq4Z3MWQ9v3kGUh9pDZMVJl/hRUVa6RdD6uj7c9ETsJ7sy5d/RaoS7wATL1RYPdhsyZpFzOYryXFXsdlHqGaepOkvv+SpI78S6WhjCXli1zLURVp2tkXuoETAz1jYlXmEta/9ycku3wjL51psRlmwIDAQAB",
+    "signingKey": "pgEHAlBcT2WbXPcF5Trrmb5iWojuAzgvBIEBIFkFID+qFV/5AqUM/kkSSgJ7zRvF88gXD/TkEUV0wWOdpA6pHwkLn4XGQsi24AjuYspU5JGEUnVGDZWE7F9gXM7TVYsA1pw5RDXat0WMjdpkAzG1AyYIVfnpX9B8NPbPQftcLY53mZx3EWPhR4ZGNvxA6Nl+utamlMgFfsdZz6veF8/75QhqsuTV36xHIwuIRvm97rpGhK4Ag+RC9Nmyj2X5jnZrpddUH2Kp3/4Du8efkyg+fxUgXUO/TizyAHWJ/CKOfDo8tcP4pWmkENmAXYeHH/CHdCNhd4Fke1TpALvYpcRj28XwDm5zGHl1H5mCr6JX/KaUvTO41wGKtKIDSICED6GJaTz7wTlkSv/AlNVAMU/HC2DnAnxVfvyuWOyDZ90W7bDiWSZxewe7vlrDKcEO2x9qlNs7/7aJDQ1CLvww/C3Ni4XNgylYzwz4PU+wNHi5CcUxJaG2YbOUni8ZtL+ve4QzaASu9Y9EWQivnK1KCCr60PITmqI71u+7CJjAw/7KGpQlSG20/Bi0FaAx4Jk+ij8i2LO/FBNJlqzvL7bdSRcRSfobmv+Lpwc38NkbgZROJJCw49mRokExq6za2Ls5IHxSPxrA4zcBRqUQgjlFr8mIRlXRuxnGTZTYYu5o31E5w9l2vfOqiwsG/UQWS/K4l9efU22HZ5ZhqBigRpB6cBElQWrOTbrHq1vtcvPWVd6FKW8yvQadTgcOGJtw74myatnXGiv3WVobeBOLrQuKEQAuoL4kYECyRv19HlLGAXN9q5D6vUXhfAjL9zvJK8XMhMKkZy+FGDj2vl4w/9Vw/Swm8KYi5O+I/F7f9UnClg9edPdkLaFS44dxTBjlosNvFKgjcFq0f8qlj31Q+GgvNAUTGNmzzvmAckBbO7l4FimdEA/3wKKUFLcflBSQhnHaE2FVSVfap+Fz2TXIB2CZPtuuZ8whPZou4ggXn1ehFFEFNxvhOVahuici/1BT1K7RZz0GLHKTSqdK3ioakq3khFO/SDIoGhrsrLEbFmMpMhImAT4IvN0KmMxdBVemtJZMfXghZJVjVUyHPTicdR5KYqV24hr5dcMIaLTiQS+FKOkuApHhqiXC61QA7YYmVKRv1LNVmHqPqtk8yR9EcJkgm6Phrcg3XMiPHQ+UEN+V0PM745IP7r2aUKwNnDsN5binJHjFlsYDICgI3VkjglnY0X4PqCPugWl3eH+yyXPEJ3/jHulpOyap2Y5mkoHa46mzDASyy55bZcxohYDatm8NJAA8mep3hS0SFrFSmiD+cYuBquwklrdYIgmYbOxzTUSgf/+KB1hXpfDAcpVv5CxNg6uvw0DlJbnv54elt+x73TLYWuF0mWjIQ9eoEcXalSCy+vGCltAMSvqmelJC/3mH44fn8ZITcPtawcJySqG2UiYxG20/osKvfO2fGMkyQEOBXe11ecSzGX+RxFnGGnJIs8nLLxBVATf3FgbmIJHmvcctFc43YKdGk/kA+SOO+LSTyI9EDmjkFDE2dLVPb35aK4m62belpZjU3zE+Cdnd2iAWw9OcrnHHStZZwFPFGU7yy0+z9Ipc6dfE5ieIUfy20y2eBpgHlcGqW/z3nRWB/wMmYxPrICE1vNVpprAEe6zYa5CfF78cppjNoqFNjmIDAJBZNGJxCLBwP9lWZRNe2JbhokBW28u5Gy4If59eliUFg3pJK+yi8X22RAtKnSWOyumTBUVEY9kfdfZwcc+4LncBRZlMmpBnXIds229WHPSFsEshWCCMu9YW/cbamuPIOwPTHbvP6Nm17b5kyFs2OEu+riMp+w==",
+    "signingKeyId": "5c4f659b5cf705e53aeb99be625a88ee",
+    "signingKeyThumbprint": "3882d69fe640c5960c0cf142382ed8c38294f47883b1f1f0f2928f964af3073b",
+    "userKey": "pQEEAlD9katkTsw1HNKoT14lZ+JuAzoAARF5BIQDBAUGIFggDrVKm/rcryftdNbBh+lClNzSsxMx+cTj3WaIXpYQ6MMB",
+    "userKeyId": "fd91ab644ecc351cd2a84f5e2567e26e",
+    "verifyingKey": "pQEHAlBcT2WbXPcF5Trrmb5iWojuAzgvBIECIFkFID+qFV/5AqUM/kkSSgJ7zRvF88gXD/TkEUV0wWOdpA6pHwkLn4XGQsi24AjuYspU5JGEUnVGDZWE7F9gXM7TVYsA1pw5RDXat0WMjdpkAzG1AyYIVfnpX9B8NPbPQftcLY53mZx3EWPhR4ZGNvxA6Nl+utamlMgFfsdZz6veF8/75QhqsuTV36xHIwuIRvm97rpGhK4Ag+RC9Nmyj2X5jnZrpddUH2Kp3/4Du8efkyg+fxUgXUO/TizyAHWJ/CKOfDo8tcP4pWmkENmAXYeHH/CHdCNhd4Fke1TpALvYpcRj28XwDm5zGHl1H5mCr6JX/KaUvTO41wGKtKIDSICED6GJaTz7wTlkSv/AlNVAMU/HC2DnAnxVfvyuWOyDZ90W7bDiWSZxewe7vlrDKcEO2x9qlNs7/7aJDQ1CLvww/C3Ni4XNgylYzwz4PU+wNHi5CcUxJaG2YbOUni8ZtL+ve4QzaASu9Y9EWQivnK1KCCr60PITmqI71u+7CJjAw/7KGpQlSG20/Bi0FaAx4Jk+ij8i2LO/FBNJlqzvL7bdSRcRSfobmv+Lpwc38NkbgZROJJCw49mRokExq6za2Ls5IHxSPxrA4zcBRqUQgjlFr8mIRlXRuxnGTZTYYu5o31E5w9l2vfOqiwsG/UQWS/K4l9efU22HZ5ZhqBigRpB6cBElQWrOTbrHq1vtcvPWVd6FKW8yvQadTgcOGJtw74myatnXGiv3WVobeBOLrQuKEQAuoL4kYECyRv19HlLGAXN9q5D6vUXhfAjL9zvJK8XMhMKkZy+FGDj2vl4w/9Vw/Swm8KYi5O+I/F7f9UnClg9edPdkLaFS44dxTBjlosNvFKgjcFq0f8qlj31Q+GgvNAUTGNmzzvmAckBbO7l4FimdEA/3wKKUFLcflBSQhnHaE2FVSVfap+Fz2TXIB2CZPtuuZ8whPZou4ggXn1ehFFEFNxvhOVahuici/1BT1K7RZz0GLHKTSqdK3ioakq3khFO/SDIoGhrsrLEbFmMpMhImAT4IvN0KmMxdBVemtJZMfXghZJVjVUyHPTicdR5KYqV24hr5dcMIaLTiQS+FKOkuApHhqiXC61QA7YYmVKRv1LNVmHqPqtk8yR9EcJkgm6Phrcg3XMiPHQ+UEN+V0PM745IP7r2aUKwNnDsN5binJHjFlsYDICgI3VkjglnY0X4PqCPugWl3eH+yyXPEJ3/jHulpOyap2Y5mkoHa46mzDASyy55bZcxohYDatm8NJAA8mep3hS0SFrFSmiD+cYuBquwklrdYIgmYbOxzTUSgf/+KB1hXpfDAcpVv5CxNg6uvw0DlJbnv54elt+x73TLYWuF0mWjIQ9eoEcXalSCy+vGCltAMSvqmelJC/3mH44fn8ZITcPtawcJySqG2UiYxG20/osKvfO2fGMkyQEOBXe11ecSzGX+RxFnGGnJIs8nLLxBVATf3FgbmIJHmvcctFc43YKdGk/kA+SOO+LSTyI9EDmjkFDE2dLVPb35aK4m62belpZjU3zE+Cdnd2iAWw9OcrnHHStZZwFPFGU7yy0+z9Ipc6dfE5ieIUfy20y2eBpgHlcGqW/z3nRWB/wMmYxPrICE1vNVpprAEe6zYa5CfF78cppjNoqFNjmIDAJBZNGJxCLBwP9lWZRNe2JbhokBW28u5Gy4If59eliUFg3pJK+yi8X22RAtKnSWOyumTBUVEY9kfdfZwcc+4LncBRZlMmpBnXIds229WHPSFsEs="
+  },
+  "rngSeed": "eHl6e3x9fn+AgYKDhIWGh4iJiouMjY6PkJGSk5SVlpc=",
+  "schemaVersion": 1,
+  "unlockMethods": [
+    {
+      "masterPasswordUnlock": {
+        "master_password_unlock": {
+          "kdf": {
+            "pBKDF2": {
+              "iterations": 600000
+            }
+          },
+          "masterKeyWrappedUserKey": "2.fwOu+FyWSDYPCGBaXt5oNw==|2zm9WG+IYNjraGNOLuKI85+QFBvhTz07j8PV5cqbMuZMiRO0Io8FO3Gup2JNkYQrEBNi71SPMGzk6c3J2AiJ/3suXTYRylFDUQ6htc4QFEc=|nD7MLfU9ZL9AUNudQfDN9KjwMqsfFJz4TSejQBDeDEs=",
+          "salt": "v2-pbkdf2-blob@test.bitwarden.com"
+        },
+        "password": "password-v2-pbkdf2-blob"
+      }
+    },
+    {
+      "decryptedKey": {
+        "decrypted_user_key": "pQEEAlD9katkTsw1HNKoT14lZ+JuAzoAARF5BIQDBAUGIFggDrVKm/rcryftdNbBh+lClNzSsxMx+cTj3WaIXpYQ6MMB"
+      }
+    }
+  ],
+  "vault": {
+    "ciphers": [
+      {
+        "blobEncrypted": true,
+        "decrypted": {
+          "archivedDate": null,
+          "attachmentDecryptionFailures": [],
+          "attachments": [],
+          "bankAccount": null,
+          "card": null,
+          "collectionIds": [],
+          "creationDate": "2024-01-08T00:00:00Z",
+          "deletedDate": null,
+          "driversLicense": null,
+          "edit": true,
+          "favorite": false,
+          "fields": null,
+          "folderId": null,
+          "id": "bc020700-0000-4000-8000-000000000000",
+          "identity": null,
+          "key": "7.g1g+owE6AAEReQN4ImFwcGxpY2F0aW9uL3guYml0d2FyZGVuLmxlZ2FjeS1rZXkEUP2Rq2ROzDUc0qhPXiVn4m6hBVgYWbDR8lvho7zNiHK1zFMfBIK8BDt+tB6kWFAko52J9a66NkFjfnm4CCyxiTES+erdUxiFNykYuAaFdcDtnVZFVjtR5k/xNfXHWOtK7GyIMcVyC3hnmT/C9+wb6BXZ99Y2Rcl1NpSzOZgN/w==",
+          "localData": null,
+          "login": {
+            "autofillOnPageLoad": null,
+            "fido2Credentials": null,
+            "password": "keyed-password",
+            "passwordRevisionDate": null,
+            "totp": null,
+            "uris": null,
+            "username": "keyed@example.com"
+          },
+          "name": "Keyed Login",
+          "notes": "Encrypted under a per-item cipher key",
+          "organizationId": null,
+          "organizationUseTotp": false,
+          "passport": null,
+          "passwordHistory": null,
+          "permissions": null,
+          "reprompt": 0,
+          "revisionDate": "2024-06-15T12:30:00Z",
+          "secureNote": null,
+          "sshKey": null,
+          "type": 1,
+          "viewPassword": true
+        },
+        "encrypted": {
+          "archivedDate": null,
+          "attachments": null,
+          "bankAccount": null,
+          "card": null,
+          "collectionIds": [],
+          "creationDate": "2024-01-08T00:00:00Z",
+          "data": "{\"format_version\":1,\"wrapped_cek\":\"2.mkv0Ft+K9/ObfFhUy9ef0Q==|ki/155F/69Z6w2s2RiNf3f0mV6bde+1bo6nMrGUunAYVXtXfLtpojIiwz/fU+kwCDPxW/DuJPjJTzHi97tFm8XzXgDpubSASHKpdKzLU0Eg=|cZX+A/sky0rC8M0KhkHGHIo1EJ2mH9z+LWfTFPuESmI=\",\"envelope\":\"g1hHpQEDA3gjYXBwbGljYXRpb24veC5iaXR3YXJkZW4uY2Jvci1wYWRkZWQEUBuI2wY6WFtp7tRNU62KeFs6AAE4gQI6AAE4gAGhBUxj1O/0Ozspr2slUNlY23PWP0ZHhaumjSXdAZx8Go9GMCWNyDxS5EUpY4DPb7MHYCTRoKsWvhI0n4XTfD1W6vPeVqlI/cXdANKs3qCAl96HuncGBWQxJ9PoluDDPoBndtBucX6Xj1sN2/iAAOZ36R74e79anRnazJ2566XBSDiEQg7P8FLfV6Rdhp7esoZlde2QGTcQDGR1uJ/p+N1VHcD6DnODSFSfFtAYPwIqXmcrUx1GzMO/sXOp0dMtKW6ulVQ5gzlGGhqxernxeO0VK7JDwweeezUwoZZImt9oeJ1SJKq5XlZGWI/nKA==\"}",
+          "deletedDate": null,
+          "driversLicense": null,
+          "edit": true,
+          "favorite": false,
+          "fields": null,
+          "folderId": null,
+          "id": "bc020700-0000-4000-8000-000000000000",
+          "identity": null,
+          "key": "7.g1g+owE6AAEReQN4ImFwcGxpY2F0aW9uL3guYml0d2FyZGVuLmxlZ2FjeS1rZXkEUP2Rq2ROzDUc0qhPXiVn4m6hBVgYWbDR8lvho7zNiHK1zFMfBIK8BDt+tB6kWFAko52J9a66NkFjfnm4CCyxiTES+erdUxiFNykYuAaFdcDtnVZFVjtR5k/xNfXHWOtK7GyIMcVyC3hnmT/C9+wb6BXZ99Y2Rcl1NpSzOZgN/w==",
+          "localData": null,
+          "login": null,
+          "name": "2.Pgc6r5i5IE2ObsIrIrPlzQ==|RZ1ffKFbfbdfdmWLRDtOLw==|lVfUrWT0/xH3uc4tkLsHHqa/vWWXwTeat76CmtT7WJk=",
+          "notes": null,
+          "organizationId": null,
+          "organizationUseTotp": false,
+          "passport": null,
+          "passwordHistory": null,
+          "permissions": null,
+          "reprompt": 0,
+          "revisionDate": "2024-06-15T12:30:00Z",
+          "secureNote": null,
+          "sshKey": null,
+          "type": 1,
+          "viewPassword": true
+        },
+        "id": "bc020700-0000-4000-8000-000000000000",
+        "keys": {
+          "attachments": {},
+          "cipherKey": "8WrB3pNm9MlJ2r5inlvTw7X8TuRidRDjDESgBIxLTiH4KRb9FILC+5mUcx6EtjDm1L4PTNJxg+LDPjDGE0JwBg==",
+          "cipherKeyId": null
+        }
+      },
+      {
+        "blobEncrypted": true,
+        "decrypted": {
+          "archivedDate": null,
+          "attachmentDecryptionFailures": [],
+          "attachments": [
+            {
+              "fileName": "secret.txt",
+              "id": "attachment-7-1",
+              "key": "2.shGpkKa5zp9oT0nbrHprMg==|L8uChRn8bC2xbUhijMVzFpdYQaaCgvrXuCCpkBw2w5+q6nItmB3ouw8llBxIa6Gxwz4MaFFCaoX0q7347L9dn7yrhnu1XFp5okknoP5R4/0=|UNTxDnMvUc3ff4GmQNo9GGcThjpY+y1GW7J9Ec8H1Vo=",
+              "size": "512",
+              "sizeName": "512 Bytes",
+              "url": null
+            }
+          ],
+          "bankAccount": null,
+          "card": null,
+          "collectionIds": [],
+          "creationDate": "2024-01-08T00:00:00Z",
+          "deletedDate": null,
+          "driversLicense": null,
+          "edit": true,
+          "favorite": false,
+          "fields": null,
+          "folderId": null,
+          "id": "bc020701-0000-4000-8000-000000000000",
+          "identity": null,
+          "key": "7.g1g+owE6AAEReQN4ImFwcGxpY2F0aW9uL3guYml0d2FyZGVuLmxlZ2FjeS1rZXkEUP2Rq2ROzDUc0qhPXiVn4m6hBVgYyZRzzOTJGFXkMcJtaYFeAzi/VlWkVaOtWFBchRslxf1Yzn6pLkuwrztoowWnV6dljddTn85ZcGV0F1qfpgk3cILq9F/hmvfjouOLV1qYbL7vkNmj6ktul7bDtOXoSbjO0qBK22ENJd/xTg==",
+          "localData": null,
+          "login": {
+            "autofillOnPageLoad": null,
+            "fido2Credentials": null,
+            "password": "v2-password",
+            "passwordRevisionDate": null,
+            "totp": null,
+            "uris": null,
+            "username": "v2@example.com"
+          },
+          "name": "Attachment v2",
+          "notes": null,
+          "organizationId": null,
+          "organizationUseTotp": false,
+          "passport": null,
+          "passwordHistory": null,
+          "permissions": null,
+          "reprompt": 0,
+          "revisionDate": "2024-06-15T12:30:00Z",
+          "secureNote": null,
+          "sshKey": null,
+          "type": 1,
+          "viewPassword": true
+        },
+        "encrypted": {
+          "archivedDate": null,
+          "attachments": [
+            {
+              "fileName": "2.z85slZ25VbZSKkSsCpyF6w==|7QW20vxefpf2boN2paJgBA==|EF34Yc9qur+T72v5vCzMrlyNYIdShZdICBy0CNegVt0=",
+              "id": "attachment-7-1",
+              "key": "2.shGpkKa5zp9oT0nbrHprMg==|L8uChRn8bC2xbUhijMVzFpdYQaaCgvrXuCCpkBw2w5+q6nItmB3ouw8llBxIa6Gxwz4MaFFCaoX0q7347L9dn7yrhnu1XFp5okknoP5R4/0=|UNTxDnMvUc3ff4GmQNo9GGcThjpY+y1GW7J9Ec8H1Vo=",
+              "size": "512",
+              "sizeName": "512 Bytes",
+              "url": null
+            }
+          ],
+          "bankAccount": null,
+          "card": null,
+          "collectionIds": [],
+          "creationDate": "2024-01-08T00:00:00Z",
+          "data": "{\"format_version\":1,\"wrapped_cek\":\"2.sXx7jnpwnxknv9MYuBiZxw==|lgnmQwUpmb7GsqQ0pheYP36jj4de6sN9Z5uVhnRWsHTtPqkS2TgWcCBXUv+/pkwiC7Ix8pIsfTj84nwlNrDrDHrNUkU7G4gp1HGgKkLbgUQ=|Oy8sOG8yKUuRrIO/hQZXX8rsTaVKd0qgl1RegZkqxaM=\",\"envelope\":\"g1hHpQEDA3gjYXBwbGljYXRpb24veC5iaXR3YXJkZW4uY2Jvci1wYWRkZWQEUJdwMrHdwAiTddR4bVe30sA6AAE4gQI6AAE4gAGhBUwS6Okiq8WWX4oqyW1YscTvv4lGbam01nhagtwUXYaWlhyE6SU9KNEjwGc9MF73ccF0lOu23rr3WaM9om7KnTi5uFwE5qReGfSOOnB1gVMy6/GDpBumyoA5qLb8S1Ef01skqvlci6Ho3mGNdxLvH9klLisoSJcx21nUMOc7iQMfw8zEkyyd+x3hO42N65m3kbdQi3AelabT+tw8pNnsRcGU2MoRX2NdAilMgI0gkMml0dpq1lyo1J3aV7JZsP0Ttg==\"}",
+          "deletedDate": null,
+          "driversLicense": null,
+          "edit": true,
+          "favorite": false,
+          "fields": null,
+          "folderId": null,
+          "id": "bc020701-0000-4000-8000-000000000000",
+          "identity": null,
+          "key": "7.g1g+owE6AAEReQN4ImFwcGxpY2F0aW9uL3guYml0d2FyZGVuLmxlZ2FjeS1rZXkEUP2Rq2ROzDUc0qhPXiVn4m6hBVgYyZRzzOTJGFXkMcJtaYFeAzi/VlWkVaOtWFBchRslxf1Yzn6pLkuwrztoowWnV6dljddTn85ZcGV0F1qfpgk3cILq9F/hmvfjouOLV1qYbL7vkNmj6ktul7bDtOXoSbjO0qBK22ENJd/xTg==",
+          "localData": null,
+          "login": null,
+          "name": "2.mUrNag/JPVQmg4Ov5yaUvA==|Kznq9ecMSrLGDtVBzNCBbg==|4xIAeKjWeOFCDKiFkxae1q1qM93dZSdBrJn2tkFKWcU=",
+          "notes": null,
+          "organizationId": null,
+          "organizationUseTotp": false,
+          "passport": null,
+          "passwordHistory": null,
+          "permissions": null,
+          "reprompt": 0,
+          "revisionDate": "2024-06-15T12:30:00Z",
+          "secureNote": null,
+          "sshKey": null,
+          "type": 1,
+          "viewPassword": true
+        },
+        "id": "bc020701-0000-4000-8000-000000000000",
+        "keys": {
+          "attachments": {
+            "attachment-7-1": {
+              "key": "aLZ628uLmQx/frAB3GLYYivLKFnDYpX3r/Ztj0UyAeluKrWDejsu98Lz0FbUltKUIYhTI47kFj7NLXDkyegogA==",
+              "keyId": null,
+              "version": "V2"
+            }
+          },
+          "cipherKey": "8mu4Nc1goR1IiDLBW/h7uvxc+FMElQ+DlSsN04EcXCBFShVTrXNWF4dL3h7eY+IKjdoDDU14Tvu072XxMRqLSw==",
+          "cipherKeyId": null
+        }
+      }
+    ],
+    "collections": [],
+    "folders": [
+      {
+        "decrypted": {
+          "id": "bc030700-0000-4000-8000-000000000000",
+          "name": "Test Folder",
+          "revisionDate": "2024-06-15T12:30:00Z"
+        },
+        "encrypted": {
+          "id": "bc030700-0000-4000-8000-000000000000",
+          "name": "7.g1g/owE6AAEReQN4I2FwcGxpY2F0aW9uL3guYml0d2FyZGVuLnV0ZjgtcGFkZGVkBFD9katkTsw1HNKoT14lZ+JuoQVYGDBzOV2SxTT8xGIfvwQQuYILpA6lFAHfa1gwMFjSmwrEuBOhEUDxhnkg+daNpoDHR3ecDRV4/czWpqFiQL6ffv2WEmnGnqPsTZv3",
+          "revisionDate": "2024-06-15T12:30:00Z"
+        },
+        "id": "bc030700-0000-4000-8000-000000000000"
+      }
+    ],
+    "sends": []
+  }
+}

--- a/test-vectors/users/v2-pbkdf2-key-connector.json
+++ b/test-vectors/users/v2-pbkdf2-key-connector.json
@@ -1,0 +1,243 @@
+{
+  "account": {
+    "accountCryptographicState": {
+      "V2": {
+        "private_key": "7.g1gdowE6AAEReQMZARwEUKTRzd9iA/xHFq+CcSWoa4ChBVgYkfZQPzYiPX229iuPW/FAvozfGwr9foz0WQTRvbbqlZmdKMz5/v2FABXESZWEH1AwWj87r7F4OsBBY3kZlstrbCPFaAd70DSS/y0yFRXz8yis3KFL3dIGNq6CFupsLtcRQd/x+pCC3cLKjzjHMFFEMrEKmGguqsVEFRcred0kf2LtL1itmu2Mt2tE7b40iAhWtxoTeGprKgf1vchMJshlizMn2Vut70sBRrIbpLQvhw1LbYHrY0N0dxUX9TmEM86Wyudl6c8mlKiMcsKAHESgY7Tz0tVjY2XRjqimZPubc3Do6C2SUyLI9MBSnPVSJlUMnmXgoijvA7i4gZW8s1kwqd/JCZ/Bhedm/5PVzj1Gl0BJ3RufF+lGssz+MpmpgQXHIh6OIsVdz6UwZ3FuzabJhprHGZQAg18cK6Essc2aVTgxxViU5pUqVZfOfFOrt1NKLBqCkDMR3RguEwBZlQaQDaXBPklFNoczbuLAgEkoj3B3jv8Nv0RByftcy0hJJhy3PbH+Nl/LDwaYFvt/2YsPrDQv/304etghiqBOOu4RQatd8/tJFx1dL9LFCRO7muWgGInGp+rqzrBDBb0tlcrsbFQ1FSytCq5/k23dItuL9Ts7kqZOA2kUbBvBTEaZzAXRUtWjHLBxaEtsV2jGaaYJeAW/fCmwdmBIrlfictbdJMzwAUB+jk+ilWM5HK/ymLEBg17gzeZzgtEL6YqgwhJ6K9nB/kEVPrdGL9+2jQ0HlXJjS2PkllUwufEDt7QrQCCKZDdaEObr/CTjxgaQGrvN5rliN5k+O/I3kQYaEs0xd4wjjO05DTmLsORg/KPIqIoeR5nmWdf4JTFnKJD7yhcc68P6AiSMAX00Qy1g3wJq4sJICM4bRFzZqjTFeXbviZC7TDdY+jFoWvLgNG2t5EBRewUb+hWTyUlApy6PQgtYJcD+Eb7xwB54KfscUakHiNADeeM09qsR6JZVRdNxau+Udygnjq/9O3fcMX8nlyOyZhJe1NWDM0AsYg/asunfrPVJrPWzU0dDzl82Usww6zLiBlgUdphuGjO89g3I0HNB/dkU2o46BLuKteSmHENdJLt3Y8UN+5d7XR1Zcsm/A9jgbcqv49MNuKjb9ZeRHi9jQvW4UGVwJuhCxV5AkkX+DkddW7sMXjFRabS+uTr2u6ivV91j5A11ExRomyj8o0WiaPQ+Apt5kubemxA3EWNie/MywSlz9YMlJShURNPxgt/cD4q1bpC7gMur3LeyZmhMHmTHibxfyWUS9DhhYtHHR+CyY1KZyqzvc/ycIyrNYKLbMQ0j0/QVcCnaZ5bbg9pHaqYhEzn31XqzC0HNkH8HYaGqEgaKvr42ml773xBQmSWrT+e+uZhgVNo5zH7Ps/KWbcYamZSo+AtpWwlhrE4mrKKibr+/c8VTRgGSpAJAYwQVQITM7Cir2EvIh0xgqZq3sscn8xq+tp4dpJ1Z3RlmQW6UC/btSpfstvMrOXcidsA2z/hDZOH7y6EowmXBlN8pFeMrKYoaMpK2q8tEszI8WW9a7HRqAC3CCRDq6bHrl3PAT/dQucMAwTyYj76By3Q18I/IqfCftzqJEd/NZsLItHsQRlp8fSsnlcOF68Pt5JIufupNZQ8WB/AZLyG8KkeSRuD60TVcsJVp+pKFHue6RUMzwin/aj/IkOOP4i/z",
+        "security_state": "hFgfpAE4LwMYPARQoIQn52idGB5VpAOT/XQe6zoAATh/AqBKoWd2ZXJzaW9uAlkJdIsZhJnfYEfsy4QDakEj+G4m/0ybqS/+mqc9p4MbocPEMJc2c7dSgonqhaBx75zxFN/WzMo2TtfzPwkEamtmTh3VQENuvQxgHx4vE/sg7etBSLzIiNDIhoUkcHFxbDg0QagWg0shm7Y4ePFTcSxrhKLJatw7SYp1ZSCuaJbYBmMy6ncX0ZpqvXmLrejZN0QJUM2ORZtkouffHM7xccFoashx+KL9uTZGq9nK3/wi2htMCcURdY5gvxPGZXFN+c1Iqv8WJnJ+H+FEqeCr7wuYqOg94U74ddtXGZ1f0YbdaZD5NHzL3Lgv2ohgJDN8akgIlXmN8/m+J8/6Xh1HROwp9vduoz/frR2Yscp8okd/ZVMCZ91OaHkEEf5XEIp3dkcZ7opRcP7XXq326o6uHAsliZL8L12obpqT6bzaHushnrhJwMemshwmyBu/Y8YQRFo4oGnsiyC6Kh7HV1sRs/dZZmOL3ItnYjJaN8vHUcva+BfemwmOk7MGFG8RvRzxBqbvVWFZqLhF1LGHMvpD97U6iUgUJarApvtUataw5qaXZJ0hC8ck5SAVo0CRmg7JfK8QugRyGlO9mSblwAW9WfoInbwZ51D7SNxNqQ6LTo3J2v7LkfaifjsGNi84KPyDBH4NDWlA9ERTOa4M8fd+pw+ABLRmFXKmbgEagDpcFV3KKBu4bJvUqJ07DlFJTF/eToo+z/GRrNMT6A1f/y6SMzCxLc0EXRy4yCcPvzGIFpGW6rs3vP1e3s0I9UuYw0xxfnR34mlUV6Np99eCooURgsRuYhfflKQyavWwrgOK3eeKBN9ALfH1aHVWdiZsTKn1LrCkhr/rCkZhyBFugDGP4Tpky4u5gC/93kUzPJUI7jTCz2ZHTH13utUQ4yYydpC1zCh1ncv+TMp6e6Ck1saY0gqLwsoX4LxePy9woS0muxNIJeOMxaU+BtOoaJuYgcy0B7ovZ2dfbeScupFrXoth2i+e/nnFU+a8QdyIj9X8Qy+TLIpOoZkNcAjlNuIij3B7AZSp3Qd3L2jASk7vuxDvYwE2hDrDPDu0zTbxvtpcY46DhWVO6mAGTEhGAQg1mu0IPsO0rVtCr9wpT+iVyT/V/2qXcqqXBbG1Tr2v8rHkBZ1QT5LRrlH/2/i87gj3VPSXfadfSUShbAnvKywMa4CznQTCOdBDjVQgbSCafqZ+EyoeoWxxCX9VhaHndx1M2XsWJnYzKDhBKnfkR+dkflTzTEc1hDVvTlQY7M6sObh3aQBngHjXT0igXQcMKxM6KS+maIhJuHlYsZd/quBOBtgfq+UEIJJHF7qk3BqK3deAs996KPMjTgluSfT8xutb3a48rO24/rXNtUDNYHeC1hoCvcYUJ7EBUJKgeViCI3YGOh1lOL3zVyD9aSiFdbWhYPM4oCsevEVV7E0RyLLG592lbLVfBn5E8+WMCaa7nKAvPacZ6KcuxKxrkotz/2mq/UOhNVLFzTyZzHEKKgDUQ6GPrhAPO5MyktdHRHPgq0SnZ1MV1GLXmohV5r66y0Z67Ua47hOS5u24YkwsT3g+GdubiA8v42HSG2EoLtvn3avoU18nf3dCJ+C4wAOQYYFijbQTflLXq2GvjW5KZodAOmTmD1I43uiR3FY3c3D4vuQgVqOBuuTM37oTCqVnc9YXNbqHb/vw8ZwYIOpM4Ijz6JeRaq7n9CJaZj575Vblkyi8Tco1kbsbbVmRHNxzRBvazlt4dlg1cuI/RE8Nbh6vAF7jtOAM+0bDY/8Y0whyPMk8TBEYtHi9OcCB4yUgWHRCog/3K+e0DCTiDErHcYVIhh04Ic9EWe+bVtC4v9/+Cn/uxJXtgWFOnmJekapr+lXvnJeWOVSrVF+XhwHadOxqQHxbZrS0QFAViwZFpeL3CiPQX5zi8eR2uSbOChkoLTPmtX8miqSwasBiiGLK/HTSLk0mRrAuA2KjqPN9F+gFRDdKY0N7oGWsBUgzpMr5IMsL91XBgLMiWWeQQOGP4gtO5fJaS+SLhaEpcglU8+0ZHnLQI+J+aQ+dHWbfO17N4/+CiS7Qv356Zp6qCuoRgujDJbtgDA0tB4hKMr3FTq5Klip6Qc5GzhmsLjqBMy8ToSEJG4UWTm86Dy3qlkXk/UChWC60DAsyqZniZWa8kZaMaS2KDvx8FDjEqq/JQ00DTimVF/ykibCa3AeGJI2KMg9xet29ExbTeB7uolw9xrVzbPq2M8jNxFNAHJ4PjhP299qxFq+3kfmPsZ6ebWuLnA3gSW7o4I8vWPRklgiq83hX128ek6TjnGvJjQF4Utm0EhyF8Ry3VD8nJNPLDZk6Dk5vJhybitWKkABJy+qCaIP0EuJ+TMwD+3/MdDILz5cv+ywCsNnawfRbya0OEmynnhS9cvcy/NDTN4E8Wtmd14qi/VwBfu637jweG9ovgSsjr5lDXKhjBczzz2QT++mJcsU/PKUVZbesaSg9kTP/VZbND3QeUbJU+2XHvKl/Aq7WFX4Evv6k+Zfo6ZQzNvbrXwG4Gqx3ihYxTUwl4WglPVoCtMITTfZFXIRA2Gx/Gyccgs0XOxf7sG7noTVbP3g6sME1YveDy6LPMS/pxJPSIWcNVOZiV9GYXNzeSS1My5R7pBmC7gJ6vy2kn0dAxsn0BBc70B4WmPuDG4uJP0MlPRKWM9SBjXUzL90pG0iBHAnPUma9Pn37eK61Ib9PaSTYCIMWeH+bg/EawVYq7ftwFQUyphYLDtPaEV1w6MWGRQxSXRV7tvIyfQ6ZXQ20Cd7yx+yt/oA0fhhTOkDrqM2GcxsU5MZG5z+e5BVJlyhumvuBaagM/M7OBtgeEnVpRjl4fBvncUk0mmo/ZIJvJUjZwKjSbYbh30FiOj/dnl3qGLGsIhhImMwLqQbAxeIHG//2wGytDY6BMx9hcSdhCjALcMREGwfSdaQyYPt/KWy/R+gWrXvcSMn67tfcb46eopQ1x7RZFUThWIdqFPj3LEY585VY0OL5NKaFhndhKxiC4EAb7Smr0XT10cGdMRjCej1/4MHbwEnRztuGb/n4aU1M/5N8g8xwBgacSQ+4DXYANvNg+YGq1Wy274yZb/xT7nE3tAEdWHI6DM3f1I5fCQaKxiGTE5ldL9WjSSumBQccVVZofZygw8nx/Q0XGzZEbH2BjqHG293sDBtHSGBqb4mOrcrQ3PT/FCYtMFBpbHd7fISPoa7Q1+n2AAAAAAAAAAAAAAAAAAAAAAAAAAANGyo8",
+        "signed_public_key": "hFgfpAE4LwMYPARQoIQn52idGB5VpAOT/XQe6zoAATh/AaBZAU6jaWFsZ29yaXRobQBtY29udGVudEZvcm1hdABpcHVibGljS2V5WQEmMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAs1db3xNu8KhD9rF5a46nD6v6iADuQyW+ou2Md1GySuyGonu65ajWgSg3q56+YzSid1gO3P7pAmC0hFh4cz5udnFUSs1A4rTHdDgtaYpZnpqizVGPgO9hJPSZb2FOx99jxC1+Lswcf76MRPQ8Mg3CXLfiWiRdm7AqWUSvIfZ5hsGsOfPueC3X8IjlVdzO+8xD0Kw/rFAA6QPH2zeFKLqoIMrH9i7CSk9ZR647q4LAXk/jHmQWDDm8KPtv2uoa4LOaM1+ujNoEjYAoKTPBfHAdMDQzaIvz/jvwasMjERaGWseNe+LYsKjvZIz0gtoj6VC420rCyQ5ShuhNJMVo/EowxwIDAQABWQl0ArYNdaSlSz32C06YBmFC5kTKGFKpZHj5kj2IVBCM4+MunEzc8/DBIBoe14FzRfcdhxZVvz20oQ6oa2u0hgvcxImc9DgUPqIPHmTtyk7HgeTU4/zNFY5UaM5nOZPLSwaTXHyDduRDw63ugIagyEsMKmTfVrhOC9SwrgaPSk+UM1UW1Md9xlGB9in77seTwSMJLWVhTveeXecl4qXSxGLolSLZoDqnk9w2bMQSuq/2UuKjb/TrUJSMVhef3HQFyEJjyvYzDf3Bi5C585akFSBG1Rq8UiPCqk23UCnUtdTQdLfwUOb+vz50wGjN1ilx7TSp0NQ8iXJIWdy6zACvp+Zip9fzS3JFsgxC700tBiPJUuwK7hwHYIbM0VaKRx0NYG4NtOYVsK43qtvFlsywEd6Ql6mMHzlBIgCGLrbA2hQvl60dC6Zmjs2DyTiCqX+0KVLNDmMd3dtq8I4yoOd62MH6Imngvx5QxNrzSg2n+e8L3AOXDwkEugPwjxYIT3gsci52z7BKkCGCGSunH9+xRyKSXCzTXqWOCgl+Wa9kAdOZvx3gCV3G4b7xxddt8XT5AKuJSUa4DNJteoP2brlS//ujwmOQiUuq5fV81aG7aWKZJh5NvnCuyzNo15uS2NYFBtxD/2lAR6UrgbHT5pqyUalaKWEZHQzzoi/r33+D2NJ3DCLPxpzmvc02pkl7haZQgjku1BUVwX0NXl0rbKWIq62+2l466WwqANfIEv5NN5zO0uiutaqLN7hskgVCklqOJB3Pt8EXawPskS10cMY5SgauEgEmCIJw+w905Bh8KdDZL1kx7T5NrGvI9c7YfFi6G+qWQQfOIqYDeZO+d36r+l3PBPwh0l3rdn7ima2VV+/f17UYlSV6g+FtHjANUiOkI8yhXeTaz6uZpKI/fbjJCe42uE8B6pR5b4rF0cpYNyNocrf/oJ5db42g6JqiuFhpmTGc8DkbUGmbYm212cmk/MxMcqwDzFCktUA4Csos91bVgCdBC5HhHlKBAxzQlcpK79jDFbImW4g0hSw11Jkyhznfm+e31zxvhVv7TjqRfkLN4zv+CfAc+GdSXf1jnhSthwqrOsXLId8DB1ErDZtzlJqkdz/3W/rcSCMxat2FqBMfKH+3cpDyosZ5taBuwKFTxdFRsmGUqfcTgIOoRraB4ajzo/5WzdUk+8x0qgRY5Rn87Trdk8J+iBAFvy6ziHgbwfeF5HHJWdB+HcudYaZgGbeqvt8+yaxqsCLEFtmPe5Fph+3s/miJKFBzvLofqBErbpuAohZOXw125AiA3VdTM9qJEpiepqrZVMR2dAeyC7+ZnCuTqaxsLw9EQac77vH4LbGlmS7RCGNomIathwh2kFBXYJSFx8T1WedeZXJOgTDfOeFsHw/lAIQrVcZ0ihXsqA9X8d8eW7W2rr6lM40RW/yD2hucSEB3ut5X/kYZzo34XMRlPqQFUIQDjDlKjfxn+gr7hkolM8jQpoXvSdMDF8AQ3WgIVUCoc2XKIE+3mujOVJ0xsWODQUj2oOx2Pyds7UjlD86AiyNkKIp3Jyg9quhGEbTyzqGL2ZSqysZ0fIYGwOjgfngX2TvrBbAgJf3LoWtEPOjn+0Uk4UZpcZKC3kzZU6B+Zv++QNd5AygRIgn7f8++D+MPWk+FJxwDdgKHvwpRvmSbZ3gVtPDQBMZeJVfNZk6WzO0qs+wKBqKdsHvBoJPR2h7s5OJeb0tCJjNZPHWwPc1QGX2NY2MSvn8X2nZjNY0KUxCCfhkV1D8k3LkMvN/8wwJWPEUw/uNHFYFIs0dALUt0awSEkytQr+1EVeJRBT5CD5FsEjfaUAt1gDbJw84QxEmlKyCN9qL9/liD/AvPr90+irljE9sUMPFtTwVvJbdMbWoxaxGxkmEXYg88bXKjwqhz6q89A8gClim6Ry0mwXV1Qe+q8pEc6QoNh/8lkS9PCdjMHJtm3/r0zyJrc7Tu5sqJjKWz9HIwhfwx6g9K6BehsDexjmqTqCo5PNcDxxEc2DvsdJrBxWcws9NDFp5thT2yMADsThPvujcB9ndqz2R1UdaYXh9ovC1x7D2A0jIPp5FOiNz/+xiRErrrwntyFvwT9OAzaGZCv2s8YqJjlDbrKMZN+8cQr1Dofle0iaQY0ma9m+aaUWe0ZF6M2RC/PsyQw4eaBG7IBIZBKiCU7CJOwuV9UlVNbABeyg+3nphv8LPRGw/ebIDs527PQHn/9JdmyLTntMt/ew/IN+ERoz8mtfaO+84xzwQSpw6/Hq2vv4W9FQvvJOBoz0q3Ffj/fT6QumGTa7IPB7DAxI1sQTnCC4udZ7L/thP0tjwAOa+WDK2KyBA0kRAVXkbDh1onP6OhY+lDMyRvW77gft9f63uwsbujdqWVU4e3hrZoFlrXkWRUAaHCDZ9enUcH3aQ3gKWt24xMQiZ3Ue+0pVg92flEJZtyMFU6X78S3cMgLFIij2uYL525EP6W9UNB5WJloOsXeWTzy0Nji90ZK+fikNatajTVO0BaFm8fXLlp8fEw/8zuA1cOVh4pAZX65T3mIkcKFhGYOAXStHPcnDQBc6nbUrmwg76M2jchq/BIW3DOnD0t7Gjp5cpmkR3rRzI/I2nRFMK6Lj038ZsdQK0GeQC8WZzjqIfAJF3OIIE5SEM7Hj8mVvch8/mqVkvvGYygC40hjoCOYyynxdgafXCo3oxMN2N5cEsaY1DOxWxpEZ4y/kx9Hdm0mLv59AjpMfVcjQJaGH1rew3CUUJGjAxhmHSUKbxiKunV8VMrGI5eTgB/q/nSqr8hbgUMWNoFxkzbGOcAvq54VqoUqNi23aA1rC/9UU02CCz9N3fBonuA5j/pIKn/6R+75IwXDn2GSREUu1bjv6RF6IxyYNByLi1ZED3/vFa6lsbEq1Eb4Cnb3BuPZbCcf8Y46c8rlWOXixUkU7GpHpndpNGizST65zdhTDKQdQoS0yFQZ50ggXlPVPQnfsl8+XW9QGYo7DLXqb99SZwecRAnrs6u65UEyXWHV8h3VQ1T6IhNpudKDzM+CtyNazda6hnzNFM6AVZpjSjmR0NFpx8m9Y/49oaUrc7wZ3qQyCHSh1LKenpU0nM6FDWtuMlQgiQbpwTIdStWoYICDhUhXF57foeotMXH0uMTHyA4TWBhgIOdpxQcHTZCSU9sjZylsen19gQIDBMZHEdPYWp1jY6hqLCywsjV5Ozu9gAAAAAAAAAAAAAAAAAAAA8aKUE=",
+        "signing_key": "7.g1gcowE6AAEReQMYZQRQpNHN32ID/EcWr4JxJahrgKEFWBiACgFI4ucOYUwU4eOOUjv4gy3RG3YKbAdZBXI1ocVvLgUGRYTod1wrqhaSwCCiFlrh660P2fp5sLf1j+uNr1aR8tdRnj1dYXJ6mQ0qFz+DwT0sel/2o5XLkHw6B/2Hsi60W3Q4KSO9znCWnjJ0egmGjvDwABSR0heZDSDVIlwW69fST9sACQ5WS9jAHVVVJKcAw4cHXG8sKu6riFC/9erh3WqMHYzOKY8eUyMoHd4tfTvfMfVI1bttYHeDriKlZ27ccxK3KQm/+jDYkTlLv/+cjAPwjxaHEsVrLfz9Au5HdKLm15OOsazEWIwJy6BhlFvDP9huZEe6dMIpgMqyd2s0mepHsqlGdLa4t8gY30HZlPMNOcPNstd+13vpNypU5aA0PNpAlsflNBhVK+2BI9Xo1fbgH3b8Cy+LBpqeWpV167iqDA3I15ReApaVlAjUGWyqinHHy3XIwavflAR60VqC2W/MbEyrXjPy4/MSkDpaPiUBWAWMiv5QtZ8b5/PPxhYZzhrn13UinjE2WN0JMcU1yukrQVrzr8A4dOZWz2W8ITd8B4shMEw1GvsKpsNlrUmUZnJxpKSMyMRVhYIFF6jeAKhdJ9841B0KuoTum9Lk3Zlrhh8B6i8sutb/XUB/T6K5DO3WfVfkXeBI/s0mXer/tAcCl45a853ETCIPNcAUKbVHPj1Ba5exwBk/6V2Ype1BbAzoa/g4PZ5QfwhfBU8LpX4JOJmNDo+oV6Hx6zEdljC9FplwTN6SEcJtbKoI7Il2znh69Yo6DEPvzPBZKKjRbgkYV9NjHvTUQIMTdSrFT8YbAPQyLkQ4wAs4USe/jSQtPZlwC82n7YdVbsbSV0jtchHBU7z4bkPs43kPlIccsVTCloDd2vtzDvX6kS/IVk4P4V4hmJi/wYP7coIObt4F+nFJM4qBcoGKRfrib3H0UuvN7I/K9ocx/QtHgE09vDqGyIcXIkYBO9sYDE6Fa6HdNNZxDfFsbbkI4KjZV3ugG/pt7agUUzYpSGwj5X4bDJsk49Jcg2Jft8hhKXrl88u5VC3e7ulFaG9Sc50TuDnZj2riD6D5VHjj29olI0SuRtgnwPGnyF6rtdg59loWs1U13A4xoqsqtGYlAZMSJT8ica5sUYQ3iilq3rNJ3U2ynjY5Mn0Sq/kfZUD7mOVIM0u3yL7pWeJZBg/Pxy3ZGuEvBDpsqksCNUuM8fx9aGQQOCresw3S5FgmAwX0laJ0jtjOCth3/MZdGg3/mh6nE6oHtooXqern0saA9qEDVRkCQ4TAyvg9ilCnOzPjr7YXymbG9TYPdX+gj4z0u0vrZYNwCc7Y5IkqlDcG4AhSgMEaA5nJYIxmjDCwddUe+8Oz79m3dznAiym/Mh5IarWC0T+1ID7P4OMkCZF/24qaAZQuACDcFscCop1Oswz4s7MNJU+73122Yt57kZ4r2c8OuQXX/qKoTJqYfvH0K+cOkPIHpo1MZ4SJZ/uuhjXI28OZpo0nNlDhSsud/kgWN7WilsCj6NaC2s4EBI5gc8EL9B6H+ukpWKqxS0MhPlF66DNEWcsSyiVr1LqNI4oF48c919Y1ZXM4EdJQX171XV9Jt0qe5nJXjNAnzvEQ6E3vYwDoDGEKgvm/Uw5wXqnwE9HPo/0cbB86k9SkEfPjmBcm8JhrqRiXiTpBvdsIkEndyHERneI5f7uV+TJxTqE1wfmnYeNOqw4O40+hXc6wx9d0wDggDnelYZUkl5N77Jp+6rosEm3hNPzIp6sVX0haSOS2sErTmmqThOOloi6jbpglB43cFdcJTI4Q1aXvMa3Lnv5EddwwgO4cq3enN4snjTpINsmiy44FfEBXDUSp9HMWH0WrbjGJI17c0nXE9RAz1dwr7PZIg9hHaBljqLe3kUVL6w=="
+      }
+    },
+    "email": "v2-pbkdf2-key-connector@test.bitwarden.com",
+    "kdf": {
+      "pBKDF2": {
+        "iterations": 600000
+      }
+    },
+    "password": "password-v2-pbkdf2-key-connector",
+    "securityVersion": 2,
+    "userId": "bc010800-0000-4000-8000-000000000000"
+  },
+  "description": "V2 account unlocked through a key connector, with no master password. Blob-encrypted vault.",
+  "name": "v2-pbkdf2-key-connector",
+  "rawCryptographicState": {
+    "fingerprint": "cobbler-unruffled-backside-uncivil-sitter",
+    "keyPairThumbprint": "666697c00ec28f2b5bc37a17a19a454810615546d980bd456f1098566bad44ac",
+    "masterKey": null,
+    "privateKey": "MIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQCzV1vfE27wqEP2sXlrjqcPq/qIAO5DJb6i7Yx3UbJK7Iaie7rlqNaBKDernr5jNKJ3WA7c/ukCYLSEWHhzPm52cVRKzUDitMd0OC1pilmemqLNUY+A72Ek9JlvYU7H32PELX4uzBx/voxE9DwyDcJct+JaJF2bsCpZRK8h9nmGwaw58+54LdfwiOVV3M77zEPQrD+sUADpA8fbN4Uouqggysf2LsJKT1lHrjurgsBeT+MeZBYMObwo+2/a6hrgs5ozX66M2gSNgCgpM8F8cB0wNDNoi/P+O/BqwyMRFoZax4174tiwqO9kjPSC2iPpULjbSsLJDlKG6E0kxWj8SjDHAgMBAAECggEBAJYSXy2PvIEjvSOdJWbMy52AozfV14tW9WyvbaCXO6QYwx0Kfr4Zh84ykktJnjWz4NQPWvixUtiLheNNiRWew57XfNrPYSGUd2cYb1/mxtHCwsMfIf+Z0Oe0ywR6IAt/MqQCEZolcR+wmv5Ehm64NtGRipc14SMbyoRCxm6cKtuIpMObrKjbF3nq1w45y7uV7WobuvAjQAbAaASOa+ocLELZ+wkDYhlBHqpVpdrFQfdy0BDvfxYVFuR008jyL0jgF4rhNdgf8wS91iL8XwKgh9pDIFrb8RHwUhkhKyDXTU26anVrmgK1cuYchOVQjKHpitfgldKwAc6YsC0wxjLBBykCgYEAz2SuFmWRXDUUgVlP51lpEsCqE2cqW2qiSfsZEKLOcujRPEml8SLKYYc/j89K7JKGR5q+6Lz6qVAx6TwE/lWBguFARxhzavHsAEWLPXnWLksHUugGd7OvNkfIutcSpv/RCm6zO2KhmhxpfizfifWR4j6/j6OQbxyV8BnFVI7psdsCgYEA3V+YGl2guZtpaCQJvg8ZLz3onX1HhFm/qnNkwiGpf/aUPrd4PrSkgDJGZ2f4Jt19YXHrBSXP4YpZ98jM08hfjRrb4KZC1mar/cxj8AAoSsu/oyQF18txGytJOJufMQb3r/kLCdI/rZ8w3Aem22L18OZirr7cayP0EL/EBz81foUCgYBrIBo8P2KCOnjJB5UabzizEwnG0/cxGTeS9zzPNwlkmZXaikBI+iuHjRDr+6s738O0oN4T4emoI2BklTgPF6O6Mxe8oYicqTG6QjHWI2TarK6vyGHu2sWaSCILQKTF1kXoGZ5DAoNu01Y6cntVC5+7OaZBT79/ZUidqPIg52EXGQKBgEVlz2gMi/NDviKQkaFMWGfP75lXidD61bQYorCdHubnpQeYOpDlzmAF4r5OAKQmcUTYEoY1mVqqJZQhFd0ahqHUlrNxS6is3SQeLAIz+m2gO/5nr5E7zMRoqHafiqMy/PjkiMpWZ/IE4qtHls5V0qXng24mlTDdP4j0pP5kmV+FAoGAC71UxGtQ+5XP/PeMNU4Oh6XmxK3k0wLnF3JPY+QMqNYFpMx4N6YsJbDqkDAm2Uy1eo3PX07wCThGoZvEwFpdE6vbG5o2Mqrixvqy523ifvnPdrUCFu5/MVGCMItb/TjRJLIMMfN4fApchX+Szz3nmQqCdsO1mjdFyqgfaWg93Sw=",
+    "publicKey": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAs1db3xNu8KhD9rF5a46nD6v6iADuQyW+ou2Md1GySuyGonu65ajWgSg3q56+YzSid1gO3P7pAmC0hFh4cz5udnFUSs1A4rTHdDgtaYpZnpqizVGPgO9hJPSZb2FOx99jxC1+Lswcf76MRPQ8Mg3CXLfiWiRdm7AqWUSvIfZ5hsGsOfPueC3X8IjlVdzO+8xD0Kw/rFAA6QPH2zeFKLqoIMrH9i7CSk9ZR647q4LAXk/jHmQWDDm8KPtv2uoa4LOaM1+ujNoEjYAoKTPBfHAdMDQzaIvz/jvwasMjERaGWseNe+LYsKjvZIz0gtoj6VC420rCyQ5ShuhNJMVo/EowxwIDAQAB",
+    "signingKey": "pgEHAlCghCfnaJ0YHlWkA5P9dB7rAzgvBIEBIFkFIFWUYTU3RV2jYCplNn55yQvYsCEExd+rffZKbqbE1Rey5teQsA2HXkKfd/oY/+IBU5TmiY0u3wVCRKJ/nC/DyKGrZ4k2u9gKrEw9u/HChcisSloYqp3nVnnFsTXBjpLJsBuRt7HledoXXgK9MzXhJ7ZWE/H0Pjp0HNg84ujTYDcncPTKkJZlgvDJMdkKH2qcgLH/GCvXsaoeJ3CsfriDzbwZWGRCOcJ0bArK5nM+Lb7mkBpo+EBQrO1DJ7VFcLeNZ5+nvRlT4PbZa7a280HIf8o3gKL5KWwNRQ/Mu2K/dThEei0tZUNjuj5irCqCVkhaKVj5pBiY4OlcQ6OyedUoiaWySw0C0/yJ5vtvU5LBtPuo7J+7f0KyYa4LvC/TfLkA7wQJBcjdFvRKRq9oHGlnoCtPa3owpX72AjEvC3fQusOi/gIHLkk3kVHAV6UJ9Wji/WttcSOCxT/7bOcfXXneWT2s+cAm7igsi+xyoFzIoiRuf3O58M4xoY3h9pZHNwgk0UJO9YTJLDeXnGsb+2mxMlwY/mkr/o2xAZ0wnmPYPOOW3uh57+jv74+Hf42It7IjsfWvkjRC7x1TeI+5cgTJfKp4EQlkfK7BJv1mIOS21APcB/7Ec86g1JkN3mWL3ZSUkNI1+zWssKMGW/tRV85nBl3tMLk5+vFrjtgyIldeKQt31GpZX7MDmvgpBma8bA9tCbajf6Qshgm6p3cLLqxYs0Af4u2t15L7syFyrLxSpq7Tg9rdTRzfWOhQjGiMsT2AiXgDVnKquFSj03/WlCxI9FBAE3DxHHOpZw88i6DckorOj+qKU0MQdMhSrx+CsH3sewtnhglWHJXAMIxNcHbFAu1Sy9GqhFZsFTEB5lnbFUzjUDpabJEai1fDEKZin/nju7JgsbbXx2wEuyxNCvP0sKAiHdfAXKv8eevgSHj6cqQiOc6HwoIOVC9pYf82ahHyjcAGW8VlWVejaLxerkfv6HcqZco6/4BEi09ZUMIK+xgahBUL//wX+zb1bCWeavcyl/SjHiHtov5smjg+B92UBizL5bjkM6kUuhJ2t3ze41WxrLy82tCR5xhI500qI501/gjKAzeFDKCTzpPvfWrdZuirDP0MSvPpAawipYoX32UKSYylhiUi23yT3icNxJU503wk3OsHGeda0yBTTxhqScIlc8mvDvczkgsDOItmGFYwvl9M12XkpafhX9QiYU1TsBEdetTUPe1SaLKUgqiQbAprJNhrSC7cIfYGXGavP80z2bMRcnyFb/X+ai7eFu2D1bFR3HT8iFPVw8cW3BIjBbY0410F2LTdVc6toN3SHBnoqF4LqfUZYkwhlcqbKJmAqEZlD4Fgf9wmy+lSQcOFo3v9EKQaZXgGqqBf5UgYd7COU+5C84UBW2f89451kimVmlvipUanYOEnzT/yiCdgxAi5Zqay49ythcGl7FBRegWoc58HMkphOsnrOioLr6IluiDHgVUQJLRdh5DFgsR58ZA2dnhpKOLxLoAKwxDN9Gm4It0+ciEW0Qfu11+dCF+C74eNdOF9E4oLAiVL4vFX7Ks/uSZIXG53Av9gLN4RqYNqHxpESu75PJ0pT86FwAzThlLa+67DPelQamwWc6RatgMXWOaF9eHfwTWidKv5utxR2A6P6W23zoAQTdxcIuYoQvi7K4cfdwg26BeiZ9/pHokUdDgOorU2lDdt+E/yVoMMGXbif/wMEemdYPDwhTb5+TvFxtZe16Xge7FhUG6HH4chWCCVASQLUt+7F+tCpfX2xDpBzMs0D+ziJw8A7LSP/i83Ng==",
+    "signingKeyId": "a08427e7689d181e55a40393fd741eeb",
+    "signingKeyThumbprint": "58f9606f44641a08e4e4381bf57805dbcb643956f99b085a01ddcd354e444a72",
+    "userKey": "pQEEAlCk0c3fYgP8RxavgnElqGuAAzoAARF5BIQDBAUGIFggl9GF2x8fs+ma27hKx8y41kwtnrOcmRftfzLJt/kigwYB",
+    "userKeyId": "a4d1cddf6203fc4716af827125a86b80",
+    "verifyingKey": "pQEHAlCghCfnaJ0YHlWkA5P9dB7rAzgvBIECIFkFIFWUYTU3RV2jYCplNn55yQvYsCEExd+rffZKbqbE1Rey5teQsA2HXkKfd/oY/+IBU5TmiY0u3wVCRKJ/nC/DyKGrZ4k2u9gKrEw9u/HChcisSloYqp3nVnnFsTXBjpLJsBuRt7HledoXXgK9MzXhJ7ZWE/H0Pjp0HNg84ujTYDcncPTKkJZlgvDJMdkKH2qcgLH/GCvXsaoeJ3CsfriDzbwZWGRCOcJ0bArK5nM+Lb7mkBpo+EBQrO1DJ7VFcLeNZ5+nvRlT4PbZa7a280HIf8o3gKL5KWwNRQ/Mu2K/dThEei0tZUNjuj5irCqCVkhaKVj5pBiY4OlcQ6OyedUoiaWySw0C0/yJ5vtvU5LBtPuo7J+7f0KyYa4LvC/TfLkA7wQJBcjdFvRKRq9oHGlnoCtPa3owpX72AjEvC3fQusOi/gIHLkk3kVHAV6UJ9Wji/WttcSOCxT/7bOcfXXneWT2s+cAm7igsi+xyoFzIoiRuf3O58M4xoY3h9pZHNwgk0UJO9YTJLDeXnGsb+2mxMlwY/mkr/o2xAZ0wnmPYPOOW3uh57+jv74+Hf42It7IjsfWvkjRC7x1TeI+5cgTJfKp4EQlkfK7BJv1mIOS21APcB/7Ec86g1JkN3mWL3ZSUkNI1+zWssKMGW/tRV85nBl3tMLk5+vFrjtgyIldeKQt31GpZX7MDmvgpBma8bA9tCbajf6Qshgm6p3cLLqxYs0Af4u2t15L7syFyrLxSpq7Tg9rdTRzfWOhQjGiMsT2AiXgDVnKquFSj03/WlCxI9FBAE3DxHHOpZw88i6DckorOj+qKU0MQdMhSrx+CsH3sewtnhglWHJXAMIxNcHbFAu1Sy9GqhFZsFTEB5lnbFUzjUDpabJEai1fDEKZin/nju7JgsbbXx2wEuyxNCvP0sKAiHdfAXKv8eevgSHj6cqQiOc6HwoIOVC9pYf82ahHyjcAGW8VlWVejaLxerkfv6HcqZco6/4BEi09ZUMIK+xgahBUL//wX+zb1bCWeavcyl/SjHiHtov5smjg+B92UBizL5bjkM6kUuhJ2t3ze41WxrLy82tCR5xhI500qI501/gjKAzeFDKCTzpPvfWrdZuirDP0MSvPpAawipYoX32UKSYylhiUi23yT3icNxJU503wk3OsHGeda0yBTTxhqScIlc8mvDvczkgsDOItmGFYwvl9M12XkpafhX9QiYU1TsBEdetTUPe1SaLKUgqiQbAprJNhrSC7cIfYGXGavP80z2bMRcnyFb/X+ai7eFu2D1bFR3HT8iFPVw8cW3BIjBbY0410F2LTdVc6toN3SHBnoqF4LqfUZYkwhlcqbKJmAqEZlD4Fgf9wmy+lSQcOFo3v9EKQaZXgGqqBf5UgYd7COU+5C84UBW2f89451kimVmlvipUanYOEnzT/yiCdgxAi5Zqay49ythcGl7FBRegWoc58HMkphOsnrOioLr6IluiDHgVUQJLRdh5DFgsR58ZA2dnhpKOLxLoAKwxDN9Gm4It0+ciEW0Qfu11+dCF+C74eNdOF9E4oLAiVL4vFX7Ks/uSZIXG53Av9gLN4RqYNqHxpESu75PJ0pT86FwAzThlLa+67DPelQamwWc6RatgMXWOaF9eHfwTWidKv5utxR2A6P6W23zoAQTdxcIuYoQvi7K4cfdwg26BeiZ9/pHokUdDgOorU2lDdt+E/yVoMMGXbif/wMEemdYPDwhTb5+TvFxtZe16Xge7FhUG6HH4c="
+  },
+  "rngSeed": "iYqLjI2Oj5CRkpOUlZaXmJmam5ydnp+goaKjpKWmp6g=",
+  "schemaVersion": 1,
+  "unlockMethods": [
+    {
+      "keyConnector": {
+        "master_key": "5IsSoMkYdFxODiHWoxN8ilVQeM7wSMKRTnxVpBahYy0=",
+        "user_key": "2.IR9vBRubS0peCN0bSUBhBQ==|Z+sbHMFfgpAr9o4mz2rEaomI6NKhZfffYFsWPPx786rvm8gBHvKCn4TjMkV2SepKlMFOHceqaElraD/DlMpSn/UkFR5pLQZdDFLRDFtdjiM=|vRgwDJtNVfXn3jtTKNzaYNmPHFYrlNzjxU9WHfHaPqk="
+      }
+    }
+  ],
+  "vault": {
+    "ciphers": [
+      {
+        "blobEncrypted": true,
+        "decrypted": {
+          "archivedDate": null,
+          "attachmentDecryptionFailures": [],
+          "attachments": [],
+          "bankAccount": null,
+          "card": null,
+          "collectionIds": [],
+          "creationDate": "2024-01-08T00:00:00Z",
+          "deletedDate": null,
+          "driversLicense": null,
+          "edit": true,
+          "favorite": false,
+          "fields": null,
+          "folderId": null,
+          "id": "bc020800-0000-4000-8000-000000000000",
+          "identity": null,
+          "key": "7.g1g+owE6AAEReQN4ImFwcGxpY2F0aW9uL3guYml0d2FyZGVuLmxlZ2FjeS1rZXkEUKTRzd9iA/xHFq+CcSWoa4ChBVgY3QQUyXATTVAQ5IvqWE3+Ld0C0T+VQNALWFDTrMc4rg2gRl0fsKGAkA+Ta7tuulJq0uvVA0rq+fFmaokBwli7+rfK2ThDg6NDqyu9ntoee/QzSxMS6jsvJdJC/p053RlyTsy+y9TCsvQVUw==",
+          "localData": null,
+          "login": {
+            "autofillOnPageLoad": null,
+            "fido2Credentials": null,
+            "password": "keyed-password",
+            "passwordRevisionDate": null,
+            "totp": null,
+            "uris": null,
+            "username": "keyed@example.com"
+          },
+          "name": "Keyed Login",
+          "notes": "Encrypted under a per-item cipher key",
+          "organizationId": null,
+          "organizationUseTotp": false,
+          "passport": null,
+          "passwordHistory": null,
+          "permissions": null,
+          "reprompt": 0,
+          "revisionDate": "2024-06-15T12:30:00Z",
+          "secureNote": null,
+          "sshKey": null,
+          "type": 1,
+          "viewPassword": true
+        },
+        "encrypted": {
+          "archivedDate": null,
+          "attachments": null,
+          "bankAccount": null,
+          "card": null,
+          "collectionIds": [],
+          "creationDate": "2024-01-08T00:00:00Z",
+          "data": "{\"format_version\":1,\"wrapped_cek\":\"2.GQFM4r/mgn4QzWIaINosVw==|MrqGkrDe0SAs2qxElTmph33MiK0LirZTvoPQQKEuERyH+4EGv+gE/R0CzDmY5TUiGEXKERSCl1Dt+b7TsGj2vaOxBoJ28gDpBAW5j63uwX0=|iuvHGyfNcblhZ/Y3w/r3J4G/BdIzzII2WcSnBhqMVkA=\",\"envelope\":\"g1hHpQEDA3gjYXBwbGljYXRpb24veC5iaXR3YXJkZW4uY2Jvci1wYWRkZWQEUOyGH+DPO3lDg4sUBLUTjSw6AAE4gQI6AAE4gAGhBUyM5YkY1oYDDRbEySpY21R1hcwdDNf0U+XhhyEFpB1kAzJHhTkMbCoqWEkZb1gb0aMSKAmMP3U/TeDpIBxFydRO0aOaFKDosNUIVF1zdVlwnjREMorhy3Pj4S+eInw5W6oSeaNYm8WcLQwnxb5spQdEouL+/sQ/Gs/GM2fyyi+ONHMvtrpoSOUVW9Oj5Ue6ijh0tn0Vv/dLwu4TvVdo3c63lPgbKCY7zS/yDJVo/d29tUGV1IEyXC4gUKUiIJsM+HFZ01l9G+xZVRq7L/sDr3QWSt0CA7kBA+zy0wzS/jMuIVHYiyjVB3Y0QQ==\"}",
+          "deletedDate": null,
+          "driversLicense": null,
+          "edit": true,
+          "favorite": false,
+          "fields": null,
+          "folderId": null,
+          "id": "bc020800-0000-4000-8000-000000000000",
+          "identity": null,
+          "key": "7.g1g+owE6AAEReQN4ImFwcGxpY2F0aW9uL3guYml0d2FyZGVuLmxlZ2FjeS1rZXkEUKTRzd9iA/xHFq+CcSWoa4ChBVgY3QQUyXATTVAQ5IvqWE3+Ld0C0T+VQNALWFDTrMc4rg2gRl0fsKGAkA+Ta7tuulJq0uvVA0rq+fFmaokBwli7+rfK2ThDg6NDqyu9ntoee/QzSxMS6jsvJdJC/p053RlyTsy+y9TCsvQVUw==",
+          "localData": null,
+          "login": null,
+          "name": "2.8jvfSMCrX9k9/1XC2v9rGQ==|8qZ7+HoVn+faBY0FP9mPfQ==|Yi69RL5Y245bYYMmBGeaG9MOo+eAGCkiRa4YJWiH/eo=",
+          "notes": null,
+          "organizationId": null,
+          "organizationUseTotp": false,
+          "passport": null,
+          "passwordHistory": null,
+          "permissions": null,
+          "reprompt": 0,
+          "revisionDate": "2024-06-15T12:30:00Z",
+          "secureNote": null,
+          "sshKey": null,
+          "type": 1,
+          "viewPassword": true
+        },
+        "id": "bc020800-0000-4000-8000-000000000000",
+        "keys": {
+          "attachments": {},
+          "cipherKey": "LodCGdiDqSSDWZ7nV3KsHU31lezyIlZGW3HhO9+SoPlIqqp2BlLcaf17iC1SNZPI+nRKoEgmq3sZRHyHoQjdwA==",
+          "cipherKeyId": null
+        }
+      },
+      {
+        "blobEncrypted": true,
+        "decrypted": {
+          "archivedDate": null,
+          "attachmentDecryptionFailures": [],
+          "attachments": [
+            {
+              "fileName": "secret.txt",
+              "id": "attachment-8-1",
+              "key": "2.1Wx2OOdQiuLdtagTYi42ag==|poEKqFO2dzsoHMLZNtWaypW/78OmzyIyXdO4ixhzJer6nHYrPnAEx46QkTzOIekvAaWtN3imtwfMJtJAVjhD0anSpX+vF5W891U3+uDIvJo=|ZAJLAUw6YY1g9VxsXlmwUruHhRduBYxvcAKGjUK6XTA=",
+              "size": "512",
+              "sizeName": "512 Bytes",
+              "url": null
+            }
+          ],
+          "bankAccount": null,
+          "card": null,
+          "collectionIds": [],
+          "creationDate": "2024-01-08T00:00:00Z",
+          "deletedDate": null,
+          "driversLicense": null,
+          "edit": true,
+          "favorite": false,
+          "fields": null,
+          "folderId": null,
+          "id": "bc020801-0000-4000-8000-000000000000",
+          "identity": null,
+          "key": "7.g1g+owE6AAEReQN4ImFwcGxpY2F0aW9uL3guYml0d2FyZGVuLmxlZ2FjeS1rZXkEUKTRzd9iA/xHFq+CcSWoa4ChBVgYZKaPOhV8PXOgz9wKzZji+WfOVuvhnTjKWFBrSxTb77W0XpVqIb+/Yjpx15h9tQ+nIkaqWWAfBQLocM0VhmflYlhfVF9MSmPARAtNip7CStVbrAAGoYoy46S2cDwAtAmFYB/HuAvDPKeMoQ==",
+          "localData": null,
+          "login": {
+            "autofillOnPageLoad": null,
+            "fido2Credentials": null,
+            "password": "v2-password",
+            "passwordRevisionDate": null,
+            "totp": null,
+            "uris": null,
+            "username": "v2@example.com"
+          },
+          "name": "Attachment v2",
+          "notes": null,
+          "organizationId": null,
+          "organizationUseTotp": false,
+          "passport": null,
+          "passwordHistory": null,
+          "permissions": null,
+          "reprompt": 0,
+          "revisionDate": "2024-06-15T12:30:00Z",
+          "secureNote": null,
+          "sshKey": null,
+          "type": 1,
+          "viewPassword": true
+        },
+        "encrypted": {
+          "archivedDate": null,
+          "attachments": [
+            {
+              "fileName": "2.UqDdyBOFHotXJECi8XvQvQ==|Hjl8Iru6hT6dSGvu/WiYDA==|aMGPVjyzCOfdWD+4d370KT99Fj4sKrDQ3PZnYCgYPxo=",
+              "id": "attachment-8-1",
+              "key": "2.1Wx2OOdQiuLdtagTYi42ag==|poEKqFO2dzsoHMLZNtWaypW/78OmzyIyXdO4ixhzJer6nHYrPnAEx46QkTzOIekvAaWtN3imtwfMJtJAVjhD0anSpX+vF5W891U3+uDIvJo=|ZAJLAUw6YY1g9VxsXlmwUruHhRduBYxvcAKGjUK6XTA=",
+              "size": "512",
+              "sizeName": "512 Bytes",
+              "url": null
+            }
+          ],
+          "bankAccount": null,
+          "card": null,
+          "collectionIds": [],
+          "creationDate": "2024-01-08T00:00:00Z",
+          "data": "{\"format_version\":1,\"wrapped_cek\":\"2.gyDzb7GnDd0VoQkNn15+ag==|/Ss1GCVvfgJbHzF9QWqatx2x+2cu4oSP7Vb8AFcEWaquI9lqyDku8XEHroOIMDpFPpT3Q20DxZWL+uJxqEyf9ER3imKmoNO9sD/MiU+WYJ8=|kcxQfsoWtnTP7ex8EnajtF+GXcoJfGEyUlYjWIyD2F4=\",\"envelope\":\"g1hHpQEDA3gjYXBwbGljYXRpb24veC5iaXR3YXJkZW4uY2Jvci1wYWRkZWQEUL1smkm65WFCfC/uf/k7LEA6AAE4gQI6AAE4gAGhBUw1zR/WTRnPKrSvDXlYsQzCGX2WJ2qhAWtQnwZVVLQkwrx7GpJKW8rgQXoJvwXrEMwDbEskZVP9T4s+mpfJUBjuJLxkTlZsRntxVya5RdCYP97EyG5sON8CUz94G09WYzz+r6vcuunKIEIG194PVspWdTZlvomgd/kKZVI0+pHzy38h5lwuRgtVv33IzW2Z87PFZoAgn9ncmBbmk9OSD1acuB83UzHiJ1xtI1lgPpS30YYoBUgjTriOwgC+Q7NKsg==\"}",
+          "deletedDate": null,
+          "driversLicense": null,
+          "edit": true,
+          "favorite": false,
+          "fields": null,
+          "folderId": null,
+          "id": "bc020801-0000-4000-8000-000000000000",
+          "identity": null,
+          "key": "7.g1g+owE6AAEReQN4ImFwcGxpY2F0aW9uL3guYml0d2FyZGVuLmxlZ2FjeS1rZXkEUKTRzd9iA/xHFq+CcSWoa4ChBVgYZKaPOhV8PXOgz9wKzZji+WfOVuvhnTjKWFBrSxTb77W0XpVqIb+/Yjpx15h9tQ+nIkaqWWAfBQLocM0VhmflYlhfVF9MSmPARAtNip7CStVbrAAGoYoy46S2cDwAtAmFYB/HuAvDPKeMoQ==",
+          "localData": null,
+          "login": null,
+          "name": "2.3h9/f7ou0hJ++tQMy7WBBg==|uVQzS72IncWMyCDrs+K/Yw==|7OXevx9R11+eEXRX5raRoyBNezjnnx1xAbqTZeAJYOY=",
+          "notes": null,
+          "organizationId": null,
+          "organizationUseTotp": false,
+          "passport": null,
+          "passwordHistory": null,
+          "permissions": null,
+          "reprompt": 0,
+          "revisionDate": "2024-06-15T12:30:00Z",
+          "secureNote": null,
+          "sshKey": null,
+          "type": 1,
+          "viewPassword": true
+        },
+        "id": "bc020801-0000-4000-8000-000000000000",
+        "keys": {
+          "attachments": {
+            "attachment-8-1": {
+              "key": "MQlWuVpilPpPTK1KaXIYda7/bAUOW1A/g4i6p+CxOZOFsOlL8xpNDmOHhwUatD37EeikL4gvHH/A5jZ8NcVvoQ==",
+              "keyId": null,
+              "version": "V2"
+            }
+          },
+          "cipherKey": "5y8UyEPMICeiQAt0I1F3ldxwzmeS/3SEkeJb5eKCxD3G/9TUG6wJlUVuSIGnqPSVK3I+04Izsf4+8MTml6XCdg==",
+          "cipherKeyId": null
+        }
+      }
+    ],
+    "collections": [],
+    "folders": [],
+    "sends": []
+  }
+}


### PR DESCRIPTION
Adds structured test vectors for different account versions. We will add loading functionality later. The aim here is to have all actions (pin, unlock, key rotation) tested for all version types, to prevent regressions such as "a cipher key cipher breaks upon key rotation" which we've recently had.

Ticket: https://bitwarden.atlassian.net/browse/PM-41875

There will be follow-up PR's adding support for these in the integration tests. We can also add rust facilities to make using these in unit tests easier.