### PR TITLE
deps: bump h2 to 0.4.16 (RUSTSEC-2026-0258)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3335,9 +3335,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.15"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
+checksum = "a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27"
 dependencies = [
  "atomic-waker",
  "bytes",


### PR DESCRIPTION
## 🎟️ Tracking

- Advisory: [RUSTSEC-2026-0258](https://rustsec.org/advisories/RUSTSEC-2026-0258) — h2 unbounded empty DATA frames
- Companion clients/desktop_native PR: bitwarden/clients#22514
- Unblock ticket (Aikido cooldown): TSD-3193

## 📔 Objective

Bumps `h2` from 0.4.14 to 0.4.16 in the SDK lockfile to clear RUSTSEC-2026-0258. `h2` enters the SDK transitively via `reqwest 0.13.4 → bitwarden-api-api`, reaching the uniffi (mobile), wasm (web), and `bw` (CLI) crates.

Pinned to **0.4.16 exactly** rather than the latest 0.4.x:
- 0.4.17–0.4.19 are still inside Aikido's 7-day dependency cooldown.
- 0.4.16 introduced a small-frames bug ([hyperium/h2#944](https://github.com/hyperium/h2/issues/944), fixed in 0.4.17) that affects real-time streaming clients with small request sizes, not our SDK-to-server usage. Moving to 0.4.17+ is a normal follow-up dep bump once out of cooldown.

Lockfile-only change (h2 version + checksum); no other packages modified.

## 🚨 Breaking Changes

None. Semver-compatible patch bump, validated with `cargo tree --locked --offline`.