### PR TITLE
Fix ThreadBoundRunner Clone Comment

### DIFF
--- a/crates/bitwarden-threading/src/thread_bound_runner.rs
+++ b/crates/bitwarden-threading/src/thread_bound_runner.rs
@@ -89,7 +89,7 @@ pub struct ThreadBoundRunner<ThreadState> {
 /// This creates another handle to the same underlying runner object.
 /// The underlying state is not duplicated; all clones refer to the same
 /// instance.
-// This is not implemented using derive to remove the implicit bound on `ThreadState: Clone`
+/// This is not implemented using derive to remove the implicit bound on `ThreadState: Clone`
 impl<ThreadState> Clone for ThreadBoundRunner<ThreadState> {
     fn clone(&self) -> Self {
         ThreadBoundRunner {


### PR DESCRIPTION
## 📔 Objective

I assume that this should have been a doc comment `///` rather than a normal single line comment `//`. I can close this if my assumption is incorrect.
