### PR TITLE
[PM-39460] Add `UserCryptoManagementClient.within_v2_migration_grace_period` method

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,7 +77,7 @@ bitwarden-uuid = { path = "crates/bitwarden-uuid", version = "=3.0.0" }
 bitwarden-uuid-macro = { path = "crates/bitwarden-uuid-macro", version = "=3.0.0" }
 bitwarden-vault = { path = "crates/bitwarden-vault", version = "=3.0.0" }
 cbc = { version = "0.2.0", features = ["alloc", "zeroize"] }
-chrono = { version = ">=0.4.26, <0.5", features = [
+chrono = { version = ">=0.4.34, <0.5", features = [
     "clock",
     "serde",
     "std",

--- a/crates/bitwarden-core/src/key_management/mod.rs
+++ b/crates/bitwarden-core/src/key_management/mod.rs
@@ -42,6 +42,10 @@ use tsify::Tsify;
 #[cfg(feature = "internal")]
 pub use user_decryption::UserDecryptionData;
 #[cfg(feature = "internal")]
+mod v2_encrypted_migrations_grace_period_start;
+#[cfg(feature = "internal")]
+pub use v2_encrypted_migrations_grace_period_start::V2EncryptedMigrationsGracePeriodStart;
+#[cfg(feature = "internal")]
 mod v2_upgrade_token;
 #[cfg(feature = "internal")]
 pub use v2_upgrade_token::{V2UpgradeToken, V2UpgradeTokenError};

--- a/crates/bitwarden-core/src/key_management/state_bridge.rs
+++ b/crates/bitwarden-core/src/key_management/state_bridge.rs
@@ -16,8 +16,8 @@ use wasm_bindgen::prelude::*;
 use crate::{
     Client,
     key_management::{
-        MasterPasswordUnlockData, V2UpgradeToken, WebAuthnPrfUnlockData,
-        account_cryptographic_state::WrappedAccountCryptographicState,
+        MasterPasswordUnlockData, V2EncryptedMigrationsGracePeriodStart, V2UpgradeToken,
+        WebAuthnPrfUnlockData, account_cryptographic_state::WrappedAccountCryptographicState,
     },
 };
 
@@ -153,4 +153,5 @@ bitwarden_state_bridge_macro::state_bridge! {
     masterpassword_unlock_data: MasterPasswordUnlockData as ts "MasterPasswordUnlockData",
     webauthn_prf_unlock_data: WebAuthnPrfUnlockData as ts "WebAuthnPrfUnlockData",
     kdf_config: Kdf as ts "Kdf",
+    v2_encrypted_migrations_grace_period_start: V2EncryptedMigrationsGracePeriodStart as ts "DateTime<Utc>",
 }

--- a/crates/bitwarden-core/src/key_management/v2_encrypted_migrations_grace_period_start.rs
+++ b/crates/bitwarden-core/src/key_management/v2_encrypted_migrations_grace_period_start.rs
@@ -1,0 +1,42 @@
+use chrono::{DateTime, Utc};
+
+/// Records when the user first became eligible for v2 encrypted migrations.
+#[cfg_attr(
+    feature = "wasm",
+    derive(tsify::Tsify),
+    tsify(into_wasm_abi, from_wasm_abi)
+)]
+#[derive(serde::Serialize, serde::Deserialize, Clone, Debug, PartialEq, Eq)]
+#[serde(transparent)]
+pub struct V2EncryptedMigrationsGracePeriodStart(
+    #[cfg_attr(feature = "wasm", tsify(type = "DateTime<Utc>"))] pub DateTime<Utc>,
+);
+
+#[cfg(feature = "wasm")]
+impl TryFrom<wasm_bindgen::JsValue> for V2EncryptedMigrationsGracePeriodStart {
+    type Error = serde_wasm_bindgen::Error;
+
+    fn try_from(value: wasm_bindgen::JsValue) -> Result<Self, Self::Error> {
+        serde_wasm_bindgen::from_value(value)
+    }
+}
+
+#[cfg(feature = "uniffi")]
+uniffi::custom_newtype!(V2EncryptedMigrationsGracePeriodStart, DateTime<Utc>);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn serializes_as_an_rfc3339_string() {
+        let start = "2026-08-27T12:34:56.789Z".parse().unwrap();
+        let value = V2EncryptedMigrationsGracePeriodStart(start);
+
+        let serialized = serde_json::to_value(&value).unwrap();
+        assert_eq!(serialized, serde_json::json!("2026-08-27T12:34:56.789Z"));
+
+        let deserialized = serde_json::from_value(serialized).unwrap();
+        assert_eq!(value, deserialized);
+    }
+}

--- a/crates/bitwarden-uniffi/swift/integration-tests/Tests/IntegrationTests/Utils.swift
+++ b/crates/bitwarden-uniffi/swift/integration-tests/Tests/IntegrationTests/Utils.swift
@@ -65,6 +65,7 @@ actor InMemoryStateBridge: StateBridgeForeignImpl {
     private var masterpasswordUnlockData: MasterPasswordUnlockData?
     private var webauthnPrfUnlockData: WebAuthnPrfUnlockData?
     private var kdfConfig: Kdf?
+    private var v2EncryptedMigrationsGracePeriodStart: V2EncryptedMigrationsGracePeriodStart?
 
     func setUserKey(value: SymmetricCryptoKey) { userKey = value }
     func getUserKey() -> SymmetricCryptoKey? { userKey }
@@ -105,6 +106,10 @@ actor InMemoryStateBridge: StateBridgeForeignImpl {
     func setKdfConfig(value: Kdf) { kdfConfig = value }
     func getKdfConfig() -> Kdf? { kdfConfig }
     func clearKdfConfig() { kdfConfig = nil }
+
+    func setV2EncryptedMigrationsGracePeriodStart(value: V2EncryptedMigrationsGracePeriodStart) { v2EncryptedMigrationsGracePeriodStart = value }
+    func getV2EncryptedMigrationsGracePeriodStart() -> V2EncryptedMigrationsGracePeriodStart? { v2EncryptedMigrationsGracePeriodStart }
+    func clearV2EncryptedMigrationsGracePeriodStart() { v2EncryptedMigrationsGracePeriodStart = nil }
 }
 
 final class MockTokenProvider: ClientManagedTokens {

--- a/crates/bitwarden-user-crypto-management/src/lib.rs
+++ b/crates/bitwarden-user-crypto-management/src/lib.rs
@@ -11,9 +11,11 @@ mod key_rotation;
 mod pin_settings;
 mod public_key_encryption_key_pair_regeneration;
 mod user_crypto_management_client;
+mod v2_migration_grace_period;
 pub use change_kdf::ChangeKdfError;
 pub use key_id_backfill::KeyIdBackfillError;
 pub use pin_settings::PinSettingsClient;
 pub use user_crypto_management_client::{
     UserCryptoManagementClient, UserCryptoManagementClientExt,
 };
+pub use v2_migration_grace_period::V2MigrationGracePeriodError;

--- a/crates/bitwarden-user-crypto-management/src/lib.rs
+++ b/crates/bitwarden-user-crypto-management/src/lib.rs
@@ -11,11 +11,11 @@ mod key_rotation;
 mod pin_settings;
 mod public_key_encryption_key_pair_regeneration;
 mod user_crypto_management_client;
-mod v2_migration_grace_period;
+mod v2_migration_permission;
 pub use change_kdf::ChangeKdfError;
 pub use key_id_backfill::KeyIdBackfillError;
 pub use pin_settings::PinSettingsClient;
 pub use user_crypto_management_client::{
     UserCryptoManagementClient, UserCryptoManagementClientExt,
 };
-pub use v2_migration_grace_period::V2MigrationGracePeriodError;
+pub use v2_migration_permission::MigrationPermission;

--- a/crates/bitwarden-user-crypto-management/src/v2_migration_grace_period.rs
+++ b/crates/bitwarden-user-crypto-management/src/v2_migration_grace_period.rs
@@ -1,0 +1,216 @@
+//! Grace period gating for the v2 encrypted migrations master-password prompt.
+//!
+//! A user gets two weeks before the client asks for the master password. The window is anchored by
+//! the state bridge value `v2_encrypted_migrations_grace_period_start`, which this module is the
+//! only consumer of. The first query starts the clock.
+
+use bitwarden_core::key_management::V2EncryptedMigrationsGracePeriodStart;
+use bitwarden_error::bitwarden_error;
+use chrono::{TimeDelta, Utc};
+use thiserror::Error;
+#[cfg(feature = "wasm")]
+use wasm_bindgen::prelude::*;
+
+use crate::UserCryptoManagementClient;
+
+/// How long the prompt stays suppressed after the window opens.
+const GRACE_PERIOD: TimeDelta = TimeDelta::weeks(2);
+
+/// Errors returned by the v2 migration grace period check.
+#[derive(Debug, Error)]
+#[bitwarden_error(flat)]
+pub enum V2MigrationGracePeriodError {
+    /// The grace period starting timestamp lives in client-managed state, which needs a bridge.
+    #[error("No state bridge registered, the v2 migration grace period is not supported")]
+    StateBridgeNotRegistered,
+}
+
+#[cfg_attr(feature = "wasm", wasm_bindgen)]
+#[cfg_attr(feature = "uniffi", uniffi::export(async_runtime = "tokio"))]
+impl UserCryptoManagementClient {
+    /// Returns whether the user is still inside the two-week v2 migration grace period.
+    ///
+    /// `true` means the master-password prompt must **not** be shown.
+    ///
+    /// The first call has a side effect: when no timestamp is stored, it writes
+    /// the current timestamp and returns `true`. The window is therefore two
+    /// weeks from the first call, not from login. A client that never calls
+    /// this method never opens the window.
+    ///
+    /// The SDK never clears the timestamp. Clearing is the client's decision
+    /// and resets the window. The timestamp is persisted so a user who logs out
+    /// often cannot avoid the prompt indefinitely.
+    ///
+    /// Returns an error when no state bridge is registered.
+    pub async fn within_v2_migration_grace_period(
+        &self,
+    ) -> Result<bool, V2MigrationGracePeriodError> {
+        let state_bridge = self.client.km_state_bridge();
+        if !state_bridge.is_bridge_registered() {
+            return Err(V2MigrationGracePeriodError::StateBridgeNotRegistered);
+        }
+
+        match state_bridge
+            .get_v2_encrypted_migrations_grace_period_start()
+            .await
+        {
+            // The grace period's starting timestamp isn't set yet. The user is
+            // inside the window by definition.
+            None => {
+                state_bridge
+                    .set_v2_encrypted_migrations_grace_period_start(
+                        &V2EncryptedMigrationsGracePeriodStart(Utc::now()),
+                    )
+                    .await;
+                Ok(true)
+            }
+            Some(start) => Ok(Utc::now().signed_duration_since(start.0) < GRACE_PERIOD),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use bitwarden_core::{Client, key_management::state_bridge::test_support::InMemoryStateBridge};
+    use chrono::DateTime;
+
+    use super::*;
+    use crate::UserCryptoManagementClientExt;
+
+    /// Builds a client with an empty in-memory state bridge registered.
+    fn client_with_bridge() -> Client {
+        let client = Client::new(None);
+        client
+            .km_state_bridge()
+            .register_bridge(Box::new(InMemoryStateBridge::default()));
+        client
+    }
+
+    /// Builds a client whose grace period anchor sits `offset` away from now. A negative offset is
+    /// an anchor in the past.
+    async fn client_with_anchor(offset: TimeDelta) -> Client {
+        let client = client_with_bridge();
+        client
+            .km_state_bridge()
+            .set_v2_encrypted_migrations_grace_period_start(&V2EncryptedMigrationsGracePeriodStart(
+                Utc::now() + offset,
+            ))
+            .await;
+        client
+    }
+
+    async fn stored_anchor(client: &Client) -> Option<DateTime<Utc>> {
+        client
+            .km_state_bridge()
+            .get_v2_encrypted_migrations_grace_period_start()
+            .await
+            .map(|start| start.0)
+    }
+
+    #[tokio::test]
+    async fn test_unset_anchor_starts_the_window_and_reports_within() {
+        let client = client_with_bridge();
+
+        assert!(
+            client
+                .user_crypto_management()
+                .within_v2_migration_grace_period()
+                .await
+                .unwrap()
+        );
+
+        let anchor = stored_anchor(&client).await.expect("the window was armed");
+        assert!(Utc::now().signed_duration_since(anchor) < TimeDelta::seconds(5));
+    }
+
+    #[tokio::test]
+    async fn test_second_call_does_not_move_the_anchor() {
+        let client = client_with_bridge();
+        let user_crypto_management = client.user_crypto_management();
+
+        assert!(
+            user_crypto_management
+                .within_v2_migration_grace_period()
+                .await
+                .unwrap()
+        );
+        let armed = stored_anchor(&client).await.expect("the window was armed");
+
+        assert!(
+            user_crypto_management
+                .within_v2_migration_grace_period()
+                .await
+                .unwrap()
+        );
+        assert_eq!(stored_anchor(&client).await, Some(armed));
+    }
+
+    #[tokio::test]
+    async fn test_one_week_old_anchor_is_within() {
+        let client = client_with_anchor(-TimeDelta::weeks(1)).await;
+
+        assert!(
+            client
+                .user_crypto_management()
+                .within_v2_migration_grace_period()
+                .await
+                .unwrap()
+        );
+    }
+
+    #[tokio::test]
+    async fn test_three_week_old_anchor_is_outside() {
+        let client = client_with_anchor(-TimeDelta::weeks(3)).await;
+
+        assert!(
+            !client
+                .user_crypto_management()
+                .within_v2_migration_grace_period()
+                .await
+                .unwrap()
+        );
+    }
+
+    #[tokio::test]
+    async fn test_exactly_two_weeks_is_outside() {
+        // The anchor is written a moment before it is read, so the elapsed time is just past the
+        // grace period and the strict comparison reports the user as outside it.
+        let client = client_with_anchor(-GRACE_PERIOD).await;
+
+        assert!(
+            !client
+                .user_crypto_management()
+                .within_v2_migration_grace_period()
+                .await
+                .unwrap()
+        );
+    }
+
+    #[tokio::test]
+    async fn test_future_anchor_is_within_and_untouched() {
+        let client = client_with_anchor(TimeDelta::weeks(1)).await;
+        let anchor = stored_anchor(&client).await;
+
+        assert!(
+            client
+                .user_crypto_management()
+                .within_v2_migration_grace_period()
+                .await
+                .unwrap()
+        );
+        assert_eq!(stored_anchor(&client).await, anchor);
+    }
+
+    #[tokio::test]
+    async fn test_without_a_state_bridge_errors() {
+        let client = Client::new(None);
+
+        assert!(matches!(
+            client
+                .user_crypto_management()
+                .within_v2_migration_grace_period()
+                .await,
+            Err(V2MigrationGracePeriodError::StateBridgeNotRegistered)
+        ));
+    }
+}

--- a/crates/bitwarden-user-crypto-management/src/v2_migration_permission.rs
+++ b/crates/bitwarden-user-crypto-management/src/v2_migration_permission.rs
@@ -5,9 +5,10 @@
 //! only consumer of. The first query starts the clock.
 
 use bitwarden_core::key_management::V2EncryptedMigrationsGracePeriodStart;
-use bitwarden_error::bitwarden_error;
 use chrono::{TimeDelta, Utc};
-use thiserror::Error;
+use serde::{Deserialize, Serialize};
+#[cfg(feature = "wasm")]
+use tsify::Tsify;
 #[cfg(feature = "wasm")]
 use wasm_bindgen::prelude::*;
 
@@ -16,39 +17,38 @@ use crate::UserCryptoManagementClient;
 /// How long the prompt stays suppressed after the window opens.
 const GRACE_PERIOD: TimeDelta = TimeDelta::weeks(2);
 
-/// Errors returned by the v2 migration grace period check.
-#[derive(Debug, Error)]
-#[bitwarden_error(flat)]
-pub enum V2MigrationGracePeriodError {
-    /// The grace period starting timestamp lives in client-managed state, which needs a bridge.
-    #[error("No state bridge registered, the v2 migration grace period is not supported")]
-    StateBridgeNotRegistered,
+/// Whether the client may prompt the user to migrate to v2 encryption.
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "wasm", derive(Tsify), tsify(into_wasm_abi, from_wasm_abi))]
+#[cfg_attr(feature = "uniffi", derive(uniffi::Enum))]
+pub enum MigrationPermission {
+    /// The user is inside the grace period. Do not show the migration prompt.
+    Wait,
+    /// The grace period has elapsed. Show the migration prompt.
+    Migrate,
 }
 
 #[cfg_attr(feature = "wasm", wasm_bindgen)]
 #[cfg_attr(feature = "uniffi", uniffi::export(async_runtime = "tokio"))]
 impl UserCryptoManagementClient {
-    /// Returns whether the user is still inside the two-week v2 migration grace period.
+    /// Returns whether the client may prompt the user to migrate to v2 encryption.
     ///
-    /// `true` means the master-password prompt must **not** be shown.
+    /// [`MigrationPermission::Wait`] means the user is still inside the two-week grace period and
+    /// the prompt must not be shown. [`MigrationPermission::Migrate`] means the grace period has
+    /// elapsed.
     ///
     /// The first call has a side effect: when no timestamp is stored, it writes
-    /// the current timestamp and returns `true`. The window is therefore two
-    /// weeks from the first call, not from login. A client that never calls
-    /// this method never opens the window.
+    /// the current timestamp and returns [`MigrationPermission::Wait`]. The
+    /// window is therefore two weeks from the first call, not from login. A
+    /// client that never calls this method never opens the window.
     ///
     /// The SDK never clears the timestamp. Clearing is the client's decision
     /// and resets the window. The timestamp is persisted so a user who logs out
     /// often cannot avoid the prompt indefinitely.
     ///
-    /// Returns an error when no state bridge is registered.
-    pub async fn within_v2_migration_grace_period(
-        &self,
-    ) -> Result<bool, V2MigrationGracePeriodError> {
+    /// Panics when no state bridge is registered.
+    pub async fn request_permission_to_migrate_to_v2(&self) -> MigrationPermission {
         let state_bridge = self.client.km_state_bridge();
-        if !state_bridge.is_bridge_registered() {
-            return Err(V2MigrationGracePeriodError::StateBridgeNotRegistered);
-        }
 
         match state_bridge
             .get_v2_encrypted_migrations_grace_period_start()
@@ -62,9 +62,12 @@ impl UserCryptoManagementClient {
                         &V2EncryptedMigrationsGracePeriodStart(Utc::now()),
                     )
                     .await;
-                Ok(true)
+                MigrationPermission::Wait
             }
-            Some(start) => Ok(Utc::now().signed_duration_since(start.0) < GRACE_PERIOD),
+            Some(start) if Utc::now().signed_duration_since(start.0) < GRACE_PERIOD => {
+                MigrationPermission::Wait
+            }
+            Some(_) => MigrationPermission::Migrate,
         }
     }
 }
@@ -108,15 +111,15 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_unset_anchor_starts_the_window_and_reports_within() {
+    async fn test_unset_anchor_starts_the_window_and_reports_wait() {
         let client = client_with_bridge();
 
-        assert!(
+        assert_eq!(
             client
                 .user_crypto_management()
-                .within_v2_migration_grace_period()
-                .await
-                .unwrap()
+                .request_permission_to_migrate_to_v2()
+                .await,
+            MigrationPermission::Wait
         );
 
         let anchor = stored_anchor(&client).await.expect("the window was armed");
@@ -128,89 +131,87 @@ mod tests {
         let client = client_with_bridge();
         let user_crypto_management = client.user_crypto_management();
 
-        assert!(
+        assert_eq!(
             user_crypto_management
-                .within_v2_migration_grace_period()
-                .await
-                .unwrap()
+                .request_permission_to_migrate_to_v2()
+                .await,
+            MigrationPermission::Wait
         );
         let armed = stored_anchor(&client).await.expect("the window was armed");
 
-        assert!(
+        assert_eq!(
             user_crypto_management
-                .within_v2_migration_grace_period()
-                .await
-                .unwrap()
+                .request_permission_to_migrate_to_v2()
+                .await,
+            MigrationPermission::Wait
         );
         assert_eq!(stored_anchor(&client).await, Some(armed));
     }
 
     #[tokio::test]
-    async fn test_one_week_old_anchor_is_within() {
+    async fn test_one_week_old_anchor_waits() {
         let client = client_with_anchor(-TimeDelta::weeks(1)).await;
 
-        assert!(
+        assert_eq!(
             client
                 .user_crypto_management()
-                .within_v2_migration_grace_period()
-                .await
-                .unwrap()
+                .request_permission_to_migrate_to_v2()
+                .await,
+            MigrationPermission::Wait
         );
     }
 
     #[tokio::test]
-    async fn test_three_week_old_anchor_is_outside() {
+    async fn test_three_week_old_anchor_migrates() {
         let client = client_with_anchor(-TimeDelta::weeks(3)).await;
 
-        assert!(
-            !client
+        assert_eq!(
+            client
                 .user_crypto_management()
-                .within_v2_migration_grace_period()
-                .await
-                .unwrap()
+                .request_permission_to_migrate_to_v2()
+                .await,
+            MigrationPermission::Migrate
         );
     }
 
     #[tokio::test]
-    async fn test_exactly_two_weeks_is_outside() {
+    async fn test_exactly_two_weeks_migrates() {
         // The anchor is written a moment before it is read, so the elapsed time is just past the
         // grace period and the strict comparison reports the user as outside it.
         let client = client_with_anchor(-GRACE_PERIOD).await;
 
-        assert!(
-            !client
+        assert_eq!(
+            client
                 .user_crypto_management()
-                .within_v2_migration_grace_period()
-                .await
-                .unwrap()
+                .request_permission_to_migrate_to_v2()
+                .await,
+            MigrationPermission::Migrate
         );
     }
 
     #[tokio::test]
-    async fn test_future_anchor_is_within_and_untouched() {
+    async fn test_future_anchor_waits_and_is_untouched() {
         let client = client_with_anchor(TimeDelta::weeks(1)).await;
         let anchor = stored_anchor(&client).await;
 
-        assert!(
+        assert_eq!(
             client
                 .user_crypto_management()
-                .within_v2_migration_grace_period()
-                .await
-                .unwrap()
+                .request_permission_to_migrate_to_v2()
+                .await,
+            MigrationPermission::Wait
         );
         assert_eq!(stored_anchor(&client).await, anchor);
     }
 
     #[tokio::test]
-    async fn test_without_a_state_bridge_errors() {
+    #[should_panic(expected = "StateBridge not registered")]
+    async fn test_without_a_state_bridge_panics() {
         let client = Client::new(None);
 
-        assert!(matches!(
-            client
-                .user_crypto_management()
-                .within_v2_migration_grace_period()
-                .await,
-            Err(V2MigrationGracePeriodError::StateBridgeNotRegistered)
-        ));
+        client
+            .user_crypto_management()
+            .request_permission_to_migrate_to_v2()
+            .await;
     }
 }

--- a/crates/bitwarden-wasm-internal/integration-tests/tests/utils.ts
+++ b/crates/bitwarden-wasm-internal/integration-tests/tests/utils.ts
@@ -9,6 +9,8 @@ import {
   WebAuthnPrfUnlockData,
   Kdf,
   KeyId,
+  DateTime,
+  Utc,
   PasswordManagerClient,
   init_sdk,
   TokenProvider,
@@ -56,6 +58,7 @@ export function makeStateBridge(): WasmStateBridge {
   let accountCryptographicState: WrappedAccountCryptographicState | null;
   let masterPasswordUnlockData: MasterPasswordUnlockData | null;
   let webauthnPrfUnlockData: WebAuthnPrfUnlockData | null;
+  let v2EncryptedMigrationsGracePeriodStart: DateTime<Utc> | null;
   // Initialized, unlike the slots above, so an untouched bridge reports `null` rather than
   // `undefined` — tests assert on the absence of a KDF config after a failed change.
   let kdfConfig: Kdf | null = null;
@@ -139,6 +142,15 @@ export function makeStateBridge(): WasmStateBridge {
     get_kdf_config: async () => kdfConfig,
     clear_kdf_config: async () => {
       kdfConfig = null;
+    },
+
+    set_v2_encrypted_migrations_grace_period_start: async (v: DateTime<Utc>) => {
+      v2EncryptedMigrationsGracePeriodStart = v;
+    },
+    get_v2_encrypted_migrations_grace_period_start: async () =>
+      v2EncryptedMigrationsGracePeriodStart,
+    clear_v2_encrypted_migrations_grace_period_start: async () => {
+      v2EncryptedMigrationsGracePeriodStart = null;
     },
   };
 }


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-39460

## 📔 Objective

When v1 encryption users become eligible to upgrade to v2 encryption, we don't want to immediately prompt users to enter their master password until necessary. Users regularly enter their master password for other reasons (login, unlock) and the encrypted migration v1 -> v2 can take place then. In order to allow time for this to happen, this PR introduces a new client-callable SDK method that tracks if a user is within the grace period before we prompt them. This is done by storing the timestamp the first time the grace period is checked, and only return that a user is not within the grace period once the timestamp is 2 weeks or older. This is done via the new `v2_encrypted_migrations_grace_period_start` state in the KM state bridge. Once this PR is merged, a corresponding clients PR will introduce `v2_encrypted_migrations_grace_period_start` to clients and use the new `UserCryptoManagementClient.within_v2_migration_grace_period` method.

`V2EncryptedMigrationsGracePeriodStart` is a newly introduced wrapper type for `DateTime<Utc>`. This is necessary because `DateTime<Utc>` doesn't implement the `into_wasm_abi, from_wasm_abi` attributes, which are required for the state bridge macro.

`Cargo.toml` is updated with a new version minimum for the `chrono` dependency. This is because the `chrono::TimeDelta` type used in this PR was introduced in `0.4.32` and the const version we use introduced after.

## 🚨 Breaking Changes

Yes. This PR introduces new KM state bridge state and client's state bridge implementations will need to be updated to support this. For the `clients` repository, the PR to fix this is [clients#22653](https://github.com/bitwarden/clients/pull/22653). Similar PRs will be necessary for `android` and `ios`. The PRs should add support for new state bridge value `v2_encrypted_migrations_grace_period_start`. The new value should be persisted to disk and *not* cleared on logout or lock.
