### PR TITLE
[PM-39455] Return no untrusted organization public keys on v1 to v2 key rotation.

### DIFF
--- a/crates/bitwarden-user-crypto-management/src/key_rotation/mod.rs
+++ b/crates/bitwarden-user-crypto-management/src/key_rotation/mod.rs
@@ -19,7 +19,11 @@ use wasm_bindgen::prelude::*;
 
 use crate::{
     UserCryptoManagementClient,
-    key_rotation::unlock::{V1EmergencyAccessMembership, V1OrganizationMembership},
+    key_rotation::{
+        rotate_user_keys::UpgradeTokenAction,
+        rotation_context::organization_memberships_needing_trust,
+        unlock::{V1EmergencyAccessMembership, V1OrganizationMembership},
+    },
 };
 
 /// Response model for untrusted memberships, containing both organization and emergency access
@@ -33,17 +37,24 @@ pub struct UntrustedMembershipsResponse {
 
 #[cfg_attr(feature = "wasm", wasm_bindgen)]
 impl UserCryptoManagementClient {
-    /// Fetches the organization public keys for V1 organization memberships for the user for
-    /// organizations for which reset password is enrolled.
-    /// These have to be trusted manually be the user before rotating.
+    /// The organization public keys the user has to confirm as trusted before a key rotation.
+    ///
+    /// When the rotation creates a V2 upgrade token, the list is empty. Organization admins update
+    /// account recovery from that token, so the user confirms nothing. Every other rotation returns
+    /// one entry per organization the user is enrolled in for account recovery.
     pub async fn get_untrusted_organization_public_keys(
         &self,
+        upgrade_token_action: UpgradeTokenAction,
     ) -> Result<Vec<V1OrganizationMembership>, RotateUserKeysError> {
         let api_client = &self.client.internal.get_api_configurations().api_client;
         let key_rotation_data = sync::get_key_rotation_data(api_client)
             .await
             .map_err(|_| RotateUserKeysError::Api)?;
-        Ok(key_rotation_data.organization_memberships)
+        Ok(organization_memberships_needing_trust(
+            key_rotation_data.organization_memberships,
+            upgrade_token_action,
+            self.client.internal.get_key_store(),
+        ))
     }
 
     /// Fetches the emergency access public keys for V1 emergency access memberships for the user.
@@ -58,10 +69,18 @@ impl UserCryptoManagementClient {
         Ok(key_rotation_data.emergency_access_memberships)
     }
 
-    /// Fetches all untrusted public keys from user's organization and emergency access memberships.
-    /// These have to be trusted manually by the user before rotating.
+    /// The organization and emergency access public keys the user has to confirm as trusted before
+    /// a key rotation.
+    ///
+    /// When the rotation creates a V2 upgrade token, the organization list is empty. Organization
+    /// admins update account recovery from that token, so the user confirms nothing. Every other
+    /// rotation returns one entry per organization the user is enrolled in for account recovery.
+    ///
+    /// Emergency access grantees always need a confirmation, because every rotation shares the new
+    /// user key with each of them.
     pub async fn get_untrusted_memberships(
         &self,
+        upgrade_token_action: UpgradeTokenAction,
     ) -> Result<UntrustedMembershipsResponse, RotateUserKeysError> {
         let api_client = &self.client.internal.get_api_configurations().api_client;
         let key_rotation_data = sync::get_key_rotation_data(api_client)
@@ -69,7 +88,11 @@ impl UserCryptoManagementClient {
             .map_err(|_| RotateUserKeysError::Api)?;
         Ok(UntrustedMembershipsResponse {
             emergency_access_memberships: key_rotation_data.emergency_access_memberships,
-            organization_memberships: key_rotation_data.organization_memberships,
+            organization_memberships: organization_memberships_needing_trust(
+                key_rotation_data.organization_memberships,
+                upgrade_token_action,
+                self.client.internal.get_key_store(),
+            ),
         })
     }
 }

--- a/crates/bitwarden-user-crypto-management/src/key_rotation/rotation_context.rs
+++ b/crates/bitwarden-user-crypto-management/src/key_rotation/rotation_context.rs
@@ -1,5 +1,5 @@
 use bitwarden_core::key_management::{KeySlotIds, SymmetricKeySlotId};
-use bitwarden_crypto::{KeyStoreContext, PublicKey, SymmetricKeyAlgorithm};
+use bitwarden_crypto::{KeyStore, KeyStoreContext, PublicKey, SymmetricKeyAlgorithm};
 use tracing::{debug, info, warn};
 
 use super::{
@@ -15,10 +15,10 @@ struct UntrustedKeyError;
 /// Whether the rotation creates a V2 upgrade token.
 ///
 /// A token only makes sense when the user moves from a V1 to a V2 user key. Every other rotation
-/// logs the user out of their other sessions.
+/// logs the user out of their other sessions. The SDK always rotates into a V2 user key, so the
+/// current user key decides the answer.
 fn creates_v2_upgrade_token(
     current_user_key_id: SymmetricKeySlotId,
-    new_user_key_id: SymmetricKeySlotId,
     upgrade_token_action: UpgradeTokenAction,
     ctx: &KeyStoreContext<KeySlotIds>,
 ) -> bool {
@@ -27,16 +27,34 @@ fn creates_v2_upgrade_token(
         return false;
     }
 
-    matches!(
-        (
-            ctx.get_symmetric_key_algorithm(current_user_key_id),
-            ctx.get_symmetric_key_algorithm(new_user_key_id),
-        ),
-        (
-            Ok(SymmetricKeyAlgorithm::Aes256CbcHmac),
-            Ok(SymmetricKeyAlgorithm::XAes256Gcm)
-        )
-    )
+    ctx.is_v1_symmetric_key(current_user_key_id)
+        .unwrap_or(false)
+}
+
+/// The organization memberships the user has to confirm as trusted before the rotation.
+///
+/// When the rotation creates a V2 upgrade token, returns no memberships. Organization admins update
+/// account recovery from that token, so the user confirms nothing. Every other rotation returns the
+/// memberships it was given.
+pub(super) fn organization_memberships_needing_trust(
+    organization_memberships: Vec<V1OrganizationMembership>,
+    upgrade_token_action: UpgradeTokenAction,
+    key_store: &KeyStore<KeySlotIds>,
+) -> Vec<V1OrganizationMembership> {
+    let creates_v2_upgrade_token = {
+        let ctx = key_store.context();
+        creates_v2_upgrade_token(SymmetricKeySlotId::User, upgrade_token_action, &ctx)
+    };
+
+    if creates_v2_upgrade_token {
+        info!(
+            "Rotation creates a V2 upgrade token, none of the {} organization public key(s) need confirmation",
+            organization_memberships.len()
+        );
+        return vec![];
+    }
+
+    organization_memberships
 }
 
 fn filter_trusted_organization(
@@ -109,12 +127,8 @@ pub(super) fn make_rotation_context(
     debug!("Generating new XAES-256-GCM user key for key rotation");
     let new_user_key_id = ctx.make_symmetric_key(SymmetricKeyAlgorithm::XAes256Gcm);
 
-    let creates_v2_upgrade_token = creates_v2_upgrade_token(
-        current_user_key_id,
-        new_user_key_id,
-        upgrade_token_action,
-        ctx,
-    );
+    let creates_v2_upgrade_token =
+        creates_v2_upgrade_token(current_user_key_id, upgrade_token_action, ctx);
 
     let v1_organization_memberships = if creates_v2_upgrade_token {
         // Organization admins update account recovery from the token. The user is never asked to
@@ -165,51 +179,46 @@ mod tests {
         },
         RotateUserKeysError, UpgradeTokenAction, creates_v2_upgrade_token,
         filter_trusted_emergency_access, filter_trusted_organization, make_rotation_context,
+        organization_memberships_needing_trust,
     };
 
     #[test]
-    fn test_creates_v2_upgrade_token_v1_to_v2_with_create_if_needed() {
+    fn test_creates_v2_upgrade_token_v1_user_key_with_create_if_needed() {
         let store: KeyStore<KeySlotIds> = KeyStore::default();
         let mut ctx = store.context_mut();
 
         let current_user_key_id = ctx.make_symmetric_key(SymmetricKeyAlgorithm::Aes256CbcHmac);
-        let new_user_key_id = ctx.make_symmetric_key(SymmetricKeyAlgorithm::XAes256Gcm);
 
         assert!(creates_v2_upgrade_token(
             current_user_key_id,
-            new_user_key_id,
             UpgradeTokenAction::CreateIfNeeded,
             &ctx,
         ));
     }
 
     #[test]
-    fn test_creates_v2_upgrade_token_v1_to_v2_with_skip() {
+    fn test_creates_v2_upgrade_token_v1_user_key_with_skip() {
         let store: KeyStore<KeySlotIds> = KeyStore::default();
         let mut ctx = store.context_mut();
 
         let current_user_key_id = ctx.make_symmetric_key(SymmetricKeyAlgorithm::Aes256CbcHmac);
-        let new_user_key_id = ctx.make_symmetric_key(SymmetricKeyAlgorithm::XAes256Gcm);
 
         assert!(!creates_v2_upgrade_token(
             current_user_key_id,
-            new_user_key_id,
             UpgradeTokenAction::Skip,
             &ctx,
         ));
     }
 
     #[test]
-    fn test_creates_v2_upgrade_token_v2_to_v2_with_create_if_needed() {
+    fn test_creates_v2_upgrade_token_v2_user_key_with_create_if_needed() {
         let store: KeyStore<KeySlotIds> = KeyStore::default();
         let mut ctx = store.context_mut();
 
         let current_user_key_id = ctx.make_symmetric_key(SymmetricKeyAlgorithm::XAes256Gcm);
-        let new_user_key_id = ctx.make_symmetric_key(SymmetricKeyAlgorithm::XAes256Gcm);
 
         assert!(!creates_v2_upgrade_token(
             current_user_key_id,
-            new_user_key_id,
             UpgradeTokenAction::CreateIfNeeded,
             &ctx,
         ));
@@ -218,14 +227,11 @@ mod tests {
     #[test]
     fn test_creates_v2_upgrade_token_missing_current_user_key() {
         let store: KeyStore<KeySlotIds> = KeyStore::default();
-        let mut ctx = store.context_mut();
-
-        let new_user_key_id = ctx.make_symmetric_key(SymmetricKeyAlgorithm::XAes256Gcm);
+        let ctx = store.context();
 
         assert!(
             !creates_v2_upgrade_token(
                 SymmetricKeySlotId::User,
-                new_user_key_id,
                 UpgradeTokenAction::CreateIfNeeded,
                 &ctx,
             ),
@@ -559,5 +565,61 @@ mod tests {
         let result = make_rotation_context(&sync, &[], &[], UpgradeTokenAction::Skip, &mut ctx);
 
         assert!(matches!(result, Err(RotateUserKeysError::UntrustedKey)));
+    }
+
+    /// Persists a user key of the given algorithm and returns one organization membership.
+    fn make_store_with_user_key(
+        algorithm: SymmetricKeyAlgorithm,
+    ) -> (KeyStore<KeySlotIds>, V1OrganizationMembership) {
+        let store: KeyStore<KeySlotIds> = KeyStore::default();
+        let org = {
+            let mut ctx = store.context_mut();
+            let user_key = ctx.make_symmetric_key(algorithm);
+            ctx.persist_symmetric_key(user_key, SymmetricKeySlotId::User)
+                .expect("persisting the user key should work");
+            make_org_membership(&mut ctx).0
+        };
+
+        (store, org)
+    }
+
+    #[test]
+    fn test_organization_memberships_needing_trust_v1_user_key_with_create_if_needed_is_empty() {
+        let (store, org) = make_store_with_user_key(SymmetricKeyAlgorithm::Aes256CbcHmac);
+
+        let memberships = organization_memberships_needing_trust(
+            vec![org],
+            UpgradeTokenAction::CreateIfNeeded,
+            &store,
+        );
+
+        assert!(memberships.is_empty());
+    }
+
+    #[test]
+    fn test_organization_memberships_needing_trust_v1_user_key_with_skip() {
+        let (store, org) = make_store_with_user_key(SymmetricKeyAlgorithm::Aes256CbcHmac);
+        let expected_org = org.clone();
+
+        let memberships =
+            organization_memberships_needing_trust(vec![org], UpgradeTokenAction::Skip, &store);
+
+        assert_eq!(memberships.len(), 1);
+        assert_org_membership_eq(&memberships[0], &expected_org);
+    }
+
+    #[test]
+    fn test_organization_memberships_needing_trust_v2_user_key_with_create_if_needed() {
+        let (store, org) = make_store_with_user_key(SymmetricKeyAlgorithm::XAes256Gcm);
+        let expected_org = org.clone();
+
+        let memberships = organization_memberships_needing_trust(
+            vec![org],
+            UpgradeTokenAction::CreateIfNeeded,
+            &store,
+        );
+
+        assert_eq!(memberships.len(), 1);
+        assert_org_membership_eq(&memberships[0], &expected_org);
     }
 }


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-39455

## 📔 Objective

When the key rotation creates a V2 upgrade token, the organization public keys for account recovery are not needed. Later organization admins rotate account recovery keys from the user's v2 token, so the user confirms nothing (separate PR).

## 🚨 Breaking Changes

Breaks TS clients compatibility, TS clients PR to address it: https://github.com/bitwarden/clients/pull/22490

<!-- Does this PR introduce any breaking changes? If so, please describe the impact and migration path for clients.

If you're unsure, the automated TypeScript compatibility check will run when you open/update this PR and provide feedback.

For breaking changes:
1. Describe what changed in the client interface
2. Explain why the change was necessary
3. Provide migration steps for client developers
4. Link to any paired client PRs if needed

Otherwise, you can remove this section. -->
