### PR TITLE
[PM-8313] Add WASM bindings for FIDO2 authenticator operations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -868,6 +868,8 @@ dependencies = [
  "bitwarden-core",
  "bitwarden-crypto",
  "bitwarden-encoding",
+ "bitwarden-error",
+ "bitwarden-threading",
  "bitwarden-vault",
  "chrono",
  "coset",
@@ -881,8 +883,11 @@ dependencies = [
  "thiserror 2.0.19",
  "tokio",
  "tracing",
+ "tsify",
  "uniffi",
  "uuid",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
 ]
 
 [[package]]
@@ -1549,6 +1554,7 @@ dependencies = [
  "bitwarden-crypto",
  "bitwarden-crypto-sync-handler",
  "bitwarden-error",
+ "bitwarden-fido",
  "bitwarden-ipc",
  "bitwarden-logging",
  "bitwarden-managed-settings",

--- a/crates/bitwarden-fido/Cargo.toml
+++ b/crates/bitwarden-fido/Cargo.toml
@@ -16,6 +16,16 @@ keywords.workspace = true
 
 [features]
 uniffi = ["dep:uniffi", "bitwarden-core/uniffi", "bitwarden-vault/uniffi"]
+wasm = [
+    "bitwarden-core/wasm",
+    "bitwarden-encoding/wasm",
+    "bitwarden-error/wasm",
+    "bitwarden-threading/wasm",
+    "bitwarden-vault/wasm",
+    "dep:tsify",
+    "dep:wasm-bindgen",
+    "dep:wasm-bindgen-futures",
+] # WASM support
 
 [dependencies]
 async-trait = { workspace = true }
@@ -23,6 +33,8 @@ bitwarden-api-api = { workspace = true }
 bitwarden-core = { workspace = true }
 bitwarden-crypto = { workspace = true }
 bitwarden-encoding = { workspace = true }
+bitwarden-error = { workspace = true }
+bitwarden-threading = { workspace = true }
 bitwarden-vault = { workspace = true }
 chrono = { workspace = true }
 coset = ">=0.3.7, <0.5"
@@ -37,8 +49,11 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
+tsify = { workspace = true, optional = true }
 uniffi = { workspace = true, optional = true }
 uuid = { workspace = true }
+wasm-bindgen = { workspace = true, optional = true }
+wasm-bindgen-futures = { workspace = true, optional = true }
 
 [dev-dependencies]
 tokio = { workspace = true }

--- a/crates/bitwarden-fido/src/authenticator.rs
+++ b/crates/bitwarden-fido/src/authenticator.rs
@@ -2,6 +2,7 @@ use std::sync::Mutex;
 
 use bitwarden_core::Client;
 use bitwarden_crypto::CryptoError;
+use bitwarden_error::bitwarden_error;
 use bitwarden_vault::{CipherError, CipherView, EncryptError, VaultClientExt};
 use itertools::Itertools;
 use passkey::{
@@ -36,7 +37,7 @@ pub enum GetSelectedCredentialError {
 
 #[allow(missing_docs)]
 #[derive(Debug, Error)]
-#[cfg_attr(feature = "uniffi", derive(uniffi::Error), uniffi(flat_error))]
+#[bitwarden_error(flat)]
 pub enum MakeCredentialError {
     #[error(transparent)]
     PublicKeyCredentialParameters(#[from] PublicKeyCredentialParametersError),
@@ -44,13 +45,15 @@ pub enum MakeCredentialError {
     UnknownEnum(#[from] UnknownEnumError),
     #[error("Missing attested_credential_data")]
     MissingAttestedCredentialData,
+    #[error("The created credential's public key algorithm is not supported")]
+    UnsupportedPublicKeyAlgorithm,
     #[error("make_credential error: {0}")]
     Other(String),
 }
 
 #[allow(missing_docs)]
 #[derive(Debug, Error)]
-#[cfg_attr(feature = "uniffi", derive(uniffi::Error), uniffi(flat_error))]
+#[bitwarden_error(flat)]
 pub enum GetAssertionError {
     #[error(transparent)]
     UnknownEnum(#[from] UnknownEnumError),
@@ -66,7 +69,7 @@ pub enum GetAssertionError {
 
 #[allow(missing_docs)]
 #[derive(Debug, Error)]
-#[cfg_attr(feature = "uniffi", derive(uniffi::Error), uniffi(flat_error))]
+#[bitwarden_error(flat)]
 pub enum SilentlyDiscoverCredentialsError {
     #[error(transparent)]
     Cipher(#[from] CipherError),
@@ -80,7 +83,7 @@ pub enum SilentlyDiscoverCredentialsError {
 
 #[allow(missing_docs)]
 #[derive(Debug, Error)]
-#[cfg_attr(feature = "uniffi", derive(uniffi::Error), uniffi(flat_error))]
+#[bitwarden_error(flat)]
 pub enum CredentialsForAutofillError {
     #[error(transparent)]
     Cipher(#[from] CipherError),
@@ -180,6 +183,9 @@ impl<'a> Fido2Authenticator<'a> {
             .attested_credential_data
             .ok_or(MakeCredentialError::MissingAttestedCredentialData)?;
         let credential_id = attested_credential_data.credential_id().to_vec();
+        let (public_key, public_key_algorithm) =
+            public_key_der_and_algorithm(&attested_credential_data.key)
+                .ok_or(MakeCredentialError::UnsupportedPublicKeyAlgorithm)?;
         let extensions = response.unsigned_extension_outputs.into();
 
         Ok(MakeCredentialResult {
@@ -187,6 +193,8 @@ impl<'a> Fido2Authenticator<'a> {
             attestation_object,
             credential_id,
             extensions,
+            public_key,
+            public_key_algorithm,
         })
     }
 
@@ -698,10 +706,21 @@ mod tests {
         CheckUserOptions, CheckUserResult, Fido2CallbackError, Fido2CredentialStore,
         Fido2UserInterface, GetAssertionExtensionsInput, GetAssertionPrfInput, PrfInputValues,
         guid_bytes_to_string,
-        types::{GetAssertionRequest, Options, UV},
+        types::{
+            GetAssertionRequest, MakeCredentialRequest, Options, PublicKeyCredentialParameters,
+            PublicKeyCredentialRpEntity, PublicKeyCredentialUserEntity, UV,
+        },
     };
 
-    struct MockUserInterface;
+    /// The only algorithm this authenticator creates keys for.
+    const ES256_ALGORITHM: i64 = -7;
+
+    /// Approves everything it is asked. `new_credential_cipher` is the cipher the creation path
+    /// hands back, and is only set by tests that call `make_credential`.
+    #[derive(Default)]
+    struct MockUserInterface {
+        new_credential_cipher: Option<CipherView>,
+    }
 
     #[async_trait]
     impl Fido2UserInterface for MockUserInterface {
@@ -731,7 +750,18 @@ mod tests {
             _options: CheckUserOptions,
             _new_credential: Fido2CredentialNewView,
         ) -> Result<(CipherView, CheckUserResult), Fido2CallbackError> {
-            unimplemented!("not needed for this test")
+            let cipher = self
+                .new_credential_cipher
+                .clone()
+                .expect("this test does not create credentials");
+
+            Ok((
+                cipher,
+                CheckUserResult {
+                    user_present: true,
+                    user_verified: true,
+                },
+            ))
         }
 
         fn is_verification_enabled(&self) -> bool {
@@ -850,9 +880,16 @@ mod tests {
     /// authenticator, we have disabled the configuration.
     /// When we implement PRF, this test should be updated to test that PRF _is_
     /// evaluated when PRF extension input is received.
-    #[tokio::test]
-    async fn test_prf_is_not_evaluated() {
+    async fn create_test_client() -> Client {
         let client = Client::new(None);
+
+        // `save_credential` encrypts through `client.vault().ciphers()`, which needs a user id.
+        client
+            .internal
+            .init_user_id("11111111-1111-1111-1111-111111111111".parse().unwrap())
+            .await
+            .unwrap();
+
         let user_key: SymmetricCryptoKey =
             "w2LO+nwV4oxwswVYCxlOfRUseXfvU03VzvKQHrqeklPgiMZrspUe6sOBToCnDn9Ay0tuCBn8ykVVRb7PWhub2Q=="
                 .to_string()
@@ -867,12 +904,19 @@ mod tests {
             .set_symmetric_key(SymmetricKeySlotId::User, user_key)
             .unwrap();
 
+        client
+    }
+
+    #[tokio::test]
+    async fn test_prf_is_not_evaluated() {
+        let client = create_test_client().await;
+
         let cipher = {
             let mut ctx = client.internal.get_key_store().context();
             create_test_cipher(&mut ctx)
         };
 
-        let user_interface = MockUserInterface;
+        let user_interface = MockUserInterface::default();
         let credential_store = MockCredentialStore { cipher };
         let mut authenticator =
             Fido2Authenticator::new(&client, &user_interface, &credential_store);
@@ -905,5 +949,66 @@ mod tests {
             result.extensions.prf.is_none(),
             "PRF should not be evaluated"
         );
+    }
+
+    /// `public_key` and `public_key_algorithm` exist so that callers of this CTAP-level operation
+    /// can build a WebAuthn `AuthenticatorAttestationResponse` without parsing the attestation
+    /// object themselves. The DER is parsed back into a P-256 point here, so the test fails if the
+    /// encoding is ever anything other than what `getPublicKey()` is specified to return.
+    #[tokio::test]
+    async fn test_make_credential_returns_the_public_key() {
+        use p256::pkcs8::DecodePublicKey;
+
+        let client = create_test_client().await;
+
+        // The creation path is handed a cipher with no passkey on it yet; the authenticator adds
+        // one and saves it back.
+        let cipher = {
+            let mut ctx = client.internal.get_key_store().context();
+            let mut cipher = create_test_cipher(&mut ctx);
+            cipher
+                .login
+                .as_mut()
+                .expect("the test cipher is a login")
+                .fido2_credentials = None;
+            cipher
+        };
+
+        let user_interface = MockUserInterface {
+            new_credential_cipher: Some(cipher.clone()),
+        };
+        let credential_store = MockCredentialStore { cipher };
+        let mut authenticator =
+            Fido2Authenticator::new(&client, &user_interface, &credential_store);
+
+        let result = authenticator
+            .make_credential(MakeCredentialRequest {
+                client_data_hash: vec![0u8; 32],
+                rp: PublicKeyCredentialRpEntity {
+                    id: TEST_FIDO_RP_ID.to_string(),
+                    name: Some("Example".to_string()),
+                },
+                user: PublicKeyCredentialUserEntity {
+                    id: vec![1, 2, 3, 4],
+                    display_name: "Test User".to_string(),
+                    name: "test@example.com".to_string(),
+                },
+                pub_key_cred_params: vec![PublicKeyCredentialParameters {
+                    ty: "public-key".to_string(),
+                    alg: ES256_ALGORITHM,
+                }],
+                exclude_list: None,
+                options: Options {
+                    rk: true,
+                    uv: UV::Required,
+                },
+                extensions: None,
+            })
+            .await
+            .unwrap();
+
+        assert_eq!(ES256_ALGORITHM, result.public_key_algorithm);
+        p256::PublicKey::from_public_key_der(&result.public_key)
+            .expect("the public key should be a parseable SPKI-encoded P-256 key");
     }
 }

--- a/crates/bitwarden-fido/src/client.rs
+++ b/crates/bitwarden-fido/src/client.rs
@@ -1,3 +1,4 @@
+use bitwarden_error::bitwarden_error;
 use passkey::client::WebauthnError;
 use thiserror::Error;
 
@@ -15,7 +16,7 @@ use crate::types::InvalidOriginError;
 
 #[allow(missing_docs)]
 #[derive(Debug, Error)]
-#[cfg_attr(feature = "uniffi", derive(uniffi::Error), uniffi(flat_error))]
+#[bitwarden_error(flat)]
 pub enum Fido2ClientError {
     #[error(transparent)]
     InvalidOrigin(#[from] InvalidOriginError),

--- a/crates/bitwarden-fido/src/client_fido.rs
+++ b/crates/bitwarden-fido/src/client_fido.rs
@@ -1,4 +1,5 @@
 use bitwarden_core::Client;
+use bitwarden_error::bitwarden_error;
 use bitwarden_vault::CipherView;
 use thiserror::Error;
 
@@ -16,7 +17,7 @@ pub struct ClientFido2 {
 
 #[allow(missing_docs)]
 #[derive(Debug, Error)]
-#[cfg_attr(feature = "uniffi", derive(uniffi::Error), uniffi(flat_error))]
+#[bitwarden_error(flat)]
 pub enum DecryptFido2AutofillCredentialsError {
     #[error(transparent)]
     Fido2CredentialAutofillView(#[from] Fido2CredentialAutofillViewError),

--- a/crates/bitwarden-fido/src/lib.rs
+++ b/crates/bitwarden-fido/src/lib.rs
@@ -21,6 +21,8 @@ mod crypto;
 mod device_auth_key;
 mod traits;
 mod types;
+#[cfg(feature = "wasm")]
+pub mod wasm;
 pub use authenticator::{
     CredentialsForAutofillError, Fido2Authenticator, GetAssertionError, MakeCredentialError,
     SilentlyDiscoverCredentialsError,
@@ -58,7 +60,14 @@ const AAGUID: Aaguid = Aaguid([
 ]);
 
 #[allow(dead_code, missing_docs)]
+#[derive(serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
 #[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
+#[cfg_attr(
+    feature = "wasm",
+    derive(tsify::Tsify),
+    tsify(into_wasm_abi, from_wasm_abi)
+)]
 pub struct SelectedCredential {
     cipher: CipherView,
     credential: Fido2CredentialView,

--- a/crates/bitwarden-fido/src/traits.rs
+++ b/crates/bitwarden-fido/src/traits.rs
@@ -1,6 +1,9 @@
 use bitwarden_vault::{CipherListView, CipherView, EncryptionContext, Fido2CredentialNewView};
 use passkey::authenticator::UiHint;
+use serde::{Deserialize, Serialize};
 use thiserror::Error;
+#[cfg(feature = "wasm")]
+use tsify::Tsify;
 
 #[allow(missing_docs)]
 #[derive(Debug, Error)]
@@ -51,16 +54,20 @@ pub trait Fido2CredentialStore: Send + Sync {
 }
 
 #[allow(missing_docs)]
-#[derive(Clone)]
+#[derive(Serialize, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
 #[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
+#[cfg_attr(feature = "wasm", derive(Tsify), tsify(into_wasm_abi, from_wasm_abi))]
 pub struct CheckUserOptions {
     pub require_presence: bool,
     pub require_verification: Verification,
 }
 
 #[allow(missing_docs)]
-#[derive(Clone)]
+#[derive(Serialize, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
 #[cfg_attr(feature = "uniffi", derive(uniffi::Enum))]
+#[cfg_attr(feature = "wasm", derive(Tsify), tsify(into_wasm_abi, from_wasm_abi))]
 pub enum Verification {
     Discouraged,
     Preferred,
@@ -68,6 +75,9 @@ pub enum Verification {
 }
 
 #[allow(missing_docs)]
+#[derive(Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "wasm", derive(Tsify), tsify(into_wasm_abi, from_wasm_abi))]
 pub struct CheckUserResult {
     pub user_present: bool,
     pub user_verified: bool,

--- a/crates/bitwarden-fido/src/types.rs
+++ b/crates/bitwarden-fido/src/types.rs
@@ -8,6 +8,8 @@ use passkey::types::webauthn::UserVerificationRequirement;
 use reqwest::Url;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
+#[cfg(feature = "wasm")]
+use tsify::Tsify;
 
 use super::{
     InvalidGuidError, SelectedCredential, UnknownEnumError, Verification,
@@ -18,6 +20,7 @@ use super::{
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 #[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
+#[cfg_attr(feature = "wasm", derive(Tsify), tsify(into_wasm_abi, from_wasm_abi))]
 pub struct Fido2CredentialAutofillView {
     pub credential_id: Vec<u8>,
     pub cipher_id: uuid::Uuid,
@@ -151,7 +154,10 @@ impl Fido2CredentialAutofillView {
 }
 
 #[allow(missing_docs)]
+#[derive(Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 #[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
+#[cfg_attr(feature = "wasm", derive(Tsify), tsify(into_wasm_abi, from_wasm_abi))]
 pub struct PublicKeyCredentialRpEntity {
     pub id: String,
     pub name: Option<String>,
@@ -188,7 +194,10 @@ impl TryFrom<&bitwarden_api_api::models::PublicKeyCredentialRpEntity>
 }
 
 #[allow(missing_docs)]
+#[derive(Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 #[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
+#[cfg_attr(feature = "wasm", derive(Tsify), tsify(into_wasm_abi, from_wasm_abi))]
 pub struct PublicKeyCredentialUserEntity {
     pub id: Vec<u8>,
     pub display_name: String,
@@ -251,7 +260,10 @@ pub enum WebAuthnEntityError {
     UnknownEnum(#[from] UnknownEnumError),
 }
 
+#[derive(Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 #[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
+#[cfg_attr(feature = "wasm", derive(Tsify), tsify(into_wasm_abi, from_wasm_abi))]
 pub struct PublicKeyCredentialParameters {
     pub ty: String,
     pub alg: i64,
@@ -299,7 +311,10 @@ impl TryFrom<PublicKeyCredentialParameters>
     }
 }
 
+#[derive(Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 #[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
+#[cfg_attr(feature = "wasm", derive(Tsify), tsify(into_wasm_abi, from_wasm_abi))]
 pub struct PublicKeyCredentialDescriptor {
     pub ty: String,
     pub id: Vec<u8>,
@@ -377,7 +392,10 @@ impl TryFrom<&bitwarden_api_api::models::PublicKeyCredentialDescriptor>
 }
 
 #[allow(missing_docs)]
+#[derive(Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 #[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
+#[cfg_attr(feature = "wasm", derive(Tsify), tsify(into_wasm_abi, from_wasm_abi))]
 pub struct MakeCredentialRequest {
     pub client_data_hash: Vec<u8>,
     pub rp: PublicKeyCredentialRpEntity,
@@ -397,7 +415,10 @@ pub struct MakeCredentialRequest {
 ///
 /// [pub-key-cred]: https://www.w3.org/TR/webauthn-3/#publickeycredential
 /// [authenticator-attestation-response]: https://www.w3.org/TR/webauthn-3/#authenticatorattestationresponse
+#[derive(Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 #[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
+#[cfg_attr(feature = "wasm", derive(Tsify), tsify(into_wasm_abi, from_wasm_abi))]
 pub struct MakeCredentialResult {
     /// The authenticator data extracted from within the
     /// [`attestation_object`][Self::attestation_object].
@@ -422,6 +443,22 @@ pub struct MakeCredentialResult {
     /// [unsigned-extensions]: https://www.w3.org/TR/webauthn-3/#unsigned-extension-outputs
     /// [webauthn-client-extensions]: https://www.w3.org/TR/webauthn-3/#dom-publickeycredential-clientextensionsresults-slot
     pub extensions: MakeCredentialExtensionsOutput,
+
+    /// The credential's public key in SPKI DER form, as returned by
+    /// [AuthenticatorAttestationResponse.getPublicKey()][get-public-key].
+    ///
+    /// The key is also in [`attestation_object`][Self::attestation_object], COSE-encoded inside the
+    /// attested credential data. It is lifted out here because callers of this CTAP-level operation
+    /// need the WebAuthn-level form, and deriving it requires parsing the attestation object.
+    ///
+    /// [get-public-key]: https://www.w3.org/TR/webauthn-3/#dom-authenticatorattestationresponse-getpublickey
+    pub public_key: Vec<u8>,
+
+    /// COSE algorithm identifier of [`public_key`][Self::public_key], as returned by
+    /// [AuthenticatorAttestationResponse.getPublicKeyAlgorithm()][get-algorithm].
+    ///
+    /// [get-algorithm]: https://www.w3.org/TR/webauthn-3/#dom-authenticatorattestationresponse-getpublickeyalgorithm
+    pub public_key_algorithm: i64,
 }
 
 impl TryFrom<passkey::types::ctap2::make_credential::Response> for MakeCredentialResult {
@@ -436,18 +473,46 @@ impl TryFrom<passkey::types::ctap2::make_credential::Response> for MakeCredentia
             WebAuthnEntityError::MissingRequiredFields(vec!["attestedCredentialData".to_string()]),
         )?;
         let credential_id = attested_credential_data.credential_id().to_vec();
+        let (public_key, public_key_algorithm) =
+            public_key_der_and_algorithm(&attested_credential_data.key)
+                .ok_or(PublicKeyCredentialParametersError::InvalidAlgorithm)?;
         let extensions: MakeCredentialExtensionsOutput = value.unsigned_extension_outputs.into();
         Ok(MakeCredentialResult {
             authenticator_data,
             attestation_object,
             credential_id,
             extensions,
+            public_key,
+            public_key_algorithm,
         })
     }
 }
 
+/// A credential's public key in SPKI DER form, paired with its COSE algorithm identifier.
+///
+/// `None` when the key is not one that can be encoded that way, which in practice means anything
+/// other than ES256 — the only algorithm this authenticator creates.
+pub(super) fn public_key_der_and_algorithm(key: &coset::CoseKey) -> Option<(Vec<u8>, i64)> {
+    use coset::iana::EnumI64;
+
+    let algorithm = match key.alg.as_ref()? {
+        coset::Algorithm::Assigned(algorithm) => algorithm.to_i64(),
+        coset::Algorithm::PrivateUse(algorithm) => *algorithm,
+        coset::Algorithm::Text(_) => return None,
+    };
+
+    // The same conversion `passkey-client` performs when it builds a WebAuthn registration
+    // response, so the two levels cannot disagree about the encoding.
+    let der = passkey::authenticator::public_key_der_from_cose_key(key).ok()?;
+
+    Some((der.to_vec(), algorithm))
+}
+
 /// WebAuthn extension input for WebAuthn registration extensions.
+#[derive(Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 #[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
+#[cfg_attr(feature = "wasm", derive(Tsify), tsify(into_wasm_abi, from_wasm_abi))]
 #[derive(Debug, Default)]
 pub struct MakeCredentialExtensionsInput {
     /// PRF input for WebAuthn registration request.
@@ -482,7 +547,10 @@ impl From<bitwarden_api_api::models::AuthenticationExtensionsClientInputs>
 }
 
 /// WebAuthn extension output for registration extensions.
+#[derive(Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 #[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
+#[cfg_attr(feature = "wasm", derive(Tsify), tsify(into_wasm_abi, from_wasm_abi))]
 #[derive(Debug)]
 pub struct MakeCredentialExtensionsOutput {
     /// PRF output for registration extensions.
@@ -516,7 +584,10 @@ impl From<passkey::types::ctap2::make_credential::UnsignedExtensionOutputs>
 }
 
 /// WebAuthn PRF extension input for use during registration.
+#[derive(Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 #[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
+#[cfg_attr(feature = "wasm", derive(Tsify), tsify(into_wasm_abi, from_wasm_abi))]
 #[derive(Debug)]
 pub struct MakeCredentialPrfInput {
     /// PRF inputs.
@@ -533,7 +604,10 @@ impl From<MakeCredentialPrfInput> for passkey::types::ctap2::extensions::Authent
 }
 
 /// WebAuthn PRF extension output used during registration.
+#[derive(Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 #[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
+#[cfg_attr(feature = "wasm", derive(Tsify), tsify(into_wasm_abi, from_wasm_abi))]
 #[derive(Debug)]
 pub struct MakeCredentialPrfOutput {
     /// Whether PRF is successfully processed for the newly created credential.
@@ -548,7 +622,10 @@ pub struct MakeCredentialPrfOutput {
 /// [`PublicKeyCredentialRequestOptions`][pubkey-cred-request-options].
 ///
 /// [pubkey-cred-request-options]: https://www.w3.org/TR/webauthn-3/#dictdef-publickeycredentialrequestoptions
+#[derive(Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 #[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
+#[cfg_attr(feature = "wasm", derive(Tsify), tsify(into_wasm_abi, from_wasm_abi))]
 pub struct GetAssertionRequest {
     /// The RP ID for the request used to select credentials.
     pub rp_id: String,
@@ -572,7 +649,10 @@ pub struct GetAssertionRequest {
 ///
 /// [pub-key-cred]: https://www.w3.org/TR/webauthn-3/#publickeycredential
 /// [authenticator-assertion-response]: https://www.w3.org/TR/webauthn-3/#authenticatorassertionresponse
+#[derive(Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 #[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
+#[cfg_attr(feature = "wasm", derive(Tsify), tsify(into_wasm_abi, from_wasm_abi))]
 pub struct GetAssertionResult {
     /// ID for this credential, corresponding to [PublicKeyCredential.rawId][raw-id].
     ///
@@ -597,7 +677,10 @@ pub struct GetAssertionResult {
 }
 
 /// WebAuthn extension input for WebAuthn authentication extensions.
+#[derive(Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 #[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
+#[cfg_attr(feature = "wasm", derive(Tsify), tsify(into_wasm_abi, from_wasm_abi))]
 #[derive(Debug)]
 pub struct GetAssertionExtensionsInput {
     /// PRF input for the authentication ceremony.
@@ -616,7 +699,10 @@ impl From<GetAssertionExtensionsInput> for passkey::types::ctap2::get_assertion:
 }
 
 /// WebAuthn extension output of an authentication ceremony.
+#[derive(Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 #[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
+#[cfg_attr(feature = "wasm", derive(Tsify), tsify(into_wasm_abi, from_wasm_abi))]
 #[derive(Debug)]
 pub struct GetAssertionExtensionsOutput {
     /// PRF output for an authentication ceremony.
@@ -647,7 +733,10 @@ impl From<passkey::types::ctap2::get_assertion::UnsignedExtensionOutputs>
 }
 
 /// Input for WebAuthn PRF extension during authentication ceremonies.
+#[derive(Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 #[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
+#[cfg_attr(feature = "wasm", derive(Tsify), tsify(into_wasm_abi, from_wasm_abi))]
 #[derive(Debug)]
 pub struct GetAssertionPrfInput {
     /// A PRF input to use for authentication. If a map of credential IDs to PRF
@@ -685,7 +774,10 @@ impl From<GetAssertionPrfInput> for passkey::types::ctap2::extensions::Authentic
 
 /// WebAuthn PRF extension output during an authentication ceremony.
 #[allow(missing_docs)]
+#[derive(Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 #[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
+#[cfg_attr(feature = "wasm", derive(Tsify), tsify(into_wasm_abi, from_wasm_abi))]
 #[derive(Debug)]
 pub struct GetAssertionPrfOutput {
     /// The PRF output for the ceremony.
@@ -693,7 +785,10 @@ pub struct GetAssertionPrfOutput {
 }
 
 #[allow(missing_docs)]
+#[derive(Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 #[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
+#[cfg_attr(feature = "wasm", derive(Tsify), tsify(into_wasm_abi, from_wasm_abi))]
 pub struct Options {
     pub rk: bool,
     pub uv: UV,
@@ -717,8 +812,10 @@ impl From<Options> for super::CheckUserOptions {
     }
 }
 
-#[derive(Eq, PartialEq, Clone, Copy)]
+#[derive(Serialize, Deserialize, Eq, PartialEq, Clone, Copy)]
+#[serde(rename_all = "camelCase")]
 #[cfg_attr(feature = "uniffi", derive(uniffi::Enum))]
+#[cfg_attr(feature = "wasm", derive(Tsify), tsify(into_wasm_abi, from_wasm_abi))]
 pub enum UV {
     Discouraged,
     Preferred,
@@ -767,7 +864,11 @@ impl From<UserVerificationRequirement> for UV {
 }
 
 #[allow(missing_docs)]
+#[derive(Serialize, Deserialize)]
+// `rename_all` renames variants, not the fields inside struct variants; both are needed here.
+#[serde(rename_all = "camelCase", rename_all_fields = "camelCase")]
 #[cfg_attr(feature = "uniffi", derive(uniffi::Enum))]
+#[cfg_attr(feature = "wasm", derive(Tsify), tsify(into_wasm_abi, from_wasm_abi))]
 pub enum ClientData {
     DefaultWithExtraData { android_package_name: String },
     DefaultWithCustomHash { hash: Vec<u8> },
@@ -800,7 +901,10 @@ impl passkey::client::ClientData<Option<AndroidClientData>> for ClientData {
 }
 
 /// Salt inputs for WebAuthn PRF extension.
+#[derive(Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 #[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
+#[cfg_attr(feature = "wasm", derive(Tsify), tsify(into_wasm_abi, from_wasm_abi))]
 pub struct PrfInputValues {
     /// An input on which to evaluate PRF. Required.
     pub first: Vec<u8>,
@@ -842,7 +946,10 @@ impl From<PrfInputValues> for passkey::types::ctap2::extensions::AuthenticatorPr
 }
 
 /// WebAuthn PRF output values.
+#[derive(Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 #[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
+#[cfg_attr(feature = "wasm", derive(Tsify), tsify(into_wasm_abi, from_wasm_abi))]
 pub struct PrfOutputValues {
     /// The output of the PRF evaluation of the first PRF input.
     pub first: Vec<u8>,
@@ -868,12 +975,18 @@ impl From<passkey::types::ctap2::extensions::AuthenticatorPrfValues> for PrfOutp
         }
     }
 }
+#[derive(Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 #[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
+#[cfg_attr(feature = "wasm", derive(Tsify), tsify(into_wasm_abi, from_wasm_abi))]
 pub struct ClientExtensionResults {
     pub cred_props: Option<CredPropsResult>,
 }
 
+#[derive(Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 #[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
+#[cfg_attr(feature = "wasm", derive(Tsify), tsify(into_wasm_abi, from_wasm_abi))]
 pub struct CredPropsResult {
     pub rk: Option<bool>,
 }
@@ -887,7 +1000,10 @@ impl From<passkey::types::webauthn::CredentialPropertiesOutput> for CredPropsRes
 }
 
 #[allow(missing_docs)]
+#[derive(Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 #[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
+#[cfg_attr(feature = "wasm", derive(Tsify), tsify(into_wasm_abi, from_wasm_abi))]
 pub struct PublicKeyCredentialAuthenticatorAttestationResponse {
     pub id: String,
     pub raw_id: Vec<u8>,
@@ -899,7 +1015,10 @@ pub struct PublicKeyCredentialAuthenticatorAttestationResponse {
 }
 
 #[allow(missing_docs)]
+#[derive(Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 #[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
+#[cfg_attr(feature = "wasm", derive(Tsify), tsify(into_wasm_abi, from_wasm_abi))]
 pub struct AuthenticatorAttestationResponse {
     pub client_data_json: Vec<u8>,
     pub authenticator_data: Vec<u8>,
@@ -910,7 +1029,10 @@ pub struct AuthenticatorAttestationResponse {
 }
 
 #[allow(missing_docs)]
+#[derive(Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 #[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
+#[cfg_attr(feature = "wasm", derive(Tsify), tsify(into_wasm_abi, from_wasm_abi))]
 pub struct PublicKeyCredentialAuthenticatorAssertionResponse {
     pub id: String,
     pub raw_id: Vec<u8>,
@@ -922,7 +1044,10 @@ pub struct PublicKeyCredentialAuthenticatorAssertionResponse {
 }
 
 #[allow(missing_docs)]
+#[derive(Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 #[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
+#[cfg_attr(feature = "wasm", derive(Tsify), tsify(into_wasm_abi, from_wasm_abi))]
 pub struct AuthenticatorAssertionResponse {
     pub client_data_json: Vec<u8>,
     pub authenticator_data: Vec<u8>,
@@ -934,7 +1059,10 @@ pub struct AuthenticatorAssertionResponse {
 #[error("Invalid origin: {0}")]
 pub struct InvalidOriginError(String);
 
+#[derive(Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 #[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
+#[cfg_attr(feature = "wasm", derive(Tsify), tsify(into_wasm_abi, from_wasm_abi))]
 /// An Unverified asset link.
 pub struct UnverifiedAssetLink {
     /// Application package name.
@@ -948,7 +1076,10 @@ pub struct UnverifiedAssetLink {
     asset_link_url: Option<String>,
 }
 
+#[derive(Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 #[cfg_attr(feature = "uniffi", derive(uniffi::Enum))]
+#[cfg_attr(feature = "wasm", derive(Tsify), tsify(into_wasm_abi, from_wasm_abi))]
 /// The origin of a WebAuthn request.
 pub enum Origin {
     /// A Url, meant for a request in the web browser.

--- a/crates/bitwarden-fido/src/wasm/client.rs
+++ b/crates/bitwarden-fido/src/wasm/client.rs
@@ -1,0 +1,154 @@
+use bitwarden_vault::CipherView;
+use wasm_bindgen::prelude::wasm_bindgen;
+
+use super::{
+    credential_store::{JsFido2CredentialStore, RawJsFido2CredentialStore},
+    user_interface::{JsFido2UserInterface, RawJsFido2UserInterface},
+};
+use crate::{
+    ClientData, ClientFido2, CredentialsForAutofillError, DecryptFido2AutofillCredentialsError,
+    Fido2ClientError, Fido2CredentialAutofillView, GetAssertionError, GetAssertionRequest,
+    GetAssertionResult, MakeCredentialError, MakeCredentialRequest, MakeCredentialResult, Origin,
+    PublicKeyCredentialAuthenticatorAssertionResponse,
+    PublicKeyCredentialAuthenticatorAttestationResponse, SilentlyDiscoverCredentialsError,
+};
+
+/// FIDO2 credential provider operations.
+#[wasm_bindgen(js_name = Fido2Client)]
+pub struct WasmFido2Client(ClientFido2);
+
+impl WasmFido2Client {
+    /// Wrap a [ClientFido2] for the JavaScript boundary.
+    pub fn new(client: ClientFido2) -> Self {
+        Self(client)
+    }
+}
+
+#[wasm_bindgen(js_class = Fido2Client)]
+impl WasmFido2Client {
+    /// Construct an authenticator bound to the given callbacks, for CTAP-level operations.
+    ///
+    /// Nothing here ties an instance to a single ceremony — the constraint comes from JavaScript.
+    /// `user_interface` is a per-ceremony session object, so reusing one instance across ceremonies
+    /// drives the wrong session. Construct one per ceremony.
+    pub fn authenticator(
+        &self,
+        user_interface: RawJsFido2UserInterface,
+        credential_store: RawJsFido2CredentialStore,
+    ) -> WasmFido2Authenticator {
+        WasmFido2Authenticator {
+            client: self.0.clone(),
+            user_interface: JsFido2UserInterface::new(user_interface),
+            credential_store: JsFido2CredentialStore::new(credential_store),
+        }
+    }
+
+    /// Construct a WebAuthn client bound to the given callbacks, for full ceremonies.
+    pub fn client(
+        &self,
+        user_interface: RawJsFido2UserInterface,
+        credential_store: RawJsFido2CredentialStore,
+    ) -> WasmFido2WebAuthnClient {
+        WasmFido2WebAuthnClient(self.authenticator(user_interface, credential_store))
+    }
+
+    /// Decrypt the FIDO2 credentials in a cipher into the form used for autofill.
+    pub fn decrypt_fido2_autofill_credentials(
+        &self,
+        cipher_view: CipherView,
+    ) -> Result<Vec<Fido2CredentialAutofillView>, DecryptFido2AutofillCredentialsError> {
+        self.0.decrypt_fido2_autofill_credentials(cipher_view)
+    }
+}
+
+/// CTAP-level FIDO2 operations.
+#[wasm_bindgen(js_name = Fido2Authenticator)]
+pub struct WasmFido2Authenticator {
+    client: ClientFido2,
+    user_interface: JsFido2UserInterface,
+    credential_store: JsFido2CredentialStore,
+}
+
+impl WasmFido2Authenticator {
+    /// Build a [crate::Fido2Authenticator] for a single call.
+    ///
+    /// [crate::Fido2Authenticator] borrows its callbacks, so it is constructed per call rather
+    /// than stored: the borrow then lives and dies inside one method and its lifetime never has
+    /// to escape into a field.
+    fn create_authenticator(&self) -> crate::Fido2Authenticator<'_> {
+        self.client
+            .create_authenticator(&self.user_interface, &self.credential_store)
+    }
+}
+
+#[wasm_bindgen(js_class = Fido2Authenticator)]
+impl WasmFido2Authenticator {
+    /// Create a new credential, as CTAP `authenticatorMakeCredential`.
+    pub async fn make_credential(
+        &self,
+        request: MakeCredentialRequest,
+    ) -> Result<MakeCredentialResult, MakeCredentialError> {
+        self.create_authenticator().make_credential(request).await
+    }
+
+    /// Assert an existing credential, as CTAP `authenticatorGetAssertion`.
+    pub async fn get_assertion(
+        &self,
+        request: GetAssertionRequest,
+    ) -> Result<GetAssertionResult, GetAssertionError> {
+        self.create_authenticator().get_assertion(request).await
+    }
+
+    /// List the credentials matching a relying party without prompting the user.
+    pub async fn silently_discover_credentials(
+        &self,
+        rp_id: String,
+        user_handle: Option<Vec<u8>>,
+    ) -> Result<Vec<Fido2CredentialAutofillView>, SilentlyDiscoverCredentialsError> {
+        self.create_authenticator()
+            .silently_discover_credentials(rp_id, user_handle)
+            .await
+    }
+
+    /// List every credential in the vault that can be offered for autofill.
+    pub async fn credentials_for_autofill(
+        &self,
+    ) -> Result<Vec<Fido2CredentialAutofillView>, CredentialsForAutofillError> {
+        self.create_authenticator().credentials_for_autofill().await
+    }
+}
+
+/// WebAuthn-level FIDO2 ceremonies.
+#[wasm_bindgen(js_name = Fido2WebAuthnClient)]
+pub struct WasmFido2WebAuthnClient(WasmFido2Authenticator);
+
+#[wasm_bindgen(js_class = Fido2WebAuthnClient)]
+impl WasmFido2WebAuthnClient {
+    /// Run a full WebAuthn registration ceremony.
+    pub async fn register(
+        &self,
+        origin: Origin,
+        request: String,
+        client_data: ClientData,
+    ) -> Result<PublicKeyCredentialAuthenticatorAttestationResponse, Fido2ClientError> {
+        self.0
+            .client
+            .create_client(&self.0.user_interface, &self.0.credential_store)
+            .register(origin, request, client_data)
+            .await
+    }
+
+    /// Run a full WebAuthn authentication ceremony.
+    pub async fn authenticate(
+        &self,
+        origin: Origin,
+        request: String,
+        client_data: ClientData,
+    ) -> Result<PublicKeyCredentialAuthenticatorAssertionResponse, Fido2ClientError> {
+        self.0
+            .client
+            .create_client(&self.0.user_interface, &self.0.credential_store)
+            .authenticate(origin, request, client_data)
+            .await
+    }
+}

--- a/crates/bitwarden-fido/src/wasm/credential_store.rs
+++ b/crates/bitwarden-fido/src/wasm/credential_store.rs
@@ -1,0 +1,93 @@
+use bitwarden_threading::ThreadBoundRunner;
+use bitwarden_vault::{CipherListView, CipherView, EncryptionContext};
+use wasm_bindgen::{JsValue, prelude::wasm_bindgen};
+
+use super::{from_js, js_error, to_js};
+use crate::{Fido2CallbackError, Fido2CredentialStore};
+
+#[wasm_bindgen(typescript_custom_section)]
+const CREDENTIAL_STORE_CUSTOM_TS_TYPE: &'static str = r#"
+export interface Fido2CredentialStore {
+    // Byte arrays cross as `number[]`, not `Uint8Array`: `serde_wasm_bindgen` only emits a
+    // `Uint8Array` for `serialize_bytes`, and these are plain `Vec<u8>`.
+    find_credentials(ids: number[][] | undefined, rip_id: string, user_handle: number[] | undefined): Promise<CipherView[]>;
+    all_credentials(): Promise<CipherListView[]>;
+    save_credential(cred: EncryptionContext): Promise<void>;
+}
+"#;
+
+#[wasm_bindgen]
+extern "C" {
+    /// JavaScript implementation of the credential store consulted during a FIDO2 ceremony.
+    #[wasm_bindgen(js_name = Fido2CredentialStore, typescript_type = "Fido2CredentialStore")]
+    pub type RawJsFido2CredentialStore;
+
+    /// `rip_id` is misspelled to match [Fido2CredentialStore::find_credentials]. Renaming it here
+    /// would silently stop matching the JavaScript object.
+    #[wasm_bindgen(method, catch)]
+    async fn find_credentials(
+        this: &RawJsFido2CredentialStore,
+        ids: JsValue,
+        rip_id: String,
+        user_handle: JsValue,
+    ) -> Result<JsValue, JsValue>;
+
+    #[wasm_bindgen(method, catch)]
+    async fn all_credentials(this: &RawJsFido2CredentialStore) -> Result<JsValue, JsValue>;
+
+    #[wasm_bindgen(method, catch)]
+    async fn save_credential(
+        this: &RawJsFido2CredentialStore,
+        cred: JsValue,
+    ) -> Result<(), JsValue>;
+}
+
+/// Adapts a JavaScript credential store to the [Fido2CredentialStore] trait.
+pub(super) struct JsFido2CredentialStore {
+    runner: ThreadBoundRunner<RawJsFido2CredentialStore>,
+}
+
+impl JsFido2CredentialStore {
+    pub(super) fn new(store: RawJsFido2CredentialStore) -> Self {
+        Self {
+            runner: ThreadBoundRunner::new(store),
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl Fido2CredentialStore for JsFido2CredentialStore {
+    async fn find_credentials(
+        &self,
+        ids: Option<Vec<Vec<u8>>>,
+        rip_id: String,
+        user_handle: Option<Vec<u8>>,
+    ) -> Result<Vec<CipherView>, Fido2CallbackError> {
+        self.runner
+            .run_in_thread(move |store| async move {
+                let credentials = store
+                    .find_credentials(to_js(&ids)?, rip_id, to_js(&user_handle)?)
+                    .await
+                    .map_err(js_error)?;
+                from_js(credentials)
+            })
+            .await?
+    }
+
+    async fn all_credentials(&self) -> Result<Vec<CipherListView>, Fido2CallbackError> {
+        self.runner
+            .run_in_thread(|store| async move {
+                let credentials = store.all_credentials().await.map_err(js_error)?;
+                from_js(credentials)
+            })
+            .await?
+    }
+
+    async fn save_credential(&self, cred: EncryptionContext) -> Result<(), Fido2CallbackError> {
+        self.runner
+            .run_in_thread(move |store| async move {
+                store.save_credential(to_js(&cred)?).await.map_err(js_error)
+            })
+            .await?
+    }
+}

--- a/crates/bitwarden-fido/src/wasm/mod.rs
+++ b/crates/bitwarden-fido/src/wasm/mod.rs
@@ -1,0 +1,59 @@
+//! WebAssembly bindings for FIDO2 credential provider operations.
+//!
+//! The host contract ([crate::Fido2CredentialStore] and [crate::Fido2UserInterface]) is defined
+//! in terms of owned Rust types and requires
+//! `Send + Sync`, while [::wasm_bindgen] can only hand us an opaque, thread-bound [JsValue]. Each
+//! bridge in this module reconciles the two in three layers:
+//!
+//! 1. A hand-written `typescript_custom_section` declaring the interface JavaScript must satisfy.
+//! 2. An `extern "C"` block binding that interface as an opaque type. Every callback uses
+//!    `#[wasm_bindgen(method, catch)]` so a JavaScript exception arrives as `Err` instead of
+//!    trapping the WebAssembly instance.
+//! 3. A wrapper holding the JavaScript object in a [::bitwarden_threading::ThreadBoundRunner],
+//!    which pins it to its original thread and exposes a `Send` handle. This is what makes the
+//!    `Send + Sync` bound on the traits satisfiable.
+
+mod client;
+mod credential_store;
+mod user_interface;
+
+use bitwarden_threading::CallError;
+pub use client::{WasmFido2Authenticator, WasmFido2Client, WasmFido2WebAuthnClient};
+pub use credential_store::RawJsFido2CredentialStore;
+pub use user_interface::{
+    CheckUserAndPickCredentialForCreationResult, Fido2UiHint, RawJsFido2UserInterface,
+};
+use wasm_bindgen::JsValue;
+
+use crate::Fido2CallbackError;
+
+/// A [ThreadBoundRunner](::bitwarden_threading::ThreadBoundRunner) call that never reached the
+/// JavaScript object. Only happens if the bridge closure itself panics.
+impl From<CallError> for Fido2CallbackError {
+    fn from(error: CallError) -> Self {
+        Fido2CallbackError::Unknown(error.to_string())
+    }
+}
+
+/// Serialize a value for a JavaScript callback.
+fn to_js<T: serde::Serialize>(value: &T) -> Result<JsValue, Fido2CallbackError> {
+    ::tsify::serde_wasm_bindgen::to_value(value)
+        .map_err(|e| Fido2CallbackError::Unknown(e.to_string()))
+}
+
+/// Deserialize a value returned by a JavaScript callback.
+fn from_js<T: serde::de::DeserializeOwned>(value: JsValue) -> Result<T, Fido2CallbackError> {
+    ::tsify::serde_wasm_bindgen::from_value(value)
+        .map_err(|e| Fido2CallbackError::Unknown(e.to_string()))
+}
+
+/// Convert an exception thrown by a JavaScript callback into a [Fido2CallbackError].
+///
+/// Every rejection maps to [Fido2CallbackError::Unknown]. The other two variants are deliberately
+/// unused: the authenticator flattens all callback errors to a single CTAP status code before they
+/// reach the caller, so a finer-grained mapping here would carry no information across the
+/// boundary. Ceremony-level signals such as "the user asked for the browser instead" travel on the
+/// caller's `AbortController`, not on this error.
+fn js_error(error: JsValue) -> Fido2CallbackError {
+    Fido2CallbackError::Unknown(format!("{error:?}"))
+}

--- a/crates/bitwarden-fido/src/wasm/user_interface.rs
+++ b/crates/bitwarden-fido/src/wasm/user_interface.rs
@@ -1,0 +1,207 @@
+use bitwarden_threading::ThreadBoundRunner;
+use bitwarden_vault::{CipherView, Fido2CredentialNewView};
+use serde::{Deserialize, Serialize};
+use tsify::Tsify;
+use wasm_bindgen::{JsValue, prelude::wasm_bindgen};
+
+use super::{from_js, js_error, to_js};
+use crate::{
+    CheckUserOptions, CheckUserResult, Fido2CallbackError, Fido2UserInterface,
+    PublicKeyCredentialRpEntity, PublicKeyCredentialUserEntity, UiHint,
+};
+
+/// Owned mirror of [UiHint].
+///
+/// [UiHint] is generic, borrows its payload, and is defined upstream in `passkey`, so it cannot
+/// cross the boundary as-is. The borrowed cipher is cloned into this type before the callback.
+#[derive(Serialize, Deserialize, Tsify)]
+#[serde(rename_all = "camelCase", rename_all_fields = "camelCase")]
+#[tsify(into_wasm_abi, from_wasm_abi)]
+pub enum Fido2UiHint {
+    /// The relying party excluded a credential the vault already holds, so registration cannot
+    /// continue.
+    InformExcludedCredentialFound(CipherView),
+    /// No credential in the vault can satisfy the request.
+    InformNoCredentialsFound,
+    /// Registration needs a cipher to store the new credential in.
+    RequestNewCredential {
+        /// The account the relying party is registering.
+        user: PublicKeyCredentialUserEntity,
+        /// The relying party requesting registration.
+        rp: PublicKeyCredentialRpEntity,
+    },
+    /// Authentication needs the user to confirm the credential to assert with.
+    RequestExistingCredential(CipherView),
+}
+
+impl From<UiHint<'_, CipherView>> for Fido2UiHint {
+    fn from(hint: UiHint<'_, CipherView>) -> Self {
+        match hint {
+            UiHint::InformExcludedCredentialFound(cipher) => {
+                Fido2UiHint::InformExcludedCredentialFound(cipher.clone())
+            }
+            UiHint::InformNoCredentialsFound => Fido2UiHint::InformNoCredentialsFound,
+            UiHint::RequestNewCredential(user, rp) => Fido2UiHint::RequestNewCredential {
+                user: PublicKeyCredentialUserEntity {
+                    id: user.id.clone().into(),
+                    name: user.name.clone().unwrap_or_default(),
+                    display_name: user.display_name.clone().unwrap_or_default(),
+                },
+                rp: PublicKeyCredentialRpEntity {
+                    id: rp.id.clone(),
+                    name: rp.name.clone(),
+                },
+            },
+            UiHint::RequestExistingCredential(cipher) => {
+                Fido2UiHint::RequestExistingCredential(cipher.clone())
+            }
+        }
+    }
+}
+
+/// Result of [Fido2UserInterface::check_user_and_pick_credential_for_creation].
+///
+/// The trait returns a tuple, which serializes as a positional array. A named struct is used here
+/// so the TypeScript contract stays readable.
+#[derive(Serialize, Deserialize, Tsify)]
+#[serde(rename_all = "camelCase")]
+#[tsify(into_wasm_abi, from_wasm_abi)]
+pub struct CheckUserAndPickCredentialForCreationResult {
+    /// The cipher the new credential will be stored in.
+    pub cipher: CipherView,
+    /// The outcome of the user check performed while picking it.
+    pub check_user_result: CheckUserResult,
+}
+
+#[wasm_bindgen(typescript_custom_section)]
+const USER_INTERFACE_CUSTOM_TS_TYPE: &'static str = r#"
+export interface Fido2UserInterface {
+    check_user(options: CheckUserOptions, hint: Fido2UiHint): Promise<CheckUserResult>;
+    pick_credential_for_authentication(available_credentials: CipherView[]): Promise<CipherView>;
+    check_user_and_pick_credential_for_creation(options: CheckUserOptions, new_credential: Fido2CredentialNewView): Promise<CheckUserAndPickCredentialForCreationResult>;
+    // Read once, when the authenticator is built. Later changes are not observed, so this is a
+    // property rather than a method.
+    readonly is_verification_enabled: boolean;
+}
+"#;
+
+#[wasm_bindgen]
+extern "C" {
+    /// JavaScript implementation of the user interface driven during a FIDO2 ceremony.
+    #[wasm_bindgen(js_name = Fido2UserInterface, typescript_type = "Fido2UserInterface")]
+    pub type RawJsFido2UserInterface;
+
+    #[wasm_bindgen(method, catch)]
+    async fn check_user(
+        this: &RawJsFido2UserInterface,
+        options: JsValue,
+        hint: JsValue,
+    ) -> Result<JsValue, JsValue>;
+
+    #[wasm_bindgen(method, catch)]
+    async fn pick_credential_for_authentication(
+        this: &RawJsFido2UserInterface,
+        available_credentials: JsValue,
+    ) -> Result<JsValue, JsValue>;
+
+    #[wasm_bindgen(method, catch)]
+    async fn check_user_and_pick_credential_for_creation(
+        this: &RawJsFido2UserInterface,
+        options: JsValue,
+        new_credential: JsValue,
+    ) -> Result<JsValue, JsValue>;
+
+    #[wasm_bindgen(method, getter, catch)]
+    fn is_verification_enabled(this: &RawJsFido2UserInterface) -> Result<bool, JsValue>;
+}
+
+/// Adapts a JavaScript user interface to the [Fido2UserInterface] trait.
+pub(super) struct JsFido2UserInterface {
+    runner: ThreadBoundRunner<RawJsFido2UserInterface>,
+    verification_enabled: bool,
+}
+
+impl JsFido2UserInterface {
+    pub(super) fn new(user_interface: RawJsFido2UserInterface) -> Self {
+        // `is_verification_enabled` is synchronous on the trait, but once the JavaScript object is
+        // handed to the runner it can only be reached through an async call. Read it here, while
+        // still on the thread that constructed it, and answer from the cached value afterwards.
+        // A throwing implementation degrades to "not enabled", which weakens the ceremony, so it is
+        // logged rather than swallowed.
+        let verification_enabled = match user_interface.is_verification_enabled() {
+            Ok(enabled) => enabled,
+            Err(error) => {
+                tracing::error!(
+                    ?error,
+                    "is_verification_enabled threw; treating verification as disabled"
+                );
+                false
+            }
+        };
+
+        Self {
+            runner: ThreadBoundRunner::new(user_interface),
+            verification_enabled,
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl Fido2UserInterface for JsFido2UserInterface {
+    async fn check_user<'a>(
+        &self,
+        options: CheckUserOptions,
+        hint: UiHint<'a, CipherView>,
+    ) -> Result<CheckUserResult, Fido2CallbackError> {
+        let hint = Fido2UiHint::from(hint);
+
+        self.runner
+            .run_in_thread(move |ui| async move {
+                let result = ui
+                    .check_user(to_js(&options)?, to_js(&hint)?)
+                    .await
+                    .map_err(js_error)?;
+                from_js(result)
+            })
+            .await?
+    }
+
+    async fn pick_credential_for_authentication(
+        &self,
+        available_credentials: Vec<CipherView>,
+    ) -> Result<CipherView, Fido2CallbackError> {
+        self.runner
+            .run_in_thread(move |ui| async move {
+                let credential = ui
+                    .pick_credential_for_authentication(to_js(&available_credentials)?)
+                    .await
+                    .map_err(js_error)?;
+                from_js(credential)
+            })
+            .await?
+    }
+
+    async fn check_user_and_pick_credential_for_creation(
+        &self,
+        options: CheckUserOptions,
+        new_credential: Fido2CredentialNewView,
+    ) -> Result<(CipherView, CheckUserResult), Fido2CallbackError> {
+        self.runner
+            .run_in_thread(move |ui| async move {
+                let result = ui
+                    .check_user_and_pick_credential_for_creation(
+                        to_js(&options)?,
+                        to_js(&new_credential)?,
+                    )
+                    .await
+                    .map_err(js_error)?;
+                let result: CheckUserAndPickCredentialForCreationResult = from_js(result)?;
+                Ok((result.cipher, result.check_user_result))
+            })
+            .await?
+    }
+
+    fn is_verification_enabled(&self) -> bool {
+        self.verification_enabled
+    }
+}

--- a/crates/bitwarden-wasm-internal/Cargo.toml
+++ b/crates/bitwarden-wasm-internal/Cargo.toml
@@ -39,6 +39,7 @@ bitwarden-core = { workspace = true, features = ["wasm", "internal"] }
 bitwarden-crypto = { workspace = true, features = ["wasm"] }
 bitwarden-crypto-sync-handler = { workspace = true, features = ["wasm"] }
 bitwarden-error = { workspace = true }
+bitwarden-fido = { workspace = true, features = ["wasm"] }
 bitwarden-ipc = { workspace = true, features = ["wasm"] }
 bitwarden-logging = { workspace = true, features = ["wasm"] }
 bitwarden-managed-settings = { workspace = true, features = ["wasm"] }

--- a/crates/bitwarden-wasm-internal/integration-tests/tests/fido2/fido2-bridge.test.ts
+++ b/crates/bitwarden-wasm-internal/integration-tests/tests/fido2/fido2-bridge.test.ts
@@ -1,0 +1,114 @@
+// Exercises the bitwarden-fido WASM bridge from TypeScript.
+//
+// The point is the FFI boundary, not the FIDO2 logic: these tests confirm that a plain
+// JavaScript object satisfies the `Fido2CredentialStore` / `Fido2UserInterface` interfaces,
+// that callbacks reach it through `ThreadBoundRunner`, and that a throw arrives as a
+// rejection rather than trapping the WebAssembly instance.
+
+import { Fido2CredentialStore, Fido2UserInterface } from "@bitwarden/sdk-internal";
+
+import { makeInitializedPasswordmanagerClient, makeStateBridge } from "../utils";
+
+/** A store that records calls and returns empty results. */
+function makeStore(overrides: Partial<Fido2CredentialStore> = {}) {
+  const calls: string[] = [];
+  const store: Fido2CredentialStore = {
+    find_credentials: async () => {
+      calls.push("find_credentials");
+      return [];
+    },
+    all_credentials: async () => {
+      calls.push("all_credentials");
+      return [];
+    },
+    save_credential: async () => {
+      calls.push("save_credential");
+    },
+    ...overrides,
+  };
+  return { store, calls };
+}
+
+/**
+ * `is_verification_enabled` is a property, not a method: the SDK reads it once while
+ * constructing the authenticator and caches it.
+ */
+function makeUserInterface(overrides: Partial<Fido2UserInterface> = {}) {
+  return {
+    check_user: async () => {
+      throw new Error("not used");
+    },
+    pick_credential_for_authentication: async () => {
+      throw new Error("not used");
+    },
+    check_user_and_pick_credential_for_creation: async () => {
+      throw new Error("not used");
+    },
+    is_verification_enabled: true,
+    ...overrides,
+  } as unknown as Fido2UserInterface;
+}
+
+async function makeFido2Client() {
+  return (await makeInitializedPasswordmanagerClient(makeStateBridge())).platform().fido2();
+}
+
+describe("fido2 bridge", () => {
+  it("exposes the authenticator through platform().fido2()", async () => {
+    const fido2 = await makeFido2Client();
+
+    expect(fido2.authenticator(makeUserInterface(), makeStore().store)).toBeDefined();
+  });
+
+  it("routes credentials_for_autofill to the JavaScript credential store", async () => {
+    const fido2 = await makeFido2Client();
+    const { store, calls } = makeStore();
+
+    const result = await fido2.authenticator(makeUserInterface(), store).credentials_for_autofill();
+
+    expect(calls).toEqual(["all_credentials"]);
+    expect(result).toEqual([]);
+  });
+
+  it("accepts is_verification_enabled as a plain property", async () => {
+    const fido2 = await makeFido2Client();
+
+    // Constructing the authenticator is what reads the property. A method would not satisfy
+    // the interface, so reaching a result at all is the assertion.
+    const result = await fido2
+      .authenticator(makeUserInterface({ is_verification_enabled: false } as never), makeStore().store)
+      .credentials_for_autofill();
+
+    expect(result).toEqual([]);
+  });
+
+  it("surfaces a throwing callback as a rejection instead of trapping", async () => {
+    const fido2 = await makeFido2Client();
+    const { store } = makeStore({
+      all_credentials: async () => {
+        throw new Error("store exploded");
+      },
+    });
+
+    await expect(
+      fido2.authenticator(makeUserInterface(), store).credentials_for_autofill(),
+    ).rejects.toBeDefined();
+  });
+
+  it("still works after a callback threw, so the instance was not poisoned", async () => {
+    const fido2 = await makeFido2Client();
+    const { store } = makeStore({
+      all_credentials: async () => {
+        throw new Error("store exploded");
+      },
+    });
+    const authenticator = fido2.authenticator(makeUserInterface(), store);
+
+    await expect(authenticator.credentials_for_autofill()).rejects.toBeDefined();
+
+    const healthy = await fido2
+      .authenticator(makeUserInterface(), makeStore().store)
+      .credentials_for_autofill();
+    expect(healthy).toEqual([]);
+  });
+});

--- a/crates/bitwarden-wasm-internal/integration-tests/tests/fido2/fido2-ceremony.test.ts
+++ b/crates/bitwarden-wasm-internal/integration-tests/tests/fido2/fido2-ceremony.test.ts
@@ -1,0 +1,231 @@
+// Runs real CTAP ceremonies through the WASM bridge: make_credential, then get_assertion over
+// the credential that produced.
+//
+// Unlike fido2-bridge.test.ts, which only checks that callbacks arrive, this exercises the
+// FIDO2 logic end to end. The credential round-trips through encryption: `save_credential`
+// receives an `EncryptionContext` and stores the encrypted cipher, and `find_credentials`
+// decrypts it again, so nothing is passed back as the same in-memory object.
+
+import {
+  Cipher,
+  CipherId,
+  CipherRepromptType,
+  CipherType,
+  CipherView,
+  EncryptionContext,
+  Fido2CredentialStore,
+  Fido2UserInterface,
+  GetAssertionRequest,
+  MakeCredentialRequest,
+  PasswordManagerClient,
+} from "@bitwarden/sdk-internal";
+
+import { makeInitializedPasswordmanagerClient, makeStateBridge } from "../utils";
+
+const RP_ID = "bitwarden.com";
+const USER_HANDLE = [1, 2, 3, 4];
+const CLIENT_DATA_HASH = Array.from({ length: 32 }, (_, i) => i);
+/** ES256, the only algorithm the authenticator supports. */
+const ES256 = -7;
+
+const cipherId = (s: string) => s as unknown as CipherId;
+
+/** An empty login cipher, standing in for the one a user would pick during registration. */
+function blankLoginCipher(): CipherView {
+  const now = new Date().toISOString() as unknown as CipherView["creationDate"];
+  return {
+    id: cipherId("00000000-0000-0000-0000-000000000001"),
+    organizationId: undefined,
+    folderId: undefined,
+    collectionIds: [],
+    key: undefined,
+    name: "bitwarden.com passkey",
+    notes: undefined,
+    type: CipherType.Login,
+    login: {
+      username: undefined,
+      password: undefined,
+      passwordRevisionDate: undefined,
+      uris: undefined,
+      totp: undefined,
+      autofillOnPageLoad: undefined,
+      fido2Credentials: undefined,
+    },
+    identity: undefined,
+    card: undefined,
+    secureNote: undefined,
+    sshKey: undefined,
+    bankAccount: undefined,
+    driversLicense: undefined,
+    passport: undefined,
+    favorite: false,
+    reprompt: CipherRepromptType.None,
+    organizationUseTotp: false,
+    edit: true,
+    permissions: undefined,
+    viewPassword: true,
+    localData: undefined,
+    attachments: undefined,
+    fields: undefined,
+    passwordHistory: undefined,
+    creationDate: now,
+    deletedDate: undefined,
+    revisionDate: now,
+    archivedDate: undefined,
+  };
+}
+
+/**
+ * A credential store backed by the client's own encryption, so credentials survive the same
+ * encrypt/decrypt trip they would in a real vault.
+ */
+function makeVaultStore(client: PasswordManagerClient) {
+  const ciphers = client.vault().ciphers();
+  const saved: Cipher[] = [];
+  /** Argument shapes observed at the boundary, asserted on below. */
+  const observed: { ids: unknown; userHandle: unknown }[] = [];
+
+  const store: Fido2CredentialStore = {
+    find_credentials: async (ids, rip_id, user_handle) => {
+      observed.push({ ids, userHandle: user_handle });
+      const views = await Promise.all(saved.map((c) => ciphers.decrypt(c)));
+      return views.filter((view) =>
+        // `rpId` is only readable once the credential is decrypted: the `fido2Credentials` on a
+        // CipherView are still the encrypted type.
+        ciphers.decrypt_fido2_credentials(view).some((cred) => cred.rpId === rip_id),
+      );
+    },
+    all_credentials: async () => ciphers.decrypt_list(saved),
+    save_credential: async (cred: EncryptionContext) => {
+      saved.push(cred.cipher);
+    },
+  };
+
+  return { store, saved, observed };
+}
+
+/** A user interface that approves everything, as a user who taps through the prompts would. */
+function makeApprovingUserInterface() {
+  const calls: string[] = [];
+  const ui = {
+    check_user: async () => {
+      calls.push("check_user");
+      return { userPresent: true, userVerified: true };
+    },
+    pick_credential_for_authentication: async (available: CipherView[]) => {
+      calls.push("pick_credential_for_authentication");
+      return available[0];
+    },
+    check_user_and_pick_credential_for_creation: async () => {
+      calls.push("check_user_and_pick_credential_for_creation");
+      return {
+        cipher: blankLoginCipher(),
+        checkUserResult: { userPresent: true, userVerified: true },
+      };
+    },
+    is_verification_enabled: true,
+  } as unknown as Fido2UserInterface;
+
+  return { ui, calls };
+}
+
+function makeCredentialRequest(): MakeCredentialRequest {
+  return {
+    clientDataHash: CLIENT_DATA_HASH,
+    rp: { id: RP_ID, name: "Bitwarden" },
+    user: { id: USER_HANDLE, name: "user@bitwarden.com", displayName: "Test User" },
+    pubKeyCredParams: [{ ty: "public-key", alg: ES256 }],
+    excludeList: undefined,
+    // `rk: true` makes the credential discoverable, which is what lets get_assertion and
+    // silently_discover_credentials find it afterwards.
+    options: { rk: true, uv: "discouraged" },
+    extensions: undefined,
+  };
+}
+
+function getAssertionRequest(credentialId: number[]): GetAssertionRequest {
+  return {
+    rpId: RP_ID,
+    clientDataHash: CLIENT_DATA_HASH,
+    allowList: [{ ty: "public-key", id: credentialId, transports: undefined }],
+    options: { rk: true, uv: "discouraged" },
+    extensions: undefined,
+  };
+}
+
+describe("fido2 ceremony", () => {
+  let client: PasswordManagerClient;
+
+  beforeEach(async () => {
+    client = await makeInitializedPasswordmanagerClient(makeStateBridge());
+  });
+
+  it("creates a credential and persists it through save_credential", async () => {
+    const { store, saved } = makeVaultStore(client);
+    const { ui, calls } = makeApprovingUserInterface();
+    const authenticator = client.platform().fido2().authenticator(ui, store);
+
+    const result = await authenticator.make_credential(makeCredentialRequest());
+
+    expect(calls).toContain("check_user_and_pick_credential_for_creation");
+    expect(result.credentialId.length).toBeGreaterThan(0);
+    expect(result.attestationObject.length).toBeGreaterThan(0);
+    expect(saved).toHaveLength(1);
+  });
+
+  it("asserts the credential it just created", async () => {
+    const { store } = makeVaultStore(client);
+    const { ui } = makeApprovingUserInterface();
+    const fido2 = client.platform().fido2();
+
+    const created = await fido2.authenticator(ui, store).make_credential(makeCredentialRequest());
+    // A fresh authenticator, as a second ceremony would use.
+    const assertion = await fido2
+      .authenticator(makeApprovingUserInterface().ui, store)
+      .get_assertion(getAssertionRequest(created.credentialId));
+
+    expect(assertion.credentialId).toEqual(created.credentialId);
+    expect(assertion.signature.length).toBeGreaterThan(0);
+    expect(assertion.userHandle).toEqual(USER_HANDLE);
+    expect(assertion.selectedCredential.credential.rpId).toBe(RP_ID);
+  });
+
+  it("hands find_credentials plain arrays, not Uint8Array", async () => {
+    const { store, observed } = makeVaultStore(client);
+    const { ui } = makeApprovingUserInterface();
+    const fido2 = client.platform().fido2();
+
+    const created = await fido2.authenticator(ui, store).make_credential(makeCredentialRequest());
+    await fido2
+      .authenticator(makeApprovingUserInterface().ui, store)
+      .get_assertion(getAssertionRequest(created.credentialId));
+
+    // The interface declares `number[][]` and `number[]` because serde_wasm_bindgen does not
+    // emit Uint8Array for a plain Vec<u8>. This is that claim, checked.
+    const withIds = observed.filter((o) => o.ids !== undefined);
+    expect(withIds.length).toBeGreaterThan(0);
+    for (const { ids } of withIds) {
+      expect(Array.isArray(ids)).toBe(true);
+      for (const id of ids as unknown[]) {
+        expect(Array.isArray(id)).toBe(true);
+        expect(id).not.toBeInstanceOf(Uint8Array);
+      }
+    }
+  });
+
+  it("discovers the credential silently, with no user interaction", async () => {
+    const { store } = makeVaultStore(client);
+    const { ui } = makeApprovingUserInterface();
+    const fido2 = client.platform().fido2();
+
+    await fido2.authenticator(ui, store).make_credential(makeCredentialRequest());
+    const silent = makeApprovingUserInterface();
+    const discovered = await fido2
+      .authenticator(silent.ui, store)
+      .silently_discover_credentials(RP_ID);
+
+    expect(discovered).toHaveLength(1);
+    expect(discovered[0].rpId).toBe(RP_ID);
+    expect(silent.calls).toEqual([]);
+  });
+});

--- a/crates/bitwarden-wasm-internal/src/platform/mod.rs
+++ b/crates/bitwarden-wasm-internal/src/platform/mod.rs
@@ -1,4 +1,5 @@
 use bitwarden_core::Client;
+use bitwarden_fido::{ClientFido2Ext, wasm::WasmFido2Client};
 use serde::{Deserialize, Serialize};
 use tsify::Tsify;
 use wasm_bindgen::{JsValue, prelude::wasm_bindgen};
@@ -30,6 +31,11 @@ impl PlatformClient {
 impl PlatformClient {
     pub fn state(&self) -> StateClient {
         StateClient::new(self.0.clone())
+    }
+
+    /// FIDO2 credential provider operations.
+    pub fn fido2(&self) -> WasmFido2Client {
+        WasmFido2Client::new(self.0.fido2())
     }
 
     /// Load feature flags into the client


### PR DESCRIPTION
Adds crates/bitwarden-fido/src/wasm/ — bindings for Fido2Authenticator, Fido2CredentialStore and Fido2UserInterface — and exposes them through PlatformClient::fido2(). This is a wrapper over the existing crate, not a refactor of it; no existing Rust caller changes behavior.

Adds public_key and public_key_algorithm to MakeCredentialResult, filled by the new public_key_der_and_algorithm helper. That helper calls the same passkey::authenticator::public_key_der_from_cose_key that passkey-client::register uses, so the two levels cannot drift apart. The WebAuthn-level getPublicKey() form was the one field the CTAP-level result did not carry. The fields are appended after extensions because adding a field changes the arity of the generated positional constructors.

MakeCredentialResult is a uniffi Record, so the two new fields break three Swift test-fixture construction sites in the iOS repo. No production Swift constructs it, and Android does not use the type.

## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

## 🚨 Breaking Changes

<!-- Does this PR introduce any breaking changes? If so, please describe the impact and migration path for clients.

If you're unsure, the automated TypeScript compatibility check will run when you open/update this PR and provide feedback.

For breaking changes:
1. Describe what changed in the client interface
2. Explain why the change was necessary
3. Provide migration steps for client developers
4. Link to any paired client PRs if needed

Otherwise, you can remove this section. -->
