### PR TITLE
[PM-40985] Introduce managed settings crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -986,6 +986,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "bitwarden-managed-settings-types"
+version = "3.0.0"
+dependencies = [
+ "bitwarden-error",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "bitwarden-organization-crypto"
 version = "3.0.0"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -986,6 +986,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "bitwarden-managed-settings"
+version = "3.0.0"
+dependencies = [
+ "bitwarden-managed-settings-types",
+]
+
+[[package]]
 name = "bitwarden-managed-settings-types"
 version = "3.0.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,7 @@ bitwarden-importers = { path = "crates/bitwarden-importers", version = "=3.0.0" 
 bitwarden-ipc = { path = "crates/bitwarden-ipc", version = "=3.0.0" }
 bitwarden-logging = { path = "crates/bitwarden-logging", version = "=3.0.0" }
 bitwarden-logging-macro = { path = "crates/bitwarden-logging-macro", version = "=3.0.0" }
+bitwarden-managed-settings = { path = "crates/bitwarden-managed-settings", version = "=3.0.0" }
 bitwarden-managed-settings-types = { path = "crates/bitwarden-managed-settings-types", version = "=3.0.0" }
 bitwarden-organization-crypto = { path = "crates/bitwarden-organization-crypto", version = "=3.0.0" }
 bitwarden-organization-invite-link = { path = "crates/bitwarden-organization-invite-link", version = "=3.0.0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,7 @@ bitwarden-importers = { path = "crates/bitwarden-importers", version = "=3.0.0" 
 bitwarden-ipc = { path = "crates/bitwarden-ipc", version = "=3.0.0" }
 bitwarden-logging = { path = "crates/bitwarden-logging", version = "=3.0.0" }
 bitwarden-logging-macro = { path = "crates/bitwarden-logging-macro", version = "=3.0.0" }
+bitwarden-managed-settings-types = { path = "crates/bitwarden-managed-settings-types", version = "=3.0.0" }
 bitwarden-organization-crypto = { path = "crates/bitwarden-organization-crypto", version = "=3.0.0" }
 bitwarden-organization-invite-link = { path = "crates/bitwarden-organization-invite-link", version = "=3.0.0" }
 bitwarden-organizations = { path = "crates/bitwarden-organizations", version = "=3.0.0" }

--- a/crates/bitwarden-managed-settings-types/Cargo.toml
+++ b/crates/bitwarden-managed-settings-types/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "bitwarden-managed-settings-types"
+description = """
+Shared data types for managed settings, the configuration an organization's IT administrators
+enforce through the host operating system's Unified Endpoint Management (UEM) channel.
+Internal crate for the bitwarden crate. Do not use.
+"""
+
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+readme.workspace = true
+homepage.workspace = true
+repository.workspace = true
+license = "GPL-3.0-only OR LicenseRef-Bitwarden-SDK"
+keywords.workspace = true
+
+[dependencies]
+bitwarden-error = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+thiserror = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/bitwarden-managed-settings-types/README.md
+++ b/crates/bitwarden-managed-settings-types/README.md
@@ -1,0 +1,25 @@
+# Bitwarden Managed Settings Types
+
+Contains the shared data types for managed settings — configuration an organization's IT
+administrators enforce through the host operating system's Unified Endpoint Management (UEM)
+channel.
+
+[`ManagementProfile`] is a point-in-time snapshot of that configuration: a schema
+[`version`](ManagementProfile::version), an [`updated_at`](ManagementProfile::updated_at) timestamp
+recording when the host last refreshed it, and a [`settings`](ManagementProfile::settings) map of
+dotted keys (e.g. `"environment.base"`) to JSON-encoded value strings. Values are stored as plain
+`String` rather than `serde_json::Value` because `String` has a UniFFI representation; callers
+decode on demand.
+
+Read a profile with [`ManagementProfile::is_managed`] to test whether a key is administrator-forced,
+[`ManagementProfile::get`] for the raw JSON-encoded string, or [`ManagementProfile::get_as`] to
+decode into a concrete type — which fails with [`ManagedSettingsError::Decode`] when the stored
+value does not match the requested shape. [`ManagementProfile::empty`] builds a profile that manages
+nothing.
+
+This crate exists separately from `bitwarden-managed-settings` to break a dependency cycle:
+`bitwarden-core` must name [`ManagementProfile`] to hold the shared profile cell, while the
+higher-level `ManagedSettingsClient` handle depends on `bitwarden-core`.
+
+Managed settings are administrator-supplied client configuration. They are not Vault Data, involve
+no cryptography, and carry no key material.

--- a/crates/bitwarden-managed-settings-types/src/lib.rs
+++ b/crates/bitwarden-managed-settings-types/src/lib.rs
@@ -1,0 +1,4 @@
+#![doc = include_str!("../README.md")]
+
+mod profile;
+pub use profile::{ManagedSettingsError, ManagementProfile};

--- a/crates/bitwarden-managed-settings-types/src/profile.rs
+++ b/crates/bitwarden-managed-settings-types/src/profile.rs
@@ -1,0 +1,154 @@
+use std::collections::HashMap;
+
+use bitwarden_error::bitwarden_error;
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+/// Errors that can occur while reading a [`ManagementProfile`].
+#[bitwarden_error(flat)]
+#[derive(Debug, Error)]
+pub enum ManagedSettingsError {
+    /// The value stored under the requested key could not be parsed as the expected shape.
+    #[error("Failed to decode managed settings value: {0}")]
+    Decode(String),
+}
+
+/// A point-in-time snapshot of administrator-forced configuration for this client.
+///
+/// `settings` maps dotted keys (e.g. `"generator.password.length"`) to JSON-encoded
+/// strings. A plain `String` is used (not `serde_json::Value`) because it has a UniFFI
+/// representation. Callers parse on demand through [`get_as`](ManagementProfile::get_as).
+///
+/// This is client configuration forced by an operating system's Unified Endpoint Management
+/// (UEM/MDM) channel. It is not Vault Data and involves no cryptography.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct ManagementProfile {
+    /// Schema version. Bumped when the dotted-key namespace changes incompatibly.
+    pub version: u32,
+    /// Unix timestamp (seconds) at which the host last refreshed the profile.
+    ///
+    /// This field participates in equality, so two profiles carrying identical `settings` compare
+    /// unequal when the host re-read the source and re-stamped the timestamp. Do not use `==` to
+    /// detect whether the managed settings themselves changed; compare `settings` instead.
+    pub updated_at: i64,
+    /// Dotted key to JSON-encoded value string.
+    pub settings: HashMap<String, String>,
+}
+
+impl ManagementProfile {
+    /// An empty profile, equivalent to "no admin overrides". Every `is_managed` returns `false`.
+    pub fn empty() -> Self {
+        Self {
+            version: 1,
+            updated_at: 0,
+            settings: HashMap::new(),
+        }
+    }
+
+    /// Returns `true` if `key` is present. Presence implies the value is forced.
+    pub fn is_managed(&self, key: &str) -> bool {
+        self.settings.contains_key(key)
+    }
+
+    /// Returns the raw JSON-encoded string stored under `key`, if any.
+    pub fn get(&self, key: &str) -> Option<String> {
+        self.settings.get(key).cloned()
+    }
+
+    /// Get and JSON-decode a value to `T`.
+    pub fn get_as<T: serde::de::DeserializeOwned>(
+        &self,
+        key: &str,
+    ) -> Result<Option<T>, ManagedSettingsError> {
+        match self.settings.get(key) {
+            None => Ok(None),
+            Some(raw) => serde_json::from_str(raw)
+                .map(Some)
+                .map_err(|e| ManagedSettingsError::Decode(e.to_string())),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn profile_with(entries: &[(&str, &str)]) -> ManagementProfile {
+        ManagementProfile {
+            version: 1,
+            updated_at: 1_750_000_000,
+            settings: entries
+                .iter()
+                .map(|(k, v)| (k.to_string(), v.to_string()))
+                .collect(),
+        }
+    }
+
+    #[test]
+    fn is_managed_reflects_key_presence() {
+        let profile = profile_with(&[("environment.base", "\"https://vault.example.com\"")]);
+
+        assert!(profile.is_managed("environment.base"));
+        assert!(!profile.is_managed("environment.api"));
+    }
+
+    #[test]
+    fn get_returns_the_raw_json_encoded_value() {
+        let profile = profile_with(&[("environment.base", "\"https://vault.example.com\"")]);
+
+        assert_eq!(
+            profile.get("environment.base"),
+            Some("\"https://vault.example.com\"".to_string())
+        );
+    }
+
+    #[test]
+    fn get_returns_none_for_an_absent_key() {
+        let profile = profile_with(&[("environment.base", "\"https://vault.example.com\"")]);
+
+        assert_eq!(profile.get("environment.api"), None);
+    }
+
+    #[test]
+    fn get_as_decodes_a_present_value() {
+        let profile = profile_with(&[("generator.password.length", "14")]);
+
+        assert_eq!(
+            profile.get_as::<u32>("generator.password.length").unwrap(),
+            Some(14)
+        );
+    }
+
+    #[test]
+    fn get_as_returns_none_for_an_absent_key() {
+        let profile = profile_with(&[("generator.password.length", "14")]);
+
+        assert_eq!(
+            profile
+                .get_as::<u32>("generator.password.uppercase")
+                .unwrap(),
+            None
+        );
+    }
+
+    #[test]
+    fn get_as_errors_when_the_value_does_not_match_the_requested_type() {
+        let profile = profile_with(&[("generator.password.length", "\"fourteen\"")]);
+
+        let error = profile
+            .get_as::<u32>("generator.password.length")
+            .expect_err("decoding a string as u32 should fail");
+
+        assert!(matches!(error, ManagedSettingsError::Decode(_)));
+    }
+
+    #[test]
+    fn empty_profile_manages_nothing() {
+        let profile = ManagementProfile::empty();
+
+        assert!(!profile.is_managed("environment.base"));
+        assert_eq!(profile.get("environment.base"), None);
+        assert_eq!(profile.get_as::<u32>("environment.base").unwrap(), None);
+    }
+}

--- a/crates/bitwarden-managed-settings/Cargo.toml
+++ b/crates/bitwarden-managed-settings/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "bitwarden-managed-settings"
+description = """
+Read access to managed settings, the configuration an organization's IT administrators enforce
+through the host operating system's Unified Endpoint Management (UEM) channel.
+Internal crate for the bitwarden crate. Do not use.
+"""
+
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+readme.workspace = true
+homepage.workspace = true
+repository.workspace = true
+license = "GPL-3.0-only OR LicenseRef-Bitwarden-SDK"
+keywords.workspace = true
+
+[dependencies]
+bitwarden-managed-settings-types = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/bitwarden-managed-settings/README.md
+++ b/crates/bitwarden-managed-settings/README.md
@@ -1,0 +1,27 @@
+# Bitwarden Managed Settings
+
+Provides [`ManagedSettingsClient`], the SDK's read handle onto the settings an organization's IT
+administrators enforce through the host operating system's Unified Endpoint Management (UEM)
+channel.
+
+The host application constructs a [`ManagedSettingsClient`] at startup with
+[`ManagedSettingsClient::new`], acquires a [`ManagementProfile`] from the host platform, and pushes
+it in with [`ManagedSettingsClient::update_profile`]. Passing `None` clears the profile. Clones of
+the handle share one profile, so an update pushed through any clone is observed by all of them, as
+does the shared cell returned by [`ManagedSettingsClient::cell`].
+
+Consumers read a value with [`ManagedSettingsClient::get`] for the raw JSON-encoded string, or
+decode it into a concrete type with [`ManagementProfile::get_as`] on the profile returned by
+[`ManagedSettingsClient::current_profile`]. Guard writes to the corresponding state with
+[`ManagedSettingsClient::is_managed`], only writing when the key is not administrator-forced.
+
+The first profile push is asynchronous on every platform, so a consumer may not observe a managed
+setting immediately after startup.
+
+A managed setting overrides user and global state and built-in defaults. It carries no automatic
+precedence over an enterprise policy — where a policy and a managed setting both bear on one
+effective setting, the consuming feature is responsible for resolving the conflict.
+
+> **Not yet wired into `bitwarden-core`.** Attaching this handle to a `Client`, so SDK feature
+> crates read the profile the host pushes, lands in a follow-up alongside the WASM and UniFFI
+> bindings.

--- a/crates/bitwarden-managed-settings/src/lib.rs
+++ b/crates/bitwarden-managed-settings/src/lib.rs
@@ -1,0 +1,5 @@
+#![doc = include_str!("../README.md")]
+
+mod managed_settings_client;
+pub use bitwarden_managed_settings_types::ManagementProfile;
+pub use managed_settings_client::ManagedSettingsClient;

--- a/crates/bitwarden-managed-settings/src/managed_settings_client.rs
+++ b/crates/bitwarden-managed-settings/src/managed_settings_client.rs
@@ -1,0 +1,147 @@
+use std::sync::{Arc, RwLock};
+
+use bitwarden_managed_settings_types::ManagementProfile;
+
+/// Handle to the host system's Unified Endpoint Management profile.
+///
+/// The host application constructs one of these at boot and pushes profiles into it. Clones share
+/// the underlying profile, so an update pushed through one clone is observed by all of them.
+#[derive(Clone)]
+pub struct ManagedSettingsClient {
+    profile: Arc<RwLock<Option<ManagementProfile>>>,
+}
+
+impl Default for ManagedSettingsClient {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl ManagedSettingsClient {
+    /// Fresh handle with no active profile. The host should call this once at boot.
+    pub fn new() -> Self {
+        Self {
+            profile: Arc::new(RwLock::new(None)),
+        }
+    }
+
+    /// The shared profile cell, so a constructed SDK client can read the same profile the host
+    /// pushes into this handle.
+    pub fn cell(&self) -> Arc<RwLock<Option<ManagementProfile>>> {
+        self.profile.clone()
+    }
+
+    /// The active profile, or `None` when the host has not pushed one.
+    pub fn current_profile(&self) -> Option<ManagementProfile> {
+        self.profile
+            .read()
+            .expect("managed-settings cell poisoned")
+            .clone()
+    }
+
+    /// Replace the active profile. Clear the profile with `None`.
+    pub fn update_profile(&self, profile: Option<ManagementProfile>) {
+        *self
+            .profile
+            .write()
+            .expect("managed-settings cell poisoned") = profile;
+    }
+
+    /// Returns `true` if `key` is present in the active profile.
+    pub fn is_managed(&self, key: String) -> bool {
+        self.profile
+            .read()
+            .expect("managed-settings cell poisoned")
+            .as_ref()
+            .is_some_and(|p| p.is_managed(&key))
+    }
+
+    /// Raw JSON-encoded value for `key`, if a value is present.
+    pub fn get(&self, key: String) -> Option<String> {
+        self.profile
+            .read()
+            .expect("managed-settings cell poisoned")
+            .as_ref()
+            .and_then(|p| p.get(&key))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use super::*;
+
+    fn profile_with(key: &str, json_value: &str) -> ManagementProfile {
+        ManagementProfile {
+            version: 1,
+            updated_at: 1_750_000_000,
+            settings: HashMap::from([(key.to_string(), json_value.to_string())]),
+        }
+    }
+
+    #[test]
+    fn a_new_client_manages_nothing() {
+        let client = ManagedSettingsClient::new();
+
+        assert_eq!(client.get("environment.base".to_string()), None);
+        assert!(!client.is_managed("environment.base".to_string()));
+        assert_eq!(client.current_profile(), None);
+    }
+
+    #[test]
+    fn get_reflects_an_updated_profile() {
+        let client = ManagedSettingsClient::new();
+        let profile = profile_with("environment.base", "\"https://vault.example.com\"");
+
+        client.update_profile(Some(profile.clone()));
+
+        assert_eq!(
+            client.get("environment.base".to_string()),
+            Some("\"https://vault.example.com\"".to_string())
+        );
+        assert!(client.is_managed("environment.base".to_string()));
+        assert_eq!(client.current_profile(), Some(profile));
+    }
+
+    #[test]
+    fn updating_with_none_clears_the_profile() {
+        let client = ManagedSettingsClient::new();
+        client.update_profile(Some(profile_with("environment.base", "\"https://a\"")));
+
+        client.update_profile(None);
+
+        assert_eq!(client.get("environment.base".to_string()), None);
+        assert!(!client.is_managed("environment.base".to_string()));
+        assert_eq!(client.current_profile(), None);
+    }
+
+    #[test]
+    fn a_clone_observes_an_update_made_on_the_original() {
+        let client = ManagedSettingsClient::new();
+        let clone = client.clone();
+        let profile = profile_with("environment.base", "\"https://vault.example.com\"");
+
+        client.update_profile(Some(profile.clone()));
+
+        assert_eq!(
+            clone.get("environment.base".to_string()),
+            Some("\"https://vault.example.com\"".to_string())
+        );
+        assert_eq!(clone.current_profile(), Some(profile));
+    }
+
+    #[test]
+    fn the_shared_cell_observes_an_update_made_through_the_handle() {
+        let client = ManagedSettingsClient::new();
+        let cell = client.cell();
+        let profile = profile_with("environment.base", "\"https://vault.example.com\"");
+
+        client.update_profile(Some(profile.clone()));
+
+        assert_eq!(
+            *cell.read().expect("managed-settings cell poisoned"),
+            Some(profile)
+        );
+    }
+}


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-40985

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
This PR introduces 2 new crates aimed to define types and a client to consume client configuration forced by an operating system's Unified Endpoint Management (UEM/MDM) channel. 

These new crates are not wired up to `bitwarden-core/ClientBuilder` or `bitwarden_pm::PasswordManagerClient` yet.
In follow up PRs I'll be adding support for wasm and uniffi and include the plumbing which will cause a breaking change for TS clients and mobile clients

### Changes
- **Create bitwarden-managed-settings-types crate** - https://github.com/bitwarden/sdk-internal/commit/a192bf94a2f938de7b0d5860ddeb60d07ded8925
- **Create bitwarden-managed-settings crate** - https://github.com/bitwarden/sdk-internal/commit/3dc009b6321f81e82951c2dc969a0db5137e44da
