### PR TITLE
feat: add trust log spec

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -55,6 +55,7 @@ crates/bitwarden-send/** @bitwarden/team-tools-dev
 crates/bitwarden-shared-unlock/** @bitwarden/team-key-management-dev
 crates/bitwarden-ssh/** @bitwarden/team-tools-dev
 crates/bitwarden-state-bridge-macro/** @bitwarden/team-key-management-dev
+crates/bitwarden-trust-log/** @bitwarden/team-key-management-dev
 crates/bitwarden-unlock/** @bitwarden/team-key-management-dev
 crates/bitwarden-user-crypto-management/** @bitwarden/team-key-management-dev
 crates/bitwarden-vault/** @bitwarden/team-vault-dev

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1400,6 +1400,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "bitwarden-trust-log"
+version = "3.0.0"
+
+[[package]]
 name = "bitwarden-uniffi"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,6 +68,7 @@ bitwarden-sync = { path = "crates/bitwarden-sync", version = "=3.0.0" }
 bitwarden-test = { path = "crates/bitwarden-test", version = "=3.0.0" }
 bitwarden-test-macro = { path = "crates/bitwarden-test-macro", version = "=3.0.0" }
 bitwarden-threading = { path = "crates/bitwarden-threading", version = "=3.0.0" }
+bitwarden-trust-log = { path = "crates/bitwarden-trust-log", version = "=3.0.0" }
 bitwarden-uniffi-error = { path = "crates/bitwarden-uniffi-error", version = "=3.0.0" }
 bitwarden-unlock = { path = "crates/bitwarden-unlock", version = "=3.0.0" }
 bitwarden-user-crypto-management = { path = "crates/bitwarden-user-crypto-management", version = "=3.0.0" }

--- a/crates/bitwarden-trust-log/Cargo.toml
+++ b/crates/bitwarden-trust-log/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "bitwarden-trust-log"
+description = """
+Internal crate for the bitwarden crate. Do not use.
+"""
+
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+readme.workspace = true
+homepage.workspace = true
+repository.workspace = true
+license = "GPL-3.0-only OR LicenseRef-Bitwarden-SDK"
+keywords.workspace = true
+
+[dependencies]
+
+[lints]
+workspace = true

--- a/crates/bitwarden-trust-log/README.md
+++ b/crates/bitwarden-trust-log/README.md
@@ -1,0 +1,26 @@
+# bitwarden-trust-log
+
+Implements the Bitwarden **trust log**: a tamper-resistant, append-only chain of signed actions (key
+additions and revocations, organization membership changes, device inventory, critical policy
+changes) kept per actor — user, organization, or provider.
+
+Each entry is a _link_ consisting of a small signed **outer link**, always served to any authorized
+reader, and an **inner message** carrying the payload, whose readability is gated by the visibility
+declared in the outer link. The chain of outer links gives completeness (no insertion, removal, or
+reordering of an account's own history); a global transparency tree over every account's log head
+gives freshness (no truncation or split view over time).
+
+The full design — data structures, chain validation rules, key validity, the transparency tree, the
+threat model, and the open questions — lives in [`trust-log.md`](./trust-log.md). That spec is a
+**draft**: several load-bearing questions (epoch-head equivocation, inner-message confidentiality,
+genesis-key trust) are unresolved.
+
+## Status
+
+Empty scaffold — nothing is implemented yet.
+
+## Layering
+
+This crate is a foundation crate: it must not depend on `bitwarden-core` or anything that does. The
+`Client` surface for authoring and verifying logs will live in a separate feature crate once the
+core types are in place.

--- a/crates/bitwarden-trust-log/organization-cryptography-v2.md
+++ b/crates/bitwarden-trust-log/organization-cryptography-v2.md
@@ -1,0 +1,374 @@
+# Organization Cryptography V2 - Trust Log - Phase One
+
+**Audience:** engineers implementing or reviewing organization cryptography v2 in clients, the SDK,
+or the server.
+
+**Status:** draft — under discussion inside Bitwarden.
+
+**Owner:** Key-management team
+
+**Related:** [Trust log design](./trust-log.md)
+
+## Overview
+
+This draft assumes that each entity (users, organizations) have a trust log where the owner can
+publish messages. The trust logs properties are not further described here. This document
+investigates the different operations a user will publish for v2 organization cryptography.
+
+**Scope:** v1 of the protocol. Key revocation and automatic policy enablement are possible
+extensions, but not part of the initial rollout.
+
+## Assumptions
+
+- The organization has a trust log, signed by the organization signature key and writable by
+  privileged members.
+- The user has a trust log, signed by the user's own signature key.
+
+## Messages
+
+`TrustLogLink` (log id + sequence + outer link hash) pins a counterparty that has a log.
+`Thumbprint` pins a legacy counterparty that does not.
+
+```
+Thumbprint = bytes[32]         // over the counterparty's public keys
+
+Pin = enum {
+  legacy      { thumbprint: Thumbprint },
+  trust_log   { link: TrustLogLink },
+}
+```
+
+| Message             | Written in | Meaning                                                                  |
+| ------------------- | ---------- | ------------------------------------------------------------------------ |
+| `add_key`           | user, org  | The actor added a key it controls, in a given scope.                     |
+| `join_team`         | user       | The user joined an organization, pinned as legacy or by log.             |
+| `leave_team`        | user       | The user ended that membership.                                          |
+| `add_member`        | org        | The organization admitted a member, pinned as legacy or by log.          |
+| `remove_member`     | org        | The organization removed a member.                                       |
+| `upgrade_team`      | user       | The user re-pins a team it had joined as legacy, now by log.             |
+| `upgrade_member`    | org        | The organization re-pins a member it had admitted as legacy, now by log. |
+| `set_security_flag` | user, org  | The user/organization changed a security flag.                           |
+| `share_key`         | user, org  | The actor shared a key with a counterparty, sealed to that counterparty. |
+
+```
+AddKeyBody = {
+  key_id:      bytes[16],
+  thumbprint:  bytes[32],
+  type:        enum { kem, public_key_encryption, signature },
+  algorithm:   enum { ml-dsa, rsa },
+  // What the key may be used for. A verifier must reject a signature made by a key
+  // outside the scope the signed message requires.
+  scope:       enum { default, invite_link },   // absent => default
+  // For signature keys, you prove that you control the key by signing over the thumbprint
+  // seqno and chain
+  proof_of_possession: Signature({ thumbprint, id, timestamp, previous_outer_hash, seqno }) | null
+}
+
+JoinTeamBody = {
+  team_id:  uuid,
+  type:     enum { organization, provider },
+  log:      Pin,        // legacy => thumbprint, non-legacy => log link
+}
+
+LeaveTeamBody = {
+  team_id:  uuid,
+}
+
+AddMemberBody = {
+  user_id:          uuid,
+  member:           Pin,        // legacy => thumbprint, non-legacy => log link
+}
+
+RemoveMemberBody = {
+  user_id:          uuid,
+}
+
+UpgradeTeamBody = {              // legacy -> non-legacy only
+  team_id:  uuid,
+  current:          TrustLogLink,
+}
+
+UpgradeMemberBody = {            // legacy -> non-legacy only
+  user_id:          uuid,
+  current:          TrustLogLink,
+}
+
+ShareKeyBody = {                // semi_public: the wrapped key is readable only by the recipient
+  recipient:        { kind: enum { user, organization }, id: uuid },
+  purpose:          enum { organization_key, provider_key, account_recovery, emergency_access },
+  wrapped_key:      bytes,          // signcrypted: sealed to the recipient KEM / RSA key
+}
+
+SetSecurityFlagBody = {
+  disable_no_trustlog_organization_keys: bool | null,
+  ...: bool,
+}
+```
+
+## Flows
+
+Invite (the organization inviting a user) carries no trust log message in v1 of the protocol. The
+two logged steps are **accept** (the user agrees, in the user's log) and **confirm** (the
+organization admits the user, in the organization's log).
+
+> **Note:** invite is not recorded for the first release — for either invite flow, invite email or
+> invite link. Recording it in the organization's log would give autoconfirm something to check
+> against. The server would still have to be trusted that the correct user is joining, but it could
+> not lie about the fact that a user was invited: if no user was invited, the server cannot pretend
+> one was.
+
+### V2 user joins V2 org
+
+```mermaid
+sequenceDiagram
+    participant U as User (v2)
+    participant UL as User log
+    participant OL as Org log
+    participant A as Admin (v2 org)
+    A->>U: invite (not logged)
+    U->>OL: fetch and verify
+    U->>UL: join_team { log: trust_log(org head) }
+    A->>UL: fetch and verify up to join_team
+    A->>OL: add_member { member: trust_log(user head) }
+    A->>U: organization_key wrapped to the user key attested in the user log
+```
+
+1. **Accept** — the user fetches and verifies the organization's log, then appends to its own log:
+   `join_team { team_id, log: trust_log(link to the org head it verified) }`.
+2. **Confirm** — a privileged member fetches and verifies the user's log up to and including that
+   `join_team`, then appends to the organization's log:
+   `add_member { user_id, member: trust_log(link to the user head it verified) }`.
+3. **Share** — the admin wraps the organization key to the user's RSA/KEM key attested by `add_key`
+   in the user's log at the pinned position. (This MAY be signcryption)
+
+### V2 user joins V1 org
+
+```mermaid
+sequenceDiagram
+    participant U as User (v2)
+    participant UL as User log
+    participant A as Admin (v1 org)
+    A->>U: invite (not logged)
+    U->>A: fetch organization public keys
+    U->>UL: join_team { log: legacy(thumbprint) }
+    U->>A: publish own RSA public key
+    A->>U: organization_key wrapped to user RSA public key
+    Note over A: no org log, no add_member, no share_key
+```
+
+1. **Accept** — the user appends
+   `join_team { team_id, log: legacy(thumbprint over the organization's public keys) }`.
+2. **Confirm** — the admin wraps the organization key to the user's public RSA key, and writes no
+   trust log message.
+
+### V2 user joined V1 org and org upgrades to V2
+
+```mermaid
+sequenceDiagram
+    participant A as Admin (org upgrading)
+    participant OL as Org log
+    participant U as User (v2 member)
+    participant UL as User log
+    A->>OL: add_key (organization signature key)
+    A->>OL: add_key (organization public encryption key)
+    A->>OL: add_member per member, trust_log or legacy
+    U->>OL: fetch and verify
+    U->>U: compare pinned thumbprint with org log keys
+    U->>UL: upgrade_team { current: org head }
+```
+
+1. The organization creates its log and appends `add_key` for its signature key, then a second
+   `add_key` for its public encryption key.
+2. For every existing member, the organization appends `add_member` — `trust_log(...)` for members
+   that have a log, `legacy(thumbprint)` for the rest. There is no earlier organization-side pin to
+   update, so this is `add_member`, not `upgrade_member`.
+3. Each member verifies the new organization log, checks that the thumbprint it pinned at
+   `join_team` matches the keys the log now claims, and appends
+   `upgrade_team { team_id, current: link to the org head }`.
+
+### V1 user joins V2 org
+
+```mermaid
+sequenceDiagram
+    participant A as Admin (v2 org)
+    participant OL as Org log
+    participant U as User (v1)
+    A->>U: invite (not logged)
+    U->>A: accept, publish own RSA public key
+    Note over U: no user log, no join_team
+    A->>OL: add_member { user_id, member: legacy(thumbprint) }
+    A->>U: organization_key wrapped to user RSA public key
+```
+
+The user has no log, so the user cannot accept in a verifiable way.
+
+1. **Accept** — the user accepts the invite the v1 way and publishes its public keys to the server.
+   It has no log, so there is no `join_team` and nothing about the acceptance is attested.
+2. **Confirm** — the admin fetches the user's public keys from the server and appends to the
+   organization's log:
+   `add_member { user_id, member: legacy(thumbprint over the user's public keys) }`.
+3. **Share** — the admin wraps the organization key to the user's public RSA key, the v1 way. The
+   key comes from the server and is pinned only by the thumbprint in `add_member`, so the share is
+   bound to a key the user never attested to.
+
+If the organization has `disable_no_trustlog_organization_keys` enabled, confirm is refused instead
+— refusing the legacy pin is what stops the organization key from being shared to a server-supplied
+key.
+
+### V1 user joined V2 org and user upgrades to V2
+
+```mermaid
+sequenceDiagram
+    participant U as User (upgrading)
+    participant UL as User log
+    participant OL as Org log
+    participant A as Admin (v2 org)
+    U->>UL: add_key (user signature key)
+    U->>UL: add_key (user public encryption key)
+    U->>OL: fetch and verify
+    U->>UL: join_team { log: trust_log(org head) }
+    A->>UL: fetch and verify
+    A->>A: compare pinned thumbprint with user log keys
+    A->>OL: upgrade_member { current: user head }
+```
+
+1. The user creates its log and appends `add_key` for its signature key, then a second `add_key` for
+   its public encryption key.
+2. The user verifies the organization's log and appends
+   `join_team { team_id, log: trust_log(link to the org head) }`. There is no earlier user-side pin
+   to update, so this is `join_team`, not `upgrade_team`.
+3. A privileged member verifies the new user log, checks that the thumbprint pinned at `add_member`
+   matches the keys the user log claims, and appends
+   `upgrade_member { user_id, current: link to the user head }`.
+
+### Organization removes member
+
+The two sides are independent messages: the organization records the removal in its own log, the
+user records it in theirs. Neither can write the other's log, so removal is one-sided until the user
+observes it.
+
+1. A privileged member appends `remove_member { user_id }` to the organization's log. From that link
+   on, the organization's log state no longer counts the user as a member.
+2. The user observes the removal when it next replays the organization's log and appends
+   `leave_team { team_id }` to its own log, closing the membership on its side.
+
+Any key the organization shared with the removed member (`share_key { purpose: organization_key }`)
+must be considered known to that member forever. Removal does not unshare it — rotating the
+organization key and re-sharing to the remaining members does.
+
+> **Info:** the trust log only records the removal. The server still enforces it the way it does
+> today: once the user is out, access control stops serving that user the shared keys and the data
+> they protect. The log makes the removal provable.
+
+```mermaid
+sequenceDiagram
+    participant A as Admin (v2 org)
+    participant OL as Org log
+    participant U as User (member)
+    participant UL as User log
+    A->>OL: remove_member { user_id }
+    U->>OL: replay, observe remove_member
+    U->>UL: leave_team { team_id }
+    Note over OL,UL: both sides closed, shared org key compromised until rotation
+```
+
+### User leaves organization
+
+Same two messages, initiated from the other end.
+
+1. The user appends `leave_team { team_id }` to its own log.
+2. A privileged member observes it when replaying the user's log and appends
+   `remove_member { user_id }` to the organization's log.
+
+A `leave_team` is unilateral and effective on the user's side immediately: it does not need the
+organization's acknowledgement, and the organization cannot make the user's log claim a membership
+the user has closed.
+
+```mermaid
+sequenceDiagram
+    participant U as User (member)
+    participant UL as User log
+    participant OL as Org log
+    participant A as Admin (v2 org)
+    U->>UL: leave_team { team_id }
+    A->>UL: replay, observe leave_team
+    A->>OL: remove_member { user_id }
+```
+
+### Upgrade to signcrypted organization key / signcrypted account recovery
+
+**Precondition:** the membership must be mutually trust-log based — the user's `join_team` pins the
+organization by log and the organization's `add_member` (or `upgrade_member`) pins the user by log.
+
+Both upgrades are the same message in opposite directions:
+
+- **organization key** — an admin shares the organization key with a member:
+  `share_key { recipient: user, purpose: organization_key }` in the **organization's** log.
+- **account recovery** — a member shares its account recovery key with the organization:
+  `share_key { recipient: organization, purpose: account_recovery }` in the **user's** log.
+
+The sender re-verifies the recipient's log from the pinned position to its head, picks the
+recipient's current RSA/KEM key, signcrypts the shared key to it, and appends `share_key`. The
+message is `semi_public`: the chain counts it, so the server cannot hide that a share happened, but
+only the recipient can unwrap it.
+
+```mermaid
+sequenceDiagram
+    participant A as Admin (v2 org)
+    participant OL as Org log
+    participant UL as User log
+    participant U as User (v2 member)
+    A->>UL: verify join_team pins this org by log
+    A->>OL: verify add_member pins this user by log
+    A->>UL: replay from pinned position to head, take current RSA/KEM key
+    A->>OL: share_key { recipient: user, purpose: organization_key, wrapped_key }
+    U->>OL: read share_key, unwrap, verify sender signature
+```
+
+Replacing a shared key (organization key rotation, recovery key rotation) is a new `share_key` for
+the same `purpose` — the latest one in the log wins. Revoking a share is out of scope for v1; it
+follows key revocation.
+
+### Invite link (follow-up)
+
+Not part of the initial rollout.
+
+Confirm with trustlogs from the organization's side requires sharing a key to the user, and
+recording the joining message. To do this, a special key signing key is created and published on the
+trust log, scoped to joining a member. The member, on joining uses the signing key and appends a
+join message to the trust log, and a key share message.
+
+Until then, joining via an invite link is a V1 membership.
+
+## Rollout plan
+
+| #   | Phase                        | Messages                                                      | Ships as                 |
+| --- | ---------------------------- | ------------------------------------------------------------- | ------------------------ |
+| 1   | Trust logs exist             | `add_key`                                                     | own release              |
+| 2   | Record membership            | `join_team`, `leave_team`, `add_member`, `remove_member`      | own release              |
+| 3   | Upgrade pins                 | `upgrade_team`, `upgrade_member`                              | own release              |
+| 4   | Disable legacy compatibility | `set_security_flag { disable_no_trustlog_organization_keys }` | separate release, opt-in |
+| 5   | Share signcrypted key        | `share_key`                                                   | own release              |
+| 6   | UI warning                   | —                                                             | client-only              |
+| 7   | Signcrypted keys enforced    | `share_key`                                                   | own release              |
+
+1. **Organizations and users gain a trust log** with their own signature key. Nothing depends on it
+   yet; logs are created and `add_key` recorded so that later phases have something to pin.
+2. **Record join and leave on the trust log.** New memberships write both sides. Counterparties that
+   have not reached phase 1 are recorded as legacy, so this phase works against any client.
+3. **Upgrade the trust log pins.** Memberships recorded as legacy in phase 2 are re-pinned by log
+   position as each counterparty gains a log (`upgrade_team` / `upgrade_member`). This runs as a
+   background reconciliation, not a user-facing action.
+4. **Disable legacy compatibility** — a separate update, because it is the only breaking phase. With
+   `disable_no_trustlog_organization_keys` set, an organization refuses legacy pins and legacy
+   members outright, so every key an actor relies on must come from a signed log. This is what
+   closes the server-side key injection vulnerability (the ETH finding): a server can no longer hand
+   a client an unattested public key for a counterparty.
+5. **Add the signcrypted key and share it with owner on org creation** -> Key replacement fixed for
+   admins
+6. Add signcrypted key on manual confirm. -> Key replacement fixed for newly joining users
+7. **UI warning.** Before the old key path is removed, users on clients that cannot read the
+   signcrypted key must be told, or phase 7 locks them out silently.
+8. Re-share org keys to users -> Key replacement fixed for existing users
+9. Re-share account recovery keys to orgs -> Key replacement fixed for existing users account
+   recoveries

--- a/crates/bitwarden-trust-log/organization-cryptography-v2.md
+++ b/crates/bitwarden-trust-log/organization-cryptography-v2.md
@@ -93,7 +93,7 @@ UpgradeMemberBody = {            // legacy -> non-legacy only
   current:          TrustLogLink,
 }
 
-ShareKeyBody = {                // semi_public: the wrapped key is readable only by the recipient
+ShareKeyBody = {                // privileged: the wrapped key is readable only by the recipient
   recipient:        { kind: enum { user, organization }, id: uuid },
   purpose:          enum { organization_key, provider_key, account_recovery, emergency_access },
   wrapped_key:      bytes,          // signcrypted: sealed to the recipient KEM / RSA key
@@ -309,7 +309,7 @@ Both upgrades are the same message in opposite directions:
 
 The sender re-verifies the recipient's log from the pinned position to its head, picks the
 recipient's current RSA/KEM key, signcrypts the shared key to it, and appends `share_key`. The
-message is `semi_public`: the chain counts it, so the server cannot hide that a share happened, but
+message is `privileged`: the chain counts it, so the server cannot hide that a share happened, but
 only the recipient can unwrap it.
 
 ```mermaid

--- a/crates/bitwarden-trust-log/src/lib.rs
+++ b/crates/bitwarden-trust-log/src/lib.rs
@@ -1,0 +1,1 @@
+#![doc = include_str!("../README.md")]

--- a/crates/bitwarden-trust-log/trust-log.md
+++ b/crates/bitwarden-trust-log/trust-log.md
@@ -399,6 +399,38 @@ is out of scope for this version of the document.
 
 ---
 
+## Split view attack
+
+The hash chain makes a log internally consistent, but internal consistency says nothing about
+_which_ chain a reader was shown. The server is the sole distributor of logs, so it can maintain two
+divergent chains for the same actor and serve one to Alice and the other to Bob. Both views validate
+under [Chain validation](#chain-validation).
+
+```mermaid
+flowchart LR
+  L0["seq 0"] --> L1["seq 1"] --> L2["seq 2"]
+  L2 --> A3["seq 3: add_key K_attacker"]
+  L2 --> B3["seq 3: revoke_key K_old"]
+  A3 --> AV["View served to Bob"]
+  B3 --> BV["View served to Alice"]
+```
+
+The consequence is that a key revocation can be made effective for the account holder while never
+becoming effective for the relying parties encrypting to that account, and vice versa: an
+attacker-controlled key can be accepted by everyone except the account holder, who would notice it.
+Each party's view is self-consistent, so no local check fires. The `pin` mechanism
+([Log state](#log-state)) narrows the window between parties who exchange pins, but does not close
+it: the server chooses which view each party pins against.
+
+Detecting a split view requires comparing views across parties — gossip between clients, a
+transparency log with an independent witness set, or a signed-tree-head auditing protocol as in
+[RFC9162] and [CONIKS]. **Resolving the split view attack is out of scope for this document.**
+
+We will revisit this later; most likely using a tlog that holds a merkle tree that in each epoch
+commits to all latest head hashes.
+
+---
+
 ## Chain validation
 
 A verifier processing a trust log must, in sequence order:

--- a/crates/bitwarden-trust-log/trust-log.md
+++ b/crates/bitwarden-trust-log/trust-log.md
@@ -1,0 +1,450 @@
+# Trust log design
+
+**Audience:** engineers implementing or reviewing the trust log in clients, the SDK, or the server.
+
+**Status:** draft — under discussion inside Bitwarden.
+
+**Owner:** Key-management team
+
+## Overview
+
+The trust log is a tamper-resistant, append-only, signed log of security-critical actions, kept per
+actor — a user, an organization, or a provider — and served by an untrusted server. Each log entry
+is a **link**, split into a small signed **outer link** and an **inner message**. The chain of outer
+links provides completeness: no action can be inserted, removed, or reordered without detection.
+
+This set of logs acts as the key-transparency system for Bitwarden. Additionally, it allows us to
+cryptographically record and attest to permissions (policies around data transfer, etc).
+
+This will serve as the foundation to:
+
+- Organization Encryption V2
+- Organization Cryptographically Enforced Policies
+  - Automatic Key Connector Enrollment
+  - Automatic Data Ownership Transfer
+  - Automatic Retroactive Account Recovery Enrollment
+  - Automatic Activation of Auto-Confirmation
+    - Safer Autoconfirmation
+- Emergency Access V2
+- (Maybe) Device Keys
+
+With the key-transparency effective, this will prevent most fingerprints while preventing the server
+from injecting public keys.
+
+## Introduction
+
+The trust log is a tamper-resistant, append-only data structure that records actions. Each actor — a
+user, an organization, or a provider — has one trust log each. The goal is to record actions
+concerning that actor in a way that provably came from the actor, that can be revoked (by appending
+an action stating the revocation), and that the server can neither inject into, modify, nor omit
+from.
+
+The trust log is intended to become the central root from which clients determine:
+
+- the currently valid keys of other users, organizations, and providers;
+- their own currently valid keys;
+- the organizations and providers they agreed to be part of;
+- the security-critical permissions an organization holds over a user;
+- the devices currently active for a user.
+
+Each entry in the log is a **link**, and every link has two parts:
+
+- an **outer link** — small, always visible to any authorized reader of the log, and **the thing
+  that is signed**;
+- an **inner message** — the full payload, whose readability is gated by the outer link's declared
+  visibility.
+
+The chain of outer links gives _completeness_: the account holder can prove no action was inserted,
+removed, or reordered.
+
+### Goals
+
+| #   | Goal                                                                                                                                                   |
+| --- | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| G1  | An account holder can detect any modification, reordering, or omission of their own history.                                                           |
+| G2  | A relying party can determine which keys an account controlled _at a given point in its history_, without trusting the server.                         |
+| G3  | The server cannot suppress a security-critical action (key revocation, policy change)                                                                  |
+| G4  | Confidential actions (organization membership, device inventory) stay confidential from unauthorized readers while still being _counted_ in the chain. |
+
+---
+
+## Architecture overview
+
+The logs and the references between them:
+
+```mermaid
+flowchart TB
+  subgraph ALICE["Alice's trust log"]
+    direction RL
+    A4["L4 (head)"] --> A3["L3"] --> A2["L2"] --> A1["L1"] --> A0["L0"]
+  end
+  subgraph ORG["Organization's trust log"]
+    direction RL
+    O2["L2"] --> O1["L1"] --> O0["L0"]
+  end
+  A3 -. "pin: at my L3, your log stood at L2 with head h" .-> O2
+```
+
+A link consists of two parts, and each commits to the next:
+
+```mermaid
+flowchart TB
+  KEY["Signing key valid at this sequence number"] -. signs .-> OUTER
+  OUTER["<b>OuterLink</b> (~75 bytes)<br/>version, sequence_number, type, visibility<br/>previous_outer_link_hash<br/>current_inner_link_hash"]
+  PREV["HASH(OuterLink[n-1])"]
+  INNER["<b>InnerMessage</b> (payload)<br/>version, sequence_number, creation_time<br/>body (discriminated by outer.type)<br/>client_metadata"]
+  OUTER -- previous_outer_link_hash --> PREV
+  OUTER -- "current_inner_link_hash = HASH(InnerMessage[n])" --> INNER
+  OUTER -. "inner served only to readers entitled by visibility" .-> INNER
+```
+
+And the chain, with one inner message withheld from an unauthorized reader:
+
+```mermaid
+flowchart LR
+  subgraph OUTERCHAIN["Outer chain — served whole to every authorized reader"]
+    direction TB
+    O3["seq 3<br/>remove_key<br/>public"] --> O2["seq 2<br/>join_team<br/>semi_public"] --> O1["seq 1<br/>add_key<br/>public"] --> O0["seq 0<br/>add_key (genesis)<br/>public"]
+  end
+  subgraph INNERS["Inner messages — gated by visibility"]
+    direction TB
+    I3["RemoveKeyBody"] ~~~ I2["WITHHELD"] ~~~ I1["AddKeyBody"] ~~~ I0["AddKeyBody"]
+  end
+  OUTERCHAIN ~~~ INNERS
+  O3 -.-> I3
+  O2 -.-> I2
+  O1 -.-> I1
+  O0 -.-> I0
+```
+
+---
+
+## Data structures
+
+### Outer link
+
+```
+OuterLink = {
+  version:                  uint,        // structure + algorithm version
+  sequence_number:          uint,        // 0 for genesis, strictly +1 thereafter
+  previous_outer_link_hash: bytes[32],   // HASH of the previous OuterLink; all-zero for genesis
+  current_inner_link_hash:  bytes[32],   // HASH of this link's InnerMessage
+  type:                     MessageType, // see message types
+  visibility:               Visibility,  // public, semi_public or private; see visibility
+}
+```
+
+The key signing the outer link must be of `type = signature` and must be valid at this
+`sequence_number` ([Chain validation](#chain-validation)).
+
+Rationale: `type` and `visibility` are inside the signed structure so the server cannot misrepresent
+what an action was, nor how confidential it is ([Visibility](#visibility)).
+
+### Inner message
+
+```
+InnerMessage = {
+  version:                     uint,       // structure + algorithm version
+  sequence_number:             uint,       // must equal the outer link's sequence_number
+  creation_time:               uint64,     // client-asserted, UNIX ms — untrusted
+  body:                        Body,       // discriminated by the outer link's `type`
+  client_metadata:             ClientMetadata,
+}
+
+ClientMetadata = {
+  client_type:    enum { web, browser_extension, desktop, mobile, cli, server },
+  client_version: string,
+  device_id:      bytes[16] | null,
+}
+```
+
+### Signed outer link
+
+```
+SignedOuterLink = {
+  outer:      OuterLink,
+  signature:  bytes,     // over the canonical encoding of `outer`
+}
+```
+
+### Genesis link
+
+The link at `sequence_number = 0` must be `add_key` carrying a key of `type = signature`, must be
+self-signed by that key, and must carry `previous_outer_link_hash` of all zeroes. The body carries
+only the key's thumbprint, so checking the genesis self-signature requires the verifying key itself,
+which is fetched separately and checked against that thumbprint. A trust log must always at least
+have one valid signing key.
+
+---
+
+## Visibility
+
+```
+Visibility = enum { public, semi_public, private }
+```
+
+| Value         | Who may read the inner message                                                                                                            |
+| ------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
+| `public`      | Anyone who may read the outer chain.                                                                                                      |
+| `semi_public` | The account holder, and principals sharing the relevant scope (e.g. members/admins of the organization named in the body and the server). |
+| `private`     | The account holder only.                                                                                                                  |
+
+Each message type maps statically to one visibility ([Message types](#message-types)), so a verifier
+must reject any link whose `outer.visibility` disagrees with that mapping; the server therefore
+cannot claim an action is more confidential than it is in order to withhold it (G3).
+
+Private links are not yet specified in this document. If they are implemented, then the body would
+be encrypted when stored on the server, so that the server cannot read the body.
+
+### Preventing omission by the server
+
+The outer chain is served **in full, to every authorized reader, regardless of visibility**.
+Visibility gates inner messages only. Since sequence numbers are contiguous and each link commits to
+the previous link's hash, a missing link in the interior of the chain is immediately visible (the
+_Sequence_ and _Outer chain_ checks, [Chain validation](#chain-validation)). A missing link at the
+_tail_ is **not** covered by this document: an actor notices truncation of its own log because it
+knows its own head, and a relying party notices it only as far as its last pin
+([Log application rules](#log-application-rules)). Detecting truncation against an independent
+witness is an open problem here.
+
+If the server serves the outer link but refuses an inner message the reader is entitled to — this is
+detectable but not preventable by this design. This counts as an attack by the server. It is a
+denial of service, and clients must treat "outer link present, entitled inner message unavailable"
+as a verification failure (the _Entitlement_ check, [Chain validation](#chain-validation)), not as a
+skippable entry.
+
+---
+
+## Message types
+
+Each link carries a message type. For this document, only two message types are relevant: `add_key`
+and `remove_key`.
+
+| Type         | Description                            | Principals                   | Visibility |
+| ------------ | -------------------------------------- | ---------------------------- | ---------- |
+| `add_key`    | The actor added a key it controls.     | user, organization, provider | `public`   |
+| `remove_key` | The actor revoked one of its own keys. | user, organization, provider | `public`   |
+
+Applications specify their own message types on top of these, for instance those in
+[Organization Cryptography V2](./organization-cryptography-v2.md).
+
+The `private` visibility value is currently unused.
+
+---
+
+## Log state
+
+The log state is the local accumulated state obtained by applying all actions in the log.
+
+```
+state(n) = apply links[0], links[1], ..., links[n] in order, starting from InitialState
+```
+
+```mermaid
+flowchart LR
+  INIT["InitialState"] -- "apply(L0)" --> S0["state(0)"] -- "apply(L1)" --> S1["state(1)"] -- "..." --> SN["state(n)<br/>as_of_sequence = n<br/>head_hash = HASH(L_n.outer)"]
+```
+
+Each `apply` is a pure function of `(state, outer, inner)`.
+
+Every key an actor learns of, its own or a counterparty's, is recorded as a `KeyState`, derived from
+the `add_key` / `remove_key` links of whichever log the key was read from:
+
+```
+KeyState = {
+  key_id:               bytes[16],
+  type:                 enum { kem, public_key_encryption, signature },
+  algorithm:            enum { ml-dsa, rsa },
+  thumbprint:           bytes[16],         // as carried by the add_key body; the public key
+                                           // itself is fetched out of band and checked against it
+  scope:                enum { default, invite_link },
+  added_at_sequence:    uint,              // position in the log this key was read from
+  revoked_at_sequence:  uint | null,       // null while valid
+  revocation_reason:    enum { rotation, compromise } | null,
+}
+```
+
+The sequence numbers belong to the log the key came from. The key is only valid for the log it came
+from for the Chain validation check.
+
+Revoked keys are **retained, not deleted**. Removing them would destroy the ability to check a
+signature made before the revocation, which must stay checkable forever.
+
+### Log application rules
+
+| Message type | Effect on state                                                                                       |
+| ------------ | ----------------------------------------------------------------------------------------------------- |
+| `add_key`    | Insert into this trust log's key set (`trust_log_keys`). Genesis establishes the first signature key. |
+| `remove_key` | Set `revoked_at_sequence` + `revocation_reason` on that key of `trust_log_keys`.                      |
+
+Application-specific message types carry their own effects on the rest of the state — memberships,
+policies, and the positions at which this log has witnessed another actor's log. Those are specified
+by the application, for instance in
+[Organization Cryptography V2](./organization-cryptography-v2.md).
+
+---
+
+## Scaling: sparse replay
+
+### Post-quantum signature size issues
+
+Post-quantum signatures ([FIPS204], ML-DSA) signatures are large, roughly 2-4KiB per signature. This
+means that for large sets of operations on a chain, we do not want to bear the cost of downloading
+all of the signatures. For example:
+
+| Links     | Outer chain links | Signatures |
+| --------- | ----------------- | ---------- |
+| 10,000    | ~0.75 MB          | ~20 MB     |
+| 100,000   | ~7.5 MB           | ~200 MB    |
+| 1,000,000 | ~75 MB            | ~2 GB      |
+
+We want to optimize this to eliminate login latency and network transfer, especially for large
+organizations. For this, we introduce sparse replay and checkpoints.
+
+#### Sparse replay — example
+
+A concrete log: an organization with **25,000 current members**.
+
+Per-link sizes, ML-DSA-44:
+
+```
+outer link          ~75 bytes     (two 32-byte hashes and small integers)
+signature         ~2,420 bytes    (FIPS 204, ML-DSA-44)
+inner message       ~200 bytes    (chain hash, creation_time, client metadata,
+                                    and a ~70-byte body; an add_key
+                                    body carries a thumbprint, not a public key)
+```
+
+Link inventory:
+
+```
+add_member                 25,000
+add_key                         2     (signature key + encryption key, at genesis)
+                           ------
+total                      25,002
+```
+
+| Reader profile                                              | Outer links | Signatures      | Inner messages | Total       |
+| ----------------------------------------------------------- | ----------- | --------------- | -------------- | ----------- |
+| **Full replay** — every link, signature, inner message      | ~1.9 MB     | ~61 MB (25,002) | ~5.0 MB        | **~67 MB**  |
+| **Sparse, no types requested** — key events only            | ~1.9 MB     | ~4.8 KB (2)     | ~0.4 KB (2)    | **~1.9 MB** |
+| **Sparse + checkpoint** — one day's activity, ~50 new links | ~3.8 KB     | ~121 KB (50)    | ~10 KB         | **~135 KB** |
+
+### Sparse replay
+
+The key idea of sparse replay is that a reader needs to verify only two things in full: **every
+change to the log's key set**, and **the head**. Everything in between is verified implicitly by the
+signature on the head ([Why skipping signatures is sound](#why-skipping-signatures-is-sound)).
+
+A reader therefore requests the message types it actually cares about, and the server serves:
+
+- the **complete outer chain**, every link, always —
+  [Preventing omission by the server](#preventing-omission-by-the-server) is unchanged and
+  non-negotiable;
+- signatures and inner messages for the requested types, **plus every `add_key` and `remove_key`
+  link, whether or not they were requested**.
+
+A request for the outer chain accordingly names the types wanted and whether signatures are wanted.
+
+| Check                 | On a replayed link | On a skipped link            |
+| --------------------- | ------------------ | ---------------------------- |
+| Version               | must               | must                         |
+| Sequence              | must               | **must**                     |
+| Outer hash chain      | must               | **must**                     |
+| Registry visibility   | must               | must                         |
+| Signature             | must               | may skip                     |
+| Inner binding         | must               | must, if the inner arrived   |
+| Entitlement           | must               | relative to the types wanted |
+| Body validity + state | must               | may skip                     |
+| Principal kind        | must               | must                         |
+
+1. **`add_key` and `remove_key` are never skippable.** A verifier must fully validate every key
+   event of the log it is replaying — signature, inner message, and body — whatever else it asked
+   for. Skipping a `remove_key` would leave a revoked key in the derived validity set, and every
+   signature check is evaluated against that set.
+2. **Hash and sequence integrity are never skippable.** Contiguous sequence numbers and an unbroken
+   outer hash chain must be checked over every link, including skipped ones. This is what makes
+   skipping signatures sound at all
+   ([Why skipping signatures is sound](#why-skipping-signatures-is-sound)).
+
+### Why skipping signatures is sound
+
+```mermaid
+flowchart RL
+  L4["L4<br/>signature verified here"] --> L3["L3"] --> L2["L2"] --> L1["L1"] --> L0["L0"]
+```
+
+`HASH(L3)` is committed by `L4`, `HASH(L2)` by `L3`, and so on, so one valid signature at `L4` fixes
+the content of `L0..L3` as well. The verified link is normally the head.
+
+Each outer link commits to the hash of its predecessor, so a single verified signature authenticates
+the **entire prefix** below it, not merely the link it sits on. This follows by induction over the
+chain.
+
+In practice this means a reader that
+
+1. checks the unbroken hash chain and contiguous sequence numbers over **every** outer link, and
+2. verifies the signature on at least one link at or after the highest sequence it relies on —
+   normally the head,
+
+has authenticated the content of every earlier link, including the ones whose signatures it never
+fetched. Note that step 2 is why key events are never skippable: the head's signature counts only if
+the key that made it was valid at the head, and that is knowable only from the complete set of key
+events ([Sparse replay](#sparse-replay) rule 1).
+
+### Checkpoints and incremental replay
+
+A client may persist a verified checkpoint and on the next sync replay only the links after it. This
+is out of scope for this version of the document.
+
+---
+
+## Chain validation
+
+A verifier processing a trust log must, in sequence order:
+
+1. **Version.** `outer.version` is implemented. Reject otherwise.
+2. **Sequence.** `seq == 0` for the first link; `seq == prev.seq + 1` thereafter.
+3. **Outer chain.** `outer.previous_outer_link_hash == HASH(prev.outer)`; all-zero at genesis.
+4. **Registry.** `outer.visibility == REGISTRY[outer.type].visibility`.
+5. **Signature.** `signature` verifies over `outer` under the key its own envelope identifies, that
+   key is of `type = signature` in this log, and it was **valid at this sequence number**.
+6. **Inner binding.** If the inner message was received:
+   `HASH(inner) == outer.current_inner_link_hash` and
+   `inner.sequence_number == outer.sequence_number`.
+7. **Entitlement.** If the verifier is entitled to the inner message under `outer.visibility`,
+   requested it ([Sparse replay](#sparse-replay)), and did not receive it: **fail**. Do not skip.
+8. **Body validity.** The body parses under `outer.type`, and its semantic preconditions hold
+   against derived state ([Log application rules](#log-application-rules)).
+
+Failure of any check invalidates the log **from that link onward**. Prefix links already verified
+remain valid — this matters, because it means a compromised tail does not erase provable history.
+
+---
+
+## Security considerations
+
+This whole document is a security consideration; this section states what the construction defends
+against.
+
+| Attack                                        | Defeated by                                                                                               |
+| --------------------------------------------- | --------------------------------------------------------------------------------------------------------- |
+| Insert a forged action                        | Signature over the outer link ([Chain validation](#chain-validation))                                     |
+| Delete an interior action                     | Contiguous sequence + hash chain ([Chain validation](#chain-validation))                                  |
+| Reorder actions                               | Hash chain ([Chain validation](#chain-validation))                                                        |
+| Swap an inner payload between links           | `current_inner_link_hash` + duplicated sequence number ([Chain validation](#chain-validation))            |
+| Hide a key revocation behind confidentiality  | Type→visibility binding ([Visibility](#visibility), [Chain validation](#chain-validation))                |
+| Misrepresent which key signed a link          | The signature names its own key, checked against the validity set ([Chain validation](#chain-validation)) |
+| Backdate an action to before a key revocation | Position-based key validity — timestamps are not consulted ([Chain validation](#chain-validation))        |
+
+---
+
+## Related Reading
+
+- **[FIPS204]** NIST, "Module-Lattice-Based Digital Signature Standard (ML-DSA)", FIPS 204,
+  August 2024.
+- **[RFC9162]** Laurie, B., et al., "Certificate Transparency Version 2.0", RFC 9162, December 2021.
+- **[CONIKS]** Melara, M., et al., "CONIKS: Bringing Key Transparency to End Users", USENIX
+  Security 2015. The per-user key-directory model, and the split-view problem.
+- **[SEEMless]** Chase, M., Deshpande, A., Ghosh, E., Malvai, H., "SEEMless: Secure End-to-End
+  Encrypted Messaging with less trust", CCS 2019. Sparse-trie key transparency with privacy.

--- a/crates/bitwarden-trust-log/trust-log.md
+++ b/crates/bitwarden-trust-log/trust-log.md
@@ -104,11 +104,11 @@ And the chain, with one inner message withheld from an unauthorized reader:
 flowchart LR
   subgraph OUTERCHAIN["Outer chain — served whole to every authorized reader"]
     direction TB
-    O3["seq 3<br/>remove_key<br/>public"] --> O2["seq 2<br/>join_team<br/>semi_public"] --> O1["seq 1<br/>add_key<br/>public"] --> O0["seq 0<br/>add_key (genesis)<br/>public"]
+    O3["seq 3<br/>revoke_key<br/>public"] --> O2["seq 2<br/>join_team<br/>semi_public"] --> O1["seq 1<br/>add_key<br/>public"] --> O0["seq 0<br/>add_key (genesis)<br/>public"]
   end
   subgraph INNERS["Inner messages — gated by visibility"]
     direction TB
-    I3["RemoveKeyBody"] ~~~ I2["WITHHELD"] ~~~ I1["AddKeyBody"] ~~~ I0["AddKeyBody"]
+    I3["RevokeKeyBody"] ~~~ I2["WITHHELD"] ~~~ I1["AddKeyBody"] ~~~ I0["AddKeyBody"]
   end
   OUTERCHAIN ~~~ INNERS
   O3 -.-> I3
@@ -218,12 +218,12 @@ skippable entry.
 ## Message types
 
 Each link carries a message type. For this document, only two message types are relevant: `add_key`
-and `remove_key`.
+and `revoke_key`.
 
 | Type         | Description                            | Principals                   | Visibility |
 | ------------ | -------------------------------------- | ---------------------------- | ---------- |
 | `add_key`    | The actor added a key it controls.     | user, organization, provider | `public`   |
-| `remove_key` | The actor revoked one of its own keys. | user, organization, provider | `public`   |
+| `revoke_key` | The actor revoked one of its own keys. | user, organization, provider | `public`   |
 
 Applications specify their own message types on top of these, for instance those in
 [Organization Cryptography V2](./organization-cryptography-v2.md).
@@ -248,7 +248,7 @@ flowchart LR
 Each `apply` is a pure function of `(state, outer, inner)`.
 
 Every key an actor learns of, its own or a counterparty's, is recorded as a `KeyState`, derived from
-the `add_key` / `remove_key` links of whichever log the key was read from:
+the `add_key` / `revoke_key` links of whichever log the key was read from:
 
 ```
 KeyState = {
@@ -275,7 +275,7 @@ signature made before the revocation, which must stay checkable forever.
 | Message type | Effect on state                                                                                       |
 | ------------ | ----------------------------------------------------------------------------------------------------- |
 | `add_key`    | Insert into this trust log's key set (`trust_log_keys`). Genesis establishes the first signature key. |
-| `remove_key` | Set `revoked_at_sequence` + `revocation_reason` on that key of `trust_log_keys`.                      |
+| `revoke_key` | Set `revoked_at_sequence` + `revocation_reason` on that key of `trust_log_keys`.                      |
 
 Application-specific message types carry their own effects on the rest of the state — memberships,
 policies, and the positions at which this log has witnessed another actor's log. Those are specified
@@ -341,7 +341,7 @@ A reader therefore requests the message types it actually cares about, and the s
 - the **complete outer chain**, every link, always —
   [Preventing omission by the server](#preventing-omission-by-the-server) is unchanged and
   non-negotiable;
-- signatures and inner messages for the requested types, **plus every `add_key` and `remove_key`
+- signatures and inner messages for the requested types, **plus every `add_key` and `revoke_key`
   link, whether or not they were requested**.
 
 A request for the outer chain accordingly names the types wanted and whether signatures are wanted.
@@ -358,9 +358,9 @@ A request for the outer chain accordingly names the types wanted and whether sig
 | Body validity + state | must               | may skip                     |
 | Principal kind        | must               | must                         |
 
-1. **`add_key` and `remove_key` are never skippable.** A verifier must fully validate every key
+1. **`add_key` and `revoke_key` are never skippable.** A verifier must fully validate every key
    event of the log it is replaying — signature, inner message, and body — whatever else it asked
-   for. Skipping a `remove_key` would leave a revoked key in the derived validity set, and every
+   for. Skipping a `revoke_key` would leave a revoked key in the derived validity set, and every
    signature check is evaluated against that set.
 2. **Hash and sequence integrity are never skippable.** Contiguous sequence numbers and an unbroken
    outer hash chain must be checked over every link, including skipped ones. This is what makes

--- a/crates/bitwarden-trust-log/trust-log.md
+++ b/crates/bitwarden-trust-log/trust-log.md
@@ -104,7 +104,7 @@ And the chain, with one inner message withheld from an unauthorized reader:
 flowchart LR
   subgraph OUTERCHAIN["Outer chain — served whole to every authorized reader"]
     direction TB
-    O3["seq 3<br/>revoke_key<br/>public"] --> O2["seq 2<br/>join_team<br/>semi_public"] --> O1["seq 1<br/>add_key<br/>public"] --> O0["seq 0<br/>add_key (genesis)<br/>public"]
+    O3["seq 3<br/>revoke_key<br/>public"] --> O2["seq 2<br/>join_team<br/>privileged"] --> O1["seq 1<br/>add_key<br/>public"] --> O0["seq 0<br/>add_key (genesis)<br/>public"]
   end
   subgraph INNERS["Inner messages — gated by visibility"]
     direction TB
@@ -130,7 +130,7 @@ OuterLink = {
   previous_outer_link_hash: bytes[32],   // HASH of the previous OuterLink; all-zero for genesis
   current_inner_link_hash:  bytes[32],   // HASH of this link's InnerMessage
   type:                     MessageType, // see message types
-  visibility:               Visibility,  // public, semi_public or private; see visibility
+  visibility:               Visibility,  // public, privileged or private; see visibility
 }
 ```
 
@@ -180,14 +180,14 @@ have one valid signing key.
 ## Visibility
 
 ```
-Visibility = enum { public, semi_public, private }
+Visibility = enum { public, privileged, private }
 ```
 
-| Value         | Who may read the inner message                                                                                                            |
-| ------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
-| `public`      | Anyone who may read the outer chain.                                                                                                      |
-| `semi_public` | The account holder, and principals sharing the relevant scope (e.g. members/admins of the organization named in the body and the server). |
-| `private`     | The account holder only.                                                                                                                  |
+| Value        | Who may read the inner message                                                                                                            |
+| ------------ | ----------------------------------------------------------------------------------------------------------------------------------------- |
+| `public`     | Anyone who may read the outer chain.                                                                                                      |
+| `privileged` | The account holder, and principals sharing the relevant scope (e.g. members/admins of the organization named in the body and the server). |
+| `private`    | The account holder only.                                                                                                                  |
 
 Each message type maps statically to one visibility ([Message types](#message-types)), so a verifier
 must reject any link whose `outer.visibility` disagrees with that mapping; the server therefore


### PR DESCRIPTION
Adds an empty trust log crate, plus specs for the trust log, and how it is used with organizations.