### PR TITLE
[PM-41447] Add destination filtering to shared unlock

### DIFF
--- a/crates/bitwarden-shared-unlock/src/lib.rs
+++ b/crates/bitwarden-shared-unlock/src/lib.rs
@@ -111,6 +111,7 @@
 
 use bitwarden_core::UserId;
 use bitwarden_crypto::SymmetricCryptoKey;
+use bitwarden_ipc::Endpoint;
 use serde::{Deserialize, Serialize};
 
 mod active_peers;
@@ -180,4 +181,34 @@ pub enum DeviceEvent {
         #[cfg_attr(feature = "wasm", tsify(type = "SymmetricKey"))]
         user_key: SymmetricCryptoKey,
     },
+}
+
+/// A kind of client a peer may share unlock state with, independent of the IPC endpoint variants
+/// that address its individual contexts (foreground/background, renderer/main).
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[cfg_attr(
+    feature = "wasm",
+    derive(tsify::Tsify),
+    tsify(into_wasm_abi, from_wasm_abi)
+)]
+pub enum SharedUnlockClient {
+    /// The browser extension, in any of its contexts.
+    Browser,
+    /// The desktop app, in any of its processes.
+    Desktop,
+    /// A web vault tab.
+    Web,
+}
+
+impl SharedUnlockClient {
+    /// The client an endpoint belongs to.
+    pub(crate) fn of_endpoint(endpoint: &Endpoint) -> Self {
+        match endpoint {
+            Endpoint::Web { .. } => SharedUnlockClient::Web,
+            Endpoint::BrowserForeground { .. } | Endpoint::BrowserBackground { .. } => {
+                SharedUnlockClient::Browser
+            }
+            Endpoint::DesktopRenderer | Endpoint::DesktopMain => SharedUnlockClient::Desktop,
+        }
+    }
 }

--- a/crates/bitwarden-shared-unlock/src/peer.rs
+++ b/crates/bitwarden-shared-unlock/src/peer.rs
@@ -344,10 +344,6 @@ impl<D: SharedUnlockDriver + Send + Sync + 'static> SharedUnlockPeer<D> {
     }
 
     async fn sync_user_to(&self, user_id: UserId, target: &SyncTarget) {
-        if !self.is_destination(user_id, &target.endpoint) {
-            return;
-        }
-
         if !self.may_sync_user_to(user_id, target).await {
             return;
         }
@@ -361,11 +357,18 @@ impl<D: SharedUnlockDriver + Send + Sync + 'static> SharedUnlockPeer<D> {
 
     /// Whether a user's state may be sent to a peer.
     ///
-    /// A web peer is entitled only to the users whose vault URL is the origin it was validated
+    /// The peer must be among the user's configured destinations.
+    ///
+    /// A web peer is additionally entitled only to the users whose vault URL is the
+    /// origin it was validated
     /// against — the same rule [`SharedUnlockPeer::receive_message`] applies to incoming syncs,
     /// applied outbound so a page served by one vault is never handed another vault's key material.
     /// A web peer with no recorded origin fails closed.
     async fn may_sync_user_to(&self, user_id: UserId, target: &SyncTarget) -> bool {
+        if !self.is_destination(user_id, &target.endpoint) {
+            return false;
+        }
+
         if !matches!(target.endpoint, Endpoint::Web { .. }) {
             return true;
         }

--- a/crates/bitwarden-shared-unlock/src/peer.rs
+++ b/crates/bitwarden-shared-unlock/src/peer.rs
@@ -7,7 +7,7 @@
 //! users whose vault URL is that origin, in either direction.
 
 use std::{
-    collections::HashMap,
+    collections::{HashMap, HashSet},
     sync::{Arc, Mutex},
     time::Duration,
 };
@@ -22,7 +22,7 @@ use thiserror::Error;
 use tracing::warn;
 
 use crate::{
-    DeviceEvent, LockState, SharedUnlockSync, TimestampedLockState,
+    DeviceEvent, LockState, SharedUnlockClient, SharedUnlockSync, TimestampedLockState,
     active_peers::{ActivePeerTracker, SyncTarget},
     drivers::SharedUnlockDriver,
     timing::{SharedUnlockTiming, now_millis},
@@ -53,6 +53,10 @@ struct InnerPeer<D: SharedUnlockDriver> {
     states: Mutex<HashMap<UserId, TimestampedLockState>>,
     active_peers: ActivePeerTracker,
     timing: SharedUnlockTiming,
+    /// The client kinds this peer is allowed to sync to. Empty until
+    /// [`SharedUnlockPeer::set_destinations`] is called, so a peer syncs to nothing until its
+    /// client opts in.
+    destinations: Mutex<HashSet<SharedUnlockClient>>,
 }
 
 impl<D: SharedUnlockDriver + Send + Sync + 'static> SharedUnlockPeer<D> {
@@ -93,7 +97,29 @@ impl<D: SharedUnlockDriver + Send + Sync + 'static> SharedUnlockPeer<D> {
             states: Mutex::new(HashMap::new()),
             active_peers: ActivePeerTracker::default(),
             timing,
+            destinations: Mutex::new(HashSet::new()),
         }))
+    }
+
+    /// Sets which clients this peer shares unlock state with, in both directions: a client that is
+    /// not in the set is never synced to, and its syncs are dropped on arrival.
+    ///
+    /// Defaults to no client at all — a peer neither sends nor accepts anything until this is
+    /// called.
+    pub fn set_destinations(&self, destinations: Vec<SharedUnlockClient>) {
+        *self
+            .0
+            .destinations
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner()) = destinations.into_iter().collect();
+    }
+
+    fn is_destination(&self, endpoint: &Endpoint) -> bool {
+        self.0
+            .destinations
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .contains(&SharedUnlockClient::of_endpoint(endpoint))
     }
 
     /// Starts the receive loop and the sync timer, then announces this peer's state once so it does
@@ -170,6 +196,14 @@ impl<D: SharedUnlockDriver + Send + Sync + 'static> SharedUnlockPeer<D> {
     ) -> Result<(), ()> {
         let source = incoming_message.source;
         let SharedUnlockSync { user_id, state } = incoming_message.payload;
+
+        if !self.is_destination(&source.to_endpoint()) {
+            tracing::debug!(
+                ?source,
+                "Ignoring shared unlock sync from a client not shared with"
+            );
+            return Ok(());
+        }
 
         // Validate the origin of web sources against the user's vault URL
         if let Source::Web { origin, .. } = &source {
@@ -307,6 +341,10 @@ impl<D: SharedUnlockDriver + Send + Sync + 'static> SharedUnlockPeer<D> {
     }
 
     async fn sync_user_to(&self, user_id: UserId, target: &SyncTarget) {
+        if !self.is_destination(&target.endpoint) {
+            return;
+        }
+
         if !self.may_sync_user_to(user_id, target).await {
             return;
         }

--- a/crates/bitwarden-shared-unlock/src/peer.rs
+++ b/crates/bitwarden-shared-unlock/src/peer.rs
@@ -53,10 +53,10 @@ struct InnerPeer<D: SharedUnlockDriver> {
     states: Mutex<HashMap<UserId, TimestampedLockState>>,
     active_peers: ActivePeerTracker,
     timing: SharedUnlockTiming,
-    /// The client kinds this peer is allowed to sync to. Empty until
-    /// [`SharedUnlockPeer::set_destinations`] is called, so a peer syncs to nothing until its
-    /// client opts in.
-    destinations: Mutex<HashSet<SharedUnlockClient>>,
+    /// Per user, the client kinds this peer is allowed to sync that user to. A user is absent
+    /// until [`SharedUnlockPeer::set_destinations`] is called for it, so a user is shared with
+    /// nothing until its client opts in.
+    destinations: Mutex<HashMap<UserId, HashSet<SharedUnlockClient>>>,
 }
 
 impl<D: SharedUnlockDriver + Send + Sync + 'static> SharedUnlockPeer<D> {
@@ -97,29 +97,31 @@ impl<D: SharedUnlockDriver + Send + Sync + 'static> SharedUnlockPeer<D> {
             states: Mutex::new(HashMap::new()),
             active_peers: ActivePeerTracker::default(),
             timing,
-            destinations: Mutex::new(HashSet::new()),
+            destinations: Mutex::new(HashMap::new()),
         }))
     }
 
-    /// Sets which clients this peer shares unlock state with, in both directions: a client that is
-    /// not in the set is never synced to, and its syncs are dropped on arrival.
+    /// Sets which clients this peer shares one user's unlock state with, in both directions: a
+    /// client that is not in the set is never synced that user, and that user's syncs from it are
+    /// dropped on arrival. Replaces any previous set for the user.
     ///
-    /// Defaults to no client at all — a peer neither sends nor accepts anything until this is
-    /// called.
-    pub fn set_destinations(&self, destinations: Vec<SharedUnlockClient>) {
-        *self
-            .0
-            .destinations
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner()) = destinations.into_iter().collect();
-    }
-
-    fn is_destination(&self, endpoint: &Endpoint) -> bool {
+    /// Every user defaults to no client at all — a peer neither sends nor accepts anything for a
+    /// user until this is called for it.
+    pub fn set_destinations(&self, user_id: UserId, destinations: Vec<SharedUnlockClient>) {
         self.0
             .destinations
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner())
-            .contains(&SharedUnlockClient::of_endpoint(endpoint))
+            .insert(user_id, destinations.into_iter().collect());
+    }
+
+    fn is_destination(&self, user_id: UserId, endpoint: &Endpoint) -> bool {
+        self.0
+            .destinations
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .get(&user_id)
+            .is_some_and(|clients| clients.contains(&SharedUnlockClient::of_endpoint(endpoint)))
     }
 
     /// Starts the receive loop and the sync timer, then announces this peer's state once so it does
@@ -197,10 +199,11 @@ impl<D: SharedUnlockDriver + Send + Sync + 'static> SharedUnlockPeer<D> {
         let source = incoming_message.source;
         let SharedUnlockSync { user_id, state } = incoming_message.payload;
 
-        if !self.is_destination(&source.to_endpoint()) {
+        if !self.is_destination(user_id, &source.to_endpoint()) {
             tracing::debug!(
                 ?source,
-                "Ignoring shared unlock sync from a client not shared with"
+                %user_id,
+                "Ignoring shared unlock sync from a client this user is not shared with"
             );
             return Ok(());
         }
@@ -341,7 +344,7 @@ impl<D: SharedUnlockDriver + Send + Sync + 'static> SharedUnlockPeer<D> {
     }
 
     async fn sync_user_to(&self, user_id: UserId, target: &SyncTarget) {
-        if !self.is_destination(&target.endpoint) {
+        if !self.is_destination(user_id, &target.endpoint) {
             return;
         }
 

--- a/crates/bitwarden-shared-unlock/src/wasm/peer.rs
+++ b/crates/bitwarden-shared-unlock/src/wasm/peer.rs
@@ -1,3 +1,4 @@
+use bitwarden_core::UserId;
 use bitwarden_threading::cancellation_token::wasm::{AbortController, AbortControllerExt};
 use wasm_bindgen::prelude::wasm_bindgen;
 
@@ -23,10 +24,10 @@ impl SharedUnlockPeer {
         Self { peer }
     }
 
-    /// Sets which clients this peer shares unlock state with. Defaults to none.
+    /// Sets which clients this peer shares one user's unlock state with. Defaults to none.
     #[wasm_bindgen]
-    pub fn set_destinations(&self, destinations: Vec<SharedUnlockClient>) {
-        self.peer.set_destinations(destinations);
+    pub fn set_destinations(&self, user_id: UserId, destinations: Vec<SharedUnlockClient>) {
+        self.peer.set_destinations(user_id, destinations);
     }
 
     /// Starts the shared-unlock peer

--- a/crates/bitwarden-shared-unlock/src/wasm/peer.rs
+++ b/crates/bitwarden-shared-unlock/src/wasm/peer.rs
@@ -2,7 +2,7 @@ use bitwarden_threading::cancellation_token::wasm::{AbortController, AbortContro
 use wasm_bindgen::prelude::wasm_bindgen;
 
 use super::drivers::{JsSharedUnlockDriver, RawJsSharedUnlockDriver};
-use crate::{DeviceEvent, PeerStartError, SharedUnlockPeer as Peer};
+use crate::{DeviceEvent, PeerStartError, SharedUnlockClient, SharedUnlockPeer as Peer};
 
 /// Shared-unlock peer for WASM clients.
 #[wasm_bindgen]
@@ -21,6 +21,12 @@ impl SharedUnlockPeer {
         let driver = JsSharedUnlockDriver::new(driver);
         let peer = Peer::create(driver, ipc_client.client.clone());
         Self { peer }
+    }
+
+    /// Sets which clients this peer shares unlock state with. Defaults to none.
+    #[wasm_bindgen]
+    pub fn set_destinations(&self, destinations: Vec<SharedUnlockClient>) {
+        self.peer.set_destinations(destinations);
     }
 
     /// Starts the shared-unlock peer

--- a/crates/bitwarden-wasm-internal/integration-tests/tests/unlock/shared-unlock.test.ts
+++ b/crates/bitwarden-wasm-internal/integration-tests/tests/unlock/shared-unlock.test.ts
@@ -73,7 +73,10 @@ async function setupPair(options: {
 }) {
   init_sdk();
 
-  const [followerBackend, leaderBackend] = makeMockTransportPair("DesktopMain", "DesktopRenderer");
+  const [followerBackend, leaderBackend] = makeMockTransportPair(
+    { BrowserBackground: { id: "Own" } },
+    "DesktopRenderer",
+  );
 
   const leaderIpc = IpcClient.newWithSdkInMemorySessions(leaderBackend);
   const followerIpc = IpcClient.newWithSdkInMemorySessions(followerBackend);
@@ -85,6 +88,11 @@ async function setupPair(options: {
 
   const leader = new SharedUnlockPeer(leaderIpc, leaderDriver.driver);
   const follower = new SharedUnlockPeer(followerIpc, followerDriver.driver);
+
+  // A peer sends to nothing until told which clients it may share with: the desktop leader serves
+  // the browser below it, the browser follower syncs up to the desktop.
+  leader.set_destinations(["Browser"]);
+  follower.set_destinations(["Desktop"]);
 
   const leaderAbort = new AbortController();
   const followerAbort = new AbortController();

--- a/crates/bitwarden-wasm-internal/integration-tests/tests/unlock/shared-unlock.test.ts
+++ b/crates/bitwarden-wasm-internal/integration-tests/tests/unlock/shared-unlock.test.ts
@@ -89,10 +89,10 @@ async function setupPair(options: {
   const leader = new SharedUnlockPeer(leaderIpc, leaderDriver.driver);
   const follower = new SharedUnlockPeer(followerIpc, followerDriver.driver);
 
-  // A peer sends to nothing until told which clients it may share with: the desktop leader serves
-  // the browser below it, the browser follower syncs up to the desktop.
-  leader.set_destinations(["Browser"]);
-  follower.set_destinations(["Desktop"]);
+  // A peer sends nothing for a user until told which clients that user may be shared with: the
+  // desktop leader serves the browser below it, the browser follower syncs up to the desktop.
+  leader.set_destinations(USER_A, ["Browser"]);
+  follower.set_destinations(USER_A, ["Desktop"]);
 
   const leaderAbort = new AbortController();
   const followerAbort = new AbortController();


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-41447

## 📔 Objective

Let a shared unlock peer declare which client kinds (browser, desktop, web) it shares unlock state with. This is necessary to implement the setting for enabling / disabling shared unlock.

Filtering applies in both directions: a client not in the set is never synced to, and its incoming syncs are dropped on arrival. The set defaults to empty, so a peer neither sends nor accepts anything until the client calls `setDestinations`.

## 🚨 Breaking Changes

`SharedUnlockPeer` now syncs to nothing by default. Clients must call `setDestinations` after construction to restore syncing.
