### PR TITLE
feat(ipc): route RPC responses on per-request dedicated topics [Option A]

### DIFF
--- a/crates/bitwarden-ipc/src/ipc_client.rs
+++ b/crates/bitwarden-ipc/src/ipc_client.rs
@@ -11,10 +11,7 @@ use crate::{
         AlreadyRunningError, ErrorKind, IpcErrorKind, ReceiveError, SendError, SubscribeError,
         TypedReceiveError,
     },
-    message::{
-        IncomingMessage, OutgoingMessage, PayloadTypeName, TypedIncomingMessage,
-        TypedOutgoingMessage,
-    },
+    message::{IncomingMessage, OutgoingMessage, PayloadTypeName, TypedIncomingMessage},
     rpc::{
         exec::{handler::ErasedRpcHandler, handler_registry::RpcHandlerRegistry},
         request_message::{RPC_REQUEST_PAYLOAD_TYPE_NAME, RpcRequestPayload},
@@ -308,14 +305,15 @@ fn handle_rpc_request<Crypto, Com, Ses>(
                 result: response,
             };
 
-            let outgoing = TypedOutgoingMessage {
-                payload: response_message,
-                destination: incoming_message.source.into(),
-            }
-            .try_into()
-            .map_err(|e: serde_utils::SerializeError| HandleError::Serialize(e.to_string()))?;
+            // Publish the response on the dedicated topic the requester is subscribed to.
+            let payload = serde_utils::to_vec(&response_message)
+                .map_err(|e: serde_utils::SerializeError| HandleError::Serialize(e.to_string()))?;
 
-            Ok(outgoing)
+            Ok(OutgoingMessage {
+                payload,
+                destination: incoming_message.source.into(),
+                topic: Some(request.response_topic().to_owned()),
+            })
         }
 
         match handle(incoming_message, &inner.handlers).await {
@@ -985,9 +983,9 @@ mod tests {
                     tab_id: 9001,
                     document_id: "doc-1".to_string(),
                 },
-                topic: Some(
-                    IncomingRpcResponseMessage::<TestRequest>::PAYLOAD_TYPE_NAME.to_owned(),
-                ),
+                // The requester subscribes to the dedicated topic it minted, so the response must
+                // be published there.
+                topic: Some(outgoing_request.response_topic.clone()),
             };
             communication_provider.push_incoming(simulated_response);
 
@@ -996,11 +994,10 @@ mod tests {
             assert_eq!(result.unwrap().result, 3);
         }
 
-        /// A response belonging to one in-flight request must not disturb another. Both requests
-        /// subscribe to the same topic (every RPC response shares one payload type name), so each
-        /// one sees the other's response; correlating on `request_id` before deserializing the body
-        /// is what keeps `OtherResponse::Available` -- a bare JSON string -- from being force-fit
-        /// into `TestResponse` and failing the unrelated request.
+        /// Two requests in flight at once must each receive their own response. Each request mints
+        /// its own response topic, so `TestRequest` and `OtherRequest` never see each other's
+        /// responses even though their response types differ (`OtherResponse::Available` is a bare
+        /// JSON string that would not deserialize into `TestResponse`).
         #[tokio::test]
         async fn concurrent_request_of_a_different_type_does_not_disturb_a_pending_request() {
             let crypto_provider = NoEncryptionCryptoProvider;
@@ -1037,19 +1034,20 @@ mod tests {
             };
             tokio::time::sleep(Duration::from_millis(100)).await;
 
-            // Recover both request ids from the wire.
+            // Recover both requests from the wire, keyed by type, so we can answer each on the
+            // dedicated response topic it minted.
             let outgoing = communication_provider.outgoing().await;
-            let request_ids: HashMap<String, String> = outgoing
+            let requests: HashMap<String, RpcRequestMessage<serde_json::Value>> = outgoing
                 .iter()
                 .map(|message| {
                     let partial: RpcRequestMessage<serde_json::Value> =
                         serde_utils::from_slice(&message.payload)
                             .expect("Deserialization should not fail");
-                    (partial.request_type, partial.request_id)
+                    (partial.request_type.clone(), partial)
                 })
                 .collect();
 
-            let respond = |payload: Vec<u8>| {
+            let respond = |topic: String, payload: Vec<u8>| {
                 communication_provider.push_incoming(IncomingMessage {
                     payload,
                     source: Source::BrowserBackground { id: HostId::Own },
@@ -1057,25 +1055,27 @@ mod tests {
                         tab_id: 9001,
                         document_id: "doc-1".to_string(),
                     },
-                    topic: Some(IncomingRpcResponseMessage::<()>::PAYLOAD_TYPE_NAME.to_owned()),
+                    topic: Some(topic),
                 });
             };
 
-            // Answer `OtherRequest` first, while `TestRequest` is still waiting.
+            // Answer `OtherRequest` first, while `TestRequest` is still waiting. Each response goes
+            // to its own dedicated topic, so the two can never be confused for one another.
             respond(
+                requests["OtherRequest"].response_topic.clone(),
                 serde_utils::to_vec(&IncomingRpcResponseMessage {
                     result: Ok(OtherResponse::Available),
-                    request_id: request_ids["OtherRequest"].clone(),
+                    request_id: requests["OtherRequest"].request_id.clone(),
                     request_type: "OtherRequest".to_string(),
                 })
                 .expect("Serialization should not fail"),
             );
 
-            // `TestRequest` must have ignored the message above and still be waiting for its own.
             respond(
+                requests["TestRequest"].response_topic.clone(),
                 serde_utils::to_vec(&IncomingRpcResponseMessage {
                     result: Ok(TestResponse { result: 3 }),
-                    request_id: request_ids["TestRequest"].clone(),
+                    request_id: requests["TestRequest"].request_id.clone(),
                     request_type: "TestRequest".to_string(),
                 })
                 .expect("Serialization should not fail"),
@@ -1097,6 +1097,67 @@ mod tests {
             );
         }
 
+        /// A response that reaches this request's dedicated topic but fails to deserialize into the
+        /// expected response type is a genuine error for *this* request: because the topic is
+        /// dedicated, there is no other request it could belong to, so the failure is surfaced
+        /// immediately.
+        #[tokio::test]
+        async fn malformed_response_surfaces_error_instead_of_hanging() {
+            let crypto_provider = NoEncryptionCryptoProvider;
+            let communication_provider = TestCommunicationBackend::new();
+            let session_map = InMemorySessionRepository::default();
+            let client =
+                IpcClientImpl::new(crypto_provider, communication_provider.clone(), session_map);
+            let _ = client.start(None).await;
+
+            let result_handle = {
+                let client = client.clone();
+                tokio::spawn(async move {
+                    client
+                        .request::<TestRequest>(
+                            TestRequest { a: 1, b: 2 },
+                            Endpoint::BrowserBackground { id: HostId::Own },
+                            None,
+                        )
+                        .await
+                })
+            };
+            tokio::time::sleep(Duration::from_millis(100)).await;
+
+            // Recover the dedicated response topic and answer it with a body that cannot be
+            // deserialized into `TestResponse` (`OtherResponse::Available` serializes to a bare
+            // string).
+            let outgoing = communication_provider.outgoing().await;
+            let request: RpcRequestMessage<TestRequest> =
+                serde_utils::from_slice(&outgoing[0].payload)
+                    .expect("Deserialization should not fail");
+            let malformed = IncomingRpcResponseMessage {
+                result: Ok(OtherResponse::Available),
+                request_id: request.request_id.clone(),
+                request_type: request.request_type.clone(),
+            };
+            communication_provider.push_incoming(IncomingMessage {
+                payload: serde_utils::to_vec(&malformed).expect("Serialization should not fail"),
+                source: Source::BrowserBackground { id: HostId::Own },
+                destination: Endpoint::Web {
+                    tab_id: 9001,
+                    document_id: "doc-1".to_string(),
+                },
+                topic: Some(request.response_topic.clone()),
+            });
+
+            let result = tokio::time::timeout(Duration::from_secs(5), result_handle)
+                .await
+                .expect("request must not hang on a malformed response")
+                .unwrap();
+            assert!(matches!(
+                result,
+                Err(crate::error::RequestError::Rpc(
+                    crate::rpc::error::RpcError::ResponseDeserialization(_)
+                ))
+            ));
+        }
+
         #[tokio::test]
         async fn incoming_rpc_message_handles_request_and_returns_response() {
             let crypto_provider = NoEncryptionCryptoProvider;
@@ -1113,10 +1174,12 @@ mod tests {
             client.register_rpc_handler(TestHandler).await;
 
             // Simulate receiving a request
+            let response_topic = format!("RpcResponseMessage:{request_id}");
             let simulated_request = RpcRequestMessage {
                 request,
                 request_id: request_id.clone(),
                 request_type: "TestRequest".to_string(),
+                response_topic: response_topic.clone(),
             };
             let simulated_request_message = IncomingMessage {
                 payload: serde_utils::to_vec(&simulated_request)
@@ -1140,10 +1203,8 @@ mod tests {
                 serde_utils::from_slice(&outgoing_messages[0].payload)
                     .expect("Deserialization should not fail");
 
-            assert_eq!(
-                outgoing_messages[0].topic,
-                Some(IncomingRpcResponseMessage::<TestResponse>::PAYLOAD_TYPE_NAME.to_owned())
-            );
+            // The response must be published on the dedicated topic carried by the request.
+            assert_eq!(outgoing_messages[0].topic, Some(response_topic));
             assert_eq!(outgoing_response.request_type, "TestRequest");
             assert_eq!(outgoing_response.result, Ok(response));
         }

--- a/crates/bitwarden-ipc/src/ipc_client_ext.rs
+++ b/crates/bitwarden-ipc/src/ipc_client_ext.rs
@@ -4,12 +4,14 @@ use serde::{Serialize, de::DeserializeOwned};
 use crate::{
     RpcHandler,
     endpoint::Endpoint,
-    error::{RequestError, SubscribeError, TypedReceiveError},
+    error::{RequestError, SubscribeError},
     ipc_client::IpcClientTypedSubscription,
     ipc_client_trait::IpcClient,
-    message::{PayloadTypeName, TypedOutgoingMessage},
+    message::{OutgoingMessage, PayloadTypeName, TypedOutgoingMessage},
     rpc::{
-        error::RpcError, request::RpcRequest, request_message::RpcRequestMessage,
+        error::RpcError,
+        request::RpcRequest,
+        request_message::{RPC_REQUEST_PAYLOAD_TYPE_NAME, RpcRequestMessage},
         response_message::IncomingRpcResponseMessage,
     },
     serde_utils,
@@ -89,50 +91,39 @@ pub trait IpcClientExt: IpcClient {
         Request::Response: Send,
     {
         async move {
-            let request_id = uuid::Uuid::new_v4().to_string();
+            let request_payload = RpcRequestMessage::new(request);
+
+            // Each request gets its own response topic, subscribed to before sending. The handler
+            // publishes its reply there, so this subscription receives exactly one message: the
+            // response to this request. A deserialization failure is therefore unambiguously a
+            // malformed response to this request.
             let mut response_subscription = self
-                .subscribe_typed::<IncomingRpcResponseMessage<Request::Response>>()
+                .subscribe(Some(request_payload.response_topic.clone()))
                 .await?;
 
-            let request_payload = RpcRequestMessage {
-                request,
-                request_id: request_id.clone(),
-                request_type: Request::NAME.to_owned(),
-            };
-
-            let message = TypedOutgoingMessage {
-                payload: request_payload,
+            // Requests are dispatched by a single fixed topic that the receiver matches on to route
+            // them to the handler registry.
+            let payload = serde_utils::to_vec(&request_payload)
+                .map_err(|e| RequestError::Rpc(RpcError::RequestSerialization(e.to_string())))?;
+            let message = OutgoingMessage {
+                payload,
                 destination,
-            }
-            .try_into()
-            .map_err(|e: serde_utils::DeserializeError| {
-                RequestError::Rpc(RpcError::RequestSerialization(e.to_string()))
-            })?;
+                topic: Some(RPC_REQUEST_PAYLOAD_TYPE_NAME.to_owned()),
+            };
 
             self.send(message).await.map_err(RequestError::from)?;
 
-            let response = loop {
-                let received = match response_subscription
-                    .receive(cancellation_token.clone())
-                    .await
-                {
-                    Ok(received) => received,
-                    // Every RPC response shares a single payload type name, and therefore a single
-                    // topic, so this subscription also receives the responses belonging to other
-                    // requests that are in flight concurrently. Those do not necessarily
-                    // deserialize into this request's response type, so a typing error here is
-                    // expected: skip the message and keep waiting for our own response rather than
-                    // failing over a message that was never addressed to us.
-                    Err(TypedReceiveError::Typing(_)) => continue,
-                    Err(error) => return Err(RequestError::Receive(error)),
-                };
+            let received = response_subscription
+                .receive(cancellation_token)
+                .await
+                .map_err(|e| RequestError::Receive(e.into()))?;
 
-                if received.payload.request_id == request_id {
-                    break received;
-                }
-            };
+            let response: IncomingRpcResponseMessage<Request::Response> =
+                serde_utils::from_slice(&received.payload).map_err(|e| {
+                    RequestError::Rpc(RpcError::ResponseDeserialization(e.to_string()))
+                })?;
 
-            Ok(response.payload.result?)
+            Ok(response.result?)
         }
     }
 }

--- a/crates/bitwarden-ipc/src/rpc/exec/handler_registry.rs
+++ b/crates/bitwarden-ipc/src/rpc/exec/handler_registry.rs
@@ -86,6 +86,7 @@ mod test {
             request,
             request_id: "test_id".to_string(),
             request_type: "TestRequest".to_string(),
+            response_topic: "RpcResponseMessage:test_id".to_string(),
         };
         let serialized_request =
             RpcRequestPayload::from_slice(serde_utils::to_vec(&message).unwrap()).unwrap();
@@ -106,6 +107,7 @@ mod test {
             request,
             request_id: "test_id".to_string(),
             request_type: "TestRequest".to_string(),
+            response_topic: "RpcResponseMessage:test_id".to_string(),
         };
         let serialized_request =
             RpcRequestPayload::from_slice(serde_utils::to_vec(&message).unwrap()).unwrap();

--- a/crates/bitwarden-ipc/src/rpc/request_message.rs
+++ b/crates/bitwarden-ipc/src/rpc/request_message.rs
@@ -1,11 +1,12 @@
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    message::PayloadTypeName,
-    rpc::{error::RpcError, request::RpcRequest},
+    rpc::{error::RpcError, request::RpcRequest, response_message::RPC_RESPONSE_PAYLOAD_TYPE_NAME},
     serde_utils,
 };
 
+/// Fixed topic every RPC request is published on. The receiver matches incoming messages against
+/// this topic to route them to the handler registry.
 pub const RPC_REQUEST_PAYLOAD_TYPE_NAME: &str = "RpcRequestMessage";
 
 /// Represents the payload of an RPC request.
@@ -32,6 +33,12 @@ impl RpcRequestPayload {
         &self.partial.request_type
     }
 
+    /// The topic the response is published on. The handler publishes its reply here, and the
+    /// requester subscribes to it to receive the response.
+    pub fn response_topic(&self) -> &str {
+        &self.partial.response_topic
+    }
+
     pub fn deserialize_full<T>(&self) -> Result<RpcRequestMessage<T>, RpcError>
     where
         T: RpcRequest,
@@ -46,14 +53,28 @@ pub struct RpcRequestMessage<T> {
     pub request: T,
     pub request_id: String,
     pub request_type: String,
+    /// Dedicated topic the response should be published on. See
+    /// [`RpcRequestPayload::response_topic`].
+    pub response_topic: String,
+}
+
+impl<T: RpcRequest> RpcRequestMessage<T> {
+    /// Wrap a request, assigning it a fresh id and its own dedicated response topic.
+    pub fn new(request: T) -> Self {
+        let request_id = uuid::Uuid::new_v4().to_string();
+        let response_topic = format!("{RPC_RESPONSE_PAYLOAD_TYPE_NAME}:{request_id}");
+        Self {
+            request,
+            request_type: T::NAME.to_owned(),
+            request_id,
+            response_topic,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 struct PartialRpcRequestMessage {
     pub request_id: String,
     pub request_type: String,
-}
-
-impl<T> PayloadTypeName for RpcRequestMessage<T> {
-    const PAYLOAD_TYPE_NAME: &str = RPC_REQUEST_PAYLOAD_TYPE_NAME;
+    pub response_topic: String,
 }

--- a/crates/bitwarden-ipc/src/rpc/response_message.rs
+++ b/crates/bitwarden-ipc/src/rpc/response_message.rs
@@ -2,7 +2,12 @@ use erased_serde::Serialize as ErasedSerialize;
 use serde::{Deserialize, Serialize};
 
 use super::error::RpcError;
-use crate::message::PayloadTypeName;
+
+/// Prefix for the per-request dedicated response topic, formatted as
+/// `"{RPC_RESPONSE_PAYLOAD_TYPE_NAME}:{request_id}"`. Each response is published on the dedicated
+/// topic carried by its request, so response types do not implement
+/// [`PayloadTypeName`](crate::message::PayloadTypeName).
+pub const RPC_RESPONSE_PAYLOAD_TYPE_NAME: &str = "RpcResponseMessage";
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct IncomingRpcResponseMessage<T> {
@@ -16,12 +21,4 @@ pub struct OutgoingRpcResponseMessage<'a> {
     pub result: Result<Box<dyn ErasedSerialize>, RpcError>,
     pub request_id: &'a str,
     pub request_type: &'a str,
-}
-
-impl<T> PayloadTypeName for IncomingRpcResponseMessage<T> {
-    const PAYLOAD_TYPE_NAME: &str = "RpcResponseMessage";
-}
-
-impl<'a> PayloadTypeName for OutgoingRpcResponseMessage<'a> {
-    const PAYLOAD_TYPE_NAME: &'static str = "RpcResponseMessage";
 }

--- a/crates/bitwarden-wasm-internal/integration-tests/tests/unlock/biometrics-ipc.test.ts
+++ b/crates/bitwarden-wasm-internal/integration-tests/tests/unlock/biometrics-ipc.test.ts
@@ -109,15 +109,16 @@ describe("biometrics ipc", () => {
       authenticate_biometrics: async () => true,
     });
 
-    // Capture the settled state up front: the rejection we are hunting happens
-    // while awaiting the status request, before any handler would be attached.
+    // Capture the unlock's settled state without awaiting it, so that if the concurrent status
+    // request below were to settle the unlock early, it surfaces as a failed assertion rather than
+    // an unhandled rejection.
     const unlock = ipcRequestUnlockBiometrics(requester, TEST_USER_ID).then(
       (ok) => ({ ok }),
       (err) => ({ err: String(err) }),
     );
 
-    // A status poll completes while the unlock is still in flight. Its response is
-    // broadcast to every pending RPC waiter, including the unlock waiter.
+    // A status request completes while the unlock is still in flight. Its response is delivered
+    // only to that request's own response topic, so it must leave the pending unlock untouched.
     await expect(ipcRequestGetBiometricsStatus(requester, TEST_USER_ID)).resolves.toBe(
       BiometricsStatus.Available,
     );


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-42445

> **One of two alternative designs for PM-42445.** This is **Option A (per-request dedicated response topic)**. The sibling PR #1410 implements **Option B (deferred-body envelope)** as a non-breaking alternative. They are mutually exclusive — pick one, close the other.

## 📔 Objective

Redesign the RPC request-response correlation. Today every response is published on a single shared `RpcResponseMessage` topic, and the client subscribes to that catch-all and loops, filtering by `request_id`. Because the typed subscription deserializes the body *before* `request_id` is inspected, a concurrent response of a different type either force-fits into the wrong `Response` type or (with the #1392 skip-fix) gets silently skipped — which also swallows a genuinely malformed response to *this* request and turns it into an indefinite wait.

This PR gives each request that expects a reply a **dedicated response topic** (`"RpcResponseMessage:{request_id}"`). The requester subscribes only to that topic before sending, and the handler echoes the response onto it. Because the topic is unique per request:

- the manual receive loop and the typed-`Err` handling disappear from the request path;
- concurrent requests of different types can no longer see each other's responses (fixes the #1392 biometric-unlock concurrency bug); and
- a malformed response to this request surfaces as an error immediately instead of hanging.

The RPC layer stays cleanly layered on top of IPC: the topic is just an opaque routing string that IPC never interprets.

### Changes
- `RpcRequestMessage::new(request)` mints the request id and dedicated response topic and sets `request_type` from the request's `NAME`; `RpcRequestPayload::response_topic()` accessor added.
- `request()` builds the message via `RpcRequestMessage::new`, subscribes to its `response_topic`, sends, and deserializes the single response directly (no loop, no `request_id` filter).
- `handle_rpc_request` publishes the response on the request's `response_topic`.
- RPC message types no longer implement `PayloadTypeName`. Both send paths build `OutgoingMessage` directly with an explicit topic — `RPC_REQUEST_PAYLOAD_TYPE_NAME` for requests (the fixed dispatch topic the receiver matches on) and the per-request topic for responses. The RPC layer no longer goes through `TypedOutgoingMessage`; that machinery remains only for general typed pub/sub (`send_typed`, `subscribe_typed`, `LeaderMessage`/`FollowerMessage`).
- Tests updated to route responses per-topic; new `malformed_response_surfaces_error_instead_of_hanging` regression test.

## ✅ Verification

- `cargo test -p bitwarden-ipc`: 31 passed.
- WASM integration tests (`bitwarden-wasm-internal/integration-tests`): 70 passed / 11 suites, including `unlock/biometrics-ipc.test.ts`, which drives `IpcClient.request()` and the registered handlers end-to-end over IPC.

## 🚨 Breaking Changes

Yes, at the wire level: `RpcRequestMessage` gains a required `response_topic` field and responses move from the shared `RpcResponseMessage` topic to a per-request topic. Requester and handler must run matching SDK versions — mixed old/new peers (either direction) hang rather than error, and because `discover` (the version-skew detection request) rides the same path, it hangs too.

**In practice this has no impact.** The RPC request/response API has no released consumers: it is entirely behind feature flags and has never shipped, so there is no older peer to skew against. The break can land now for free. A backward-compat migration (keep the shared topic and `request_id` filter for one release, make `response_topic` optional) would only be warranted if there were deployed consumers — there are none.

Note this is a runtime wire break, not a TypeScript API break, so the automated SDK compatibility check (which only compiles clients) does not flag it.