### PR TITLE
Map the server's PAM error codes onto typed error variants

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1044,6 +1044,7 @@ dependencies = [
  "bitwarden-api-api",
  "bitwarden-collections",
  "bitwarden-core",
+ "bitwarden-crypto",
  "bitwarden-error",
  "bitwarden-uuid",
  "bitwarden-vault",

--- a/bitwarden_license/bitwarden-pam/Cargo.toml
+++ b/bitwarden_license/bitwarden-pam/Cargo.toml
@@ -29,6 +29,7 @@ wasm = [
 bitwarden-api-api = { workspace = true }
 bitwarden-collections = { workspace = true }
 bitwarden-core = { workspace = true, features = ["internal"] }
+bitwarden-crypto = { workspace = true }
 bitwarden-error = { workspace = true }
 bitwarden-uuid = { workspace = true }
 bitwarden-vault = { workspace = true }

--- a/bitwarden_license/bitwarden-pam/src/access_requests/client.rs
+++ b/bitwarden_license/bitwarden-pam/src/access_requests/client.rs
@@ -5,11 +5,14 @@ use bitwarden_vault::CipherId;
 #[cfg(feature = "wasm")]
 use wasm_bindgen::prelude::wasm_bindgen;
 
-use super::models::{
-    AccessPreCheckView, AccessRequestCreateRequest, AccessRequestResultView, AccessRequestView,
-    CipherAccessStateView,
+use super::{
+    error::AccessRequestError,
+    models::{
+        AccessPreCheckView, AccessRequestCreateRequest, AccessRequestResultView, AccessRequestView,
+        CipherAccessStateView,
+    },
 };
-use crate::{AccessRequestId, error::LeasingError, leases::AccessLeaseView};
+use crate::{AccessRequestId, leases::AccessLeaseView};
 
 /// Client for a requester's PAM access requests.
 ///
@@ -30,7 +33,10 @@ impl AccessRequestsClient {
     /// Resolves the approval outcome for a cipher without submitting a request, so the client can
     /// present the right workflow (pick a duration vs. pick a window and justify) before the
     /// requester commits.
-    pub async fn pre_check(&self, cipher_id: CipherId) -> Result<AccessPreCheckView, LeasingError> {
+    pub async fn pre_check(
+        &self,
+        cipher_id: CipherId,
+    ) -> Result<AccessPreCheckView, AccessRequestError> {
         let response = self
             .api_configurations
             .api_client
@@ -38,7 +44,7 @@ impl AccessRequestsClient {
             .pre_check(cipher_id.into())
             .await?;
 
-        AccessPreCheckView::try_from(response)
+        Ok(AccessPreCheckView::try_from(response)?)
     }
 
     /// Reads the caller's current access state for a cipher - powers the cipher-view banner and
@@ -46,7 +52,7 @@ impl AccessRequestsClient {
     pub async fn cipher_access_state(
         &self,
         cipher_id: CipherId,
-    ) -> Result<CipherAccessStateView, LeasingError> {
+    ) -> Result<CipherAccessStateView, AccessRequestError> {
         let response = self
             .api_configurations
             .api_client
@@ -54,7 +60,7 @@ impl AccessRequestsClient {
             .state(cipher_id.into())
             .await?;
 
-        CipherAccessStateView::try_from(response)
+        Ok(CipherAccessStateView::try_from(response)?)
     }
 
     /// Validates and opens an access request for a cipher. Run [`pre_check`](Self::pre_check)
@@ -63,21 +69,19 @@ impl AccessRequestsClient {
         &self,
         cipher_id: CipherId,
         request: AccessRequestCreateRequest,
-    ) -> Result<AccessRequestResultView, LeasingError> {
-        request.validate()?;
-
+    ) -> Result<AccessRequestResultView, AccessRequestError> {
         let response = self
             .api_configurations
             .api_client
             .cipher_lease_api()
-            .post(cipher_id.into(), request.into())
+            .post(cipher_id.into(), request.try_into()?)
             .await?;
 
-        AccessRequestResultView::try_from(response)
+        Ok(AccessRequestResultView::try_from(response)?)
     }
 
     /// Lists the caller's own access requests.
-    pub async fn list_mine(&self) -> Result<Vec<AccessRequestView>, LeasingError> {
+    pub async fn list_mine(&self) -> Result<Vec<AccessRequestView>, AccessRequestError> {
         let response = self
             .api_configurations
             .api_client
@@ -90,11 +94,12 @@ impl AccessRequestsClient {
             .unwrap_or_default()
             .into_iter()
             .map(AccessRequestView::try_from)
-            .collect()
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(Into::into)
     }
 
     /// Retrieves a single access request by ID.
-    pub async fn get(&self, id: AccessRequestId) -> Result<AccessRequestView, LeasingError> {
+    pub async fn get(&self, id: AccessRequestId) -> Result<AccessRequestView, AccessRequestError> {
         let response = self
             .api_configurations
             .api_client
@@ -102,7 +107,7 @@ impl AccessRequestsClient {
             .get_details(id.into())
             .await?;
 
-        AccessRequestView::try_from(response)
+        Ok(AccessRequestView::try_from(response)?)
     }
 
     /// Activates an approved request, minting and returning the resulting lease.
@@ -110,7 +115,10 @@ impl AccessRequestsClient {
     /// This is the second half of the automatic flow: once a request reaches
     /// [`Approved`](super::AccessRequestStatus::Approved), the requester activates it to obtain a
     /// short-lived [`AccessLease`](AccessLeaseView) over the cipher.
-    pub async fn activate(&self, id: AccessRequestId) -> Result<AccessLeaseView, LeasingError> {
+    pub async fn activate(
+        &self,
+        id: AccessRequestId,
+    ) -> Result<AccessLeaseView, AccessRequestError> {
         let response = self
             .api_configurations
             .api_client
@@ -118,11 +126,11 @@ impl AccessRequestsClient {
             .activate(id.into())
             .await?;
 
-        AccessLeaseView::try_from(response)
+        Ok(AccessLeaseView::try_from(response)?)
     }
 
     /// Cancels the caller's own request while it is still pending.
-    pub async fn cancel(&self, id: AccessRequestId) -> Result<(), LeasingError> {
+    pub async fn cancel(&self, id: AccessRequestId) -> Result<(), AccessRequestError> {
         self.api_configurations
             .api_client
             .access_requests_api()
@@ -261,7 +269,7 @@ mod tests {
 
         let result = client(api_client).activate(request_id()).await;
 
-        assert!(matches!(result, Err(LeasingError::Api(_))));
+        assert!(matches!(result, Err(AccessRequestError::Api(_))));
     }
 
     #[tokio::test]
@@ -318,7 +326,7 @@ mod tests {
 
         let result = client(api_client).pre_check(cipher_id()).await;
 
-        assert!(matches!(result, Err(LeasingError::Api(_))));
+        assert!(matches!(result, Err(AccessRequestError::Api(_))));
     }
 
     #[tokio::test]
@@ -401,7 +409,7 @@ mod tests {
 
         let result = client(api_client).request(cipher_id(), request).await;
 
-        assert!(matches!(result, Err(LeasingError::Validation(_))));
+        assert!(matches!(result, Err(AccessRequestError::Validation(_))));
     }
 
     #[tokio::test]
@@ -424,6 +432,6 @@ mod tests {
             .request(cipher_id(), AccessRequestCreateRequest::default())
             .await;
 
-        assert!(matches!(result, Err(LeasingError::Api(_))));
+        assert!(matches!(result, Err(AccessRequestError::Api(_))));
     }
 }

--- a/bitwarden_license/bitwarden-pam/src/access_requests/client.rs
+++ b/bitwarden_license/bitwarden-pam/src/access_requests/client.rs
@@ -57,13 +57,15 @@ impl AccessRequestsClient {
         CipherAccessStateView::try_from(response)
     }
 
-    /// Opens an access request for a cipher. Run [`pre_check`](Self::pre_check) first to know
-    /// which fields [`AccessRequestCreateRequest`] expects.
+    /// Validates and opens an access request for a cipher. Run [`pre_check`](Self::pre_check)
+    /// first to know which fields [`AccessRequestCreateRequest`] expects.
     pub async fn request(
         &self,
         cipher_id: CipherId,
         request: AccessRequestCreateRequest,
     ) -> Result<AccessRequestResultView, LeasingError> {
+        request.validate()?;
+
         let response = self
             .api_configurations
             .api_client
@@ -384,6 +386,22 @@ mod tests {
 
         assert_eq!(result.approval_mode, AccessApprovalMode::Automatic);
         assert_eq!(result.request.id, request_id());
+    }
+
+    #[tokio::test]
+    async fn request_rejects_an_over_long_window_without_calling_the_api() {
+        let api_client = ApiClient::new_mocked(|mock| {
+            mock.cipher_lease_api.expect_post().never();
+        });
+
+        let request = AccessRequestCreateRequest {
+            duration_seconds: NonZeroU32::new(86_401),
+            ..Default::default()
+        };
+
+        let result = client(api_client).request(cipher_id(), request).await;
+
+        assert!(matches!(result, Err(LeasingError::Validation(_))));
     }
 
     #[tokio::test]

--- a/bitwarden_license/bitwarden-pam/src/access_requests/client.rs
+++ b/bitwarden_license/bitwarden-pam/src/access_requests/client.rs
@@ -6,13 +6,13 @@ use bitwarden_vault::CipherId;
 use wasm_bindgen::prelude::wasm_bindgen;
 
 use super::{
-    error::AccessRequestError,
+    error::{AccessRequestActivateError, AccessRequestCancelError, AccessRequestSubmitError},
     models::{
         AccessPreCheckView, AccessRequestCreateRequest, AccessRequestResultView, AccessRequestView,
         CipherAccessStateView,
     },
 };
-use crate::{AccessRequestId, leases::AccessLeaseView};
+use crate::{AccessRequestId, PamReadError, leases::AccessLeaseView};
 
 /// Client for a requester's PAM access requests.
 ///
@@ -33,10 +33,7 @@ impl AccessRequestsClient {
     /// Resolves the approval outcome for a cipher without submitting a request, so the client can
     /// present the right workflow (pick a duration vs. pick a window and justify) before the
     /// requester commits.
-    pub async fn pre_check(
-        &self,
-        cipher_id: CipherId,
-    ) -> Result<AccessPreCheckView, AccessRequestError> {
+    pub async fn pre_check(&self, cipher_id: CipherId) -> Result<AccessPreCheckView, PamReadError> {
         let response = self
             .api_configurations
             .api_client
@@ -52,7 +49,7 @@ impl AccessRequestsClient {
     pub async fn cipher_access_state(
         &self,
         cipher_id: CipherId,
-    ) -> Result<CipherAccessStateView, AccessRequestError> {
+    ) -> Result<CipherAccessStateView, PamReadError> {
         let response = self
             .api_configurations
             .api_client
@@ -69,7 +66,7 @@ impl AccessRequestsClient {
         &self,
         cipher_id: CipherId,
         request: AccessRequestCreateRequest,
-    ) -> Result<AccessRequestResultView, AccessRequestError> {
+    ) -> Result<AccessRequestResultView, AccessRequestSubmitError> {
         let response = self
             .api_configurations
             .api_client
@@ -81,7 +78,7 @@ impl AccessRequestsClient {
     }
 
     /// Lists the caller's own access requests.
-    pub async fn list_mine(&self) -> Result<Vec<AccessRequestView>, AccessRequestError> {
+    pub async fn list_mine(&self) -> Result<Vec<AccessRequestView>, PamReadError> {
         let response = self
             .api_configurations
             .api_client
@@ -99,7 +96,7 @@ impl AccessRequestsClient {
     }
 
     /// Retrieves a single access request by ID.
-    pub async fn get(&self, id: AccessRequestId) -> Result<AccessRequestView, AccessRequestError> {
+    pub async fn get(&self, id: AccessRequestId) -> Result<AccessRequestView, PamReadError> {
         let response = self
             .api_configurations
             .api_client
@@ -118,7 +115,7 @@ impl AccessRequestsClient {
     pub async fn activate(
         &self,
         id: AccessRequestId,
-    ) -> Result<AccessLeaseView, AccessRequestError> {
+    ) -> Result<AccessLeaseView, AccessRequestActivateError> {
         let response = self
             .api_configurations
             .api_client
@@ -130,7 +127,7 @@ impl AccessRequestsClient {
     }
 
     /// Cancels the caller's own request while it is still pending.
-    pub async fn cancel(&self, id: AccessRequestId) -> Result<(), AccessRequestError> {
+    pub async fn cancel(&self, id: AccessRequestId) -> Result<(), AccessRequestCancelError> {
         self.api_configurations
             .api_client
             .access_requests_api()
@@ -269,7 +266,7 @@ mod tests {
 
         let result = client(api_client).activate(request_id()).await;
 
-        assert!(matches!(result, Err(AccessRequestError::Api(_))));
+        assert!(matches!(result, Err(AccessRequestActivateError::Api(_))));
     }
 
     #[tokio::test]
@@ -326,7 +323,7 @@ mod tests {
 
         let result = client(api_client).pre_check(cipher_id()).await;
 
-        assert!(matches!(result, Err(AccessRequestError::Api(_))));
+        assert!(matches!(result, Err(PamReadError::Api(_))));
     }
 
     #[tokio::test]
@@ -409,7 +406,10 @@ mod tests {
 
         let result = client(api_client).request(cipher_id(), request).await;
 
-        assert!(matches!(result, Err(AccessRequestError::Validation(_))));
+        assert!(matches!(
+            result,
+            Err(AccessRequestSubmitError::Validation(_))
+        ));
     }
 
     #[tokio::test]
@@ -432,6 +432,6 @@ mod tests {
             .request(cipher_id(), AccessRequestCreateRequest::default())
             .await;
 
-        assert!(matches!(result, Err(AccessRequestError::Api(_))));
+        assert!(matches!(result, Err(AccessRequestSubmitError::Api(_))));
     }
 }

--- a/bitwarden_license/bitwarden-pam/src/access_requests/error.rs
+++ b/bitwarden_license/bitwarden-pam/src/access_requests/error.rs
@@ -3,23 +3,203 @@ use bitwarden_error::bitwarden_error;
 use thiserror::Error;
 
 use super::validate::AccessRequestWindowError;
-use crate::error::PamDecodeError;
+use crate::{error::PamDecodeError, problem};
 
 /// Errors returned from [`super::AccessRequestsClient`] operations.
 ///
 /// Local validation is reachable only from
 /// [`request`](super::AccessRequestsClient::request) - the read paths cannot produce it - which is
 /// why the requester surface carries a `Validation` variant the approver and lease surfaces do not.
+///
+/// The named server failures below each correspond to one stable code in the server's problem
+/// response; see [`from_code`](Self::from_code) for the mapping, which is the whole contract in one
+/// place. A code this SDK version does not recognize stays [`Api`](Self::Api), so a server that
+/// grows one never needs a client release to be safe.
 #[bitwarden_error(flat)]
 #[derive(Debug, Error)]
 pub enum AccessRequestError {
     /// The request failed local validation before being sent to the server.
     #[error(transparent)]
     Validation(#[from] AccessRequestWindowError),
+
+    /// The requester already holds a live lease on this cipher.
+    ///
+    /// Not a failure to report: the state they asked for already exists. Reconcile - re-read the
+    /// access state and let it drive the UI - rather than showing an error.
+    #[error("You already have active access to this item")]
+    AlreadyActive,
+    /// The requester already has a request awaiting a decision. Reconcile, as with
+    /// [`AlreadyActive`](Self::AlreadyActive).
+    #[error("You already have a pending request for this item")]
+    AlreadyPending,
+    /// The requester already has an approved request waiting to be activated. Reconcile, as with
+    /// [`AlreadyActive`](Self::AlreadyActive).
+    #[error("You already have an approved request for this item")]
+    AlreadyApproved,
+
+    /// No access rule governs the cipher, so there is nothing to lease.
+    #[error("This item does not require a lease")]
+    CipherNotGated,
+    /// The cipher is approved automatically, so the request must carry a duration - not the window
+    /// it carried. Run [`pre_check`](super::AccessRequestsClient::pre_check) first.
+    #[error("This item is approved automatically; provide a duration, not a window")]
+    DurationExpected,
+    /// The cipher needs a human decision, so the request must carry a window - not the duration it
+    /// carried. Run [`pre_check`](super::AccessRequestsClient::pre_check) first.
+    #[error("This item requires human approval; provide a start and end date, not a duration")]
+    WindowExpected,
+    /// A duration was expected but was absent, zero or negative.
+    #[error("A positive duration is required")]
+    DurationMustBePositive,
+    /// The requested duration is longer than the governing rule allows. The bound is on
+    /// [`AccessPreCheckView`](crate::AccessPreCheckView).
+    #[error("The requested duration exceeds the maximum for this item")]
+    DurationExceedsMax,
+    /// A window was expected but one or both of its ends was absent.
+    #[error("A start and end date are required")]
+    WindowRequired,
+    /// The requested window ends at or before it starts.
+    #[error("The start date must be before the end date")]
+    WindowEndBeforeStart,
+    /// The requested window is longer than the governing rule allows. The bound is on
+    /// [`AccessPreCheckView`](crate::AccessPreCheckView).
+    #[error("The requested window exceeds the maximum for this item")]
+    WindowExceedsMax,
+    /// The cipher needs a human decision, and an approver cannot decide without a stated reason.
+    #[error("A reason is required for items that need human approval")]
+    ReasonRequired,
+
+    /// The governing rule's IP allowlist does not cover the caller's address. A denial, not bad
+    /// input: the same request from an allowed network would succeed.
+    #[error("Access to this item is not permitted from your current network")]
+    DeniedByNetwork,
+    /// The governing rule's time window does not cover now. A denial, not bad input: the same
+    /// request inside the window would succeed.
+    #[error("Access to this item is not permitted at this time")]
+    DeniedBySchedule,
+    /// The governing rule denied the request for a reason this SDK version does not name.
+    #[error("Access to this item is not permitted right now")]
+    Denied,
+
+    /// The request already minted a lease and that lease has ended. A request authorizes access at
+    /// most once, so there is nothing left to activate.
+    #[error("This request's access has already been used and is no longer active")]
+    LeaseAlreadyUsed,
+    /// The request is still waiting on an approver, so there is no approval to activate yet.
+    #[error("This request has not been approved yet")]
+    NotApproved,
+    /// The request has settled into a state activation cannot start from, or lost a race to another
+    /// activation that has since ended.
+    #[error("This request can no longer be activated")]
+    NotActivatable,
+    /// The approved window has not opened yet.
+    #[error("The approved access window has not started yet")]
+    ApprovedWindowNotStarted,
+    /// The approved window has closed, so activating it would mint a dead lease.
+    #[error("The approved access window has already ended")]
+    ApprovedWindowEnded,
+    /// The cipher's rule permits one active lease at a time and someone else holds it. Transient -
+    /// the same activation succeeds once that lease ends.
+    #[error("Another active lease exists for this item")]
+    SingleActiveLeaseConflict,
+    /// The request has already been decided, cancelled or expired, so there is nothing to cancel.
+    #[error("This request has already been resolved")]
+    AlreadyResolved,
+    /// The request has minted a live lease, which now governs the access - end it with
+    /// [`LeasesClient::end`](crate::LeasesClient::end) rather than cancelling the request.
+    #[error("This request has an active lease; revoke the lease instead")]
+    HasActiveLease,
+
     /// A server response could not be decoded into the requested type.
     #[error(transparent)]
     Decode(#[from] PamDecodeError),
-    /// A network or (de)serialization error occurred while calling the server.
+    /// A network or (de)serialization error occurred while calling the server, or the server
+    /// refused with a code this SDK version does not recognize.
     #[error(transparent)]
-    Api(#[from] ApiError),
+    Api(ApiError),
+}
+
+impl AccessRequestError {
+    /// The server's codes, in the order the access-request surface can produce them.
+    fn from_code(code: &str) -> Option<Self> {
+        Some(match code {
+            "access_already_active" => Self::AlreadyActive,
+            "access_request_already_pending" => Self::AlreadyPending,
+            "access_request_already_approved" => Self::AlreadyApproved,
+            "cipher_not_gated" => Self::CipherNotGated,
+            "duration_expected" => Self::DurationExpected,
+            "window_expected" => Self::WindowExpected,
+            "duration_must_be_positive" => Self::DurationMustBePositive,
+            "duration_exceeds_max" => Self::DurationExceedsMax,
+            "window_required" => Self::WindowRequired,
+            "window_end_before_start" => Self::WindowEndBeforeStart,
+            "window_exceeds_max" => Self::WindowExceedsMax,
+            "reason_required" => Self::ReasonRequired,
+            "access_denied_by_network" => Self::DeniedByNetwork,
+            "access_denied_by_schedule" => Self::DeniedBySchedule,
+            "access_denied" => Self::Denied,
+            "access_lease_already_used" => Self::LeaseAlreadyUsed,
+            "access_request_not_approved" => Self::NotApproved,
+            "access_request_not_activatable" => Self::NotActivatable,
+            "approved_window_not_started" => Self::ApprovedWindowNotStarted,
+            "approved_window_ended" => Self::ApprovedWindowEnded,
+            "single_active_lease_conflict" => Self::SingleActiveLeaseConflict,
+            "access_request_already_resolved" => Self::AlreadyResolved,
+            "access_request_has_active_lease" => Self::HasActiveLease,
+            _ => return None,
+        })
+    }
+}
+
+/// Classifies every failed call on this surface, so a caller gets the typed variant whichever
+/// method it came from - a code means the same thing at every endpoint that can emit it.
+impl From<ApiError> for AccessRequestError {
+    fn from(error: ApiError) -> Self {
+        problem::classify(&error, Self::from_code).unwrap_or(Self::Api(error))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use bitwarden_api_api::ResponseContent;
+    use reqwest::StatusCode;
+
+    use super::*;
+
+    fn problem(status: StatusCode, code: &str) -> ApiError {
+        ApiError::Response(ResponseContent {
+            status,
+            message: format!(r#"{{"errors":{{"code":[{{"type":"{code}"}}]}}}}"#),
+        })
+    }
+
+    #[test]
+    fn a_reconcile_conflict_becomes_its_own_variant() {
+        let error: AccessRequestError =
+            problem(StatusCode::CONFLICT, "access_already_active").into();
+
+        assert!(matches!(error, AccessRequestError::AlreadyActive));
+    }
+
+    #[test]
+    fn a_field_failure_becomes_its_own_variant() {
+        let error: AccessRequestError = problem(StatusCode::BAD_REQUEST, "reason_required").into();
+
+        assert!(matches!(error, AccessRequestError::ReasonRequired));
+    }
+
+    #[test]
+    fn an_unrecognized_code_stays_untyped() {
+        let error: AccessRequestError =
+            problem(StatusCode::BAD_REQUEST, "invented_next_year").into();
+
+        assert!(matches!(error, AccessRequestError::Api(_)));
+    }
+
+    #[test]
+    fn a_transport_failure_stays_untyped() {
+        let error: AccessRequestError = ApiError::Io(std::io::Error::other("reset")).into();
+
+        assert!(matches!(error, AccessRequestError::Api(_)));
+    }
 }

--- a/bitwarden_license/bitwarden-pam/src/access_requests/error.rs
+++ b/bitwarden_license/bitwarden-pam/src/access_requests/error.rs
@@ -1,3 +1,14 @@
+//! Each write on the requester surface names the failures that one call can produce, rather than
+//! every failure the surface can produce. The sets are disjoint and come from the server: one
+//! command backs each endpoint and returns an explicit list, so `from_code` below is transcribed
+//! from `SubmitAccessRequestCommand`, `ActivateAccessRequestCommand` and
+//! `CancelAccessRequestCommand` rather than inferred.
+//!
+//! Reads use [`PamReadError`](crate::PamReadError) - they have no failure of their own to report.
+//!
+//! A code this SDK version does not recognize stays `Api` on every one of these, so a server that
+//! grows a code never needs a client release to be safe.
+
 use bitwarden_core::ApiError;
 use bitwarden_error::bitwarden_error;
 use thiserror::Error;
@@ -5,19 +16,13 @@ use thiserror::Error;
 use super::validate::AccessRequestWindowError;
 use crate::{error::PamDecodeError, problem};
 
-/// Errors returned from [`super::AccessRequestsClient`] operations.
+/// Errors from [`AccessRequestsClient::request`](super::AccessRequestsClient::request).
 ///
-/// Local validation is reachable only from
-/// [`request`](super::AccessRequestsClient::request) - the read paths cannot produce it - which is
-/// why the requester surface carries a `Validation` variant the approver and lease surfaces do not.
-///
-/// The named server failures below each correspond to one stable code in the server's problem
-/// response; see [`from_code`](Self::from_code) for the mapping, which is the whole contract in one
-/// place. A code this SDK version does not recognize stays [`Api`](Self::Api), so a server that
-/// grows one never needs a client release to be safe.
+/// Local validation is reachable only from here - the read paths cannot produce it - which is why
+/// this is the only requester error carrying a [`Validation`](Self::Validation) variant.
 #[bitwarden_error(flat)]
 #[derive(Debug, Error)]
-pub enum AccessRequestError {
+pub enum AccessRequestSubmitError {
     /// The request failed local validation before being sent to the server.
     #[error(transparent)]
     Validation(#[from] AccessRequestWindowError),
@@ -81,6 +86,52 @@ pub enum AccessRequestError {
     #[error("Access to this item is not permitted right now")]
     Denied,
 
+    /// A server response could not be decoded into the requested type.
+    #[error(transparent)]
+    Decode(#[from] PamDecodeError),
+    /// A network or (de)serialization error occurred while calling the server, or the server
+    /// refused with a code this SDK version does not recognize.
+    #[error(transparent)]
+    Api(ApiError),
+}
+
+impl AccessRequestSubmitError {
+    /// The codes `SubmitAccessRequestCommand` can return.
+    fn from_code(code: &str) -> Option<Self> {
+        Some(match code {
+            "access_already_active" => Self::AlreadyActive,
+            "access_request_already_pending" => Self::AlreadyPending,
+            "access_request_already_approved" => Self::AlreadyApproved,
+            "cipher_not_gated" => Self::CipherNotGated,
+            "duration_expected" => Self::DurationExpected,
+            "window_expected" => Self::WindowExpected,
+            "duration_must_be_positive" => Self::DurationMustBePositive,
+            "duration_exceeds_max" => Self::DurationExceedsMax,
+            "window_required" => Self::WindowRequired,
+            "window_end_before_start" => Self::WindowEndBeforeStart,
+            "window_exceeds_max" => Self::WindowExceedsMax,
+            "reason_required" => Self::ReasonRequired,
+            "access_denied_by_network" => Self::DeniedByNetwork,
+            "access_denied_by_schedule" => Self::DeniedBySchedule,
+            "access_denied" => Self::Denied,
+            _ => return None,
+        })
+    }
+}
+
+impl From<ApiError> for AccessRequestSubmitError {
+    fn from(error: ApiError) -> Self {
+        problem::classify(&error, Self::from_code).unwrap_or(Self::Api(error))
+    }
+}
+
+/// Errors from [`AccessRequestsClient::activate`](super::AccessRequestsClient::activate).
+///
+/// Every one of these is about the request's state at the moment activation was attempted, so a
+/// caller's usual response is to re-read the request rather than to correct an input.
+#[bitwarden_error(flat)]
+#[derive(Debug, Error)]
+pub enum AccessRequestActivateError {
     /// The request already minted a lease and that lease has ended. A request authorizes access at
     /// most once, so there is nothing left to activate.
     #[error("This request's access has already been used and is no longer active")]
@@ -102,13 +153,6 @@ pub enum AccessRequestError {
     /// the same activation succeeds once that lease ends.
     #[error("Another active lease exists for this item")]
     SingleActiveLeaseConflict,
-    /// The request has already been decided, cancelled or expired, so there is nothing to cancel.
-    #[error("This request has already been resolved")]
-    AlreadyResolved,
-    /// The request has minted a live lease, which now governs the access - end it with
-    /// [`LeasesClient::end`](crate::LeasesClient::end) rather than cancelling the request.
-    #[error("This request has an active lease; revoke the lease instead")]
-    HasActiveLease,
 
     /// A server response could not be decoded into the requested type.
     #[error(transparent)]
@@ -119,31 +163,51 @@ pub enum AccessRequestError {
     Api(ApiError),
 }
 
-impl AccessRequestError {
-    /// The server's codes, in the order the access-request surface can produce them.
+impl AccessRequestActivateError {
+    /// The codes `ActivateAccessRequestCommand` can return.
     fn from_code(code: &str) -> Option<Self> {
         Some(match code {
-            "access_already_active" => Self::AlreadyActive,
-            "access_request_already_pending" => Self::AlreadyPending,
-            "access_request_already_approved" => Self::AlreadyApproved,
-            "cipher_not_gated" => Self::CipherNotGated,
-            "duration_expected" => Self::DurationExpected,
-            "window_expected" => Self::WindowExpected,
-            "duration_must_be_positive" => Self::DurationMustBePositive,
-            "duration_exceeds_max" => Self::DurationExceedsMax,
-            "window_required" => Self::WindowRequired,
-            "window_end_before_start" => Self::WindowEndBeforeStart,
-            "window_exceeds_max" => Self::WindowExceedsMax,
-            "reason_required" => Self::ReasonRequired,
-            "access_denied_by_network" => Self::DeniedByNetwork,
-            "access_denied_by_schedule" => Self::DeniedBySchedule,
-            "access_denied" => Self::Denied,
             "access_lease_already_used" => Self::LeaseAlreadyUsed,
             "access_request_not_approved" => Self::NotApproved,
             "access_request_not_activatable" => Self::NotActivatable,
             "approved_window_not_started" => Self::ApprovedWindowNotStarted,
             "approved_window_ended" => Self::ApprovedWindowEnded,
             "single_active_lease_conflict" => Self::SingleActiveLeaseConflict,
+            _ => return None,
+        })
+    }
+}
+
+impl From<ApiError> for AccessRequestActivateError {
+    fn from(error: ApiError) -> Self {
+        problem::classify(&error, Self::from_code).unwrap_or(Self::Api(error))
+    }
+}
+
+/// Errors from [`AccessRequestsClient::cancel`](super::AccessRequestsClient::cancel).
+///
+/// Cancelling decodes nothing, so unlike its siblings this carries no `Decode` variant.
+#[bitwarden_error(flat)]
+#[derive(Debug, Error)]
+pub enum AccessRequestCancelError {
+    /// The request has already been decided, cancelled or expired, so there is nothing to cancel.
+    #[error("This request has already been resolved")]
+    AlreadyResolved,
+    /// The request has minted a live lease, which now governs the access - end it with
+    /// [`LeasesClient::end`](crate::LeasesClient::end) rather than cancelling the request.
+    #[error("This request has an active lease; revoke the lease instead")]
+    HasActiveLease,
+
+    /// A network or (de)serialization error occurred while calling the server, or the server
+    /// refused with a code this SDK version does not recognize.
+    #[error(transparent)]
+    Api(ApiError),
+}
+
+impl AccessRequestCancelError {
+    /// The codes `CancelAccessRequestCommand` can return.
+    fn from_code(code: &str) -> Option<Self> {
+        Some(match code {
             "access_request_already_resolved" => Self::AlreadyResolved,
             "access_request_has_active_lease" => Self::HasActiveLease,
             _ => return None,
@@ -151,9 +215,7 @@ impl AccessRequestError {
     }
 }
 
-/// Classifies every failed call on this surface, so a caller gets the typed variant whichever
-/// method it came from - a code means the same thing at every endpoint that can emit it.
-impl From<ApiError> for AccessRequestError {
+impl From<ApiError> for AccessRequestCancelError {
     fn from(error: ApiError) -> Self {
         problem::classify(&error, Self::from_code).unwrap_or(Self::Api(error))
     }
@@ -175,31 +237,68 @@ mod tests {
 
     #[test]
     fn a_reconcile_conflict_becomes_its_own_variant() {
-        let error: AccessRequestError =
+        let error: AccessRequestSubmitError =
             problem(StatusCode::CONFLICT, "access_already_active").into();
 
-        assert!(matches!(error, AccessRequestError::AlreadyActive));
+        assert!(matches!(error, AccessRequestSubmitError::AlreadyActive));
     }
 
     #[test]
     fn a_field_failure_becomes_its_own_variant() {
-        let error: AccessRequestError = problem(StatusCode::BAD_REQUEST, "reason_required").into();
+        let error: AccessRequestSubmitError =
+            problem(StatusCode::BAD_REQUEST, "reason_required").into();
 
-        assert!(matches!(error, AccessRequestError::ReasonRequired));
+        assert!(matches!(error, AccessRequestSubmitError::ReasonRequired));
     }
 
     #[test]
     fn an_unrecognized_code_stays_untyped() {
-        let error: AccessRequestError =
+        let error: AccessRequestSubmitError =
             problem(StatusCode::BAD_REQUEST, "invented_next_year").into();
 
-        assert!(matches!(error, AccessRequestError::Api(_)));
+        assert!(matches!(error, AccessRequestSubmitError::Api(_)));
     }
 
     #[test]
     fn a_transport_failure_stays_untyped() {
-        let error: AccessRequestError = ApiError::Io(std::io::Error::other("reset")).into();
+        let error: AccessRequestSubmitError = ApiError::Io(std::io::Error::other("reset")).into();
 
-        assert!(matches!(error, AccessRequestError::Api(_)));
+        assert!(matches!(error, AccessRequestSubmitError::Api(_)));
+    }
+
+    #[test]
+    fn activation_classifies_its_own_codes() {
+        let error: AccessRequestActivateError =
+            problem(StatusCode::CONFLICT, "single_active_lease_conflict").into();
+
+        assert!(matches!(
+            error,
+            AccessRequestActivateError::SingleActiveLeaseConflict
+        ));
+    }
+
+    #[test]
+    fn cancellation_classifies_its_own_codes() {
+        let error: AccessRequestCancelError =
+            problem(StatusCode::CONFLICT, "access_request_has_active_lease").into();
+
+        assert!(matches!(error, AccessRequestCancelError::HasActiveLease));
+    }
+
+    /// The split is only worth having if each enum refuses the codes it cannot receive. A submit
+    /// code reaching the activate classifier would mean the sets had drifted from the server's.
+    #[test]
+    fn an_enum_does_not_classify_another_calls_code() {
+        let submit_code = problem(StatusCode::CONFLICT, "access_already_active");
+        let activate_code = problem(StatusCode::CONFLICT, "approved_window_ended");
+
+        assert!(matches!(
+            AccessRequestActivateError::from(submit_code),
+            AccessRequestActivateError::Api(_)
+        ));
+        assert!(matches!(
+            AccessRequestSubmitError::from(activate_code),
+            AccessRequestSubmitError::Api(_)
+        ));
     }
 }

--- a/bitwarden_license/bitwarden-pam/src/access_requests/error.rs
+++ b/bitwarden_license/bitwarden-pam/src/access_requests/error.rs
@@ -1,0 +1,25 @@
+use bitwarden_core::ApiError;
+use bitwarden_error::bitwarden_error;
+use thiserror::Error;
+
+use super::validate::AccessRequestWindowError;
+use crate::error::PamDecodeError;
+
+/// Errors returned from [`super::AccessRequestsClient`] operations.
+///
+/// Local validation is reachable only from
+/// [`request`](super::AccessRequestsClient::request) - the read paths cannot produce it - which is
+/// why the requester surface carries a `Validation` variant the approver and lease surfaces do not.
+#[bitwarden_error(flat)]
+#[derive(Debug, Error)]
+pub enum AccessRequestError {
+    /// The request failed local validation before being sent to the server.
+    #[error(transparent)]
+    Validation(#[from] AccessRequestWindowError),
+    /// A server response could not be decoded into the requested type.
+    #[error(transparent)]
+    Decode(#[from] PamDecodeError),
+    /// A network or (de)serialization error occurred while calling the server.
+    #[error(transparent)]
+    Api(#[from] ApiError),
+}

--- a/bitwarden_license/bitwarden-pam/src/access_requests/mod.rs
+++ b/bitwarden_license/bitwarden-pam/src/access_requests/mod.rs
@@ -13,10 +13,13 @@
 
 mod client;
 mod models;
+mod validate;
 
 pub use client::AccessRequestsClient;
 pub use models::{
-    AccessApprovalMode, AccessApprover, AccessDecider, AccessDecisionVerdict, AccessPreCheckView,
-    AccessRequestCreateRequest, AccessRequestDecisionView, AccessRequestResultView,
-    AccessRequestStatus, AccessRequestSummaryView, AccessRequestView, CipherAccessStateView,
+    AccessApprovalMode, AccessApprover, AccessBadgeState, AccessDecider, AccessDecisionVerdict,
+    AccessPreCheckView, AccessRequestCreateRequest, AccessRequestDecisionView,
+    AccessRequestResultView, AccessRequestStatus, AccessRequestSummaryView, AccessRequestView,
+    CipherAccessStateView,
 };
+pub use validate::AccessRequestWindowError;

--- a/bitwarden_license/bitwarden-pam/src/access_requests/mod.rs
+++ b/bitwarden_license/bitwarden-pam/src/access_requests/mod.rs
@@ -24,4 +24,6 @@ pub use models::{
     AccessRequestResultView, AccessRequestStatus, AccessRequestSummaryView, AccessRequestView,
     CipherAccessStateView,
 };
-pub use validate::AccessRequestWindowError;
+pub use validate::{
+    AccessRequestWindowError, MAX_REQUEST_ACCESS_WINDOW_SECONDS, max_request_access_window_seconds,
+};

--- a/bitwarden_license/bitwarden-pam/src/access_requests/mod.rs
+++ b/bitwarden_license/bitwarden-pam/src/access_requests/mod.rs
@@ -25,5 +25,7 @@ pub use models::{
     CipherAccessStateView,
 };
 pub use validate::{
-    AccessRequestWindowError, MAX_REQUEST_ACCESS_WINDOW_SECONDS, max_request_access_window_seconds,
+    AccessRequestWindowError, DEFAULT_REQUEST_ACCESS_DURATION_SECONDS,
+    MAX_REQUEST_ACCESS_WINDOW_SECONDS, default_request_access_duration_seconds,
+    max_request_access_window_seconds,
 };

--- a/bitwarden_license/bitwarden-pam/src/access_requests/mod.rs
+++ b/bitwarden_license/bitwarden-pam/src/access_requests/mod.rs
@@ -17,7 +17,7 @@ mod models;
 mod validate;
 
 pub use client::AccessRequestsClient;
-pub use error::AccessRequestError;
+pub use error::{AccessRequestActivateError, AccessRequestCancelError, AccessRequestSubmitError};
 pub use models::{
     AccessApprovalMode, AccessApprover, AccessBadgeState, AccessDecider, AccessDecisionVerdict,
     AccessPreCheckView, AccessRequestCreateRequest, AccessRequestDecisionView,

--- a/bitwarden_license/bitwarden-pam/src/access_requests/mod.rs
+++ b/bitwarden_license/bitwarden-pam/src/access_requests/mod.rs
@@ -12,10 +12,12 @@
 //! activating an approved one, and cancelling a pending one.
 
 mod client;
+mod error;
 mod models;
 mod validate;
 
 pub use client::AccessRequestsClient;
+pub use error::AccessRequestError;
 pub use models::{
     AccessApprovalMode, AccessApprover, AccessBadgeState, AccessDecider, AccessDecisionVerdict,
     AccessPreCheckView, AccessRequestCreateRequest, AccessRequestDecisionView,

--- a/bitwarden_license/bitwarden-pam/src/access_requests/models.rs
+++ b/bitwarden_license/bitwarden-pam/src/access_requests/models.rs
@@ -188,6 +188,10 @@ pub struct AccessRequestView {
     pub submitted_at: DateTime<Utc>,
     /// When the request was approved, denied, or cancelled (UTC); None while pending.
     pub resolved_at: Option<DateTime<Utc>>,
+    /// When an approved request lapsed unactivated (UTC); None otherwise. The server does not
+    /// track this in v1, so it is always None today - its absence does not prove the request
+    /// is still live.
+    pub expired_at: Option<DateTime<Utc>>,
     /// The request's decision log, oldest first. Empty only while pending.
     pub decisions: Vec<AccessRequestDecisionView>,
     /// The lease produced once this (approved) request was activated. None until activation.
@@ -221,6 +225,7 @@ impl TryFrom<AccessRequestDetailsResponseModel> for AccessRequestView {
             reason: response.reason,
             submitted_at: require!(response.submitted_at).parse()?,
             resolved_at: response.resolved_at.map(|d| d.parse()).transpose()?,
+            expired_at: response.expired_at.map(|d| d.parse()).transpose()?,
             decisions: response
                 .decisions
                 .unwrap_or_default()
@@ -492,6 +497,7 @@ mod tests {
             reason: Some("Need to fix an incident".to_string()),
             submitted_at: Some("2025-01-01T00:00:00Z".to_string()),
             resolved_at: Some("2025-01-01T00:30:00Z".to_string()),
+            expired_at: Some("2025-01-02T00:00:00Z".to_string()),
             decisions: Some(vec![automatic_decision(), human_decision()]),
             produced_lease_id: Some(Uuid::new_v4()),
             produced_lease_status: Some(ApiAccessLeaseStatus::Active),
@@ -536,6 +542,18 @@ mod tests {
         assert_eq!(approver.email.as_deref(), Some("ana@example.com"));
         assert_eq!(decision.comment.as_deref(), Some("Looks fine"));
         assert_eq!(decision.verdict, AccessDecisionVerdict::Approve);
+    }
+
+    #[test]
+    fn full_response_converts_expired_at() {
+        let response = full_response();
+
+        let view = AccessRequestView::try_from(response).unwrap();
+
+        assert_eq!(
+            view.expired_at,
+            Some("2025-01-02T00:00:00Z".parse().unwrap())
+        );
     }
 
     #[test]

--- a/bitwarden_license/bitwarden-pam/src/access_requests/models.rs
+++ b/bitwarden_license/bitwarden-pam/src/access_requests/models.rs
@@ -15,7 +15,10 @@ use serde::{Deserialize, Serialize};
 #[cfg(feature = "wasm")]
 use tsify::Tsify;
 
-use super::validate::AccessRequestWindowError;
+use super::validate::{
+    AccessRequestWindowError, DEFAULT_REQUEST_ACCESS_DURATION_SECONDS,
+    MAX_REQUEST_ACCESS_WINDOW_SECONDS,
+};
 use crate::{
     AccessLeaseId, AccessLeaseStatus, AccessRequestId, AccessRuleId, error::PamDecodeError,
     leases::AccessLeaseView,
@@ -281,18 +284,48 @@ pub struct AccessPreCheckView {
     /// True when the caller already holds an active lease: reveal the credential, no request
     /// needed.
     pub has_active_lease: bool,
+    /// The duration, in seconds, a request form should pre-select - the governing rule's own
+    /// default where it sets one, already clamped to
+    /// [`max_duration_seconds`](Self::max_duration_seconds).
+    pub default_duration_seconds: u32,
+    /// The longest duration (automatic path) or window span (human path), in seconds, the server
+    /// will accept for this cipher: the governing rule's cap narrowed by the global ceiling.
+    ///
+    /// A duration picker should offer nothing above this. It is not merely advisory - submit
+    /// enforces the same number and rejects a request that exceeds it.
+    pub max_duration_seconds: u32,
 }
 
 impl TryFrom<AccessPreCheckResponseModel> for AccessPreCheckView {
     type Error = PamDecodeError;
 
     fn try_from(response: AccessPreCheckResponseModel) -> Result<Self, Self::Error> {
+        // Both bounds fall back rather than `require!`: a server predating them omits both, and a
+        // client that cannot read a pre-check at all cannot render a request form. Falling back to
+        // the global constants reproduces the pre-per-rule-cap behaviour instead.
+        let max_duration_seconds = positive_u32(response.max_duration_seconds)
+            .unwrap_or(MAX_REQUEST_ACCESS_WINDOW_SECONDS)
+            .min(MAX_REQUEST_ACCESS_WINDOW_SECONDS);
+
         Ok(Self {
             cipher_id: CipherId::new(require!(response.cipher_id)),
             approval_mode: AccessApprovalMode::from(require!(response.approval_mode)),
             has_active_lease: require!(response.has_active_lease),
+            // Re-clamped here as well as server-side: the two bounds arrive as independent fields,
+            // so a default above the cap would otherwise pre-fill a value submit refuses.
+            default_duration_seconds: positive_u32(response.default_duration_seconds)
+                .unwrap_or(DEFAULT_REQUEST_ACCESS_DURATION_SECONDS)
+                .min(max_duration_seconds),
+            max_duration_seconds,
         })
     }
+}
+
+/// Reads an optional wire-side duration as a positive `u32`, mapping absent, zero, and negative
+/// alike onto `None` so the caller applies its fallback. Zero is not a meaningful duration bound,
+/// and a negative one only arises from a malformed response.
+fn positive_u32(value: Option<i32>) -> Option<u32> {
+    value.filter(|v| *v > 0).map(|v| v as u32)
 }
 
 /// A decrypted view of an access request as its requester sees it right after submitting it.
@@ -727,6 +760,72 @@ mod tests {
         let view = AccessPreCheckView::try_from(response).unwrap();
 
         assert_eq!(view.approval_mode, AccessApprovalMode::Unknown);
+    }
+
+    fn pre_check_response(
+        default_duration_seconds: Option<i32>,
+        max_duration_seconds: Option<i32>,
+    ) -> AccessPreCheckResponseModel {
+        AccessPreCheckResponseModel {
+            cipher_id: Some(cipher_id()),
+            approval_mode: Some(ApiAccessApprovalMode::Automatic),
+            has_active_lease: Some(false),
+            default_duration_seconds,
+            max_duration_seconds,
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn pre_check_view_carries_the_rules_duration_bounds() {
+        let view = AccessPreCheckView::try_from(pre_check_response(Some(900), Some(1800))).unwrap();
+
+        assert_eq!(view.default_duration_seconds, 900);
+        assert_eq!(view.max_duration_seconds, 1800);
+    }
+
+    #[test]
+    fn pre_check_view_falls_back_when_bounds_are_absent() {
+        // A server predating the bounds omits both; the view reproduces the previous global-only
+        // behaviour rather than failing to decode.
+        let view = AccessPreCheckView::try_from(pre_check_response(None, None)).unwrap();
+
+        assert_eq!(
+            view.default_duration_seconds,
+            DEFAULT_REQUEST_ACCESS_DURATION_SECONDS
+        );
+        assert_eq!(view.max_duration_seconds, MAX_REQUEST_ACCESS_WINDOW_SECONDS);
+    }
+
+    #[test]
+    fn pre_check_view_clamps_default_to_max() {
+        // PM-39858's shape: a rule left at a 1h default but capped at 15m. Pre-filling the default
+        // would hand the requester a duration submit refuses.
+        let view = AccessPreCheckView::try_from(pre_check_response(Some(3600), Some(900))).unwrap();
+
+        assert_eq!(view.default_duration_seconds, 900);
+        assert_eq!(view.max_duration_seconds, 900);
+    }
+
+    #[test]
+    fn pre_check_view_clamps_max_to_the_global_ceiling() {
+        let view =
+            AccessPreCheckView::try_from(pre_check_response(None, Some(7 * 86_400))).unwrap();
+
+        assert_eq!(view.max_duration_seconds, MAX_REQUEST_ACCESS_WINDOW_SECONDS);
+    }
+
+    #[test]
+    fn pre_check_view_treats_non_positive_bounds_as_absent() {
+        // Zero is the client's "no cap" sentinel and never a meaningful bound; a negative value
+        // only arises from a malformed response. Neither should collapse the picker to nothing.
+        let view = AccessPreCheckView::try_from(pre_check_response(Some(0), Some(-1))).unwrap();
+
+        assert_eq!(
+            view.default_duration_seconds,
+            DEFAULT_REQUEST_ACCESS_DURATION_SECONDS
+        );
+        assert_eq!(view.max_duration_seconds, MAX_REQUEST_ACCESS_WINDOW_SECONDS);
     }
 
     fn sample_created_request() -> AccessRequestDetailsResponseModel {

--- a/bitwarden_license/bitwarden-pam/src/access_requests/models.rs
+++ b/bitwarden_license/bitwarden-pam/src/access_requests/models.rs
@@ -210,12 +210,50 @@ pub struct AccessRequestView {
     /// The requester's email, denormalized by the server. None only when the user could not be
     /// resolved.
     pub requester_email: Option<String>,
+    /// True when this request is approved but has not been activated into a lease yet, so the
+    /// requester still has something to do with it.
+    ///
+    /// Activation is not a status: an activated request stays
+    /// [`Approved`](AccessRequestStatus::Approved) and is recognised by the
+    /// [`produced_lease_id`](Self::produced_lease_id) it minted. Every client needs this
+    /// distinction - to badge a navigation counter, to decide whether to offer a Start action, to
+    /// keep an already-started grant out of a pending list - and deriving it from two fields is
+    /// exactly the kind of rule each of them would otherwise get subtly wrong.
+    ///
+    /// Deliberately says nothing about whether the activation window is still open. That depends
+    /// on wall-clock time at the moment the client renders, not at the moment this view was
+    /// fetched, so it stays a client decision - the same line [`AccessBadgeState`] draws for its
+    /// "ending soon" escalation.
+    pub awaiting_activation: bool,
+    /// The human decision recorded on this request - the deciding approver, or the holder ending
+    /// their own lease - or None when only an access rule decided it, or nothing has yet.
+    ///
+    /// An automatic (access-rule) decision carries no approver identity, so "who approved this"
+    /// and "was this decided by a rule" are the same question, answered here once instead of by
+    /// each client scanning the decision log for a non-automatic decider.
+    pub human_decision: Option<AccessRequestDecisionView>,
 }
 
 impl TryFrom<AccessRequestDetailsResponseModel> for AccessRequestView {
     type Error = PamDecodeError;
 
     fn try_from(response: AccessRequestDetailsResponseModel) -> Result<Self, Self::Error> {
+        let status = AccessRequestStatus::from(require!(response.status));
+        let produced_lease_id = response.produced_lease_id.map(AccessLeaseId::new);
+        let decisions = response
+            .decisions
+            .unwrap_or_default()
+            .into_iter()
+            .map(AccessRequestDecisionView::try_from)
+            .collect::<Result<Vec<_>, _>>()?;
+
+        // An automatic decision carries no approver, so a human decision is simply one whose
+        // decider is not `Automatic`. v0/v1 records at most one.
+        let human_decision = decisions
+            .iter()
+            .find(|decision| !matches!(decision.decider, AccessDecider::Automatic))
+            .cloned();
+
         Ok(Self {
             id: AccessRequestId::new(require!(response.id)),
             cipher_id: CipherId::new(require!(response.cipher_id)),
@@ -223,20 +261,18 @@ impl TryFrom<AccessRequestDetailsResponseModel> for AccessRequestView {
             organization_id: response.organization_id.map(OrganizationId::new),
             requester_id: UserId::new(require!(response.requester_id)),
             rule_id: response.rule_id.map(AccessRuleId::new),
-            status: AccessRequestStatus::from(require!(response.status)),
+            status,
             lease_not_before: require!(response.lease_not_before).parse()?,
             lease_not_after: require!(response.lease_not_after).parse()?,
             reason: response.reason,
             submitted_at: require!(response.submitted_at).parse()?,
             resolved_at: response.resolved_at.map(|d| d.parse()).transpose()?,
             expired_at: response.expired_at.map(|d| d.parse()).transpose()?,
-            decisions: response
-                .decisions
-                .unwrap_or_default()
-                .into_iter()
-                .map(AccessRequestDecisionView::try_from)
-                .collect::<Result<Vec<_>, _>>()?,
-            produced_lease_id: response.produced_lease_id.map(AccessLeaseId::new),
+            awaiting_activation: status == AccessRequestStatus::Approved
+                && produced_lease_id.is_none(),
+            human_decision,
+            decisions,
+            produced_lease_id,
             produced_lease_status: response.produced_lease_status.map(AccessLeaseStatus::from),
             extension_of_lease_id: response.extension_of_lease_id.map(AccessLeaseId::new),
             requester_name: response.requester_name,
@@ -1074,5 +1110,85 @@ mod tests {
             result.unwrap_err(),
             AccessRequestWindowError::EndBeforeStart
         );
+    }
+
+    #[test]
+    fn awaiting_activation_is_true_for_an_approved_request_with_no_lease_yet() {
+        let response = AccessRequestDetailsResponseModel {
+            status: Some(ApiAccessRequestStatus::Approved),
+            produced_lease_id: None,
+            ..full_response()
+        };
+
+        let view = AccessRequestView::try_from(response).unwrap();
+
+        assert!(view.awaiting_activation);
+    }
+
+    /// Activation does not change the status, so only the minted lease separates "still to start"
+    /// from "already running".
+    #[test]
+    fn awaiting_activation_is_false_once_the_request_has_minted_a_lease() {
+        let response = AccessRequestDetailsResponseModel {
+            status: Some(ApiAccessRequestStatus::Approved),
+            produced_lease_id: Some(Uuid::new_v4()),
+            ..full_response()
+        };
+
+        let view = AccessRequestView::try_from(response).unwrap();
+
+        assert!(!view.awaiting_activation);
+        assert_eq!(view.status, AccessRequestStatus::Approved);
+    }
+
+    #[test]
+    fn awaiting_activation_is_false_for_a_request_still_pending() {
+        let response = AccessRequestDetailsResponseModel {
+            status: Some(ApiAccessRequestStatus::Pending),
+            produced_lease_id: None,
+            ..full_response()
+        };
+
+        let view = AccessRequestView::try_from(response).unwrap();
+
+        assert!(!view.awaiting_activation);
+    }
+
+    #[test]
+    fn human_decision_skips_the_automatic_one() {
+        let response = AccessRequestDetailsResponseModel {
+            decisions: Some(vec![automatic_decision(), human_decision()]),
+            ..full_response()
+        };
+
+        let view = AccessRequestView::try_from(response).unwrap();
+
+        let decision = view.human_decision.expect("a human decided this request");
+        assert!(matches!(decision.decider, AccessDecider::Human(_)));
+        assert_eq!(decision.comment.as_deref(), Some("Looks fine"));
+    }
+
+    #[test]
+    fn human_decision_is_none_when_only_an_access_rule_decided() {
+        let response = AccessRequestDetailsResponseModel {
+            decisions: Some(vec![automatic_decision()]),
+            ..full_response()
+        };
+
+        let view = AccessRequestView::try_from(response).unwrap();
+
+        assert!(view.human_decision.is_none());
+    }
+
+    #[test]
+    fn human_decision_is_none_while_the_request_is_undecided() {
+        let response = AccessRequestDetailsResponseModel {
+            decisions: Some(vec![]),
+            ..full_response()
+        };
+
+        let view = AccessRequestView::try_from(response).unwrap();
+
+        assert!(view.human_decision.is_none());
     }
 }

--- a/bitwarden_license/bitwarden-pam/src/access_requests/models.rs
+++ b/bitwarden_license/bitwarden-pam/src/access_requests/models.rs
@@ -15,8 +15,9 @@ use serde::{Deserialize, Serialize};
 #[cfg(feature = "wasm")]
 use tsify::Tsify;
 
+use super::validate::AccessRequestWindowError;
 use crate::{
-    AccessLeaseId, AccessLeaseStatus, AccessRequestId, AccessRuleId, error::LeasingError,
+    AccessLeaseId, AccessLeaseStatus, AccessRequestId, AccessRuleId, error::PamDecodeError,
     leases::AccessLeaseView,
 };
 
@@ -129,7 +130,7 @@ pub struct AccessApprover {
 }
 
 impl TryFrom<AccessRequestDecisionResponseModel> for AccessRequestDecisionView {
-    type Error = LeasingError;
+    type Error = PamDecodeError;
 
     fn try_from(response: AccessRequestDecisionResponseModel) -> Result<Self, Self::Error> {
         let decider = match require!(response.decider_kind) {
@@ -140,7 +141,7 @@ impl TryFrom<AccessRequestDecisionResponseModel> for AccessRequestDecisionView {
                 email: response.email,
             }),
             ApiAccessDeciderKind::__Unknown(_) => {
-                return Err(LeasingError::UnrecognizedDeciderKind);
+                return Err(PamDecodeError::UnrecognizedDeciderKind);
             }
         };
 
@@ -209,7 +210,7 @@ pub struct AccessRequestView {
 }
 
 impl TryFrom<AccessRequestDetailsResponseModel> for AccessRequestView {
-    type Error = LeasingError;
+    type Error = PamDecodeError;
 
     fn try_from(response: AccessRequestDetailsResponseModel) -> Result<Self, Self::Error> {
         Ok(Self {
@@ -283,7 +284,7 @@ pub struct AccessPreCheckView {
 }
 
 impl TryFrom<AccessPreCheckResponseModel> for AccessPreCheckView {
-    type Error = LeasingError;
+    type Error = PamDecodeError;
 
     fn try_from(response: AccessPreCheckResponseModel) -> Result<Self, Self::Error> {
         Ok(Self {
@@ -324,7 +325,7 @@ pub struct AccessRequestSummaryView {
 }
 
 impl TryFrom<AccessRequestDetailsResponseModel> for AccessRequestSummaryView {
-    type Error = LeasingError;
+    type Error = PamDecodeError;
 
     fn try_from(response: AccessRequestDetailsResponseModel) -> Result<Self, Self::Error> {
         Ok(Self {
@@ -358,7 +359,7 @@ pub struct AccessRequestResultView {
 }
 
 impl TryFrom<AccessRequestResultResponseModel> for AccessRequestResultView {
-    type Error = LeasingError;
+    type Error = PamDecodeError;
 
     fn try_from(response: AccessRequestResultResponseModel) -> Result<Self, Self::Error> {
         Ok(Self {
@@ -438,7 +439,7 @@ pub struct CipherAccessStateView {
 }
 
 impl TryFrom<CipherAccessStateResponseModel> for CipherAccessStateView {
-    type Error = LeasingError;
+    type Error = PamDecodeError;
 
     fn try_from(response: CipherAccessStateResponseModel) -> Result<Self, Self::Error> {
         let active_lease = response
@@ -500,14 +501,22 @@ pub struct AccessRequestCreateRequest {
     pub reason: Option<String>,
 }
 
-impl From<AccessRequestCreateRequest> for AccessRequestCreateRequestModel {
-    fn from(request: AccessRequestCreateRequest) -> Self {
-        Self {
+impl TryFrom<AccessRequestCreateRequest> for AccessRequestCreateRequestModel {
+    type Error = AccessRequestWindowError;
+
+    /// Validates the request's activation window on the way to the wire model.
+    ///
+    /// Validation lives here rather than at the call site so it cannot be circumvented: building
+    /// the model *is* the only way to reach the server, so every path is checked.
+    fn try_from(request: AccessRequestCreateRequest) -> Result<Self, Self::Error> {
+        request.validate()?;
+
+        Ok(Self {
             duration_seconds: request.duration_seconds.map(|d| d.get() as i32),
             start: request.start.map(|d| d.to_rfc3339()),
             end: request.end.map(|d| d.to_rfc3339()),
             reason: request.reason,
-        }
+        })
     }
 }
 
@@ -942,11 +951,29 @@ mod tests {
             reason: Some("Need access".to_string()),
         };
 
-        let model = AccessRequestCreateRequestModel::from(request);
+        let model = AccessRequestCreateRequestModel::try_from(request).unwrap();
 
         assert_eq!(model.duration_seconds, Some(3600));
         assert_eq!(model.start, Some("2025-01-01T00:00:00+00:00".to_string()));
         assert_eq!(model.end, Some("2025-01-01T01:00:00+00:00".to_string()));
         assert_eq!(model.reason, Some("Need access".to_string()));
+    }
+
+    #[test]
+    fn access_request_create_request_conversion_enforces_validation() {
+        // Building the wire model is the only route to the server, so an invalid window cannot
+        // reach it even if a caller skips the client method.
+        let request = AccessRequestCreateRequest {
+            start: Some("2025-01-01T01:00:00Z".parse().unwrap()),
+            end: Some("2025-01-01T00:00:00Z".parse().unwrap()),
+            ..Default::default()
+        };
+
+        let result = AccessRequestCreateRequestModel::try_from(request);
+
+        assert_eq!(
+            result.unwrap_err(),
+            AccessRequestWindowError::EndBeforeStart
+        );
     }
 }

--- a/bitwarden_license/bitwarden-pam/src/access_requests/models.rs
+++ b/bitwarden_license/bitwarden-pam/src/access_requests/models.rs
@@ -368,13 +368,50 @@ impl TryFrom<AccessRequestResultResponseModel> for AccessRequestResultView {
     }
 }
 
+/// The single badge to show for a gated cipher, derived from [`CipherAccessStateView`]'s
+/// [`active_lease`](CipherAccessStateView::active_lease),
+/// [`approved_request`](CipherAccessStateView::approved_request), and
+/// [`pending_request`](CipherAccessStateView::pending_request) by precedence: exactly one badge
+/// shows for a gated item at a time - an active lease authorizes access right now, an approved
+/// request is ready to activate, and a pending request is merely awaiting a decision, so the
+/// first of those that is present wins over the rest. Absent all three, the item is gated but
+/// resting - no lease, no request in flight.
+///
+/// [`Active`](Self::Active) carries only [`expires_at`](Self::Active::expires_at). Whether that
+/// time is soon enough to warrant an "ending soon" escalation is a live-countdown threshold that
+/// depends on wall-clock time as the client renders it, so it stays a presentation concern for
+/// the client rather than something this view decides once at fetch time.
+///
+/// This deliberately does not model `unavailable` (the item is currently held by another user) or
+/// `expired`: the server's per-cipher access-state response is scoped to the calling user, so
+/// there is no data today from which either could be derived. Producing them would need a server
+/// response-model change plus a new SDK field, and is tracked separately.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "wasm", derive(Tsify), tsify(into_wasm_abi, from_wasm_abi))]
+#[serde(rename_all = "camelCase")]
+pub enum AccessBadgeState {
+    /// The caller holds an active lease; the cipher is unlocked until it expires.
+    Active {
+        /// When the active lease's access window closes (UTC).
+        #[serde(rename = "expiresAt")]
+        expires_at: DateTime<Utc>,
+    },
+    /// The caller's request was approved and is ready to be activated into a lease.
+    Ready,
+    /// The caller has a request awaiting a decision.
+    Pending,
+    /// No active lease, approved request, or pending request - the item is gated and resting.
+    Privileged,
+}
+
 /// A single-snapshot read of the caller's access state for one cipher, powering the cipher-view
 /// banner and the vault-row badge.
 ///
 /// At most one of [`active_lease`](Self::active_lease), [`pending_request`](Self::pending_request),
 /// and [`approved_request`](Self::approved_request) is meaningfully "next": an active lease
 /// authorizes access, a pending request awaits a decision, and an approved request awaits
-/// activation by the caller.
+/// activation by the caller. [`badge_state`](Self::badge_state) collapses those three into the
+/// single badge the client should show.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "wasm", derive(Tsify), tsify(into_wasm_abi, from_wasm_abi))]
 #[serde(rename_all = "camelCase")]
@@ -388,6 +425,11 @@ pub struct CipherAccessStateView {
     /// The caller's approved-but-not-yet-activated request on this cipher, if any. Lapsed
     /// approvals are never surfaced here.
     pub approved_request: Option<AccessRequestView>,
+    /// The single badge to show for this cipher, derived from
+    /// [`active_lease`](Self::active_lease), [`approved_request`](Self::approved_request), and
+    /// [`pending_request`](Self::pending_request) by precedence. See [`AccessBadgeState`] for
+    /// the precedence order and its rationale.
+    pub badge_state: AccessBadgeState,
     /// Whether the active lease can still be extended.
     pub extensions_allowed: bool,
     /// The longest a single extension of the active lease may run, in seconds; None when there is
@@ -399,20 +441,39 @@ impl TryFrom<CipherAccessStateResponseModel> for CipherAccessStateView {
     type Error = LeasingError;
 
     fn try_from(response: CipherAccessStateResponseModel) -> Result<Self, Self::Error> {
+        let active_lease = response
+            .active_lease
+            .map(|lease| AccessLeaseView::try_from(*lease))
+            .transpose()?;
+        let pending_request = response
+            .pending_request
+            .map(|request| AccessRequestView::try_from(*request))
+            .transpose()?;
+        let approved_request = response
+            .approved_request
+            .map(|request| AccessRequestView::try_from(*request))
+            .transpose()?;
+
+        // active lease -> approved (ready to activate) -> pending approval -> privileged
+        // (resting). Mirrors the precedence documented on `AccessBadgeState`.
+        let badge_state = if let Some(lease) = &active_lease {
+            AccessBadgeState::Active {
+                expires_at: lease.not_after,
+            }
+        } else if approved_request.is_some() {
+            AccessBadgeState::Ready
+        } else if pending_request.is_some() {
+            AccessBadgeState::Pending
+        } else {
+            AccessBadgeState::Privileged
+        };
+
         Ok(Self {
             cipher_id: CipherId::new(require!(response.cipher_id)),
-            active_lease: response
-                .active_lease
-                .map(|lease| AccessLeaseView::try_from(*lease))
-                .transpose()?,
-            pending_request: response
-                .pending_request
-                .map(|request| AccessRequestView::try_from(*request))
-                .transpose()?,
-            approved_request: response
-                .approved_request
-                .map(|request| AccessRequestView::try_from(*request))
-                .transpose()?,
+            active_lease,
+            pending_request,
+            approved_request,
+            badge_state,
             extensions_allowed: require!(response.extensions_allowed),
             max_extension_duration_seconds: response.max_extension_duration_seconds,
         })
@@ -716,6 +777,7 @@ mod tests {
         assert_eq!(view.active_lease, None);
         assert_eq!(view.pending_request, None);
         assert_eq!(view.approved_request, None);
+        assert_eq!(view.badge_state, AccessBadgeState::Privileged);
         assert!(!view.extensions_allowed);
         assert_eq!(view.max_extension_duration_seconds, None);
     }
@@ -747,8 +809,128 @@ mod tests {
         assert!(view.active_lease.is_some());
         assert!(view.pending_request.is_some());
         assert!(view.approved_request.is_some());
+        // An active lease outranks the (also-populated) approved and pending requests.
+        assert_eq!(
+            view.badge_state,
+            AccessBadgeState::Active {
+                expires_at: "2025-01-01T01:00:00Z".parse().unwrap()
+            }
+        );
         assert!(view.extensions_allowed);
         assert_eq!(view.max_extension_duration_seconds, Some(3600));
+    }
+
+    fn cipher_access_state_response_with(
+        active_lease: Option<Box<AccessLeaseResponseModel>>,
+        pending_request: Option<Box<AccessRequestDetailsResponseModel>>,
+        approved_request: Option<Box<AccessRequestDetailsResponseModel>>,
+    ) -> CipherAccessStateResponseModel {
+        CipherAccessStateResponseModel {
+            cipher_id: Some(cipher_id()),
+            active_lease,
+            pending_request,
+            approved_request,
+            extensions_allowed: Some(false),
+            max_extension_duration_seconds: None,
+            ..Default::default()
+        }
+    }
+
+    fn sample_active_lease() -> Box<AccessLeaseResponseModel> {
+        Box::new(AccessLeaseResponseModel {
+            id: Some(uuid!("33333333-3333-3333-3333-333333333333")),
+            request_id: Some(request_id().into()),
+            cipher_id: Some(cipher_id()),
+            collection_id: Some(uuid!("66666666-6666-6666-6666-666666666666")),
+            requester_id: Some(uuid!("88888888-8888-8888-8888-888888888888")),
+            status: Some(ApiAccessLeaseStatus::Active),
+            not_before: Some("2025-01-01T00:00:00Z".to_string()),
+            not_after: Some("2025-01-01T01:00:00Z".to_string()),
+            ..Default::default()
+        })
+    }
+
+    #[test]
+    fn badge_state_is_active_when_only_an_active_lease_is_present() {
+        let response = cipher_access_state_response_with(Some(sample_active_lease()), None, None);
+
+        let view = CipherAccessStateView::try_from(response).unwrap();
+
+        assert_eq!(
+            view.badge_state,
+            AccessBadgeState::Active {
+                expires_at: "2025-01-01T01:00:00Z".parse().unwrap()
+            }
+        );
+    }
+
+    #[test]
+    fn badge_state_is_ready_when_approved_request_is_present_without_a_lease() {
+        let response =
+            cipher_access_state_response_with(None, None, Some(Box::new(full_response())));
+
+        let view = CipherAccessStateView::try_from(response).unwrap();
+
+        assert_eq!(view.badge_state, AccessBadgeState::Ready);
+    }
+
+    #[test]
+    fn badge_state_prefers_ready_over_pending() {
+        let response = cipher_access_state_response_with(
+            None,
+            Some(Box::new(full_response())),
+            Some(Box::new(full_response())),
+        );
+
+        let view = CipherAccessStateView::try_from(response).unwrap();
+
+        assert_eq!(view.badge_state, AccessBadgeState::Ready);
+    }
+
+    #[test]
+    fn badge_state_is_pending_when_only_a_pending_request_is_present() {
+        let response =
+            cipher_access_state_response_with(None, Some(Box::new(full_response())), None);
+
+        let view = CipherAccessStateView::try_from(response).unwrap();
+
+        assert_eq!(view.badge_state, AccessBadgeState::Pending);
+    }
+
+    #[test]
+    fn badge_state_is_privileged_when_nothing_is_present() {
+        let response = cipher_access_state_response_with(None, None, None);
+
+        let view = CipherAccessStateView::try_from(response).unwrap();
+
+        assert_eq!(view.badge_state, AccessBadgeState::Privileged);
+    }
+
+    #[test]
+    fn active_badge_state_serializes_with_camel_case_expires_at() {
+        let state = AccessBadgeState::Active {
+            expires_at: "2025-01-01T01:00:00Z".parse().unwrap(),
+        };
+
+        let json = serde_json::to_value(&state).unwrap();
+
+        assert_eq!(json["active"]["expiresAt"], "2025-01-01T01:00:00Z");
+    }
+
+    #[test]
+    fn unit_badge_states_serialize_as_bare_strings() {
+        assert_eq!(
+            serde_json::to_value(AccessBadgeState::Ready).unwrap(),
+            serde_json::json!("ready")
+        );
+        assert_eq!(
+            serde_json::to_value(AccessBadgeState::Pending).unwrap(),
+            serde_json::json!("pending")
+        );
+        assert_eq!(
+            serde_json::to_value(AccessBadgeState::Privileged).unwrap(),
+            serde_json::json!("privileged")
+        );
     }
 
     #[test]

--- a/bitwarden_license/bitwarden-pam/src/access_requests/validate.rs
+++ b/bitwarden_license/bitwarden-pam/src/access_requests/validate.rs
@@ -24,6 +24,25 @@ pub fn max_request_access_window_seconds() -> u32 {
     MAX_REQUEST_ACCESS_WINDOW_SECONDS
 }
 
+/// Duration, in seconds, a request form pre-selects when neither the governing rule nor the server
+/// names one - mirrors the server's global default.
+///
+/// Only a fallback. The authority is
+/// [`default_duration_seconds`](super::AccessPreCheckView::default_duration_seconds), which
+/// resolves the governing rule's own default; this applies when a pre-check response predates that
+/// field.
+pub const DEFAULT_REQUEST_ACCESS_DURATION_SECONDS: u32 = 3_600;
+
+/// [`DEFAULT_REQUEST_ACCESS_DURATION_SECONDS`], for callers that cannot read a Rust `const`.
+///
+/// Same reason [`max_request_access_window_seconds`] exists: wasm-bindgen exports functions rather
+/// than constants, and a client that hardcodes its own copy drifts the day the server's default
+/// moves.
+#[cfg_attr(feature = "wasm", wasm_bindgen)]
+pub fn default_request_access_duration_seconds() -> u32 {
+    DEFAULT_REQUEST_ACCESS_DURATION_SECONDS
+}
+
 /// Errors returned when a locally-constructed [`AccessRequestCreateRequest`] fails validation
 /// before being sent to the server.
 #[derive(Debug, Error, PartialEq, Eq)]

--- a/bitwarden_license/bitwarden-pam/src/access_requests/validate.rs
+++ b/bitwarden_license/bitwarden-pam/src/access_requests/validate.rs
@@ -1,5 +1,7 @@
 use chrono::Duration;
 use thiserror::Error;
+#[cfg(feature = "wasm")]
+use wasm_bindgen::prelude::wasm_bindgen;
 
 use super::models::AccessRequestCreateRequest;
 
@@ -7,7 +9,20 @@ use super::models::AccessRequestCreateRequest;
 /// cap. Applies to both the automatic path's
 /// [`duration_seconds`](AccessRequestCreateRequest::duration_seconds) and the human path's
 /// [`start`](AccessRequestCreateRequest::start)/[`end`](AccessRequestCreateRequest::end) span.
-const MAX_REQUEST_ACCESS_WINDOW_SECONDS: u32 = 86_400;
+pub const MAX_REQUEST_ACCESS_WINDOW_SECONDS: u32 = 86_400;
+
+/// [`MAX_REQUEST_ACCESS_WINDOW_SECONDS`], for callers that cannot read a Rust `const`.
+///
+/// A client collecting a window in a form validates it as the requester types - long before there
+/// is an [`AccessRequestCreateRequest`] to hand to
+/// [`request`](super::AccessRequestsClient::request), which is where
+/// [`validate`](AccessRequestCreateRequest::validate) applies the same cap. So the number has to be
+/// readable on its own, or every client hardcodes its own copy and they drift the day the server's
+/// cap moves. wasm-bindgen exports functions rather than constants, hence a getter.
+#[cfg_attr(feature = "wasm", wasm_bindgen)]
+pub fn max_request_access_window_seconds() -> u32 {
+    MAX_REQUEST_ACCESS_WINDOW_SECONDS
+}
 
 /// Errors returned when a locally-constructed [`AccessRequestCreateRequest`] fails validation
 /// before being sent to the server.

--- a/bitwarden_license/bitwarden-pam/src/access_requests/validate.rs
+++ b/bitwarden_license/bitwarden-pam/src/access_requests/validate.rs
@@ -35,7 +35,7 @@ impl AccessRequestCreateRequest {
     /// - A request with neither a duration nor a start/end pair is **not** rejected here: the
     ///   server decides which path applies to an incomplete request, and rejecting it locally would
     ///   reject requests the server is willing to accept.
-    pub fn validate(&self) -> Result<(), AccessRequestWindowError> {
+    pub(crate) fn validate(&self) -> Result<(), AccessRequestWindowError> {
         if let (Some(start), Some(end)) = (self.start, self.end) {
             if end <= start {
                 return Err(AccessRequestWindowError::EndBeforeStart);

--- a/bitwarden_license/bitwarden-pam/src/access_requests/validate.rs
+++ b/bitwarden_license/bitwarden-pam/src/access_requests/validate.rs
@@ -1,0 +1,178 @@
+use chrono::Duration;
+use thiserror::Error;
+
+use super::models::AccessRequestCreateRequest;
+
+/// Maximum span, in seconds, of an access request's activation window - mirrors the server's
+/// cap. Applies to both the automatic path's
+/// [`duration_seconds`](AccessRequestCreateRequest::duration_seconds) and the human path's
+/// [`start`](AccessRequestCreateRequest::start)/[`end`](AccessRequestCreateRequest::end) span.
+const MAX_REQUEST_ACCESS_WINDOW_SECONDS: u32 = 86_400;
+
+/// Errors returned when a locally-constructed [`AccessRequestCreateRequest`] fails validation
+/// before being sent to the server.
+#[derive(Debug, Error, PartialEq, Eq)]
+pub enum AccessRequestWindowError {
+    /// `end` was not strictly after `start`.
+    #[error("end must be strictly after start")]
+    EndBeforeStart,
+    /// The requested window was longer than the server's 24h cap.
+    #[error(
+        "The requested window exceeds the maximum of {MAX_REQUEST_ACCESS_WINDOW_SECONDS} seconds"
+    )]
+    ExceedsMaxWindow,
+}
+
+impl AccessRequestCreateRequest {
+    /// Validates the request's activation window before it is sent to the server.
+    ///
+    /// - When both [`start`](Self::start) and [`end`](Self::end) are supplied (the human path),
+    ///   `end` must be strictly after `start` and the span between them must not exceed
+    ///   `MAX_REQUEST_ACCESS_WINDOW_SECONDS`.
+    /// - When [`duration_seconds`](Self::duration_seconds) is supplied (the automatic path), it
+    ///   must not exceed `MAX_REQUEST_ACCESS_WINDOW_SECONDS`. It is a `NonZeroU32`, so positivity
+    ///   is already guaranteed by the type and is not re-checked here.
+    /// - A request with neither a duration nor a start/end pair is **not** rejected here: the
+    ///   server decides which path applies to an incomplete request, and rejecting it locally would
+    ///   reject requests the server is willing to accept.
+    pub fn validate(&self) -> Result<(), AccessRequestWindowError> {
+        if let (Some(start), Some(end)) = (self.start, self.end) {
+            if end <= start {
+                return Err(AccessRequestWindowError::EndBeforeStart);
+            }
+            if end - start > Duration::seconds(MAX_REQUEST_ACCESS_WINDOW_SECONDS as i64) {
+                return Err(AccessRequestWindowError::ExceedsMaxWindow);
+            }
+        }
+
+        if let Some(duration_seconds) = self.duration_seconds
+            && duration_seconds.get() > MAX_REQUEST_ACCESS_WINDOW_SECONDS
+        {
+            return Err(AccessRequestWindowError::ExceedsMaxWindow);
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::num::NonZeroU32;
+
+    use super::*;
+
+    fn base_request() -> AccessRequestCreateRequest {
+        AccessRequestCreateRequest {
+            duration_seconds: None,
+            start: None,
+            end: None,
+            reason: None,
+        }
+    }
+
+    #[test]
+    fn neither_duration_nor_window_is_not_rejected_locally() {
+        // The server decides which path applies to an incomplete request; an SDK-side rule here
+        // would reject requests the server accepts.
+        assert_eq!(base_request().validate(), Ok(()));
+    }
+
+    #[test]
+    fn end_equal_to_start_is_invalid() {
+        let start: chrono::DateTime<chrono::Utc> = "2025-01-01T00:00:00Z".parse().unwrap();
+        let request = AccessRequestCreateRequest {
+            start: Some(start),
+            end: Some(start),
+            ..base_request()
+        };
+
+        assert_eq!(
+            request.validate(),
+            Err(AccessRequestWindowError::EndBeforeStart)
+        );
+    }
+
+    #[test]
+    fn end_before_start_is_invalid() {
+        let request = AccessRequestCreateRequest {
+            start: Some("2025-01-01T01:00:00Z".parse().unwrap()),
+            end: Some("2025-01-01T00:00:00Z".parse().unwrap()),
+            ..base_request()
+        };
+
+        assert_eq!(
+            request.validate(),
+            Err(AccessRequestWindowError::EndBeforeStart)
+        );
+    }
+
+    #[test]
+    fn window_span_of_exactly_24_hours_is_valid() {
+        let request = AccessRequestCreateRequest {
+            start: Some("2025-01-01T00:00:00Z".parse().unwrap()),
+            end: Some("2025-01-02T00:00:00Z".parse().unwrap()),
+            ..base_request()
+        };
+
+        assert_eq!(request.validate(), Ok(()));
+    }
+
+    #[test]
+    fn window_span_over_24_hours_is_invalid() {
+        let request = AccessRequestCreateRequest {
+            start: Some("2025-01-01T00:00:00Z".parse().unwrap()),
+            end: Some("2025-01-02T00:00:01Z".parse().unwrap()),
+            ..base_request()
+        };
+
+        assert_eq!(
+            request.validate(),
+            Err(AccessRequestWindowError::ExceedsMaxWindow)
+        );
+    }
+
+    #[test]
+    fn duration_seconds_of_exactly_24_hours_is_valid() {
+        let request = AccessRequestCreateRequest {
+            duration_seconds: NonZeroU32::new(86_400),
+            ..base_request()
+        };
+
+        assert_eq!(request.validate(), Ok(()));
+    }
+
+    #[test]
+    fn duration_seconds_over_24_hours_is_invalid() {
+        let request = AccessRequestCreateRequest {
+            duration_seconds: NonZeroU32::new(86_401),
+            ..base_request()
+        };
+
+        assert_eq!(
+            request.validate(),
+            Err(AccessRequestWindowError::ExceedsMaxWindow)
+        );
+    }
+
+    #[test]
+    fn small_duration_seconds_is_valid() {
+        let request = AccessRequestCreateRequest {
+            duration_seconds: NonZeroU32::new(3600),
+            ..base_request()
+        };
+
+        assert_eq!(request.validate(), Ok(()));
+    }
+
+    #[test]
+    fn only_start_without_end_is_not_window_checked_locally() {
+        // The human path isn't complete without both `start` and `end`; the server is the source
+        // of truth for rejecting an incomplete pair.
+        let request = AccessRequestCreateRequest {
+            start: Some("2025-01-01T00:00:00Z".parse().unwrap()),
+            ..base_request()
+        };
+
+        assert_eq!(request.validate(), Ok(()));
+    }
+}

--- a/bitwarden_license/bitwarden-pam/src/access_rules/client.rs
+++ b/bitwarden_license/bitwarden-pam/src/access_rules/client.rs
@@ -40,7 +40,8 @@ impl AccessRulesClient {
             .collect()
     }
 
-    /// Retrieves a single access rule by ID.
+    /// Retrieves a single access rule by ID. Fails with
+    /// [`NotFound`](AccessRuleError::NotFound) when no such rule is visible to the caller.
     pub async fn get(
         &self,
         organization_id: OrganizationId,
@@ -51,7 +52,8 @@ impl AccessRulesClient {
             .api_client
             .access_rules_api()
             .get(organization_id.into(), id.into())
-            .await?;
+            .await
+            .map_err(AccessRuleError::from_by_id_api_error)?;
 
         AccessRuleView::try_from(response)
     }
@@ -74,7 +76,8 @@ impl AccessRulesClient {
         AccessRuleView::try_from(response)
     }
 
-    /// Validates and updates an existing access rule.
+    /// Validates and updates an existing access rule. Fails with
+    /// [`NotFound`](AccessRuleError::NotFound) when the rule was deleted before the write landed.
     pub async fn update(
         &self,
         organization_id: OrganizationId,
@@ -88,12 +91,14 @@ impl AccessRulesClient {
             .api_client
             .access_rules_api()
             .put(organization_id.into(), id.into(), request.try_into()?)
-            .await?;
+            .await
+            .map_err(AccessRuleError::from_by_id_api_error)?;
 
         AccessRuleView::try_from(response)
     }
 
-    /// Deletes an access rule.
+    /// Deletes an access rule. Fails with [`NotFound`](AccessRuleError::NotFound) when the rule is
+    /// already gone.
     pub async fn delete(
         &self,
         organization_id: OrganizationId,
@@ -103,7 +108,8 @@ impl AccessRulesClient {
             .api_client
             .access_rules_api()
             .delete(organization_id.into(), id.into())
-            .await?;
+            .await
+            .map_err(AccessRuleError::from_by_id_api_error)?;
 
         Ok(())
     }
@@ -199,8 +205,32 @@ mod tests {
         assert_eq!(result.id, rule);
     }
 
+    fn api_error(status: reqwest::StatusCode) -> bitwarden_api_api::ApiError {
+        bitwarden_api_api::ApiError::Response(bitwarden_api_api::ResponseContent {
+            status,
+            message: String::new(),
+        })
+    }
+
     #[tokio::test]
-    async fn get_surfaces_api_error() {
+    async fn get_maps_not_found_to_not_found() {
+        let organization_id = org_id();
+        let rule = rule_id();
+
+        let api_client = ApiClient::new_mocked(move |mock| {
+            mock.access_rules_api
+                .expect_get()
+                .returning(move |_org_id, _id| Err(api_error(reqwest::StatusCode::NOT_FOUND)))
+                .once();
+        });
+
+        let result = client(api_client).get(organization_id, rule).await;
+
+        assert!(matches!(result, Err(AccessRuleError::NotFound)));
+    }
+
+    #[tokio::test]
+    async fn get_surfaces_other_api_errors_as_api() {
         let organization_id = org_id();
         let rule = rule_id();
 
@@ -208,17 +238,68 @@ mod tests {
             mock.access_rules_api
                 .expect_get()
                 .returning(move |_org_id, _id| {
-                    Err(bitwarden_api_api::ApiError::Response(
-                        bitwarden_api_api::ResponseContent {
-                            status: reqwest::StatusCode::NOT_FOUND,
-                            message: String::new(),
-                        },
-                    ))
+                    Err(api_error(reqwest::StatusCode::INTERNAL_SERVER_ERROR))
                 })
                 .once();
         });
 
         let result = client(api_client).get(organization_id, rule).await;
+
+        assert!(matches!(result, Err(AccessRuleError::Api(_))));
+    }
+
+    #[tokio::test]
+    async fn update_maps_not_found_to_not_found() {
+        let organization_id = org_id();
+        let rule = rule_id();
+
+        let api_client = ApiClient::new_mocked(move |mock| {
+            mock.access_rules_api
+                .expect_put()
+                .returning(move |_org_id, _id, _request| {
+                    Err(api_error(reqwest::StatusCode::NOT_FOUND))
+                })
+                .once();
+        });
+
+        let result = client(api_client)
+            .update(organization_id, rule, sample_request())
+            .await;
+
+        assert!(matches!(result, Err(AccessRuleError::NotFound)));
+    }
+
+    #[tokio::test]
+    async fn delete_maps_not_found_to_not_found() {
+        let organization_id = org_id();
+        let rule = rule_id();
+
+        let api_client = ApiClient::new_mocked(move |mock| {
+            mock.access_rules_api
+                .expect_delete()
+                .returning(move |_org_id, _id| Err(api_error(reqwest::StatusCode::NOT_FOUND)))
+                .once();
+        });
+
+        let result = client(api_client).delete(organization_id, rule).await;
+
+        assert!(matches!(result, Err(AccessRuleError::NotFound)));
+    }
+
+    /// The org-scoped calls deliberately do NOT map `404` onto a missing rule - see
+    /// [`AccessRuleError::from_by_id_api_error`].
+    #[tokio::test]
+    async fn list_leaves_not_found_as_api() {
+        let organization_id = org_id();
+
+        let api_client = ApiClient::new_mocked(move |mock| {
+            mock.access_rules_api
+                .expect_get_all()
+                .returning(move |_org_id| Err(api_error(reqwest::StatusCode::NOT_FOUND)))
+                .once();
+        });
+
+        let result = client(api_client).list(organization_id).await;
 
         assert!(matches!(result, Err(AccessRuleError::Api(_))));
     }

--- a/bitwarden_license/bitwarden-pam/src/access_rules/client.rs
+++ b/bitwarden_license/bitwarden-pam/src/access_rules/client.rs
@@ -5,7 +5,7 @@ use bitwarden_core::{FromClient, OrganizationId, client::ApiConfigurations};
 use wasm_bindgen::prelude::wasm_bindgen;
 
 use super::{
-    error::AccessRuleError,
+    error::{AccessRuleDeleteError, AccessRuleReadError, AccessRuleWriteError},
     models::{AccessRuleAddEditRequest, AccessRuleView},
     validate::validate_request,
 };
@@ -24,7 +24,7 @@ impl AccessRulesClient {
     pub async fn list(
         &self,
         organization_id: OrganizationId,
-    ) -> Result<Vec<AccessRuleView>, AccessRuleError> {
+    ) -> Result<Vec<AccessRuleView>, AccessRuleReadError> {
         let response = self
             .api_configurations
             .api_client
@@ -37,25 +37,26 @@ impl AccessRulesClient {
             .unwrap_or_default()
             .into_iter()
             .map(AccessRuleView::try_from)
-            .collect()
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(Into::into)
     }
 
     /// Retrieves a single access rule by ID. Fails with
-    /// [`NotFound`](AccessRuleError::NotFound) when no such rule is visible to the caller.
+    /// [`NotFound`](AccessRuleReadError::NotFound) when no such rule is visible to the caller.
     pub async fn get(
         &self,
         organization_id: OrganizationId,
         id: AccessRuleId,
-    ) -> Result<AccessRuleView, AccessRuleError> {
+    ) -> Result<AccessRuleView, AccessRuleReadError> {
         let response = self
             .api_configurations
             .api_client
             .access_rules_api()
             .get(organization_id.into(), id.into())
             .await
-            .map_err(AccessRuleError::from_by_id_api_error)?;
+            .map_err(AccessRuleReadError::from_by_id_api_error)?;
 
-        AccessRuleView::try_from(response)
+        Ok(AccessRuleView::try_from(response)?)
     }
 
     /// Validates and creates a new access rule.
@@ -63,7 +64,7 @@ impl AccessRulesClient {
         &self,
         organization_id: OrganizationId,
         request: AccessRuleAddEditRequest,
-    ) -> Result<AccessRuleView, AccessRuleError> {
+    ) -> Result<AccessRuleView, AccessRuleWriteError> {
         validate_request(&request)?;
 
         let response = self
@@ -73,17 +74,18 @@ impl AccessRulesClient {
             .post(organization_id.into(), request.try_into()?)
             .await?;
 
-        AccessRuleView::try_from(response)
+        Ok(AccessRuleView::try_from(response)?)
     }
 
     /// Validates and updates an existing access rule. Fails with
-    /// [`NotFound`](AccessRuleError::NotFound) when the rule was deleted before the write landed.
+    /// [`NotFound`](AccessRuleWriteError::NotFound) when the rule was deleted before the write
+    /// landed.
     pub async fn update(
         &self,
         organization_id: OrganizationId,
         id: AccessRuleId,
         request: AccessRuleAddEditRequest,
-    ) -> Result<AccessRuleView, AccessRuleError> {
+    ) -> Result<AccessRuleView, AccessRuleWriteError> {
         validate_request(&request)?;
 
         let response = self
@@ -92,9 +94,9 @@ impl AccessRulesClient {
             .access_rules_api()
             .put(organization_id.into(), id.into(), request.try_into()?)
             .await
-            .map_err(AccessRuleError::from_by_id_api_error)?;
+            .map_err(AccessRuleWriteError::from_by_id_api_error)?;
 
-        AccessRuleView::try_from(response)
+        Ok(AccessRuleView::try_from(response)?)
     }
 
     /// Enables or disables a rule, leaving everything else about it untouched.
@@ -109,7 +111,7 @@ impl AccessRulesClient {
         organization_id: OrganizationId,
         rule: AccessRuleView,
         enabled: bool,
-    ) -> Result<AccessRuleView, AccessRuleError> {
+    ) -> Result<AccessRuleView, AccessRuleWriteError> {
         let id = rule.id;
         let request = AccessRuleAddEditRequest {
             enabled,
@@ -119,19 +121,19 @@ impl AccessRulesClient {
         self.update(organization_id, id, request).await
     }
 
-    /// Deletes an access rule. Fails with [`NotFound`](AccessRuleError::NotFound) when the rule is
-    /// already gone.
+    /// Deletes an access rule. Fails with [`NotFound`](AccessRuleDeleteError::NotFound) when the
+    /// rule is already gone.
     pub async fn delete(
         &self,
         organization_id: OrganizationId,
         id: AccessRuleId,
-    ) -> Result<(), AccessRuleError> {
+    ) -> Result<(), AccessRuleDeleteError> {
         self.api_configurations
             .api_client
             .access_rules_api()
             .delete(organization_id.into(), id.into())
             .await
-            .map_err(AccessRuleError::from_by_id_api_error)?;
+            .map_err(AccessRuleDeleteError::from_by_id_api_error)?;
 
         Ok(())
     }
@@ -248,7 +250,7 @@ mod tests {
 
         let result = client(api_client).get(organization_id, rule).await;
 
-        assert!(matches!(result, Err(AccessRuleError::NotFound)));
+        assert!(matches!(result, Err(AccessRuleReadError::NotFound)));
     }
 
     #[tokio::test]
@@ -267,7 +269,7 @@ mod tests {
 
         let result = client(api_client).get(organization_id, rule).await;
 
-        assert!(matches!(result, Err(AccessRuleError::Api(_))));
+        assert!(matches!(result, Err(AccessRuleReadError::Api(_))));
     }
 
     #[tokio::test]
@@ -288,7 +290,7 @@ mod tests {
             .update(organization_id, rule, sample_request())
             .await;
 
-        assert!(matches!(result, Err(AccessRuleError::NotFound)));
+        assert!(matches!(result, Err(AccessRuleWriteError::NotFound)));
     }
 
     #[tokio::test]
@@ -305,11 +307,11 @@ mod tests {
 
         let result = client(api_client).delete(organization_id, rule).await;
 
-        assert!(matches!(result, Err(AccessRuleError::NotFound)));
+        assert!(matches!(result, Err(AccessRuleDeleteError::NotFound)));
     }
 
     /// The org-scoped calls deliberately do NOT map `404` onto a missing rule - see
-    /// [`AccessRuleError::from_by_id_api_error`].
+    /// [`AccessRuleReadError::from_by_id_api_error`].
     #[tokio::test]
     async fn list_leaves_not_found_as_api() {
         let organization_id = org_id();
@@ -323,7 +325,7 @@ mod tests {
 
         let result = client(api_client).list(organization_id).await;
 
-        assert!(matches!(result, Err(AccessRuleError::Api(_))));
+        assert!(matches!(result, Err(AccessRuleReadError::Api(_))));
     }
 
     #[tokio::test]
@@ -338,7 +340,7 @@ mod tests {
 
         let result = client(api_client).create(organization_id, request).await;
 
-        assert!(matches!(result, Err(AccessRuleError::Validation(_))));
+        assert!(matches!(result, Err(AccessRuleWriteError::Validation(_))));
     }
 
     #[tokio::test]
@@ -384,7 +386,7 @@ mod tests {
             .create(organization_id, sample_request())
             .await;
 
-        assert!(matches!(result, Err(AccessRuleError::Api(_))));
+        assert!(matches!(result, Err(AccessRuleWriteError::Api(_))));
     }
 
     #[tokio::test]

--- a/bitwarden_license/bitwarden-pam/src/access_rules/client.rs
+++ b/bitwarden_license/bitwarden-pam/src/access_rules/client.rs
@@ -97,6 +97,28 @@ impl AccessRulesClient {
         AccessRuleView::try_from(response)
     }
 
+    /// Enables or disables a rule, leaving everything else about it untouched.
+    ///
+    /// Takes the rule as the caller already has it - every surface that offers this toggle is
+    /// listing rules - so this costs one round trip rather than a read followed by a write. The
+    /// full payload is rebuilt from that view by [`From<AccessRuleView>`], so no caller has to
+    /// enumerate the editable fields and none can drop one; see that conversion for the bug this
+    /// prevents.
+    pub async fn set_enabled(
+        &self,
+        organization_id: OrganizationId,
+        rule: AccessRuleView,
+        enabled: bool,
+    ) -> Result<AccessRuleView, AccessRuleError> {
+        let id = rule.id;
+        let request = AccessRuleAddEditRequest {
+            enabled,
+            ..rule.into()
+        };
+
+        self.update(organization_id, id, request).await
+    }
+
     /// Deletes an access rule. Fails with [`NotFound`](AccessRuleError::NotFound) when the rule is
     /// already gone.
     pub async fn delete(
@@ -401,5 +423,70 @@ mod tests {
         let result = client(api_client).delete(organization_id, rule).await;
 
         assert!(result.is_ok());
+    }
+
+    /// The regression this exists to prevent: flipping `enabled` must not disturb any other field.
+    /// The web client's hand-written equivalent once omitted the two extension fields, so toggling
+    /// a rule silently wiped its extension settings.
+    #[tokio::test]
+    async fn set_enabled_flips_enabled_and_preserves_every_other_field() {
+        let organization_id = org_id();
+        let rule = rule_id();
+        let mut response = sample_response(rule.into(), organization_id.into());
+        response.enabled = Some(true);
+        response.allows_extensions = Some(true);
+        response.max_extension_duration_seconds = Some(3600);
+        response.single_active_lease = Some(true);
+        response.default_lease_duration_seconds = Some(1800);
+        response.max_lease_duration_seconds = Some(7200);
+        response.description = Some("Production database access".to_string());
+
+        let view = AccessRuleView::try_from(response.clone()).unwrap();
+        let returned = response.clone();
+
+        let api_client = ApiClient::new_mocked(move |mock| {
+            mock.access_rules_api
+                .expect_put()
+                .withf(|_org_id, _id, request| {
+                    request.enabled == Some(false)
+                        && request.allows_extensions == Some(true)
+                        && request.max_extension_duration_seconds == Some(3600)
+                        && request.single_active_lease == Some(true)
+                        && request.default_lease_duration_seconds == Some(1800)
+                        && request.max_lease_duration_seconds == Some(7200)
+                        && request.name == "My rule"
+                        && request.description.as_deref() == Some("Production database access")
+                })
+                .returning(move |_org_id, _id, _request| Ok(returned.clone()))
+                .once();
+        });
+
+        let result = client(api_client)
+            .set_enabled(organization_id, view, false)
+            .await
+            .unwrap();
+
+        assert_eq!(result.id, rule);
+    }
+
+    #[tokio::test]
+    async fn set_enabled_targets_the_rule_it_was_given() {
+        let organization_id = org_id();
+        let rule = rule_id();
+        let response = sample_response(rule.into(), organization_id.into());
+        let view = AccessRuleView::try_from(response.clone()).unwrap();
+
+        let api_client = ApiClient::new_mocked(move |mock| {
+            mock.access_rules_api
+                .expect_put()
+                .withf(move |_org_id, id, _request| *id == uuid::Uuid::from(rule_id()))
+                .returning(move |_org_id, _id, _request| Ok(response.clone()))
+                .once();
+        });
+
+        client(api_client)
+            .set_enabled(organization_id, view, true)
+            .await
+            .unwrap();
     }
 }

--- a/bitwarden_license/bitwarden-pam/src/access_rules/error.rs
+++ b/bitwarden_license/bitwarden-pam/src/access_rules/error.rs
@@ -1,3 +1,13 @@
+//! The access-rule surface splits three ways: reading a rule, writing one, and deleting one.
+//!
+//! Unlike the other PAM surfaces this one does not use [`PamReadError`](crate::PamReadError),
+//! because a rule response carries a `conditions` document the SDK interprets itself - a decode
+//! failure this crate's shared decode error has no variant for.
+//!
+//! The write codes come from `AccessRuleWriteValidator`, which backs both `CreateAccessRuleCommand`
+//! and `UpdateAccessRuleCommand`, so those two share a set. A code this SDK version does not
+//! recognize stays `Api`, so a server that grows a code never needs a client release to be safe.
+
 use bitwarden_core::{ApiError, MissingFieldError};
 use bitwarden_error::bitwarden_error;
 use reqwest::StatusCode;
@@ -6,23 +16,80 @@ use thiserror::Error;
 use super::validate::AccessRuleValidationError;
 use crate::problem;
 
-/// Errors returned from [`super::AccessRulesClient`] operations.
+/// Errors from turning an access-rule response into an [`AccessRuleView`](super::AccessRuleView).
 ///
-/// The named write failures each correspond to one stable code in the server's problem response;
-/// see [`from_code`](Self::from_code) for the mapping. A code this SDK version does not recognize
-/// stays [`Api`](Self::Api), so a server that grows one never needs a client release to be safe.
+/// Separate from this crate's [`PamDecodeError`](crate::PamDecodeError) because a rule response
+/// carries a `conditions` document the SDK interprets itself, which the shared decode error has no
+/// variant for. Both [`AccessRuleReadError`] and [`AccessRuleWriteError`] wrap it, so a decode
+/// failure reads the same whichever call hit it.
 #[bitwarden_error(flat)]
 #[derive(Debug, Error)]
-pub enum AccessRuleError {
+pub enum AccessRuleDecodeError {
+    /// The `conditions` field of a server response could not be interpreted.
+    #[error("Invalid conditions: {0}")]
+    InvalidConditions(String),
+    /// The server response was missing a field required to build the requested type.
+    #[error(transparent)]
+    MissingField(#[from] MissingFieldError),
+    /// A date field in the server response could not be parsed.
+    #[error(transparent)]
+    Chrono(#[from] chrono::ParseError),
+}
+
+/// Errors from the access-rule reads, [`list`](super::AccessRulesClient::list) and
+/// [`get`](super::AccessRulesClient::get).
+///
+/// [`NotFound`](Self::NotFound) is reachable only from `get`: it comes from the server's `404`, and
+/// on the org-scoped `list` a `404` says nothing about a rule, so there it stays
+/// [`Api`](Self::Api).
+#[bitwarden_error(flat)]
+#[derive(Debug, Error)]
+pub enum AccessRuleReadError {
+    /// The rule named by the request does not exist, or the caller cannot see it.
+    #[error("The access rule does not exist")]
+    NotFound,
+    /// An access-rule response could not be decoded into a view.
+    #[error(transparent)]
+    Decode(#[from] AccessRuleDecodeError),
+    /// A network or (de)serialization error occurred while calling the server.
+    #[error(transparent)]
+    Api(ApiError),
+}
+
+impl AccessRuleReadError {
+    /// Maps the server's `404` onto [`NotFound`](Self::NotFound). See
+    /// [`AccessRuleWriteError::from_by_id_api_error`] for why this is pinned to the by-id calls.
+    pub(crate) fn from_by_id_api_error(error: ApiError) -> Self {
+        match &error {
+            ApiError::Response(content) if content.status == StatusCode::NOT_FOUND => {
+                Self::NotFound
+            }
+            _ => Self::Api(error),
+        }
+    }
+}
+
+impl From<ApiError> for AccessRuleReadError {
+    fn from(error: ApiError) -> Self {
+        Self::Api(error)
+    }
+}
+
+/// Errors from the access-rule writes: [`create`](super::AccessRulesClient::create),
+/// [`update`](super::AccessRulesClient::update) and
+/// [`set_enabled`](super::AccessRulesClient::set_enabled).
+///
+/// The three share a set because they share a validator server-side. [`NotFound`](Self::NotFound)
+/// is reachable only from the two that name a rule by id - `create` has no id to miss.
+#[bitwarden_error(flat)]
+#[derive(Debug, Error)]
+pub enum AccessRuleWriteError {
     /// The request failed local validation before being sent to the server.
     #[error(transparent)]
     Validation(#[from] AccessRuleValidationError),
     /// The rule named by the request does not exist, or the caller cannot see it.
     #[error("The access rule does not exist")]
     NotFound,
-    /// The `conditions` field of a server response could not be interpreted.
-    #[error("Invalid conditions: {0}")]
-    InvalidConditions(String),
 
     /// The rule has no name. Rules are picked out by name wherever they are listed.
     #[error("Name is required")]
@@ -45,7 +112,7 @@ pub enum AccessRuleError {
     #[error("The default lease duration cannot exceed the maximum lease duration")]
     DefaultDurationExceedsMax,
     /// The server refused the conditions document. Distinct from
-    /// [`InvalidConditions`](Self::InvalidConditions), which is this SDK failing to read a document
+    /// [`AccessRuleDecodeError::InvalidConditions`], which is this SDK failing to read a document
     /// the server sent back.
     #[error("The access rule's conditions were rejected")]
     ConditionsRejected,
@@ -59,20 +126,18 @@ pub enum AccessRuleError {
     /// rule. A collection has at most one access rule.
     #[error("One or more collections are already governed by another access rule")]
     CollectionsAlreadyGoverned,
-    /// The server response was missing a field required to build the requested type.
+
+    /// An access-rule response could not be decoded into a view.
     #[error(transparent)]
-    MissingField(#[from] MissingFieldError),
-    /// A date field in the server response could not be parsed.
-    #[error(transparent)]
-    Chrono(#[from] chrono::ParseError),
+    Decode(#[from] AccessRuleDecodeError),
     /// A network or (de)serialization error occurred while calling the server, or the server
     /// refused with a code this SDK version does not recognize.
     #[error(transparent)]
     Api(ApiError),
 }
 
-impl AccessRuleError {
-    /// The server's codes, in the order the access-rule write paths can produce them.
+impl AccessRuleWriteError {
+    /// The codes `AccessRuleWriteValidator` can return.
     fn from_code(code: &str) -> Option<Self> {
         Some(match code {
             "rule_name_required" => Self::NameRequired,
@@ -90,14 +155,10 @@ impl AccessRuleError {
     }
 
     /// Classifies a failed call that addressed one rule by id, mapping the server's `404` onto
-    /// [`NotFound`](Self::NotFound) and leaving every other failure as
-    /// [`Api`](Self::Api).
+    /// [`NotFound`](Self::NotFound) and reading the codes out of anything else.
     ///
-    /// Only the by-id calls ([`get`](super::AccessRulesClient::get),
-    /// [`update`](super::AccessRulesClient::update),
-    /// [`delete`](super::AccessRulesClient::delete)) route through this. On the org-scoped calls a
-    /// `404` says nothing about a rule, so mapping it to a missing rule there would report the
-    /// wrong thing.
+    /// Only the by-id calls route through this. On an org-scoped call a `404` says nothing about a
+    /// rule, so mapping it to a missing rule there would report the wrong thing.
     ///
     /// Without this, a caller wanting to tell "this rule is gone" from a generic failure has to
     /// match on the status code inside a stringified [`ApiError`] - which is what the web client
@@ -112,11 +173,43 @@ impl AccessRuleError {
     }
 }
 
-/// Classifies every failed call on this surface. A code is unambiguous wherever it appears, unlike
+/// Classifies every failed write on this surface. A code is unambiguous wherever it appears, unlike
 /// a status - which is why the `404` rule above stays pinned to the by-id calls and this does not.
-impl From<ApiError> for AccessRuleError {
+impl From<ApiError> for AccessRuleWriteError {
     fn from(error: ApiError) -> Self {
         problem::classify(&error, Self::from_code).unwrap_or(Self::Api(error))
+    }
+}
+
+/// Errors from [`AccessRulesClient::delete`](super::AccessRulesClient::delete).
+///
+/// Deleting decodes nothing and the server refuses it in exactly one way: the rule is not there.
+#[bitwarden_error(flat)]
+#[derive(Debug, Error)]
+pub enum AccessRuleDeleteError {
+    /// The rule named by the request does not exist, or the caller cannot see it.
+    #[error("The access rule does not exist")]
+    NotFound,
+    /// A network or (de)serialization error occurred while calling the server.
+    #[error(transparent)]
+    Api(ApiError),
+}
+
+impl AccessRuleDeleteError {
+    /// Maps the server's `404` onto [`NotFound`](Self::NotFound), as the other by-id calls do.
+    pub(crate) fn from_by_id_api_error(error: ApiError) -> Self {
+        match &error {
+            ApiError::Response(content) if content.status == StatusCode::NOT_FOUND => {
+                Self::NotFound
+            }
+            _ => Self::Api(error),
+        }
+    }
+}
+
+impl From<ApiError> for AccessRuleDeleteError {
+    fn from(error: ApiError) -> Self {
+        Self::Api(error)
     }
 }
 
@@ -134,34 +227,59 @@ mod tests {
         })
     }
 
+    fn not_found() -> ApiError {
+        ApiError::Response(ResponseContent {
+            status: StatusCode::NOT_FOUND,
+            message: String::new(),
+        })
+    }
+
     #[test]
     fn a_write_failure_becomes_its_own_variant() {
-        let error: AccessRuleError = problem("collections_already_governed").into();
+        let error: AccessRuleWriteError = problem("collections_already_governed").into();
 
-        assert!(matches!(error, AccessRuleError::CollectionsAlreadyGoverned));
+        assert!(matches!(
+            error,
+            AccessRuleWriteError::CollectionsAlreadyGoverned
+        ));
     }
 
     #[test]
     fn a_code_is_read_even_on_a_by_id_call_that_did_not_404() {
-        let error = AccessRuleError::from_by_id_api_error(problem("rule_name_taken"));
+        let error = AccessRuleWriteError::from_by_id_api_error(problem("rule_name_taken"));
 
-        assert!(matches!(error, AccessRuleError::NameTaken));
+        assert!(matches!(error, AccessRuleWriteError::NameTaken));
     }
 
     #[test]
     fn a_by_id_404_still_wins_over_the_code_reader() {
-        let error = AccessRuleError::from_by_id_api_error(ApiError::Response(ResponseContent {
-            status: StatusCode::NOT_FOUND,
-            message: String::new(),
-        }));
+        assert!(matches!(
+            AccessRuleWriteError::from_by_id_api_error(not_found()),
+            AccessRuleWriteError::NotFound
+        ));
+        assert!(matches!(
+            AccessRuleReadError::from_by_id_api_error(not_found()),
+            AccessRuleReadError::NotFound
+        ));
+        assert!(matches!(
+            AccessRuleDeleteError::from_by_id_api_error(not_found()),
+            AccessRuleDeleteError::NotFound
+        ));
+    }
 
-        assert!(matches!(error, AccessRuleError::NotFound));
+    /// A `404` reached without going through a by-id classifier is not a missing rule - that is the
+    /// whole reason the mapping is not on `From<ApiError>`.
+    #[test]
+    fn an_org_scoped_404_is_not_a_missing_rule() {
+        let error: AccessRuleReadError = not_found().into();
+
+        assert!(matches!(error, AccessRuleReadError::Api(_)));
     }
 
     #[test]
     fn an_unrecognized_code_stays_untyped() {
-        let error: AccessRuleError = problem("invented_next_year").into();
+        let error: AccessRuleWriteError = problem("invented_next_year").into();
 
-        assert!(matches!(error, AccessRuleError::Api(_)));
+        assert!(matches!(error, AccessRuleWriteError::Api(_)));
     }
 }

--- a/bitwarden_license/bitwarden-pam/src/access_rules/error.rs
+++ b/bitwarden_license/bitwarden-pam/src/access_rules/error.rs
@@ -1,5 +1,6 @@
 use bitwarden_core::{ApiError, MissingFieldError};
 use bitwarden_error::bitwarden_error;
+use reqwest::StatusCode;
 use thiserror::Error;
 
 use super::validate::AccessRuleValidationError;
@@ -11,6 +12,9 @@ pub enum AccessRuleError {
     /// The request failed local validation before being sent to the server.
     #[error(transparent)]
     Validation(#[from] AccessRuleValidationError),
+    /// The rule named by the request does not exist, or the caller cannot see it.
+    #[error("The access rule does not exist")]
+    NotFound,
     /// The `conditions` field of a server response could not be interpreted.
     #[error("Invalid conditions: {0}")]
     InvalidConditions(String),
@@ -23,4 +27,28 @@ pub enum AccessRuleError {
     /// A network or (de)serialization error occurred while calling the server.
     #[error(transparent)]
     Api(#[from] ApiError),
+}
+
+impl AccessRuleError {
+    /// Classifies a failed call that addressed one rule by id, mapping the server's `404` onto
+    /// [`NotFound`](Self::NotFound) and leaving every other failure as
+    /// [`Api`](Self::Api).
+    ///
+    /// Only the by-id calls ([`get`](super::AccessRulesClient::get),
+    /// [`update`](super::AccessRulesClient::update),
+    /// [`delete`](super::AccessRulesClient::delete)) route through this. On the org-scoped calls a
+    /// `404` says nothing about a rule, so mapping it to a missing rule there would report the
+    /// wrong thing.
+    ///
+    /// Without this, a caller wanting to tell "this rule is gone" from a generic failure has to
+    /// match on the status code inside a stringified [`ApiError`] - which is what the web client
+    /// did before this variant existed.
+    pub(crate) fn from_by_id_api_error(error: ApiError) -> Self {
+        match &error {
+            ApiError::Response(content) if content.status == StatusCode::NOT_FOUND => {
+                Self::NotFound
+            }
+            _ => Self::Api(error),
+        }
+    }
 }

--- a/bitwarden_license/bitwarden-pam/src/access_rules/error.rs
+++ b/bitwarden_license/bitwarden-pam/src/access_rules/error.rs
@@ -4,8 +4,13 @@ use reqwest::StatusCode;
 use thiserror::Error;
 
 use super::validate::AccessRuleValidationError;
+use crate::problem;
 
 /// Errors returned from [`super::AccessRulesClient`] operations.
+///
+/// The named write failures each correspond to one stable code in the server's problem response;
+/// see [`from_code`](Self::from_code) for the mapping. A code this SDK version does not recognize
+/// stays [`Api`](Self::Api), so a server that grows one never needs a client release to be safe.
 #[bitwarden_error(flat)]
 #[derive(Debug, Error)]
 pub enum AccessRuleError {
@@ -18,18 +23,72 @@ pub enum AccessRuleError {
     /// The `conditions` field of a server response could not be interpreted.
     #[error("Invalid conditions: {0}")]
     InvalidConditions(String),
+
+    /// The rule has no name. Rules are picked out by name wherever they are listed.
+    #[error("Name is required")]
+    NameRequired,
+    /// Another rule in the same organization already has this name, compared case-insensitively.
+    #[error("A rule with that name already exists")]
+    NameTaken,
+    /// The rule allows extensions without capping them, which would leave every extension
+    /// unbounded.
+    #[error("A maximum extension length is required when extensions are allowed")]
+    ExtensionLengthRequired,
+    /// The rule's default lease duration is zero or negative.
+    #[error("The default lease duration must be a positive value")]
+    DefaultDurationMustBePositive,
+    /// The rule's maximum lease duration is zero or negative.
+    #[error("The maximum lease duration must be a positive value")]
+    MaxDurationMustBePositive,
+    /// The rule pre-fills requests with a duration its own cap would then refuse, so every request
+    /// against it would fail at submit.
+    #[error("The default lease duration cannot exceed the maximum lease duration")]
+    DefaultDurationExceedsMax,
+    /// The server refused the conditions document. Distinct from
+    /// [`InvalidConditions`](Self::InvalidConditions), which is this SDK failing to read a document
+    /// the server sent back.
+    #[error("The access rule's conditions were rejected")]
+    ConditionsRejected,
+    /// One or more of the collections the rule would govern does not exist.
+    #[error("One or more collections could not be found")]
+    CollectionsMissing,
+    /// One or more of the collections the rule would govern belongs to another organization.
+    #[error("One or more collections do not belong to this organization")]
+    CollectionsForeign,
+    /// One or more of the collections the rule would govern is already governed by a different
+    /// rule. A collection has at most one access rule.
+    #[error("One or more collections are already governed by another access rule")]
+    CollectionsAlreadyGoverned,
     /// The server response was missing a field required to build the requested type.
     #[error(transparent)]
     MissingField(#[from] MissingFieldError),
     /// A date field in the server response could not be parsed.
     #[error(transparent)]
     Chrono(#[from] chrono::ParseError),
-    /// A network or (de)serialization error occurred while calling the server.
+    /// A network or (de)serialization error occurred while calling the server, or the server
+    /// refused with a code this SDK version does not recognize.
     #[error(transparent)]
-    Api(#[from] ApiError),
+    Api(ApiError),
 }
 
 impl AccessRuleError {
+    /// The server's codes, in the order the access-rule write paths can produce them.
+    fn from_code(code: &str) -> Option<Self> {
+        Some(match code {
+            "rule_name_required" => Self::NameRequired,
+            "rule_name_taken" => Self::NameTaken,
+            "extension_length_required" => Self::ExtensionLengthRequired,
+            "rule_default_duration_must_be_positive" => Self::DefaultDurationMustBePositive,
+            "rule_max_duration_must_be_positive" => Self::MaxDurationMustBePositive,
+            "rule_default_duration_exceeds_max" => Self::DefaultDurationExceedsMax,
+            "rule_invalid_conditions" => Self::ConditionsRejected,
+            "collections_missing" => Self::CollectionsMissing,
+            "collections_foreign" => Self::CollectionsForeign,
+            "collections_already_governed" => Self::CollectionsAlreadyGoverned,
+            _ => return None,
+        })
+    }
+
     /// Classifies a failed call that addressed one rule by id, mapping the server's `404` onto
     /// [`NotFound`](Self::NotFound) and leaving every other failure as
     /// [`Api`](Self::Api).
@@ -48,7 +107,61 @@ impl AccessRuleError {
             ApiError::Response(content) if content.status == StatusCode::NOT_FOUND => {
                 Self::NotFound
             }
-            _ => Self::Api(error),
+            _ => error.into(),
         }
+    }
+}
+
+/// Classifies every failed call on this surface. A code is unambiguous wherever it appears, unlike
+/// a status - which is why the `404` rule above stays pinned to the by-id calls and this does not.
+impl From<ApiError> for AccessRuleError {
+    fn from(error: ApiError) -> Self {
+        problem::classify(&error, Self::from_code).unwrap_or(Self::Api(error))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use bitwarden_api_api::ResponseContent;
+    use reqwest::StatusCode;
+
+    use super::*;
+
+    fn problem(code: &str) -> ApiError {
+        ApiError::Response(ResponseContent {
+            status: StatusCode::BAD_REQUEST,
+            message: format!(r#"{{"errors":{{"code":[{{"type":"{code}"}}]}}}}"#),
+        })
+    }
+
+    #[test]
+    fn a_write_failure_becomes_its_own_variant() {
+        let error: AccessRuleError = problem("collections_already_governed").into();
+
+        assert!(matches!(error, AccessRuleError::CollectionsAlreadyGoverned));
+    }
+
+    #[test]
+    fn a_code_is_read_even_on_a_by_id_call_that_did_not_404() {
+        let error = AccessRuleError::from_by_id_api_error(problem("rule_name_taken"));
+
+        assert!(matches!(error, AccessRuleError::NameTaken));
+    }
+
+    #[test]
+    fn a_by_id_404_still_wins_over_the_code_reader() {
+        let error = AccessRuleError::from_by_id_api_error(ApiError::Response(ResponseContent {
+            status: StatusCode::NOT_FOUND,
+            message: String::new(),
+        }));
+
+        assert!(matches!(error, AccessRuleError::NotFound));
+    }
+
+    #[test]
+    fn an_unrecognized_code_stays_untyped() {
+        let error: AccessRuleError = problem("invented_next_year").into();
+
+        assert!(matches!(error, AccessRuleError::Api(_)));
     }
 }

--- a/bitwarden_license/bitwarden-pam/src/access_rules/mod.rs
+++ b/bitwarden_license/bitwarden-pam/src/access_rules/mod.rs
@@ -49,6 +49,8 @@ mod validate;
 
 pub use client::AccessRulesClient;
 pub use conditions::AccessCondition;
-pub use error::AccessRuleError;
+pub use error::{
+    AccessRuleDecodeError, AccessRuleDeleteError, AccessRuleReadError, AccessRuleWriteError,
+};
 pub use models::{AccessRuleAddEditRequest, AccessRuleView};
 pub use validate::{AccessRuleValidationError, is_valid_cidr};

--- a/bitwarden_license/bitwarden-pam/src/access_rules/models.rs
+++ b/bitwarden_license/bitwarden-pam/src/access_rules/models.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 #[cfg(feature = "wasm")]
 use tsify::Tsify;
 
-use super::{conditions::AccessCondition, error::AccessRuleError};
+use super::{conditions::AccessCondition, error::AccessRuleDecodeError};
 use crate::AccessRuleId;
 
 /// A decrypted view of an access rule, as returned by the server.
@@ -83,15 +83,15 @@ pub struct AccessRuleAddEditRequest {
 }
 
 impl TryFrom<AccessRuleResponseModel> for AccessRuleView {
-    type Error = AccessRuleError;
+    type Error = AccessRuleDecodeError;
 
     fn try_from(response: AccessRuleResponseModel) -> Result<Self, Self::Error> {
         let conditions = match response.conditions {
             None => Vec::new(),
             Some(value @ serde_json::Value::Array(_)) => serde_json::from_value(value)
-                .map_err(|e| AccessRuleError::InvalidConditions(e.to_string()))?,
+                .map_err(|e| AccessRuleDecodeError::InvalidConditions(e.to_string()))?,
             Some(other) => {
-                return Err(AccessRuleError::InvalidConditions(format!(
+                return Err(AccessRuleDecodeError::InvalidConditions(format!(
                     "expected `conditions` to be a JSON array, got: {other}"
                 )));
             }
@@ -152,13 +152,13 @@ impl From<AccessRuleView> for AccessRuleAddEditRequest {
 }
 
 impl TryFrom<AccessRuleAddEditRequest> for AccessRuleRequestModel {
-    type Error = AccessRuleError;
+    type Error = AccessRuleDecodeError;
 
     fn try_from(request: AccessRuleAddEditRequest) -> Result<Self, Self::Error> {
         // The server requires `conditions` to always be present; an empty vec serializes to
         // the empty array it expects.
         let conditions = serde_json::to_value(&request.conditions)
-            .map_err(|e| AccessRuleError::InvalidConditions(e.to_string()))?;
+            .map_err(|e| AccessRuleDecodeError::InvalidConditions(e.to_string()))?;
 
         Ok(Self {
             name: request.name.trim().to_string(),
@@ -243,7 +243,10 @@ mod tests {
 
         let result = AccessRuleView::try_from(response);
 
-        assert!(matches!(result, Err(AccessRuleError::MissingField(_))));
+        assert!(matches!(
+            result,
+            Err(AccessRuleDecodeError::MissingField(_))
+        ));
     }
 
     #[test]
@@ -273,7 +276,10 @@ mod tests {
 
         let result = AccessRuleView::try_from(response);
 
-        assert!(matches!(result, Err(AccessRuleError::InvalidConditions(_))));
+        assert!(matches!(
+            result,
+            Err(AccessRuleDecodeError::InvalidConditions(_))
+        ));
     }
 
     #[test]

--- a/bitwarden_license/bitwarden-pam/src/access_rules/models.rs
+++ b/bitwarden_license/bitwarden-pam/src/access_rules/models.rs
@@ -122,6 +122,35 @@ impl TryFrom<AccessRuleResponseModel> for AccessRuleView {
     }
 }
 
+/// Rebuilds the write payload for a rule that already exists.
+///
+/// The rule endpoints have no PATCH: changing one field means PUTting the whole rule back. Doing
+/// that by hand means listing every editable field at the call site and getting it right - and a
+/// caller that forgets one silently erases it. The web client shipped exactly that bug, wiping a
+/// rule's extension settings whenever its enabled state was toggled, because its hand-written
+/// mapping omitted `allows_extensions` and `max_extension_duration_seconds`.
+///
+/// Mapped field by field rather than by struct update syntax on purpose: the view carries
+/// server-owned fields (`id`, `organization_id`, the timestamps) that are not part of the request,
+/// so a wholesale copy would not compile the day one is added - which is the point, since that is
+/// when a human has to decide whether the new field is editable.
+impl From<AccessRuleView> for AccessRuleAddEditRequest {
+    fn from(view: AccessRuleView) -> Self {
+        Self {
+            name: view.name,
+            description: view.description,
+            enabled: view.enabled,
+            conditions: view.conditions,
+            single_active_lease: view.single_active_lease,
+            default_lease_duration_seconds: view.default_lease_duration_seconds,
+            max_lease_duration_seconds: view.max_lease_duration_seconds,
+            allows_extensions: view.allows_extensions,
+            max_extension_duration_seconds: view.max_extension_duration_seconds,
+            collections: view.collections,
+        }
+    }
+}
+
 impl TryFrom<AccessRuleAddEditRequest> for AccessRuleRequestModel {
     type Error = AccessRuleError;
 

--- a/bitwarden_license/bitwarden-pam/src/access_rules/validate.rs
+++ b/bitwarden_license/bitwarden-pam/src/access_rules/validate.rs
@@ -26,6 +26,10 @@ pub enum AccessRuleValidationError {
     /// positive.
     #[error("Lease durations must be positive")]
     InvalidLeaseDuration,
+    /// `default_lease_duration_seconds` exceeded `max_lease_duration_seconds`, which would pre-fill
+    /// every request under the rule with a duration the rule's own cap forbids.
+    #[error("The default lease duration cannot exceed the maximum lease duration")]
+    DefaultLeaseDurationExceedsMax,
     /// More than 10 conditions were provided.
     #[error("A rule may have at most {MAX_CONDITIONS} conditions")]
     TooManyConditions,
@@ -62,6 +66,15 @@ pub fn validate_request(
         || request.max_lease_duration_seconds.is_some_and(|m| m <= 0)
     {
         return Err(AccessRuleValidationError::InvalidLeaseDuration);
+    }
+
+    // An absent max is "no cap", so it never constrains the default.
+    if let (Some(default), Some(max)) = (
+        request.default_lease_duration_seconds,
+        request.max_lease_duration_seconds,
+    ) && default > max
+    {
+        return Err(AccessRuleValidationError::DefaultLeaseDurationExceedsMax);
     }
 
     if request.conditions.len() > MAX_CONDITIONS {
@@ -483,6 +496,34 @@ mod tests {
     fn none_lease_durations_are_valid() {
         let mut request = base_request();
         request.default_lease_duration_seconds = None;
+        request.max_lease_duration_seconds = None;
+        assert_eq!(validate_request(&request), Ok(()));
+    }
+
+    #[test]
+    fn default_lease_duration_above_max_is_invalid() {
+        let mut request = base_request();
+        request.default_lease_duration_seconds = Some(3600);
+        request.max_lease_duration_seconds = Some(900);
+        assert_eq!(
+            validate_request(&request),
+            Err(AccessRuleValidationError::DefaultLeaseDurationExceedsMax)
+        );
+    }
+
+    #[test]
+    fn default_lease_duration_equal_to_max_is_valid() {
+        let mut request = base_request();
+        request.default_lease_duration_seconds = Some(900);
+        request.max_lease_duration_seconds = Some(900);
+        assert_eq!(validate_request(&request), Ok(()));
+    }
+
+    #[test]
+    fn default_lease_duration_without_a_max_is_valid() {
+        // An absent max is "no cap" - it cannot be exceeded.
+        let mut request = base_request();
+        request.default_lease_duration_seconds = Some(7 * 86_400);
         request.max_lease_duration_seconds = None;
         assert_eq!(validate_request(&request), Ok(()));
     }

--- a/bitwarden_license/bitwarden-pam/src/approvals/client.rs
+++ b/bitwarden_license/bitwarden-pam/src/approvals/client.rs
@@ -1,0 +1,286 @@
+use std::sync::Arc;
+
+use bitwarden_api_api::models::AccessDecisionRequestModel;
+use bitwarden_core::{FromClient, client::ApiConfigurations};
+#[cfg(feature = "wasm")]
+use wasm_bindgen::prelude::wasm_bindgen;
+
+use super::models::AccessDecisionRequest;
+use crate::{AccessRequestId, access_requests::AccessRequestView, error::LeasingError};
+
+/// Client for a PAM approver's queue.
+///
+/// Covers the approver side of the request lifecycle: reading the pending requests awaiting the
+/// caller's decision ([`list_inbox`](ApprovalsClient::list_inbox)), reading the ones the caller has
+/// already decided ([`list_history`](ApprovalsClient::list_history)), and
+/// [`decide`](ApprovalsClient::decide)ing a pending request. The requester side of the same
+/// lifecycle is [`AccessRequestsClient`](crate::AccessRequestsClient).
+#[cfg_attr(feature = "wasm", wasm_bindgen)]
+#[derive(FromClient)]
+pub struct ApprovalsClient {
+    pub(crate) api_configurations: Arc<ApiConfigurations>,
+}
+
+#[cfg_attr(feature = "wasm", wasm_bindgen)]
+impl ApprovalsClient {
+    /// Lists the pending access requests awaiting the caller's decision.
+    ///
+    /// `GET /access-requests/inbox`. The server scopes this by Manage permission on the request's
+    /// collection and returns only pending requests, so an empty list is the normal answer for a
+    /// member who approves nothing.
+    pub async fn list_inbox(&self) -> Result<Vec<AccessRequestView>, LeasingError> {
+        let response = self
+            .api_configurations
+            .api_client
+            .access_requests_api()
+            .get_inbox()
+            .await?;
+
+        response
+            .data
+            .unwrap_or_default()
+            .into_iter()
+            .map(AccessRequestView::try_from)
+            .collect()
+    }
+
+    /// Lists the decided access requests for collections the caller manages.
+    ///
+    /// `GET /access-requests/history`. Same response shape as [`list_inbox`](Self::list_inbox),
+    /// not an audit-event shape.
+    pub async fn list_history(&self) -> Result<Vec<AccessRequestView>, LeasingError> {
+        let response = self
+            .api_configurations
+            .api_client
+            .access_requests_api()
+            .get_history()
+            .await?;
+
+        response
+            .data
+            .unwrap_or_default()
+            .into_iter()
+            .map(AccessRequestView::try_from)
+            .collect()
+    }
+
+    /// Records a decision on a pending access request.
+    ///
+    /// `POST /access-requests/{id}/decision`. Only `status`, `resolved_at`, and the decision just
+    /// recorded are guaranteed populated on the response, so callers should merge it onto the row
+    /// they already hold rather than replacing it.
+    pub async fn decide(
+        &self,
+        id: AccessRequestId,
+        request: AccessDecisionRequest,
+    ) -> Result<AccessRequestView, LeasingError> {
+        let model = AccessDecisionRequestModel::try_from(request)?;
+
+        let response = self
+            .api_configurations
+            .api_client
+            .access_requests_api()
+            .decide(id.into(), model)
+            .await?;
+
+        AccessRequestView::try_from(response)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use bitwarden_api_api::{
+        apis::ApiClient,
+        models::{
+            AccessDecisionVerdict as ApiAccessDecisionVerdict, AccessRequestDetailsResponseModel,
+            AccessRequestDetailsResponseModelListResponseModel,
+            AccessRequestStatus as ApiAccessRequestStatus,
+        },
+    };
+    use uuid::uuid;
+
+    use super::*;
+    use crate::{AccessDecisionVerdict, AccessRequestStatus};
+
+    fn request_id() -> AccessRequestId {
+        AccessRequestId::new(uuid!("44444444-4444-4444-4444-444444444444"))
+    }
+
+    fn client(api_client: ApiClient) -> ApprovalsClient {
+        ApprovalsClient {
+            api_configurations: Arc::new(ApiConfigurations::from_api_client(api_client)),
+        }
+    }
+
+    fn sample_request() -> AccessRequestDetailsResponseModel {
+        AccessRequestDetailsResponseModel {
+            id: Some(request_id().into()),
+            cipher_id: Some(uuid!("55555555-5555-5555-5555-555555555555")),
+            collection_id: Some(uuid!("66666666-6666-6666-6666-666666666666")),
+            requester_id: Some(uuid!("88888888-8888-8888-8888-888888888888")),
+            status: Some(ApiAccessRequestStatus::Pending),
+            lease_not_before: Some("2025-01-01T00:00:00Z".to_string()),
+            lease_not_after: Some("2025-01-01T01:00:00Z".to_string()),
+            submitted_at: Some("2025-01-01T00:00:00Z".to_string()),
+            ..Default::default()
+        }
+    }
+
+    #[tokio::test]
+    async fn list_inbox_returns_views() {
+        let api_client = ApiClient::new_mocked(move |mock| {
+            mock.access_requests_api
+                .expect_get_inbox()
+                .returning(move || {
+                    let mut list = AccessRequestDetailsResponseModelListResponseModel::new();
+                    list.data = Some(vec![sample_request()]);
+                    Ok(list)
+                })
+                .once();
+        });
+
+        let result = client(api_client).list_inbox().await.unwrap();
+
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].id, request_id());
+        assert_eq!(result[0].status, AccessRequestStatus::Pending);
+    }
+
+    #[tokio::test]
+    async fn list_inbox_returns_empty_vec_when_server_sends_no_data() {
+        let api_client = ApiClient::new_mocked(move |mock| {
+            mock.access_requests_api
+                .expect_get_inbox()
+                .returning(move || Ok(AccessRequestDetailsResponseModelListResponseModel::new()))
+                .once();
+        });
+
+        let result = client(api_client).list_inbox().await.unwrap();
+
+        assert_eq!(result, Vec::new());
+    }
+
+    #[tokio::test]
+    async fn list_history_returns_views() {
+        let api_client = ApiClient::new_mocked(move |mock| {
+            mock.access_requests_api
+                .expect_get_history()
+                .returning(move || {
+                    let mut list = AccessRequestDetailsResponseModelListResponseModel::new();
+                    list.data = Some(vec![sample_request()]);
+                    Ok(list)
+                })
+                .once();
+        });
+
+        let result = client(api_client).list_history().await.unwrap();
+
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].id, request_id());
+    }
+
+    #[tokio::test]
+    async fn decide_returns_updated_view_and_sends_approve_verdict() {
+        let api_client = ApiClient::new_mocked(move |mock| {
+            mock.access_requests_api
+                .expect_decide()
+                .returning(move |_id, model| {
+                    assert_eq!(model.verdict, ApiAccessDecisionVerdict::Approve);
+                    assert_eq!(model.comment.as_deref(), Some("Looks fine"));
+
+                    Ok(AccessRequestDetailsResponseModel {
+                        status: Some(ApiAccessRequestStatus::Approved),
+                        resolved_at: Some("2025-01-01T00:30:00Z".to_string()),
+                        ..sample_request()
+                    })
+                })
+                .once();
+        });
+
+        let request = AccessDecisionRequest {
+            verdict: AccessDecisionVerdict::Approve,
+            comment: Some("Looks fine".to_string()),
+        };
+
+        let result = client(api_client)
+            .decide(request_id(), request)
+            .await
+            .unwrap();
+
+        assert_eq!(result.id, request_id());
+        assert_eq!(result.status, AccessRequestStatus::Approved);
+    }
+
+    #[tokio::test]
+    async fn decide_sends_deny_verdict() {
+        let api_client = ApiClient::new_mocked(move |mock| {
+            mock.access_requests_api
+                .expect_decide()
+                .returning(move |_id, model| {
+                    assert_eq!(model.verdict, ApiAccessDecisionVerdict::Deny);
+                    assert_eq!(model.comment.as_deref(), Some("Not authorized"));
+
+                    Ok(AccessRequestDetailsResponseModel {
+                        status: Some(ApiAccessRequestStatus::Denied),
+                        resolved_at: Some("2025-01-01T00:30:00Z".to_string()),
+                        ..sample_request()
+                    })
+                })
+                .once();
+        });
+
+        let request = AccessDecisionRequest {
+            verdict: AccessDecisionVerdict::Deny,
+            comment: Some("Not authorized".to_string()),
+        };
+
+        let result = client(api_client)
+            .decide(request_id(), request)
+            .await
+            .unwrap();
+
+        assert_eq!(result.status, AccessRequestStatus::Denied);
+    }
+
+    #[tokio::test]
+    async fn decide_rejects_unknown_verdict_without_calling_the_api() {
+        let api_client = ApiClient::new_mocked(|mock| {
+            mock.access_requests_api.expect_decide().never();
+        });
+
+        let request = AccessDecisionRequest {
+            verdict: AccessDecisionVerdict::Unknown,
+            comment: None,
+        };
+
+        let result = client(api_client).decide(request_id(), request).await;
+
+        assert!(matches!(result, Err(LeasingError::UnsubmittableVerdict)));
+    }
+
+    #[tokio::test]
+    async fn decide_surfaces_api_error() {
+        let api_client = ApiClient::new_mocked(move |mock| {
+            mock.access_requests_api
+                .expect_decide()
+                .returning(move |_id, _model| {
+                    Err(bitwarden_api_api::apis::Error::Response(
+                        bitwarden_api_api::apis::ResponseContent {
+                            status: reqwest::StatusCode::CONFLICT,
+                            message: "Already decided".to_string(),
+                        },
+                    ))
+                })
+                .once();
+        });
+
+        let request = AccessDecisionRequest {
+            verdict: AccessDecisionVerdict::Approve,
+            comment: None,
+        };
+
+        let result = client(api_client).decide(request_id(), request).await;
+
+        assert!(matches!(result, Err(LeasingError::Api(_))));
+    }
+}

--- a/bitwarden_license/bitwarden-pam/src/approvals/client.rs
+++ b/bitwarden_license/bitwarden-pam/src/approvals/client.rs
@@ -5,8 +5,8 @@ use bitwarden_core::{FromClient, client::ApiConfigurations};
 #[cfg(feature = "wasm")]
 use wasm_bindgen::prelude::wasm_bindgen;
 
-use super::models::AccessDecisionRequest;
-use crate::{AccessRequestId, access_requests::AccessRequestView, error::LeasingError};
+use super::{error::ApprovalError, models::AccessDecisionRequest};
+use crate::{AccessRequestId, access_requests::AccessRequestView};
 
 /// Client for a PAM approver's queue.
 ///
@@ -28,7 +28,7 @@ impl ApprovalsClient {
     /// `GET /access-requests/inbox`. The server scopes this by Manage permission on the request's
     /// collection and returns only pending requests, so an empty list is the normal answer for a
     /// member who approves nothing.
-    pub async fn list_inbox(&self) -> Result<Vec<AccessRequestView>, LeasingError> {
+    pub async fn list_inbox(&self) -> Result<Vec<AccessRequestView>, ApprovalError> {
         let response = self
             .api_configurations
             .api_client
@@ -41,14 +41,15 @@ impl ApprovalsClient {
             .unwrap_or_default()
             .into_iter()
             .map(AccessRequestView::try_from)
-            .collect()
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(Into::into)
     }
 
     /// Lists the decided access requests for collections the caller manages.
     ///
     /// `GET /access-requests/history`. Same response shape as [`list_inbox`](Self::list_inbox),
     /// not an audit-event shape.
-    pub async fn list_history(&self) -> Result<Vec<AccessRequestView>, LeasingError> {
+    pub async fn list_history(&self) -> Result<Vec<AccessRequestView>, ApprovalError> {
         let response = self
             .api_configurations
             .api_client
@@ -61,7 +62,8 @@ impl ApprovalsClient {
             .unwrap_or_default()
             .into_iter()
             .map(AccessRequestView::try_from)
-            .collect()
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(Into::into)
     }
 
     /// Records a decision on a pending access request.
@@ -73,7 +75,7 @@ impl ApprovalsClient {
         &self,
         id: AccessRequestId,
         request: AccessDecisionRequest,
-    ) -> Result<AccessRequestView, LeasingError> {
+    ) -> Result<AccessRequestView, ApprovalError> {
         let model = AccessDecisionRequestModel::try_from(request)?;
 
         let response = self
@@ -83,7 +85,7 @@ impl ApprovalsClient {
             .decide(id.into(), model)
             .await?;
 
-        AccessRequestView::try_from(response)
+        Ok(AccessRequestView::try_from(response)?)
     }
 }
 
@@ -255,7 +257,7 @@ mod tests {
 
         let result = client(api_client).decide(request_id(), request).await;
 
-        assert!(matches!(result, Err(LeasingError::UnsubmittableVerdict)));
+        assert!(matches!(result, Err(ApprovalError::UnsubmittableVerdict)));
     }
 
     #[tokio::test]
@@ -281,6 +283,6 @@ mod tests {
 
         let result = client(api_client).decide(request_id(), request).await;
 
-        assert!(matches!(result, Err(LeasingError::Api(_))));
+        assert!(matches!(result, Err(ApprovalError::Api(_))));
     }
 }

--- a/bitwarden_license/bitwarden-pam/src/approvals/client.rs
+++ b/bitwarden_license/bitwarden-pam/src/approvals/client.rs
@@ -5,8 +5,8 @@ use bitwarden_core::{FromClient, client::ApiConfigurations};
 #[cfg(feature = "wasm")]
 use wasm_bindgen::prelude::wasm_bindgen;
 
-use super::{error::ApprovalError, models::AccessDecisionRequest};
-use crate::{AccessRequestId, access_requests::AccessRequestView};
+use super::{error::AccessDecisionError, models::AccessDecisionRequest};
+use crate::{AccessRequestId, PamReadError, access_requests::AccessRequestView};
 
 /// Client for a PAM approver's queue.
 ///
@@ -28,7 +28,7 @@ impl ApprovalsClient {
     /// `GET /access-requests/inbox`. The server scopes this by Manage permission on the request's
     /// collection and returns only pending requests, so an empty list is the normal answer for a
     /// member who approves nothing.
-    pub async fn list_inbox(&self) -> Result<Vec<AccessRequestView>, ApprovalError> {
+    pub async fn list_inbox(&self) -> Result<Vec<AccessRequestView>, PamReadError> {
         let response = self
             .api_configurations
             .api_client
@@ -49,7 +49,7 @@ impl ApprovalsClient {
     ///
     /// `GET /access-requests/history`. Same response shape as [`list_inbox`](Self::list_inbox),
     /// not an audit-event shape.
-    pub async fn list_history(&self) -> Result<Vec<AccessRequestView>, ApprovalError> {
+    pub async fn list_history(&self) -> Result<Vec<AccessRequestView>, PamReadError> {
         let response = self
             .api_configurations
             .api_client
@@ -75,7 +75,7 @@ impl ApprovalsClient {
         &self,
         id: AccessRequestId,
         request: AccessDecisionRequest,
-    ) -> Result<AccessRequestView, ApprovalError> {
+    ) -> Result<AccessRequestView, AccessDecisionError> {
         let model = AccessDecisionRequestModel::try_from(request)?;
 
         let response = self
@@ -257,7 +257,10 @@ mod tests {
 
         let result = client(api_client).decide(request_id(), request).await;
 
-        assert!(matches!(result, Err(ApprovalError::UnsubmittableVerdict)));
+        assert!(matches!(
+            result,
+            Err(AccessDecisionError::UnsubmittableVerdict)
+        ));
     }
 
     #[tokio::test]
@@ -283,6 +286,6 @@ mod tests {
 
         let result = client(api_client).decide(request_id(), request).await;
 
-        assert!(matches!(result, Err(ApprovalError::Api(_))));
+        assert!(matches!(result, Err(AccessDecisionError::Api(_))));
     }
 }

--- a/bitwarden_license/bitwarden-pam/src/approvals/error.rs
+++ b/bitwarden_license/bitwarden-pam/src/approvals/error.rs
@@ -1,0 +1,26 @@
+use bitwarden_core::ApiError;
+use bitwarden_error::bitwarden_error;
+use thiserror::Error;
+
+use crate::error::PamDecodeError;
+
+/// Errors returned from [`super::ApprovalsClient`] operations.
+///
+/// [`UnsubmittableVerdict`](Self::UnsubmittableVerdict) is reachable only from
+/// [`decide`](super::ApprovalsClient::decide) - it is the one write path on the approver surface -
+/// so no other PAM client exposes it.
+#[bitwarden_error(flat)]
+#[derive(Debug, Error)]
+pub enum ApprovalError {
+    /// A decision was submitted with a verdict this SDK cannot put on the wire.
+    /// [`AccessDecisionVerdict::Unknown`](crate::AccessDecisionVerdict::Unknown) is a read-side
+    /// spelling for a verdict a newer server returned, never something to submit.
+    #[error("An access-request decision cannot be submitted with an unrecognized verdict")]
+    UnsubmittableVerdict,
+    /// A server response could not be decoded into the requested type.
+    #[error(transparent)]
+    Decode(#[from] PamDecodeError),
+    /// A network or (de)serialization error occurred while calling the server.
+    #[error(transparent)]
+    Api(#[from] ApiError),
+}

--- a/bitwarden_license/bitwarden-pam/src/approvals/error.rs
+++ b/bitwarden_license/bitwarden-pam/src/approvals/error.rs
@@ -4,16 +4,15 @@ use thiserror::Error;
 
 use crate::{error::PamDecodeError, problem};
 
-/// Errors returned from [`super::ApprovalsClient`] operations.
+/// Errors from [`ApprovalsClient::decide`](super::ApprovalsClient::decide), the one write path on
+/// the approver surface.
 ///
-/// [`UnsubmittableVerdict`](Self::UnsubmittableVerdict) is reachable only from
-/// [`decide`](super::ApprovalsClient::decide) - it is the one write path on the approver surface -
-/// so no other PAM client exposes it. The same is true of the three named server failures below,
-/// which each correspond to one stable code in the server's problem response; a code this SDK
-/// version does not recognize stays [`Api`](Self::Api).
+/// The reads use [`PamReadError`](crate::PamReadError). The three named server failures are the
+/// codes `DecideAccessRequestCommand` can return; a code this SDK version does not recognize stays
+/// [`Api`](Self::Api).
 #[bitwarden_error(flat)]
 #[derive(Debug, Error)]
-pub enum ApprovalError {
+pub enum AccessDecisionError {
     /// A decision was submitted with a verdict this SDK cannot put on the wire.
     /// [`AccessDecisionVerdict::Unknown`](crate::AccessDecisionVerdict::Unknown) is a read-side
     /// spelling for a verdict a newer server returned, never something to submit.
@@ -41,8 +40,8 @@ pub enum ApprovalError {
     Api(ApiError),
 }
 
-impl ApprovalError {
-    /// The server's codes, in the order the approver surface can produce them.
+impl AccessDecisionError {
+    /// The codes `DecideAccessRequestCommand` can return.
     fn from_code(code: &str) -> Option<Self> {
         Some(match code {
             "access_request_already_resolved" => Self::AlreadyResolved,
@@ -53,9 +52,7 @@ impl ApprovalError {
     }
 }
 
-/// Classifies every failed call on this surface, so a caller gets the typed variant whichever
-/// method it came from.
-impl From<ApiError> for ApprovalError {
+impl From<ApiError> for AccessDecisionError {
     fn from(error: ApiError) -> Self {
         problem::classify(&error, Self::from_code).unwrap_or(Self::Api(error))
     }
@@ -77,22 +74,22 @@ mod tests {
 
     #[test]
     fn a_settled_request_becomes_its_own_variant() {
-        let error: ApprovalError = problem("access_request_already_resolved").into();
+        let error: AccessDecisionError = problem("access_request_already_resolved").into();
 
-        assert!(matches!(error, ApprovalError::AlreadyResolved));
+        assert!(matches!(error, AccessDecisionError::AlreadyResolved));
     }
 
     #[test]
     fn a_self_approval_becomes_its_own_variant() {
-        let error: ApprovalError = problem("cannot_decide_own_request").into();
+        let error: AccessDecisionError = problem("cannot_decide_own_request").into();
 
-        assert!(matches!(error, ApprovalError::CannotDecideOwnRequest));
+        assert!(matches!(error, AccessDecisionError::CannotDecideOwnRequest));
     }
 
     #[test]
     fn an_unrecognized_code_stays_untyped() {
-        let error: ApprovalError = problem("invented_next_year").into();
+        let error: AccessDecisionError = problem("invented_next_year").into();
 
-        assert!(matches!(error, ApprovalError::Api(_)));
+        assert!(matches!(error, AccessDecisionError::Api(_)));
     }
 }

--- a/bitwarden_license/bitwarden-pam/src/approvals/error.rs
+++ b/bitwarden_license/bitwarden-pam/src/approvals/error.rs
@@ -2,13 +2,15 @@ use bitwarden_core::ApiError;
 use bitwarden_error::bitwarden_error;
 use thiserror::Error;
 
-use crate::error::PamDecodeError;
+use crate::{error::PamDecodeError, problem};
 
 /// Errors returned from [`super::ApprovalsClient`] operations.
 ///
 /// [`UnsubmittableVerdict`](Self::UnsubmittableVerdict) is reachable only from
 /// [`decide`](super::ApprovalsClient::decide) - it is the one write path on the approver surface -
-/// so no other PAM client exposes it.
+/// so no other PAM client exposes it. The same is true of the three named server failures below,
+/// which each correspond to one stable code in the server's problem response; a code this SDK
+/// version does not recognize stays [`Api`](Self::Api).
 #[bitwarden_error(flat)]
 #[derive(Debug, Error)]
 pub enum ApprovalError {
@@ -17,10 +19,80 @@ pub enum ApprovalError {
     /// spelling for a verdict a newer server returned, never something to submit.
     #[error("An access-request decision cannot be submitted with an unrecognized verdict")]
     UnsubmittableVerdict,
+    /// The request has already been decided, cancelled or expired, so there is no decision to
+    /// take. Whichever approver arrives second finds it settled.
+    #[error("This request has already been resolved")]
+    AlreadyResolved,
+    /// The caller is the request's own requester. Self-approval is refused server-side even though
+    /// an approver surface should not offer it.
+    #[error("You cannot decide your own request")]
+    CannotDecideOwnRequest,
+    /// The window the requester asked for has already closed, so approving it would mint an
+    /// approval that can never be activated. Denying it is still allowed.
+    #[error("The requested access window has already ended")]
+    RequestedWindowEnded,
+
     /// A server response could not be decoded into the requested type.
     #[error(transparent)]
     Decode(#[from] PamDecodeError),
-    /// A network or (de)serialization error occurred while calling the server.
+    /// A network or (de)serialization error occurred while calling the server, or the server
+    /// refused with a code this SDK version does not recognize.
     #[error(transparent)]
-    Api(#[from] ApiError),
+    Api(ApiError),
+}
+
+impl ApprovalError {
+    /// The server's codes, in the order the approver surface can produce them.
+    fn from_code(code: &str) -> Option<Self> {
+        Some(match code {
+            "access_request_already_resolved" => Self::AlreadyResolved,
+            "cannot_decide_own_request" => Self::CannotDecideOwnRequest,
+            "requested_window_ended" => Self::RequestedWindowEnded,
+            _ => return None,
+        })
+    }
+}
+
+/// Classifies every failed call on this surface, so a caller gets the typed variant whichever
+/// method it came from.
+impl From<ApiError> for ApprovalError {
+    fn from(error: ApiError) -> Self {
+        problem::classify(&error, Self::from_code).unwrap_or(Self::Api(error))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use bitwarden_api_api::ResponseContent;
+    use reqwest::StatusCode;
+
+    use super::*;
+
+    fn problem(code: &str) -> ApiError {
+        ApiError::Response(ResponseContent {
+            status: StatusCode::BAD_REQUEST,
+            message: format!(r#"{{"errors":{{"code":[{{"type":"{code}"}}]}}}}"#),
+        })
+    }
+
+    #[test]
+    fn a_settled_request_becomes_its_own_variant() {
+        let error: ApprovalError = problem("access_request_already_resolved").into();
+
+        assert!(matches!(error, ApprovalError::AlreadyResolved));
+    }
+
+    #[test]
+    fn a_self_approval_becomes_its_own_variant() {
+        let error: ApprovalError = problem("cannot_decide_own_request").into();
+
+        assert!(matches!(error, ApprovalError::CannotDecideOwnRequest));
+    }
+
+    #[test]
+    fn an_unrecognized_code_stays_untyped() {
+        let error: ApprovalError = problem("invented_next_year").into();
+
+        assert!(matches!(error, ApprovalError::Api(_)));
+    }
 }

--- a/bitwarden_license/bitwarden-pam/src/approvals/mod.rs
+++ b/bitwarden_license/bitwarden-pam/src/approvals/mod.rs
@@ -11,7 +11,9 @@
 //! [`decide`](ApprovalsClient::decide)ing a pending request.
 
 mod client;
+mod error;
 mod models;
 
 pub use client::ApprovalsClient;
+pub use error::ApprovalError;
 pub use models::AccessDecisionRequest;

--- a/bitwarden_license/bitwarden-pam/src/approvals/mod.rs
+++ b/bitwarden_license/bitwarden-pam/src/approvals/mod.rs
@@ -15,5 +15,5 @@ mod error;
 mod models;
 
 pub use client::ApprovalsClient;
-pub use error::ApprovalError;
+pub use error::AccessDecisionError;
 pub use models::AccessDecisionRequest;

--- a/bitwarden_license/bitwarden-pam/src/approvals/mod.rs
+++ b/bitwarden_license/bitwarden-pam/src/approvals/mod.rs
@@ -1,0 +1,17 @@
+//! PAM approver operations.
+//!
+//! This is the *approver* side of the same request lifecycle the requester side covers in
+//! [`AccessRequestsClient`](crate::AccessRequestsClient): an approver reads the requests awaiting
+//! their decision, reads the ones they've already decided, and records a decision on a pending
+//! request.
+//!
+//! [`ApprovalsClient`] is obtained from the [`PamClient`](crate::PamClient) and covers
+//! [`list_inbox`](ApprovalsClient::list_inbox)ing pending requests the caller may decide,
+//! [`list_history`](ApprovalsClient::list_history)ing the ones they've decided, and
+//! [`decide`](ApprovalsClient::decide)ing a pending request.
+
+mod client;
+mod models;
+
+pub use client::ApprovalsClient;
+pub use models::AccessDecisionRequest;

--- a/bitwarden_license/bitwarden-pam/src/approvals/models.rs
+++ b/bitwarden_license/bitwarden-pam/src/approvals/models.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 #[cfg(feature = "wasm")]
 use tsify::Tsify;
 
-use super::error::ApprovalError;
+use super::error::AccessDecisionError;
 use crate::AccessDecisionVerdict;
 
 /// An approver's decision on a pending access request.
@@ -22,13 +22,15 @@ pub struct AccessDecisionRequest {
 }
 
 impl TryFrom<AccessDecisionRequest> for AccessDecisionRequestModel {
-    type Error = ApprovalError;
+    type Error = AccessDecisionError;
 
     fn try_from(request: AccessDecisionRequest) -> Result<Self, Self::Error> {
         let verdict = match request.verdict {
             AccessDecisionVerdict::Approve => ApiAccessDecisionVerdict::Approve,
             AccessDecisionVerdict::Deny => ApiAccessDecisionVerdict::Deny,
-            AccessDecisionVerdict::Unknown => return Err(ApprovalError::UnsubmittableVerdict),
+            AccessDecisionVerdict::Unknown => {
+                return Err(AccessDecisionError::UnsubmittableVerdict);
+            }
         };
 
         Ok(Self {
@@ -77,6 +79,9 @@ mod tests {
 
         let result = AccessDecisionRequestModel::try_from(request);
 
-        assert!(matches!(result, Err(ApprovalError::UnsubmittableVerdict)));
+        assert!(matches!(
+            result,
+            Err(AccessDecisionError::UnsubmittableVerdict)
+        ));
     }
 }

--- a/bitwarden_license/bitwarden-pam/src/approvals/models.rs
+++ b/bitwarden_license/bitwarden-pam/src/approvals/models.rs
@@ -5,7 +5,8 @@ use serde::{Deserialize, Serialize};
 #[cfg(feature = "wasm")]
 use tsify::Tsify;
 
-use crate::{AccessDecisionVerdict, error::LeasingError};
+use super::error::ApprovalError;
+use crate::AccessDecisionVerdict;
 
 /// An approver's decision on a pending access request.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
@@ -21,13 +22,13 @@ pub struct AccessDecisionRequest {
 }
 
 impl TryFrom<AccessDecisionRequest> for AccessDecisionRequestModel {
-    type Error = LeasingError;
+    type Error = ApprovalError;
 
     fn try_from(request: AccessDecisionRequest) -> Result<Self, Self::Error> {
         let verdict = match request.verdict {
             AccessDecisionVerdict::Approve => ApiAccessDecisionVerdict::Approve,
             AccessDecisionVerdict::Deny => ApiAccessDecisionVerdict::Deny,
-            AccessDecisionVerdict::Unknown => return Err(LeasingError::UnsubmittableVerdict),
+            AccessDecisionVerdict::Unknown => return Err(ApprovalError::UnsubmittableVerdict),
         };
 
         Ok(Self {
@@ -76,6 +77,6 @@ mod tests {
 
         let result = AccessDecisionRequestModel::try_from(request);
 
-        assert!(matches!(result, Err(LeasingError::UnsubmittableVerdict)));
+        assert!(matches!(result, Err(ApprovalError::UnsubmittableVerdict)));
     }
 }

--- a/bitwarden_license/bitwarden-pam/src/approvals/models.rs
+++ b/bitwarden_license/bitwarden-pam/src/approvals/models.rs
@@ -1,0 +1,81 @@
+use bitwarden_api_api::models::{
+    AccessDecisionRequestModel, AccessDecisionVerdict as ApiAccessDecisionVerdict,
+};
+use serde::{Deserialize, Serialize};
+#[cfg(feature = "wasm")]
+use tsify::Tsify;
+
+use crate::{AccessDecisionVerdict, error::LeasingError};
+
+/// An approver's decision on a pending access request.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "wasm", derive(Tsify), tsify(into_wasm_abi, from_wasm_abi))]
+#[serde(rename_all = "camelCase")]
+pub struct AccessDecisionRequest {
+    /// The verdict to record. [`AccessDecisionVerdict::Unknown`] is a read-side spelling and
+    /// cannot be submitted.
+    pub verdict: AccessDecisionVerdict,
+    /// An optional note recorded with the decision - for example the reason for a denial. Surfaced
+    /// to the requester.
+    pub comment: Option<String>,
+}
+
+impl TryFrom<AccessDecisionRequest> for AccessDecisionRequestModel {
+    type Error = LeasingError;
+
+    fn try_from(request: AccessDecisionRequest) -> Result<Self, Self::Error> {
+        let verdict = match request.verdict {
+            AccessDecisionVerdict::Approve => ApiAccessDecisionVerdict::Approve,
+            AccessDecisionVerdict::Deny => ApiAccessDecisionVerdict::Deny,
+            AccessDecisionVerdict::Unknown => return Err(LeasingError::UnsubmittableVerdict),
+        };
+
+        Ok(Self {
+            verdict,
+            comment: request.comment,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn approve_converts_to_model() {
+        let request = AccessDecisionRequest {
+            verdict: AccessDecisionVerdict::Approve,
+            comment: Some("Looks fine".to_string()),
+        };
+
+        let model = AccessDecisionRequestModel::try_from(request).unwrap();
+
+        assert_eq!(model.verdict, ApiAccessDecisionVerdict::Approve);
+        assert_eq!(model.comment, Some("Looks fine".to_string()));
+    }
+
+    #[test]
+    fn deny_converts_to_model() {
+        let request = AccessDecisionRequest {
+            verdict: AccessDecisionVerdict::Deny,
+            comment: None,
+        };
+
+        let model = AccessDecisionRequestModel::try_from(request).unwrap();
+
+        assert_eq!(model.verdict, ApiAccessDecisionVerdict::Deny);
+        assert_eq!(model.comment, None);
+    }
+
+    #[test]
+    fn unknown_verdict_is_rejected() {
+        let request = AccessDecisionRequest {
+            verdict: AccessDecisionVerdict::Unknown,
+            comment: None,
+        };
+
+        let result = AccessDecisionRequestModel::try_from(request);
+
+        assert!(matches!(result, Err(LeasingError::UnsubmittableVerdict)));
+    }
+}

--- a/bitwarden_license/bitwarden-pam/src/error.rs
+++ b/bitwarden_license/bitwarden-pam/src/error.rs
@@ -3,12 +3,13 @@ use bitwarden_error::bitwarden_error;
 use thiserror::Error;
 
 /// Errors returned from the PAM leasing clients
-/// ([`AccessRequestsClient`](crate::AccessRequestsClient)
-/// and [`LeasesClient`](crate::LeasesClient)).
+/// ([`AccessRequestsClient`](crate::AccessRequestsClient),
+/// [`LeasesClient`](crate::LeasesClient), and [`ApprovalsClient`](crate::ApprovalsClient)).
 ///
-/// Access requests and leases are two sides of the same lifecycle - activating a request mints a
-/// lease, and extending a lease returns the updated request - so both clients share one error type
-/// rather than each defining a near-identical one.
+/// Access requests, leases, and approvals are facets of the same lifecycle - activating a request
+/// mints a lease, extending a lease returns the updated request, and deciding a request is the
+/// approver-side counterpart of submitting one - so all three clients share one error type rather
+/// than each defining a near-identical one.
 #[bitwarden_error(flat)]
 #[derive(Debug, Error)]
 pub enum LeasingError {
@@ -18,6 +19,10 @@ pub enum LeasingError {
     /// The server returned an access-request decider kind this SDK version does not recognize.
     #[error("The server returned an unrecognized access-request decider kind")]
     UnrecognizedDeciderKind,
+    /// A decision was submitted with a verdict this SDK cannot put on the wire. `Unknown` is a
+    /// read-side spelling for a verdict a newer server returned, never something to submit.
+    #[error("An access-request decision cannot be submitted with an unrecognized verdict")]
+    UnsubmittableVerdict,
     /// A date field in the server response could not be parsed.
     #[error(transparent)]
     Chrono(#[from] chrono::ParseError),

--- a/bitwarden_license/bitwarden-pam/src/error.rs
+++ b/bitwarden_license/bitwarden-pam/src/error.rs
@@ -1,4 +1,5 @@
-use bitwarden_core::MissingFieldError;
+use bitwarden_core::{ApiError, MissingFieldError};
+use bitwarden_error::bitwarden_error;
 use thiserror::Error;
 
 /// Errors from decoding a PAM server response into a domain view.
@@ -20,4 +21,31 @@ pub enum PamDecodeError {
     /// A date field in the server response could not be parsed.
     #[error(transparent)]
     Chrono(#[from] chrono::ParseError),
+}
+
+/// Errors from a PAM read - a list, a get, a pre-check.
+///
+/// Shared by every read on every PAM client, because a read has no failure of its own to report: it
+/// either reaches the server and decodes, or it does not. The server refuses a read it must not
+/// serve with a `404`, which carries no code, so there is nothing here for a caller to switch on
+/// beyond "it did not work".
+///
+/// Write operations do not use this. Each returns its own enum naming exactly the failures that one
+/// call can produce, so a caller matching on it is matching on a set the compiler agrees is
+/// complete.
+#[bitwarden_error(flat)]
+#[derive(Debug, Error)]
+pub enum PamReadError {
+    /// A server response could not be decoded into the requested type.
+    #[error(transparent)]
+    Decode(#[from] PamDecodeError),
+    /// A network or (de)serialization error occurred while calling the server.
+    #[error(transparent)]
+    Api(ApiError),
+}
+
+impl From<ApiError> for PamReadError {
+    fn from(error: ApiError) -> Self {
+        Self::Api(error)
+    }
 }

--- a/bitwarden_license/bitwarden-pam/src/error.rs
+++ b/bitwarden_license/bitwarden-pam/src/error.rs
@@ -2,6 +2,8 @@ use bitwarden_core::{ApiError, MissingFieldError};
 use bitwarden_error::bitwarden_error;
 use thiserror::Error;
 
+use crate::access_requests::AccessRequestWindowError;
+
 /// Errors returned from the PAM leasing clients
 /// ([`AccessRequestsClient`](crate::AccessRequestsClient),
 /// [`LeasesClient`](crate::LeasesClient), and [`ApprovalsClient`](crate::ApprovalsClient)).
@@ -13,6 +15,9 @@ use thiserror::Error;
 #[bitwarden_error(flat)]
 #[derive(Debug, Error)]
 pub enum LeasingError {
+    /// The request failed local validation before being sent to the server.
+    #[error(transparent)]
+    Validation(#[from] AccessRequestWindowError),
     /// The server response was missing a field required to build the requested type.
     #[error(transparent)]
     MissingField(#[from] MissingFieldError),

--- a/bitwarden_license/bitwarden-pam/src/error.rs
+++ b/bitwarden_license/bitwarden-pam/src/error.rs
@@ -1,37 +1,23 @@
-use bitwarden_core::{ApiError, MissingFieldError};
-use bitwarden_error::bitwarden_error;
+use bitwarden_core::MissingFieldError;
 use thiserror::Error;
 
-use crate::access_requests::AccessRequestWindowError;
-
-/// Errors returned from the PAM leasing clients
-/// ([`AccessRequestsClient`](crate::AccessRequestsClient),
-/// [`LeasesClient`](crate::LeasesClient), and [`ApprovalsClient`](crate::ApprovalsClient)).
+/// Errors from decoding a PAM server response into a domain view.
 ///
-/// Access requests, leases, and approvals are facets of the same lifecycle - activating a request
-/// mints a lease, extending a lease returns the updated request, and deciding a request is the
-/// approver-side counterpart of submitting one - so all three clients share one error type rather
-/// than each defining a near-identical one.
-#[bitwarden_error(flat)]
+/// This is shared by all three leasing clients because they decode the *same* payloads, not because
+/// their operations are alike: [`ApprovalsClient`](crate::ApprovalsClient) and
+/// [`LeasesClient::extend`](crate::LeasesClient::extend) both return
+/// [`AccessRequestView`](crate::AccessRequestView)s, so a malformed access-request payload fails
+/// identically whichever client asked for it. Each client wraps this in its own error type rather
+/// than exposing it directly, so a caller only sees the failure modes its own call can produce.
 #[derive(Debug, Error)]
-pub enum LeasingError {
-    /// The request failed local validation before being sent to the server.
-    #[error(transparent)]
-    Validation(#[from] AccessRequestWindowError),
+pub enum PamDecodeError {
     /// The server response was missing a field required to build the requested type.
     #[error(transparent)]
     MissingField(#[from] MissingFieldError),
     /// The server returned an access-request decider kind this SDK version does not recognize.
     #[error("The server returned an unrecognized access-request decider kind")]
     UnrecognizedDeciderKind,
-    /// A decision was submitted with a verdict this SDK cannot put on the wire. `Unknown` is a
-    /// read-side spelling for a verdict a newer server returned, never something to submit.
-    #[error("An access-request decision cannot be submitted with an unrecognized verdict")]
-    UnsubmittableVerdict,
     /// A date field in the server response could not be parsed.
     #[error(transparent)]
     Chrono(#[from] chrono::ParseError),
-    /// A network or (de)serialization error occurred while calling the server.
-    #[error(transparent)]
-    Api(#[from] ApiError),
 }

--- a/bitwarden_license/bitwarden-pam/src/leases/client.rs
+++ b/bitwarden_license/bitwarden-pam/src/leases/client.rs
@@ -4,8 +4,11 @@ use bitwarden_core::{FromClient, client::ApiConfigurations};
 #[cfg(feature = "wasm")]
 use wasm_bindgen::prelude::wasm_bindgen;
 
-use super::models::{AccessLeaseExtensionRequest, AccessLeaseRevokeRequest, AccessLeaseView};
-use crate::{AccessLeaseId, access_requests::AccessRequestView, error::LeasingError};
+use super::{
+    error::AccessLeaseError,
+    models::{AccessLeaseExtensionRequest, AccessLeaseRevokeRequest, AccessLeaseView},
+};
+use crate::{AccessLeaseId, access_requests::AccessRequestView};
 
 /// Client for reading and managing a requester's PAM access leases.
 ///
@@ -21,7 +24,7 @@ pub struct LeasesClient {
 #[cfg_attr(feature = "wasm", wasm_bindgen)]
 impl LeasesClient {
     /// Lists the caller's currently active leases.
-    pub async fn list_active(&self) -> Result<Vec<AccessLeaseView>, LeasingError> {
+    pub async fn list_active(&self) -> Result<Vec<AccessLeaseView>, AccessLeaseError> {
         let response = self
             .api_configurations
             .api_client
@@ -34,11 +37,12 @@ impl LeasesClient {
             .unwrap_or_default()
             .into_iter()
             .map(AccessLeaseView::try_from)
-            .collect()
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(Into::into)
     }
 
     /// Lists all of the caller's leases, active or not.
-    pub async fn list_mine(&self) -> Result<Vec<AccessLeaseView>, LeasingError> {
+    pub async fn list_mine(&self) -> Result<Vec<AccessLeaseView>, AccessLeaseError> {
         let response = self
             .api_configurations
             .api_client
@@ -51,7 +55,8 @@ impl LeasesClient {
             .unwrap_or_default()
             .into_iter()
             .map(AccessLeaseView::try_from)
-            .collect()
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(Into::into)
     }
 
     /// Extends an active lease, returning the updated originating request.
@@ -59,7 +64,7 @@ impl LeasesClient {
         &self,
         lease_id: AccessLeaseId,
         request: AccessLeaseExtensionRequest,
-    ) -> Result<AccessRequestView, LeasingError> {
+    ) -> Result<AccessRequestView, AccessLeaseError> {
         let response = self
             .api_configurations
             .api_client
@@ -67,7 +72,7 @@ impl LeasesClient {
             .extend(lease_id.into(), request.into())
             .await?;
 
-        AccessRequestView::try_from(response)
+        Ok(AccessRequestView::try_from(response)?)
     }
 
     /// Ends a lease before it expires, re-locking the cipher.
@@ -75,7 +80,7 @@ impl LeasesClient {
         &self,
         lease_id: AccessLeaseId,
         request: AccessLeaseRevokeRequest,
-    ) -> Result<(), LeasingError> {
+    ) -> Result<(), AccessLeaseError> {
         self.api_configurations
             .api_client
             .leases_api()
@@ -166,7 +171,7 @@ mod tests {
 
         let result = client(api_client).list_mine().await;
 
-        assert!(matches!(result, Err(LeasingError::Api(_))));
+        assert!(matches!(result, Err(AccessLeaseError::Api(_))));
     }
 
     #[tokio::test]

--- a/bitwarden_license/bitwarden-pam/src/leases/client.rs
+++ b/bitwarden_license/bitwarden-pam/src/leases/client.rs
@@ -1,6 +1,8 @@
 use std::sync::Arc;
 
-use bitwarden_core::{FromClient, client::ApiConfigurations};
+use bitwarden_core::{FromClient, client::ApiConfigurations, key_management::KeySlotIds};
+use bitwarden_crypto::KeyStore;
+use bitwarden_vault::{Cipher, CipherId, CipherView};
 #[cfg(feature = "wasm")]
 use wasm_bindgen::prelude::wasm_bindgen;
 
@@ -18,6 +20,7 @@ use crate::{AccessLeaseId, access_requests::AccessRequestView};
 #[cfg_attr(feature = "wasm", wasm_bindgen)]
 #[derive(FromClient)]
 pub struct LeasesClient {
+    pub(crate) key_store: KeyStore<KeySlotIds>,
     pub(crate) api_configurations: Arc<ApiConfigurations>,
 }
 
@@ -89,6 +92,44 @@ impl LeasesClient {
 
         Ok(())
     }
+
+    /// Reads the full cipher a lease unlocks, straight from the server.
+    ///
+    /// Returns `None` when the server still answers with a restricted (partial) payload, which
+    /// means the caller's lease is not in effect - it lapsed between the access-state read that
+    /// sent them here and this call. Handing the partial back as if it were unlocked would show
+    /// an empty credential as though it were the real one.
+    ///
+    /// Three properties make this a lease operation rather than a plain vault read:
+    ///
+    /// - It goes through the STANDARD single-cipher endpoint. The server already decides per caller
+    ///   what a cipher's payload contains - restricted without a lease, complete with one - so
+    ///   there is no PAM-specific route to call, and the partial-cipher pivot deliberately left the
+    ///   old `GET /leases/ciphers/{id}/cipher` without a successor.
+    /// - The result is NEVER written to the cipher repository. Local state stays partial for the
+    ///   lease's whole life, so closing and reopening the item re-reads it, and a lapsed lease
+    ///   cannot leave decryptable secrets behind in state.
+    /// - It is the read that a lease authorizes, so it fails with the same [`AccessLeaseError`] as
+    ///   the rest of this client.
+    pub async fn leased_cipher(
+        &self,
+        cipher_id: CipherId,
+    ) -> Result<Option<CipherView>, AccessLeaseError> {
+        let response = self
+            .api_configurations
+            .api_client
+            .ciphers_api()
+            .get_details(cipher_id.into())
+            .await?;
+
+        let cipher = Cipher::try_from(response)?;
+
+        if cipher.partial_data.is_some() {
+            return Ok(None);
+        }
+
+        Ok(Some(self.key_store.decrypt(&cipher)?))
+    }
 }
 
 #[cfg(test)]
@@ -100,8 +141,11 @@ mod tests {
         models::{
             AccessLeaseResponseModel, AccessLeaseResponseModelListResponseModel,
             AccessLeaseStatus as ApiAccessLeaseStatus, AccessRequestDetailsResponseModel,
+            CipherDetailsResponseModel,
         },
     };
+    use bitwarden_core::key_management::create_test_crypto_with_user_key;
+    use bitwarden_crypto::{SymmetricCryptoKey, SymmetricKeyAlgorithm};
     use chrono::{DateTime, Utc};
     use uuid::uuid;
 
@@ -114,7 +158,29 @@ mod tests {
 
     fn client(api_client: ApiClient) -> LeasesClient {
         LeasesClient {
+            key_store: create_test_crypto_with_user_key(SymmetricCryptoKey::make(
+                SymmetricKeyAlgorithm::Aes256CbcHmac,
+            )),
             api_configurations: Arc::new(ApiConfigurations::from_api_client(api_client)),
+        }
+    }
+
+    fn cipher_id() -> CipherId {
+        CipherId::new(uuid!("55555555-5555-5555-5555-555555555555"))
+    }
+
+    /// A full (unrestricted) cipher payload, as the server answers a caller holding a lease. Its
+    /// `name` is encrypted under a key the test store does not have, which is all the decrypt path
+    /// needs to be exercised - see `leased_cipher_surfaces_a_decrypt_failure`.
+    fn full_cipher_response() -> CipherDetailsResponseModel {
+        CipherDetailsResponseModel {
+            id: Some(cipher_id().into()),
+            name: Some("2.pMS6/icTQABtulw52pq2lg==|XXbxKxDTh+mWiN1HjH2N1w==|Q6PkuT+KX/axrgN9ubD5Ajk2YNwxQkgs3WJM0S0wtG8=".to_string()),
+            r#type: Some(bitwarden_api_api::models::CipherType::Login),
+            login: Some(Box::new(bitwarden_api_api::models::CipherLoginModel::default())),
+            creation_date: Some("2025-01-01T00:00:00Z".to_string()),
+            revision_date: Some("2025-01-01T00:00:00Z".to_string()),
+            ..Default::default()
         }
     }
 
@@ -224,5 +290,71 @@ mod tests {
             .await;
 
         assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn leased_cipher_reports_no_access_when_the_server_still_restricts_the_cipher() {
+        let api_client = ApiClient::new_mocked(move |mock| {
+            mock.ciphers_api
+                .expect_get_details()
+                .returning(move |_id| {
+                    Ok(CipherDetailsResponseModel {
+                        partial_data: Some(r#"{"name":"Prod DB root"}"#.to_string()),
+                        ..full_cipher_response()
+                    })
+                })
+                .once();
+        });
+
+        let result = client(api_client).leased_cipher(cipher_id()).await.unwrap();
+
+        // The lease lapsed between the access-state read and this one. Returning the partial would
+        // reveal an empty credential dressed as the real one.
+        assert!(result.is_none());
+    }
+
+    /// A full payload is decrypted and handed back. Producing the *right* plaintext is
+    /// bitwarden-vault's contract, covered by its own tests - and note that its decrypt degrades
+    /// gracefully, so a field this store holds no key for arrives as an empty string rather than an
+    /// error. What matters here is that a non-restricted payload takes the decrypt branch and comes
+    /// back as a view the caller can render, marked `partial: false`.
+    #[tokio::test]
+    async fn leased_cipher_returns_a_view_for_a_full_payload() {
+        let api_client = ApiClient::new_mocked(move |mock| {
+            mock.ciphers_api
+                .expect_get_details()
+                .returning(move |_id| Ok(full_cipher_response()))
+                .once();
+        });
+
+        let view = client(api_client)
+            .leased_cipher(cipher_id())
+            .await
+            .unwrap()
+            .expect("a full payload should resolve to a view");
+
+        assert_eq!(view.id, Some(cipher_id()));
+        assert!(!view.partial);
+    }
+
+    #[tokio::test]
+    async fn leased_cipher_surfaces_api_errors() {
+        let api_client = ApiClient::new_mocked(move |mock| {
+            mock.ciphers_api
+                .expect_get_details()
+                .returning(move |_id| {
+                    Err(bitwarden_api_api::ApiError::Response(
+                        bitwarden_api_api::ResponseContent {
+                            status: reqwest::StatusCode::NOT_FOUND,
+                            message: String::new(),
+                        },
+                    ))
+                })
+                .once();
+        });
+
+        let result = client(api_client).leased_cipher(cipher_id()).await;
+
+        assert!(matches!(result, Err(AccessLeaseError::Api(_))));
     }
 }

--- a/bitwarden_license/bitwarden-pam/src/leases/client.rs
+++ b/bitwarden_license/bitwarden-pam/src/leases/client.rs
@@ -7,10 +7,10 @@ use bitwarden_vault::{Cipher, CipherId, CipherView};
 use wasm_bindgen::prelude::wasm_bindgen;
 
 use super::{
-    error::AccessLeaseError,
+    error::{AccessLeaseEndError, AccessLeaseExtendError, LeasedCipherError},
     models::{AccessLeaseExtensionRequest, AccessLeaseRevokeRequest, AccessLeaseView},
 };
-use crate::{AccessLeaseId, access_requests::AccessRequestView};
+use crate::{AccessLeaseId, PamReadError, access_requests::AccessRequestView};
 
 /// Client for reading and managing a requester's PAM access leases.
 ///
@@ -27,7 +27,7 @@ pub struct LeasesClient {
 #[cfg_attr(feature = "wasm", wasm_bindgen)]
 impl LeasesClient {
     /// Lists the caller's currently active leases.
-    pub async fn list_active(&self) -> Result<Vec<AccessLeaseView>, AccessLeaseError> {
+    pub async fn list_active(&self) -> Result<Vec<AccessLeaseView>, PamReadError> {
         let response = self
             .api_configurations
             .api_client
@@ -45,7 +45,7 @@ impl LeasesClient {
     }
 
     /// Lists all of the caller's leases, active or not.
-    pub async fn list_mine(&self) -> Result<Vec<AccessLeaseView>, AccessLeaseError> {
+    pub async fn list_mine(&self) -> Result<Vec<AccessLeaseView>, PamReadError> {
         let response = self
             .api_configurations
             .api_client
@@ -67,7 +67,7 @@ impl LeasesClient {
         &self,
         lease_id: AccessLeaseId,
         request: AccessLeaseExtensionRequest,
-    ) -> Result<AccessRequestView, AccessLeaseError> {
+    ) -> Result<AccessRequestView, AccessLeaseExtendError> {
         let response = self
             .api_configurations
             .api_client
@@ -83,7 +83,7 @@ impl LeasesClient {
         &self,
         lease_id: AccessLeaseId,
         request: AccessLeaseRevokeRequest,
-    ) -> Result<(), AccessLeaseError> {
+    ) -> Result<(), AccessLeaseEndError> {
         self.api_configurations
             .api_client
             .leases_api()
@@ -109,12 +109,12 @@ impl LeasesClient {
     /// - The result is NEVER written to the cipher repository. Local state stays partial for the
     ///   lease's whole life, so closing and reopening the item re-reads it, and a lapsed lease
     ///   cannot leave decryptable secrets behind in state.
-    /// - It is the read that a lease authorizes, so it fails with the same [`AccessLeaseError`] as
-    ///   the rest of this client.
+    /// - It is the read that a lease authorizes, so it fails with [`LeasedCipherError`] rather than
+    ///   as the rest of this client.
     pub async fn leased_cipher(
         &self,
         cipher_id: CipherId,
-    ) -> Result<Option<CipherView>, AccessLeaseError> {
+    ) -> Result<Option<CipherView>, LeasedCipherError> {
         let response = self
             .api_configurations
             .api_client
@@ -237,7 +237,7 @@ mod tests {
 
         let result = client(api_client).list_mine().await;
 
-        assert!(matches!(result, Err(AccessLeaseError::Api(_))));
+        assert!(matches!(result, Err(PamReadError::Api(_))));
     }
 
     #[tokio::test]
@@ -355,6 +355,6 @@ mod tests {
 
         let result = client(api_client).leased_cipher(cipher_id()).await;
 
-        assert!(matches!(result, Err(AccessLeaseError::Api(_))));
+        assert!(matches!(result, Err(LeasedCipherError::Api(_))));
     }
 }

--- a/bitwarden_license/bitwarden-pam/src/leases/error.rs
+++ b/bitwarden_license/bitwarden-pam/src/leases/error.rs
@@ -4,7 +4,7 @@ use bitwarden_error::bitwarden_error;
 use bitwarden_vault::VaultParseError;
 use thiserror::Error;
 
-use crate::error::PamDecodeError;
+use crate::{error::PamDecodeError, problem};
 
 /// Errors returned from [`super::LeasesClient`] operations.
 ///
@@ -16,19 +16,110 @@ use crate::error::PamDecodeError;
 /// [`VaultParse`](Self::VaultParse) and [`Crypto`](Self::Crypto) are reachable only from
 /// [`leased_cipher`](super::LeasesClient::leased_cipher), the one call that reads a vault payload
 /// rather than a leasing one.
+///
+/// The named server failures each correspond to one stable code in the server's problem response;
+/// see [`from_code`](Self::from_code) for the mapping. A code this SDK version does not recognize
+/// stays [`Api`](Self::Api), so a server that grows one never needs a client release to be safe.
 #[bitwarden_error(flat)]
 #[derive(Debug, Error)]
 pub enum AccessLeaseError {
     /// A server response could not be decoded into the requested type.
     #[error(transparent)]
     Decode(#[from] PamDecodeError),
+    /// The lease has ended - revoked, cancelled or lapsed - so there is nothing to extend or end.
+    #[error("This lease is no longer active")]
+    NotActive,
+    /// No access rule governs the cipher any more, and an extension reuses the cipher's governing
+    /// rule.
+    #[error("This item does not require a lease")]
+    CipherNotGated,
+    /// The cipher's governing rule does not opt in to extensions.
+    #[error("This item does not allow extending a lease")]
+    ExtensionsNotAllowed,
+    /// The requested extension is absent, zero or negative.
+    #[error("A positive duration is required")]
+    DurationMustBePositive,
+    /// The requested extension is longer than the governing rule's maximum extension length.
+    #[error("The requested duration exceeds the maximum extension length for this item")]
+    ExtensionExceedsMax,
+    /// An extension is recorded against the audit trail, so it has to say why it was taken.
+    #[error("A justification is required to extend a lease")]
+    ExtensionReasonRequired,
+    /// A lease may be extended exactly once, and this one already has been.
+    #[error("This lease has already been extended")]
+    AlreadyExtended,
+
     /// A cipher payload could not be parsed into the SDK's vault model.
     #[error(transparent)]
     VaultParse(#[from] VaultParseError),
     /// A leased cipher could not be decrypted.
     #[error(transparent)]
     Crypto(#[from] CryptoError),
-    /// A network or (de)serialization error occurred while calling the server.
+    /// A network or (de)serialization error occurred while calling the server, or the server
+    /// refused with a code this SDK version does not recognize.
     #[error(transparent)]
-    Api(#[from] ApiError),
+    Api(ApiError),
+}
+
+impl AccessLeaseError {
+    /// The server's codes, in the order the lease surface can produce them.
+    fn from_code(code: &str) -> Option<Self> {
+        Some(match code {
+            "access_lease_not_active" => Self::NotActive,
+            "cipher_not_gated" => Self::CipherNotGated,
+            "extensions_not_allowed" => Self::ExtensionsNotAllowed,
+            "duration_must_be_positive" => Self::DurationMustBePositive,
+            "extension_exceeds_max" => Self::ExtensionExceedsMax,
+            "extension_reason_required" => Self::ExtensionReasonRequired,
+            "access_lease_already_extended" => Self::AlreadyExtended,
+            _ => return None,
+        })
+    }
+}
+
+/// Classifies every failed call on this surface, so a caller gets the typed variant whichever
+/// method it came from.
+impl From<ApiError> for AccessLeaseError {
+    fn from(error: ApiError) -> Self {
+        problem::classify(&error, Self::from_code).unwrap_or(Self::Api(error))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use bitwarden_api_api::ResponseContent;
+    use reqwest::StatusCode;
+
+    use super::*;
+
+    fn problem(code: &str) -> ApiError {
+        ApiError::Response(ResponseContent {
+            status: StatusCode::BAD_REQUEST,
+            message: format!(r#"{{"errors":{{"code":[{{"type":"{code}"}}]}}}}"#),
+        })
+    }
+
+    #[test]
+    fn an_extension_failure_becomes_its_own_variant() {
+        let error: AccessLeaseError = problem("extension_exceeds_max").into();
+
+        assert!(matches!(error, AccessLeaseError::ExtensionExceedsMax));
+    }
+
+    #[test]
+    fn a_code_shared_with_the_request_surface_maps_to_this_surfaces_variant() {
+        // `duration_must_be_positive` means the same thing wherever it is raised, so both surfaces
+        // name it - each in its own enum, because a caller only sees the failures its call can
+        // make.
+        let error: AccessLeaseError = problem("duration_must_be_positive").into();
+
+        assert!(matches!(error, AccessLeaseError::DurationMustBePositive));
+    }
+
+    #[test]
+    fn an_unrecognized_code_stays_untyped() {
+        let error: AccessLeaseError = problem("invented_next_year").into();
+
+        assert!(matches!(error, AccessLeaseError::Api(_)));
+    }
 }

--- a/bitwarden_license/bitwarden-pam/src/leases/error.rs
+++ b/bitwarden_license/bitwarden-pam/src/leases/error.rs
@@ -1,3 +1,16 @@
+//! Each write on the lease surface names the failures that one call can produce. The sets come
+//! from the server: `RequestLeaseExtensionCommand` backs [`extend`](super::LeasesClient::extend)
+//! and `RevokeAccessLeaseCommand` backs [`end`](super::LeasesClient::end), so the `from_code`
+//! tables below are transcribed from those rather than inferred.
+//!
+//! The two list calls use [`PamReadError`](crate::PamReadError).
+//! [`leased_cipher`](super::LeasesClient::leased_cipher) is the one call that reads a vault payload
+//! rather than a leasing one, so it has its own error naming the crypto failures the others cannot
+//! produce.
+//!
+//! A code this SDK version does not recognize stays `Api` on every one of these, so a server that
+//! grows a code never needs a client release to be safe.
+
 use bitwarden_core::ApiError;
 use bitwarden_crypto::CryptoError;
 use bitwarden_error::bitwarden_error;
@@ -6,27 +19,11 @@ use thiserror::Error;
 
 use crate::{error::PamDecodeError, problem};
 
-/// Errors returned from [`super::LeasesClient`] operations.
-///
-/// The lease surface has no local validation and no write-side enum narrowing, so it mostly carries
-/// the decode and transport variants every PAM call can produce. It decodes access-request payloads
-/// as well as lease payloads, because [`extend`](super::LeasesClient::extend) returns the updated
-/// [`AccessRequestView`](crate::AccessRequestView).
-///
-/// [`VaultParse`](Self::VaultParse) and [`Crypto`](Self::Crypto) are reachable only from
-/// [`leased_cipher`](super::LeasesClient::leased_cipher), the one call that reads a vault payload
-/// rather than a leasing one.
-///
-/// The named server failures each correspond to one stable code in the server's problem response;
-/// see [`from_code`](Self::from_code) for the mapping. A code this SDK version does not recognize
-/// stays [`Api`](Self::Api), so a server that grows one never needs a client release to be safe.
+/// Errors from [`LeasesClient::extend`](super::LeasesClient::extend).
 #[bitwarden_error(flat)]
 #[derive(Debug, Error)]
-pub enum AccessLeaseError {
-    /// A server response could not be decoded into the requested type.
-    #[error(transparent)]
-    Decode(#[from] PamDecodeError),
-    /// The lease has ended - revoked, cancelled or lapsed - so there is nothing to extend or end.
+pub enum AccessLeaseExtendError {
+    /// The lease has ended - revoked, cancelled or lapsed - so there is nothing to extend.
     #[error("This lease is no longer active")]
     NotActive,
     /// No access rule governs the cipher any more, and an extension reuses the cipher's governing
@@ -49,20 +46,18 @@ pub enum AccessLeaseError {
     #[error("This lease has already been extended")]
     AlreadyExtended,
 
-    /// A cipher payload could not be parsed into the SDK's vault model.
+    /// A server response could not be decoded into the requested type. Extending returns the
+    /// updated [`AccessRequestView`](crate::AccessRequestView), so it decodes a request payload.
     #[error(transparent)]
-    VaultParse(#[from] VaultParseError),
-    /// A leased cipher could not be decrypted.
-    #[error(transparent)]
-    Crypto(#[from] CryptoError),
+    Decode(#[from] PamDecodeError),
     /// A network or (de)serialization error occurred while calling the server, or the server
     /// refused with a code this SDK version does not recognize.
     #[error(transparent)]
     Api(ApiError),
 }
 
-impl AccessLeaseError {
-    /// The server's codes, in the order the lease surface can produce them.
+impl AccessLeaseExtendError {
+    /// The codes `RequestLeaseExtensionCommand` can return.
     fn from_code(code: &str) -> Option<Self> {
         Some(match code {
             "access_lease_not_active" => Self::NotActive,
@@ -77,11 +72,71 @@ impl AccessLeaseError {
     }
 }
 
-/// Classifies every failed call on this surface, so a caller gets the typed variant whichever
-/// method it came from.
-impl From<ApiError> for AccessLeaseError {
+impl From<ApiError> for AccessLeaseExtendError {
     fn from(error: ApiError) -> Self {
         problem::classify(&error, Self::from_code).unwrap_or(Self::Api(error))
+    }
+}
+
+/// Errors from [`LeasesClient::end`](super::LeasesClient::end).
+///
+/// Ending a lease decodes nothing and has one refusal: the lease was not active to begin with.
+#[bitwarden_error(flat)]
+#[derive(Debug, Error)]
+pub enum AccessLeaseEndError {
+    /// The lease has ended - revoked, cancelled or lapsed - so there is nothing to end.
+    #[error("This lease is no longer active")]
+    NotActive,
+
+    /// A network or (de)serialization error occurred while calling the server, or the server
+    /// refused with a code this SDK version does not recognize.
+    #[error(transparent)]
+    Api(ApiError),
+}
+
+impl AccessLeaseEndError {
+    /// The codes `RevokeAccessLeaseCommand` can return. `access_lease_not_active` is the one code
+    /// the server deliberately shares between ending and extending - the same condition reached
+    /// from two endpoints - so it appears here and on
+    /// [`AccessLeaseExtendError`](AccessLeaseExtendError::NotActive) both.
+    fn from_code(code: &str) -> Option<Self> {
+        Some(match code {
+            "access_lease_not_active" => Self::NotActive,
+            _ => return None,
+        })
+    }
+}
+
+impl From<ApiError> for AccessLeaseEndError {
+    fn from(error: ApiError) -> Self {
+        problem::classify(&error, Self::from_code).unwrap_or(Self::Api(error))
+    }
+}
+
+/// Errors from [`LeasesClient::leased_cipher`](super::LeasesClient::leased_cipher).
+///
+/// The one PAM call that decrypts a vault payload, so it is the only one that can fail on crypto.
+/// The server refuses a cipher the lease does not cover with a `404`, which carries no code.
+#[bitwarden_error(flat)]
+#[derive(Debug, Error)]
+pub enum LeasedCipherError {
+    /// A cipher payload could not be parsed into the SDK's vault model.
+    #[error(transparent)]
+    VaultParse(#[from] VaultParseError),
+    /// A leased cipher could not be decrypted.
+    #[error(transparent)]
+    Crypto(#[from] CryptoError),
+    /// A server response could not be decoded into the requested type.
+    #[error(transparent)]
+    Decode(#[from] PamDecodeError),
+    /// A network or (de)serialization error occurred while calling the server.
+    #[error(transparent)]
+    Api(ApiError),
+}
+
+impl From<ApiError> for LeasedCipherError {
+    fn from(error: ApiError) -> Self {
+        Self::Api(error)
     }
 }
 
@@ -101,25 +156,45 @@ mod tests {
 
     #[test]
     fn an_extension_failure_becomes_its_own_variant() {
-        let error: AccessLeaseError = problem("extension_exceeds_max").into();
+        let error: AccessLeaseExtendError = problem("extension_exceeds_max").into();
 
-        assert!(matches!(error, AccessLeaseError::ExtensionExceedsMax));
+        assert!(matches!(error, AccessLeaseExtendError::ExtensionExceedsMax));
     }
 
     #[test]
-    fn a_code_shared_with_the_request_surface_maps_to_this_surfaces_variant() {
-        // `duration_must_be_positive` means the same thing wherever it is raised, so both surfaces
+    fn a_code_shared_with_the_request_surface_maps_to_this_calls_variant() {
+        // `duration_must_be_positive` means the same thing wherever it is raised, so both calls
         // name it - each in its own enum, because a caller only sees the failures its call can
         // make.
-        let error: AccessLeaseError = problem("duration_must_be_positive").into();
+        let error: AccessLeaseExtendError = problem("duration_must_be_positive").into();
 
-        assert!(matches!(error, AccessLeaseError::DurationMustBePositive));
+        assert!(matches!(
+            error,
+            AccessLeaseExtendError::DurationMustBePositive
+        ));
+    }
+
+    #[test]
+    fn the_shared_not_active_code_is_named_by_both_lease_writes() {
+        let extending: AccessLeaseExtendError = problem("access_lease_not_active").into();
+        let ending: AccessLeaseEndError = problem("access_lease_not_active").into();
+
+        assert!(matches!(extending, AccessLeaseExtendError::NotActive));
+        assert!(matches!(ending, AccessLeaseEndError::NotActive));
+    }
+
+    /// Ending a lease cannot produce an extension's refusals, so its classifier must not name them.
+    #[test]
+    fn ending_does_not_classify_an_extension_code() {
+        let error: AccessLeaseEndError = problem("extension_exceeds_max").into();
+
+        assert!(matches!(error, AccessLeaseEndError::Api(_)));
     }
 
     #[test]
     fn an_unrecognized_code_stays_untyped() {
-        let error: AccessLeaseError = problem("invented_next_year").into();
+        let error: AccessLeaseExtendError = problem("invented_next_year").into();
 
-        assert!(matches!(error, AccessLeaseError::Api(_)));
+        assert!(matches!(error, AccessLeaseExtendError::Api(_)));
     }
 }

--- a/bitwarden_license/bitwarden-pam/src/leases/error.rs
+++ b/bitwarden_license/bitwarden-pam/src/leases/error.rs
@@ -1,21 +1,33 @@
 use bitwarden_core::ApiError;
+use bitwarden_crypto::CryptoError;
 use bitwarden_error::bitwarden_error;
+use bitwarden_vault::VaultParseError;
 use thiserror::Error;
 
 use crate::error::PamDecodeError;
 
 /// Errors returned from [`super::LeasesClient`] operations.
 ///
-/// The lease surface has no local validation and no write-side enum narrowing, so it carries only
+/// The lease surface has no local validation and no write-side enum narrowing, so it mostly carries
 /// the decode and transport variants every PAM call can produce. It decodes access-request payloads
 /// as well as lease payloads, because [`extend`](super::LeasesClient::extend) returns the updated
 /// [`AccessRequestView`](crate::AccessRequestView).
+///
+/// [`VaultParse`](Self::VaultParse) and [`Crypto`](Self::Crypto) are reachable only from
+/// [`leased_cipher`](super::LeasesClient::leased_cipher), the one call that reads a vault payload
+/// rather than a leasing one.
 #[bitwarden_error(flat)]
 #[derive(Debug, Error)]
 pub enum AccessLeaseError {
     /// A server response could not be decoded into the requested type.
     #[error(transparent)]
     Decode(#[from] PamDecodeError),
+    /// A cipher payload could not be parsed into the SDK's vault model.
+    #[error(transparent)]
+    VaultParse(#[from] VaultParseError),
+    /// A leased cipher could not be decrypted.
+    #[error(transparent)]
+    Crypto(#[from] CryptoError),
     /// A network or (de)serialization error occurred while calling the server.
     #[error(transparent)]
     Api(#[from] ApiError),

--- a/bitwarden_license/bitwarden-pam/src/leases/error.rs
+++ b/bitwarden_license/bitwarden-pam/src/leases/error.rs
@@ -1,0 +1,22 @@
+use bitwarden_core::ApiError;
+use bitwarden_error::bitwarden_error;
+use thiserror::Error;
+
+use crate::error::PamDecodeError;
+
+/// Errors returned from [`super::LeasesClient`] operations.
+///
+/// The lease surface has no local validation and no write-side enum narrowing, so it carries only
+/// the decode and transport variants every PAM call can produce. It decodes access-request payloads
+/// as well as lease payloads, because [`extend`](super::LeasesClient::extend) returns the updated
+/// [`AccessRequestView`](crate::AccessRequestView).
+#[bitwarden_error(flat)]
+#[derive(Debug, Error)]
+pub enum AccessLeaseError {
+    /// A server response could not be decoded into the requested type.
+    #[error(transparent)]
+    Decode(#[from] PamDecodeError),
+    /// A network or (de)serialization error occurred while calling the server.
+    #[error(transparent)]
+    Api(#[from] ApiError),
+}

--- a/bitwarden_license/bitwarden-pam/src/leases/mod.rs
+++ b/bitwarden_license/bitwarden-pam/src/leases/mod.rs
@@ -17,7 +17,7 @@ mod error;
 mod models;
 
 pub use client::LeasesClient;
-pub use error::AccessLeaseError;
+pub use error::{AccessLeaseEndError, AccessLeaseExtendError, LeasedCipherError};
 pub use models::{
     AccessLeaseExtensionRequest, AccessLeaseRevokeRequest, AccessLeaseStatus,
     AccessLeaseTermination, AccessLeaseView,

--- a/bitwarden_license/bitwarden-pam/src/leases/mod.rs
+++ b/bitwarden_license/bitwarden-pam/src/leases/mod.rs
@@ -13,9 +13,12 @@
 //! [`AccessRequestsClient::activate`](crate::AccessRequestsClient::activate).
 
 mod client;
+mod error;
 mod models;
 
 pub use client::LeasesClient;
+pub use error::AccessLeaseError;
 pub use models::{
-    AccessLeaseExtensionRequest, AccessLeaseRevokeRequest, AccessLeaseStatus, AccessLeaseView,
+    AccessLeaseExtensionRequest, AccessLeaseRevokeRequest, AccessLeaseStatus,
+    AccessLeaseTermination, AccessLeaseView,
 };

--- a/bitwarden_license/bitwarden-pam/src/leases/models.rs
+++ b/bitwarden_license/bitwarden-pam/src/leases/models.rs
@@ -12,7 +12,7 @@ use serde::{Deserialize, Serialize};
 #[cfg(feature = "wasm")]
 use tsify::Tsify;
 
-use crate::{AccessLeaseId, AccessRequestId, error::LeasingError};
+use crate::{AccessLeaseId, AccessRequestId, error::PamDecodeError};
 
 /// The lifecycle state of an access lease.
 #[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq)]
@@ -73,26 +73,59 @@ pub struct AccessLeaseView {
     pub not_before: DateTime<Utc>,
     /// When the lease's access window closes (UTC).
     pub not_after: DateTime<Utc>,
-    /// When the lease was revoked early (UTC); None unless it was revoked before expiry.
-    pub revoked_at: Option<DateTime<Utc>>,
-    /// The user who revoked the lease; None unless it was revoked early.
-    pub revoked_by_user_id: Option<UserId>,
-    /// Whether the holder ended their own lease, as opposed to an operator revoking it. `false`
-    /// for a lease that was never revoked. This exists because
-    /// [`AccessLeaseStatus::Revoked`] alone can't tell the two apart - it covers both a
-    /// self-service end and an operator-initiated revoke - so callers no longer need to infer it
-    /// by scanning the originating request's decision log for a human `deny` whose decider id
-    /// matches the requester.
-    pub ended_by_holder: bool,
+    /// How the lease's access ended ahead of its window, or None if it ran to
+    /// [`Expired`](AccessLeaseStatus::Expired) or is still [`Active`](AccessLeaseStatus::Active).
+    ///
+    /// This carries what [`AccessLeaseStatus::Revoked`] cannot: that status covers both a
+    /// self-service end and an operator-initiated revoke, and callers had to tell them apart by
+    /// scanning the originating request's decision log for a human `deny` whose decider id matched
+    /// the requester. Modelling it as an enum also makes the incoherent states unrepresentable -
+    /// a revoker with no revocation time, or a self-end attributed to another user.
+    pub termination: Option<AccessLeaseTermination>,
+}
+
+/// How an access lease's grant ended before its window closed.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "wasm", derive(Tsify), tsify(into_wasm_abi, from_wasm_abi))]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum AccessLeaseTermination {
+    /// The holder ended their own lease.
+    EndedByHolder {
+        /// When the holder ended it (UTC).
+        at: DateTime<Utc>,
+    },
+    /// An operator revoked the lease out from under the holder.
+    Revoked {
+        /// When it was revoked (UTC).
+        at: DateTime<Utc>,
+        /// The operator who revoked it. None when the server did not attribute the revocation.
+        by_user_id: Option<UserId>,
+    },
 }
 
 impl TryFrom<AccessLeaseResponseModel> for AccessLeaseView {
-    type Error = LeasingError;
+    type Error = PamDecodeError;
 
     fn try_from(response: AccessLeaseResponseModel) -> Result<Self, Self::Error> {
         let requester_id = UserId::new(require!(response.requester_id));
         let revoked_by_user_id = response.revoked_by_user_id.map(UserId::new);
-        let ended_by_holder = revoked_by_user_id == Some(requester_id);
+        // `revoked_at` is the authoritative marker that access was cut short: a revoker id without
+        // a revocation time is incoherent server data, and treating it as "not terminated" keeps
+        // the lease readable rather than failing the whole list.
+        let termination = response
+            .revoked_at
+            .map(|at| at.parse())
+            .transpose()?
+            .map(|at| {
+                if revoked_by_user_id == Some(requester_id) {
+                    AccessLeaseTermination::EndedByHolder { at }
+                } else {
+                    AccessLeaseTermination::Revoked {
+                        at,
+                        by_user_id: revoked_by_user_id,
+                    }
+                }
+            });
 
         Ok(Self {
             id: AccessLeaseId::new(require!(response.id)),
@@ -104,9 +137,7 @@ impl TryFrom<AccessLeaseResponseModel> for AccessLeaseView {
             status: AccessLeaseStatus::from(require!(response.status)),
             not_before: require!(response.not_before).parse()?,
             not_after: require!(response.not_after).parse()?,
-            revoked_at: response.revoked_at.map(|d| d.parse()).transpose()?,
-            revoked_by_user_id,
-            ended_by_holder,
+            termination,
         })
     }
 }
@@ -189,7 +220,7 @@ mod tests {
     }
 
     #[test]
-    fn ended_by_holder_is_true_when_revoker_is_the_requester() {
+    fn termination_is_ended_by_holder_when_revoker_is_the_requester() {
         let response = AccessLeaseResponseModel {
             revoked_at: Some("2025-01-01T00:30:00Z".to_string()),
             revoked_by_user_id: Some(requester_id()),
@@ -198,11 +229,16 @@ mod tests {
 
         let view = AccessLeaseView::try_from(response).unwrap();
 
-        assert!(view.ended_by_holder);
+        assert_eq!(
+            view.termination,
+            Some(AccessLeaseTermination::EndedByHolder {
+                at: "2025-01-01T00:30:00Z".parse().unwrap()
+            })
+        );
     }
 
     #[test]
-    fn ended_by_holder_is_false_when_revoker_is_an_operator() {
+    fn termination_is_revoked_when_revoker_is_an_operator() {
         let response = AccessLeaseResponseModel {
             revoked_at: Some("2025-01-01T00:30:00Z".to_string()),
             revoked_by_user_id: Some(uuid!("99999999-9999-9999-9999-999999999999")),
@@ -211,11 +247,51 @@ mod tests {
 
         let view = AccessLeaseView::try_from(response).unwrap();
 
-        assert!(!view.ended_by_holder);
+        assert_eq!(
+            view.termination,
+            Some(AccessLeaseTermination::Revoked {
+                at: "2025-01-01T00:30:00Z".parse().unwrap(),
+                by_user_id: Some(UserId::new(uuid!("99999999-9999-9999-9999-999999999999"))),
+            })
+        );
     }
 
     #[test]
-    fn ended_by_holder_is_false_when_the_lease_was_never_revoked() {
+    fn termination_is_revoked_with_no_attribution_when_the_server_omits_the_revoker() {
+        let response = AccessLeaseResponseModel {
+            revoked_at: Some("2025-01-01T00:30:00Z".to_string()),
+            revoked_by_user_id: None,
+            ..base_lease_response()
+        };
+
+        let view = AccessLeaseView::try_from(response).unwrap();
+
+        assert_eq!(
+            view.termination,
+            Some(AccessLeaseTermination::Revoked {
+                at: "2025-01-01T00:30:00Z".parse().unwrap(),
+                by_user_id: None,
+            })
+        );
+    }
+
+    #[test]
+    fn a_revoker_without_a_revocation_time_is_not_a_termination() {
+        // Incoherent server data: `revoked_at` is the authoritative marker, so the lease stays
+        // readable rather than failing the whole list.
+        let response = AccessLeaseResponseModel {
+            revoked_at: None,
+            revoked_by_user_id: Some(requester_id()),
+            ..base_lease_response()
+        };
+
+        let view = AccessLeaseView::try_from(response).unwrap();
+
+        assert_eq!(view.termination, None);
+    }
+
+    #[test]
+    fn termination_is_none_when_the_lease_was_never_revoked() {
         let response = AccessLeaseResponseModel {
             status: Some(ApiAccessLeaseStatus::Active),
             revoked_at: None,
@@ -225,6 +301,6 @@ mod tests {
 
         let view = AccessLeaseView::try_from(response).unwrap();
 
-        assert!(!view.ended_by_holder);
+        assert_eq!(view.termination, None);
     }
 }

--- a/bitwarden_license/bitwarden-pam/src/leases/models.rs
+++ b/bitwarden_license/bitwarden-pam/src/leases/models.rs
@@ -77,24 +77,36 @@ pub struct AccessLeaseView {
     pub revoked_at: Option<DateTime<Utc>>,
     /// The user who revoked the lease; None unless it was revoked early.
     pub revoked_by_user_id: Option<UserId>,
+    /// Whether the holder ended their own lease, as opposed to an operator revoking it. `false`
+    /// for a lease that was never revoked. This exists because
+    /// [`AccessLeaseStatus::Revoked`] alone can't tell the two apart - it covers both a
+    /// self-service end and an operator-initiated revoke - so callers no longer need to infer it
+    /// by scanning the originating request's decision log for a human `deny` whose decider id
+    /// matches the requester.
+    pub ended_by_holder: bool,
 }
 
 impl TryFrom<AccessLeaseResponseModel> for AccessLeaseView {
     type Error = LeasingError;
 
     fn try_from(response: AccessLeaseResponseModel) -> Result<Self, Self::Error> {
+        let requester_id = UserId::new(require!(response.requester_id));
+        let revoked_by_user_id = response.revoked_by_user_id.map(UserId::new);
+        let ended_by_holder = revoked_by_user_id == Some(requester_id);
+
         Ok(Self {
             id: AccessLeaseId::new(require!(response.id)),
             request_id: AccessRequestId::new(require!(response.request_id)),
             cipher_id: CipherId::new(require!(response.cipher_id)),
             collection_id: CollectionId::new(require!(response.collection_id)),
             organization_id: response.organization_id.map(OrganizationId::new),
-            requester_id: UserId::new(require!(response.requester_id)),
+            requester_id,
             status: AccessLeaseStatus::from(require!(response.status)),
             not_before: require!(response.not_before).parse()?,
             not_after: require!(response.not_after).parse()?,
             revoked_at: response.revoked_at.map(|d| d.parse()).transpose()?,
-            revoked_by_user_id: response.revoked_by_user_id.map(UserId::new),
+            revoked_by_user_id,
+            ended_by_holder,
         })
     }
 }
@@ -141,6 +153,8 @@ impl From<AccessLeaseRevokeRequest> for AccessLeaseRevokeRequestModel {
 mod tests {
     use std::num::NonZeroU32;
 
+    use uuid::uuid;
+
     use super::*;
 
     #[test]
@@ -154,5 +168,63 @@ mod tests {
 
         assert_eq!(model.duration_seconds, Some(3600));
         assert_eq!(model.reason, "Need more time".to_string());
+    }
+
+    fn requester_id() -> uuid::Uuid {
+        uuid!("88888888-8888-8888-8888-888888888888")
+    }
+
+    fn base_lease_response() -> AccessLeaseResponseModel {
+        AccessLeaseResponseModel {
+            id: Some(uuid!("33333333-3333-3333-3333-333333333333")),
+            request_id: Some(uuid!("44444444-4444-4444-4444-444444444444")),
+            cipher_id: Some(uuid!("55555555-5555-5555-5555-555555555555")),
+            collection_id: Some(uuid!("66666666-6666-6666-6666-666666666666")),
+            requester_id: Some(requester_id()),
+            status: Some(ApiAccessLeaseStatus::Revoked),
+            not_before: Some("2025-01-01T00:00:00Z".to_string()),
+            not_after: Some("2025-01-01T01:00:00Z".to_string()),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn ended_by_holder_is_true_when_revoker_is_the_requester() {
+        let response = AccessLeaseResponseModel {
+            revoked_at: Some("2025-01-01T00:30:00Z".to_string()),
+            revoked_by_user_id: Some(requester_id()),
+            ..base_lease_response()
+        };
+
+        let view = AccessLeaseView::try_from(response).unwrap();
+
+        assert!(view.ended_by_holder);
+    }
+
+    #[test]
+    fn ended_by_holder_is_false_when_revoker_is_an_operator() {
+        let response = AccessLeaseResponseModel {
+            revoked_at: Some("2025-01-01T00:30:00Z".to_string()),
+            revoked_by_user_id: Some(uuid!("99999999-9999-9999-9999-999999999999")),
+            ..base_lease_response()
+        };
+
+        let view = AccessLeaseView::try_from(response).unwrap();
+
+        assert!(!view.ended_by_holder);
+    }
+
+    #[test]
+    fn ended_by_holder_is_false_when_the_lease_was_never_revoked() {
+        let response = AccessLeaseResponseModel {
+            status: Some(ApiAccessLeaseStatus::Active),
+            revoked_at: None,
+            revoked_by_user_id: None,
+            ..base_lease_response()
+        };
+
+        let view = AccessLeaseView::try_from(response).unwrap();
+
+        assert!(!view.ended_by_holder);
     }
 }

--- a/bitwarden_license/bitwarden-pam/src/lib.rs
+++ b/bitwarden_license/bitwarden-pam/src/lib.rs
@@ -18,6 +18,7 @@ pub use access_requests::{
     AccessPreCheckView, AccessRequestCreateRequest, AccessRequestDecisionView, AccessRequestError,
     AccessRequestResultView, AccessRequestStatus, AccessRequestSummaryView, AccessRequestView,
     AccessRequestWindowError, AccessRequestsClient, CipherAccessStateView,
+    MAX_REQUEST_ACCESS_WINDOW_SECONDS, max_request_access_window_seconds,
 };
 pub use access_rules::{
     AccessCondition, AccessRuleAddEditRequest, AccessRuleError, AccessRuleValidationError,

--- a/bitwarden_license/bitwarden-pam/src/lib.rs
+++ b/bitwarden_license/bitwarden-pam/src/lib.rs
@@ -18,7 +18,8 @@ pub use access_requests::{
     AccessPreCheckView, AccessRequestCreateRequest, AccessRequestDecisionView, AccessRequestError,
     AccessRequestResultView, AccessRequestStatus, AccessRequestSummaryView, AccessRequestView,
     AccessRequestWindowError, AccessRequestsClient, CipherAccessStateView,
-    MAX_REQUEST_ACCESS_WINDOW_SECONDS, max_request_access_window_seconds,
+    DEFAULT_REQUEST_ACCESS_DURATION_SECONDS, MAX_REQUEST_ACCESS_WINDOW_SECONDS,
+    default_request_access_duration_seconds, max_request_access_window_seconds,
 };
 pub use access_rules::{
     AccessCondition, AccessRuleAddEditRequest, AccessRuleError, AccessRuleValidationError,

--- a/bitwarden_license/bitwarden-pam/src/lib.rs
+++ b/bitwarden_license/bitwarden-pam/src/lib.rs
@@ -16,20 +16,23 @@ uuid_newtype!(pub AccessRuleId);
 
 pub use access_requests::{
     AccessApprovalMode, AccessApprover, AccessBadgeState, AccessDecider, AccessDecisionVerdict,
-    AccessPreCheckView, AccessRequestCreateRequest, AccessRequestDecisionView, AccessRequestError,
-    AccessRequestResultView, AccessRequestStatus, AccessRequestSummaryView, AccessRequestView,
+    AccessPreCheckView, AccessRequestActivateError, AccessRequestCancelError,
+    AccessRequestCreateRequest, AccessRequestDecisionView, AccessRequestResultView,
+    AccessRequestStatus, AccessRequestSubmitError, AccessRequestSummaryView, AccessRequestView,
     AccessRequestWindowError, AccessRequestsClient, CipherAccessStateView,
     DEFAULT_REQUEST_ACCESS_DURATION_SECONDS, MAX_REQUEST_ACCESS_WINDOW_SECONDS,
     default_request_access_duration_seconds, max_request_access_window_seconds,
 };
 pub use access_rules::{
-    AccessCondition, AccessRuleAddEditRequest, AccessRuleError, AccessRuleValidationError,
-    AccessRuleView, AccessRulesClient, is_valid_cidr,
+    AccessCondition, AccessRuleAddEditRequest, AccessRuleDecodeError, AccessRuleDeleteError,
+    AccessRuleReadError, AccessRuleValidationError, AccessRuleView, AccessRuleWriteError,
+    AccessRulesClient, is_valid_cidr,
 };
-pub use approvals::{AccessDecisionRequest, ApprovalError, ApprovalsClient};
-pub use error::PamDecodeError;
+pub use approvals::{AccessDecisionError, AccessDecisionRequest, ApprovalsClient};
+pub use error::{PamDecodeError, PamReadError};
 pub use leases::{
-    AccessLeaseError, AccessLeaseExtensionRequest, AccessLeaseRevokeRequest, AccessLeaseStatus,
-    AccessLeaseTermination, AccessLeaseView, LeasesClient,
+    AccessLeaseEndError, AccessLeaseExtendError, AccessLeaseExtensionRequest,
+    AccessLeaseRevokeRequest, AccessLeaseStatus, AccessLeaseTermination, AccessLeaseView,
+    LeasedCipherError, LeasesClient,
 };
 pub use pam_client::{PamClient, PamClientExt};

--- a/bitwarden_license/bitwarden-pam/src/lib.rs
+++ b/bitwarden_license/bitwarden-pam/src/lib.rs
@@ -14,10 +14,10 @@ uuid_newtype!(pub AccessRequestId);
 uuid_newtype!(pub AccessRuleId);
 
 pub use access_requests::{
-    AccessApprovalMode, AccessApprover, AccessDecider, AccessDecisionVerdict, AccessPreCheckView,
-    AccessRequestCreateRequest, AccessRequestDecisionView, AccessRequestResultView,
-    AccessRequestStatus, AccessRequestSummaryView, AccessRequestView, AccessRequestsClient,
-    CipherAccessStateView,
+    AccessApprovalMode, AccessApprover, AccessBadgeState, AccessDecider, AccessDecisionVerdict,
+    AccessPreCheckView, AccessRequestCreateRequest, AccessRequestDecisionView,
+    AccessRequestResultView, AccessRequestStatus, AccessRequestSummaryView, AccessRequestView,
+    AccessRequestWindowError, AccessRequestsClient, CipherAccessStateView,
 };
 pub use access_rules::{
     AccessCondition, AccessRuleAddEditRequest, AccessRuleError, AccessRuleValidationError,

--- a/bitwarden_license/bitwarden-pam/src/lib.rs
+++ b/bitwarden_license/bitwarden-pam/src/lib.rs
@@ -8,6 +8,7 @@ mod approvals;
 mod error;
 mod leases;
 mod pam_client;
+mod problem;
 
 uuid_newtype!(pub AccessLeaseId);
 uuid_newtype!(pub AccessRequestId);

--- a/bitwarden_license/bitwarden-pam/src/lib.rs
+++ b/bitwarden_license/bitwarden-pam/src/lib.rs
@@ -15,7 +15,7 @@ uuid_newtype!(pub AccessRuleId);
 
 pub use access_requests::{
     AccessApprovalMode, AccessApprover, AccessBadgeState, AccessDecider, AccessDecisionVerdict,
-    AccessPreCheckView, AccessRequestCreateRequest, AccessRequestDecisionView,
+    AccessPreCheckView, AccessRequestCreateRequest, AccessRequestDecisionView, AccessRequestError,
     AccessRequestResultView, AccessRequestStatus, AccessRequestSummaryView, AccessRequestView,
     AccessRequestWindowError, AccessRequestsClient, CipherAccessStateView,
 };
@@ -23,10 +23,10 @@ pub use access_rules::{
     AccessCondition, AccessRuleAddEditRequest, AccessRuleError, AccessRuleValidationError,
     AccessRuleView, AccessRulesClient, is_valid_cidr,
 };
-pub use approvals::{AccessDecisionRequest, ApprovalsClient};
-pub use error::LeasingError;
+pub use approvals::{AccessDecisionRequest, ApprovalError, ApprovalsClient};
+pub use error::PamDecodeError;
 pub use leases::{
-    AccessLeaseExtensionRequest, AccessLeaseRevokeRequest, AccessLeaseStatus, AccessLeaseView,
-    LeasesClient,
+    AccessLeaseError, AccessLeaseExtensionRequest, AccessLeaseRevokeRequest, AccessLeaseStatus,
+    AccessLeaseTermination, AccessLeaseView, LeasesClient,
 };
 pub use pam_client::{PamClient, PamClientExt};

--- a/bitwarden_license/bitwarden-pam/src/lib.rs
+++ b/bitwarden_license/bitwarden-pam/src/lib.rs
@@ -4,6 +4,7 @@ use bitwarden_uuid::uuid_newtype;
 
 mod access_requests;
 mod access_rules;
+mod approvals;
 mod error;
 mod leases;
 mod pam_client;
@@ -22,6 +23,7 @@ pub use access_rules::{
     AccessCondition, AccessRuleAddEditRequest, AccessRuleError, AccessRuleValidationError,
     AccessRuleView, AccessRulesClient, is_valid_cidr,
 };
+pub use approvals::{AccessDecisionRequest, ApprovalsClient};
 pub use error::LeasingError;
 pub use leases::{
     AccessLeaseExtensionRequest, AccessLeaseRevokeRequest, AccessLeaseStatus, AccessLeaseView,

--- a/bitwarden_license/bitwarden-pam/src/pam_client.rs
+++ b/bitwarden_license/bitwarden-pam/src/pam_client.rs
@@ -5,7 +5,8 @@ use bitwarden_core::{Client, FromClient, client::ApiConfigurations};
 use wasm_bindgen::prelude::*;
 
 use crate::{
-    access_requests::AccessRequestsClient, access_rules::AccessRulesClient, leases::LeasesClient,
+    access_requests::AccessRequestsClient, access_rules::AccessRulesClient,
+    approvals::ApprovalsClient, leases::LeasesClient,
 };
 
 /// Entry point for Privileged Access Management (PAM) operations.
@@ -27,6 +28,13 @@ impl PamClient {
     /// Access request operations (activate, cancel, and read the caller's requests).
     pub fn access_requests(&self) -> AccessRequestsClient {
         AccessRequestsClient {
+            api_configurations: self.api_configurations.clone(),
+        }
+    }
+
+    /// Approver-side access request operations (inbox, history, and recording a decision).
+    pub fn approvals(&self) -> ApprovalsClient {
+        ApprovalsClient {
             api_configurations: self.api_configurations.clone(),
         }
     }

--- a/bitwarden_license/bitwarden-pam/src/pam_client.rs
+++ b/bitwarden_license/bitwarden-pam/src/pam_client.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 
-use bitwarden_core::{Client, FromClient, client::ApiConfigurations};
+use bitwarden_core::{Client, FromClient, client::ApiConfigurations, key_management::KeySlotIds};
+use bitwarden_crypto::KeyStore;
 #[cfg(feature = "wasm")]
 use wasm_bindgen::prelude::*;
 
@@ -13,6 +14,9 @@ use crate::{
 #[derive(Clone, FromClient)]
 #[cfg_attr(feature = "wasm", wasm_bindgen)]
 pub struct PamClient {
+    /// Only [`LeasesClient`] needs this: reading the cipher a lease unlocks is the one PAM call
+    /// that decrypts a vault payload rather than a leasing one.
+    pub(crate) key_store: KeyStore<KeySlotIds>,
     pub(crate) api_configurations: Arc<ApiConfigurations>,
 }
 
@@ -42,6 +46,7 @@ impl PamClient {
     /// Access lease operations (read, extend, and end the caller's leases).
     pub fn leases(&self) -> LeasesClient {
         LeasesClient {
+            key_store: self.key_store.clone(),
             api_configurations: self.api_configurations.clone(),
         }
     }

--- a/bitwarden_license/bitwarden-pam/src/problem.rs
+++ b/bitwarden_license/bitwarden-pam/src/problem.rs
@@ -1,0 +1,144 @@
+//! Reading the codes out of a PAM problem response.
+//!
+//! The server answers a refused PAM request with an RFC 7807 problem whose stable, machine-readable
+//! code sits at `errors.<property>[].type`. That code is the contract - never localized, never
+//! reworded - so it, and not the human-readable `detail` beside it, is what this SDK switches on to
+//! pick a typed error variant.
+//!
+//! Lives in this crate because PAM is the first surface to speak it. Nothing here is
+//! PAM-specific; when a second crate needs it, lift it into `bitwarden-core` unchanged.
+
+use bitwarden_core::ApiError;
+use serde::Deserialize;
+
+/// The slice of an RFC 7807 body worth reading. Everything else - `type`, `title`, `status`,
+/// `detail` - is either display copy or already known from the response itself.
+#[derive(Deserialize)]
+struct ProblemBody {
+    errors: Option<std::collections::BTreeMap<String, Vec<ProblemCode>>>,
+}
+
+#[derive(Deserialize)]
+struct ProblemCode {
+    #[serde(rename = "type")]
+    code: String,
+}
+
+/// Every code the server put in the body, in a stable order.
+///
+/// Empty for a transport failure, a non-problem body, or a problem carrying no codes - all of which
+/// leave the caller with the untyped [`ApiError`] it started with. Model-state rejections are one
+/// such case: they answer with the server's older `ErrorResponseModel` body and carry no code,
+/// because a request that never bound cleanly leaves nothing for a client to act on differently.
+///
+/// A refused PAM request carries exactly one code; the signature stays plural so a body naming
+/// several fields at once does not need this to change.
+pub(crate) fn codes(error: &ApiError) -> Vec<String> {
+    let ApiError::Response(content) = error else {
+        return Vec::new();
+    };
+
+    let Ok(body) = serde_json::from_str::<ProblemBody>(&content.message) else {
+        return Vec::new();
+    };
+
+    body.errors
+        .unwrap_or_default()
+        .into_values()
+        .flatten()
+        .map(|entry| entry.code)
+        .collect()
+}
+
+/// Applies `classify` to each code the server returned, returning the first match.
+///
+/// An unrecognized code yields `None`, so a server that grows a code no client release has seen
+/// degrades to the generic transport error rather than to the wrong typed variant.
+pub(crate) fn classify<T>(error: &ApiError, classify: impl Fn(&str) -> Option<T>) -> Option<T> {
+    codes(error).iter().find_map(|code| classify(code))
+}
+
+#[cfg(test)]
+mod tests {
+    use bitwarden_api_api::ResponseContent;
+    use reqwest::StatusCode;
+
+    use super::*;
+
+    fn response(status: StatusCode, body: &str) -> ApiError {
+        ApiError::Response(ResponseContent {
+            status,
+            message: body.to_string(),
+        })
+    }
+
+    #[test]
+    fn codes_reads_the_code_out_of_a_problem_body() {
+        let error = response(
+            StatusCode::BAD_REQUEST,
+            r#"{"type":"validation_error","status":400,"errors":{"reason":[{"type":"reason_required","detail":"A reason is required."}]}}"#,
+        );
+
+        assert_eq!(codes(&error), vec!["reason_required"]);
+    }
+
+    #[test]
+    fn codes_reads_a_conflict_the_same_way_as_a_validation_failure() {
+        // The status differs so a caller that reads no further still learns something, but the body
+        // is identical - one parser covers both.
+        let error = response(
+            StatusCode::CONFLICT,
+            r#"{"type":"conflict_error","status":409,"errors":{"code":[{"type":"access_already_active","detail":"You already have active access to this item."}]}}"#,
+        );
+
+        assert_eq!(codes(&error), vec!["access_already_active"]);
+    }
+
+    #[test]
+    fn codes_reads_every_code_in_a_body_naming_several_properties() {
+        // The server sends one code per refusal today. This pins the ordering anyway, so a body
+        // that grows a second entry classifies deterministically rather than by map iteration.
+        let error = response(
+            StatusCode::BAD_REQUEST,
+            r#"{"type":"validation_error","errors":{"reason":[{"type":"reason_required","detail":"x"}],"durationSeconds":[{"type":"duration_exceeds_max","detail":"y"}]}}"#,
+        );
+
+        // Ordered by property name, so a caller matching several codes gets the same answer twice.
+        assert_eq!(
+            codes(&error),
+            vec!["duration_exceeds_max", "reason_required"]
+        );
+    }
+
+    #[test]
+    fn codes_is_empty_for_a_body_that_is_not_a_problem() {
+        // The shape a model-state rejection still answers with: no codes, so the caller keeps the
+        // generic `Api` error rather than being handed a wrong typed variant.
+        let error = response(
+            StatusCode::BAD_REQUEST,
+            r#"{"object":"error","message":"Something went wrong."}"#,
+        );
+
+        assert!(codes(&error).is_empty());
+    }
+
+    #[test]
+    fn codes_is_empty_for_a_transport_failure() {
+        let error = ApiError::Io(std::io::Error::other("connection reset"));
+
+        assert!(codes(&error).is_empty());
+    }
+
+    #[test]
+    fn classify_ignores_a_code_this_version_does_not_know() {
+        let error = response(
+            StatusCode::BAD_REQUEST,
+            r#"{"errors":{"code":[{"type":"invented_next_year"}]}}"#,
+        );
+
+        assert_eq!(
+            classify(&error, |code| (code == "reason_required").then_some(())),
+            None
+        );
+    }
+}

--- a/crates/bitwarden-api-api/src/models/access_pre_check_response_model.rs
+++ b/crates/bitwarden-api-api/src/models/access_pre_check_response_model.rs
@@ -43,6 +43,23 @@ pub struct AccessPreCheckResponseModel {
         skip_serializing_if = "Option::is_none"
     )]
     pub has_active_lease: Option<bool>,
+    /// The duration, in seconds, the request form should pre-select — the governing rule's default
+    /// when it sets one, otherwise the global default, clamped to `maxDurationSeconds`.
+    #[serde(
+        rename = "defaultDurationSeconds",
+        alias = "DefaultDurationSeconds",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub default_duration_seconds: Option<i32>,
+    /// The longest duration (automatic path) or window span (human path), in seconds, that a
+    /// request for this cipher may ask for: the governing rule's cap narrowed by the global
+    /// ceiling. Clients should offer nothing above it — submit enforces the same number.
+    #[serde(
+        rename = "maxDurationSeconds",
+        alias = "MaxDurationSeconds",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub max_duration_seconds: Option<i32>,
 }
 
 impl AccessPreCheckResponseModel {
@@ -55,6 +72,8 @@ impl AccessPreCheckResponseModel {
             cipher_id: None,
             approval_mode: None,
             has_active_lease: None,
+            default_duration_seconds: None,
+            max_duration_seconds: None,
         }
     }
 }

--- a/crates/bitwarden-crypto/src/error.rs
+++ b/crates/bitwarden-crypto/src/error.rs
@@ -32,6 +32,8 @@ pub enum CryptoError {
     KeyOperationNotSupported(KeyOperation),
     #[error("Cannot encrypt a restricted (partial) view; its secret fields were never decrypted")]
     EncryptRestrictedView,
+    #[error("A restricted (partial) cipher can only be decrypted when it is organization-owned")]
+    RestrictedCipherRequiresOrganization,
 
     // Note: These variants will be moved into their own key store error in a follow up ticket,
     // since the crypto error is growing too large

--- a/crates/bitwarden-crypto/src/error.rs
+++ b/crates/bitwarden-crypto/src/error.rs
@@ -30,6 +30,8 @@ pub enum CryptoError {
     MissingKeyId(String),
     #[error("Key operation not supported by key: {0:?}")]
     KeyOperationNotSupported(KeyOperation),
+    #[error("Cannot encrypt a restricted (partial) view; its secret fields were never decrypted")]
+    EncryptRestrictedView,
 
     // Note: These variants will be moved into their own key store error in a follow up ticket,
     // since the crypto error is growing too large

--- a/crates/bitwarden-exporters/src/lib.rs
+++ b/crates/bitwarden-exporters/src/lib.rs
@@ -258,6 +258,7 @@ impl From<ImportingCipher> for CipherView {
         };
 
         Self {
+            partial: false,
             id: None,
             organization_id: None,
             folder_id: value.folder_id.map(FolderId::new),

--- a/crates/bitwarden-exporters/src/models.rs
+++ b/crates/bitwarden-exporters/src/models.rs
@@ -274,6 +274,7 @@ mod tests {
 
         let test_id: uuid::Uuid = "fd411a1a-fec8-4070-985d-0e6560860e69".parse().unwrap();
         let view = CipherView {
+            partial: false,
             r#type: CipherType::Login,
             login: Some(LoginView {
                 username: Some("test_username".to_string()),
@@ -330,6 +331,7 @@ mod tests {
 
         let test_id: uuid::Uuid = "fd411a1a-fec8-4070-985d-0e6560860e69".parse().unwrap();
         let cipher_view = CipherView {
+            partial: false,
             r#type: CipherType::Login,
             login: Some(LoginView {
                 username: Some("test_username".to_string()),

--- a/crates/bitwarden-fido/src/authenticator.rs
+++ b/crates/bitwarden-fido/src/authenticator.rs
@@ -804,6 +804,7 @@ mod tests {
         };
 
         CipherView {
+            partial: false,
             id: Some("c2c7e624-dcfd-4f23-af41-b177014ffcb5".parse().unwrap()),
             organization_id: None,
             folder_id: None,

--- a/crates/bitwarden-user-crypto-management/src/key_rotation/data.rs
+++ b/crates/bitwarden-user-crypto-management/src/key_rotation/data.rs
@@ -224,6 +224,7 @@ mod tests {
 
     fn make_test_cipher(attachments: Option<Vec<Attachment>>) -> Cipher {
         Cipher {
+            partial_data: None,
             id: None,
             organization_id: None,
             folder_id: None,
@@ -316,6 +317,7 @@ mod tests {
     fn make_cipher_view() -> bitwarden_vault::CipherView {
         use bitwarden_vault::{CipherView, LoginView};
         CipherView {
+            partial: false,
             id: None,
             organization_id: None,
             folder_id: None,

--- a/crates/bitwarden-user-crypto-management/src/key_rotation/password_change_and_rotate_user_keys.rs
+++ b/crates/bitwarden-user-crypto-management/src/key_rotation/password_change_and_rotate_user_keys.rs
@@ -319,6 +319,7 @@ mod tests {
 
         // Add a cipher with an old attachment (key is None)
         sync.ciphers = vec![Cipher {
+            partial_data: None,
             id: None,
             organization_id: None,
             folder_id: None,

--- a/crates/bitwarden-user-crypto-management/src/key_rotation/rotate_user_keys.rs
+++ b/crates/bitwarden-user-crypto-management/src/key_rotation/rotate_user_keys.rs
@@ -743,6 +743,7 @@ mod tests {
 
         // Add a cipher with an old attachment (key is None)
         sync.ciphers = vec![Cipher {
+            partial_data: None,
             id: None,
             organization_id: None,
             folder_id: None,

--- a/crates/bitwarden-user-crypto-management/src/public_key_encryption_key_pair_regeneration/should_regenerate.rs
+++ b/crates/bitwarden-user-crypto-management/src/public_key_encryption_key_pair_regeneration/should_regenerate.rs
@@ -779,6 +779,7 @@ mod tests {
                 .encrypt(&mut ctx, cipher_key)
                 .unwrap();
             Cipher {
+                partial_data: None,
                 id: None,
                 organization_id: None,
                 folder_id: None,

--- a/crates/bitwarden-vault/src/cipher/attachment.rs
+++ b/crates/bitwarden-vault/src/cipher/attachment.rs
@@ -407,6 +407,7 @@ mod tests {
 
         let attachment_file = AttachmentFileView {
             cipher: Cipher {
+                partial_data: None,
                 id: None,
                 organization_id: None,
                 folder_id: None,
@@ -467,6 +468,7 @@ mod tests {
         };
 
         let cipher  = Cipher {
+            partial_data: None,
             id: None,
             organization_id: None,
             folder_id: None,
@@ -531,6 +533,7 @@ mod tests {
         };
 
         let cipher  = Cipher {
+            partial_data: None,
             id: None,
             organization_id: None,
             folder_id: None,

--- a/crates/bitwarden-vault/src/cipher/attachment_client/create.rs
+++ b/crates/bitwarden-vault/src/cipher/attachment_client/create.rs
@@ -273,6 +273,7 @@ mod tests {
 
     fn test_cipher() -> Cipher {
         Cipher {
+            partial_data: None,
             id: TEST_CIPHER_ID.parse().ok(),
             name: Some(TEST_CIPHER_NAME.parse().unwrap()),
             r#type: CipherType::Login,

--- a/crates/bitwarden-vault/src/cipher/attachment_client/delete.rs
+++ b/crates/bitwarden-vault/src/cipher/attachment_client/delete.rs
@@ -87,6 +87,7 @@ mod tests {
 
     fn test_cipher() -> Cipher {
         Cipher {
+            partial_data: None,
             id: TEST_CIPHER_ID.parse().ok(),
             name: Some(TEST_CIPHER_NAME.parse().unwrap()),
             r#type: CipherType::Login,

--- a/crates/bitwarden-vault/src/cipher/attachment_client/download_url.rs
+++ b/crates/bitwarden-vault/src/cipher/attachment_client/download_url.rs
@@ -144,6 +144,7 @@ mod tests {
 
     fn test_cipher() -> Cipher {
         Cipher {
+            partial_data: None,
             id: TEST_CIPHER_ID.parse().ok(),
             name: Some(TEST_CIPHER_NAME.parse().unwrap()),
             r#type: CipherType::Login,

--- a/crates/bitwarden-vault/src/cipher/attachment_client/upgrade.rs
+++ b/crates/bitwarden-vault/src/cipher/attachment_client/upgrade.rs
@@ -329,6 +329,7 @@ mod tests {
 
     fn cipher_with(name: EncString, attachments: Option<Vec<Attachment>>) -> Cipher {
         Cipher {
+            partial_data: None,
             id: TEST_CIPHER_ID.parse().ok(),
             name: Some(name),
             r#type: CipherType::Login,

--- a/crates/bitwarden-vault/src/cipher/blob/conversions/mod.rs
+++ b/crates/bitwarden-vault/src/cipher/blob/conversions/mod.rs
@@ -268,6 +268,7 @@ pub(crate) mod test_support {
 
     pub(crate) fn create_shell_cipher_view(cipher_type: CipherType) -> CipherView {
         CipherView {
+            partial: false,
             id: None,
             organization_id: None,
             folder_id: None,

--- a/crates/bitwarden-vault/src/cipher/blob/encryption.rs
+++ b/crates/bitwarden-vault/src/cipher/blob/encryption.rs
@@ -108,6 +108,7 @@ pub(crate) fn encrypt_blob_cipher_with_wrapping_key(
     let name = "".encrypt(ctx, cipher_key)?;
 
     Ok(Cipher {
+        partial_data: None,
         // Metadata
         id: view.id,
         organization_id: view.organization_id,
@@ -175,6 +176,7 @@ pub(crate) fn decrypt_blob_cipher(
     let local_data = cipher.local_data.decrypt(ctx, cipher_key).ok().flatten();
 
     let mut view = CipherView {
+        partial: false,
         // Metadata
         id: cipher.id,
         organization_id: cipher.organization_id,
@@ -250,6 +252,7 @@ mod tests {
             )
             .unwrap();
         Cipher {
+            partial_data: None,
             id: None,
             organization_id: None,
             folder_id: None,

--- a/crates/bitwarden-vault/src/cipher/blob/encryption.rs
+++ b/crates/bitwarden-vault/src/cipher/blob/encryption.rs
@@ -96,7 +96,9 @@ pub(crate) fn encrypt_blob_cipher_with_wrapping_key(
     // Fail closed: a restricted (partial) view has all secret fields stripped; re-encrypting it
     // would overwrite the item's secrets with empty values. See `decrypt_restricted_cipher_view`.
     if view.partial {
-        return Err(BlobEncryptionError::Crypto(CryptoError::EncryptRestrictedView));
+        return Err(BlobEncryptionError::Crypto(
+            CryptoError::EncryptRestrictedView,
+        ));
     }
 
     if view.key.is_none() {

--- a/crates/bitwarden-vault/src/cipher/blob/encryption.rs
+++ b/crates/bitwarden-vault/src/cipher/blob/encryption.rs
@@ -93,6 +93,12 @@ pub(crate) fn encrypt_blob_cipher_with_wrapping_key(
     ctx: &mut KeyStoreContext<KeySlotIds>,
     wrapping_key: SymmetricKeySlotId,
 ) -> Result<Cipher, BlobEncryptionError> {
+    // Fail closed: a restricted (partial) view has all secret fields stripped; re-encrypting it
+    // would overwrite the item's secrets with empty values. See `decrypt_restricted_cipher_view`.
+    if view.partial {
+        return Err(BlobEncryptionError::Crypto(CryptoError::EncryptRestrictedView));
+    }
+
     if view.key.is_none() {
         view.generate_cipher_key(ctx, wrapping_key)?;
     }

--- a/crates/bitwarden-vault/src/cipher/cipher.rs
+++ b/crates/bitwarden-vault/src/cipher/cipher.rs
@@ -33,7 +33,7 @@ use super::{
     cipher_permissions::CipherPermissions,
     drivers_license, field, identity,
     local_data::{LocalData, LocalDataView},
-    login::LoginListView,
+    login::{LoginListView, LoginUri, LoginUriView, UriMatchType},
     passport, secure_note, ssh_key,
 };
 use crate::{
@@ -340,6 +340,15 @@ pub struct Cipher {
     pub revision_date: DateTime<Utc>,
     pub archived_date: Option<DateTime<Utc>>,
     pub data: Option<String>,
+
+    /// Raw JSON envelope for a server-restricted (PAM-gated) cipher: the encrypted name and,
+    /// for logins, the encrypted URIs — every secret field is withheld by the server. Its
+    /// presence marks the cipher restricted; the decrypt path parses only these allowlisted
+    /// fields and produces a view with `partial = true`, never reading the secret payloads.
+    /// Distinct from `data` (the full sealed blob) and from the unrelated `PartialCipher`
+    /// merge trait.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub partial_data: Option<String>,
 }
 
 /// Represents the result of re-wrapping a cipher key, which can be needed when changing the
@@ -486,6 +495,12 @@ pub struct CipherView {
     pub deleted_date: Option<DateTime<Utc>>,
     pub revision_date: DateTime<Utc>,
     pub archived_date: Option<DateTime<Utc>>,
+
+    /// True when this view was produced from a server-restricted (PAM-gated) cipher: only the
+    /// name and (for logins) URIs are populated; every secret field is absent. See
+    /// [`Cipher::partial_data`].
+    #[serde(default)]
+    pub partial: bool,
 }
 
 #[allow(missing_docs)]
@@ -578,6 +593,11 @@ pub struct CipherListView {
     pub copyable_fields: Vec<CopyableCipherFields>,
 
     pub local_data: Option<LocalDataView>,
+
+    /// True when this view was produced from a server-restricted (PAM-gated) cipher: only the
+    /// name and (for logins) URIs are populated. See [`Cipher::partial_data`].
+    #[serde(default)]
+    pub partial: bool,
 
     /// Decrypted cipher notes for search indexing.
     #[cfg(feature = "wasm")]
@@ -672,6 +692,7 @@ impl CipherView {
         cipher_view.generate_checksums();
 
         Ok(Cipher {
+            partial_data: None,
             id: cipher_view.id,
             organization_id: cipher_view.organization_id,
             folder_id: cipher_view.folder_id,
@@ -740,6 +761,7 @@ pub(crate) fn lenient_decrypt_cipher_view(
         );
 
     let mut view = CipherView {
+        partial: false,
         id: cipher.id,
         organization_id: cipher.organization_id,
         folder_id: cipher.folder_id,
@@ -1161,6 +1183,7 @@ impl CipherView {
         };
 
         Ok(CipherListView {
+            partial: false,
             id: self.id,
             organization_id: self.organization_id,
             folder_id: self.folder_id,
@@ -1425,6 +1448,7 @@ pub(crate) fn lenient_decrypt_cipher_list_view(
     let ciphers_key = Cipher::decrypt_cipher_key(ctx, key, &cipher.key)?;
 
     Ok(CipherListView {
+        partial: false,
         id: cipher.id,
         organization_id: cipher.organization_id,
         folder_id: cipher.folder_id,
@@ -1523,6 +1547,207 @@ impl IdentifyKey<SymmetricKeySlotId> for Cipher {
     }
 }
 
+/// The server's reduced payload for a restricted (PAM-gated) cipher, mirroring
+/// `PartialCipherData.Strip` on the server. Deserialized with PascalCase to match the server's
+/// wire shape. This struct is the single authoritative allowlist for what a gated view may
+/// expose: the encrypted name and, for logins, the encrypted URIs — nothing else, so an
+/// over-sharing server blob can never leak a password or TOTP onto a gated view.
+#[derive(Deserialize, Default)]
+#[serde(rename_all = "PascalCase")]
+struct RestrictedCipherData {
+    name: Option<EncString>,
+    uris: Option<Vec<RestrictedLoginUri>>,
+}
+
+/// A single URI entry inside [`RestrictedCipherData`] (server PascalCase shape). Structurally a
+/// [`LoginUri`]; converted to one for decryption.
+#[derive(Deserialize)]
+#[serde(rename_all = "PascalCase")]
+struct RestrictedLoginUri {
+    uri: Option<EncString>,
+    r#match: Option<UriMatchType>,
+    uri_checksum: Option<EncString>,
+}
+
+impl From<RestrictedLoginUri> for LoginUri {
+    fn from(u: RestrictedLoginUri) -> Self {
+        LoginUri {
+            uri: u.uri,
+            r#match: u.r#match,
+            uri_checksum: u.uri_checksum,
+        }
+    }
+}
+
+/// Decrypt the allowlisted URIs from a restricted envelope. A URI that fails to decrypt is
+/// dropped rather than failing the whole cipher.
+fn decrypt_restricted_uris(
+    uris: Option<Vec<RestrictedLoginUri>>,
+    ctx: &mut KeyStoreContext<KeySlotIds>,
+    ciphers_key: SymmetricKeySlotId,
+) -> Option<Vec<LoginUriView>> {
+    uris.map(|list| {
+        list.into_iter()
+            .filter_map(|u| LoginUri::from(u).decrypt(ctx, ciphers_key).ok())
+            .collect()
+    })
+}
+
+/// Decrypt a restricted (PAM-gated) cipher into a [`CipherView`].
+///
+/// Parses `partial_data` and decrypts ONLY the allowlisted fields — the name and, for logins,
+/// the URIs. It never reads the cipher's secret payloads (`login.password`, `card`, …), which
+/// the server withholds anyway. Fail-closed: a malformed envelope or an undecryptable field
+/// degrades to empty rather than un-gating the row — the view is always `partial = true`.
+fn decrypt_restricted_cipher_view(
+    cipher: &Cipher,
+    raw: &str,
+    ctx: &mut KeyStoreContext<KeySlotIds>,
+    key: SymmetricKeySlotId,
+) -> Result<CipherView, CryptoError> {
+    let ciphers_key = Cipher::decrypt_cipher_key(ctx, key, &cipher.key)?;
+    let restricted: RestrictedCipherData = serde_json::from_str(raw).unwrap_or_default();
+
+    let name = restricted
+        .name
+        .as_ref()
+        .and_then(|n| n.decrypt(ctx, ciphers_key).ok())
+        .unwrap_or_default();
+
+    // Only logins carry URIs; expose them so the partial view can render a domain
+    // (favicon / launch). Every other login field stays absent.
+    let login = matches!(cipher.r#type, CipherType::Login).then(|| LoginView {
+        username: None,
+        password: None,
+        password_revision_date: None,
+        uris: decrypt_restricted_uris(restricted.uris, ctx, ciphers_key),
+        totp: None,
+        autofill_on_page_load: None,
+        fido2_credentials: None,
+    });
+
+    let mut view = CipherView {
+        id: cipher.id,
+        organization_id: cipher.organization_id,
+        folder_id: cipher.folder_id,
+        collection_ids: cipher.collection_ids.clone(),
+        // ⚠️ pass-through of the wrapped, key-bound cipher key — see the contract-violation note
+        // in `lenient_decrypt_cipher_view`.
+        key: cipher.key.clone(),
+        name,
+        notes: None,
+        r#type: cipher.r#type,
+        login,
+        identity: None,
+        card: None,
+        secure_note: None,
+        ssh_key: None,
+        bank_account: None,
+        drivers_license: None,
+        passport: None,
+        favorite: cipher.favorite,
+        reprompt: cipher.reprompt,
+        organization_use_totp: cipher.organization_use_totp,
+        edit: cipher.edit,
+        permissions: cipher.permissions,
+        view_password: cipher.view_password,
+        local_data: cipher.local_data.decrypt(ctx, ciphers_key).ok().flatten(),
+        attachments: None,
+        attachment_decryption_failures: None,
+        fields: None,
+        password_history: None,
+        creation_date: cipher.creation_date,
+        deleted_date: cipher.deleted_date,
+        revision_date: cipher.revision_date,
+        archived_date: cipher.archived_date,
+        partial: true,
+    };
+
+    // Drop URIs whose checksum doesn't validate — guards against a tampering server, mirroring
+    // the full decrypt paths (same gate as `lenient_decrypt_cipher_view`).
+    if view.key.is_some()
+        || ctx.get_security_state_version() >= MINIMUM_ENFORCE_ICON_URI_HASH_VERSION
+    {
+        view.remove_invalid_checksums();
+    }
+
+    Ok(view)
+}
+
+/// Decrypt a restricted (PAM-gated) cipher into a [`CipherListView`]. See
+/// [`decrypt_restricted_cipher_view`] for the allowlist and fail-closed contract. The type
+/// discriminant is preserved (so the row keeps its icon) but every type payload is empty apart
+/// from a login's URIs.
+fn decrypt_restricted_cipher_list_view(
+    cipher: &Cipher,
+    raw: &str,
+    ctx: &mut KeyStoreContext<KeySlotIds>,
+    key: SymmetricKeySlotId,
+) -> Result<CipherListView, CryptoError> {
+    let ciphers_key = Cipher::decrypt_cipher_key(ctx, key, &cipher.key)?;
+    let restricted: RestrictedCipherData = serde_json::from_str(raw).unwrap_or_default();
+
+    let name = restricted
+        .name
+        .as_ref()
+        .and_then(|n| n.decrypt(ctx, ciphers_key).ok())
+        .unwrap_or_default();
+
+    let r#type = match cipher.r#type {
+        CipherType::Login => CipherListViewType::Login(LoginListView {
+            fido2_credentials: None,
+            has_fido2: false,
+            username: None,
+            totp: None,
+            uris: decrypt_restricted_uris(restricted.uris, ctx, ciphers_key),
+        }),
+        CipherType::SecureNote => CipherListViewType::SecureNote,
+        CipherType::Card => CipherListViewType::Card(CardListView { brand: None }),
+        CipherType::Identity => CipherListViewType::Identity,
+        CipherType::SshKey => CipherListViewType::SshKey,
+        CipherType::BankAccount => CipherListViewType::BankAccount(BankAccountListView {
+            account_number: None,
+            account_type: None,
+        }),
+        CipherType::Passport => CipherListViewType::Passport,
+        CipherType::DriversLicense => CipherListViewType::DriversLicense,
+    };
+
+    Ok(CipherListView {
+        id: cipher.id,
+        organization_id: cipher.organization_id,
+        folder_id: cipher.folder_id,
+        collection_ids: cipher.collection_ids.clone(),
+        // ⚠️ pass-through of the wrapped, key-bound cipher key — see the contract-violation note
+        // in `lenient_decrypt_cipher_view`.
+        key: cipher.key.clone(),
+        name,
+        subtitle: String::new(),
+        r#type,
+        favorite: cipher.favorite,
+        reprompt: cipher.reprompt,
+        organization_use_totp: cipher.organization_use_totp,
+        edit: cipher.edit,
+        permissions: cipher.permissions,
+        view_password: cipher.view_password,
+        attachments: 0,
+        has_old_attachments: false,
+        creation_date: cipher.creation_date,
+        deleted_date: cipher.deleted_date,
+        revision_date: cipher.revision_date,
+        archived_date: cipher.archived_date,
+        copyable_fields: vec![],
+        local_data: cipher.local_data.decrypt(ctx, ciphers_key).ok().flatten(),
+        partial: true,
+        #[cfg(feature = "wasm")]
+        notes: None,
+        #[cfg(feature = "wasm")]
+        fields: None,
+        #[cfg(feature = "wasm")]
+        attachment_names: None,
+    })
+}
+
 impl Decryptable<KeySlotIds, SymmetricKeySlotId, CipherView> for Cipher {
     #[bitwarden_logging::instrument(err, fields(cipher_id = ?self.id, org_id = ?self.organization_id, kind = ?self.r#type))]
     fn decrypt(
@@ -1530,6 +1755,9 @@ impl Decryptable<KeySlotIds, SymmetricKeySlotId, CipherView> for Cipher {
         ctx: &mut KeyStoreContext<KeySlotIds>,
         key: SymmetricKeySlotId,
     ) -> Result<CipherView, CryptoError> {
+        if let Some(raw) = &self.partial_data {
+            return decrypt_restricted_cipher_view(self, raw, ctx, key);
+        }
         match try_parse_blob(self) {
             Some(sealed) => decrypt_blob_cipher(self, &sealed, ctx, key).map_err(CryptoError::from),
             None => lenient_decrypt_cipher_view(self, ctx, key),
@@ -1543,6 +1771,9 @@ impl Decryptable<KeySlotIds, SymmetricKeySlotId, CipherListView> for Cipher {
         ctx: &mut KeyStoreContext<KeySlotIds>,
         key: SymmetricKeySlotId,
     ) -> Result<CipherListView, CryptoError> {
+        if let Some(raw) = &self.partial_data {
+            return decrypt_restricted_cipher_list_view(self, raw, ctx, key);
+        }
         match try_parse_blob(self) {
             Some(sealed) => decrypt_blob_cipher(self, &sealed, ctx, key)?.to_list_view(ctx, key),
             None => lenient_decrypt_cipher_list_view(self, ctx, key),
@@ -1591,6 +1822,9 @@ impl Decryptable<KeySlotIds, SymmetricKeySlotId, CipherView> for StrictDecrypt<C
         ctx: &mut KeyStoreContext<KeySlotIds>,
         key: SymmetricKeySlotId,
     ) -> Result<CipherView, CryptoError> {
+        if let Some(raw) = &self.0.partial_data {
+            return decrypt_restricted_cipher_view(&self.0, raw, ctx, key);
+        }
         match try_parse_blob(&self.0) {
             Some(sealed) => {
                 decrypt_blob_cipher(&self.0, &sealed, ctx, key).map_err(CryptoError::from)
@@ -1618,6 +1852,7 @@ fn strict_decrypt_cipher_view(
         );
 
     let mut view = CipherView {
+        partial: false,
         id: cipher.id,
         organization_id: cipher.organization_id,
         folder_id: cipher.folder_id,
@@ -1695,6 +1930,9 @@ impl Decryptable<KeySlotIds, SymmetricKeySlotId, CipherListView> for StrictDecry
         ctx: &mut KeyStoreContext<KeySlotIds>,
         key: SymmetricKeySlotId,
     ) -> Result<CipherListView, CryptoError> {
+        if let Some(raw) = &self.0.partial_data {
+            return decrypt_restricted_cipher_list_view(&self.0, raw, ctx, key);
+        }
         match try_parse_blob(&self.0) {
             Some(sealed) => decrypt_blob_cipher(&self.0, &sealed, ctx, key)?.to_list_view(ctx, key),
             None => strict_decrypt_cipher_list_view(&self.0, ctx, key),
@@ -1712,6 +1950,7 @@ fn strict_decrypt_cipher_list_view(
     let ciphers_key = Cipher::decrypt_cipher_key(ctx, key, &cipher.key)?;
 
     Ok(CipherListView {
+        partial: false,
         id: cipher.id,
         organization_id: cipher.organization_id,
         folder_id: cipher.folder_id,
@@ -1863,6 +2102,7 @@ impl TryFrom<CipherDetailsResponseModel> for Cipher {
 
     fn try_from(cipher: CipherDetailsResponseModel) -> Result<Self, Self::Error> {
         Ok(Self {
+            partial_data: None,
             id: cipher.id.map(CipherId::new),
             organization_id: cipher.organization_id.map(OrganizationId::new),
             folder_id: cipher.folder_id.map(FolderId::new),
@@ -1996,6 +2236,7 @@ impl From<CipherRepromptType> for bitwarden_api_api::models::CipherRepromptType 
 impl PartialCipher for CipherResponseModel {
     fn merge_with_cipher(self, cipher: Option<Cipher>) -> Result<Cipher, VaultParseError> {
         Ok(Cipher {
+            partial_data: None,
             collection_ids: cipher
                 .as_ref()
                 .map(|c| c.collection_ids.clone())
@@ -2051,6 +2292,7 @@ impl PartialCipher for CipherMiniResponseModel {
     fn merge_with_cipher(self, cipher: Option<Cipher>) -> Result<Cipher, VaultParseError> {
         let cipher = cipher.as_ref();
         Ok(Cipher {
+            partial_data: None,
             id: self.id.map(CipherId::new),
             organization_id: self.organization_id.map(OrganizationId::new),
             key: EncString::try_from_optional(self.key)?,
@@ -2111,6 +2353,7 @@ impl PartialCipher for CipherMiniDetailsResponseModel {
     fn merge_with_cipher(self, cipher: Option<Cipher>) -> Result<Cipher, VaultParseError> {
         let cipher = cipher.as_ref();
         Ok(Cipher {
+            partial_data: None,
             id: self.id.map(CipherId::new),
             organization_id: self.organization_id.map(OrganizationId::new),
             key: EncString::try_from_optional(self.key)?,
@@ -2196,6 +2439,7 @@ mod tests {
     fn generate_cipher() -> CipherView {
         let test_id = "fd411a1a-fec8-4070-985d-0e6560860e69".parse().unwrap();
         CipherView {
+            partial: false,
             r#type: CipherType::Login,
             login: Some(LoginView {
                 username: Some("test_username".to_string()),
@@ -2259,12 +2503,206 @@ mod tests {
         }
     }
 
+    /// Builds a server-restricted (PAM-gated) cipher: no top-level secret fields, only the
+    /// `partial_data` envelope the server sends in their place.
+    fn restricted_cipher(r#type: CipherType, partial_data: String) -> Cipher {
+        Cipher {
+            partial_data: Some(partial_data),
+            id: Some(TEST_UUID.parse().unwrap()),
+            organization_id: None,
+            folder_id: None,
+            collection_ids: vec![],
+            key: None,
+            name: None,
+            notes: None,
+            r#type,
+            login: None,
+            identity: None,
+            card: None,
+            secure_note: None,
+            ssh_key: None,
+            bank_account: None,
+            drivers_license: None,
+            passport: None,
+            favorite: false,
+            reprompt: CipherRepromptType::None,
+            organization_use_totp: false,
+            edit: true,
+            permissions: None,
+            view_password: true,
+            local_data: None,
+            attachments: None,
+            fields: None,
+            password_history: None,
+            creation_date: "2024-01-30T17:55:36.150Z".parse().unwrap(),
+            deleted_date: None,
+            revision_date: "2024-01-30T17:55:36.150Z".parse().unwrap(),
+            archived_date: None,
+            data: None,
+        }
+    }
+
+    #[test]
+    fn test_decrypt_restricted_cipher_list_view_login() {
+        let key_store = create_test_crypto_with_user_key(SymmetricCryptoKey::make(
+            SymmetricKeyAlgorithm::Aes256CbcHmac,
+        ));
+        let enc_name = "Restricted Name"
+            .to_string()
+            .encrypt(&mut key_store.context(), SymmetricKeySlotId::User)
+            .unwrap();
+        let enc_uri = "https://example.com"
+            .to_string()
+            .encrypt(&mut key_store.context(), SymmetricKeySlotId::User)
+            .unwrap();
+        let envelope = serde_json::json!({
+            "Name": enc_name,
+            "Uris": [{ "Uri": enc_uri, "UriChecksum": null, "Match": null }],
+        })
+        .to_string();
+
+        let cipher = restricted_cipher(CipherType::Login, envelope);
+        let view: CipherListView = key_store.decrypt(&cipher).unwrap();
+
+        assert!(view.partial);
+        assert_eq!(view.name, "Restricted Name".to_string());
+        assert!(view.subtitle.is_empty());
+        assert!(view.copyable_fields.is_empty());
+        assert_eq!(view.attachments, 0);
+        match view.r#type {
+            CipherListViewType::Login(login) => {
+                assert_eq!(
+                    login.uris.unwrap()[0].uri.as_deref(),
+                    Some("https://example.com")
+                );
+                assert_eq!(login.username, None);
+                assert_eq!(login.totp, None);
+                assert!(!login.has_fido2);
+            }
+            other => panic!("expected Login list view, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_decrypt_restricted_cipher_view_login_omits_secrets() {
+        let key_store = create_test_crypto_with_user_key(SymmetricCryptoKey::make(
+            SymmetricKeyAlgorithm::Aes256CbcHmac,
+        ));
+        let enc_name = "Restricted Name"
+            .to_string()
+            .encrypt(&mut key_store.context(), SymmetricKeySlotId::User)
+            .unwrap();
+        let enc_uri = "https://example.com"
+            .to_string()
+            .encrypt(&mut key_store.context(), SymmetricKeySlotId::User)
+            .unwrap();
+        // A rogue/over-sharing server also stuffs an encrypted password into the envelope; the
+        // allowlist (`RestrictedCipherData`) must ignore anything outside name + uris.
+        let enc_pw = "s3cret"
+            .to_string()
+            .encrypt(&mut key_store.context(), SymmetricKeySlotId::User)
+            .unwrap();
+        let envelope = serde_json::json!({
+            "Name": enc_name,
+            "Uris": [{ "Uri": enc_uri, "UriChecksum": null, "Match": null }],
+            "Password": enc_pw,
+        })
+        .to_string();
+
+        let cipher = restricted_cipher(CipherType::Login, envelope);
+        let view: CipherView = key_store.decrypt(&cipher).unwrap();
+
+        assert!(view.partial);
+        assert_eq!(view.name, "Restricted Name".to_string());
+        let login = view
+            .login
+            .expect("login populated so the view can render a domain");
+        assert_eq!(
+            login.uris.unwrap()[0].uri.as_deref(),
+            Some("https://example.com")
+        );
+        assert_eq!(login.username, None);
+        assert_eq!(login.password, None);
+        assert_eq!(login.totp, None);
+        assert_eq!(view.notes, None);
+        assert!(view.card.is_none());
+    }
+
+    #[test]
+    fn test_decrypt_restricted_non_login_name_only() {
+        let key_store = create_test_crypto_with_user_key(SymmetricCryptoKey::make(
+            SymmetricKeyAlgorithm::Aes256CbcHmac,
+        ));
+        let enc_name = "Gated Note"
+            .to_string()
+            .encrypt(&mut key_store.context(), SymmetricKeySlotId::User)
+            .unwrap();
+        let envelope = serde_json::json!({ "Name": enc_name }).to_string();
+        let cipher = restricted_cipher(CipherType::SecureNote, envelope);
+
+        let list: CipherListView = key_store.decrypt(&cipher).unwrap();
+        assert!(list.partial);
+        assert_eq!(list.name, "Gated Note".to_string());
+        assert_eq!(list.r#type, CipherListViewType::SecureNote);
+
+        let view: CipherView = key_store.decrypt(&cipher).unwrap();
+        assert!(view.partial);
+        assert_eq!(view.name, "Gated Note".to_string());
+        assert!(view.login.is_none());
+        assert!(view.secure_note.is_none());
+    }
+
+    #[test]
+    fn test_decrypt_restricted_malformed_envelope_fails_closed() {
+        let key_store = create_test_crypto_with_user_key(SymmetricCryptoKey::make(
+            SymmetricKeyAlgorithm::Aes256CbcHmac,
+        ));
+        // A malformed envelope must not un-gate the row: it stays partial, just nameless.
+        let cipher = restricted_cipher(CipherType::Login, "not valid json".to_string());
+
+        let list: CipherListView = key_store.decrypt(&cipher).unwrap();
+        assert!(list.partial);
+        assert!(list.name.is_empty());
+
+        let view: CipherView = key_store.decrypt(&cipher).unwrap();
+        assert!(view.partial);
+        assert!(view.name.is_empty());
+    }
+
+    #[test]
+    fn test_decrypt_restricted_works_in_strict_mode() {
+        let key_store = create_test_crypto_with_user_key(SymmetricCryptoKey::make(
+            SymmetricKeyAlgorithm::Aes256CbcHmac,
+        ));
+        let enc_name = "Restricted Card"
+            .to_string()
+            .encrypt(&mut key_store.context(), SymmetricKeySlotId::User)
+            .unwrap();
+        let envelope = serde_json::json!({ "Name": enc_name }).to_string();
+        // A Card with no card payload would hit `MissingField("card")` under strict decrypt —
+        // the restricted branch must short-circuit before that.
+        let cipher = restricted_cipher(CipherType::Card, envelope);
+
+        let list: CipherListView = key_store.decrypt(&StrictDecrypt(cipher.clone())).unwrap();
+        assert!(list.partial);
+        assert_eq!(list.name, "Restricted Card".to_string());
+        assert_eq!(
+            list.r#type,
+            CipherListViewType::Card(CardListView { brand: None })
+        );
+
+        let view: CipherView = key_store.decrypt(&StrictDecrypt(cipher)).unwrap();
+        assert!(view.partial);
+        assert!(view.card.is_none());
+    }
+
     #[test]
     fn test_decrypt_cipher_list_view() {
         let key: SymmetricCryptoKey = "w2LO+nwV4oxwswVYCxlOfRUseXfvU03VzvKQHrqeklPgiMZrspUe6sOBToCnDn9Ay0tuCBn8ykVVRb7PWhub2Q==".to_string().try_into().unwrap();
         let key_store = create_test_crypto_with_user_key(key);
 
         let cipher = Cipher {
+            partial_data: None,
             id: Some("090c19ea-a61a-4df6-8963-262b97bc6266".parse().unwrap()),
             organization_id: None,
             folder_id: None,
@@ -2314,6 +2752,7 @@ mod tests {
         assert_eq!(
             view,
             CipherListView {
+                partial: false,
                 id: cipher.id,
                 organization_id: cipher.organization_id,
                 folder_id: cipher.folder_id,
@@ -3028,6 +3467,7 @@ mod tests {
     #[test]
     fn test_populate_cipher_types_login_with_valid_data() {
         let mut cipher = Cipher {
+            partial_data: None,
             id: Some(TEST_UUID.parse().unwrap()),
             organization_id: None,
             folder_id: None,
@@ -3077,6 +3517,7 @@ mod tests {
     #[test]
     fn test_populate_cipher_types_secure_note() {
         let mut cipher = Cipher {
+            partial_data: None,
             id: Some(TEST_UUID.parse().unwrap()),
             organization_id: None,
             folder_id: None,
@@ -3120,6 +3561,7 @@ mod tests {
     #[test]
     fn test_populate_cipher_types_card() {
         let mut cipher = Cipher {
+            partial_data: None,
             id: Some(TEST_UUID.parse().unwrap()),
             organization_id: None,
             folder_id: None,
@@ -3187,6 +3629,7 @@ mod tests {
     #[test]
     fn test_populate_cipher_types_identity() {
         let mut cipher = Cipher {
+            partial_data: None,
             id: Some(TEST_UUID.parse().unwrap()),
             organization_id: None,
             folder_id: None,
@@ -3347,6 +3790,7 @@ mod tests {
     #[test]
     fn test_populate_cipher_types_ssh_key() {
         let mut cipher = Cipher {
+            partial_data: None,
             id: Some(TEST_UUID.parse().unwrap()),
             organization_id: None,
             folder_id: None,
@@ -3397,6 +3841,7 @@ mod tests {
     #[test]
     fn test_populate_cipher_types_with_null_data() {
         let mut cipher = Cipher {
+            partial_data: None,
             id: Some(TEST_UUID.parse().unwrap()),
             organization_id: None,
             folder_id: None,
@@ -3440,6 +3885,7 @@ mod tests {
     #[test]
     fn test_populate_cipher_types_with_invalid_json() {
         let mut cipher = Cipher {
+            partial_data: None,
             id: Some(TEST_UUID.parse().unwrap()),
             organization_id: None,
             folder_id: None,
@@ -3501,6 +3947,7 @@ mod tests {
             .unwrap();
 
         let cipher = Cipher {
+            partial_data: None,
             id: Some("090c19ea-a61a-4df6-8963-262b97bc6266".parse().unwrap()),
             organization_id: None,
             folder_id: None,

--- a/crates/bitwarden-vault/src/cipher/cipher.rs
+++ b/crates/bitwarden-vault/src/cipher/cipher.rs
@@ -33,7 +33,7 @@ use super::{
     cipher_permissions::CipherPermissions,
     drivers_license, field, identity,
     local_data::{LocalData, LocalDataView},
-    login::{LoginListView, LoginUri, LoginUriView},
+    login::{LoginListView, LoginUri},
     passport, secure_note, ssh_key,
 };
 use crate::{
@@ -341,12 +341,10 @@ pub struct Cipher {
     pub archived_date: Option<DateTime<Utc>>,
     pub data: Option<String>,
 
-    /// Raw JSON envelope for a server-restricted (PAM-gated) cipher: the encrypted name and,
-    /// for logins, the encrypted URIs — every secret field is withheld by the server. Its
-    /// presence marks the cipher restricted; the decrypt path parses only these allowlisted
-    /// fields and produces a view with `partial = true`, never reading the secret payloads.
-    /// Distinct from `data` (the full sealed blob) and from the unrelated `PartialCipher`
-    /// merge trait.
+    /// Raw JSON envelope for a server-restricted (PAM-gated) cipher: only contains a sub-set of
+    /// non sensitive fields, all other fields are withheld by the server. Its presence marks the
+    /// cipher restricted; the decrypt path parses only these allowlisted fields and produces a
+    /// view with `partial = true`, never reading the secret payloads.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub partial_data: Option<String>,
 }
@@ -496,8 +494,8 @@ pub struct CipherView {
     pub revision_date: DateTime<Utc>,
     pub archived_date: Option<DateTime<Utc>>,
 
-    /// True when this view was produced from a server-restricted (PAM-gated) cipher: only the
-    /// name and (for logins) URIs are populated; every secret field is absent. See
+    /// True when this view was produced from a server-restricted (PAM-gated) cipher. Only a
+    /// sub-set of fields are populated; every secret field is absent. See
     /// [`Cipher::partial_data`].
     #[serde(default)]
     pub partial: bool,
@@ -594,8 +592,8 @@ pub struct CipherListView {
 
     pub local_data: Option<LocalDataView>,
 
-    /// True when this view was produced from a server-restricted (PAM-gated) cipher: only the
-    /// name and (for logins) URIs are populated. See [`Cipher::partial_data`].
+    /// True when this view was produced from a server-restricted (PAM-gated) cipher. Only a
+    /// sub-set of fields are populated. See [`Cipher::partial_data`].
     #[serde(default)]
     pub partial: bool,
 
@@ -1548,33 +1546,18 @@ impl IdentifyKey<SymmetricKeySlotId> for Cipher {
 }
 
 /// The server's reduced payload for a restricted (PAM-gated) cipher, produced by
-/// `PartialCipherData.Strip` on the server. The server emits a purpose-built camelCase envelope
-/// carrying the same [`LoginUri`] fields the full decrypt path uses, so the URIs deserialize
-/// straight into [`LoginUri`] with no parallel representation.
+/// `PartialCipherData.Strip` on the server.
 ///
 /// This struct is the single authoritative allowlist for what a gated view may expose: the
 /// encrypted name and, for logins, the encrypted URIs — nothing else. It is deliberately NOT
-/// `deny_unknown_fields`: an over-sharing server blob (e.g. a stray `password` or `totp`) is
-/// silently dropped by the allowlist rather than surfaced onto the view or failing the parse.
+/// `deny_unknown_fields`: the server may decide to include additional non sensitive fields in the
+/// future; these are silently dropped by the allowlist rather than surfaced onto the view or
+/// failing the parse.
 #[derive(Deserialize, Default)]
 #[serde(rename_all = "camelCase")]
 struct RestrictedCipherData {
     name: Option<EncString>,
     uris: Option<Vec<LoginUri>>,
-}
-
-/// Decrypt the allowlisted URIs from a restricted envelope. A URI that fails to decrypt is
-/// dropped rather than failing the whole cipher.
-fn decrypt_restricted_uris(
-    uris: Option<Vec<LoginUri>>,
-    ctx: &mut KeyStoreContext<KeySlotIds>,
-    ciphers_key: SymmetricKeySlotId,
-) -> Option<Vec<LoginUriView>> {
-    uris.map(|list| {
-        list.into_iter()
-            .filter_map(|u| u.decrypt(ctx, ciphers_key).ok())
-            .collect()
-    })
 }
 
 /// Decrypt a restricted (PAM-gated) cipher into a [`CipherView`].
@@ -1604,7 +1587,7 @@ fn decrypt_restricted_cipher_view(
         username: None,
         password: None,
         password_revision_date: None,
-        uris: decrypt_restricted_uris(restricted.uris, ctx, ciphers_key),
+        uris: restricted.uris.decrypt(ctx, ciphers_key).ok().flatten(),
         totp: None,
         autofill_on_page_load: None,
         fido2_credentials: None,
@@ -1683,7 +1666,7 @@ fn decrypt_restricted_cipher_list_view(
             has_fido2: false,
             username: None,
             totp: None,
-            uris: decrypt_restricted_uris(restricted.uris, ctx, ciphers_key),
+            uris: restricted.uris.decrypt(ctx, ciphers_key).ok().flatten(),
         }),
         CipherType::SecureNote => CipherListViewType::SecureNote,
         CipherType::Card => CipherListViewType::Card(CardListView { brand: None }),

--- a/crates/bitwarden-vault/src/cipher/cipher.rs
+++ b/crates/bitwarden-vault/src/cipher/cipher.rs
@@ -497,6 +497,9 @@ pub struct CipherView {
     /// True when this view was produced from a server-restricted (PAM-gated) cipher. Only a
     /// sub-set of fields are populated; every secret field is absent. See
     /// [`Cipher::partial_data`].
+    /// Such a view is fail-closed against re-encryption: passing it to any encrypt path returns
+    /// [`bitwarden_crypto::CryptoError::EncryptRestrictedView`] rather than silently stripping
+    /// secrets.
     #[serde(default)]
     pub partial: bool,
 }
@@ -684,6 +687,12 @@ impl CipherView {
         ctx: &mut KeyStoreContext<KeySlotIds>,
         key: SymmetricKeySlotId,
     ) -> Result<Cipher, CryptoError> {
+        // Fail closed: a restricted (partial) view has all secret fields stripped; re-encrypting it
+        // would overwrite the item's secrets with empty values. See `decrypt_restricted_cipher_view`.
+        if self.partial {
+            return Err(CryptoError::EncryptRestrictedView);
+        }
+
         let ciphers_key = Cipher::decrypt_cipher_key(ctx, key, &self.key)?;
 
         let mut cipher_view = self.clone();
@@ -2978,6 +2987,48 @@ mod tests {
             strict_result.is_err(),
             "Strict decryption should fail when login username is encrypted with a different key"
         );
+    }
+
+    #[test]
+    fn test_encrypt_legacy_fails_closed_for_partial_view() {
+        let key_store = create_test_crypto_with_user_key(SymmetricCryptoKey::make(
+            SymmetricKeyAlgorithm::Aes256CbcHmac,
+        ));
+
+        let mut view = generate_cipher();
+        view.partial = true;
+
+        let result = key_store.encrypt(EncryptMode::Legacy(view));
+        assert!(matches!(result, Err(CryptoError::EncryptRestrictedView)));
+    }
+
+    #[test]
+    fn test_encrypt_blob_fails_closed_for_partial_view() {
+        let key_store = create_test_crypto_with_user_key(SymmetricCryptoKey::make(
+            SymmetricKeyAlgorithm::Aes256CbcHmac,
+        ));
+
+        let mut view = generate_cipher();
+        view.partial = true;
+
+        let result = key_store.encrypt(EncryptMode::Blob(view));
+        assert!(matches!(result, Err(CryptoError::EncryptRestrictedView)));
+    }
+
+    #[test]
+    fn test_encrypt_succeeds_for_non_partial_view() {
+        let key_store = create_test_crypto_with_user_key(SymmetricCryptoKey::make(
+            SymmetricKeyAlgorithm::Aes256CbcHmac,
+        ));
+
+        // Control: the same shape of view, but with `partial: false`, must still encrypt
+        // successfully — proving the guard is specific to `partial` rather than some other
+        // difference between test fixtures.
+        let view = generate_cipher();
+        assert!(!view.partial);
+
+        let result = key_store.encrypt(EncryptMode::Legacy(view));
+        assert!(result.is_ok());
     }
 
     #[test]

--- a/crates/bitwarden-vault/src/cipher/cipher.rs
+++ b/crates/bitwarden-vault/src/cipher/cipher.rs
@@ -1608,9 +1608,9 @@ fn decrypt_restricted_cipher_view(
         organization_id: cipher.organization_id,
         folder_id: cipher.folder_id,
         collection_ids: cipher.collection_ids.clone(),
-        // ⚠️ pass-through of the wrapped, key-bound cipher key — see the contract-violation note
-        // in `lenient_decrypt_cipher_view`.
-        key: cipher.key.clone(),
+        // A restricted view is never re-encrypted (the encrypt paths fail closed on `partial`),
+        // so it carries no cipher key.
+        key: None,
         name,
         notes: None,
         r#type: cipher.r#type,
@@ -1642,7 +1642,7 @@ fn decrypt_restricted_cipher_view(
 
     // Drop URIs whose checksum doesn't validate — guards against a tampering server, mirroring
     // the full decrypt paths (same gate as `lenient_decrypt_cipher_view`).
-    if view.key.is_some()
+    if cipher.key.is_some()
         || ctx.get_security_state_version() >= MINIMUM_ENFORCE_ICON_URI_HASH_VERSION
     {
         view.remove_invalid_checksums();
@@ -1695,9 +1695,9 @@ fn decrypt_restricted_cipher_list_view(
         organization_id: cipher.organization_id,
         folder_id: cipher.folder_id,
         collection_ids: cipher.collection_ids.clone(),
-        // ⚠️ pass-through of the wrapped, key-bound cipher key — see the contract-violation note
-        // in `lenient_decrypt_cipher_view`.
-        key: cipher.key.clone(),
+        // A restricted view is never re-encrypted (the encrypt paths fail closed on `partial`),
+        // so it carries no cipher key.
+        key: None,
         name,
         subtitle: String::new(),
         r#type,
@@ -1733,6 +1733,12 @@ impl Decryptable<KeySlotIds, SymmetricKeySlotId, CipherView> for Cipher {
         key: SymmetricKeySlotId,
     ) -> Result<CipherView, CryptoError> {
         if let Some(raw) = &self.partial_data {
+            // Partial (PAM-gated) data is only ever produced for organization ciphers. Refuse the
+            // restricted path for a personal cipher so a user item can never be exposed through the
+            // weaker partial format. Fail closed.
+            if self.organization_id.is_none() {
+                return Err(CryptoError::RestrictedCipherRequiresOrganization);
+            }
             return decrypt_restricted_cipher_view(self, raw, ctx, key);
         }
         match try_parse_blob(self) {
@@ -1749,6 +1755,12 @@ impl Decryptable<KeySlotIds, SymmetricKeySlotId, CipherListView> for Cipher {
         key: SymmetricKeySlotId,
     ) -> Result<CipherListView, CryptoError> {
         if let Some(raw) = &self.partial_data {
+            // Partial (PAM-gated) data is only ever produced for organization ciphers. Refuse the
+            // restricted path for a personal cipher so a user item can never be exposed through the
+            // weaker partial format. Fail closed.
+            if self.organization_id.is_none() {
+                return Err(CryptoError::RestrictedCipherRequiresOrganization);
+            }
             return decrypt_restricted_cipher_list_view(self, raw, ctx, key);
         }
         match try_parse_blob(self) {
@@ -1800,6 +1812,10 @@ impl Decryptable<KeySlotIds, SymmetricKeySlotId, CipherView> for StrictDecrypt<C
         key: SymmetricKeySlotId,
     ) -> Result<CipherView, CryptoError> {
         if let Some(raw) = &self.0.partial_data {
+            // See the org-gate note in the non-strict `Decryptable for Cipher` impl.
+            if self.0.organization_id.is_none() {
+                return Err(CryptoError::RestrictedCipherRequiresOrganization);
+            }
             return decrypt_restricted_cipher_view(&self.0, raw, ctx, key);
         }
         match try_parse_blob(&self.0) {
@@ -1908,6 +1924,10 @@ impl Decryptable<KeySlotIds, SymmetricKeySlotId, CipherListView> for StrictDecry
         key: SymmetricKeySlotId,
     ) -> Result<CipherListView, CryptoError> {
         if let Some(raw) = &self.0.partial_data {
+            // See the org-gate note in the non-strict `Decryptable for Cipher` impl.
+            if self.0.organization_id.is_none() {
+                return Err(CryptoError::RestrictedCipherRequiresOrganization);
+            }
             return decrypt_restricted_cipher_list_view(&self.0, raw, ctx, key);
         }
         match try_parse_blob(&self.0) {
@@ -2139,7 +2159,11 @@ impl TryFrom<CipherDetailsResponseModel> for Cipher {
 impl PartialCipher for CipherDetailsResponseModel {
     fn merge_with_cipher(self, cipher: Option<Cipher>) -> Result<Cipher, VaultParseError> {
         Ok(Cipher {
-            local_data: cipher.and_then(|c| c.local_data),
+            local_data: cipher.as_ref().and_then(|c| c.local_data.clone()),
+            // Preserve PAM gating across a partial/full update; these merge responses never change
+            // gating. TODO: prefer the response's partialData once the generated API model carries
+            // it.
+            partial_data: cipher.and_then(|c| c.partial_data),
             ..self.try_into()?
         })
     }
@@ -2213,7 +2237,10 @@ impl From<CipherRepromptType> for bitwarden_api_api::models::CipherRepromptType 
 impl PartialCipher for CipherResponseModel {
     fn merge_with_cipher(self, cipher: Option<Cipher>) -> Result<Cipher, VaultParseError> {
         Ok(Cipher {
-            partial_data: None,
+            // Preserve PAM gating across a partial/full update; these merge responses never change
+            // gating. TODO: prefer the response's partialData once the generated API model carries
+            // it.
+            partial_data: cipher.as_ref().and_then(|c| c.partial_data.clone()),
             collection_ids: cipher
                 .as_ref()
                 .map(|c| c.collection_ids.clone())
@@ -2269,7 +2296,10 @@ impl PartialCipher for CipherMiniResponseModel {
     fn merge_with_cipher(self, cipher: Option<Cipher>) -> Result<Cipher, VaultParseError> {
         let cipher = cipher.as_ref();
         Ok(Cipher {
-            partial_data: None,
+            // Preserve PAM gating across a partial/full update; these merge responses never change
+            // gating. TODO: prefer the response's partialData once the generated API model carries
+            // it.
+            partial_data: cipher.and_then(|c| c.partial_data.clone()),
             id: self.id.map(CipherId::new),
             organization_id: self.organization_id.map(OrganizationId::new),
             key: EncString::try_from_optional(self.key)?,
@@ -2330,7 +2360,10 @@ impl PartialCipher for CipherMiniDetailsResponseModel {
     fn merge_with_cipher(self, cipher: Option<Cipher>) -> Result<Cipher, VaultParseError> {
         let cipher = cipher.as_ref();
         Ok(Cipher {
-            partial_data: None,
+            // Preserve PAM gating across a partial/full update; these merge responses never change
+            // gating. TODO: prefer the response's partialData once the generated API model carries
+            // it.
+            partial_data: cipher.and_then(|c| c.partial_data.clone()),
             id: self.id.map(CipherId::new),
             organization_id: self.organization_id.map(OrganizationId::new),
             key: EncString::try_from_optional(self.key)?,
@@ -2399,7 +2432,7 @@ mod tests {
     use bitwarden_core::key_management::{
         create_test_crypto_with_user_and_org_key, create_test_crypto_with_user_key,
     };
-    use bitwarden_crypto::{SymmetricCryptoKey, SymmetricKeyAlgorithm};
+    use bitwarden_crypto::{KeyStore, SymmetricCryptoKey, SymmetricKeyAlgorithm};
 
     use super::*;
     use crate::{Fido2Credential, PasswordHistoryView, login::Fido2CredentialListView};
@@ -2412,6 +2445,32 @@ mod tests {
     const TEST_ENC_STRING_5: &str = "2.hqdioUAc81FsKQmO1XuLQg==|oDRdsJrQjoFu9NrFVy8tcJBAFKBx95gHaXZnWdXbKpsxWnOr2sKipIG43pKKUFuq|3gKZMiboceIB5SLVOULKg2iuyu6xzos22dfJbvx0EHk=";
     const TEST_CIPHER_NAME: &str = "2.d3rzo0P8rxV9Hs1m1BmAjw==|JOwna6i0zs+K7ZghwrZRuw==|SJqKreLag1ID+g6H1OdmQr0T5zTrVWKzD6hGy3fDqB0=";
     const TEST_UUID: &str = "fd411a1a-fec8-4070-985d-0e6560860e69";
+
+    /// Fixed org id + key for the restricted-cipher test vectors (partials are always org-owned).
+    const RESTRICTED_ORG_UUID: &str = "3cf0d3ba-3ded-4bf3-a51c-b03fd9ac6e07";
+    const RESTRICTED_ORG_KEY_B64: &str =
+        "w2LO+nwV4oxwswVYCxlOfRUseXfvU03VzvKQHrqeklPgiMZrspUe6sOBToCnDn9Ay0tuCBn8ykVVRb7PWhub2Q==";
+
+    /// `partial_data` vectors: EncStrings encrypted once under [`RESTRICTED_ORG_KEY_B64`] and
+    /// pinned, so decrypt runs against fixed ciphertext and the format can't silently break.
+    const RESTRICTED_LOGIN_ENVELOPE: &str = r#"{"name":"2.qip4DSwdOzU2KwY3jgDjUg==|CsGRQgTwAzmszz+dkk5xIg==|rmW/mlnHq2MulR9uNKclD+1UBFLfOimedkq5tPRSLOc=","uris":[{"uri":"2.2na8mpfA1B1OBTUHkDz+fw==|yTWB1nEf3EHIZgsDINM8JnTYyxf7KVZvXraIGAVOiEg=|i2swsODSjEMRaYNnBHAigdphZBBUg2lkPNo763fX12w=","uriChecksum":null,"match":null}]}"#;
+    /// [`RESTRICTED_LOGIN_ENVELOPE`] plus an extra `password` field the allowlist must drop.
+    const RESTRICTED_LOGIN_ENVELOPE_WITH_PASSWORD: &str = r#"{"name":"2.qip4DSwdOzU2KwY3jgDjUg==|CsGRQgTwAzmszz+dkk5xIg==|rmW/mlnHq2MulR9uNKclD+1UBFLfOimedkq5tPRSLOc=","uris":[{"uri":"2.2na8mpfA1B1OBTUHkDz+fw==|yTWB1nEf3EHIZgsDINM8JnTYyxf7KVZvXraIGAVOiEg=|i2swsODSjEMRaYNnBHAigdphZBBUg2lkPNo763fX12w=","uriChecksum":null,"match":null}],"password":"2.cKf+VYTb7KF2ITGLDmGzig==|zC66OfcYpUB8V6jLB6GQvQ==|hnDFyYCAf6RPD4lPmXZCzEWzXwniRyFnCVrO0KZMPlc="}"#;
+    const RESTRICTED_SECURE_NOTE_ENVELOPE: &str = r#"{"name":"2.EwVjyRAgPmUvRpyT68lbjQ==|73O9id1+DZevAB3K+2fXnA==|OoJhN3p9UgjQ4yk55OUBZ4nYQMlFcf9wTHPxrOPhQVI="}"#;
+    const RESTRICTED_CARD_ENVELOPE: &str = r#"{"name":"2.HF21EOZVqF3eyeZtEgxaCg==|zuChVgXPqxipFE6zOBUBXQ==|gxyvw0+gMf5Grxk8EAhpLCBeXdA0kvea2maJmpLIUIw="}"#;
+
+    /// Key store for the restricted-cipher vectors: [`RESTRICTED_ORG_KEY_B64`] under
+    /// [`RESTRICTED_ORG_UUID`] (the user key is unused — restricted decrypt is org-keyed).
+    fn restricted_test_key_store() -> (OrganizationId, KeyStore<KeySlotIds>) {
+        let org: OrganizationId = RESTRICTED_ORG_UUID.parse().unwrap();
+        let org_key: SymmetricCryptoKey = RESTRICTED_ORG_KEY_B64.to_string().try_into().unwrap();
+        let key_store = create_test_crypto_with_user_and_org_key(
+            SymmetricCryptoKey::make(SymmetricKeyAlgorithm::Aes256CbcHmac),
+            org,
+            org_key,
+        );
+        (org, key_store)
+    }
 
     fn generate_cipher() -> CipherView {
         let test_id = "fd411a1a-fec8-4070-985d-0e6560860e69".parse().unwrap();
@@ -2481,12 +2540,16 @@ mod tests {
     }
 
     /// Builds a server-restricted (PAM-gated) cipher: no top-level secret fields, only the
-    /// `partial_data` envelope the server sends in their place.
-    fn restricted_cipher(r#type: CipherType, partial_data: String) -> Cipher {
+    /// `partial_data` envelope. Org-owned, since partials always are.
+    fn restricted_cipher(
+        organization_id: OrganizationId,
+        r#type: CipherType,
+        partial_data: String,
+    ) -> Cipher {
         Cipher {
             partial_data: Some(partial_data),
             id: Some(TEST_UUID.parse().unwrap()),
-            organization_id: None,
+            organization_id: Some(organization_id),
             folder_id: None,
             collection_ids: vec![],
             key: None,
@@ -2521,24 +2584,12 @@ mod tests {
 
     #[test]
     fn test_decrypt_restricted_cipher_list_view_login() {
-        let key_store = create_test_crypto_with_user_key(SymmetricCryptoKey::make(
-            SymmetricKeyAlgorithm::Aes256CbcHmac,
-        ));
-        let enc_name = "Restricted Name"
-            .to_string()
-            .encrypt(&mut key_store.context(), SymmetricKeySlotId::User)
-            .unwrap();
-        let enc_uri = "https://example.com"
-            .to_string()
-            .encrypt(&mut key_store.context(), SymmetricKeySlotId::User)
-            .unwrap();
-        let envelope = serde_json::json!({
-            "name": enc_name,
-            "uris": [{ "uri": enc_uri, "uriChecksum": null, "match": null }],
-        })
-        .to_string();
-
-        let cipher = restricted_cipher(CipherType::Login, envelope);
+        let (org, key_store) = restricted_test_key_store();
+        let cipher = restricted_cipher(
+            org,
+            CipherType::Login,
+            RESTRICTED_LOGIN_ENVELOPE.to_string(),
+        );
         let view: CipherListView = key_store.decrypt(&cipher).unwrap();
 
         assert!(view.partial);
@@ -2562,31 +2613,14 @@ mod tests {
 
     #[test]
     fn test_decrypt_restricted_cipher_view_login_omits_secrets() {
-        let key_store = create_test_crypto_with_user_key(SymmetricCryptoKey::make(
-            SymmetricKeyAlgorithm::Aes256CbcHmac,
-        ));
-        let enc_name = "Restricted Name"
-            .to_string()
-            .encrypt(&mut key_store.context(), SymmetricKeySlotId::User)
-            .unwrap();
-        let enc_uri = "https://example.com"
-            .to_string()
-            .encrypt(&mut key_store.context(), SymmetricKeySlotId::User)
-            .unwrap();
+        let (org, key_store) = restricted_test_key_store();
         // A rogue/over-sharing server also stuffs an encrypted password into the envelope; the
         // allowlist (`RestrictedCipherData`) must ignore anything outside name + uris.
-        let enc_pw = "s3cret"
-            .to_string()
-            .encrypt(&mut key_store.context(), SymmetricKeySlotId::User)
-            .unwrap();
-        let envelope = serde_json::json!({
-            "name": enc_name,
-            "uris": [{ "uri": enc_uri, "uriChecksum": null, "match": null }],
-            "password": enc_pw,
-        })
-        .to_string();
-
-        let cipher = restricted_cipher(CipherType::Login, envelope);
+        let cipher = restricted_cipher(
+            org,
+            CipherType::Login,
+            RESTRICTED_LOGIN_ENVELOPE_WITH_PASSWORD.to_string(),
+        );
         let view: CipherView = key_store.decrypt(&cipher).unwrap();
 
         assert!(view.partial);
@@ -2607,15 +2641,12 @@ mod tests {
 
     #[test]
     fn test_decrypt_restricted_non_login_name_only() {
-        let key_store = create_test_crypto_with_user_key(SymmetricCryptoKey::make(
-            SymmetricKeyAlgorithm::Aes256CbcHmac,
-        ));
-        let enc_name = "Gated Note"
-            .to_string()
-            .encrypt(&mut key_store.context(), SymmetricKeySlotId::User)
-            .unwrap();
-        let envelope = serde_json::json!({ "name": enc_name }).to_string();
-        let cipher = restricted_cipher(CipherType::SecureNote, envelope);
+        let (org, key_store) = restricted_test_key_store();
+        let cipher = restricted_cipher(
+            org,
+            CipherType::SecureNote,
+            RESTRICTED_SECURE_NOTE_ENVELOPE.to_string(),
+        );
 
         let list: CipherListView = key_store.decrypt(&cipher).unwrap();
         assert!(list.partial);
@@ -2631,11 +2662,9 @@ mod tests {
 
     #[test]
     fn test_decrypt_restricted_malformed_envelope_fails_closed() {
-        let key_store = create_test_crypto_with_user_key(SymmetricCryptoKey::make(
-            SymmetricKeyAlgorithm::Aes256CbcHmac,
-        ));
+        let (org, key_store) = restricted_test_key_store();
         // A malformed envelope must not un-gate the row: it stays partial, just nameless.
-        let cipher = restricted_cipher(CipherType::Login, "not valid json".to_string());
+        let cipher = restricted_cipher(org, CipherType::Login, "not valid json".to_string());
 
         let list: CipherListView = key_store.decrypt(&cipher).unwrap();
         assert!(list.partial);
@@ -2648,17 +2677,10 @@ mod tests {
 
     #[test]
     fn test_decrypt_restricted_works_in_strict_mode() {
-        let key_store = create_test_crypto_with_user_key(SymmetricCryptoKey::make(
-            SymmetricKeyAlgorithm::Aes256CbcHmac,
-        ));
-        let enc_name = "Restricted Card"
-            .to_string()
-            .encrypt(&mut key_store.context(), SymmetricKeySlotId::User)
-            .unwrap();
-        let envelope = serde_json::json!({ "name": enc_name }).to_string();
+        let (org, key_store) = restricted_test_key_store();
         // A Card with no card payload would hit `MissingField("card")` under strict decrypt —
         // the restricted branch must short-circuit before that.
-        let cipher = restricted_cipher(CipherType::Card, envelope);
+        let cipher = restricted_cipher(org, CipherType::Card, RESTRICTED_CARD_ENVELOPE.to_string());
 
         let list: CipherListView = key_store.decrypt(&StrictDecrypt(cipher.clone())).unwrap();
         assert!(list.partial);
@@ -2671,6 +2693,33 @@ mod tests {
         let view: CipherView = key_store.decrypt(&StrictDecrypt(cipher)).unwrap();
         assert!(view.partial);
         assert!(view.card.is_none());
+    }
+
+    #[test]
+    fn test_decrypt_restricted_non_org_cipher_fails_closed() {
+        // A personal cipher carrying `partial_data` must fail closed, never take the restricted
+        // path.
+        let (org, key_store) = restricted_test_key_store();
+        let cipher = Cipher {
+            organization_id: None,
+            ..restricted_cipher(
+                org,
+                CipherType::SecureNote,
+                RESTRICTED_SECURE_NOTE_ENVELOPE.to_string(),
+            )
+        };
+
+        let view_result: Result<CipherView, CryptoError> = key_store.decrypt(&cipher);
+        assert!(matches!(
+            view_result.unwrap_err(),
+            CryptoError::RestrictedCipherRequiresOrganization
+        ));
+
+        let list_result: Result<CipherListView, CryptoError> = key_store.decrypt(&cipher);
+        assert!(matches!(
+            list_result.unwrap_err(),
+            CryptoError::RestrictedCipherRequiresOrganization
+        ));
     }
 
     #[test]

--- a/crates/bitwarden-vault/src/cipher/cipher.rs
+++ b/crates/bitwarden-vault/src/cipher/cipher.rs
@@ -688,7 +688,8 @@ impl CipherView {
         key: SymmetricKeySlotId,
     ) -> Result<Cipher, CryptoError> {
         // Fail closed: a restricted (partial) view has all secret fields stripped; re-encrypting it
-        // would overwrite the item's secrets with empty values. See `decrypt_restricted_cipher_view`.
+        // would overwrite the item's secrets with empty values. See
+        // `decrypt_restricted_cipher_view`.
         if self.partial {
             return Err(CryptoError::EncryptRestrictedView);
         }

--- a/crates/bitwarden-vault/src/cipher/cipher.rs
+++ b/crates/bitwarden-vault/src/cipher/cipher.rs
@@ -2133,7 +2133,7 @@ impl TryFrom<CipherDetailsResponseModel> for Cipher {
 
     fn try_from(cipher: CipherDetailsResponseModel) -> Result<Self, Self::Error> {
         Ok(Self {
-            partial_data: None,
+            partial_data: cipher.partial_data,
             id: cipher.id.map(CipherId::new),
             organization_id: cipher.organization_id.map(OrganizationId::new),
             folder_id: cipher.folder_id.map(FolderId::new),
@@ -2193,11 +2193,7 @@ impl TryFrom<CipherDetailsResponseModel> for Cipher {
 impl PartialCipher for CipherDetailsResponseModel {
     fn merge_with_cipher(self, cipher: Option<Cipher>) -> Result<Cipher, VaultParseError> {
         Ok(Cipher {
-            local_data: cipher.as_ref().and_then(|c| c.local_data.clone()),
-            // Preserve PAM gating across a partial/full update; these merge responses never change
-            // gating. TODO: prefer the response's partialData once the generated API model carries
-            // it.
-            partial_data: cipher.and_then(|c| c.partial_data),
+            local_data: cipher.and_then(|c| c.local_data),
             ..self.try_into()?
         })
     }
@@ -2271,10 +2267,7 @@ impl From<CipherRepromptType> for bitwarden_api_api::models::CipherRepromptType 
 impl PartialCipher for CipherResponseModel {
     fn merge_with_cipher(self, cipher: Option<Cipher>) -> Result<Cipher, VaultParseError> {
         Ok(Cipher {
-            // Preserve PAM gating across a partial/full update; these merge responses never change
-            // gating. TODO: prefer the response's partialData once the generated API model carries
-            // it.
-            partial_data: cipher.as_ref().and_then(|c| c.partial_data.clone()),
+            partial_data: self.partial_data,
             collection_ids: cipher
                 .as_ref()
                 .map(|c| c.collection_ids.clone())
@@ -2330,10 +2323,7 @@ impl PartialCipher for CipherMiniResponseModel {
     fn merge_with_cipher(self, cipher: Option<Cipher>) -> Result<Cipher, VaultParseError> {
         let cipher = cipher.as_ref();
         Ok(Cipher {
-            // Preserve PAM gating across a partial/full update; these merge responses never change
-            // gating. TODO: prefer the response's partialData once the generated API model carries
-            // it.
-            partial_data: cipher.and_then(|c| c.partial_data.clone()),
+            partial_data: self.partial_data,
             id: self.id.map(CipherId::new),
             organization_id: self.organization_id.map(OrganizationId::new),
             key: EncString::try_from_optional(self.key)?,
@@ -2394,10 +2384,7 @@ impl PartialCipher for CipherMiniDetailsResponseModel {
     fn merge_with_cipher(self, cipher: Option<Cipher>) -> Result<Cipher, VaultParseError> {
         let cipher = cipher.as_ref();
         Ok(Cipher {
-            // Preserve PAM gating across a partial/full update; these merge responses never change
-            // gating. TODO: prefer the response's partialData once the generated API model carries
-            // it.
-            partial_data: cipher.and_then(|c| c.partial_data.clone()),
+            partial_data: self.partial_data,
             id: self.id.map(CipherId::new),
             organization_id: self.organization_id.map(OrganizationId::new),
             key: EncString::try_from_optional(self.key)?,
@@ -4337,6 +4324,68 @@ mod tests {
             cipher.view_password,
             "view_password should default to true for CipherMiniDetailsResponseModel"
         );
+    }
+
+    /// PAM gating is authoritative from the server response: `merge_with_cipher` takes
+    /// `partial_data` from the response, so it gates when the response carries the restricted
+    /// envelope and un-gates when it does not — regardless of the local cipher's prior state.
+    #[test]
+    fn test_merge_takes_partial_data_from_response() {
+        use chrono::Utc;
+
+        let org: OrganizationId = RESTRICTED_ORG_UUID.parse().unwrap();
+        // A local cipher that is currently PAM-gated; the response's gating must win over it.
+        let local_restricted = || {
+            Some(restricted_cipher(
+                org,
+                CipherType::Login,
+                RESTRICTED_LOGIN_ENVELOPE.to_string(),
+            ))
+        };
+        let now = Utc::now().to_rfc3339();
+
+        macro_rules! assert_gating_from_response {
+            ($model:ident) => {{
+                let base = $model {
+                    id: Some(TEST_UUID.parse().unwrap()),
+                    organization_id: Some(org.to_string().parse().unwrap()),
+                    r#type: Some(bitwarden_api_api::models::CipherType::Login),
+                    creation_date: Some(now.clone()),
+                    revision_date: Some(now.clone()),
+                    ..Default::default()
+                };
+
+                // A full response (no `partial_data`) un-gates a locally-restricted cipher.
+                assert_eq!(
+                    base.clone()
+                        .merge_with_cipher(local_restricted())
+                        .unwrap()
+                        .partial_data,
+                    None,
+                    concat!(stringify!($model), ": full response must un-gate"),
+                );
+
+                // A restricted response gates the row even when the local cipher was full.
+                let restricted = $model {
+                    partial_data: Some(RESTRICTED_LOGIN_ENVELOPE.to_string()),
+                    ..base
+                };
+                assert_eq!(
+                    restricted
+                        .merge_with_cipher(None)
+                        .unwrap()
+                        .partial_data
+                        .as_deref(),
+                    Some(RESTRICTED_LOGIN_ENVELOPE),
+                    concat!(stringify!($model), ": restricted response must gate"),
+                );
+            }};
+        }
+
+        assert_gating_from_response!(CipherResponseModel);
+        assert_gating_from_response!(CipherDetailsResponseModel);
+        assert_gating_from_response!(CipherMiniResponseModel);
+        assert_gating_from_response!(CipherMiniDetailsResponseModel);
     }
 
     // ---------- Cipher Decryptable dispatch + CipherView::to_list_view ----------

--- a/crates/bitwarden-vault/src/cipher/cipher.rs
+++ b/crates/bitwarden-vault/src/cipher/cipher.rs
@@ -33,7 +33,7 @@ use super::{
     cipher_permissions::CipherPermissions,
     drivers_license, field, identity,
     local_data::{LocalData, LocalDataView},
-    login::{LoginListView, LoginUri},
+    login::{LoginListView, LoginUri, LoginUriView},
     passport, secure_note, ssh_key,
 };
 use crate::{
@@ -1570,38 +1570,75 @@ struct RestrictedCipherData {
     uris: Option<Vec<LoginUri>>,
 }
 
+/// Decrypt the restricted `name`. An absent field is legitimate and stays empty in both modes; a
+/// field that is present but fails to decrypt is a real decryption failure (wrong key / corruption
+/// / tampering) — it propagates in strict mode and degrades to empty in lenient mode.
+fn decrypt_restricted_name(
+    restricted: &RestrictedCipherData,
+    ctx: &mut KeyStoreContext<KeySlotIds>,
+    ciphers_key: SymmetricKeySlotId,
+    strict: bool,
+) -> Result<String, CryptoError> {
+    let Some(name) = restricted.name.as_ref() else {
+        return Ok(String::new());
+    };
+    if strict {
+        name.decrypt(ctx, ciphers_key)
+    } else {
+        Ok(name.decrypt(ctx, ciphers_key).ok().unwrap_or_default())
+    }
+}
+
+/// Decrypt the restricted login `uris`. Absent → `None` in both modes; present-but-undecryptable →
+/// error in strict mode, `None` in lenient mode. See [`decrypt_restricted_name`].
+fn decrypt_restricted_uris(
+    restricted: &RestrictedCipherData,
+    ctx: &mut KeyStoreContext<KeySlotIds>,
+    ciphers_key: SymmetricKeySlotId,
+    strict: bool,
+) -> Result<Option<Vec<LoginUriView>>, CryptoError> {
+    if strict {
+        restricted.uris.decrypt(ctx, ciphers_key)
+    } else {
+        Ok(restricted.uris.decrypt(ctx, ciphers_key).ok().flatten())
+    }
+}
+
 /// Decrypt a restricted (PAM-gated) cipher into a [`CipherView`].
 ///
 /// Parses `partial_data` and decrypts ONLY the allowlisted fields — the name and, for logins,
 /// the URIs. It never reads the cipher's secret payloads (`login.password`, `card`, …), which
-/// the server withholds anyway. Fail-closed: a malformed envelope or an undecryptable field
-/// degrades to empty rather than un-gating the row — the view is always `partial = true`.
+/// the server withholds anyway. Fail-closed: a malformed envelope always degrades to empty
+/// rather than un-gating the row (the view is always `partial = true`). A field that is present
+/// but fails to decrypt degrades to empty in lenient mode, but propagates as an error under
+/// strict decryption (`strict = true`).
 fn decrypt_restricted_cipher_view(
     cipher: &Cipher,
     raw: &str,
     ctx: &mut KeyStoreContext<KeySlotIds>,
     key: SymmetricKeySlotId,
+    strict: bool,
 ) -> Result<CipherView, CryptoError> {
     let ciphers_key = Cipher::decrypt_cipher_key(ctx, key, &cipher.key)?;
     let restricted: RestrictedCipherData = serde_json::from_str(raw).unwrap_or_default();
 
-    let name = restricted
-        .name
-        .as_ref()
-        .and_then(|n| n.decrypt(ctx, ciphers_key).ok())
-        .unwrap_or_default();
+    let name = decrypt_restricted_name(&restricted, ctx, ciphers_key, strict)?;
 
     // Only logins carry URIs; expose them so the partial view can render a domain
     // (favicon / launch). Every other login field stays absent.
-    let login = matches!(cipher.r#type, CipherType::Login).then(|| LoginView {
-        username: None,
-        password: None,
-        password_revision_date: None,
-        uris: restricted.uris.decrypt(ctx, ciphers_key).ok().flatten(),
-        totp: None,
-        autofill_on_page_load: None,
-        fido2_credentials: None,
-    });
+    let login = if matches!(cipher.r#type, CipherType::Login) {
+        Some(LoginView {
+            username: None,
+            password: None,
+            password_revision_date: None,
+            uris: decrypt_restricted_uris(&restricted, ctx, ciphers_key, strict)?,
+            totp: None,
+            autofill_on_page_load: None,
+            fido2_credentials: None,
+        })
+    } else {
+        None
+    };
 
     let mut view = CipherView {
         id: cipher.id,
@@ -1660,15 +1697,12 @@ fn decrypt_restricted_cipher_list_view(
     raw: &str,
     ctx: &mut KeyStoreContext<KeySlotIds>,
     key: SymmetricKeySlotId,
+    strict: bool,
 ) -> Result<CipherListView, CryptoError> {
     let ciphers_key = Cipher::decrypt_cipher_key(ctx, key, &cipher.key)?;
     let restricted: RestrictedCipherData = serde_json::from_str(raw).unwrap_or_default();
 
-    let name = restricted
-        .name
-        .as_ref()
-        .and_then(|n| n.decrypt(ctx, ciphers_key).ok())
-        .unwrap_or_default();
+    let name = decrypt_restricted_name(&restricted, ctx, ciphers_key, strict)?;
 
     let r#type = match cipher.r#type {
         CipherType::Login => CipherListViewType::Login(LoginListView {
@@ -1676,7 +1710,7 @@ fn decrypt_restricted_cipher_list_view(
             has_fido2: false,
             username: None,
             totp: None,
-            uris: restricted.uris.decrypt(ctx, ciphers_key).ok().flatten(),
+            uris: decrypt_restricted_uris(&restricted, ctx, ciphers_key, strict)?,
         }),
         CipherType::SecureNote => CipherListViewType::SecureNote,
         CipherType::Card => CipherListViewType::Card(CardListView { brand: None }),
@@ -1739,7 +1773,7 @@ impl Decryptable<KeySlotIds, SymmetricKeySlotId, CipherView> for Cipher {
             if self.organization_id.is_none() {
                 return Err(CryptoError::RestrictedCipherRequiresOrganization);
             }
-            return decrypt_restricted_cipher_view(self, raw, ctx, key);
+            return decrypt_restricted_cipher_view(self, raw, ctx, key, false);
         }
         match try_parse_blob(self) {
             Some(sealed) => decrypt_blob_cipher(self, &sealed, ctx, key).map_err(CryptoError::from),
@@ -1761,7 +1795,7 @@ impl Decryptable<KeySlotIds, SymmetricKeySlotId, CipherListView> for Cipher {
             if self.organization_id.is_none() {
                 return Err(CryptoError::RestrictedCipherRequiresOrganization);
             }
-            return decrypt_restricted_cipher_list_view(self, raw, ctx, key);
+            return decrypt_restricted_cipher_list_view(self, raw, ctx, key, false);
         }
         match try_parse_blob(self) {
             Some(sealed) => decrypt_blob_cipher(self, &sealed, ctx, key)?.to_list_view(ctx, key),
@@ -1816,7 +1850,7 @@ impl Decryptable<KeySlotIds, SymmetricKeySlotId, CipherView> for StrictDecrypt<C
             if self.0.organization_id.is_none() {
                 return Err(CryptoError::RestrictedCipherRequiresOrganization);
             }
-            return decrypt_restricted_cipher_view(&self.0, raw, ctx, key);
+            return decrypt_restricted_cipher_view(&self.0, raw, ctx, key, true);
         }
         match try_parse_blob(&self.0) {
             Some(sealed) => {
@@ -1928,7 +1962,7 @@ impl Decryptable<KeySlotIds, SymmetricKeySlotId, CipherListView> for StrictDecry
             if self.0.organization_id.is_none() {
                 return Err(CryptoError::RestrictedCipherRequiresOrganization);
             }
-            return decrypt_restricted_cipher_list_view(&self.0, raw, ctx, key);
+            return decrypt_restricted_cipher_list_view(&self.0, raw, ctx, key, true);
         }
         match try_parse_blob(&self.0) {
             Some(sealed) => decrypt_blob_cipher(&self.0, &sealed, ctx, key)?.to_list_view(ctx, key),
@@ -2673,6 +2707,12 @@ mod tests {
         let view: CipherView = key_store.decrypt(&cipher).unwrap();
         assert!(view.partial);
         assert!(view.name.is_empty());
+
+        // A malformed envelope is a wire-shape problem, not a crypto failure: lenient even in
+        // strict mode.
+        let strict_view: CipherView = key_store.decrypt(&StrictDecrypt(cipher.clone())).unwrap();
+        assert!(strict_view.partial);
+        assert!(strict_view.name.is_empty());
     }
 
     #[test]
@@ -2693,6 +2733,35 @@ mod tests {
         let view: CipherView = key_store.decrypt(&StrictDecrypt(cipher)).unwrap();
         assert!(view.partial);
         assert!(view.card.is_none());
+    }
+
+    #[test]
+    fn test_decrypt_restricted_strict_propagates_field_decrypt_error() {
+        let (org, key_store) = restricted_test_key_store();
+        // Encrypt a name under an UNRELATED key so it is present in the envelope but cannot be
+        // decrypted with the organization key.
+        let wrong_key_store = create_test_crypto_with_user_key(SymmetricCryptoKey::make(
+            SymmetricKeyAlgorithm::Aes256CbcHmac,
+        ));
+        let bad_name = "boom"
+            .to_string()
+            .encrypt(&mut wrong_key_store.context(), SymmetricKeySlotId::User)
+            .unwrap();
+        let envelope = serde_json::json!({ "name": bad_name }).to_string();
+        let cipher = restricted_cipher(org, CipherType::Login, envelope);
+
+        // Lenient degrades to an empty name, still gated.
+        let view: CipherView = key_store.decrypt(&cipher).unwrap();
+        assert!(view.partial);
+        assert!(view.name.is_empty());
+
+        // Strict surfaces the present-but-undecryptable field as an error (both view and list).
+        let view_result: Result<CipherView, CryptoError> =
+            key_store.decrypt(&StrictDecrypt(cipher.clone()));
+        assert!(view_result.is_err());
+        let list_result: Result<CipherListView, CryptoError> =
+            key_store.decrypt(&StrictDecrypt(cipher));
+        assert!(list_result.is_err());
     }
 
     #[test]

--- a/crates/bitwarden-vault/src/cipher/cipher.rs
+++ b/crates/bitwarden-vault/src/cipher/cipher.rs
@@ -33,7 +33,7 @@ use super::{
     cipher_permissions::CipherPermissions,
     drivers_license, field, identity,
     local_data::{LocalData, LocalDataView},
-    login::{LoginListView, LoginUri, LoginUriView, UriMatchType},
+    login::{LoginListView, LoginUri, LoginUriView},
     passport, secure_note, ssh_key,
 };
 use crate::{
@@ -1547,48 +1547,32 @@ impl IdentifyKey<SymmetricKeySlotId> for Cipher {
     }
 }
 
-/// The server's reduced payload for a restricted (PAM-gated) cipher, mirroring
-/// `PartialCipherData.Strip` on the server. Deserialized with PascalCase to match the server's
-/// wire shape. This struct is the single authoritative allowlist for what a gated view may
-/// expose: the encrypted name and, for logins, the encrypted URIs — nothing else, so an
-/// over-sharing server blob can never leak a password or TOTP onto a gated view.
+/// The server's reduced payload for a restricted (PAM-gated) cipher, produced by
+/// `PartialCipherData.Strip` on the server. The server emits a purpose-built camelCase envelope
+/// carrying the same [`LoginUri`] fields the full decrypt path uses, so the URIs deserialize
+/// straight into [`LoginUri`] with no parallel representation.
+///
+/// This struct is the single authoritative allowlist for what a gated view may expose: the
+/// encrypted name and, for logins, the encrypted URIs — nothing else. It is deliberately NOT
+/// `deny_unknown_fields`: an over-sharing server blob (e.g. a stray `password` or `totp`) is
+/// silently dropped by the allowlist rather than surfaced onto the view or failing the parse.
 #[derive(Deserialize, Default)]
-#[serde(rename_all = "PascalCase")]
+#[serde(rename_all = "camelCase")]
 struct RestrictedCipherData {
     name: Option<EncString>,
-    uris: Option<Vec<RestrictedLoginUri>>,
-}
-
-/// A single URI entry inside [`RestrictedCipherData`] (server PascalCase shape). Structurally a
-/// [`LoginUri`]; converted to one for decryption.
-#[derive(Deserialize)]
-#[serde(rename_all = "PascalCase")]
-struct RestrictedLoginUri {
-    uri: Option<EncString>,
-    r#match: Option<UriMatchType>,
-    uri_checksum: Option<EncString>,
-}
-
-impl From<RestrictedLoginUri> for LoginUri {
-    fn from(u: RestrictedLoginUri) -> Self {
-        LoginUri {
-            uri: u.uri,
-            r#match: u.r#match,
-            uri_checksum: u.uri_checksum,
-        }
-    }
+    uris: Option<Vec<LoginUri>>,
 }
 
 /// Decrypt the allowlisted URIs from a restricted envelope. A URI that fails to decrypt is
 /// dropped rather than failing the whole cipher.
 fn decrypt_restricted_uris(
-    uris: Option<Vec<RestrictedLoginUri>>,
+    uris: Option<Vec<LoginUri>>,
     ctx: &mut KeyStoreContext<KeySlotIds>,
     ciphers_key: SymmetricKeySlotId,
 ) -> Option<Vec<LoginUriView>> {
     uris.map(|list| {
         list.into_iter()
-            .filter_map(|u| LoginUri::from(u).decrypt(ctx, ciphers_key).ok())
+            .filter_map(|u| u.decrypt(ctx, ciphers_key).ok())
             .collect()
     })
 }
@@ -2556,8 +2540,8 @@ mod tests {
             .encrypt(&mut key_store.context(), SymmetricKeySlotId::User)
             .unwrap();
         let envelope = serde_json::json!({
-            "Name": enc_name,
-            "Uris": [{ "Uri": enc_uri, "UriChecksum": null, "Match": null }],
+            "name": enc_name,
+            "uris": [{ "uri": enc_uri, "uriChecksum": null, "match": null }],
         })
         .to_string();
 
@@ -2603,9 +2587,9 @@ mod tests {
             .encrypt(&mut key_store.context(), SymmetricKeySlotId::User)
             .unwrap();
         let envelope = serde_json::json!({
-            "Name": enc_name,
-            "Uris": [{ "Uri": enc_uri, "UriChecksum": null, "Match": null }],
-            "Password": enc_pw,
+            "name": enc_name,
+            "uris": [{ "uri": enc_uri, "uriChecksum": null, "match": null }],
+            "password": enc_pw,
         })
         .to_string();
 
@@ -2637,7 +2621,7 @@ mod tests {
             .to_string()
             .encrypt(&mut key_store.context(), SymmetricKeySlotId::User)
             .unwrap();
-        let envelope = serde_json::json!({ "Name": enc_name }).to_string();
+        let envelope = serde_json::json!({ "name": enc_name }).to_string();
         let cipher = restricted_cipher(CipherType::SecureNote, envelope);
 
         let list: CipherListView = key_store.decrypt(&cipher).unwrap();
@@ -2678,7 +2662,7 @@ mod tests {
             .to_string()
             .encrypt(&mut key_store.context(), SymmetricKeySlotId::User)
             .unwrap();
-        let envelope = serde_json::json!({ "Name": enc_name }).to_string();
+        let envelope = serde_json::json!({ "name": enc_name }).to_string();
         // A Card with no card payload would hit `MissingField("card")` under strict decrypt —
         // the restricted branch must short-circuit before that.
         let cipher = restricted_cipher(CipherType::Card, envelope);

--- a/crates/bitwarden-vault/src/cipher/cipher_client/admin/edit.rs
+++ b/crates/bitwarden-vault/src/cipher/cipher_client/admin/edit.rs
@@ -214,6 +214,7 @@ mod tests {
 
     fn generate_test_cipher() -> CipherView {
         CipherView {
+            partial: false,
             id: Some(TEST_CIPHER_ID.parse().unwrap()),
             organization_id: None,
             folder_id: None,

--- a/crates/bitwarden-vault/src/cipher/cipher_client/admin/get.rs
+++ b/crates/bitwarden-vault/src/cipher/cipher_client/admin/get.rs
@@ -183,6 +183,7 @@ mod tests {
 
     fn generate_test_cipher() -> Cipher {
         Cipher {
+            partial_data: None,
             id: TEST_CIPHER_ID_1.parse().ok(),
             name: Some("2.pMS6/icTQABtulw52pq2lg==|XXbxKxDTh+mWiN1HjH2N1w==|Q6PkuT+KX/axrgN9ubD5Ajk2YNwxQkgs3WJM0S0wtG8=".parse().unwrap()),
             r#type: CipherType::Login,

--- a/crates/bitwarden-vault/src/cipher/cipher_client/admin/restore.rs
+++ b/crates/bitwarden-vault/src/cipher/cipher_client/admin/restore.rs
@@ -140,6 +140,7 @@ mod tests {
 
     fn generate_test_cipher() -> Cipher {
         Cipher {
+            partial_data: None,
             id: TEST_CIPHER_ID.parse().ok(),
             name: Some("2.pMS6/icTQABtulw52pq2lg==|XXbxKxDTh+mWiN1HjH2N1w==|Q6PkuT+KX/axrgN9ubD5Ajk2YNwxQkgs3WJM0S0wtG8=".parse().unwrap()),
             r#type: crate::CipherType::Login,

--- a/crates/bitwarden-vault/src/cipher/cipher_client/bulk_update_collections.rs
+++ b/crates/bitwarden-vault/src/cipher/cipher_client/bulk_update_collections.rs
@@ -101,6 +101,7 @@ mod tests {
 
     fn generate_test_cipher() -> Cipher {
         Cipher {
+            partial_data: None,
             id: TEST_CIPHER_ID.parse().ok(),
             name: Some("2.pMS6/icTQABtulw52pq2lg==|XXbxKxDTh+mWiN1HjH2N1w==|Q6PkuT+KX/axrgN9ubD5Ajk2YNwxQkgs3WJM0S0wtG8=".parse().unwrap()),
             r#type: crate::CipherType::Login,

--- a/crates/bitwarden-vault/src/cipher/cipher_client/create.rs
+++ b/crates/bitwarden-vault/src/cipher/cipher_client/create.rs
@@ -70,6 +70,7 @@ pub(crate) fn convert_request_to_cipher_view(r: CipherCreateRequest) -> CipherVi
     // merge; `Utc::now()` is a safe placeholder.
     let now = chrono::Utc::now();
     CipherView {
+        partial: false,
         id: None,
         organization_id: r.organization_id,
         folder_id: r.folder_id,

--- a/crates/bitwarden-vault/src/cipher/cipher_client/delete.rs
+++ b/crates/bitwarden-vault/src/cipher/cipher_client/delete.rs
@@ -155,6 +155,7 @@ mod tests {
 
     fn generate_test_cipher() -> Cipher {
         Cipher {
+            partial_data: None,
             id: TEST_CIPHER_ID.parse().ok(),
             name: Some("2.pMS6/icTQABtulw52pq2lg==|XXbxKxDTh+mWiN1HjH2N1w==|Q6PkuT+KX/axrgN9ubD5Ajk2YNwxQkgs3WJM0S0wtG8=".parse().unwrap()),
             r#type: crate::CipherType::Login,

--- a/crates/bitwarden-vault/src/cipher/cipher_client/edit.rs
+++ b/crates/bitwarden-vault/src/cipher/cipher_client/edit.rs
@@ -123,6 +123,7 @@ pub struct CipherPartialEditRequest {
 /// as the `CipherView` produced will not have all fields populated (e.g. `collection_ids`).
 pub(crate) fn convert_request_to_cipher_view(r: CipherEditRequest) -> CipherView {
     CipherView {
+        partial: false,
         id: Some(r.id),
         organization_id: r.organization_id,
         folder_id: r.folder_id,
@@ -371,6 +372,7 @@ mod tests {
 
     fn generate_test_cipher() -> CipherView {
         CipherView {
+            partial: false,
             id: Some(TEST_CIPHER_ID.parse().unwrap()),
             organization_id: None,
             folder_id: None,
@@ -431,6 +433,7 @@ mod tests {
             let mut ctx = store.context();
 
             Cipher {
+                partial_data: None,
                 id: Some(cipher_id),
                 organization_id: None,
                 folder_id: None,

--- a/crates/bitwarden-vault/src/cipher/cipher_client/mod.rs
+++ b/crates/bitwarden-vault/src/cipher/cipher_client/mod.rs
@@ -397,6 +397,7 @@ mod tests {
 
     fn test_cipher() -> Cipher {
         Cipher {
+            partial_data: None,
             id: Some("358f2b2b-9326-4e5e-94a8-b18100bb0908".parse().unwrap()),
             organization_id: None,
             folder_id: None,
@@ -443,6 +444,7 @@ mod tests {
     fn test_cipher_view() -> CipherView {
         let test_id = "fd411a1a-fec8-4070-985d-0e6560860e69".parse().unwrap();
         CipherView {
+            partial: false,
             r#type: CipherType::Login,
             login: Some(crate::LoginView {
                 username: Some("test_username".to_string()),
@@ -515,6 +517,7 @@ mod tests {
             .vault()
             .ciphers()
             .decrypt_list(vec![Cipher {
+                partial_data: None,
                 id: Some("a1569f46-0797-4d3f-b859-b181009e2e49".parse().unwrap()),
                 organization_id: Some("1bc9ac1e-f5aa-45f2-94bf-b181009709b8".parse().unwrap()),
                 folder_id: None,

--- a/crates/bitwarden-vault/src/cipher/cipher_client/move_many.rs
+++ b/crates/bitwarden-vault/src/cipher/cipher_client/move_many.rs
@@ -70,6 +70,7 @@ mod tests {
 
     fn generate_test_cipher() -> Cipher {
         Cipher {
+            partial_data: None,
             id: TEST_CIPHER_ID.parse().ok(),
             name: Some("2.pMS6/icTQABtulw52pq2lg==|XXbxKxDTh+mWiN1HjH2N1w==|Q6PkuT+KX/axrgN9ubD5Ajk2YNwxQkgs3WJM0S0wtG8=".parse().unwrap()),
             r#type: crate::CipherType::Login,

--- a/crates/bitwarden-vault/src/cipher/cipher_client/restore.rs
+++ b/crates/bitwarden-vault/src/cipher/cipher_client/restore.rs
@@ -174,6 +174,7 @@ mod tests {
 
     fn generate_test_cipher() -> Cipher {
         Cipher {
+            partial_data: None,
             id: TEST_CIPHER_ID.parse().ok(),
             name: Some("2.pMS6/icTQABtulw52pq2lg==|XXbxKxDTh+mWiN1HjH2N1w==|Q6PkuT+KX/axrgN9ubD5Ajk2YNwxQkgs3WJM0S0wtG8=".parse().unwrap()),
             r#type: crate::CipherType::Login,

--- a/crates/bitwarden-vault/src/cipher/cipher_client/share_cipher.rs
+++ b/crates/bitwarden-vault/src/cipher/cipher_client/share_cipher.rs
@@ -77,6 +77,7 @@ async fn share_ciphers_bulk(
             .await?;
 
         let cipher: Cipher = Cipher {
+            partial_data: None,
             id: cipher_mini.id.map(CipherId::new),
             organization_id: cipher_mini.organization_id.map(OrganizationId::new),
             key: EncString::try_from_optional(cipher_mini.key)?,
@@ -321,6 +322,7 @@ mod tests {
 
     fn test_cipher_view_without_org() -> CipherView {
         CipherView {
+            partial: false,
             r#type: CipherType::Login,
             login: Some(LoginView {
                 username: Some("test@example.com".to_string()),
@@ -521,6 +523,7 @@ mod tests {
 
         // Create a minimal encrypted cipher for testing the API logic
         let cipher = Cipher {
+                partial_data: None,
                 r#type: CipherType::Login,
                 login: Some(Login {
                     username: Some("2.EI9Km5BfrIqBa1W+WCccfA==|laWxNnx+9H3MZww4zm7cBSLisjpi81zreaQntRhegVI=|x42+qKFf5ga6DIL0OW5pxCdLrC/gm8CXJvf3UASGteI=".parse().unwrap()),
@@ -688,6 +691,7 @@ mod tests {
 
         // Pre-populate repository with original cipher data that will be used for missing fields
         let original_cipher = Cipher {
+                partial_data: None,
                 r#type: CipherType::Login,
                 login: Some(crate::cipher::Login {
                     username: Some("2.EI9Km5BfrIqBa1W+WCccfA==|laWxNnx+9H3MZww4zm7cBSLisjpi81zreaQntRhegVI=|x42+qKFf5ga6DIL0OW5pxCdLrC/gm8CXJvf3UASGteI=".parse().unwrap()),

--- a/crates/bitwarden-vault/src/cipher/secure_note.rs
+++ b/crates/bitwarden-vault/src/cipher/secure_note.rs
@@ -152,6 +152,7 @@ mod tests {
 
     fn create_cipher_for_note(note: SecureNote) -> Cipher {
         Cipher {
+            partial_data: None,
             id: Some("090c19ea-a61a-4df6-8963-262b97bc6266".parse().unwrap()),
             organization_id: None,
             folder_id: None,

--- a/crates/bitwarden-vault/src/totp.rs
+++ b/crates/bitwarden-vault/src/totp.rs
@@ -731,6 +731,7 @@ mod tests {
     #[test]
     fn test_generate_totp_cipher_view() {
         let view = CipherListView {
+            partial: false,
             id: Some("090c19ea-a61a-4df6-8963-262b97bc6266".parse().unwrap()),
             organization_id: None,
             folder_id: None,


### PR DESCRIPTION
## 🎟️ Tracking

Middle link of a three-repo chain, all targeting `pam/uat`:

- **server** [bitwarden/server#8235](https://github.com/bitwarden/server/pull/8235) — emits the codes
- **sdk-internal** — this PR: maps them onto typed variants
- **clients** [bitwarden/clients#22544](https://github.com/bitwarden/clients/pull/22544) — deletes the two sentence-matching catalogs

## 📔 Objective

PAM endpoints used to reject with a human-readable message and no discriminant, so a client that had to act differently on different failures could only match the server's English sentence. The web client had grown **two** catalogs of eighteen sentences matched with `String.includes()` — three of which are not failures at all, but states the UI reconciles with.

The server now answers with an RFC 7807 problem carrying a stable code at `errors.<property>[].type`. This maps those codes onto typed error variants.

### Shape

`problem::codes` reads the codes out of the body; each surface's error enum maps them through a `from_code` table — the whole contract in one greppable place:

```rust
fn from_code(code: &str) -> Option<Self> {
    Some(match code {
        "access_already_active" => Self::AlreadyActive,
        "access_request_already_pending" => Self::AlreadyPending,
        …
        _ => return None,
    })
}
```

Because the enums are `#[bitwarden_error(flat)]`, the **variant name is what reaches TypeScript** — which is the point. `AccessRequestError` now surfaces as a union a client can switch on:

```ts
variant: "Validation" | "AlreadyActive" | "AlreadyPending" | "AlreadyApproved" | "CipherNotGated"
  | "DurationExpected" | "WindowExpected" | … | "Decode" | "Api";
```

A payload-carrying variant would not have reached TS at all in flat mode, so one variant per code is not verbosity — it is the mechanism.

### Where classification hangs

On `From<ApiError>`, so every call on a surface gets it: a code means the same thing at every endpoint that can emit it, by construction.

Status-based mapping stays exactly where it was — pinned to the by-id calls in `AccessRuleError::from_by_id_api_error` — because a `404` is only about a rule when the call named one. That asymmetry is deliberate and commented: codes are context-free, statuses are not.

### Unknown codes

An unrecognized code stays `Api`. That is what makes the server's "adding codes is additive" promise real: a server that grows a code never needs a client release to be safe, and never gets silently mapped to the wrong variant.

### Placement

`problem` lives in this crate because PAM is the first surface to speak RFC 7807. Nothing in it is PAM-specific — lift it into `bitwarden-core` unchanged when a second crate needs it.

### Tests

Per-surface: a code becomes its own variant, a shared code (`duration_must_be_positive`, raised by both the request and lease surfaces) maps to each surface's own variant, a `404` still wins over the code reader on the by-id calls, and an unrecognized code and a transport failure both stay untyped. `problem` covers a validation body, a conflict body, a multi-field model-state body, a non-problem body, and a transport failure. 171 tests pass; `cargo clippy --all-features` and nightly `cargo fmt` are clean.

Verified end-to-end with a local WASM build (`build.sh` + `build.sh -b`) linked into clients: the generated `.d.ts` carries the variants above, and the clients PR type-checks and its 628 PAM tests pass against it.

