### PR TITLE
fix(ipc): correlate RPC responses before deserializing the body [Option B]

### DIFF
--- a/crates/bitwarden-ipc/src/ipc_client.rs
+++ b/crates/bitwarden-ipc/src/ipc_client.rs
@@ -1097,6 +1097,66 @@ mod tests {
             );
         }
 
+        /// A response that carries *this* request's `request_id` but whose body cannot be
+        /// deserialized into the expected response type is a genuine error for this request, and
+        /// must surface immediately.
+        #[tokio::test]
+        async fn malformed_response_surfaces_error_instead_of_hanging() {
+            let crypto_provider = NoEncryptionCryptoProvider;
+            let communication_provider = TestCommunicationBackend::new();
+            let session_map = InMemorySessionRepository::default();
+            let client =
+                IpcClientImpl::new(crypto_provider, communication_provider.clone(), session_map);
+            let _ = client.start(None).await;
+
+            let result_handle = {
+                let client = client.clone();
+                tokio::spawn(async move {
+                    client
+                        .request::<TestRequest>(
+                            TestRequest { a: 1, b: 2 },
+                            Endpoint::BrowserBackground { id: HostId::Own },
+                            None,
+                        )
+                        .await
+                })
+            };
+            tokio::time::sleep(Duration::from_millis(100)).await;
+
+            // Recover the request id and answer with a body that carries the right id but cannot be
+            // deserialized into `TestResponse` (`OtherResponse::Available` serializes to a bare
+            // string).
+            let outgoing = communication_provider.outgoing().await;
+            let request: RpcRequestMessage<TestRequest> =
+                serde_utils::from_slice(&outgoing[0].payload)
+                    .expect("Deserialization should not fail");
+            let malformed = IncomingRpcResponseMessage {
+                result: Ok(OtherResponse::Available),
+                request_id: request.request_id.clone(),
+                request_type: request.request_type.clone(),
+            };
+            communication_provider.push_incoming(IncomingMessage {
+                payload: serde_utils::to_vec(&malformed).expect("Serialization should not fail"),
+                source: Source::BrowserBackground { id: HostId::Own },
+                destination: Endpoint::Web {
+                    tab_id: 9001,
+                    document_id: "doc-1".to_string(),
+                },
+                topic: Some(IncomingRpcResponseMessage::<()>::PAYLOAD_TYPE_NAME.to_owned()),
+            });
+
+            let result = tokio::time::timeout(Duration::from_secs(5), result_handle)
+                .await
+                .expect("request must not hang on a malformed response")
+                .unwrap();
+            assert!(matches!(
+                result,
+                Err(crate::error::RequestError::Rpc(
+                    crate::rpc::error::RpcError::ResponseDeserialization(_)
+                ))
+            ));
+        }
+
         #[tokio::test]
         async fn incoming_rpc_message_handles_request_and_returns_response() {
             let crypto_provider = NoEncryptionCryptoProvider;

--- a/crates/bitwarden-ipc/src/ipc_client_ext.rs
+++ b/crates/bitwarden-ipc/src/ipc_client_ext.rs
@@ -4,13 +4,15 @@ use serde::{Serialize, de::DeserializeOwned};
 use crate::{
     RpcHandler,
     endpoint::Endpoint,
-    error::{RequestError, SubscribeError, TypedReceiveError},
+    error::{RequestError, SubscribeError},
     ipc_client::IpcClientTypedSubscription,
     ipc_client_trait::IpcClient,
     message::{PayloadTypeName, TypedOutgoingMessage},
     rpc::{
-        error::RpcError, request::RpcRequest, request_message::RpcRequestMessage,
-        response_message::IncomingRpcResponseMessage,
+        error::RpcError,
+        request::RpcRequest,
+        request_message::RpcRequestMessage,
+        response_message::{RPC_RESPONSE_PAYLOAD_TYPE_NAME, RpcResponsePayload},
     },
     serde_utils,
 };
@@ -90,8 +92,14 @@ pub trait IpcClientExt: IpcClient {
     {
         async move {
             let request_id = uuid::Uuid::new_v4().to_string();
+
+            // Subscribe untyped to the shared response topic. Every RPC response shares this topic,
+            // so this subscription also receives responses belonging to other requests that are in
+            // flight concurrently. We correlate on `request_id` from the envelope *before*
+            // deserializing the body: an unrelated response is skipped by identity, and a body that
+            // fails to deserialize is attributed to *this* request as a genuine error.
             let mut response_subscription = self
-                .subscribe_typed::<IncomingRpcResponseMessage<Request::Response>>()
+                .subscribe(Some(RPC_RESPONSE_PAYLOAD_TYPE_NAME.to_owned()))
                 .await?;
 
             let request_payload = RpcRequestMessage {
@@ -112,27 +120,24 @@ pub trait IpcClientExt: IpcClient {
             self.send(message).await.map_err(RequestError::from)?;
 
             let response = loop {
-                let received = match response_subscription
+                let received = response_subscription
                     .receive(cancellation_token.clone())
                     .await
-                {
-                    Ok(received) => received,
-                    // Every RPC response shares a single payload type name, and therefore a single
-                    // topic, so this subscription also receives the responses belonging to other
-                    // requests that are in flight concurrently. Those do not necessarily
-                    // deserialize into this request's response type, so a typing error here is
-                    // expected: skip the message and keep waiting for our own response rather than
-                    // failing over a message that was never addressed to us.
-                    Err(TypedReceiveError::Typing(_)) => continue,
-                    Err(error) => return Err(RequestError::Receive(error)),
-                };
+                    .map_err(|e| RequestError::Receive(e.into()))?;
 
-                if received.payload.request_id == request_id {
-                    break received;
+                let payload = RpcResponsePayload::from_slice(received.payload).map_err(|e| {
+                    RequestError::Rpc(RpcError::ResponseDeserialization(e.to_string()))
+                })?;
+
+                // Skip responses addressed to other concurrent requests.
+                if payload.request_id() != request_id {
+                    continue;
                 }
+
+                break payload.deserialize_full::<Request::Response>()?;
             };
 
-            Ok(response.payload.result?)
+            Ok(response.result?)
         }
     }
 }

--- a/crates/bitwarden-ipc/src/rpc/response_message.rs
+++ b/crates/bitwarden-ipc/src/rpc/response_message.rs
@@ -1,14 +1,59 @@
 use erased_serde::Serialize as ErasedSerialize;
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize, de::DeserializeOwned};
 
 use super::error::RpcError;
-use crate::message::PayloadTypeName;
+use crate::{message::PayloadTypeName, serde_utils};
+
+/// Payload type name shared by every RPC response, also used as the topic responses are published
+/// on.
+pub const RPC_RESPONSE_PAYLOAD_TYPE_NAME: &str = "RpcResponseMessage";
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct IncomingRpcResponseMessage<T> {
     pub result: Result<T, RpcError>,
     pub request_id: String,
     pub request_type: String,
+}
+
+/// Represents the payload of an RPC response, mirroring [`RpcRequestPayload`] on the response side.
+///
+/// Every response shares a single topic, so a subscription receives responses for other in-flight
+/// requests too. This type lets the requester read the correlation metadata (`request_id`) from the
+/// envelope *without* first deserializing the body into the expected response type. Only once the
+/// `request_id` confirms the message belongs to this request is the body deserialized, so a typing
+/// failure is a genuine error for this request rather than an unrelated concurrent response.
+///
+/// [`RpcRequestPayload`]: crate::rpc::request_message::RpcRequestPayload
+pub struct RpcResponsePayload {
+    data: Vec<u8>,
+    partial: PartialRpcResponseMessage,
+}
+
+impl RpcResponsePayload {
+    pub fn from_slice(data: Vec<u8>) -> Result<Self, serde_utils::DeserializeError> {
+        let partial: PartialRpcResponseMessage = serde_utils::from_slice(&data)?;
+
+        Ok(Self { data, partial })
+    }
+
+    pub fn request_id(&self) -> &str {
+        &self.partial.request_id
+    }
+
+    /// Deserialize the full response, including the body, into the concrete response type. Call
+    /// this only after [`Self::request_id`] confirms the response belongs to this request.
+    pub fn deserialize_full<T>(&self) -> Result<IncomingRpcResponseMessage<T>, RpcError>
+    where
+        T: DeserializeOwned,
+    {
+        serde_utils::from_slice(&self.data)
+            .map_err(|e| RpcError::ResponseDeserialization(e.to_string()))
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct PartialRpcResponseMessage {
+    pub request_id: String,
 }
 
 #[derive(Serialize)]
@@ -19,9 +64,9 @@ pub struct OutgoingRpcResponseMessage<'a> {
 }
 
 impl<T> PayloadTypeName for IncomingRpcResponseMessage<T> {
-    const PAYLOAD_TYPE_NAME: &str = "RpcResponseMessage";
+    const PAYLOAD_TYPE_NAME: &str = RPC_RESPONSE_PAYLOAD_TYPE_NAME;
 }
 
 impl<'a> PayloadTypeName for OutgoingRpcResponseMessage<'a> {
-    const PAYLOAD_TYPE_NAME: &'static str = "RpcResponseMessage";
+    const PAYLOAD_TYPE_NAME: &'static str = RPC_RESPONSE_PAYLOAD_TYPE_NAME;
 }


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-42445

> **One of two alternative designs for PM-42445.** This is **Option B (deferred-body envelope, non-breaking)**. The sibling PR #1409 implements **Option A (per-request dedicated response topic, breaking)**. They are mutually exclusive — pick one, close the other.

## 📔 Objective

Fix the RPC request-response correlation **without changing the wire format**. Today the requester subscribes to the shared `RpcResponseMessage` topic with a *typed* subscription, which deserializes the body into the expected `Response` type *before* `request_id` is inspected. A concurrent response of a different type therefore either force-fits into the wrong type or (with the #1392 skip-fix) is silently skipped — which also swallows a genuinely malformed response to *this* request and turns it into an indefinite wait.

This PR flips the order: read identity first, deserialize the body second. It adds an `RpcResponsePayload` that mirrors the existing `RpcRequestPayload` — it holds the raw bytes plus a partial `{request_id}` envelope, and only deserializes the full body once the `request_id` confirms the message belongs to this request.

Result:
- a concurrent response of a different type is skipped by `request_id` instead of mis-parsing (fixes the #1392 biometric-unlock concurrency bug); and
- a malformed response to this request surfaces as a `ResponseDeserialization` error immediately instead of hanging.

The manual receive loop remains — removing it requires a dedicated per-request response topic, which is the breaking alternative in #1409.

### Changes
- New `RpcResponsePayload` + `PartialRpcResponseMessage` in `response_message.rs` (symmetric with the request side); `RPC_RESPONSE_PAYLOAD_TYPE_NAME` const extracted.
- `request()` subscribes untyped, correlates on `request_id` from the envelope, then deserializes the body.
- New `malformed_response_surfaces_error_instead_of_hanging` regression test. Existing concurrency and handler tests pass unchanged, confirming wire compatibility.

## 🚨 Breaking Changes

None. The response envelope (`{result, request_id, request_type}`) is unchanged; only the client's parsing strategy changes. Old and new peers interoperate.