### PR TITLE
feat(importers): add encryption context to import cxf

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -831,6 +831,7 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 2.0.19",
+ "tokio",
  "tsify",
  "uniffi",
  "url",

--- a/crates/bitwarden-exporters/Cargo.toml
+++ b/crates/bitwarden-exporters/Cargo.toml
@@ -49,5 +49,9 @@ wasm-bindgen = { workspace = true, optional = true }
 wasm-bindgen-futures = { workspace = true, optional = true }
 zeroize = { workspace = true }
 
+[dev-dependencies]
+bitwarden-core = { workspace = true, features = ["internal", "test-fixtures"] }
+tokio = { workspace = true, features = ["rt"] }
+
 [lints]
 workspace = true

--- a/crates/bitwarden-exporters/README.md
+++ b/crates/bitwarden-exporters/README.md
@@ -69,14 +69,16 @@ async fn export(client: &Client, folders: Vec<Folder>, ciphers: Vec<Cipher>) {
 #### Import
 
 [`ExporterClient::import_cxf`] parses a CXF JSON string into [`ImportingCipher`] values, encrypts
-each one via the `KeyStore`, and returns `Vec<Cipher>` ready for storage.
+each one via the `KeyStore`, and returns `Vec<EncryptionContext>` ready for storage. Each entry
+pairs the encrypted cipher with the user it was encrypted for and the id of the key it was wrapped
+under.
 
 ```rust,no_run
 use bitwarden_core::Client;
 use bitwarden_exporters::ExporterClientExt;
 
 fn import(client: &Client, cxf_payload: String) {
-    let ciphers = client
+    let encrypted = client
         .exporters()
         .import_cxf(cxf_payload)
         .unwrap();

--- a/crates/bitwarden-exporters/src/export.rs
+++ b/crates/bitwarden-exporters/src/export.rs
@@ -1,8 +1,11 @@
 use bitwarden_collections::collection::Collection;
-use bitwarden_core::{Client, OrganizationId, key_management::KeySlotIds};
+use bitwarden_core::{
+    Client, NotAuthenticatedError, OrganizationId, UserId, key_management::KeySlotIds,
+};
 use bitwarden_crypto::{CompositeEncryptable, IdentifyKey, KeyStoreContext};
 use bitwarden_vault::{
-    Cipher, CipherView, EncryptMode, Folder, FolderView, should_use_blob_encryption,
+    Cipher, CipherView, EncryptMode, EncryptionContext, Folder, FolderView,
+    should_use_blob_encryption,
 };
 
 use crate::{
@@ -75,11 +78,15 @@ pub(crate) fn export_cxf(
 /// `organization_id` is set. Shared by the importers (`import_kdbx`) and by CXF import; lives here
 /// alongside the `ImportingCipher` interchange model and the `From<ImportingCipher> for CipherView`
 /// bridge.
+///
+/// `user_id` identifies the user performing the import and is recorded on the returned
+/// [`EncryptionContext`] alongside the id of the key the cipher was wrapped under.
 pub fn encrypt_import(
     ctx: &mut KeyStoreContext<KeySlotIds>,
     cipher: ImportingCipher,
     organization_id: Option<OrganizationId>,
-) -> Result<Cipher, ExportError> {
+    user_id: UserId,
+) -> Result<EncryptionContext, ExportError> {
     let mut view: CipherView = cipher.clone().into();
     view.organization_id = organization_id;
 
@@ -95,9 +102,13 @@ pub fn encrypt_import(
         view.set_new_fido2_credentials(ctx, passkeys)?;
     }
 
+    // Capture the id of the wrapping key - the organization key for org-owned ciphers, the user key
+    // otherwise - before encrypting, since that borrows the context mutably.
+    let key = view.key_identifier();
+    let encrypted_by_key_id = ctx.get_symmetric_key_id(key).map(|id| id.to_string());
+
     // Select the encryption format based on the account's current security state, matching how
     // regular cipher saves choose between the blob and legacy field-level formats.
-    let key = view.key_identifier();
     let mode = if should_use_blob_encryption(ctx, organization_id) {
         EncryptMode::Blob(view)
     } else {
@@ -105,19 +116,87 @@ pub fn encrypt_import(
     };
     let new_cipher = mode.encrypt_composite(ctx, key)?;
 
-    Ok(new_cipher)
+    Ok(EncryptionContext {
+        cipher: new_cipher,
+        encrypted_for: user_id,
+        encrypted_by_key_id,
+    })
 }
 
 /// See [crate::ExporterClient::import_cxf] for more documentation.
-pub(crate) fn import_cxf(client: &Client, payload: String) -> Result<Vec<Cipher>, ExportError> {
+pub(crate) fn import_cxf(
+    client: &Client,
+    payload: String,
+) -> Result<Vec<EncryptionContext>, ExportError> {
+    let user_id = client.internal.get_user_id().ok_or(NotAuthenticatedError)?;
+
     let key_store = client.internal.get_key_store();
     let mut ctx = key_store.context();
 
     let ciphers = parse_cxf(payload)?;
-    let ciphers: Result<Vec<Cipher>, _> = ciphers
+    let ciphers: Result<Vec<EncryptionContext>, _> = ciphers
         .into_iter()
-        .map(|c| encrypt_import(&mut ctx, c, None))
+        .map(|c| encrypt_import(&mut ctx, c, None, user_id))
         .collect();
 
     ciphers
+}
+
+#[cfg(test)]
+mod tests {
+    use bitwarden_core::{
+        client::test_accounts::{test_bitwarden_com_account, test_bitwarden_com_account_v2},
+        key_management::SymmetricKeySlotId,
+    };
+
+    use super::*;
+
+    fn dashlane_payload() -> String {
+        std::fs::read_to_string("resources/dashlane_export.json").unwrap()
+    }
+
+    /// The imported ciphers are attributed to the importing user and are actually encrypted.
+    #[tokio::test]
+    async fn import_cxf_returns_encryption_context() {
+        let client = Client::init_test_account(test_bitwarden_com_account()).await;
+        let user_id = client.internal.get_user_id().unwrap();
+
+        let imported = import_cxf(&client, dashlane_payload()).unwrap();
+
+        assert!(!imported.is_empty());
+        assert!(imported.iter().all(|c| c.encrypted_for == user_id));
+
+        // "adobe.com" is one of the plaintext titles in the fixture; it must not survive as-is.
+        let names: Vec<String> = imported
+            .iter()
+            .map(|c| c.cipher.name.as_ref().unwrap().to_string())
+            .collect();
+        assert!(!names.iter().any(|n| n == "adobe.com"));
+    }
+
+    /// The user key's id is recorded so the server can reject writes made under a stale key. Both
+    /// the V1 (AES-CBC-HMAC) and V2 (XAES-256-GCM) user keys carry one.
+    #[tokio::test]
+    async fn import_cxf_records_user_key_id() {
+        for account in [
+            test_bitwarden_com_account(),
+            test_bitwarden_com_account_v2(),
+        ] {
+            let client = Client::init_test_account(account).await;
+            let expected = client
+                .internal
+                .get_key_store()
+                .context()
+                .get_symmetric_key_id(SymmetricKeySlotId::User)
+                .map(|id| id.to_string());
+            assert!(expected.is_some());
+
+            let imported = import_cxf(&client, dashlane_payload()).unwrap();
+
+            assert!(!imported.is_empty());
+            for context in &imported {
+                assert_eq!(context.encrypted_by_key_id, expected);
+            }
+        }
+    }
 }

--- a/crates/bitwarden-exporters/src/exporter_client.rs
+++ b/crates/bitwarden-exporters/src/exporter_client.rs
@@ -1,6 +1,6 @@
 use bitwarden_collections::collection::Collection;
 use bitwarden_core::Client;
-use bitwarden_vault::{Cipher, Folder};
+use bitwarden_vault::{Cipher, EncryptionContext, Folder};
 #[cfg(feature = "wasm")]
 use wasm_bindgen::prelude::*;
 
@@ -61,7 +61,10 @@ impl ExporterClient {
     ///
     /// For use with Apple using [ASCredentialExportManager](https://developer.apple.com/documentation/authenticationservices/ascredentialexportmanager).
     /// Ideally, the input should be immediately serialized from [ASImportableAccount](https://developer.apple.com/documentation/authenticationservices/asimportableaccount).
-    pub fn import_cxf(&self, payload: String) -> Result<Vec<Cipher>, ExportError> {
+    ///
+    /// Each returned [`EncryptionContext`] carries the encrypted cipher along with the user it was
+    /// encrypted for and the id of the key it was wrapped under.
+    pub fn import_cxf(&self, payload: String) -> Result<Vec<EncryptionContext>, ExportError> {
         import_cxf(&self.client, payload)
     }
 }

--- a/crates/bitwarden-importers/src/pipeline.rs
+++ b/crates/bitwarden-importers/src/pipeline.rs
@@ -58,10 +58,8 @@ pub(crate) async fn submit_import(
         let cipher_models = ciphers
             .into_iter()
             .map(|c| {
-                let cipher = encrypt_import(&mut ctx, c, options.organization_id)?;
-                let mut model: CipherRequestModel = cipher.try_into()?;
-                model.encrypted_for = Some(user_id.into());
-                Ok::<_, ImportError>(model)
+                let encrypted = encrypt_import(&mut ctx, c, options.organization_id, user_id)?;
+                Ok::<_, ImportError>(CipherRequestModel::from(encrypted))
             })
             .collect::<Result<Vec<_>, _>>()?;
 
@@ -451,8 +449,11 @@ mod tests {
             totp: None,
             fido2_credentials: None,
         }));
-        let cipher = encrypt_import(&mut ctx, importing("GitHub", login), None).unwrap();
+        let user_id = client.internal.get_user_id().unwrap();
+        let encrypted =
+            encrypt_import(&mut ctx, importing("GitHub", login), None, user_id).unwrap();
 
-        assert_ne!(cipher.name.unwrap().to_string(), "GitHub");
+        assert_eq!(encrypted.encrypted_for, user_id);
+        assert_ne!(encrypted.cipher.name.unwrap().to_string(), "GitHub");
     }
 }

--- a/crates/bitwarden-uniffi/src/tool/mod.rs
+++ b/crates/bitwarden-uniffi/src/tool/mod.rs
@@ -4,7 +4,7 @@ use bitwarden_generators::{
     PassphraseGeneratorRequest, PasswordGeneratorRequest, UsernameGeneratorRequest,
 };
 use bitwarden_importers::{ImportOptions, ImportSummary};
-use bitwarden_vault::{Cipher, Folder};
+use bitwarden_vault::{Cipher, EncryptionContext, Folder};
 
 use crate::error::Result;
 
@@ -83,7 +83,7 @@ impl ExporterClient {
     ///
     /// For use with Apple using [ASCredentialExportManager](https://developer.apple.com/documentation/authenticationservices/ascredentialexportmanager).
     /// Ideally the input should be immediately serialized from [ASImportableAccount](https://developer.apple.com/documentation/authenticationservices/asimportableaccount).
-    pub fn import_cxf(&self, payload: String) -> Result<Vec<Cipher>> {
+    pub fn import_cxf(&self, payload: String) -> Result<Vec<EncryptionContext>> {
         Ok(self.0.import_cxf(payload)?)
     }
 }


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-42247

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
Expose an encryption context with the user id and user key id used to encrypt the vault item.

## 🚨 Breaking Changes

`import_cxf` now returns an encryption context. This should be wired through to place the user id and key id onto the HTTP request used to post it to the server.

<!-- Does this PR introduce any breaking changes? If so, please describe the impact and migration path for clients.

If you're unsure, the automated TypeScript compatibility check will run when you open/update this PR and provide feedback.

For breaking changes:
1. Describe what changed in the client interface
2. Explain why the change was necessary
3. Provide migration steps for client developers
4. Link to any paired client PRs if needed

Otherwise, you can remove this section. -->
