### PR TITLE
fix(biometrics): fix biometric unlock over ipc with concurrent status request

### DIFF
--- a/crates/bitwarden-ipc/src/ipc_client.rs
+++ b/crates/bitwarden-ipc/src/ipc_client.rs
@@ -921,6 +921,23 @@ mod tests {
             }
         }
 
+        /// A second request type whose response is a unit enum, which serde serializes to a bare
+        /// JSON string. Deserializing it as [`TestResponse`] fails, which is what makes it a
+        /// faithful stand-in for the real `GetBiometricsStatus` / `UnlockBiometrics` pair.
+        #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+        struct OtherRequest;
+
+        #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+        enum OtherResponse {
+            Available,
+        }
+
+        impl RpcRequest for OtherRequest {
+            type Response = OtherResponse;
+
+            const NAME: &str = "OtherRequest";
+        }
+
         #[tokio::test]
         async fn request_sends_message_and_returns_response() {
             let crypto_provider = NoEncryptionCryptoProvider;
@@ -977,6 +994,107 @@ mod tests {
             // Wait for the response
             let result = result_handle.await.unwrap();
             assert_eq!(result.unwrap().result, 3);
+        }
+
+        /// A response belonging to one in-flight request must not disturb another. Both requests
+        /// subscribe to the same topic (every RPC response shares one payload type name), so each
+        /// one sees the other's response; correlating on `request_id` before deserializing the body
+        /// is what keeps `OtherResponse::Available` -- a bare JSON string -- from being force-fit
+        /// into `TestResponse` and failing the unrelated request.
+        #[tokio::test]
+        async fn concurrent_request_of_a_different_type_does_not_disturb_a_pending_request() {
+            let crypto_provider = NoEncryptionCryptoProvider;
+            let communication_provider = TestCommunicationBackend::new();
+            let session_map = InMemorySessionRepository::default();
+            let client =
+                IpcClientImpl::new(crypto_provider, communication_provider.clone(), session_map);
+            let _ = client.start(None).await;
+
+            // Put both requests in flight at the same time.
+            let test_handle = {
+                let client = client.clone();
+                tokio::spawn(async move {
+                    client
+                        .request::<TestRequest>(
+                            TestRequest { a: 1, b: 2 },
+                            Endpoint::BrowserBackground { id: HostId::Own },
+                            None,
+                        )
+                        .await
+                })
+            };
+            let other_handle = {
+                let client = client.clone();
+                tokio::spawn(async move {
+                    client
+                        .request::<OtherRequest>(
+                            OtherRequest,
+                            Endpoint::BrowserBackground { id: HostId::Own },
+                            None,
+                        )
+                        .await
+                })
+            };
+            tokio::time::sleep(Duration::from_millis(100)).await;
+
+            // Recover both request ids from the wire.
+            let outgoing = communication_provider.outgoing().await;
+            let request_ids: HashMap<String, String> = outgoing
+                .iter()
+                .map(|message| {
+                    let partial: RpcRequestMessage<serde_json::Value> =
+                        serde_utils::from_slice(&message.payload)
+                            .expect("Deserialization should not fail");
+                    (partial.request_type, partial.request_id)
+                })
+                .collect();
+
+            let respond = |payload: Vec<u8>| {
+                communication_provider.push_incoming(IncomingMessage {
+                    payload,
+                    source: Source::BrowserBackground { id: HostId::Own },
+                    destination: Endpoint::Web {
+                        tab_id: 9001,
+                        document_id: "doc-1".to_string(),
+                    },
+                    topic: Some(IncomingRpcResponseMessage::<()>::PAYLOAD_TYPE_NAME.to_owned()),
+                });
+            };
+
+            // Answer `OtherRequest` first, while `TestRequest` is still waiting.
+            respond(
+                serde_utils::to_vec(&IncomingRpcResponseMessage {
+                    result: Ok(OtherResponse::Available),
+                    request_id: request_ids["OtherRequest"].clone(),
+                    request_type: "OtherRequest".to_string(),
+                })
+                .expect("Serialization should not fail"),
+            );
+
+            // `TestRequest` must have ignored the message above and still be waiting for its own.
+            respond(
+                serde_utils::to_vec(&IncomingRpcResponseMessage {
+                    result: Ok(TestResponse { result: 3 }),
+                    request_id: request_ids["TestRequest"].clone(),
+                    request_type: "TestRequest".to_string(),
+                })
+                .expect("Serialization should not fail"),
+            );
+
+            assert_eq!(
+                other_handle
+                    .await
+                    .unwrap()
+                    .expect("OtherRequest should succeed"),
+                OtherResponse::Available
+            );
+            assert_eq!(
+                test_handle
+                    .await
+                    .unwrap()
+                    .expect("TestRequest should succeed"),
+                TestResponse { result: 3 }
+            );
         }
 
         #[tokio::test]

--- a/crates/bitwarden-ipc/src/ipc_client_ext.rs
+++ b/crates/bitwarden-ipc/src/ipc_client_ext.rs
@@ -4,7 +4,7 @@ use serde::{Serialize, de::DeserializeOwned};
 use crate::{
     RpcHandler,
     endpoint::Endpoint,
-    error::{RequestError, SubscribeError},
+    error::{RequestError, SubscribeError, TypedReceiveError},
     ipc_client::IpcClientTypedSubscription,
     ipc_client_trait::IpcClient,
     message::{PayloadTypeName, TypedOutgoingMessage},
@@ -112,10 +112,20 @@ pub trait IpcClientExt: IpcClient {
             self.send(message).await.map_err(RequestError::from)?;
 
             let response = loop {
-                let received = response_subscription
+                let received = match response_subscription
                     .receive(cancellation_token.clone())
                     .await
-                    .map_err(RequestError::Receive)?;
+                {
+                    Ok(received) => received,
+                    // Every RPC response shares a single payload type name, and therefore a single
+                    // topic, so this subscription also receives the responses belonging to other
+                    // requests that are in flight concurrently. Those do not necessarily
+                    // deserialize into this request's response type, so a typing error here is
+                    // expected: skip the message and keep waiting for our own response rather than
+                    // failing over a message that was never addressed to us.
+                    Err(TypedReceiveError::Typing(_)) => continue,
+                    Err(error) => return Err(RequestError::Receive(error)),
+                };
 
                 if received.payload.request_id == request_id {
                     break received;

--- a/crates/bitwarden-wasm-internal/integration-tests/tests/unlock/biometrics-ipc.test.ts
+++ b/crates/bitwarden-wasm-internal/integration-tests/tests/unlock/biometrics-ipc.test.ts
@@ -6,6 +6,7 @@ import {
   ipcRequestGetBiometricsStatus,
   ipcRequestUnlockBiometrics,
   init_sdk,
+  SymmetricKey,
 } from "@bitwarden/sdk-internal";
 import {
   makeMockBiometricsDriver,
@@ -91,5 +92,38 @@ describe("biometrics ipc", () => {
     );
 
     expect(await ipcRequestAuthenticateBiometrics(requester)).toBe(false);
+  });
+
+  it("does not fail an in-flight unlock when a concurrent status response arrives", async () => {
+    const userKey = testSymmetricKey(0x37);
+    let releaseUnlock!: (key: SymmetricKey | undefined) => void;
+    const unlockGate = new Promise<SymmetricKey | undefined>((resolve) => {
+      releaseUnlock = resolve;
+    });
+
+    const { requester } = await setupClientPair({
+      get_biometrics_status: async () => BiometricsStatus.Available,
+      // Stays pending until the test releases it, so the unlock request is
+      // guaranteed to still be in flight below.
+      unlock_biometrics: () => unlockGate,
+      authenticate_biometrics: async () => true,
+    });
+
+    // Capture the settled state up front: the rejection we are hunting happens
+    // while awaiting the status request, before any handler would be attached.
+    const unlock = ipcRequestUnlockBiometrics(requester, TEST_USER_ID).then(
+      (ok) => ({ ok }),
+      (err) => ({ err: String(err) }),
+    );
+
+    // A status poll completes while the unlock is still in flight. Its response is
+    // broadcast to every pending RPC waiter, including the unlock waiter.
+    await expect(ipcRequestGetBiometricsStatus(requester, TEST_USER_ID)).resolves.toBe(
+      BiometricsStatus.Available,
+    );
+
+    releaseUnlock(userKey);
+
+    expect(await unlock).toEqual({ ok: { user_key: userKey } });
   });
 });


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-42191

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
There is a concurrency issue where the typed request subscription breaks on parsing the wrong request type. In this case `unlock`, `status` are concurrent / breaking *only when the browser ui is open*, so only when using the popout browser not the popup which closes during bio unlock.

Adds concurrency tests proving that this works correctly now.

## 🚨 Breaking Changes

<!-- Does this PR introduce any breaking changes? If so, please describe the impact and migration path for clients.

If you're unsure, the automated TypeScript compatibility check will run when you open/update this PR and provide feedback.

For breaking changes:
1. Describe what changed in the client interface
2. Explain why the change was necessary
3. Provide migration steps for client developers
4. Link to any paired client PRs if needed

Otherwise, you can remove this section. -->
