### PR TITLE
[PM-40994] Add and generate wasm and uniffi bindings for managed settings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -990,6 +990,8 @@ name = "bitwarden-managed-settings"
 version = "3.0.0"
 dependencies = [
  "bitwarden-managed-settings-types",
+ "tracing",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1000,6 +1002,9 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 1.0.69",
+ "tsify",
+ "uniffi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1390,6 +1395,8 @@ dependencies = [
  "bitwarden-fido",
  "bitwarden-generators",
  "bitwarden-importers",
+ "bitwarden-managed-settings",
+ "bitwarden-managed-settings-types",
  "bitwarden-organizations",
  "bitwarden-pm",
  "bitwarden-policies",
@@ -1542,6 +1549,7 @@ dependencies = [
  "bitwarden-error",
  "bitwarden-ipc",
  "bitwarden-logging",
+ "bitwarden-managed-settings",
  "bitwarden-organization-crypto",
  "bitwarden-organization-invite-link",
  "bitwarden-pm",

--- a/crates/bitwarden-managed-settings-types/Cargo.toml
+++ b/crates/bitwarden-managed-settings-types/Cargo.toml
@@ -16,11 +16,22 @@ repository.workspace = true
 license = "GPL-3.0-only OR LicenseRef-Bitwarden-SDK"
 keywords.workspace = true
 
+[features]
+uniffi = ["dep:uniffi"] # Uniffi bindings
+wasm = [
+    "bitwarden-error/wasm",
+    "dep:tsify",
+    "dep:wasm-bindgen",
+] # WASM support
+
 [dependencies]
 bitwarden-error = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
+tsify = { workspace = true, optional = true }
+uniffi = { workspace = true, optional = true }
+wasm-bindgen = { workspace = true, optional = true }
 
 [lints]
 workspace = true

--- a/crates/bitwarden-managed-settings-types/src/lib.rs
+++ b/crates/bitwarden-managed-settings-types/src/lib.rs
@@ -1,4 +1,7 @@
 #![doc = include_str!("../README.md")]
 
+#[cfg(feature = "uniffi")]
+uniffi::setup_scaffolding!();
+
 mod profile;
 pub use profile::{ManagedSettingsError, ManagementProfile};

--- a/crates/bitwarden-managed-settings-types/src/profile.rs
+++ b/crates/bitwarden-managed-settings-types/src/profile.rs
@@ -3,6 +3,8 @@ use std::collections::HashMap;
 use bitwarden_error::bitwarden_error;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
+#[cfg(feature = "wasm")]
+use tsify::Tsify;
 
 /// Errors that can occur while reading a [`ManagementProfile`].
 #[bitwarden_error(flat)]
@@ -23,6 +25,8 @@ pub enum ManagedSettingsError {
 /// (UEM/MDM) channel. It is not Vault Data and involves no cryptography.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
+#[cfg_attr(feature = "wasm", derive(Tsify), tsify(into_wasm_abi, from_wasm_abi))]
 pub struct ManagementProfile {
     /// Schema version. Bumped when the dotted-key namespace changes incompatibly.
     pub version: u32,

--- a/crates/bitwarden-managed-settings-types/uniffi.toml
+++ b/crates/bitwarden-managed-settings-types/uniffi.toml
@@ -1,0 +1,11 @@
+[bindings.kotlin]
+package_name = "com.bitwarden.managedsettings"
+generate_immutable_records = true
+android = true
+# Temporary workaround for https://github.com/mozilla/uniffi-rs/issues/2740
+omit_checksums = true
+
+[bindings.swift]
+ffi_module_name = "BitwardenManagedSettingsFFI"
+module_name = "BitwardenManagedSettings"
+generate_immutable_records = true

--- a/crates/bitwarden-managed-settings/Cargo.toml
+++ b/crates/bitwarden-managed-settings/Cargo.toml
@@ -16,8 +16,17 @@ repository.workspace = true
 license = "GPL-3.0-only OR LicenseRef-Bitwarden-SDK"
 keywords.workspace = true
 
+[features]
+uniffi = ["bitwarden-managed-settings-types/uniffi"] # Uniffi bindings
+wasm = [
+    "bitwarden-managed-settings-types/wasm",
+    "dep:wasm-bindgen",
+] # WASM support
+
 [dependencies]
 bitwarden-managed-settings-types = { workspace = true }
+tracing = { workspace = true }
+wasm-bindgen = { workspace = true, optional = true }
 
 [lints]
 workspace = true

--- a/crates/bitwarden-managed-settings/src/managed_settings_client.rs
+++ b/crates/bitwarden-managed-settings/src/managed_settings_client.rs
@@ -1,12 +1,15 @@
 use std::sync::{Arc, RwLock};
 
 use bitwarden_managed_settings_types::ManagementProfile;
+#[cfg(feature = "wasm")]
+use wasm_bindgen::prelude::*;
 
 /// Handle to the host system's Unified Endpoint Management profile.
 ///
 /// The host application constructs one of these at boot and pushes profiles into it. Clones share
 /// the underlying profile, so an update pushed through one clone is observed by all of them.
 #[derive(Clone)]
+#[cfg_attr(feature = "wasm", wasm_bindgen)]
 pub struct ManagedSettingsClient {
     profile: Arc<RwLock<Option<ManagementProfile>>>,
 }
@@ -17,14 +20,8 @@ impl Default for ManagedSettingsClient {
     }
 }
 
+/// Methods whose signatures cannot cross an FFI boundary, so they stay off the binding surface.
 impl ManagedSettingsClient {
-    /// Fresh handle with no active profile. The host should call this once at boot.
-    pub fn new() -> Self {
-        Self {
-            profile: Arc::new(RwLock::new(None)),
-        }
-    }
-
     /// The shared profile cell, so a constructed SDK client can read the same profile the host
     /// pushes into this handle.
     pub fn cell(&self) -> Arc<RwLock<Option<ManagementProfile>>> {
@@ -38,9 +35,29 @@ impl ManagedSettingsClient {
             .expect("managed-settings cell poisoned")
             .clone()
     }
+}
+
+#[cfg_attr(feature = "wasm", wasm_bindgen)]
+impl ManagedSettingsClient {
+    /// Fresh handle with no active profile. The host should call this once at boot.
+    #[cfg_attr(feature = "wasm", wasm_bindgen(constructor))]
+    pub fn new() -> Self {
+        Self {
+            profile: Arc::new(RwLock::new(None)),
+        }
+    }
 
     /// Replace the active profile. Clear the profile with `None`.
     pub fn update_profile(&self, profile: Option<ManagementProfile>) {
+        match &profile {
+            Some(p) => tracing::info!(
+                version = p.version,
+                keys = p.settings.len(),
+                "Managed settings profile updated"
+            ),
+            None => tracing::info!("Managed settings profile cleared"),
+        }
+
         *self
             .profile
             .write()

--- a/crates/bitwarden-uniffi/Cargo.toml
+++ b/crates/bitwarden-uniffi/Cargo.toml
@@ -34,6 +34,8 @@ bitwarden-exporters = { workspace = true, features = ["uniffi"] }
 bitwarden-fido = { workspace = true, features = ["uniffi"] }
 bitwarden-generators = { workspace = true, features = ["uniffi"] }
 bitwarden-importers = { workspace = true, features = ["uniffi"] }
+bitwarden-managed-settings = { workspace = true, features = ["uniffi"] }
+bitwarden-managed-settings-types = { workspace = true, features = ["uniffi"] }
 bitwarden-organizations = { workspace = true, features = ["uniffi"] }
 bitwarden-pm = { workspace = true, features = ["uniffi"] }
 bitwarden-policies = { workspace = true, features = ["uniffi"] }

--- a/crates/bitwarden-uniffi/src/lib.rs
+++ b/crates/bitwarden-uniffi/src/lib.rs
@@ -15,6 +15,8 @@ pub mod crypto;
 pub mod error;
 mod log_callback;
 #[allow(missing_docs)]
+pub mod managed_settings;
+#[allow(missing_docs)]
 pub mod platform;
 #[allow(missing_docs)]
 pub mod policies;

--- a/crates/bitwarden-uniffi/src/managed_settings.rs
+++ b/crates/bitwarden-uniffi/src/managed_settings.rs
@@ -1,0 +1,40 @@
+use bitwarden_managed_settings::ManagedSettingsClient;
+use bitwarden_managed_settings_types::ManagementProfile;
+
+/// UniFFI wrapper for [`ManagedSettingsClient`].
+///
+/// The host application constructs one of these at boot, acquires a management profile from the
+/// operating system's Unified Endpoint Management channel, and pushes it in with
+/// [`update_profile`](ManagedSettingsBindingClient::update_profile).
+#[derive(uniffi::Object)]
+pub struct ManagedSettingsBindingClient(pub(crate) ManagedSettingsClient);
+
+impl Default for ManagedSettingsBindingClient {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[uniffi::export]
+impl ManagedSettingsBindingClient {
+    /// Fresh handle with no active profile.
+    #[uniffi::constructor]
+    pub fn new() -> Self {
+        Self(ManagedSettingsClient::new())
+    }
+
+    /// Replace the active profile. Clear the profile with `None`.
+    pub fn update_profile(&self, profile: Option<ManagementProfile>) {
+        self.0.update_profile(profile);
+    }
+
+    /// Returns `true` if `key` is present in the active profile.
+    pub fn is_managed(&self, key: String) -> bool {
+        self.0.is_managed(key)
+    }
+
+    /// Raw JSON-encoded value for `key`, if a value is present.
+    pub fn get(&self, key: String) -> Option<String> {
+        self.0.get(key)
+    }
+}

--- a/crates/bitwarden-wasm-internal/Cargo.toml
+++ b/crates/bitwarden-wasm-internal/Cargo.toml
@@ -41,6 +41,7 @@ bitwarden-crypto-sync-handler = { workspace = true, features = ["wasm"] }
 bitwarden-error = { workspace = true }
 bitwarden-ipc = { workspace = true, features = ["wasm"] }
 bitwarden-logging = { workspace = true, features = ["wasm"] }
+bitwarden-managed-settings = { workspace = true, features = ["wasm"] }
 # This dependency is not used directly, but we need to include it in order to
 # ensure wasm-bindgen is generated for the `bitwarden-organization-crypto` crate
 # See [package.metadata.cargo-udeps.ignore] above for more.

--- a/crates/bitwarden-wasm-internal/src/lib.rs
+++ b/crates/bitwarden-wasm-internal/src/lib.rs
@@ -9,6 +9,7 @@ mod pure_crypto;
 mod ssh;
 
 pub use bitwarden_ipc::wasm::*;
+pub use bitwarden_managed_settings::ManagedSettingsClient;
 pub use bitwarden_organization_invite_link::*;
 pub use bitwarden_server_communication_config::wasm::*;
 pub use bitwarden_shared_unlock::wasm::*;


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-40994

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
Split the work to add and generate wasm and uniffi bindings for the "bitwarden-managed-settings-types" and "bitwarden-managed-settings" crates.

The plumbing to include this with bitwarden-core and PasswordManagerClient will follow with the next PR.
