### PR TITLE
PM-39040: add a rotation module to the bitwarden-pam crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1108,6 +1108,7 @@ dependencies = [
  "bitwarden-commercial-marker",
  "bitwarden-core",
  "bitwarden-crypto",
+ "bitwarden-encoding",
  "bitwarden-error",
  "bitwarden-uuid",
  "bitwarden-vault",
@@ -1121,6 +1122,7 @@ dependencies = [
  "uuid",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "zeroize",
 ]
 
 [[package]]

--- a/bitwarden_license/bitwarden-pam/Cargo.toml
+++ b/bitwarden_license/bitwarden-pam/Cargo.toml
@@ -18,6 +18,7 @@ keywords.workspace = true
 wasm = [
     "bitwarden-collections/wasm",
     "bitwarden-core/wasm",
+    "bitwarden-crypto/wasm",
     "bitwarden-error/wasm",
     "bitwarden-vault/wasm",
     "dep:tsify",
@@ -31,6 +32,7 @@ bitwarden-collections = { workspace = true }
 bitwarden-commercial-marker = { workspace = true }
 bitwarden-core = { workspace = true, features = ["internal"] }
 bitwarden-crypto = { workspace = true }
+bitwarden-encoding = { workspace = true }
 bitwarden-error = { workspace = true }
 bitwarden-uuid = { workspace = true }
 bitwarden-vault = { workspace = true }
@@ -43,6 +45,7 @@ tsify = { workspace = true, optional = true }
 uuid = { workspace = true }
 wasm-bindgen = { workspace = true, optional = true }
 wasm-bindgen-futures = { workspace = true, optional = true }
+zeroize = { workspace = true }
 
 [dev-dependencies]
 bitwarden-api-api = { workspace = true, features = ["mockall"] }

--- a/bitwarden_license/bitwarden-pam/src/lib.rs
+++ b/bitwarden_license/bitwarden-pam/src/lib.rs
@@ -41,14 +41,13 @@ pub use leases::{
 };
 pub use pam_client::{PamClient, PamClientExt};
 pub use rotation::{
-    AccessConnectorDetailView, AccessConnectorRegistrationView, AccessConnectorStatus,
-    AccessConnectorView, AccessConnectorsClient, ConnectorToken, ConnectorTokenInvalidError,
-    PasswordPolicy, QuartzSchedulePreset, RotationAttemptStatus, RotationAttemptView,
-    RotationClient, RotationConfigActions, RotationConfigCreateRequest, RotationConfigDetailView,
-    RotationConfigUpdateRequest, RotationConfigView, RotationConfigsClient, RotationError,
-    RotationJobStatus, RotationJobView, RotationScheduleClient, RotationSource, RotationSyncState,
-    RotationValidationError, SessionTerminationOutcome, TargetSystemCreateRequest,
+    AccessConnector, AccessConnectorDetail, AccessConnectorRegistrationResponse,
+    AccessConnectorStatus, AccessConnectorsClient, ConnectorToken, ConnectorTokenInvalidError,
+    PasswordPolicy, QuartzSchedulePreset, RotationAttempt, RotationAttemptStatus, RotationClient,
+    RotationConfig, RotationConfigActions, RotationConfigCreateRequest, RotationConfigDetail,
+    RotationConfigUpdateRequest, RotationConfigsClient, RotationError, RotationJob,
+    RotationJobStatus, RotationScheduleClient, RotationSource, RotationSyncState,
+    RotationValidationError, SessionTerminationOutcome, TargetSystem, TargetSystemCreateRequest,
     TargetSystemKind, TargetSystemMethod, TargetSystemStatus, TargetSystemUpdateRequest,
-    TargetSystemView, TargetSystemsClient, is_likely_quartz_cron, preset_for_cron,
-    rotation_config_actions,
+    TargetSystemsClient, is_likely_quartz_cron, preset_for_cron, rotation_config_actions,
 };

--- a/bitwarden_license/bitwarden-pam/src/lib.rs
+++ b/bitwarden_license/bitwarden-pam/src/lib.rs
@@ -10,10 +10,16 @@ mod approvals;
 mod error;
 mod leases;
 mod pam_client;
+mod rotation;
 
 uuid_newtype!(pub AccessLeaseId);
 uuid_newtype!(pub AccessRequestId);
 uuid_newtype!(pub AccessRuleId);
+uuid_newtype!(pub AccessConnectorId);
+uuid_newtype!(pub RotationAttemptId);
+uuid_newtype!(pub RotationConfigId);
+uuid_newtype!(pub RotationJobId);
+uuid_newtype!(pub TargetSystemId);
 
 pub use access_requests::{
     AccessApprovalMode, AccessApprover, AccessBadgeState, AccessDecider, AccessDecisionVerdict,
@@ -34,3 +40,15 @@ pub use leases::{
     AccessLeaseTermination, AccessLeaseView, LeasesClient,
 };
 pub use pam_client::{PamClient, PamClientExt};
+pub use rotation::{
+    AccessConnectorDetailView, AccessConnectorRegistrationView, AccessConnectorStatus,
+    AccessConnectorView, AccessConnectorsClient, ConnectorToken, ConnectorTokenInvalidError,
+    PasswordPolicy, QuartzSchedulePreset, RotationAttemptStatus, RotationAttemptView,
+    RotationClient, RotationConfigActions, RotationConfigCreateRequest, RotationConfigDetailView,
+    RotationConfigUpdateRequest, RotationConfigView, RotationConfigsClient, RotationError,
+    RotationJobStatus, RotationJobView, RotationScheduleClient, RotationSource, RotationSyncState,
+    RotationValidationError, SessionTerminationOutcome, TargetSystemCreateRequest,
+    TargetSystemKind, TargetSystemMethod, TargetSystemStatus, TargetSystemUpdateRequest,
+    TargetSystemView, TargetSystemsClient, is_likely_quartz_cron, preset_for_cron,
+    rotation_config_actions,
+};

--- a/bitwarden_license/bitwarden-pam/src/pam_client.rs
+++ b/bitwarden_license/bitwarden-pam/src/pam_client.rs
@@ -14,9 +14,6 @@ use crate::{
 #[derive(Clone, FromClient)]
 #[cfg_attr(feature = "wasm", wasm_bindgen)]
 pub struct PamClient {
-    /// Needed only by the two PAM operations that touch key material rather than leasing state:
-    /// registering an access connector wraps the organization key for it, and reading the cipher a
-    /// lease unlocks decrypts a vault payload.
     pub(crate) key_store: KeyStore<KeySlotIds>,
     pub(crate) api_configurations: Arc<ApiConfigurations>,
 }

--- a/bitwarden_license/bitwarden-pam/src/pam_client.rs
+++ b/bitwarden_license/bitwarden-pam/src/pam_client.rs
@@ -7,15 +7,16 @@ use wasm_bindgen::prelude::*;
 
 use crate::{
     access_requests::AccessRequestsClient, access_rules::AccessRulesClient,
-    approvals::ApprovalsClient, leases::LeasesClient,
+    approvals::ApprovalsClient, leases::LeasesClient, rotation::RotationClient,
 };
 
 /// Entry point for Privileged Access Management (PAM) operations.
 #[derive(Clone, FromClient)]
 #[cfg_attr(feature = "wasm", wasm_bindgen)]
 pub struct PamClient {
-    /// Only [`LeasesClient`] needs this: reading the cipher a lease unlocks is the one PAM call
-    /// that decrypts a vault payload rather than a leasing one.
+    /// Needed only by the two PAM operations that touch key material rather than leasing state:
+    /// registering an access connector wraps the organization key for it, and reading the cipher a
+    /// lease unlocks decrypts a vault payload.
     pub(crate) key_store: KeyStore<KeySlotIds>,
     pub(crate) api_configurations: Arc<ApiConfigurations>,
 }
@@ -46,6 +47,14 @@ impl PamClient {
     /// Access lease operations (read, extend, and end the caller's leases).
     pub fn leases(&self) -> LeasesClient {
         LeasesClient {
+            key_store: self.key_store.clone(),
+            api_configurations: self.api_configurations.clone(),
+        }
+    }
+
+    /// Credential rotation operations (access connectors, target systems, and managed credentials).
+    pub fn rotation(&self) -> RotationClient {
+        RotationClient {
             key_store: self.key_store.clone(),
             api_configurations: self.api_configurations.clone(),
         }

--- a/bitwarden_license/bitwarden-pam/src/rotation/actions.rs
+++ b/bitwarden_license/bitwarden-pam/src/rotation/actions.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 use tsify::Tsify;
 
 use super::{
-    configs::RotationConfigView,
+    configs::RotationConfig,
     models::{TargetSystemMethod, TargetSystemStatus},
 };
 
@@ -38,7 +38,7 @@ pub struct RotationConfigActions {
 /// predicate that depends on it fails closed, so a config never offers a rotation the server would
 /// then refuse.
 pub fn rotation_config_actions(
-    config: &RotationConfigView,
+    config: &RotationConfig,
     target_status: Option<TargetSystemStatus>,
 ) -> RotationConfigActions {
     RotationConfigActions {
@@ -72,8 +72,8 @@ mod tests {
 
     /// An automatic, enabled, idle config - the one shape that offers a rotation. Each test varies
     /// exactly one field so the failing condition is unambiguous.
-    fn rotatable_config() -> RotationConfigView {
-        RotationConfigView {
+    fn rotatable_config() -> RotationConfig {
+        RotationConfig {
             id: RotationConfigId::new(uuid!("11111111-1111-1111-1111-111111111111")),
             organization_id: bitwarden_core::OrganizationId::new(uuid!(
                 "22222222-2222-2222-2222-222222222222"
@@ -112,7 +112,7 @@ mod tests {
 
     #[test]
     fn a_paused_config_cannot_rotate_and_offers_resume_instead() {
-        let config = RotationConfigView {
+        let config = RotationConfig {
             enabled: false,
             ..rotatable_config()
         };
@@ -126,7 +126,7 @@ mod tests {
 
     #[test]
     fn a_config_with_a_job_in_flight_cannot_rotate_and_locks_mutations() {
-        let config = RotationConfigView {
+        let config = RotationConfig {
             has_active_job: true,
             ..rotatable_config()
         };
@@ -157,7 +157,7 @@ mod tests {
 
     #[test]
     fn a_manual_config_offers_record_manual_rather_than_rotate() {
-        let config = RotationConfigView {
+        let config = RotationConfig {
             target_system_method: TargetSystemMethod::Manual,
             ..rotatable_config()
         };
@@ -172,7 +172,7 @@ mod tests {
     /// the operator would be offered an action the server may reject.
     #[test]
     fn an_unrecognized_method_offers_neither_rotation_action() {
-        let config = RotationConfigView {
+        let config = RotationConfig {
             target_system_method: TargetSystemMethod::Unknown,
             ..rotatable_config()
         };
@@ -195,7 +195,7 @@ mod tests {
     #[test]
     fn pause_and_resume_are_mutually_exclusive() {
         for enabled in [true, false] {
-            let config = RotationConfigView {
+            let config = RotationConfig {
                 enabled,
                 ..rotatable_config()
             };

--- a/bitwarden_license/bitwarden-pam/src/rotation/actions.rs
+++ b/bitwarden_license/bitwarden-pam/src/rotation/actions.rs
@@ -1,0 +1,208 @@
+//! Which actions a rotation config currently offers.
+
+use serde::{Deserialize, Serialize};
+#[cfg(feature = "wasm")]
+use tsify::Tsify;
+
+use super::{
+    configs::RotationConfigView,
+    models::{TargetSystemMethod, TargetSystemStatus},
+};
+
+/// The actions a rotation config offers right now.
+///
+/// Computed together rather than one predicate at a time because a caller rendering a config always
+/// needs all of them, and because they are not independent - `can_pause` and `can_resume` are
+/// exclusive, and `can_rotate_now` and `can_record_manual` are decided by the same method field.
+/// Deriving them in one place keeps a caller from showing a contradictory pair.
+#[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "wasm", derive(Tsify), tsify(into_wasm_abi, from_wasm_abi))]
+#[serde(rename_all = "camelCase")]
+pub struct RotationConfigActions {
+    /// Whether an on-demand rotation may be dispatched.
+    pub can_rotate_now: bool,
+    /// Whether the operator may record an out-of-band rotation.
+    pub can_record_manual: bool,
+    /// Whether the account identity and delete actions are locked.
+    pub mutations_locked: bool,
+    /// Whether the config may be paused.
+    pub can_pause: bool,
+    /// Whether the config may be resumed.
+    pub can_resume: bool,
+}
+
+/// Derives the actions a config offers, given the status of its target system.
+///
+/// `target_status` is `None` when the target system has not been loaded yet, which is the common
+/// case on first paint - the configs list and the target-systems list are separate calls. Every
+/// predicate that depends on it fails closed, so a config never offers a rotation the server would
+/// then refuse.
+pub fn rotation_config_actions(
+    config: &RotationConfigView,
+    target_status: Option<TargetSystemStatus>,
+) -> RotationConfigActions {
+    RotationConfigActions {
+        // All four conditions are the server's own guard on dispatching a job. `Unknown` for either
+        // the method or the status fails closed: this SDK cannot tell whether the server would
+        // accept, so it does not invite the operator to find out.
+        can_rotate_now: config.enabled
+            && config.target_system_method == TargetSystemMethod::Automatic
+            && target_status == Some(TargetSystemStatus::Active)
+            && !config.has_active_job,
+        can_record_manual: config.target_system_method == TargetSystemMethod::Manual,
+        // A running job owns the credential until it resolves. Editing the account it rotates, or
+        // deleting the config underneath it, would leave the target and the vault disagreeing.
+        mutations_locked: config.has_active_job,
+        can_pause: config.enabled,
+        can_resume: !config.enabled,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use chrono::{DateTime, Utc};
+    use uuid::uuid;
+
+    use super::*;
+    use crate::{RotationConfigId, TargetSystemId};
+
+    fn timestamp() -> DateTime<Utc> {
+        "2026-01-01T00:00:00Z".parse().expect("a valid timestamp")
+    }
+
+    /// An automatic, enabled, idle config - the one shape that offers a rotation. Each test varies
+    /// exactly one field so the failing condition is unambiguous.
+    fn rotatable_config() -> RotationConfigView {
+        RotationConfigView {
+            id: RotationConfigId::new(uuid!("11111111-1111-1111-1111-111111111111")),
+            organization_id: bitwarden_core::OrganizationId::new(uuid!(
+                "22222222-2222-2222-2222-222222222222"
+            )),
+            cipher_id: bitwarden_vault::CipherId::new(uuid!(
+                "33333333-3333-3333-3333-333333333333"
+            )),
+            target_system_id: TargetSystemId::new(uuid!("44444444-4444-4444-4444-444444444444")),
+            target_system_name: "Prod SQL".to_string(),
+            target_system_method: TargetSystemMethod::Automatic,
+            account_identity: "svc_rotation".to_string(),
+            terminate_sessions: false,
+            schedule_cron: None,
+            rotate_on_access_end: false,
+            enabled: true,
+            last_rotation_at: None,
+            next_rotation_at: None,
+            has_active_job: false,
+            awaiting_manual_rotation: false,
+            creation_date: timestamp(),
+            revision_date: timestamp(),
+        }
+    }
+
+    #[test]
+    fn an_enabled_idle_automatic_config_on_an_active_target_can_rotate() {
+        let actions =
+            rotation_config_actions(&rotatable_config(), Some(TargetSystemStatus::Active));
+
+        assert!(actions.can_rotate_now);
+        assert!(!actions.can_record_manual);
+        assert!(!actions.mutations_locked);
+        assert!(actions.can_pause);
+        assert!(!actions.can_resume);
+    }
+
+    #[test]
+    fn a_paused_config_cannot_rotate_and_offers_resume_instead() {
+        let config = RotationConfigView {
+            enabled: false,
+            ..rotatable_config()
+        };
+
+        let actions = rotation_config_actions(&config, Some(TargetSystemStatus::Active));
+
+        assert!(!actions.can_rotate_now);
+        assert!(!actions.can_pause);
+        assert!(actions.can_resume);
+    }
+
+    #[test]
+    fn a_config_with_a_job_in_flight_cannot_rotate_and_locks_mutations() {
+        let config = RotationConfigView {
+            has_active_job: true,
+            ..rotatable_config()
+        };
+
+        let actions = rotation_config_actions(&config, Some(TargetSystemStatus::Active));
+
+        assert!(!actions.can_rotate_now);
+        assert!(actions.mutations_locked);
+    }
+
+    #[test]
+    fn a_disabled_target_system_blocks_rotation() {
+        let actions =
+            rotation_config_actions(&rotatable_config(), Some(TargetSystemStatus::Disabled));
+
+        assert!(!actions.can_rotate_now);
+    }
+
+    /// First paint: the configs list has arrived, the target-systems list has not. Offering a
+    /// rotation here would let the operator dispatch a job against a target that turns out to be
+    /// disabled.
+    #[test]
+    fn an_unloaded_target_system_blocks_rotation() {
+        let actions = rotation_config_actions(&rotatable_config(), None);
+
+        assert!(!actions.can_rotate_now);
+    }
+
+    #[test]
+    fn a_manual_config_offers_record_manual_rather_than_rotate() {
+        let config = RotationConfigView {
+            target_system_method: TargetSystemMethod::Manual,
+            ..rotatable_config()
+        };
+
+        let actions = rotation_config_actions(&config, Some(TargetSystemStatus::Active));
+
+        assert!(!actions.can_rotate_now);
+        assert!(actions.can_record_manual);
+    }
+
+    /// A newer server naming a method this SDK cannot model must not fall through to either branch:
+    /// the operator would be offered an action the server may reject.
+    #[test]
+    fn an_unrecognized_method_offers_neither_rotation_action() {
+        let config = RotationConfigView {
+            target_system_method: TargetSystemMethod::Unknown,
+            ..rotatable_config()
+        };
+
+        let actions = rotation_config_actions(&config, Some(TargetSystemStatus::Active));
+
+        assert!(!actions.can_rotate_now);
+        assert!(!actions.can_record_manual);
+    }
+
+    #[test]
+    fn an_unrecognized_target_status_blocks_rotation() {
+        let actions =
+            rotation_config_actions(&rotatable_config(), Some(TargetSystemStatus::Unknown));
+
+        assert!(!actions.can_rotate_now);
+    }
+
+    /// Pause and resume are complements, never both available and never both withheld.
+    #[test]
+    fn pause_and_resume_are_mutually_exclusive() {
+        for enabled in [true, false] {
+            let config = RotationConfigView {
+                enabled,
+                ..rotatable_config()
+            };
+
+            let actions = rotation_config_actions(&config, Some(TargetSystemStatus::Active));
+
+            assert_ne!(actions.can_pause, actions.can_resume, "enabled: {enabled}");
+        }
+    }
+}

--- a/bitwarden_license/bitwarden-pam/src/rotation/configs.rs
+++ b/bitwarden_license/bitwarden-pam/src/rotation/configs.rs
@@ -121,7 +121,6 @@ impl TryFrom<PamRotationConfigResponseModel> for RotationConfig {
 #[serde(rename_all = "camelCase")]
 pub struct RotationConfigDetail {
     /// The config itself.
-    #[serde(flatten)]
     pub config: RotationConfig,
     /// The config's rotation jobs, newest first, each carrying its attempts oldest first.
     pub jobs: Vec<RotationJob>,

--- a/bitwarden_license/bitwarden-pam/src/rotation/configs.rs
+++ b/bitwarden_license/bitwarden-pam/src/rotation/configs.rs
@@ -16,7 +16,7 @@ use wasm_bindgen::prelude::wasm_bindgen;
 use super::{
     actions::{RotationConfigActions, rotation_config_actions},
     error::RotationError,
-    models::{RotationJobView, TargetSystemMethod, TargetSystemStatus},
+    models::{RotationJob, TargetSystemMethod, TargetSystemStatus},
     validate::{validate_config_create, validate_config_update},
 };
 use crate::{RotationConfigId, TargetSystemId};
@@ -26,7 +26,7 @@ use crate::{RotationConfigId, TargetSystemId};
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "wasm", derive(Tsify), tsify(into_wasm_abi, from_wasm_abi))]
 #[serde(rename_all = "camelCase")]
-pub struct RotationConfigView {
+pub struct RotationConfig {
     /// The config's unique identifier.
     pub id: RotationConfigId,
     /// The organization this config belongs to.
@@ -72,7 +72,7 @@ pub struct RotationConfigView {
     pub revision_date: DateTime<Utc>,
 }
 
-impl RotationConfigView {
+impl RotationConfig {
     /// Which actions this config offers, given the status of its target system.
     ///
     /// See [`rotation_config_actions`] for how `target_status` is treated when the target system
@@ -82,7 +82,7 @@ impl RotationConfigView {
     }
 }
 
-impl TryFrom<PamRotationConfigResponseModel> for RotationConfigView {
+impl TryFrom<PamRotationConfigResponseModel> for RotationConfig {
     type Error = RotationError;
 
     fn try_from(response: PamRotationConfigResponseModel) -> Result<Self, Self::Error> {
@@ -119,15 +119,15 @@ impl TryFrom<PamRotationConfigResponseModel> for RotationConfigView {
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "wasm", derive(Tsify), tsify(into_wasm_abi, from_wasm_abi))]
 #[serde(rename_all = "camelCase")]
-pub struct RotationConfigDetailView {
+pub struct RotationConfigDetail {
     /// The config itself.
     #[serde(flatten)]
-    pub config: RotationConfigView,
+    pub config: RotationConfig,
     /// The config's rotation jobs, newest first, each carrying its attempts oldest first.
-    pub jobs: Vec<RotationJobView>,
+    pub jobs: Vec<RotationJob>,
 }
 
-impl TryFrom<PamRotationConfigDetailResponseModel> for RotationConfigDetailView {
+impl TryFrom<PamRotationConfigDetailResponseModel> for RotationConfigDetail {
     type Error = RotationError;
 
     fn try_from(response: PamRotationConfigDetailResponseModel) -> Result<Self, Self::Error> {
@@ -136,12 +136,12 @@ impl TryFrom<PamRotationConfigDetailResponseModel> for RotationConfigDetailView 
             .clone()
             .unwrap_or_default()
             .into_iter()
-            .map(RotationJobView::try_from)
+            .map(RotationJob::try_from)
             .collect::<Result<Vec<_>, _>>()?;
 
         // The server flattens the config's own fields onto the detail payload, so the list model is
         // rebuilt from the same object rather than a nested one.
-        let config = RotationConfigView::try_from(PamRotationConfigResponseModel {
+        let config = RotationConfig::try_from(PamRotationConfigResponseModel {
             object: response.object,
             id: response.id,
             organization_id: response.organization_id,
@@ -242,7 +242,7 @@ impl RotationConfigsClient {
     pub async fn list(
         &self,
         organization_id: OrganizationId,
-    ) -> Result<Vec<RotationConfigView>, RotationError> {
+    ) -> Result<Vec<RotationConfig>, RotationError> {
         let response = self
             .api_configurations
             .api_client
@@ -254,7 +254,7 @@ impl RotationConfigsClient {
             .data
             .unwrap_or_default()
             .into_iter()
-            .map(RotationConfigView::try_from)
+            .map(RotationConfig::try_from)
             .collect()
     }
 
@@ -263,7 +263,7 @@ impl RotationConfigsClient {
         &self,
         organization_id: OrganizationId,
         id: RotationConfigId,
-    ) -> Result<RotationConfigDetailView, RotationError> {
+    ) -> Result<RotationConfigDetail, RotationError> {
         let response = self
             .api_configurations
             .api_client
@@ -271,7 +271,7 @@ impl RotationConfigsClient {
             .get(organization_id.into(), id.into())
             .await?;
 
-        RotationConfigDetailView::try_from(response)
+        RotationConfigDetail::try_from(response)
     }
 
     /// Validates and creates a rotation config.
@@ -279,7 +279,7 @@ impl RotationConfigsClient {
         &self,
         organization_id: OrganizationId,
         request: RotationConfigCreateRequest,
-    ) -> Result<RotationConfigDetailView, RotationError> {
+    ) -> Result<RotationConfigDetail, RotationError> {
         validate_config_create(&request)?;
 
         let response = self
@@ -289,7 +289,7 @@ impl RotationConfigsClient {
             .post(organization_id.into(), request.into())
             .await?;
 
-        RotationConfigDetailView::try_from(response)
+        RotationConfigDetail::try_from(response)
     }
 
     /// Validates and updates a rotation config's account and schedule.
@@ -298,7 +298,7 @@ impl RotationConfigsClient {
         organization_id: OrganizationId,
         id: RotationConfigId,
         request: RotationConfigUpdateRequest,
-    ) -> Result<RotationConfigDetailView, RotationError> {
+    ) -> Result<RotationConfigDetail, RotationError> {
         validate_config_update(&request)?;
 
         let response = self
@@ -308,7 +308,7 @@ impl RotationConfigsClient {
             .put(organization_id.into(), id.into(), request.into())
             .await?;
 
-        RotationConfigDetailView::try_from(response)
+        RotationConfigDetail::try_from(response)
     }
 
     /// Pauses a config, so no new rotation jobs are dispatched.
@@ -391,12 +391,12 @@ impl RotationConfigsClient {
     /// Which actions a config offers, given the status of its target system.
     ///
     /// Exposed on the client so non-Rust callers can reach the same predicates the Rust API has on
-    /// [`RotationConfigView::actions`] - a tsify view crosses the WASM boundary as plain data and
+    /// [`RotationConfig::actions`] - a tsify struct crosses the WASM boundary as plain data and
     /// leaves its methods behind. All five flags are derived in one call because they are not
     /// independent; see [`RotationConfigActions`].
     pub fn actions(
         &self,
-        config: RotationConfigView,
+        config: RotationConfig,
         target_status: Option<TargetSystemStatus>,
     ) -> RotationConfigActions {
         config.actions(target_status)

--- a/bitwarden_license/bitwarden-pam/src/rotation/configs.rs
+++ b/bitwarden_license/bitwarden-pam/src/rotation/configs.rs
@@ -402,3 +402,785 @@ impl RotationConfigsClient {
         config.actions(target_status)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use bitwarden_api_api::{
+        apis::ApiClient,
+        models::{
+            PamRotationConfigResponseModelListResponseModel, PamRotationJobResponseModel,
+            PamRotationJobStatus as ApiRotationJobStatus, PamRotationSource as ApiRotationSource,
+            PamTargetSystemMethod as ApiTargetSystemMethod,
+        },
+    };
+    use uuid::{Uuid, uuid};
+
+    use super::*;
+    use crate::rotation::{
+        models::{RotationJobStatus, RotationSource},
+        validate::RotationValidationError,
+    };
+
+    fn organization_id() -> OrganizationId {
+        OrganizationId::new(uuid!("11111111-1111-1111-1111-111111111111"))
+    }
+
+    fn config_id() -> RotationConfigId {
+        RotationConfigId::new(uuid!("22222222-2222-2222-2222-222222222222"))
+    }
+
+    fn cipher_id() -> CipherId {
+        CipherId::new(uuid!("33333333-3333-3333-3333-333333333333"))
+    }
+
+    fn target_system_id() -> TargetSystemId {
+        TargetSystemId::new(uuid!("44444444-4444-4444-4444-444444444444"))
+    }
+
+    fn job_id() -> Uuid {
+        uuid!("55555555-5555-5555-5555-555555555555")
+    }
+
+    fn client(api_client: ApiClient) -> RotationConfigsClient {
+        RotationConfigsClient {
+            api_configurations: Arc::new(ApiConfigurations::from_api_client(api_client)),
+        }
+    }
+
+    /// A payload with every optional field populated, so a test that clears one is unambiguous
+    /// about which field it is exercising.
+    fn sample_response() -> PamRotationConfigResponseModel {
+        PamRotationConfigResponseModel {
+            id: Some(config_id().into()),
+            organization_id: Some(organization_id().into()),
+            cipher_id: Some(cipher_id().into()),
+            target_system_id: Some(target_system_id().into()),
+            target_system_name: Some("Prod SQL".to_string()),
+            target_system_method: Some(ApiTargetSystemMethod::Automatic),
+            account_identity: Some("svc_rotation".to_string()),
+            terminate_sessions: Some(true),
+            schedule_cron: Some("0 0 0 * * ?".to_string()),
+            rotate_on_access_end: Some(true),
+            next_rotation_at: Some("2026-02-02T00:00:00Z".to_string()),
+            enabled: Some(true),
+            last_rotation_at: Some("2026-02-01T00:00:00Z".to_string()),
+            has_active_job: Some(true),
+            awaiting_manual_rotation: Some(true),
+            creation_date: Some("2026-01-01T00:00:00Z".to_string()),
+            revision_date: Some("2026-01-15T00:00:00Z".to_string()),
+            ..Default::default()
+        }
+    }
+
+    /// The same config as [`sample_response`], as the detail routes return it: the config's own
+    /// fields flattened onto the payload, plus its rotation history.
+    fn sample_detail_response(
+        jobs: Option<Vec<PamRotationJobResponseModel>>,
+    ) -> PamRotationConfigDetailResponseModel {
+        let config = sample_response();
+        PamRotationConfigDetailResponseModel {
+            object: config.object,
+            id: config.id,
+            organization_id: config.organization_id,
+            cipher_id: config.cipher_id,
+            target_system_id: config.target_system_id,
+            target_system_name: config.target_system_name,
+            target_system_method: config.target_system_method,
+            account_identity: config.account_identity,
+            terminate_sessions: config.terminate_sessions,
+            schedule_cron: config.schedule_cron,
+            rotate_on_access_end: config.rotate_on_access_end,
+            next_rotation_at: config.next_rotation_at,
+            enabled: config.enabled,
+            last_rotation_at: config.last_rotation_at,
+            has_active_job: config.has_active_job,
+            awaiting_manual_rotation: config.awaiting_manual_rotation,
+            creation_date: config.creation_date,
+            revision_date: config.revision_date,
+            jobs,
+        }
+    }
+
+    fn sample_job(id: Uuid) -> PamRotationJobResponseModel {
+        PamRotationJobResponseModel {
+            id: Some(id),
+            rotation_config_id: Some(config_id().into()),
+            source: Some(ApiRotationSource::OnDemand),
+            status: Some(ApiRotationJobStatus::Pending),
+            creation_date: Some("2026-01-10T00:00:00Z".to_string()),
+            ..Default::default()
+        }
+    }
+
+    fn create_request() -> RotationConfigCreateRequest {
+        RotationConfigCreateRequest {
+            cipher_id: cipher_id(),
+            target_system_id: target_system_id(),
+            account_identity: "svc_rotation".to_string(),
+            terminate_sessions: true,
+            schedule_cron: Some("0 0 0 * * ?".to_string()),
+            rotate_on_access_end: true,
+        }
+    }
+
+    fn update_request() -> RotationConfigUpdateRequest {
+        RotationConfigUpdateRequest {
+            account_identity: "svc_rotation".to_string(),
+            terminate_sessions: true,
+            schedule_cron: Some("0 0 0 * * ?".to_string()),
+            rotate_on_access_end: true,
+        }
+    }
+
+    #[test]
+    fn a_full_payload_maps_every_field() {
+        let config = RotationConfig::try_from(sample_response()).expect("the payload is valid");
+
+        assert_eq!(config.id, config_id());
+        assert_eq!(config.organization_id, organization_id());
+        assert_eq!(config.cipher_id, cipher_id());
+        assert_eq!(config.target_system_id, target_system_id());
+        assert_eq!(config.target_system_name, "Prod SQL");
+        assert_eq!(config.target_system_method, TargetSystemMethod::Automatic);
+        assert_eq!(config.account_identity, "svc_rotation");
+        assert!(config.terminate_sessions);
+        assert_eq!(config.schedule_cron.as_deref(), Some("0 0 0 * * ?"));
+        assert!(config.rotate_on_access_end);
+        assert!(config.enabled);
+        assert_eq!(
+            config.last_rotation_at,
+            Some("2026-02-01T00:00:00Z".parse().expect("a valid timestamp"))
+        );
+        assert_eq!(
+            config.next_rotation_at,
+            Some("2026-02-02T00:00:00Z".parse().expect("a valid timestamp"))
+        );
+        assert!(config.has_active_job);
+        assert!(config.awaiting_manual_rotation);
+        assert_eq!(
+            config.creation_date,
+            "2026-01-01T00:00:00Z".parse::<DateTime<Utc>>().unwrap()
+        );
+        assert_eq!(
+            config.revision_date,
+            "2026-01-15T00:00:00Z".parse::<DateTime<Utc>>().unwrap()
+        );
+    }
+
+    /// The one inverted default on this payload: the server omits `enabled` on an active config
+    /// rather than sending `true`. Defaulting it to `false` like the other flags would render every
+    /// running config as paused, and offer resume instead of pause.
+    #[test]
+    fn an_omitted_enabled_flag_means_the_config_is_active() {
+        let config = RotationConfig::try_from(PamRotationConfigResponseModel {
+            enabled: None,
+            ..sample_response()
+        })
+        .expect("the payload is valid");
+
+        assert!(config.enabled);
+        assert!(config.actions(Some(TargetSystemStatus::Active)).can_pause);
+        assert!(!config.actions(Some(TargetSystemStatus::Active)).can_resume);
+    }
+
+    /// Every other flag defaults the other way: absent means *not* set. A config the server has
+    /// never rotated has no timestamps, and an unnamed target reads as empty rather than failing.
+    #[test]
+    fn the_remaining_absent_fields_default_to_not_set() {
+        let config = RotationConfig::try_from(PamRotationConfigResponseModel {
+            target_system_name: None,
+            terminate_sessions: None,
+            schedule_cron: None,
+            rotate_on_access_end: None,
+            last_rotation_at: None,
+            next_rotation_at: None,
+            has_active_job: None,
+            awaiting_manual_rotation: None,
+            ..sample_response()
+        })
+        .expect("the payload is valid");
+
+        assert_eq!(config.target_system_name, "");
+        assert!(!config.terminate_sessions);
+        assert_eq!(config.schedule_cron, None);
+        assert!(!config.rotate_on_access_end);
+        assert_eq!(config.last_rotation_at, None);
+        assert_eq!(config.next_rotation_at, None);
+        assert!(!config.has_active_job);
+        assert!(!config.awaiting_manual_rotation);
+    }
+
+    #[test]
+    fn a_missing_required_field_is_reported_rather_than_defaulted() {
+        for response in [
+            PamRotationConfigResponseModel {
+                id: None,
+                ..sample_response()
+            },
+            PamRotationConfigResponseModel {
+                organization_id: None,
+                ..sample_response()
+            },
+            PamRotationConfigResponseModel {
+                cipher_id: None,
+                ..sample_response()
+            },
+            PamRotationConfigResponseModel {
+                target_system_id: None,
+                ..sample_response()
+            },
+            PamRotationConfigResponseModel {
+                target_system_method: None,
+                ..sample_response()
+            },
+            PamRotationConfigResponseModel {
+                account_identity: None,
+                ..sample_response()
+            },
+            PamRotationConfigResponseModel {
+                creation_date: None,
+                ..sample_response()
+            },
+            PamRotationConfigResponseModel {
+                revision_date: None,
+                ..sample_response()
+            },
+        ] {
+            assert!(matches!(
+                RotationConfig::try_from(response),
+                Err(RotationError::MissingField(_))
+            ));
+        }
+    }
+
+    #[test]
+    fn an_unparseable_date_is_reported() {
+        for response in [
+            PamRotationConfigResponseModel {
+                creation_date: Some("not a date".to_string()),
+                ..sample_response()
+            },
+            PamRotationConfigResponseModel {
+                revision_date: Some("not a date".to_string()),
+                ..sample_response()
+            },
+            PamRotationConfigResponseModel {
+                last_rotation_at: Some("not a date".to_string()),
+                ..sample_response()
+            },
+            PamRotationConfigResponseModel {
+                next_rotation_at: Some("not a date".to_string()),
+                ..sample_response()
+            },
+        ] {
+            assert!(matches!(
+                RotationConfig::try_from(response),
+                Err(RotationError::Chrono(_))
+            ));
+        }
+    }
+
+    #[test]
+    fn an_unrecognized_method_degrades_to_unknown() {
+        let config = RotationConfig::try_from(PamRotationConfigResponseModel {
+            target_system_method: Some(ApiTargetSystemMethod::__Unknown(9)),
+            ..sample_response()
+        })
+        .expect("an unknown method still maps");
+
+        assert_eq!(config.target_system_method, TargetSystemMethod::Unknown);
+    }
+
+    /// The detail conversion hand-copies the config's eighteen fields out of the flattened payload,
+    /// so a field dropped there would silently read as absent - and for `enabled` that would flip
+    /// an active config to paused. Comparing against the list conversion of the same config pins
+    /// all eighteen at once.
+    #[test]
+    fn the_detail_payload_yields_the_same_config_as_the_list_payload() {
+        let detail = RotationConfigDetail::try_from(sample_detail_response(Some(vec![
+            sample_job(job_id()),
+        ])))
+        .expect("the payload is valid");
+
+        assert_eq!(
+            detail.config,
+            RotationConfig::try_from(sample_response()).expect("the payload is valid")
+        );
+    }
+
+    #[test]
+    fn detail_jobs_keep_the_order_the_server_sent() {
+        let second = uuid!("66666666-6666-6666-6666-666666666666");
+        let detail = RotationConfigDetail::try_from(sample_detail_response(Some(vec![
+            sample_job(job_id()),
+            sample_job(second),
+        ])))
+        .expect("the payload is valid");
+
+        let ids: Vec<Uuid> = detail.jobs.iter().map(|job| job.id.into()).collect();
+        assert_eq!(ids, [job_id(), second]);
+        assert_eq!(detail.jobs[0].source, RotationSource::OnDemand);
+        assert_eq!(detail.jobs[0].status, RotationJobStatus::Pending);
+    }
+
+    /// A config that has never rotated is not an error - it has no history.
+    #[test]
+    fn a_detail_payload_without_jobs_has_no_jobs() {
+        let detail =
+            RotationConfigDetail::try_from(sample_detail_response(None)).expect("no jobs is fine");
+
+        assert!(detail.jobs.is_empty());
+    }
+
+    #[test]
+    fn a_malformed_job_fails_the_whole_detail() {
+        let malformed = PamRotationJobResponseModel {
+            rotation_config_id: None,
+            ..sample_job(job_id())
+        };
+
+        let result = RotationConfigDetail::try_from(sample_detail_response(Some(vec![malformed])));
+
+        assert!(matches!(result, Err(RotationError::MissingField(_))));
+    }
+
+    #[test]
+    fn a_create_request_carries_every_field() {
+        let model = CreateRotationConfigRequestModel::from(create_request());
+
+        assert_eq!(model.cipher_id, Uuid::from(cipher_id()));
+        assert_eq!(model.target_system_id, Uuid::from(target_system_id()));
+        assert_eq!(model.account_identity, "svc_rotation");
+        assert_eq!(model.terminate_sessions, Some(true));
+        assert_eq!(model.schedule_cron.as_deref(), Some("0 0 0 * * ?"));
+        assert_eq!(model.rotate_on_access_end, Some(true));
+    }
+
+    /// Clearing a schedule has to send `null`, not omit the field - an omitted cron would leave the
+    /// server's stored schedule in place and the config would keep rotating.
+    #[test]
+    fn clearing_the_schedule_sends_an_explicit_absence() {
+        let model = UpdateRotationConfigRequestModel::from(RotationConfigUpdateRequest {
+            schedule_cron: None,
+            ..update_request()
+        });
+
+        assert_eq!(model.schedule_cron, None);
+        let body = serde_json::to_value(&model).expect("it serializes");
+        assert_eq!(
+            body["scheduleCron"],
+            serde_json::Value::Null,
+            "the server must be told the schedule is gone"
+        );
+    }
+
+    #[test]
+    fn an_update_request_carries_every_field() {
+        let model = UpdateRotationConfigRequestModel::from(update_request());
+
+        assert_eq!(model.account_identity, "svc_rotation");
+        assert_eq!(model.terminate_sessions, Some(true));
+        assert_eq!(model.schedule_cron.as_deref(), Some("0 0 0 * * ?"));
+        assert_eq!(model.rotate_on_access_end, Some(true));
+    }
+
+    #[tokio::test]
+    async fn list_maps_the_organizations_configs() {
+        let api_client = ApiClient::new_mocked(move |mock| {
+            mock.pam_access_connector_rotation_configs_api
+                .expect_get_all()
+                .withf(|org_id| *org_id == Uuid::from(organization_id()))
+                .returning(move |_org_id| {
+                    Ok(PamRotationConfigResponseModelListResponseModel {
+                        data: Some(vec![sample_response()]),
+                        ..Default::default()
+                    })
+                })
+                .once();
+        });
+
+        let configs = client(api_client)
+            .list(organization_id())
+            .await
+            .expect("the list succeeds");
+
+        assert_eq!(configs.len(), 1);
+        assert_eq!(configs[0].id, config_id());
+    }
+
+    #[tokio::test]
+    async fn an_organization_with_no_configs_lists_empty() {
+        let api_client = ApiClient::new_mocked(move |mock| {
+            mock.pam_access_connector_rotation_configs_api
+                .expect_get_all()
+                .returning(move |_org_id| {
+                    Ok(PamRotationConfigResponseModelListResponseModel::default())
+                })
+                .once();
+        });
+
+        let configs = client(api_client)
+            .list(organization_id())
+            .await
+            .expect("an absent list is not an error");
+
+        assert!(configs.is_empty());
+    }
+
+    #[tokio::test]
+    async fn list_fails_if_any_config_is_malformed() {
+        let api_client = ApiClient::new_mocked(move |mock| {
+            mock.pam_access_connector_rotation_configs_api
+                .expect_get_all()
+                .returning(move |_org_id| {
+                    Ok(PamRotationConfigResponseModelListResponseModel {
+                        data: Some(vec![
+                            sample_response(),
+                            PamRotationConfigResponseModel {
+                                cipher_id: None,
+                                ..sample_response()
+                            },
+                        ]),
+                        ..Default::default()
+                    })
+                })
+                .once();
+        });
+
+        let result = client(api_client).list(organization_id()).await;
+
+        assert!(matches!(result, Err(RotationError::MissingField(_))));
+    }
+
+    #[tokio::test]
+    async fn list_surfaces_an_api_error() {
+        let api_client = ApiClient::new_mocked(move |mock| {
+            mock.pam_access_connector_rotation_configs_api
+                .expect_get_all()
+                .returning(move |_org_id| {
+                    Err(bitwarden_api_api::apis::Error::Response(
+                        bitwarden_api_api::apis::ResponseContent {
+                            status: reqwest::StatusCode::INTERNAL_SERVER_ERROR,
+                            message: String::new(),
+                        },
+                    ))
+                })
+                .once();
+        });
+
+        let result = client(api_client).list(organization_id()).await;
+
+        assert!(matches!(result, Err(RotationError::Api(_))));
+    }
+
+    #[tokio::test]
+    async fn get_reads_the_requested_config_with_its_history() {
+        let api_client = ApiClient::new_mocked(move |mock| {
+            mock.pam_access_connector_rotation_configs_api
+                .expect_get()
+                .withf(|org_id, id| {
+                    *org_id == Uuid::from(organization_id()) && *id == Uuid::from(config_id())
+                })
+                .returning(move |_org_id, _id| {
+                    Ok(sample_detail_response(Some(vec![sample_job(job_id())])))
+                })
+                .once();
+        });
+
+        let detail = client(api_client)
+            .get(organization_id(), config_id())
+            .await
+            .expect("the read succeeds");
+
+        assert_eq!(detail.config.id, config_id());
+        assert_eq!(detail.jobs.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn get_surfaces_an_api_error() {
+        let api_client = ApiClient::new_mocked(move |mock| {
+            mock.pam_access_connector_rotation_configs_api
+                .expect_get()
+                .returning(move |_org_id, _id| {
+                    Err(bitwarden_api_api::apis::Error::Response(
+                        bitwarden_api_api::apis::ResponseContent {
+                            status: reqwest::StatusCode::NOT_FOUND,
+                            message: String::new(),
+                        },
+                    ))
+                })
+                .once();
+        });
+
+        let result = client(api_client).get(organization_id(), config_id()).await;
+
+        assert!(matches!(result, Err(RotationError::Api(_))));
+    }
+
+    #[tokio::test]
+    async fn create_sends_the_request_and_returns_the_stored_config() {
+        let api_client = ApiClient::new_mocked(move |mock| {
+            mock.pam_access_connector_rotation_configs_api
+                .expect_post()
+                .withf(|org_id, request| {
+                    *org_id == Uuid::from(organization_id())
+                        && request.cipher_id == Uuid::from(cipher_id())
+                        && request.target_system_id == Uuid::from(target_system_id())
+                        && request.account_identity == "svc_rotation"
+                        && request.schedule_cron.as_deref() == Some("0 0 0 * * ?")
+                })
+                .returning(move |_org_id, _request| Ok(sample_detail_response(None)))
+                .once();
+        });
+
+        let detail = client(api_client)
+            .create(organization_id(), create_request())
+            .await
+            .expect("creation succeeds");
+
+        assert_eq!(detail.config.id, config_id());
+    }
+
+    /// A config with no schedule is valid - it rotates on demand or on access end only.
+    #[tokio::test]
+    async fn a_config_can_be_created_without_a_schedule() {
+        let api_client = ApiClient::new_mocked(move |mock| {
+            mock.pam_access_connector_rotation_configs_api
+                .expect_post()
+                .withf(|_org_id, request| request.schedule_cron.is_none())
+                .returning(move |_org_id, _request| Ok(sample_detail_response(None)))
+                .once();
+        });
+
+        client(api_client)
+            .create(
+                organization_id(),
+                RotationConfigCreateRequest {
+                    schedule_cron: None,
+                    ..create_request()
+                },
+            )
+            .await
+            .expect("creation succeeds");
+    }
+
+    /// The mock has no expectations, so any call to the server fails the test.
+    #[tokio::test]
+    async fn create_rejects_an_invalid_request_before_calling_the_server() {
+        for (request, expected) in [
+            (
+                RotationConfigCreateRequest {
+                    account_identity: "   ".to_string(),
+                    ..create_request()
+                },
+                RotationValidationError::InvalidAccountIdentity,
+            ),
+            (
+                RotationConfigCreateRequest {
+                    // A 5-field UNIX cron, which Quartz would misread field by field.
+                    schedule_cron: Some("0 0 * * *".to_string()),
+                    ..create_request()
+                },
+                RotationValidationError::InvalidCron,
+            ),
+        ] {
+            let result = client(ApiClient::new_mocked(|_| {}))
+                .create(organization_id(), request)
+                .await;
+
+            assert!(
+                matches!(result, Err(RotationError::Validation(ref actual)) if *actual == expected),
+                "expected {expected:?}, got {result:?}"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn update_sends_the_request_to_the_requested_config() {
+        let api_client = ApiClient::new_mocked(move |mock| {
+            mock.pam_access_connector_rotation_configs_api
+                .expect_put()
+                .withf(|org_id, id, request| {
+                    *org_id == Uuid::from(organization_id())
+                        && *id == Uuid::from(config_id())
+                        && request.account_identity == "svc_rotation"
+                        && request.rotate_on_access_end == Some(true)
+                })
+                .returning(move |_org_id, _id, _request| Ok(sample_detail_response(None)))
+                .once();
+        });
+
+        let detail = client(api_client)
+            .update(organization_id(), config_id(), update_request())
+            .await
+            .expect("the update succeeds");
+
+        assert_eq!(detail.config.id, config_id());
+    }
+
+    #[tokio::test]
+    async fn update_rejects_an_invalid_request_before_calling_the_server() {
+        for (request, expected) in [
+            (
+                RotationConfigUpdateRequest {
+                    account_identity: String::new(),
+                    ..update_request()
+                },
+                RotationValidationError::InvalidAccountIdentity,
+            ),
+            (
+                RotationConfigUpdateRequest {
+                    schedule_cron: Some("not a cron".to_string()),
+                    ..update_request()
+                },
+                RotationValidationError::InvalidCron,
+            ),
+        ] {
+            let result = client(ApiClient::new_mocked(|_| {}))
+                .update(organization_id(), config_id(), request)
+                .await;
+
+            assert!(
+                matches!(result, Err(RotationError::Validation(ref actual)) if *actual == expected),
+                "expected {expected:?}, got {result:?}"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn pause_targets_the_requested_config() {
+        let api_client = ApiClient::new_mocked(move |mock| {
+            mock.pam_access_connector_rotation_configs_api
+                .expect_pause()
+                .withf(|org_id, id| {
+                    *org_id == Uuid::from(organization_id()) && *id == Uuid::from(config_id())
+                })
+                .returning(move |_org_id, _id| Ok(()))
+                .once();
+        });
+
+        client(api_client)
+            .pause(organization_id(), config_id())
+            .await
+            .expect("pausing succeeds");
+    }
+
+    #[tokio::test]
+    async fn resume_targets_the_requested_config() {
+        let api_client = ApiClient::new_mocked(move |mock| {
+            mock.pam_access_connector_rotation_configs_api
+                .expect_resume()
+                .withf(|org_id, id| {
+                    *org_id == Uuid::from(organization_id()) && *id == Uuid::from(config_id())
+                })
+                .returning(move |_org_id, _id| Ok(()))
+                .once();
+        });
+
+        client(api_client)
+            .resume(organization_id(), config_id())
+            .await
+            .expect("resuming succeeds");
+    }
+
+    /// `rotate_now` maps onto the server's `rotate` route. The four unit-returning actions here are
+    /// distinguishable only by which route they hit, so each is pinned to its own.
+    #[tokio::test]
+    async fn rotate_now_dispatches_an_on_demand_rotation() {
+        let api_client = ApiClient::new_mocked(move |mock| {
+            mock.pam_access_connector_rotation_configs_api
+                .expect_rotate()
+                .withf(|org_id, id| {
+                    *org_id == Uuid::from(organization_id()) && *id == Uuid::from(config_id())
+                })
+                .returning(move |_org_id, _id| Ok(()))
+                .once();
+        });
+
+        client(api_client)
+            .rotate_now(organization_id(), config_id())
+            .await
+            .expect("dispatching succeeds");
+    }
+
+    #[tokio::test]
+    async fn record_manual_rotation_records_against_the_requested_config() {
+        let api_client = ApiClient::new_mocked(move |mock| {
+            mock.pam_access_connector_rotation_configs_api
+                .expect_record_manual()
+                .withf(|org_id, id| {
+                    *org_id == Uuid::from(organization_id()) && *id == Uuid::from(config_id())
+                })
+                .returning(move |_org_id, _id| Ok(()))
+                .once();
+        });
+
+        client(api_client)
+            .record_manual_rotation(organization_id(), config_id())
+            .await
+            .expect("recording succeeds");
+    }
+
+    #[tokio::test]
+    async fn delete_targets_the_requested_config() {
+        let api_client = ApiClient::new_mocked(move |mock| {
+            mock.pam_access_connector_rotation_configs_api
+                .expect_delete()
+                .withf(|org_id, id| {
+                    *org_id == Uuid::from(organization_id()) && *id == Uuid::from(config_id())
+                })
+                .returning(move |_org_id, _id| Ok(()))
+                .once();
+        });
+
+        client(api_client)
+            .delete(organization_id(), config_id())
+            .await
+            .expect("deleting succeeds");
+    }
+
+    /// The server's cooldown refusal is the expected failure on this route, so it has to reach the
+    /// caller rather than read as a dispatched rotation.
+    #[tokio::test]
+    async fn rotate_now_surfaces_an_api_error() {
+        let api_client = ApiClient::new_mocked(move |mock| {
+            mock.pam_access_connector_rotation_configs_api
+                .expect_rotate()
+                .returning(move |_org_id, _id| {
+                    Err(bitwarden_api_api::apis::Error::Response(
+                        bitwarden_api_api::apis::ResponseContent {
+                            status: reqwest::StatusCode::TOO_MANY_REQUESTS,
+                            message: String::new(),
+                        },
+                    ))
+                })
+                .once();
+        });
+
+        let result = client(api_client)
+            .rotate_now(organization_id(), config_id())
+            .await;
+
+        assert!(matches!(result, Err(RotationError::Api(_))));
+    }
+
+    /// The client method exists so non-Rust callers reach the same predicates the Rust API has on
+    /// [`RotationConfig::actions`]; it must not drift from them.
+    #[test]
+    fn the_client_derives_the_same_actions_as_the_config() {
+        let config = RotationConfig::try_from(sample_response()).expect("the payload is valid");
+
+        for status in [
+            None,
+            Some(TargetSystemStatus::Active),
+            Some(TargetSystemStatus::Disabled),
+            Some(TargetSystemStatus::Unknown),
+        ] {
+            assert_eq!(
+                client(ApiClient::new_mocked(|_| {})).actions(config.clone(), status),
+                config.actions(status),
+                "for {status:?}"
+            );
+        }
+    }
+}

--- a/bitwarden_license/bitwarden-pam/src/rotation/configs.rs
+++ b/bitwarden_license/bitwarden-pam/src/rotation/configs.rs
@@ -1,0 +1,404 @@
+use std::sync::Arc;
+
+use bitwarden_api_api::models::{
+    CreateRotationConfigRequestModel, PamRotationConfigDetailResponseModel,
+    PamRotationConfigResponseModel, UpdateRotationConfigRequestModel,
+};
+use bitwarden_core::{FromClient, OrganizationId, client::ApiConfigurations, require};
+use bitwarden_vault::CipherId;
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+#[cfg(feature = "wasm")]
+use tsify::Tsify;
+#[cfg(feature = "wasm")]
+use wasm_bindgen::prelude::wasm_bindgen;
+
+use super::{
+    actions::{RotationConfigActions, rotation_config_actions},
+    error::RotationError,
+    models::{RotationJobView, TargetSystemMethod, TargetSystemStatus},
+    validate::{validate_config_create, validate_config_update},
+};
+use crate::{RotationConfigId, TargetSystemId};
+
+/// A managed credential: the link between a vault cipher and the target system its credential is
+/// rotated against.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "wasm", derive(Tsify), tsify(into_wasm_abi, from_wasm_abi))]
+#[serde(rename_all = "camelCase")]
+pub struct RotationConfigView {
+    /// The config's unique identifier.
+    pub id: RotationConfigId,
+    /// The organization this config belongs to.
+    pub organization_id: OrganizationId,
+    /// The vault cipher whose credential this config manages.
+    ///
+    /// Only the id is here. The cipher's name is vault data and has to be decrypted from the
+    /// caller's own cipher state - the rotation endpoints never carry it.
+    pub cipher_id: CipherId,
+    /// The target system credentials are rotated against.
+    pub target_system_id: TargetSystemId,
+    /// The target system's display name as of the config's last write.
+    ///
+    /// Denormalized by the server, so it can lag a rename. Prefer the name from the target system
+    /// itself when it has been loaded, and treat this as the fallback.
+    pub target_system_name: String,
+    /// The target system's rotation method as of the config's last write. Denormalized, and the
+    /// field that decides which actions the config offers.
+    pub target_system_method: TargetSystemMethod,
+    /// The account within the target system - a username, UPN, or service-account name.
+    pub account_identity: String,
+    /// Whether the connector terminates the account's sessions after a successful rotation.
+    pub terminate_sessions: bool,
+    /// The Quartz cron expression driving scheduled rotation, or `None` for no schedule.
+    pub schedule_cron: Option<String>,
+    /// Whether the credential is rotated when an access lease over the cipher ends.
+    pub rotate_on_access_end: bool,
+    /// When false, no new rotation jobs are dispatched. Jobs in flight run to completion.
+    pub enabled: bool,
+    /// The most recent completed rotation (UTC), or `None` if it has never rotated.
+    pub last_rotation_at: Option<DateTime<Utc>>,
+    /// The next scheduled rotation (UTC). `None` when there is no schedule or the config is
+    /// paused.
+    pub next_rotation_at: Option<DateTime<Utc>>,
+    /// Whether a job is currently pending or claimed for this config.
+    pub has_active_job: bool,
+    /// Whether a manual-method config is waiting for an operator to record an out-of-band
+    /// rotation.
+    pub awaiting_manual_rotation: bool,
+    /// When the config was created (UTC).
+    pub creation_date: DateTime<Utc>,
+    /// When the config was last modified (UTC).
+    pub revision_date: DateTime<Utc>,
+}
+
+impl RotationConfigView {
+    /// Which actions this config offers, given the status of its target system.
+    ///
+    /// See [`rotation_config_actions`] for how `target_status` is treated when the target system
+    /// has not been loaded.
+    pub fn actions(&self, target_status: Option<TargetSystemStatus>) -> RotationConfigActions {
+        rotation_config_actions(self, target_status)
+    }
+}
+
+impl TryFrom<PamRotationConfigResponseModel> for RotationConfigView {
+    type Error = RotationError;
+
+    fn try_from(response: PamRotationConfigResponseModel) -> Result<Self, Self::Error> {
+        Ok(Self {
+            id: RotationConfigId::new(require!(response.id)),
+            organization_id: OrganizationId::new(require!(response.organization_id)),
+            cipher_id: CipherId::new(require!(response.cipher_id)),
+            target_system_id: TargetSystemId::new(require!(response.target_system_id)),
+            target_system_name: response.target_system_name.unwrap_or_default(),
+            target_system_method: require!(response.target_system_method).into(),
+            account_identity: require!(response.account_identity),
+            terminate_sessions: response.terminate_sessions.unwrap_or(false),
+            schedule_cron: response.schedule_cron,
+            rotate_on_access_end: response.rotate_on_access_end.unwrap_or(false),
+            // The server omits `enabled` on an active config rather than sending `true`.
+            enabled: response.enabled.unwrap_or(true),
+            last_rotation_at: response
+                .last_rotation_at
+                .map(|date| date.parse())
+                .transpose()?,
+            next_rotation_at: response
+                .next_rotation_at
+                .map(|date| date.parse())
+                .transpose()?,
+            has_active_job: response.has_active_job.unwrap_or(false),
+            awaiting_manual_rotation: response.awaiting_manual_rotation.unwrap_or(false),
+            creation_date: require!(response.creation_date).parse()?,
+            revision_date: require!(response.revision_date).parse()?,
+        })
+    }
+}
+
+/// A config together with its rotation history.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "wasm", derive(Tsify), tsify(into_wasm_abi, from_wasm_abi))]
+#[serde(rename_all = "camelCase")]
+pub struct RotationConfigDetailView {
+    /// The config itself.
+    #[serde(flatten)]
+    pub config: RotationConfigView,
+    /// The config's rotation jobs, newest first, each carrying its attempts oldest first.
+    pub jobs: Vec<RotationJobView>,
+}
+
+impl TryFrom<PamRotationConfigDetailResponseModel> for RotationConfigDetailView {
+    type Error = RotationError;
+
+    fn try_from(response: PamRotationConfigDetailResponseModel) -> Result<Self, Self::Error> {
+        let jobs = response
+            .jobs
+            .clone()
+            .unwrap_or_default()
+            .into_iter()
+            .map(RotationJobView::try_from)
+            .collect::<Result<Vec<_>, _>>()?;
+
+        // The server flattens the config's own fields onto the detail payload, so the list model is
+        // rebuilt from the same object rather than a nested one.
+        let config = RotationConfigView::try_from(PamRotationConfigResponseModel {
+            object: response.object,
+            id: response.id,
+            organization_id: response.organization_id,
+            cipher_id: response.cipher_id,
+            target_system_id: response.target_system_id,
+            target_system_name: response.target_system_name,
+            target_system_method: response.target_system_method,
+            account_identity: response.account_identity,
+            terminate_sessions: response.terminate_sessions,
+            schedule_cron: response.schedule_cron,
+            rotate_on_access_end: response.rotate_on_access_end,
+            next_rotation_at: response.next_rotation_at,
+            enabled: response.enabled,
+            last_rotation_at: response.last_rotation_at,
+            has_active_job: response.has_active_job,
+            awaiting_manual_rotation: response.awaiting_manual_rotation,
+            creation_date: response.creation_date,
+            revision_date: response.revision_date,
+        })?;
+
+        Ok(Self { config, jobs })
+    }
+}
+
+/// Request to create a rotation config.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "wasm", derive(Tsify), tsify(into_wasm_abi, from_wasm_abi))]
+#[serde(rename_all = "camelCase")]
+pub struct RotationConfigCreateRequest {
+    /// The vault cipher whose credential this config will manage.
+    pub cipher_id: CipherId,
+    /// The target system to rotate against.
+    pub target_system_id: TargetSystemId,
+    /// The account within the target system.
+    pub account_identity: String,
+    /// Whether to terminate the account's sessions after a successful rotation.
+    pub terminate_sessions: bool,
+    /// A Quartz cron expression, or `None` for no scheduled rotation.
+    pub schedule_cron: Option<String>,
+    /// Whether to rotate when an access lease over the cipher ends.
+    pub rotate_on_access_end: bool,
+}
+
+impl From<RotationConfigCreateRequest> for CreateRotationConfigRequestModel {
+    fn from(request: RotationConfigCreateRequest) -> Self {
+        Self {
+            cipher_id: request.cipher_id.into(),
+            target_system_id: request.target_system_id.into(),
+            account_identity: request.account_identity,
+            terminate_sessions: Some(request.terminate_sessions),
+            schedule_cron: request.schedule_cron,
+            rotate_on_access_end: Some(request.rotate_on_access_end),
+        }
+    }
+}
+
+/// Request to update a rotation config.
+///
+/// The account identity and the schedule travel together because the server takes them in one
+/// `PUT`, so a caller changing only the schedule still sends the current account identity. Note
+/// that the server locks the account identity while a job is in flight - see
+/// [`RotationConfigActions::mutations_locked`].
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "wasm", derive(Tsify), tsify(into_wasm_abi, from_wasm_abi))]
+#[serde(rename_all = "camelCase")]
+pub struct RotationConfigUpdateRequest {
+    /// The account within the target system.
+    pub account_identity: String,
+    /// Whether to terminate the account's sessions after a successful rotation.
+    pub terminate_sessions: bool,
+    /// A Quartz cron expression, or `None` for no scheduled rotation.
+    pub schedule_cron: Option<String>,
+    /// Whether to rotate when an access lease over the cipher ends.
+    pub rotate_on_access_end: bool,
+}
+
+impl From<RotationConfigUpdateRequest> for UpdateRotationConfigRequestModel {
+    fn from(request: RotationConfigUpdateRequest) -> Self {
+        Self {
+            account_identity: request.account_identity,
+            terminate_sessions: Some(request.terminate_sessions),
+            schedule_cron: request.schedule_cron,
+            rotate_on_access_end: Some(request.rotate_on_access_end),
+        }
+    }
+}
+
+/// Client for PAM managed-credential (rotation config) operations.
+#[cfg_attr(feature = "wasm", wasm_bindgen)]
+#[derive(FromClient)]
+pub struct RotationConfigsClient {
+    pub(crate) api_configurations: Arc<ApiConfigurations>,
+}
+
+#[cfg_attr(feature = "wasm", wasm_bindgen)]
+impl RotationConfigsClient {
+    /// Lists the organization's rotation configs.
+    pub async fn list(
+        &self,
+        organization_id: OrganizationId,
+    ) -> Result<Vec<RotationConfigView>, RotationError> {
+        let response = self
+            .api_configurations
+            .api_client
+            .pam_access_connector_rotation_configs_api()
+            .get_all(organization_id.into())
+            .await?;
+
+        response
+            .data
+            .unwrap_or_default()
+            .into_iter()
+            .map(RotationConfigView::try_from)
+            .collect()
+    }
+
+    /// Reads one config with its rotation history.
+    pub async fn get(
+        &self,
+        organization_id: OrganizationId,
+        id: RotationConfigId,
+    ) -> Result<RotationConfigDetailView, RotationError> {
+        let response = self
+            .api_configurations
+            .api_client
+            .pam_access_connector_rotation_configs_api()
+            .get(organization_id.into(), id.into())
+            .await?;
+
+        RotationConfigDetailView::try_from(response)
+    }
+
+    /// Validates and creates a rotation config.
+    pub async fn create(
+        &self,
+        organization_id: OrganizationId,
+        request: RotationConfigCreateRequest,
+    ) -> Result<RotationConfigDetailView, RotationError> {
+        validate_config_create(&request)?;
+
+        let response = self
+            .api_configurations
+            .api_client
+            .pam_access_connector_rotation_configs_api()
+            .post(organization_id.into(), request.into())
+            .await?;
+
+        RotationConfigDetailView::try_from(response)
+    }
+
+    /// Validates and updates a rotation config's account and schedule.
+    pub async fn update(
+        &self,
+        organization_id: OrganizationId,
+        id: RotationConfigId,
+        request: RotationConfigUpdateRequest,
+    ) -> Result<RotationConfigDetailView, RotationError> {
+        validate_config_update(&request)?;
+
+        let response = self
+            .api_configurations
+            .api_client
+            .pam_access_connector_rotation_configs_api()
+            .put(organization_id.into(), id.into(), request.into())
+            .await?;
+
+        RotationConfigDetailView::try_from(response)
+    }
+
+    /// Pauses a config, so no new rotation jobs are dispatched.
+    pub async fn pause(
+        &self,
+        organization_id: OrganizationId,
+        id: RotationConfigId,
+    ) -> Result<(), RotationError> {
+        self.api_configurations
+            .api_client
+            .pam_access_connector_rotation_configs_api()
+            .pause(organization_id.into(), id.into())
+            .await?;
+
+        Ok(())
+    }
+
+    /// Resumes a paused config.
+    pub async fn resume(
+        &self,
+        organization_id: OrganizationId,
+        id: RotationConfigId,
+    ) -> Result<(), RotationError> {
+        self.api_configurations
+            .api_client
+            .pam_access_connector_rotation_configs_api()
+            .resume(organization_id.into(), id.into())
+            .await?;
+
+        Ok(())
+    }
+
+    /// Dispatches an on-demand rotation now, subject to the server's per-config cooldown.
+    pub async fn rotate_now(
+        &self,
+        organization_id: OrganizationId,
+        id: RotationConfigId,
+    ) -> Result<(), RotationError> {
+        self.api_configurations
+            .api_client
+            .pam_access_connector_rotation_configs_api()
+            .rotate(organization_id.into(), id.into())
+            .await?;
+
+        Ok(())
+    }
+
+    /// Records that an operator rotated a manual-target config's credential out of band, clearing
+    /// its awaiting-manual-rotation state.
+    pub async fn record_manual_rotation(
+        &self,
+        organization_id: OrganizationId,
+        id: RotationConfigId,
+    ) -> Result<(), RotationError> {
+        self.api_configurations
+            .api_client
+            .pam_access_connector_rotation_configs_api()
+            .record_manual(organization_id.into(), id.into())
+            .await?;
+
+        Ok(())
+    }
+
+    /// Deletes a rotation config. The cipher and the target system are untouched; only the link
+    /// between them, and its rotation history, go away.
+    pub async fn delete(
+        &self,
+        organization_id: OrganizationId,
+        id: RotationConfigId,
+    ) -> Result<(), RotationError> {
+        self.api_configurations
+            .api_client
+            .pam_access_connector_rotation_configs_api()
+            .delete(organization_id.into(), id.into())
+            .await?;
+
+        Ok(())
+    }
+
+    /// Which actions a config offers, given the status of its target system.
+    ///
+    /// Exposed on the client so non-Rust callers can reach the same predicates the Rust API has on
+    /// [`RotationConfigView::actions`] - a tsify view crosses the WASM boundary as plain data and
+    /// leaves its methods behind. All five flags are derived in one call because they are not
+    /// independent; see [`RotationConfigActions`].
+    pub fn actions(
+        &self,
+        config: RotationConfigView,
+        target_status: Option<TargetSystemStatus>,
+    ) -> RotationConfigActions {
+        config.actions(target_status)
+    }
+}

--- a/bitwarden_license/bitwarden-pam/src/rotation/connectors.rs
+++ b/bitwarden_license/bitwarden-pam/src/rotation/connectors.rs
@@ -84,7 +84,6 @@ impl TryFrom<PamAccessConnectorResponseModel> for AccessConnector {
 #[serde(rename_all = "camelCase")]
 pub struct AccessConnectorDetail {
     /// The connector itself.
-    #[serde(flatten)]
     pub connector: AccessConnector,
     /// The jobs this connector has worked, newest first, carrying the attempts it recorded.
     ///

--- a/bitwarden_license/bitwarden-pam/src/rotation/connectors.rs
+++ b/bitwarden_license/bitwarden-pam/src/rotation/connectors.rs
@@ -329,3 +329,712 @@ impl AccessConnectorsClient {
         Ok(())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::{str::FromStr, sync::Mutex};
+
+    use bitwarden_api_api::{
+        apis::ApiClient,
+        models::{
+            PamAccessConnectorResponseModelListResponseModel,
+            PamAccessConnectorStatus as ApiAccessConnectorStatus, PamRotationJobResponseModel,
+            PamRotationJobStatus as ApiRotationJobStatus, PamRotationSource as ApiRotationSource,
+            RegisterAccessConnectorResponseModel,
+        },
+    };
+    use bitwarden_core::key_management::{
+        SymmetricKeySlotId, create_test_crypto_with_user_and_org_key,
+        create_test_crypto_with_user_key,
+    };
+    use bitwarden_crypto::{Decryptable, EncString, SymmetricCryptoKey, SymmetricKeyAlgorithm};
+    use uuid::{Uuid, uuid};
+
+    use super::*;
+    use crate::rotation::{
+        models::{RotationJobStatus, RotationSource},
+        registration::ConnectorToken,
+        validate::RotationValidationError,
+    };
+
+    fn organization_id() -> OrganizationId {
+        OrganizationId::new(uuid!("11111111-1111-1111-1111-111111111111"))
+    }
+
+    fn connector_id() -> AccessConnectorId {
+        AccessConnectorId::new(uuid!("22222222-2222-2222-2222-222222222222"))
+    }
+
+    fn target_system_id() -> TargetSystemId {
+        TargetSystemId::new(uuid!("33333333-3333-3333-3333-333333333333"))
+    }
+
+    fn job_id() -> Uuid {
+        uuid!("44444444-4444-4444-4444-444444444444")
+    }
+
+    fn api_key_id() -> Uuid {
+        uuid!("55555555-5555-5555-5555-555555555555")
+    }
+
+    fn client(api_client: ApiClient) -> AccessConnectorsClient {
+        client_with_org_key(
+            api_client,
+            SymmetricCryptoKey::make(SymmetricKeyAlgorithm::Aes256CbcHmac),
+        )
+    }
+
+    fn client_with_org_key(
+        api_client: ApiClient,
+        organization_key: SymmetricCryptoKey,
+    ) -> AccessConnectorsClient {
+        AccessConnectorsClient {
+            key_store: create_test_crypto_with_user_and_org_key(
+                SymmetricCryptoKey::make(SymmetricKeyAlgorithm::Aes256CbcHmac),
+                organization_id(),
+                organization_key,
+            ),
+            api_configurations: Arc::new(ApiConfigurations::from_api_client(api_client)),
+        }
+    }
+
+    /// A payload with every optional field populated, so a test that clears one is unambiguous
+    /// about which field it is exercising.
+    fn sample_response() -> PamAccessConnectorResponseModel {
+        PamAccessConnectorResponseModel {
+            id: Some(connector_id().into()),
+            organization_id: Some(organization_id().into()),
+            name: Some("Prod connector".to_string()),
+            status: Some(ApiAccessConnectorStatus::Enabled),
+            is_connected: Some(true),
+            last_heartbeat_at: Some("2026-02-01T12:30:00Z".to_string()),
+            assigned_target_system_ids: Some(vec![target_system_id().into()]),
+            creation_date: Some("2026-01-01T00:00:00Z".to_string()),
+            revision_date: Some("2026-01-15T00:00:00Z".to_string()),
+            ..Default::default()
+        }
+    }
+
+    /// The same connector as [`sample_response`], as the detail route returns it: the connector's
+    /// own fields flattened onto the payload, plus its recent jobs.
+    fn sample_detail_response(
+        jobs: Option<Vec<PamRotationJobResponseModel>>,
+    ) -> PamAccessConnectorDetailResponseModel {
+        let connector = sample_response();
+        PamAccessConnectorDetailResponseModel {
+            object: connector.object,
+            id: connector.id,
+            organization_id: connector.organization_id,
+            name: connector.name,
+            status: connector.status,
+            is_connected: connector.is_connected,
+            last_heartbeat_at: connector.last_heartbeat_at,
+            assigned_target_system_ids: connector.assigned_target_system_ids,
+            creation_date: connector.creation_date,
+            revision_date: connector.revision_date,
+            jobs,
+        }
+    }
+
+    fn sample_job(id: Uuid) -> PamRotationJobResponseModel {
+        PamRotationJobResponseModel {
+            id: Some(id),
+            rotation_config_id: Some(uuid!("66666666-6666-6666-6666-666666666666")),
+            source: Some(ApiRotationSource::Scheduled),
+            status: Some(ApiRotationJobStatus::Succeeded),
+            creation_date: Some("2026-01-10T00:00:00Z".to_string()),
+            ..Default::default()
+        }
+    }
+
+    fn registration_response() -> RegisterAccessConnectorResponseModel {
+        RegisterAccessConnectorResponseModel {
+            id: Some(connector_id().into()),
+            organization_id: Some(organization_id().into()),
+            name: Some("Prod connector".to_string()),
+            status: Some(ApiAccessConnectorStatus::Enabled),
+            creation_date: Some("2026-01-01T00:00:00Z".to_string()),
+            api_key_id: Some(api_key_id()),
+            client_secret: Some("client-secret-value".to_string()),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn a_full_payload_maps_every_field() {
+        let connector = AccessConnector::try_from(sample_response()).expect("the payload is valid");
+
+        assert_eq!(connector.id, connector_id());
+        assert_eq!(connector.organization_id, organization_id());
+        assert_eq!(connector.name, "Prod connector");
+        assert_eq!(connector.status, AccessConnectorStatus::Enabled);
+        assert!(connector.is_connected);
+        assert_eq!(
+            connector.last_heartbeat_at,
+            Some("2026-02-01T12:30:00Z".parse().expect("a valid timestamp"))
+        );
+        assert_eq!(connector.assigned_target_system_ids, [target_system_id()]);
+        assert_eq!(
+            connector.creation_date,
+            "2026-01-01T00:00:00Z".parse::<DateTime<Utc>>().unwrap()
+        );
+        assert_eq!(
+            connector.revision_date,
+            "2026-01-15T00:00:00Z".parse::<DateTime<Utc>>().unwrap()
+        );
+    }
+
+    /// A connector that has never phoned home reports no heartbeat and no assignments. Neither is
+    /// an error, and `is_connected` has to read as *not connected* rather than defaulting true.
+    #[test]
+    fn a_connector_that_has_never_connected_maps_to_disconnected_with_no_heartbeat() {
+        let response = PamAccessConnectorResponseModel {
+            is_connected: None,
+            last_heartbeat_at: None,
+            assigned_target_system_ids: None,
+            ..sample_response()
+        };
+
+        let connector = AccessConnector::try_from(response).expect("the payload is valid");
+
+        assert!(!connector.is_connected);
+        assert_eq!(connector.last_heartbeat_at, None);
+        assert!(connector.assigned_target_system_ids.is_empty());
+    }
+
+    #[test]
+    fn a_missing_required_field_is_reported_rather_than_defaulted() {
+        for response in [
+            PamAccessConnectorResponseModel {
+                id: None,
+                ..sample_response()
+            },
+            PamAccessConnectorResponseModel {
+                organization_id: None,
+                ..sample_response()
+            },
+            PamAccessConnectorResponseModel {
+                name: None,
+                ..sample_response()
+            },
+            PamAccessConnectorResponseModel {
+                status: None,
+                ..sample_response()
+            },
+            PamAccessConnectorResponseModel {
+                creation_date: None,
+                ..sample_response()
+            },
+            PamAccessConnectorResponseModel {
+                revision_date: None,
+                ..sample_response()
+            },
+        ] {
+            assert!(matches!(
+                AccessConnector::try_from(response.clone()),
+                Err(RotationError::MissingField(_))
+            ));
+        }
+    }
+
+    #[test]
+    fn an_unparseable_date_is_reported() {
+        for response in [
+            PamAccessConnectorResponseModel {
+                creation_date: Some("not a date".to_string()),
+                ..sample_response()
+            },
+            PamAccessConnectorResponseModel {
+                revision_date: Some("not a date".to_string()),
+                ..sample_response()
+            },
+            PamAccessConnectorResponseModel {
+                last_heartbeat_at: Some("not a date".to_string()),
+                ..sample_response()
+            },
+        ] {
+            assert!(matches!(
+                AccessConnector::try_from(response),
+                Err(RotationError::Chrono(_))
+            ));
+        }
+    }
+
+    /// A newer server naming a status this version does not model must not fail the whole list -
+    /// see the forward-compatibility note in the module docs.
+    #[test]
+    fn an_unrecognized_status_degrades_to_unknown() {
+        let response = PamAccessConnectorResponseModel {
+            status: Some(ApiAccessConnectorStatus::__Unknown(99)),
+            ..sample_response()
+        };
+
+        let connector = AccessConnector::try_from(response).expect("an unknown status still maps");
+
+        assert_eq!(connector.status, AccessConnectorStatus::Unknown);
+    }
+
+    /// The detail conversion hand-copies the connector's nine fields out of the flattened payload,
+    /// so a field dropped there would silently read as absent. Comparing against the list
+    /// conversion of the same connector pins all nine at once.
+    #[test]
+    fn the_detail_payload_yields_the_same_connector_as_the_list_payload() {
+        let detail =
+            AccessConnectorDetail::try_from(sample_detail_response(Some(vec![sample_job(
+                job_id(),
+            )])))
+            .expect("the payload is valid");
+
+        assert_eq!(
+            detail.connector,
+            AccessConnector::try_from(sample_response()).expect("the payload is valid")
+        );
+    }
+
+    #[test]
+    fn detail_jobs_keep_the_order_the_server_sent() {
+        let second = uuid!("77777777-7777-7777-7777-777777777777");
+        let detail = AccessConnectorDetail::try_from(sample_detail_response(Some(vec![
+            sample_job(job_id()),
+            sample_job(second),
+        ])))
+        .expect("the payload is valid");
+
+        let ids: Vec<Uuid> = detail.jobs.iter().map(|job| job.id.into()).collect();
+        assert_eq!(ids, [job_id(), second]);
+        assert_eq!(detail.jobs[0].source, RotationSource::Scheduled);
+        assert_eq!(detail.jobs[0].status, RotationJobStatus::Succeeded);
+    }
+
+    /// A connector that has never been dispatched work is not an error - it has no jobs.
+    #[test]
+    fn a_detail_payload_without_jobs_has_no_jobs() {
+        let detail =
+            AccessConnectorDetail::try_from(sample_detail_response(None)).expect("no jobs is fine");
+
+        assert!(detail.jobs.is_empty());
+    }
+
+    #[test]
+    fn a_malformed_job_fails_the_whole_detail() {
+        let malformed = PamRotationJobResponseModel {
+            id: None,
+            ..sample_job(job_id())
+        };
+
+        let result = AccessConnectorDetail::try_from(sample_detail_response(Some(vec![malformed])));
+
+        assert!(matches!(result, Err(RotationError::MissingField(_))));
+    }
+
+    #[tokio::test]
+    async fn list_maps_the_organizations_connectors() {
+        let api_client = ApiClient::new_mocked(move |mock| {
+            mock.pam_access_connectors_api
+                .expect_get_all()
+                .withf(|org_id| *org_id == Uuid::from(organization_id()))
+                .returning(move |_org_id| {
+                    Ok(PamAccessConnectorResponseModelListResponseModel {
+                        data: Some(vec![sample_response()]),
+                        ..Default::default()
+                    })
+                })
+                .once();
+        });
+
+        let connectors = client(api_client)
+            .list(organization_id())
+            .await
+            .expect("the list succeeds");
+
+        assert_eq!(connectors.len(), 1);
+        assert_eq!(connectors[0].id, connector_id());
+    }
+
+    #[tokio::test]
+    async fn an_organization_with_no_connectors_lists_empty() {
+        let api_client = ApiClient::new_mocked(move |mock| {
+            mock.pam_access_connectors_api
+                .expect_get_all()
+                .returning(move |_org_id| {
+                    Ok(PamAccessConnectorResponseModelListResponseModel::default())
+                })
+                .once();
+        });
+
+        let connectors = client(api_client)
+            .list(organization_id())
+            .await
+            .expect("an absent list is not an error");
+
+        assert!(connectors.is_empty());
+    }
+
+    #[tokio::test]
+    async fn list_fails_if_any_connector_is_malformed() {
+        let api_client = ApiClient::new_mocked(move |mock| {
+            mock.pam_access_connectors_api
+                .expect_get_all()
+                .returning(move |_org_id| {
+                    Ok(PamAccessConnectorResponseModelListResponseModel {
+                        data: Some(vec![
+                            sample_response(),
+                            PamAccessConnectorResponseModel {
+                                id: None,
+                                ..sample_response()
+                            },
+                        ]),
+                        ..Default::default()
+                    })
+                })
+                .once();
+        });
+
+        let result = client(api_client).list(organization_id()).await;
+
+        assert!(matches!(result, Err(RotationError::MissingField(_))));
+    }
+
+    #[tokio::test]
+    async fn list_surfaces_an_api_error() {
+        let api_client = ApiClient::new_mocked(move |mock| {
+            mock.pam_access_connectors_api
+                .expect_get_all()
+                .returning(move |_org_id| {
+                    Err(bitwarden_api_api::apis::Error::Response(
+                        bitwarden_api_api::apis::ResponseContent {
+                            status: reqwest::StatusCode::INTERNAL_SERVER_ERROR,
+                            message: String::new(),
+                        },
+                    ))
+                })
+                .once();
+        });
+
+        let result = client(api_client).list(organization_id()).await;
+
+        assert!(matches!(result, Err(RotationError::Api(_))));
+    }
+
+    #[tokio::test]
+    async fn get_reads_the_requested_connector_with_its_jobs() {
+        let api_client = ApiClient::new_mocked(move |mock| {
+            mock.pam_access_connectors_api
+                .expect_get()
+                .withf(|org_id, id| {
+                    *org_id == Uuid::from(organization_id()) && *id == Uuid::from(connector_id())
+                })
+                .returning(move |_org_id, _id| {
+                    Ok(sample_detail_response(Some(vec![sample_job(job_id())])))
+                })
+                .once();
+        });
+
+        let detail = client(api_client)
+            .get(organization_id(), connector_id())
+            .await
+            .expect("the read succeeds");
+
+        assert_eq!(detail.connector.id, connector_id());
+        assert_eq!(detail.jobs.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn get_surfaces_an_api_error() {
+        let api_client = ApiClient::new_mocked(move |mock| {
+            mock.pam_access_connectors_api
+                .expect_get()
+                .returning(move |_org_id, _id| {
+                    Err(bitwarden_api_api::apis::Error::Response(
+                        bitwarden_api_api::apis::ResponseContent {
+                            status: reqwest::StatusCode::NOT_FOUND,
+                            message: String::new(),
+                        },
+                    ))
+                })
+                .once();
+        });
+
+        let result = client(api_client)
+            .get(organization_id(), connector_id())
+            .await;
+
+        assert!(matches!(result, Err(RotationError::Api(_))));
+    }
+
+    /// The whole point of `register`: the connector must be able to recover the organization key
+    /// from the token it is handed plus the `encryptedPayload` the server stored. This walks that
+    /// path end to end through the public method - the token comes from the response, the payload
+    /// from the request that was actually sent - so a mismatch between the two halves fails here.
+    #[tokio::test]
+    async fn register_returns_a_token_that_recovers_the_organization_key() {
+        let organization_key = SymmetricCryptoKey::make(SymmetricKeyAlgorithm::Aes256CbcHmac);
+        let sent_payload = Arc::new(Mutex::new(None));
+
+        let captured = sent_payload.clone();
+        let api_client = ApiClient::new_mocked(move |mock| {
+            mock.pam_access_connectors_api
+                .expect_post()
+                .withf(|org_id, request| {
+                    *org_id == Uuid::from(organization_id()) && request.name == "Prod connector"
+                })
+                .returning(move |_org_id, request| {
+                    *captured.lock().expect("the lock is not poisoned") =
+                        Some(request.encrypted_payload);
+                    Ok(registration_response())
+                })
+                .once();
+        });
+
+        let registered = client_with_org_key(api_client, organization_key.clone())
+            .register(organization_id(), "Prod connector".to_string())
+            .await
+            .expect("registration succeeds");
+
+        assert_eq!(registered.id, connector_id());
+        assert_eq!(registered.organization_id, organization_id());
+        assert_eq!(registered.name, "Prod connector");
+        assert_eq!(registered.status, AccessConnectorStatus::Enabled);
+
+        // Everything below is what a connector does with the token it was provisioned.
+        let token = ConnectorToken::from_str(&registered.token).expect("the token parses");
+        assert_eq!(token.api_key_id, api_key_id());
+        assert_eq!(token.client_secret, "client-secret-value");
+
+        let payload: EncString = sent_payload
+            .lock()
+            .expect("the lock is not poisoned")
+            .clone()
+            .expect("the request carried an encrypted payload")
+            .parse()
+            .expect("the payload is an EncString");
+
+        let connector_store = create_test_crypto_with_user_key(token.encryption_key);
+        let decrypted: String = payload
+            .decrypt(&mut connector_store.context(), SymmetricKeySlotId::User)
+            .expect("the key derived from the token decrypts the payload");
+        let recovered: serde_json::Value =
+            serde_json::from_str(&decrypted).expect("the payload is JSON");
+
+        assert_eq!(
+            recovered["encryptionKey"].as_str(),
+            Some(organization_key.to_base64().to_string().as_str()),
+            "the connector must recover the organization key verbatim"
+        );
+    }
+
+    /// The token is unrecoverable, so the caller has to be able to show the operator which
+    /// connector it belongs to even if the server echoes no name back.
+    #[tokio::test]
+    async fn register_falls_back_to_the_requested_name_when_the_server_omits_it() {
+        let api_client = ApiClient::new_mocked(move |mock| {
+            mock.pam_access_connectors_api
+                .expect_post()
+                .returning(move |_org_id, _request| {
+                    Ok(RegisterAccessConnectorResponseModel {
+                        name: None,
+                        ..registration_response()
+                    })
+                })
+                .once();
+        });
+
+        let registered = client(api_client)
+            .register(organization_id(), "Prod connector".to_string())
+            .await
+            .expect("registration succeeds");
+
+        assert_eq!(registered.name, "Prod connector");
+    }
+
+    /// A registration that cannot produce a usable token must not leave a registered connector
+    /// behind - the operator would have no way to provision it and no way to recover the secret.
+    /// The mock has no expectations, so any call to the server fails the test.
+    #[tokio::test]
+    async fn register_rejects_an_invalid_name_before_calling_the_server() {
+        for name in ["", "   ", &"a".repeat(201)] {
+            let result = client(ApiClient::new_mocked(|_| {}))
+                .register(organization_id(), name.to_string())
+                .await;
+
+            assert!(
+                matches!(
+                    result,
+                    Err(RotationError::Validation(
+                        RotationValidationError::InvalidName
+                    ))
+                ),
+                "for {name:?}"
+            );
+        }
+    }
+
+    /// Same obligation as an invalid name, for the other failure that precedes the call: without
+    /// the organization key there is nothing to wrap into the token.
+    #[tokio::test]
+    async fn register_without_the_organization_key_never_reaches_the_server() {
+        let client = AccessConnectorsClient {
+            // A store with a user key but no organization key - the caller is not a member.
+            key_store: create_test_crypto_with_user_key(SymmetricCryptoKey::make(
+                SymmetricKeyAlgorithm::Aes256CbcHmac,
+            )),
+            api_configurations: Arc::new(ApiConfigurations::from_api_client(
+                ApiClient::new_mocked(|_| {}),
+            )),
+        };
+
+        let result = client
+            .register(organization_id(), "Prod connector".to_string())
+            .await;
+
+        assert!(matches!(result, Err(RotationError::MissingOrganizationKey)));
+    }
+
+    /// A token missing either half cannot authenticate, so a response without them has to fail
+    /// rather than hand back a string that looks like a credential.
+    #[tokio::test]
+    async fn register_fails_when_the_response_cannot_complete_the_token() {
+        for response in [
+            RegisterAccessConnectorResponseModel {
+                api_key_id: None,
+                ..registration_response()
+            },
+            RegisterAccessConnectorResponseModel {
+                client_secret: None,
+                ..registration_response()
+            },
+        ] {
+            let api_client = ApiClient::new_mocked(move |mock| {
+                mock.pam_access_connectors_api
+                    .expect_post()
+                    .returning(move |_org_id, _request| Ok(response.clone()))
+                    .once();
+            });
+
+            let result = client(api_client)
+                .register(organization_id(), "Prod connector".to_string())
+                .await;
+
+            assert!(matches!(result, Err(RotationError::MissingField(_))));
+        }
+    }
+
+    #[tokio::test]
+    async fn enable_targets_the_requested_connector() {
+        let api_client = ApiClient::new_mocked(move |mock| {
+            mock.pam_access_connectors_api
+                .expect_enable()
+                .withf(|org_id, id| {
+                    *org_id == Uuid::from(organization_id()) && *id == Uuid::from(connector_id())
+                })
+                .returning(move |_org_id, _id| Ok(()))
+                .once();
+        });
+
+        client(api_client)
+            .enable(organization_id(), connector_id())
+            .await
+            .expect("enabling succeeds");
+    }
+
+    #[tokio::test]
+    async fn disable_targets_the_requested_connector() {
+        let api_client = ApiClient::new_mocked(move |mock| {
+            mock.pam_access_connectors_api
+                .expect_disable()
+                .withf(|org_id, id| {
+                    *org_id == Uuid::from(organization_id()) && *id == Uuid::from(connector_id())
+                })
+                .returning(move |_org_id, _id| Ok(()))
+                .once();
+        });
+
+        client(api_client)
+            .disable(organization_id(), connector_id())
+            .await
+            .expect("disabling succeeds");
+    }
+
+    #[tokio::test]
+    async fn delete_targets_the_requested_connector() {
+        let api_client = ApiClient::new_mocked(move |mock| {
+            mock.pam_access_connectors_api
+                .expect_delete()
+                .withf(|org_id, id| {
+                    *org_id == Uuid::from(organization_id()) && *id == Uuid::from(connector_id())
+                })
+                .returning(move |_org_id, _id| Ok(()))
+                .once();
+        });
+
+        client(api_client)
+            .delete(organization_id(), connector_id())
+            .await
+            .expect("deleting succeeds");
+    }
+
+    #[tokio::test]
+    async fn delete_surfaces_an_api_error() {
+        let api_client = ApiClient::new_mocked(move |mock| {
+            mock.pam_access_connectors_api
+                .expect_delete()
+                .returning(move |_org_id, _id| {
+                    Err(bitwarden_api_api::apis::Error::Response(
+                        bitwarden_api_api::apis::ResponseContent {
+                            status: reqwest::StatusCode::NOT_FOUND,
+                            message: String::new(),
+                        },
+                    ))
+                })
+                .once();
+        });
+
+        let result = client(api_client)
+            .delete(organization_id(), connector_id())
+            .await;
+
+        assert!(matches!(result, Err(RotationError::Api(_))));
+    }
+
+    #[tokio::test]
+    async fn assign_target_sends_the_target_system_in_the_body() {
+        let api_client = ApiClient::new_mocked(move |mock| {
+            mock.pam_access_connectors_api
+                .expect_assign_target()
+                .withf(|org_id, id, request| {
+                    *org_id == Uuid::from(organization_id())
+                        && *id == Uuid::from(connector_id())
+                        && request.target_system_id == Uuid::from(target_system_id())
+                })
+                .returning(move |_org_id, _id, _request| Ok(()))
+                .once();
+        });
+
+        client(api_client)
+            .assign_target(organization_id(), connector_id(), target_system_id())
+            .await
+            .expect("assigning succeeds");
+    }
+
+    /// `unassign_target` puts the target system in the path rather than a body, so it takes three
+    /// same-typed identifiers in a row - transposing two would still compile.
+    #[tokio::test]
+    async fn unassign_target_sends_the_identifiers_in_the_right_order() {
+        let api_client = ApiClient::new_mocked(move |mock| {
+            mock.pam_access_connectors_api
+                .expect_unassign_target()
+                .withf(|org_id, id, target_system_id_arg| {
+                    *org_id == Uuid::from(organization_id())
+                        && *id == Uuid::from(connector_id())
+                        && *target_system_id_arg == Uuid::from(target_system_id())
+                })
+                .returning(move |_org_id, _id, _target_system_id| Ok(()))
+                .once();
+        });
+
+        client(api_client)
+            .unassign_target(organization_id(), connector_id(), target_system_id())
+            .await
+            .expect("unassigning succeeds");
+    }
+}

--- a/bitwarden_license/bitwarden-pam/src/rotation/connectors.rs
+++ b/bitwarden_license/bitwarden-pam/src/rotation/connectors.rs
@@ -17,7 +17,7 @@ use wasm_bindgen::prelude::wasm_bindgen;
 
 use super::{
     error::RotationError,
-    models::{AccessConnectorStatus, RotationJobView},
+    models::{AccessConnectorStatus, RotationJob},
     validate::validate_name,
 };
 use crate::{AccessConnectorId, TargetSystemId};
@@ -27,7 +27,7 @@ use crate::{AccessConnectorId, TargetSystemId};
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "wasm", derive(Tsify), tsify(into_wasm_abi, from_wasm_abi))]
 #[serde(rename_all = "camelCase")]
-pub struct AccessConnectorView {
+pub struct AccessConnector {
     /// The connector's unique identifier.
     pub id: AccessConnectorId,
     /// The organization this connector belongs to.
@@ -52,7 +52,7 @@ pub struct AccessConnectorView {
     pub revision_date: DateTime<Utc>,
 }
 
-impl TryFrom<PamAccessConnectorResponseModel> for AccessConnectorView {
+impl TryFrom<PamAccessConnectorResponseModel> for AccessConnector {
     type Error = RotationError;
 
     fn try_from(response: PamAccessConnectorResponseModel) -> Result<Self, Self::Error> {
@@ -82,18 +82,18 @@ impl TryFrom<PamAccessConnectorResponseModel> for AccessConnectorView {
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "wasm", derive(Tsify), tsify(into_wasm_abi, from_wasm_abi))]
 #[serde(rename_all = "camelCase")]
-pub struct AccessConnectorDetailView {
+pub struct AccessConnectorDetail {
     /// The connector itself.
     #[serde(flatten)]
-    pub connector: AccessConnectorView,
+    pub connector: AccessConnector,
     /// The jobs this connector has worked, newest first, carrying the attempts it recorded.
     ///
     /// The server caps how many it returns, so this is recent activity rather than the connector's
     /// whole history.
-    pub jobs: Vec<RotationJobView>,
+    pub jobs: Vec<RotationJob>,
 }
 
-impl TryFrom<PamAccessConnectorDetailResponseModel> for AccessConnectorDetailView {
+impl TryFrom<PamAccessConnectorDetailResponseModel> for AccessConnectorDetail {
     type Error = RotationError;
 
     fn try_from(response: PamAccessConnectorDetailResponseModel) -> Result<Self, Self::Error> {
@@ -102,11 +102,11 @@ impl TryFrom<PamAccessConnectorDetailResponseModel> for AccessConnectorDetailVie
             .clone()
             .unwrap_or_default()
             .into_iter()
-            .map(RotationJobView::try_from)
+            .map(RotationJob::try_from)
             .collect::<Result<Vec<_>, _>>()?;
 
         // The server flattens the connector's own fields onto the detail payload.
-        let connector = AccessConnectorView::try_from(PamAccessConnectorResponseModel {
+        let connector = AccessConnector::try_from(PamAccessConnectorResponseModel {
             object: response.object,
             id: response.id,
             organization_id: response.organization_id,
@@ -127,7 +127,7 @@ impl TryFrom<PamAccessConnectorDetailResponseModel> for AccessConnectorDetailVie
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[cfg_attr(feature = "wasm", derive(Tsify), tsify(into_wasm_abi, from_wasm_abi))]
 #[serde(rename_all = "camelCase")]
-pub struct AccessConnectorRegistrationView {
+pub struct AccessConnectorRegistrationResponse {
     /// The newly registered connector's unique identifier.
     pub id: AccessConnectorId,
     /// The organization the connector was registered in.
@@ -154,8 +154,6 @@ pub struct AccessConnectorRegistrationView {
 #[cfg_attr(feature = "wasm", wasm_bindgen)]
 #[derive(FromClient)]
 pub struct AccessConnectorsClient {
-    /// Registration wraps the organization key for the connector, which is the one connector
-    /// operation that touches key material.
     pub(crate) key_store: KeyStore<KeySlotIds>,
     pub(crate) api_configurations: Arc<ApiConfigurations>,
 }
@@ -166,7 +164,7 @@ impl AccessConnectorsClient {
     pub async fn list(
         &self,
         organization_id: OrganizationId,
-    ) -> Result<Vec<AccessConnectorView>, RotationError> {
+    ) -> Result<Vec<AccessConnector>, RotationError> {
         let response = self
             .api_configurations
             .api_client
@@ -178,7 +176,7 @@ impl AccessConnectorsClient {
             .data
             .unwrap_or_default()
             .into_iter()
-            .map(AccessConnectorView::try_from)
+            .map(AccessConnector::try_from)
             .collect()
     }
 
@@ -187,7 +185,7 @@ impl AccessConnectorsClient {
         &self,
         organization_id: OrganizationId,
         id: AccessConnectorId,
-    ) -> Result<AccessConnectorDetailView, RotationError> {
+    ) -> Result<AccessConnectorDetail, RotationError> {
         let response = self
             .api_configurations
             .api_client
@@ -195,19 +193,19 @@ impl AccessConnectorsClient {
             .get(organization_id.into(), id.into())
             .await?;
 
-        AccessConnectorDetailView::try_from(response)
+        AccessConnectorDetail::try_from(response)
     }
 
     /// Registers a connector and returns its one-time token.
     ///
-    /// The token is the only copy - see [`AccessConnectorRegistrationView::token`] for the handling
-    /// obligation, and the [`registration`](super::registration) module docs for what it contains
-    /// and why.
+    /// The token is the only copy - see [`AccessConnectorRegistrationResponse::token`] for the
+    /// handling obligation, and the [`registration`](super::registration) module docs for what
+    /// it contains and why.
     pub async fn register(
         &self,
         organization_id: OrganizationId,
         name: String,
-    ) -> Result<AccessConnectorRegistrationView, RotationError> {
+    ) -> Result<AccessConnectorRegistrationResponse, RotationError> {
         validate_name(&name)?;
 
         // Derived before the call so a key-store problem fails without leaving a registered
@@ -231,7 +229,7 @@ impl AccessConnectorsClient {
         let api_key_id = require!(response.api_key_id);
         let client_secret = require!(response.client_secret);
 
-        Ok(AccessConnectorRegistrationView {
+        Ok(AccessConnectorRegistrationResponse {
             id: AccessConnectorId::new(require!(response.id)),
             organization_id: OrganizationId::new(require!(response.organization_id)),
             name: response.name.unwrap_or(name),

--- a/bitwarden_license/bitwarden-pam/src/rotation/connectors.rs
+++ b/bitwarden_license/bitwarden-pam/src/rotation/connectors.rs
@@ -141,7 +141,7 @@ pub struct AccessConnectorRegistrationView {
     pub creation_date: DateTime<Utc>,
     /// The credential the operator provisions into the connector's configuration.
     ///
-    /// Format: `0.daemon.<api-key-id>.<client-secret>:<b64-seed>`.
+    /// Format: `0.access-connector.<api-key-id>.<client-secret>:<b64-seed>`.
     ///
     /// **Returned exactly once and unrecoverable.** The server keeps only a hash of the client
     /// secret, and the seed exists nowhere else. Show it for the operator to copy, deliver it

--- a/bitwarden_license/bitwarden-pam/src/rotation/connectors.rs
+++ b/bitwarden_license/bitwarden-pam/src/rotation/connectors.rs
@@ -1,0 +1,333 @@
+use std::sync::Arc;
+
+use bitwarden_api_api::models::{
+    AssignAccessConnectorTargetRequestModel, PamAccessConnectorDetailResponseModel,
+    PamAccessConnectorResponseModel, RegisterAccessConnectorRequestModel,
+};
+use bitwarden_core::{
+    FromClient, OrganizationId, client::ApiConfigurations, key_management::KeySlotIds, require,
+};
+use bitwarden_crypto::KeyStore;
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+#[cfg(feature = "wasm")]
+use tsify::Tsify;
+#[cfg(feature = "wasm")]
+use wasm_bindgen::prelude::wasm_bindgen;
+
+use super::{
+    error::RotationError,
+    models::{AccessConnectorStatus, RotationJobView},
+    validate::validate_name,
+};
+use crate::{AccessConnectorId, TargetSystemId};
+
+/// An access connector: the unattended agent that performs credential rotations for an
+/// organization.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "wasm", derive(Tsify), tsify(into_wasm_abi, from_wasm_abi))]
+#[serde(rename_all = "camelCase")]
+pub struct AccessConnectorView {
+    /// The connector's unique identifier.
+    pub id: AccessConnectorId,
+    /// The organization this connector belongs to.
+    pub organization_id: OrganizationId,
+    /// Display name.
+    ///
+    /// Stored as a plaintext server column, not vault data, and audit rows snapshot it at write
+    /// time - so it is visible to the server and should not be used to carry anything sensitive.
+    pub name: String,
+    /// Lifecycle state.
+    pub status: AccessConnectorStatus,
+    /// Whether the connector is currently connected. Reflects the server's presence check, so it
+    /// can lag reality by up to one heartbeat interval.
+    pub is_connected: bool,
+    /// The last heartbeat the server recorded (UTC), or `None` if it has never connected.
+    pub last_heartbeat_at: Option<DateTime<Utc>>,
+    /// The target systems this connector may rotate.
+    pub assigned_target_system_ids: Vec<TargetSystemId>,
+    /// When the connector was registered (UTC).
+    pub creation_date: DateTime<Utc>,
+    /// When the connector was last modified (UTC).
+    pub revision_date: DateTime<Utc>,
+}
+
+impl TryFrom<PamAccessConnectorResponseModel> for AccessConnectorView {
+    type Error = RotationError;
+
+    fn try_from(response: PamAccessConnectorResponseModel) -> Result<Self, Self::Error> {
+        Ok(Self {
+            id: AccessConnectorId::new(require!(response.id)),
+            organization_id: OrganizationId::new(require!(response.organization_id)),
+            name: require!(response.name),
+            status: require!(response.status).into(),
+            is_connected: response.is_connected.unwrap_or(false),
+            last_heartbeat_at: response
+                .last_heartbeat_at
+                .map(|date| date.parse())
+                .transpose()?,
+            assigned_target_system_ids: response
+                .assigned_target_system_ids
+                .unwrap_or_default()
+                .into_iter()
+                .map(TargetSystemId::new)
+                .collect(),
+            creation_date: require!(response.creation_date).parse()?,
+            revision_date: require!(response.revision_date).parse()?,
+        })
+    }
+}
+
+/// A connector together with its recent rotation activity.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "wasm", derive(Tsify), tsify(into_wasm_abi, from_wasm_abi))]
+#[serde(rename_all = "camelCase")]
+pub struct AccessConnectorDetailView {
+    /// The connector itself.
+    #[serde(flatten)]
+    pub connector: AccessConnectorView,
+    /// The jobs this connector has worked, newest first, carrying the attempts it recorded.
+    ///
+    /// The server caps how many it returns, so this is recent activity rather than the connector's
+    /// whole history.
+    pub jobs: Vec<RotationJobView>,
+}
+
+impl TryFrom<PamAccessConnectorDetailResponseModel> for AccessConnectorDetailView {
+    type Error = RotationError;
+
+    fn try_from(response: PamAccessConnectorDetailResponseModel) -> Result<Self, Self::Error> {
+        let jobs = response
+            .jobs
+            .clone()
+            .unwrap_or_default()
+            .into_iter()
+            .map(RotationJobView::try_from)
+            .collect::<Result<Vec<_>, _>>()?;
+
+        // The server flattens the connector's own fields onto the detail payload.
+        let connector = AccessConnectorView::try_from(PamAccessConnectorResponseModel {
+            object: response.object,
+            id: response.id,
+            organization_id: response.organization_id,
+            name: response.name,
+            status: response.status,
+            is_connected: response.is_connected,
+            last_heartbeat_at: response.last_heartbeat_at,
+            assigned_target_system_ids: response.assigned_target_system_ids,
+            creation_date: response.creation_date,
+            revision_date: response.revision_date,
+        })?;
+
+        Ok(Self { connector, jobs })
+    }
+}
+
+/// The result of registering a connector, including its one-time token.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[cfg_attr(feature = "wasm", derive(Tsify), tsify(into_wasm_abi, from_wasm_abi))]
+#[serde(rename_all = "camelCase")]
+pub struct AccessConnectorRegistrationView {
+    /// The newly registered connector's unique identifier.
+    pub id: AccessConnectorId,
+    /// The organization the connector was registered in.
+    pub organization_id: OrganizationId,
+    /// The connector's display name.
+    pub name: String,
+    /// Lifecycle state. A freshly registered connector is
+    /// [`Enabled`](AccessConnectorStatus::Enabled).
+    pub status: AccessConnectorStatus,
+    /// When the connector was registered (UTC).
+    pub creation_date: DateTime<Utc>,
+    /// The credential the operator provisions into the connector's configuration.
+    ///
+    /// Format: `0.daemon.<api-key-id>.<client-secret>:<b64-seed>`.
+    ///
+    /// **Returned exactly once and unrecoverable.** The server keeps only a hash of the client
+    /// secret, and the seed exists nowhere else. Show it for the operator to copy, deliver it
+    /// out-of-band, and do not persist or log it. If it is lost, delete the connector and register
+    /// again.
+    pub token: String,
+}
+
+/// Client for PAM access connector operations.
+#[cfg_attr(feature = "wasm", wasm_bindgen)]
+#[derive(FromClient)]
+pub struct AccessConnectorsClient {
+    /// Registration wraps the organization key for the connector, which is the one connector
+    /// operation that touches key material.
+    pub(crate) key_store: KeyStore<KeySlotIds>,
+    pub(crate) api_configurations: Arc<ApiConfigurations>,
+}
+
+#[cfg_attr(feature = "wasm", wasm_bindgen)]
+impl AccessConnectorsClient {
+    /// Lists the organization's access connectors.
+    pub async fn list(
+        &self,
+        organization_id: OrganizationId,
+    ) -> Result<Vec<AccessConnectorView>, RotationError> {
+        let response = self
+            .api_configurations
+            .api_client
+            .pam_access_connectors_api()
+            .get_all(organization_id.into())
+            .await?;
+
+        response
+            .data
+            .unwrap_or_default()
+            .into_iter()
+            .map(AccessConnectorView::try_from)
+            .collect()
+    }
+
+    /// Reads one connector with its recent rotation activity.
+    pub async fn get(
+        &self,
+        organization_id: OrganizationId,
+        id: AccessConnectorId,
+    ) -> Result<AccessConnectorDetailView, RotationError> {
+        let response = self
+            .api_configurations
+            .api_client
+            .pam_access_connectors_api()
+            .get(organization_id.into(), id.into())
+            .await?;
+
+        AccessConnectorDetailView::try_from(response)
+    }
+
+    /// Registers a connector and returns its one-time token.
+    ///
+    /// The token is the only copy - see [`AccessConnectorRegistrationView::token`] for the handling
+    /// obligation, and the [`registration`](super::registration) module docs for what it contains
+    /// and why.
+    pub async fn register(
+        &self,
+        organization_id: OrganizationId,
+        name: String,
+    ) -> Result<AccessConnectorRegistrationView, RotationError> {
+        validate_name(&name)?;
+
+        // Derived before the call so a key-store problem fails without leaving a registered
+        // connector the caller has no token for.
+        let secrets = self.registration_secrets(organization_id)?;
+
+        let response = self
+            .api_configurations
+            .api_client
+            .pam_access_connectors_api()
+            .post(
+                organization_id.into(),
+                RegisterAccessConnectorRequestModel {
+                    name: name.clone(),
+                    encrypted_payload: secrets.encrypted_payload.to_string(),
+                    key: secrets.key.to_string(),
+                },
+            )
+            .await?;
+
+        let api_key_id = require!(response.api_key_id);
+        let client_secret = require!(response.client_secret);
+
+        Ok(AccessConnectorRegistrationView {
+            id: AccessConnectorId::new(require!(response.id)),
+            organization_id: OrganizationId::new(require!(response.organization_id)),
+            name: response.name.unwrap_or(name),
+            status: require!(response.status).into(),
+            creation_date: require!(response.creation_date).parse()?,
+            token: secrets.into_token(api_key_id, &client_secret),
+        })
+    }
+
+    /// Re-enables a disabled connector so it can authenticate and claim jobs again.
+    pub async fn enable(
+        &self,
+        organization_id: OrganizationId,
+        id: AccessConnectorId,
+    ) -> Result<(), RotationError> {
+        self.api_configurations
+            .api_client
+            .pam_access_connectors_api()
+            .enable(organization_id.into(), id.into())
+            .await?;
+
+        Ok(())
+    }
+
+    /// Disables a connector: it stops claiming new jobs and its running jobs are released.
+    ///
+    /// Reversible - the credential is retained, so [`enable`](AccessConnectorsClient::enable) puts
+    /// it back to work. To retire a connector for good, use
+    /// [`delete`](AccessConnectorsClient::delete).
+    pub async fn disable(
+        &self,
+        organization_id: OrganizationId,
+        id: AccessConnectorId,
+    ) -> Result<(), RotationError> {
+        self.api_configurations
+            .api_client
+            .pam_access_connectors_api()
+            .disable(organization_id.into(), id.into())
+            .await?;
+
+        Ok(())
+    }
+
+    /// Permanently deletes a connector and invalidates its credential.
+    ///
+    /// The connector held the plaintext organization key in memory, so deletion alone does not
+    /// undo a compromise: rotating the organization key is the remediation if one is suspected.
+    pub async fn delete(
+        &self,
+        organization_id: OrganizationId,
+        id: AccessConnectorId,
+    ) -> Result<(), RotationError> {
+        self.api_configurations
+            .api_client
+            .pam_access_connectors_api()
+            .delete(organization_id.into(), id.into())
+            .await?;
+
+        Ok(())
+    }
+
+    /// Assigns a target system to a connector, so it may rotate credentials against that target.
+    pub async fn assign_target(
+        &self,
+        organization_id: OrganizationId,
+        id: AccessConnectorId,
+        target_system_id: TargetSystemId,
+    ) -> Result<(), RotationError> {
+        self.api_configurations
+            .api_client
+            .pam_access_connectors_api()
+            .assign_target(
+                organization_id.into(),
+                id.into(),
+                AssignAccessConnectorTargetRequestModel {
+                    target_system_id: target_system_id.into(),
+                },
+            )
+            .await?;
+
+        Ok(())
+    }
+
+    /// Removes a target-system assignment from a connector.
+    pub async fn unassign_target(
+        &self,
+        organization_id: OrganizationId,
+        id: AccessConnectorId,
+        target_system_id: TargetSystemId,
+    ) -> Result<(), RotationError> {
+        self.api_configurations
+            .api_client
+            .pam_access_connectors_api()
+            .unassign_target(organization_id.into(), id.into(), target_system_id.into())
+            .await?;
+
+        Ok(())
+    }
+}

--- a/bitwarden_license/bitwarden-pam/src/rotation/error.rs
+++ b/bitwarden_license/bitwarden-pam/src/rotation/error.rs
@@ -1,0 +1,46 @@
+use bitwarden_core::{ApiError, MissingFieldError};
+use bitwarden_crypto::CryptoError;
+use bitwarden_error::bitwarden_error;
+use thiserror::Error;
+
+use super::validate::RotationValidationError;
+
+/// Errors returned from the PAM rotation clients
+/// ([`AccessConnectorsClient`](crate::AccessConnectorsClient),
+/// [`TargetSystemsClient`](crate::TargetSystemsClient) and
+/// [`RotationConfigsClient`](crate::RotationConfigsClient)).
+///
+/// The three clients share one error type because they decode the same payloads and fail the same
+/// ways: a target system's job history is reachable from a connector and from a config alike, so a
+/// malformed job payload fails identically whichever client asked for it.
+#[bitwarden_error(flat)]
+#[derive(Debug, Error)]
+pub enum RotationError {
+    /// The request failed local validation before being sent to the server.
+    #[error(transparent)]
+    Validation(#[from] RotationValidationError),
+    /// The server response was missing a field required to build the requested type.
+    #[error(transparent)]
+    MissingField(#[from] MissingFieldError),
+    /// A date field in the server response could not be parsed.
+    #[error(transparent)]
+    Chrono(#[from] chrono::ParseError),
+    /// A caller passed an enum variant this SDK models only to describe what a *newer server* may
+    /// return - `Unknown` - in a position that has to be written back to the server.
+    ///
+    /// Distinct from [`Validation`](RotationError::Validation): nothing about the caller's intent
+    /// is wrong, the SDK simply cannot name the value on the wire.
+    #[error("Cannot send a variant this SDK version does not recognize to the server")]
+    UnrecognizedVariant,
+    /// The caller is not a member of the organization they addressed, or its key is not in the
+    /// key store. Registering a connector hands it the organization key, so it cannot proceed
+    /// without one.
+    #[error("The organization key is unavailable")]
+    MissingOrganizationKey,
+    /// A cryptographic operation failed while registering a connector.
+    #[error(transparent)]
+    Crypto(#[from] CryptoError),
+    /// A network or (de)serialization error occurred while calling the server.
+    #[error(transparent)]
+    Api(#[from] ApiError),
+}

--- a/bitwarden_license/bitwarden-pam/src/rotation/mod.rs
+++ b/bitwarden_license/bitwarden-pam/src/rotation/mod.rs
@@ -1,0 +1,131 @@
+//! PAM credential rotation operations.
+//!
+//! Credential rotation replaces a managed account's secret on a schedule (or on demand), writing
+//! the new value into both the target system and the vault cipher that holds it. Three things have
+//! to be configured for that to happen, and this module has a client for each:
+//!
+//! - An **access connector** ([`AccessConnectorsClient`]) - the unattended agent that performs
+//!   rotations. Registering one hands it the organization key, wrapped under a one-time token; see
+//!   `AccessConnectorsClient::register` for that contract.
+//! - A **target system** ([`TargetSystemsClient`]) - the thing being rotated against, either an
+//!   integration a connector drives ([`Automatic`](TargetSystemMethod::Automatic)) or a note that
+//!   an operator will do it by hand ([`Manual`](TargetSystemMethod::Manual)). A connector must be
+//!   assigned a target before it can rotate against it.
+//! - A **rotation config** ([`RotationConfigsClient`]), surfaced to operators as a *managed
+//!   credential* - the link between one vault cipher and one target-system account, carrying the
+//!   schedule and the triggers.
+//!
+//! Every route lives under the server's `access-connectors` prefix. Note the vocabulary: the server
+//! and this module say *access connector*, and the standalone agent that consumes the token is the
+//! *rotation daemon*. They are the same actor seen from either end.
+//!
+//! # Reading a rotation's outcome
+//!
+//! A dispatch is a [`RotationJobView`], and each of a connector's goes at it is a
+//! [`RotationAttemptView`]. An attempt reports the target system and the vault separately -
+//! [`sync_state`](RotationAttemptView::sync_state) and
+//! [`cipher_updated`](RotationAttemptView::cipher_updated) - because they can disagree.
+//! [`Indeterminate`](RotationSyncState::Indeterminate) is the case to handle deliberately: the
+//! target may or may not hold the new credential, and no vault write was attempted, so the two are
+//! possibly out of step until the next rotation succeeds.
+//!
+//! # Forward compatibility
+//!
+//! Every enum here carries an `Unknown` variant, so a newer server naming a status this version
+//! does not model degrades to an unrecognized value rather than failing a whole list. Writes are
+//! the exception: sending `Unknown` back is refused with
+//! [`RotationError::UnrecognizedVariant`], since the SDK cannot say what it would mean.
+//!
+//! # Where the rules live
+//!
+//! Requests are validated locally before being sent ([`RotationValidationError`]) so a malformed
+//! name, an unsatisfiable password policy, or a cron that is not Quartz-shaped fails fast rather
+//! than after a round trip. Two pieces of presentation logic live here as well, so every client
+//! renders rotation the same way: [`preset_for_cron`] maps cron expressions to and from named
+//! presets, and [`rotation_config_actions`] derives which actions a config currently offers. The
+//! server remains authoritative on both - notably the minimum rotation interval, which is
+//! deliberately not duplicated here.
+
+use std::sync::Arc;
+
+use bitwarden_core::{FromClient, client::ApiConfigurations, key_management::KeySlotIds};
+use bitwarden_crypto::KeyStore;
+#[cfg(feature = "wasm")]
+use wasm_bindgen::prelude::wasm_bindgen;
+
+mod actions;
+mod configs;
+mod connectors;
+mod error;
+mod models;
+mod registration;
+mod schedule;
+mod target_systems;
+mod validate;
+
+pub use actions::{RotationConfigActions, rotation_config_actions};
+pub use configs::{
+    RotationConfigCreateRequest, RotationConfigDetailView, RotationConfigUpdateRequest,
+    RotationConfigView, RotationConfigsClient,
+};
+pub use connectors::{
+    AccessConnectorDetailView, AccessConnectorRegistrationView, AccessConnectorView,
+    AccessConnectorsClient,
+};
+pub use error::RotationError;
+pub use models::{
+    AccessConnectorStatus, PasswordPolicy, RotationAttemptStatus, RotationAttemptView,
+    RotationJobStatus, RotationJobView, RotationSource, RotationSyncState,
+    SessionTerminationOutcome, TargetSystemKind, TargetSystemMethod, TargetSystemStatus,
+};
+pub use registration::{ConnectorToken, ConnectorTokenInvalidError};
+pub use schedule::{
+    QuartzSchedulePreset, RotationScheduleClient, is_likely_quartz_cron, preset_for_cron,
+};
+pub use target_systems::{
+    TargetSystemCreateRequest, TargetSystemUpdateRequest, TargetSystemView, TargetSystemsClient,
+};
+pub use validate::RotationValidationError;
+
+/// Entry point for PAM credential rotation.
+///
+/// Groups the three configuration surfaces rather than hanging eight accessors off
+/// [`PamClient`](crate::PamClient), matching how the server groups the routes.
+#[cfg_attr(feature = "wasm", wasm_bindgen)]
+#[derive(Clone, FromClient)]
+pub struct RotationClient {
+    pub(crate) key_store: KeyStore<KeySlotIds>,
+    pub(crate) api_configurations: Arc<ApiConfigurations>,
+}
+
+#[cfg_attr(feature = "wasm", wasm_bindgen)]
+impl RotationClient {
+    /// Access connector operations: register, list, enable/disable, delete, and target assignment.
+    pub fn connectors(&self) -> AccessConnectorsClient {
+        AccessConnectorsClient {
+            // Registering a connector wraps the organization key for it, so this is the one
+            // rotation sub-client that needs key material.
+            key_store: self.key_store.clone(),
+            api_configurations: self.api_configurations.clone(),
+        }
+    }
+
+    /// Target system operations.
+    pub fn target_systems(&self) -> TargetSystemsClient {
+        TargetSystemsClient {
+            api_configurations: self.api_configurations.clone(),
+        }
+    }
+
+    /// Managed credential (rotation config) operations.
+    pub fn configs(&self) -> RotationConfigsClient {
+        RotationConfigsClient {
+            api_configurations: self.api_configurations.clone(),
+        }
+    }
+
+    /// Quartz cron schedule helpers. Pure functions - no network access.
+    pub fn schedule(&self) -> RotationScheduleClient {
+        RotationScheduleClient
+    }
+}

--- a/bitwarden_license/bitwarden-pam/src/rotation/mod.rs
+++ b/bitwarden_license/bitwarden-pam/src/rotation/mod.rs
@@ -15,16 +15,15 @@
 //!   credential* - the link between one vault cipher and one target-system account, carrying the
 //!   schedule and the triggers.
 //!
-//! Every route lives under the server's `access-connectors` prefix. Note the vocabulary: the server
-//! and this module say *access connector*, and the standalone agent that consumes the token is the
-//! *rotation daemon*. They are the same actor seen from either end.
+//! Every route lives under the server's `access-connectors` prefix. The standalone agent that
+//! consumes the token is also called the *access connector* - the same actor seen from either end.
 //!
 //! # Reading a rotation's outcome
 //!
-//! A dispatch is a [`RotationJobView`], and each of a connector's goes at it is a
-//! [`RotationAttemptView`]. An attempt reports the target system and the vault separately -
-//! [`sync_state`](RotationAttemptView::sync_state) and
-//! [`cipher_updated`](RotationAttemptView::cipher_updated) - because they can disagree.
+//! A dispatch is a [`RotationJob`], and each of a connector's goes at it is a
+//! [`RotationAttempt`]. An attempt reports the target system and the vault separately -
+//! [`sync_state`](RotationAttempt::sync_state) and
+//! [`cipher_updated`](RotationAttempt::cipher_updated) - because they can disagree.
 //! [`Indeterminate`](RotationSyncState::Indeterminate) is the case to handle deliberately: the
 //! target may or may not hold the new credential, and no vault write was attempted, so the two are
 //! possibly out of step until the next rotation succeeds.
@@ -65,32 +64,29 @@ mod validate;
 
 pub use actions::{RotationConfigActions, rotation_config_actions};
 pub use configs::{
-    RotationConfigCreateRequest, RotationConfigDetailView, RotationConfigUpdateRequest,
-    RotationConfigView, RotationConfigsClient,
+    RotationConfig, RotationConfigCreateRequest, RotationConfigDetail, RotationConfigUpdateRequest,
+    RotationConfigsClient,
 };
 pub use connectors::{
-    AccessConnectorDetailView, AccessConnectorRegistrationView, AccessConnectorView,
+    AccessConnector, AccessConnectorDetail, AccessConnectorRegistrationResponse,
     AccessConnectorsClient,
 };
 pub use error::RotationError;
 pub use models::{
-    AccessConnectorStatus, PasswordPolicy, RotationAttemptStatus, RotationAttemptView,
-    RotationJobStatus, RotationJobView, RotationSource, RotationSyncState,
-    SessionTerminationOutcome, TargetSystemKind, TargetSystemMethod, TargetSystemStatus,
+    AccessConnectorStatus, PasswordPolicy, RotationAttempt, RotationAttemptStatus, RotationJob,
+    RotationJobStatus, RotationSource, RotationSyncState, SessionTerminationOutcome,
+    TargetSystemKind, TargetSystemMethod, TargetSystemStatus,
 };
 pub use registration::{ConnectorToken, ConnectorTokenInvalidError};
 pub use schedule::{
     QuartzSchedulePreset, RotationScheduleClient, is_likely_quartz_cron, preset_for_cron,
 };
 pub use target_systems::{
-    TargetSystemCreateRequest, TargetSystemUpdateRequest, TargetSystemView, TargetSystemsClient,
+    TargetSystem, TargetSystemCreateRequest, TargetSystemUpdateRequest, TargetSystemsClient,
 };
 pub use validate::RotationValidationError;
 
 /// Entry point for PAM credential rotation.
-///
-/// Groups the three configuration surfaces rather than hanging eight accessors off
-/// [`PamClient`](crate::PamClient), matching how the server groups the routes.
 #[cfg_attr(feature = "wasm", wasm_bindgen)]
 #[derive(Clone, FromClient)]
 pub struct RotationClient {
@@ -100,11 +96,9 @@ pub struct RotationClient {
 
 #[cfg_attr(feature = "wasm", wasm_bindgen)]
 impl RotationClient {
-    /// Access connector operations: register, list, enable/disable, delete, and target assignment.
+    /// Access connector operations.
     pub fn connectors(&self) -> AccessConnectorsClient {
         AccessConnectorsClient {
-            // Registering a connector wraps the organization key for it, so this is the one
-            // rotation sub-client that needs key material.
             key_store: self.key_store.clone(),
             api_configurations: self.api_configurations.clone(),
         }

--- a/bitwarden_license/bitwarden-pam/src/rotation/models.rs
+++ b/bitwarden_license/bitwarden-pam/src/rotation/models.rs
@@ -215,7 +215,7 @@ pub enum RotationAttemptStatus {
     Executing,
     /// The target system accepted the new credential.
     Rotated,
-    /// The attempt failed; see [`RotationAttemptView::failure_reason`].
+    /// The attempt failed; see [`RotationAttempt::failure_reason`].
     Errored,
     /// The attempt was abandoned, for example because the connector was revoked mid-job.
     Abandoned,
@@ -341,7 +341,7 @@ impl From<PasswordPolicy> for PamPasswordPolicyRequestModel {
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "wasm", derive(Tsify), tsify(into_wasm_abi, from_wasm_abi))]
 #[serde(rename_all = "camelCase")]
-pub struct RotationAttemptView {
+pub struct RotationAttempt {
     /// The attempt's unique identifier.
     pub id: RotationAttemptId,
     /// The job this attempt belongs to.
@@ -368,7 +368,7 @@ pub struct RotationAttemptView {
     pub ended_at: Option<DateTime<Utc>>,
 }
 
-impl TryFrom<PamRotationAttemptResponseModel> for RotationAttemptView {
+impl TryFrom<PamRotationAttemptResponseModel> for RotationAttempt {
     type Error = RotationError;
 
     fn try_from(response: PamRotationAttemptResponseModel) -> Result<Self, Self::Error> {
@@ -398,7 +398,7 @@ impl TryFrom<PamRotationAttemptResponseModel> for RotationAttemptView {
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "wasm", derive(Tsify), tsify(into_wasm_abi, from_wasm_abi))]
 #[serde(rename_all = "camelCase")]
-pub struct RotationJobView {
+pub struct RotationJob {
     /// The job's unique identifier.
     pub id: RotationJobId,
     /// The rotation config this job was dispatched for.
@@ -418,10 +418,10 @@ pub struct RotationJobView {
     /// When the job's claim deadline lapses (UTC), after which it is considered timed out.
     pub expires_at: Option<DateTime<Utc>>,
     /// The job's attempts, oldest first.
-    pub attempts: Vec<RotationAttemptView>,
+    pub attempts: Vec<RotationAttempt>,
 }
 
-impl TryFrom<PamRotationJobResponseModel> for RotationJobView {
+impl TryFrom<PamRotationJobResponseModel> for RotationJob {
     type Error = RotationError;
 
     fn try_from(response: PamRotationJobResponseModel) -> Result<Self, Self::Error> {
@@ -444,7 +444,7 @@ impl TryFrom<PamRotationJobResponseModel> for RotationJobView {
                 .attempts
                 .unwrap_or_default()
                 .into_iter()
-                .map(RotationAttemptView::try_from)
+                .map(RotationAttempt::try_from)
                 .collect::<Result<Vec<_>, _>>()?,
         })
     }

--- a/bitwarden_license/bitwarden-pam/src/rotation/models.rs
+++ b/bitwarden_license/bitwarden-pam/src/rotation/models.rs
@@ -1,0 +1,451 @@
+use bitwarden_api_api::models::{
+    PamAccessConnectorStatus as ApiAccessConnectorStatus, PamPasswordPolicyRequestModel,
+    PamPasswordPolicyResponseModel, PamRotationAttemptResponseModel,
+    PamRotationAttemptStatus as ApiRotationAttemptStatus, PamRotationJobResponseModel,
+    PamRotationJobStatus as ApiRotationJobStatus, PamRotationSource as ApiRotationSource,
+    PamRotationSyncState as ApiRotationSyncState,
+    PamSessionTerminationOutcome as ApiSessionTerminationOutcome,
+    PamTargetSystemKind as ApiTargetSystemKind, PamTargetSystemMethod as ApiTargetSystemMethod,
+    PamTargetSystemStatus as ApiTargetSystemStatus,
+};
+use bitwarden_core::require;
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+#[cfg(feature = "wasm")]
+use tsify::Tsify;
+
+use super::error::RotationError;
+use crate::{AccessConnectorId, RotationAttemptId, RotationConfigId, RotationJobId};
+
+/// Lifecycle state of an access connector.
+///
+/// [`Disabled`](AccessConnectorStatus::Disabled) is **reversible**: re-enabling flips it back to
+/// [`Enabled`](AccessConnectorStatus::Enabled). Removing a connector entirely - which invalidates
+/// its credential - is a delete, not a disable. Because a connector holds the plaintext
+/// organization key, rotating the organization key remains the remediation for a suspected
+/// compromise.
+#[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "wasm", derive(Tsify), tsify(into_wasm_abi, from_wasm_abi))]
+#[serde(rename_all = "snake_case")]
+pub enum AccessConnectorStatus {
+    /// The connector may authenticate and claim rotation jobs.
+    Enabled,
+    /// The connector cannot claim new jobs and its running jobs are released. Its credential is
+    /// retained so it can be re-enabled.
+    Disabled,
+    /// A status this SDK version does not recognize. Kept as a distinct variant so listing
+    /// connectors never fails against a newer server.
+    Unknown,
+}
+
+impl From<ApiAccessConnectorStatus> for AccessConnectorStatus {
+    fn from(status: ApiAccessConnectorStatus) -> Self {
+        match status {
+            ApiAccessConnectorStatus::Enabled => Self::Enabled,
+            ApiAccessConnectorStatus::Disabled => Self::Disabled,
+            ApiAccessConnectorStatus::__Unknown(_) => Self::Unknown,
+        }
+    }
+}
+
+/// How a target system's credential is rotated.
+#[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "wasm", derive(Tsify), tsify(into_wasm_abi, from_wasm_abi))]
+#[serde(rename_all = "snake_case")]
+pub enum TargetSystemMethod {
+    /// A connector writes the new secret directly into the target system.
+    Automatic,
+    /// An operator applies the new credential out-of-band; the config records the event.
+    Manual,
+    /// A method this SDK version does not recognize.
+    Unknown,
+}
+
+impl From<ApiTargetSystemMethod> for TargetSystemMethod {
+    fn from(method: ApiTargetSystemMethod) -> Self {
+        match method {
+            ApiTargetSystemMethod::Automatic => Self::Automatic,
+            ApiTargetSystemMethod::Manual => Self::Manual,
+            ApiTargetSystemMethod::__Unknown(_) => Self::Unknown,
+        }
+    }
+}
+
+impl TryFrom<TargetSystemMethod> for ApiTargetSystemMethod {
+    type Error = RotationError;
+
+    fn try_from(method: TargetSystemMethod) -> Result<Self, Self::Error> {
+        match method {
+            TargetSystemMethod::Automatic => Ok(Self::Automatic),
+            TargetSystemMethod::Manual => Ok(Self::Manual),
+            // A caller cannot ask the server to store a method this SDK could not name in the
+            // first place; sending `__Unknown` would serialize a meaningless tinyint.
+            TargetSystemMethod::Unknown => Err(RotationError::UnrecognizedVariant),
+        }
+    }
+}
+
+/// The technology a target system represents. Only meaningful when the target system's method is
+/// [`Automatic`](TargetSystemMethod::Automatic) - a manual rotation has no integration.
+#[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "wasm", derive(Tsify), tsify(into_wasm_abi, from_wasm_abi))]
+#[serde(rename_all = "snake_case")]
+pub enum TargetSystemKind {
+    /// Entra ID / Azure AD service-account password rotation.
+    Entra,
+    /// SQL Server login password rotation.
+    Mssql,
+    /// An operator-supplied script run by the connector.
+    CustomScript,
+    /// A kind this SDK version does not recognize.
+    Unknown,
+}
+
+impl From<ApiTargetSystemKind> for TargetSystemKind {
+    fn from(kind: ApiTargetSystemKind) -> Self {
+        match kind {
+            ApiTargetSystemKind::Entra => Self::Entra,
+            ApiTargetSystemKind::Mssql => Self::Mssql,
+            ApiTargetSystemKind::CustomScript => Self::CustomScript,
+            ApiTargetSystemKind::__Unknown(_) => Self::Unknown,
+        }
+    }
+}
+
+impl TryFrom<TargetSystemKind> for ApiTargetSystemKind {
+    type Error = RotationError;
+
+    fn try_from(kind: TargetSystemKind) -> Result<Self, Self::Error> {
+        match kind {
+            TargetSystemKind::Entra => Ok(Self::Entra),
+            TargetSystemKind::Mssql => Ok(Self::Mssql),
+            TargetSystemKind::CustomScript => Ok(Self::CustomScript),
+            TargetSystemKind::Unknown => Err(RotationError::UnrecognizedVariant),
+        }
+    }
+}
+
+/// Lifecycle state of a target system.
+#[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "wasm", derive(Tsify), tsify(into_wasm_abi, from_wasm_abi))]
+#[serde(rename_all = "snake_case")]
+pub enum TargetSystemStatus {
+    /// The target system accepts rotation jobs.
+    Active,
+    /// No new rotation jobs are dispatched; jobs already in flight run to completion.
+    Disabled,
+    /// A status this SDK version does not recognize.
+    Unknown,
+}
+
+impl From<ApiTargetSystemStatus> for TargetSystemStatus {
+    fn from(status: ApiTargetSystemStatus) -> Self {
+        match status {
+            ApiTargetSystemStatus::Active => Self::Active,
+            ApiTargetSystemStatus::Disabled => Self::Disabled,
+            ApiTargetSystemStatus::__Unknown(_) => Self::Unknown,
+        }
+    }
+}
+
+/// What triggered a rotation job.
+#[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "wasm", derive(Tsify), tsify(into_wasm_abi, from_wasm_abi))]
+#[serde(rename_all = "snake_case")]
+pub enum RotationSource {
+    /// The cron schedule fired.
+    Scheduled,
+    /// An operator asked for a rotation now.
+    OnDemand,
+    /// An access lease ended on a config with `rotate_on_access_end` set.
+    AccessEnd,
+    /// A source this SDK version does not recognize.
+    Unknown,
+}
+
+impl From<ApiRotationSource> for RotationSource {
+    fn from(source: ApiRotationSource) -> Self {
+        match source {
+            ApiRotationSource::Scheduled => Self::Scheduled,
+            ApiRotationSource::OnDemand => Self::OnDemand,
+            ApiRotationSource::AccessEnd => Self::AccessEnd,
+            ApiRotationSource::__Unknown(_) => Self::Unknown,
+        }
+    }
+}
+
+/// Overall status of a rotation job.
+#[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "wasm", derive(Tsify), tsify(into_wasm_abi, from_wasm_abi))]
+#[serde(rename_all = "snake_case")]
+pub enum RotationJobStatus {
+    /// Queued, not yet claimed by a connector.
+    Pending,
+    /// A connector is executing the job.
+    Claimed,
+    /// Every attempt succeeded and the vault cipher has been updated.
+    Succeeded,
+    /// The job exhausted its retry budget.
+    Failed,
+    /// The connector did not report back within the deadline.
+    TimedOut,
+    /// A status this SDK version does not recognize.
+    Unknown,
+}
+
+impl From<ApiRotationJobStatus> for RotationJobStatus {
+    fn from(status: ApiRotationJobStatus) -> Self {
+        match status {
+            ApiRotationJobStatus::Pending => Self::Pending,
+            ApiRotationJobStatus::Claimed => Self::Claimed,
+            ApiRotationJobStatus::Succeeded => Self::Succeeded,
+            ApiRotationJobStatus::Failed => Self::Failed,
+            ApiRotationJobStatus::TimedOut => Self::TimedOut,
+            ApiRotationJobStatus::__Unknown(_) => Self::Unknown,
+        }
+    }
+}
+
+/// Per-attempt outcome within a rotation job.
+#[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "wasm", derive(Tsify), tsify(into_wasm_abi, from_wasm_abi))]
+#[serde(rename_all = "snake_case")]
+pub enum RotationAttemptStatus {
+    /// The connector is actively running this attempt.
+    Executing,
+    /// The target system accepted the new credential.
+    Rotated,
+    /// The attempt failed; see [`RotationAttemptView::failure_reason`].
+    Errored,
+    /// The attempt was abandoned, for example because the connector was revoked mid-job.
+    Abandoned,
+    /// A status this SDK version does not recognize.
+    Unknown,
+}
+
+impl From<ApiRotationAttemptStatus> for RotationAttemptStatus {
+    fn from(status: ApiRotationAttemptStatus) -> Self {
+        match status {
+            ApiRotationAttemptStatus::Executing => Self::Executing,
+            ApiRotationAttemptStatus::Rotated => Self::Rotated,
+            ApiRotationAttemptStatus::Errored => Self::Errored,
+            ApiRotationAttemptStatus::Abandoned => Self::Abandoned,
+            ApiRotationAttemptStatus::__Unknown(_) => Self::Unknown,
+        }
+    }
+}
+
+/// Whether the target system ended up holding the rotated credential.
+#[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "wasm", derive(Tsify), tsify(into_wasm_abi, from_wasm_abi))]
+#[serde(rename_all = "snake_case")]
+pub enum RotationSyncState {
+    /// The target system was not modified, so no vault write was attempted.
+    TargetUnchanged,
+    /// The target system accepted the new credential and the vault cipher was updated.
+    TargetUpdated,
+    /// The target-system call may or may not have applied (network error or timeout). No vault
+    /// write was attempted, so the vault and the target may disagree until the next rotation.
+    Indeterminate,
+    /// A state this SDK version does not recognize.
+    Unknown,
+}
+
+impl From<ApiRotationSyncState> for RotationSyncState {
+    fn from(state: ApiRotationSyncState) -> Self {
+        match state {
+            ApiRotationSyncState::TargetUnchanged => Self::TargetUnchanged,
+            ApiRotationSyncState::TargetUpdated => Self::TargetUpdated,
+            ApiRotationSyncState::Indeterminate => Self::Indeterminate,
+            ApiRotationSyncState::__Unknown(_) => Self::Unknown,
+        }
+    }
+}
+
+/// Whether the connector terminated the account's active sessions after rotating.
+#[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "wasm", derive(Tsify), tsify(into_wasm_abi, from_wasm_abi))]
+#[serde(rename_all = "snake_case")]
+pub enum SessionTerminationOutcome {
+    /// Session termination was not requested for this config.
+    NotRequested,
+    /// The sessions were terminated.
+    Terminated,
+    /// Termination was requested but failed. The rotation itself still succeeded.
+    TermFailed,
+    /// An outcome this SDK version does not recognize.
+    Unknown,
+}
+
+impl From<ApiSessionTerminationOutcome> for SessionTerminationOutcome {
+    fn from(outcome: ApiSessionTerminationOutcome) -> Self {
+        match outcome {
+            ApiSessionTerminationOutcome::NotRequested => Self::NotRequested,
+            ApiSessionTerminationOutcome::Terminated => Self::Terminated,
+            ApiSessionTerminationOutcome::TermFailed => Self::TermFailed,
+            ApiSessionTerminationOutcome::__Unknown(_) => Self::Unknown,
+        }
+    }
+}
+
+/// Password generation policy for a target system.
+///
+/// For [`Automatic`](TargetSystemMethod::Automatic) systems the connector generates the new
+/// credential under these constraints. For [`Manual`](TargetSystemMethod::Manual) systems they are
+/// the rules the operator is expected to follow when rotating by hand - nothing enforces them.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "wasm", derive(Tsify), tsify(into_wasm_abi, from_wasm_abi))]
+#[serde(rename_all = "camelCase")]
+pub struct PasswordPolicy {
+    /// Minimum length of a generated credential.
+    pub min_length: i32,
+    /// Maximum length of a generated credential.
+    pub max_length: i32,
+    /// Whether generated credentials may include `A-Z`.
+    pub include_uppercase: bool,
+    /// Whether generated credentials may include `a-z`.
+    pub include_lowercase: bool,
+    /// Whether generated credentials may include `0-9`.
+    pub include_digits: bool,
+    /// Whether generated credentials may include punctuation.
+    pub include_symbols: bool,
+}
+
+impl From<PamPasswordPolicyResponseModel> for PasswordPolicy {
+    fn from(policy: PamPasswordPolicyResponseModel) -> Self {
+        Self {
+            min_length: policy.min_length.unwrap_or_default(),
+            max_length: policy.max_length.unwrap_or_default(),
+            include_uppercase: policy.include_uppercase.unwrap_or(false),
+            include_lowercase: policy.include_lowercase.unwrap_or(false),
+            include_digits: policy.include_digits.unwrap_or(false),
+            include_symbols: policy.include_symbols.unwrap_or(false),
+        }
+    }
+}
+
+impl From<PasswordPolicy> for PamPasswordPolicyRequestModel {
+    fn from(policy: PasswordPolicy) -> Self {
+        Self {
+            min_length: policy.min_length,
+            max_length: policy.max_length,
+            include_uppercase: Some(policy.include_uppercase),
+            include_lowercase: Some(policy.include_lowercase),
+            include_digits: Some(policy.include_digits),
+            include_symbols: Some(policy.include_symbols),
+        }
+    }
+}
+
+/// One connector's execution of the rotation sequence for a job.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "wasm", derive(Tsify), tsify(into_wasm_abi, from_wasm_abi))]
+#[serde(rename_all = "camelCase")]
+pub struct RotationAttemptView {
+    /// The attempt's unique identifier.
+    pub id: RotationAttemptId,
+    /// The job this attempt belongs to.
+    pub job_id: RotationJobId,
+    /// The connector that ran this attempt. `None` on a payload the server did not attribute.
+    pub claimed_by_access_connector_id: Option<AccessConnectorId>,
+    /// Current execution state of the attempt.
+    pub status: RotationAttemptStatus,
+    /// Operator-facing failure reason, set when the attempt errored or was abandoned.
+    ///
+    /// Server-authored text describing the *failure*, never the credential - safe to render, but
+    /// it originates off-client, so treat it as untrusted for anything beyond display.
+    pub failure_reason: Option<String>,
+    /// Whether the vault cipher was written with the rotated credential.
+    pub cipher_updated: bool,
+    /// Whether the target system ended up holding the rotated credential. `None` until the
+    /// attempt resolves.
+    pub sync_state: Option<RotationSyncState>,
+    /// Whether active sessions were terminated after rotating. `None` until the attempt resolves.
+    pub session_termination: Option<SessionTerminationOutcome>,
+    /// When the connector began this attempt (UTC).
+    pub started_at: DateTime<Utc>,
+    /// When the attempt resolved (UTC), or `None` while it is still executing.
+    pub ended_at: Option<DateTime<Utc>>,
+}
+
+impl TryFrom<PamRotationAttemptResponseModel> for RotationAttemptView {
+    type Error = RotationError;
+
+    fn try_from(response: PamRotationAttemptResponseModel) -> Result<Self, Self::Error> {
+        Ok(Self {
+            id: RotationAttemptId::new(require!(response.id)),
+            job_id: RotationJobId::new(require!(response.job_id)),
+            claimed_by_access_connector_id: response
+                .claimed_by_access_connector_id
+                .map(AccessConnectorId::new),
+            status: require!(response.status).into(),
+            failure_reason: response.failure_reason,
+            cipher_updated: response.cipher_updated.unwrap_or(false),
+            sync_state: response.sync_state.map(Into::into),
+            session_termination: response.session_termination.map(Into::into),
+            started_at: require!(response.creation_date).parse()?,
+            ended_at: response
+                .resolved_date
+                .map(|date| date.parse())
+                .transpose()?,
+        })
+    }
+}
+
+/// One dispatch of the rotation workflow for a config.
+///
+/// A job may carry several attempts - retries, or several assigned connectors racing to claim it.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "wasm", derive(Tsify), tsify(into_wasm_abi, from_wasm_abi))]
+#[serde(rename_all = "camelCase")]
+pub struct RotationJobView {
+    /// The job's unique identifier.
+    pub id: RotationJobId,
+    /// The rotation config this job was dispatched for.
+    pub rotation_config_id: RotationConfigId,
+    /// What triggered the job.
+    pub source: RotationSource,
+    /// Current lifecycle state of the job.
+    pub status: RotationJobStatus,
+    /// The connector holding the job, when one has claimed it.
+    pub claimed_by_access_connector_id: Option<AccessConnectorId>,
+    /// When the job was claimed (UTC), or `None` while it is still pending.
+    pub claimed_at: Option<DateTime<Utc>>,
+    /// When the job was queued (UTC).
+    pub created_at: DateTime<Utc>,
+    /// The earliest a connector may claim this job again after a released or failed attempt (UTC).
+    pub next_claimable_at: Option<DateTime<Utc>>,
+    /// When the job's claim deadline lapses (UTC), after which it is considered timed out.
+    pub expires_at: Option<DateTime<Utc>>,
+    /// The job's attempts, oldest first.
+    pub attempts: Vec<RotationAttemptView>,
+}
+
+impl TryFrom<PamRotationJobResponseModel> for RotationJobView {
+    type Error = RotationError;
+
+    fn try_from(response: PamRotationJobResponseModel) -> Result<Self, Self::Error> {
+        Ok(Self {
+            id: RotationJobId::new(require!(response.id)),
+            rotation_config_id: RotationConfigId::new(require!(response.rotation_config_id)),
+            source: require!(response.source).into(),
+            status: require!(response.status).into(),
+            claimed_by_access_connector_id: response
+                .claimed_by_access_connector_id
+                .map(AccessConnectorId::new),
+            claimed_at: response.claimed_at.map(|date| date.parse()).transpose()?,
+            created_at: require!(response.creation_date).parse()?,
+            next_claimable_at: response
+                .next_claimable_at
+                .map(|date| date.parse())
+                .transpose()?,
+            expires_at: response.expires_at.map(|date| date.parse()).transpose()?,
+            attempts: response
+                .attempts
+                .unwrap_or_default()
+                .into_iter()
+                .map(RotationAttemptView::try_from)
+                .collect::<Result<Vec<_>, _>>()?,
+        })
+    }
+}

--- a/bitwarden_license/bitwarden-pam/src/rotation/registration.rs
+++ b/bitwarden_license/bitwarden-pam/src/rotation/registration.rs
@@ -63,8 +63,8 @@ const DERIVE_INFO: &str = "sm-access-token";
 const TOKEN_VERSION: &str = "0";
 
 /// The token's client-kind segment. The connector builds its OAuth `client_id` as
-/// `daemon.<api_key_id>`, so this segment and that prefix have to agree.
-const TOKEN_CLIENT_KIND: &str = "daemon";
+/// `access-connector.<api_key_id>`, so this segment and that prefix have to agree.
+const TOKEN_CLIENT_KIND: &str = "access-connector";
 
 /// The locally-derived half of a registration, held between generating the key material and
 /// assembling the token around the server's response.
@@ -82,7 +82,7 @@ pub(super) struct RegistrationSecrets {
 impl RegistrationSecrets {
     /// Assembles the one-time connector token from the server's response and the local seed.
     ///
-    /// Format: `0.daemon.<api-key-id>.<client-secret>:<b64-seed>`.
+    /// Format: `0.access-connector.<api-key-id>.<client-secret>:<b64-seed>`.
     ///
     /// Consumes `self` so the seed cannot be used to mint a second token for the same connector.
     pub(super) fn into_token(self, api_key_id: Uuid, client_secret: &str) -> String {
@@ -106,7 +106,7 @@ pub enum ConnectorTokenInvalidError {
     /// The version segment was not `0`.
     #[error("Is the wrong version")]
     WrongVersion,
-    /// The client-kind segment was not `daemon`.
+    /// The client-kind segment was not `access-connector`.
     #[error("Has the wrong prefix")]
     WrongPrefix,
     /// The API key id segment was not a UUID.
@@ -133,7 +133,8 @@ pub enum ConnectorTokenInvalidError {
 /// first place. The rotation daemon carries its own copy of this parser and should converge on this
 /// one.
 pub struct ConnectorToken {
-    /// The API key identifier. The connector's OAuth `client_id` is `daemon.<api_key_id>`.
+    /// The API key identifier. The connector's OAuth `client_id` is
+    /// `access-connector.<api_key_id>`.
     pub api_key_id: Uuid,
     /// The OAuth client secret. Redacted from [`fmt::Debug`].
     pub client_secret: String,
@@ -327,11 +328,35 @@ mod tests {
         let token = secrets.into_token(api_key_id, "secret");
 
         let (prefix, seed_b64) = token.split_once(':').expect("a `:` separates the seed");
-        assert_eq!(prefix, format!("0.daemon.{api_key_id}.secret"));
+        assert_eq!(prefix, format!("0.access-connector.{api_key_id}.secret"));
 
         // The connector requires exactly 16 bytes; a different length is rejected at parse time.
         let seed: B64 = seed_b64.parse().expect("the suffix is base64");
         assert_eq!(seed.as_bytes().len(), 16);
+    }
+
+    /// The client-kind segment was renamed from `daemon` to `access-connector` as a clean break:
+    /// the parser must reject the old segment outright rather than still accepting it.
+    #[test]
+    fn a_token_with_the_old_daemon_kind_segment_is_rejected() {
+        let client = client_with_org_key(SymmetricCryptoKey::make(
+            SymmetricKeyAlgorithm::Aes256CbcHmac,
+        ));
+        let secrets = client
+            .registration_secrets(organization_id())
+            .expect("the org key is in the store");
+        let token = secrets.into_token(uuid!("22222222-2222-2222-2222-222222222222"), "secret");
+
+        // A well-formed token, but with the retired `daemon` kind segment in place of
+        // `access-connector`.
+        let stale_token = token.replacen("access-connector", "daemon", 1);
+
+        let result = ConnectorToken::from_str(&stale_token);
+
+        assert!(matches!(
+            result,
+            Err(ConnectorTokenInvalidError::WrongPrefix)
+        ));
     }
 
     /// The `key` field is not read during registration, so a mistake in it would go unnoticed until

--- a/bitwarden_license/bitwarden-pam/src/rotation/registration.rs
+++ b/bitwarden_license/bitwarden-pam/src/rotation/registration.rs
@@ -1,0 +1,406 @@
+//! The cryptographic half of registering an access connector.
+//!
+//! A connector runs unattended, outside any user's session, so it cannot unlock a vault the way a
+//! client does. Registration therefore hands it the organization key up front, wrapped so that only
+//! the holder of one operator-provisioned token can unwrap it:
+//!
+//! 1. A fresh 16-byte seed is generated. Base64-encoded, it becomes the `:` suffix of the token.
+//! 2. A symmetric key is derived from that seed via
+//!    [`derive_shareable_key`](bitwarden_crypto::derive_shareable_key), using [`DERIVE_NAME`] and
+//!    [`DERIVE_INFO`].
+//! 3. `encryptedPayload` - `{"encryptionKey":"<org key b64>"}` - is encrypted under the derived
+//!    key. The connector re-derives that key from the seed in its token and unwraps the
+//!    organization key.
+//! 4. `key` is the derived key's base64, encrypted under the organization key. Nothing in the
+//!    registration flow reads it back; it exists so an organization-key holder can re-wrap the
+//!    connector's key during an organization-key rotation.
+//!
+//! # Why the derivation constants are what they are
+//!
+//! [`DERIVE_NAME`] and [`DERIVE_INFO`] must match what the connector computes from its token, or
+//! the connector derives a different key, `encryptedPayload` fails to decrypt, and it can never
+//! authenticate. They are the same pair Secrets Manager access tokens use - see
+//! [`AccessToken`](bitwarden_core::auth::AccessToken), which parses the identical format - and the
+//! same pair the rotation daemon's own token parser uses.
+//!
+//! This is the single definition of that contract. It previously lived in the web client in
+//! TypeScript, with a different `info` string, which meant a connector registered from the web
+//! derived a key the connector itself could not reproduce.
+//!
+//! # Handling the result
+//!
+//! The token is returned exactly once and is never recoverable: the server stores only a hash of
+//! the client secret, and the seed never leaves this function except inside the token. A caller
+//! must show it once for the operator to copy and must not persist or log it. Losing it means
+//! deleting the connector and registering again.
+
+use std::{fmt, str::FromStr};
+
+use bitwarden_core::{OrganizationId, key_management::SymmetricKeySlotId};
+use bitwarden_crypto::{
+    EncString, PrimitiveEncryptable, SymmetricCryptoKey, derive_shareable_key,
+    generate_random_bytes,
+};
+use bitwarden_encoding::{B64, NotB64EncodedError};
+use thiserror::Error;
+use uuid::Uuid;
+use zeroize::Zeroizing;
+
+use super::{connectors::AccessConnectorsClient, error::RotationError};
+
+/// Key-derivation name. Combined by `derive_shareable_key` into the HKDF salt
+/// `bitwarden-accesstoken`.
+///
+/// Contract with the connector - see the module docs before changing.
+const DERIVE_NAME: &str = "accesstoken";
+
+/// Key-derivation info, used as the HKDF `info` parameter.
+///
+/// Contract with the connector - see the module docs before changing.
+const DERIVE_INFO: &str = "sm-access-token";
+
+/// The token version prefix. `0` is the only version the connector accepts.
+const TOKEN_VERSION: &str = "0";
+
+/// The token's client-kind segment. The connector builds its OAuth `client_id` as
+/// `daemon.<api_key_id>`, so this segment and that prefix have to agree.
+const TOKEN_CLIENT_KIND: &str = "daemon";
+
+/// The locally-derived half of a registration, held between generating the key material and
+/// assembling the token around the server's response.
+pub(super) struct RegistrationSecrets {
+    /// The organization key, encrypted under the derived key. Sent to the server as
+    /// `encryptedPayload`.
+    pub(super) encrypted_payload: EncString,
+    /// The derived key's base64, encrypted under the organization key. Sent to the server as
+    /// `key`.
+    pub(super) key: EncString,
+    /// The raw seed, base64-encoded. Never sent to the server - it goes only into the token.
+    seed_b64: B64,
+}
+
+impl RegistrationSecrets {
+    /// Assembles the one-time connector token from the server's response and the local seed.
+    ///
+    /// Format: `0.daemon.<api-key-id>.<client-secret>:<b64-seed>`.
+    ///
+    /// Consumes `self` so the seed cannot be used to mint a second token for the same connector.
+    pub(super) fn into_token(self, api_key_id: Uuid, client_secret: &str) -> String {
+        format!(
+            "{TOKEN_VERSION}.{TOKEN_CLIENT_KIND}.{api_key_id}.{client_secret}:{}",
+            self.seed_b64
+        )
+    }
+}
+
+/// Reasons a connector token string could not be parsed.
+///
+/// Not `PartialEq`: the base64 variant wraps
+/// [`NotB64EncodedError`], which does not implement it.
+#[derive(Debug, Error)]
+pub enum ConnectorTokenInvalidError {
+    /// The token did not split into a `:`-separated prefix and seed, or the prefix did not have
+    /// exactly four dot-separated segments.
+    #[error("Has the wrong number of parts")]
+    WrongParts,
+    /// The version segment was not `0`.
+    #[error("Is the wrong version")]
+    WrongVersion,
+    /// The client-kind segment was not `daemon`.
+    #[error("Has the wrong prefix")]
+    WrongPrefix,
+    /// The API key id segment was not a UUID.
+    #[error("Has an invalid identifier")]
+    InvalidUuid,
+    /// The seed was not valid base64.
+    #[error("Error decoding base64: {0}")]
+    InvalidBase64(#[from] NotB64EncodedError),
+    /// The seed decoded to something other than 16 bytes.
+    #[error("Invalid base64 length: expected {expected}, got {got}")]
+    InvalidLength {
+        /// The length the format requires.
+        expected: usize,
+        /// The length actually decoded.
+        got: usize,
+    },
+}
+
+/// A parsed connector token.
+///
+/// This is the *consumer* half of registration, and it lives next to
+/// [`RegistrationSecrets::into_token`] on purpose: the token format and the key derivation are one
+/// contract, and splitting them across crates is what let the derivation constants drift in the
+/// first place. The rotation daemon carries its own copy of this parser and should converge on this
+/// one.
+pub struct ConnectorToken {
+    /// The API key identifier. The connector's OAuth `client_id` is `daemon.<api_key_id>`.
+    pub api_key_id: Uuid,
+    /// The OAuth client secret. Redacted from [`fmt::Debug`].
+    pub client_secret: String,
+    /// The key derived from the token's seed, which decrypts the registration payload to recover
+    /// the organization key.
+    pub encryption_key: SymmetricCryptoKey,
+}
+
+// Redacts the secret and the key; only the identifier is safe to log.
+impl fmt::Debug for ConnectorToken {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ConnectorToken")
+            .field("api_key_id", &self.api_key_id)
+            .finish_non_exhaustive()
+    }
+}
+
+impl FromStr for ConnectorToken {
+    type Err = ConnectorTokenInvalidError;
+
+    fn from_str(token: &str) -> Result<Self, Self::Err> {
+        let (prefix, seed_b64) = token
+            .split_once(':')
+            .ok_or(ConnectorTokenInvalidError::WrongParts)?;
+
+        let [version, client_kind, api_key_id, client_secret]: [&str; 4] = prefix
+            .split('.')
+            .collect::<Vec<_>>()
+            .try_into()
+            .map_err(|_| ConnectorTokenInvalidError::WrongParts)?;
+
+        if version != TOKEN_VERSION {
+            return Err(ConnectorTokenInvalidError::WrongVersion);
+        }
+
+        if client_kind != TOKEN_CLIENT_KIND {
+            return Err(ConnectorTokenInvalidError::WrongPrefix);
+        }
+
+        let api_key_id = api_key_id
+            .parse()
+            .map_err(|_| ConnectorTokenInvalidError::InvalidUuid)?;
+
+        let seed: B64 = seed_b64.parse()?;
+        let seed: Zeroizing<[u8; 16]> =
+            Zeroizing::new(seed.as_bytes().try_into().map_err(|_| {
+                ConnectorTokenInvalidError::InvalidLength {
+                    expected: 16,
+                    got: seed.as_bytes().len(),
+                }
+            })?);
+
+        Ok(Self {
+            api_key_id,
+            client_secret: client_secret.to_owned(),
+            encryption_key: SymmetricCryptoKey::Aes256CbcHmacKey(derive_shareable_key(
+                seed,
+                DERIVE_NAME,
+                Some(DERIVE_INFO),
+            )),
+        })
+    }
+}
+
+impl AccessConnectorsClient {
+    /// Generates the key material a connector registration needs.
+    ///
+    /// Fails with [`MissingOrganizationKey`](RotationError::MissingOrganizationKey) when the
+    /// caller's key store holds no key for the organization - they are not a member of it, or the
+    /// store has not been populated. Registration cannot proceed without it, since the whole point
+    /// is to hand that key to the connector.
+    pub(super) fn registration_secrets(
+        &self,
+        organization_id: OrganizationId,
+    ) -> Result<RegistrationSecrets, RotationError> {
+        let organization_key = SymmetricKeySlotId::Organization(organization_id);
+        let mut ctx = self.key_store.context_mut();
+
+        if !ctx.has_symmetric_key(organization_key) {
+            return Err(RotationError::MissingOrganizationKey);
+        }
+
+        let seed: Zeroizing<[u8; 16]> = generate_random_bytes();
+        let seed_b64 = B64::from(seed.as_slice());
+
+        let derived_key = ctx.derive_shareable_key(seed, DERIVE_NAME, Some(DERIVE_INFO))?;
+
+        // The payload hands the connector the organization key itself, so it is encrypted under the
+        // derived key - the one secret only the token holder can reproduce.
+        #[allow(deprecated)]
+        let organization_key_b64 = ctx
+            .dangerous_get_symmetric_key(organization_key)?
+            .to_base64();
+        let payload = serde_json::json!({ "encryptionKey": organization_key_b64.to_string() });
+        let encrypted_payload = payload.to_string().encrypt(&mut ctx, derived_key)?;
+
+        #[allow(deprecated)]
+        let derived_key_b64 = ctx.dangerous_get_symmetric_key(derived_key)?.to_base64();
+        let key = derived_key_b64
+            .to_string()
+            .encrypt(&mut ctx, organization_key)?;
+
+        Ok(RegistrationSecrets {
+            encrypted_payload,
+            key,
+            seed_b64,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{str::FromStr, sync::Arc};
+
+    use bitwarden_api_api::apis::ApiClient;
+    use bitwarden_core::{
+        client::ApiConfigurations,
+        key_management::{
+            create_test_crypto_with_user_and_org_key, create_test_crypto_with_user_key,
+        },
+    };
+    use bitwarden_crypto::{Decryptable, SymmetricKeyAlgorithm};
+    use uuid::uuid;
+
+    use super::*;
+
+    fn organization_id() -> OrganizationId {
+        OrganizationId::new(uuid!("11111111-1111-1111-1111-111111111111"))
+    }
+
+    fn client_with_org_key(organization_key: SymmetricCryptoKey) -> AccessConnectorsClient {
+        AccessConnectorsClient {
+            key_store: create_test_crypto_with_user_and_org_key(
+                SymmetricCryptoKey::make(SymmetricKeyAlgorithm::Aes256CbcHmac),
+                organization_id(),
+                organization_key,
+            ),
+            api_configurations: Arc::new(ApiConfigurations::from_api_client(
+                ApiClient::new_mocked(|_| {}),
+            )),
+        }
+    }
+
+    /// The contract that matters: the connector re-derives its key from the seed in the token
+    /// alone, then decrypts `encryptedPayload` to recover the organization key. This walks that
+    /// path using [`ConnectorToken`], the parser a connector uses - so if the mint and parse
+    /// halves of this contract ever drift apart, this fails.
+    #[test]
+    fn a_connector_recovers_the_organization_key_from_its_token_alone() {
+        let organization_key = SymmetricCryptoKey::make(SymmetricKeyAlgorithm::Aes256CbcHmac);
+        let client = client_with_org_key(organization_key.clone());
+
+        let secrets = client
+            .registration_secrets(organization_id())
+            .expect("the org key is in the store");
+        let encrypted_payload = secrets.encrypted_payload.clone();
+
+        let api_key_id = uuid!("22222222-2222-2222-2222-222222222222");
+        let token = secrets.into_token(api_key_id, "client-secret-value");
+
+        // Everything below is what a connector does with nothing but the token string.
+        let parsed = ConnectorToken::from_str(&token).expect("the token parses");
+        assert_eq!(parsed.api_key_id, api_key_id);
+        assert_eq!(parsed.client_secret, "client-secret-value");
+
+        let connector_store = create_test_crypto_with_user_key(parsed.encryption_key);
+        let mut ctx = connector_store.context();
+        let payload: String = encrypted_payload
+            .decrypt(&mut ctx, SymmetricKeySlotId::User)
+            .expect("the derived key decrypts the payload");
+
+        let recovered: serde_json::Value =
+            serde_json::from_str(&payload).expect("the payload is JSON");
+        assert_eq!(
+            recovered["encryptionKey"].as_str(),
+            Some(organization_key.to_base64().to_string().as_str()),
+            "the connector must recover the organization key verbatim"
+        );
+    }
+
+    #[test]
+    fn the_token_has_the_format_the_connector_parses() {
+        let client = client_with_org_key(SymmetricCryptoKey::make(
+            SymmetricKeyAlgorithm::Aes256CbcHmac,
+        ));
+        let secrets = client
+            .registration_secrets(organization_id())
+            .expect("the org key is in the store");
+
+        let api_key_id = uuid!("22222222-2222-2222-2222-222222222222");
+        let token = secrets.into_token(api_key_id, "secret");
+
+        let (prefix, seed_b64) = token.split_once(':').expect("a `:` separates the seed");
+        assert_eq!(prefix, format!("0.daemon.{api_key_id}.secret"));
+
+        // The connector requires exactly 16 bytes; a different length is rejected at parse time.
+        let seed: B64 = seed_b64.parse().expect("the suffix is base64");
+        assert_eq!(seed.as_bytes().len(), 16);
+    }
+
+    /// The `key` field is not read during registration, so a mistake in it would go unnoticed until
+    /// an organization-key rotation. It must be the derived key's base64, wrapped under the
+    /// organization key.
+    #[test]
+    fn the_key_field_wraps_the_derived_key_under_the_organization_key() {
+        let organization_key = SymmetricCryptoKey::make(SymmetricKeyAlgorithm::Aes256CbcHmac);
+        let client = client_with_org_key(organization_key.clone());
+
+        let secrets = client
+            .registration_secrets(organization_id())
+            .expect("the org key is in the store");
+        let key_field = secrets.key.clone();
+        let token = secrets.into_token(uuid!("22222222-2222-2222-2222-222222222222"), "secret");
+
+        let mut ctx = client.key_store.context();
+        let wrapped: String = key_field
+            .decrypt(
+                &mut ctx,
+                SymmetricKeySlotId::Organization(organization_id()),
+            )
+            .expect("the org key unwraps the key field");
+
+        let derived_from_token = ConnectorToken::from_str(&token)
+            .expect("the token parses")
+            .encryption_key;
+        assert_eq!(
+            wrapped,
+            derived_from_token.to_base64().to_string(),
+            "the key field must hold the same derived key the token produces"
+        );
+    }
+
+    /// Each registration must mint fresh material, or two connectors would share a key and revoking
+    /// one would not lock out the other.
+    #[test]
+    fn each_registration_generates_a_distinct_seed() {
+        let client = client_with_org_key(SymmetricCryptoKey::make(
+            SymmetricKeyAlgorithm::Aes256CbcHmac,
+        ));
+        let api_key_id = uuid!("22222222-2222-2222-2222-222222222222");
+
+        let first = client
+            .registration_secrets(organization_id())
+            .expect("the org key is in the store")
+            .into_token(api_key_id, "secret");
+        let second = client
+            .registration_secrets(organization_id())
+            .expect("the org key is in the store")
+            .into_token(api_key_id, "secret");
+
+        assert_ne!(first, second);
+    }
+
+    #[test]
+    fn registering_without_the_organization_key_fails_before_any_network_call() {
+        let client = AccessConnectorsClient {
+            // A store with a user key but no organization key - the caller is not a member.
+            key_store: create_test_crypto_with_user_key(SymmetricCryptoKey::make(
+                SymmetricKeyAlgorithm::Aes256CbcHmac,
+            )),
+            api_configurations: Arc::new(ApiConfigurations::from_api_client(
+                ApiClient::new_mocked(|_| {}),
+            )),
+        };
+
+        let result = client.registration_secrets(organization_id());
+
+        assert!(matches!(result, Err(RotationError::MissingOrganizationKey)));
+    }
+}

--- a/bitwarden_license/bitwarden-pam/src/rotation/registration.rs
+++ b/bitwarden_license/bitwarden-pam/src/rotation/registration.rs
@@ -21,7 +21,7 @@
 //! the connector derives a different key, `encryptedPayload` fails to decrypt, and it can never
 //! authenticate. They are the same pair Secrets Manager access tokens use - see
 //! [`AccessToken`](bitwarden_core::auth::AccessToken), which parses the identical format - and the
-//! same pair the rotation daemon's own token parser uses.
+//! same pair the access connector's own token parser uses.
 //!
 //! This is the single definition of that contract. It previously lived in the web client in
 //! TypeScript, with a different `info` string, which meant a connector registered from the web
@@ -130,8 +130,8 @@ pub enum ConnectorTokenInvalidError {
 /// This is the *consumer* half of registration, and it lives next to
 /// [`RegistrationSecrets::into_token`] on purpose: the token format and the key derivation are one
 /// contract, and splitting them across crates is what let the derivation constants drift in the
-/// first place. The rotation daemon carries its own copy of this parser and should converge on this
-/// one.
+/// first place. The access connector carries its own copy of this parser and should converge on
+/// this one.
 pub struct ConnectorToken {
     /// The API key identifier. The connector's OAuth `client_id` is
     /// `access-connector.<api_key_id>`.
@@ -333,30 +333,6 @@ mod tests {
         // The connector requires exactly 16 bytes; a different length is rejected at parse time.
         let seed: B64 = seed_b64.parse().expect("the suffix is base64");
         assert_eq!(seed.as_bytes().len(), 16);
-    }
-
-    /// The client-kind segment was renamed from `daemon` to `access-connector` as a clean break:
-    /// the parser must reject the old segment outright rather than still accepting it.
-    #[test]
-    fn a_token_with_the_old_daemon_kind_segment_is_rejected() {
-        let client = client_with_org_key(SymmetricCryptoKey::make(
-            SymmetricKeyAlgorithm::Aes256CbcHmac,
-        ));
-        let secrets = client
-            .registration_secrets(organization_id())
-            .expect("the org key is in the store");
-        let token = secrets.into_token(uuid!("22222222-2222-2222-2222-222222222222"), "secret");
-
-        // A well-formed token, but with the retired `daemon` kind segment in place of
-        // `access-connector`.
-        let stale_token = token.replacen("access-connector", "daemon", 1);
-
-        let result = ConnectorToken::from_str(&stale_token);
-
-        assert!(matches!(
-            result,
-            Err(ConnectorTokenInvalidError::WrongPrefix)
-        ));
     }
 
     /// The `key` field is not read during registration, so a mistake in it would go unnoticed until

--- a/bitwarden_license/bitwarden-pam/src/rotation/schedule.rs
+++ b/bitwarden_license/bitwarden-pam/src/rotation/schedule.rs
@@ -1,0 +1,252 @@
+//! Quartz cron schedule helpers shared by every rotation surface.
+
+use serde::{Deserialize, Serialize};
+#[cfg(feature = "wasm")]
+use tsify::Tsify;
+#[cfg(feature = "wasm")]
+use wasm_bindgen::prelude::wasm_bindgen;
+
+/// The canonical Quartz cron expression for each named preset.
+///
+/// Quartz's format is `seconds minutes hours day-of-month month day-of-week [year]` - 6 or 7
+/// fields, one more than the 5-field UNIX cron. Getting that wrong shifts every field by one
+/// position, which is why these are constants rather than assembled per call site.
+const HOURLY_CRON: &str = "0 0 * * * ?";
+const EVERY_6_HOURS_CRON: &str = "0 0 */6 * * ?";
+const DAILY_CRON: &str = "0 0 0 * * ?";
+const WEEKLY_CRON: &str = "0 0 0 ? * SUN";
+const MONTHLY_CRON: &str = "0 0 0 1 * ?";
+
+/// A named rotation schedule, or the escape hatches either side of the presets.
+///
+/// This is a *presentation* concept, not a server one: the server stores only the cron string.
+/// [`Custom`](QuartzSchedulePreset::Custom) therefore means "a valid cron that is not one of ours",
+/// and round-trips unchanged.
+#[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "wasm", derive(Tsify), tsify(into_wasm_abi, from_wasm_abi))]
+#[serde(rename_all = "snake_case")]
+pub enum QuartzSchedulePreset {
+    /// No scheduled rotation. On-demand and access-end rotations still apply.
+    None,
+    /// Every hour, on the hour.
+    Hourly,
+    /// Every six hours, starting at midnight.
+    Every6Hours,
+    /// Every day at midnight.
+    Daily,
+    /// Every Sunday at midnight.
+    Weekly,
+    /// The first day of every month, at midnight.
+    Monthly,
+    /// An operator-authored expression that matches no preset.
+    Custom,
+}
+
+impl QuartzSchedulePreset {
+    /// The cron expression for this preset, or `None` for the two presets that have no fixed
+    /// expression: [`None`](QuartzSchedulePreset::None) (no schedule at all) and
+    /// [`Custom`](QuartzSchedulePreset::Custom) (whatever the operator wrote).
+    pub fn cron(&self) -> Option<&'static str> {
+        match self {
+            Self::Hourly => Some(HOURLY_CRON),
+            Self::Every6Hours => Some(EVERY_6_HOURS_CRON),
+            Self::Daily => Some(DAILY_CRON),
+            Self::Weekly => Some(WEEKLY_CRON),
+            Self::Monthly => Some(MONTHLY_CRON),
+            Self::None | Self::Custom => None,
+        }
+    }
+}
+
+/// Derives the preset that best describes a stored cron expression.
+///
+/// `None` maps to [`QuartzSchedulePreset::None`]; an exact match against a preset's expression
+/// (ignoring surrounding whitespace) maps to that preset; anything else is
+/// [`Custom`](QuartzSchedulePreset::Custom) - including a blank string, which the server should
+/// have stored as `null` but which must not be reported as a real schedule if it wasn't.
+pub fn preset_for_cron(cron: Option<&str>) -> QuartzSchedulePreset {
+    let Some(cron) = cron else {
+        return QuartzSchedulePreset::None;
+    };
+
+    let trimmed = cron.trim();
+    if trimmed.is_empty() {
+        return QuartzSchedulePreset::None;
+    }
+
+    [
+        QuartzSchedulePreset::Hourly,
+        QuartzSchedulePreset::Every6Hours,
+        QuartzSchedulePreset::Daily,
+        QuartzSchedulePreset::Weekly,
+        QuartzSchedulePreset::Monthly,
+    ]
+    .into_iter()
+    .find(|preset| preset.cron() == Some(trimmed))
+    .unwrap_or(QuartzSchedulePreset::Custom)
+}
+
+/// Reports whether a string is shaped like a Quartz cron expression.
+///
+/// Advisory only - it checks field count and the character set, not that the expression describes a
+/// reachable time. The server is authoritative, so this exists to fail an obviously-malformed entry
+/// without a round trip, and deliberately errs towards accepting.
+pub fn is_likely_quartz_cron(value: &str) -> bool {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        return false;
+    }
+
+    let fields: Vec<&str> = trimmed.split_whitespace().collect();
+    if fields.len() < 6 || fields.len() > 7 {
+        return false;
+    }
+
+    fields.iter().all(|field| {
+        !field.is_empty()
+            && field.chars().all(|c| {
+                c.is_ascii_alphanumeric()
+                    || matches!(c, '*' | '/' | ',' | '-' | '?' | '#' | 'L' | 'W')
+            })
+    })
+}
+
+/// The WASM-facing surface for the schedule helpers.
+///
+/// The functions above are plain Rust so Rust callers - and the rest of this crate - can use them
+/// without going through a client. This zero-sized client exists only because `wasm_bindgen` cannot
+/// export free functions from a crate that is not itself the entry point.
+#[cfg_attr(feature = "wasm", wasm_bindgen)]
+pub struct RotationScheduleClient;
+
+#[cfg_attr(feature = "wasm", wasm_bindgen)]
+impl RotationScheduleClient {
+    /// See [`preset_for_cron`].
+    pub fn preset_for_cron(&self, cron: Option<String>) -> QuartzSchedulePreset {
+        preset_for_cron(cron.as_deref())
+    }
+
+    /// The cron expression for a preset, or `None` when the preset has no fixed expression.
+    pub fn cron_for_preset(&self, preset: QuartzSchedulePreset) -> Option<String> {
+        preset.cron().map(ToString::to_string)
+    }
+
+    /// See [`is_likely_quartz_cron`].
+    pub fn is_likely_quartz_cron(&self, value: String) -> bool {
+        is_likely_quartz_cron(&value)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn no_cron_is_the_none_preset() {
+        assert_eq!(preset_for_cron(None), QuartzSchedulePreset::None);
+    }
+
+    #[test]
+    fn each_preset_round_trips_through_its_own_cron() {
+        for preset in [
+            QuartzSchedulePreset::Hourly,
+            QuartzSchedulePreset::Every6Hours,
+            QuartzSchedulePreset::Daily,
+            QuartzSchedulePreset::Weekly,
+            QuartzSchedulePreset::Monthly,
+        ] {
+            let cron = preset.cron().expect("a named preset has a cron");
+            assert_eq!(preset_for_cron(Some(cron)), preset, "for {cron}");
+        }
+    }
+
+    #[test]
+    fn surrounding_whitespace_does_not_hide_a_preset() {
+        assert_eq!(
+            preset_for_cron(Some("  0 0 0 * * ?  ")),
+            QuartzSchedulePreset::Daily
+        );
+    }
+
+    #[test]
+    fn an_unrecognized_expression_is_custom() {
+        assert_eq!(
+            preset_for_cron(Some("0 30 9 ? * MON-FRI")),
+            QuartzSchedulePreset::Custom
+        );
+    }
+
+    /// A blank string is not a schedule. The server should have stored `null`, but reporting
+    /// `Custom` would render an empty cron as though the operator had authored one.
+    #[test]
+    fn a_blank_expression_is_not_a_custom_schedule() {
+        assert_eq!(preset_for_cron(Some("   ")), QuartzSchedulePreset::None);
+    }
+
+    /// The presets differ only in a couple of fields, so an off-by-one in `cron()` would still look
+    /// plausible. Pinning the strings catches that.
+    #[test]
+    fn preset_crons_are_six_field_quartz_expressions() {
+        for preset in [
+            QuartzSchedulePreset::Hourly,
+            QuartzSchedulePreset::Every6Hours,
+            QuartzSchedulePreset::Daily,
+            QuartzSchedulePreset::Weekly,
+            QuartzSchedulePreset::Monthly,
+        ] {
+            let cron = preset.cron().expect("a named preset has a cron");
+            assert_eq!(cron.split_whitespace().count(), 6, "for {cron}");
+            assert!(is_likely_quartz_cron(cron), "for {cron}");
+        }
+    }
+
+    #[test]
+    fn none_and_custom_have_no_fixed_cron() {
+        assert_eq!(QuartzSchedulePreset::None.cron(), None);
+        assert_eq!(QuartzSchedulePreset::Custom.cron(), None);
+    }
+
+    #[test]
+    fn six_and_seven_field_expressions_are_accepted() {
+        assert!(is_likely_quartz_cron("0 0 0 * * ?"));
+        assert!(is_likely_quartz_cron("0 0 0 * * ? 2027"));
+    }
+
+    #[test]
+    fn field_counts_outside_six_or_seven_are_rejected() {
+        // A 5-field UNIX cron is the likeliest mistake, and Quartz would misread every field.
+        assert!(!is_likely_quartz_cron("0 0 * * *"));
+        assert!(!is_likely_quartz_cron("0 0 0 * * ? 2027 extra"));
+    }
+
+    #[test]
+    fn blank_input_is_rejected() {
+        assert!(!is_likely_quartz_cron(""));
+        assert!(!is_likely_quartz_cron("      "));
+    }
+
+    #[test]
+    fn quartz_special_characters_are_accepted() {
+        assert!(is_likely_quartz_cron("0 0 0 L * ?"));
+        assert!(is_likely_quartz_cron("0 0 0 ? * 6#3"));
+        assert!(is_likely_quartz_cron("0 0 0 1W * ?"));
+        assert!(is_likely_quartz_cron("0 0/15 * * * ?"));
+    }
+
+    #[test]
+    fn characters_outside_the_quartz_set_are_rejected() {
+        assert!(!is_likely_quartz_cron("0 0 0 * * ; rm -rf /"));
+        assert!(!is_likely_quartz_cron("0 0 0 * * $(date)"));
+    }
+
+    /// Irregular internal spacing is an operator typo, not a different schedule -
+    /// `split_whitespace` collapses runs, so this must not be read as an extra empty field.
+    #[test]
+    fn runs_of_internal_whitespace_collapse() {
+        assert!(is_likely_quartz_cron("0  0   0 * * ?"));
+        assert_eq!(
+            preset_for_cron(Some("0 0 0 * * ?")),
+            QuartzSchedulePreset::Daily
+        );
+    }
+}

--- a/bitwarden_license/bitwarden-pam/src/rotation/target_systems.rs
+++ b/bitwarden_license/bitwarden-pam/src/rotation/target_systems.rs
@@ -191,9 +191,10 @@ impl From<TargetSystemUpdateRequest> for UpdateTargetSystemRequestModel {
 
 /// Client for PAM rotation target-system operations.
 ///
-/// Note that a target system cannot be deleted: the server exposes no delete route, because configs
-/// reference targets and a rotation's history has to stay attributable. Retiring one is
-/// [`disable`](TargetSystemsClient::disable).
+/// A target can be quieted or removed, and the two are not interchangeable:
+/// [`disable`](TargetSystemsClient::disable) is reversible and leaves the target's configs intact,
+/// while [`delete`](TargetSystemsClient::delete) is permanent and the server refuses it while any
+/// config still names the target.
 #[cfg_attr(feature = "wasm", wasm_bindgen)]
 #[derive(FromClient)]
 pub struct TargetSystemsClient {
@@ -289,6 +290,32 @@ impl TargetSystemsClient {
             .api_client
             .pam_access_connector_rotation_target_systems_api()
             .disable(organization_id.into(), id.into())
+            .await?;
+
+        Ok(())
+    }
+
+    /// Permanently deletes a target system.
+    ///
+    /// The server refuses this while any rotation config still names the target: deleting it would
+    /// leave that config, and the credential it manages, pointing at nothing. Delete those configs
+    /// first, which is also what releases each cipher. The connector-to-target assignments are the
+    /// opposite case and go with it - an assignment is only that edge, and means nothing once the
+    /// target is gone. No rotation can be in flight to be torn up, since a job belongs to a config
+    /// on this target and a surviving config blocks the delete outright.
+    ///
+    /// Deliberately narrower than [`disable`](TargetSystemsClient::disable), which stops new
+    /// rotations while the target and its configs stay intact. Disable is for a target that is
+    /// merely unavailable; delete is for one that has left the estate.
+    pub async fn delete(
+        &self,
+        organization_id: OrganizationId,
+        id: TargetSystemId,
+    ) -> Result<(), RotationError> {
+        self.api_configurations
+            .api_client
+            .pam_access_connector_rotation_target_systems_api()
+            .delete(organization_id.into(), id.into())
             .await?;
 
         Ok(())
@@ -939,6 +966,51 @@ mod tests {
 
         let result = client(api_client)
             .disable(organization_id(), target_system_id())
+            .await;
+
+        assert!(matches!(result, Err(RotationError::Api(_))));
+    }
+
+    #[tokio::test]
+    async fn delete_targets_the_requested_target_system() {
+        let api_client = ApiClient::new_mocked(move |mock| {
+            mock.pam_access_connector_rotation_target_systems_api
+                .expect_delete()
+                .withf(|org_id, id| {
+                    *org_id == Uuid::from(organization_id())
+                        && *id == Uuid::from(target_system_id())
+                })
+                .returning(move |_org_id, _id| Ok(()))
+                .once();
+        });
+
+        client(api_client)
+            .delete(organization_id(), target_system_id())
+            .await
+            .expect("deleting succeeds");
+    }
+
+    /// The server, not the SDK, holds the "no config may still name it" precondition. That refusal
+    /// has to reach the caller as an error - reading it as success would take a target off the
+    /// operator's list while the server still has it.
+    #[tokio::test]
+    async fn delete_surfaces_the_refusal_when_a_config_still_names_the_target() {
+        let api_client = ApiClient::new_mocked(move |mock| {
+            mock.pam_access_connector_rotation_target_systems_api
+                .expect_delete()
+                .returning(move |_org_id, _id| {
+                    Err(bitwarden_api_api::apis::Error::Response(
+                        bitwarden_api_api::apis::ResponseContent {
+                            status: reqwest::StatusCode::CONFLICT,
+                            message: String::new(),
+                        },
+                    ))
+                })
+                .once();
+        });
+
+        let result = client(api_client)
+            .delete(organization_id(), target_system_id())
             .await;
 
         assert!(matches!(result, Err(RotationError::Api(_))));

--- a/bitwarden_license/bitwarden-pam/src/rotation/target_systems.rs
+++ b/bitwarden_license/bitwarden-pam/src/rotation/target_systems.rs
@@ -1,0 +1,296 @@
+use std::sync::Arc;
+
+use bitwarden_api_api::models::{
+    PamTargetSystemResponseModel, RegisterTargetSystemRequestModel, UpdateTargetSystemRequestModel,
+};
+use bitwarden_core::{FromClient, OrganizationId, client::ApiConfigurations, require};
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+#[cfg(feature = "wasm")]
+use tsify::Tsify;
+#[cfg(feature = "wasm")]
+use wasm_bindgen::prelude::wasm_bindgen;
+
+use super::{
+    error::RotationError,
+    models::{PasswordPolicy, TargetSystemKind, TargetSystemMethod, TargetSystemStatus},
+    validate::{validate_target_system_create, validate_target_system_update},
+};
+use crate::TargetSystemId;
+
+/// A target system a credential can be rotated against.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "wasm", derive(Tsify), tsify(into_wasm_abi, from_wasm_abi))]
+#[serde(rename_all = "camelCase")]
+pub struct TargetSystemView {
+    /// The target system's unique identifier.
+    pub id: TargetSystemId,
+    /// The organization this target system belongs to.
+    pub organization_id: OrganizationId,
+    /// Display name. Plaintext organization configuration, not vault data.
+    pub name: String,
+    /// How credentials are rotated for this target.
+    pub method: TargetSystemMethod,
+    /// The integration behind the target. `None` when the method is
+    /// [`Manual`](TargetSystemMethod::Manual) - there is no integration to name.
+    pub kind: Option<TargetSystemKind>,
+    /// Lifecycle state.
+    pub status: TargetSystemStatus,
+    /// Constraints applied when generating a rotated credential. `None` when no policy has been
+    /// configured.
+    pub password_policy: Option<PasswordPolicy>,
+    /// Whether the integration can terminate the account's sessions after rotating. `None` when
+    /// the method is Manual or the server has not surfaced the capability.
+    pub supports_session_termination: Option<bool>,
+    /// When the target system was created (UTC).
+    pub creation_date: DateTime<Utc>,
+    /// When the target system was last modified (UTC).
+    pub revision_date: DateTime<Utc>,
+}
+
+impl TryFrom<PamTargetSystemResponseModel> for TargetSystemView {
+    type Error = RotationError;
+
+    fn try_from(response: PamTargetSystemResponseModel) -> Result<Self, Self::Error> {
+        Ok(Self {
+            id: TargetSystemId::new(require!(response.id)),
+            organization_id: OrganizationId::new(require!(response.organization_id)),
+            name: require!(response.name),
+            method: require!(response.method).into(),
+            kind: response.kind.map(Into::into),
+            status: require!(response.status).into(),
+            password_policy: response.password_policy.map(|policy| (*policy).into()),
+            supports_session_termination: response.supports_session_termination,
+            creation_date: require!(response.creation_date).parse()?,
+            revision_date: require!(response.revision_date).parse()?,
+        })
+    }
+}
+
+/// Request to create a target system.
+///
+/// Modeled as a discriminated union rather than a struct of optional fields because the two methods
+/// take genuinely different input: an automatic target needs an integration and a
+/// session-termination capability, a manual one has neither. Encoding that in the type stops a
+/// caller from constructing the combination the server rejects.
+///
+/// Serializes with a `method` discriminant matching the server's own, e.g.
+/// `{"method":"manual","name":"...","passwordPolicy":{...}}`.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "wasm", derive(Tsify), tsify(into_wasm_abi, from_wasm_abi))]
+#[serde(tag = "method", rename_all = "snake_case")]
+pub enum TargetSystemCreateRequest {
+    /// A connector rotates the credential by writing it into the target system.
+    #[serde(rename_all = "camelCase")]
+    Automatic {
+        /// Display name.
+        name: String,
+        /// The integration that performs the rotation.
+        kind: TargetSystemKind,
+        /// Constraints the connector generates the new credential under.
+        password_policy: PasswordPolicy,
+        /// Whether the integration can terminate the account's sessions after rotating.
+        supports_session_termination: bool,
+    },
+    /// An operator rotates the credential out of band and records that they did.
+    #[serde(rename_all = "camelCase")]
+    Manual {
+        /// Display name.
+        name: String,
+        /// The rules the operator is expected to follow when rotating by hand. Nothing enforces
+        /// them - no connector runs a manual rotation.
+        password_policy: PasswordPolicy,
+    },
+}
+
+impl TargetSystemCreateRequest {
+    /// The display name, whichever method this request carries.
+    pub fn name(&self) -> &str {
+        match self {
+            Self::Automatic { name, .. } | Self::Manual { name, .. } => name,
+        }
+    }
+
+    /// The password policy, whichever method this request carries.
+    pub fn password_policy(&self) -> &PasswordPolicy {
+        match self {
+            Self::Automatic {
+                password_policy, ..
+            }
+            | Self::Manual {
+                password_policy, ..
+            } => password_policy,
+        }
+    }
+}
+
+impl TryFrom<TargetSystemCreateRequest> for RegisterTargetSystemRequestModel {
+    type Error = RotationError;
+
+    fn try_from(request: TargetSystemCreateRequest) -> Result<Self, Self::Error> {
+        Ok(match request {
+            TargetSystemCreateRequest::Automatic {
+                name,
+                kind,
+                password_policy,
+                supports_session_termination,
+            } => Self {
+                name,
+                method: TargetSystemMethod::Automatic.try_into()?,
+                kind: Some(kind.try_into()?),
+                password_policy: Some(Box::new(password_policy.into())),
+                supports_session_termination: Some(supports_session_termination),
+            },
+            TargetSystemCreateRequest::Manual {
+                name,
+                password_policy,
+            } => Self {
+                name,
+                method: TargetSystemMethod::Manual.try_into()?,
+                // A manual target has no integration and no session to terminate. Sending either
+                // would have the server store a capability nothing can act on.
+                kind: None,
+                password_policy: Some(Box::new(password_policy.into())),
+                supports_session_termination: None,
+            },
+        })
+    }
+}
+
+/// Request to update an existing target system.
+///
+/// The name and the policy travel together because the server takes them in one `PUT`; a caller
+/// changing only one still has to send the other's current value. Neither the method nor the
+/// integration kind can be changed after creation - the server derives rotation behaviour from
+/// them, and configs already reference the target.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "wasm", derive(Tsify), tsify(into_wasm_abi, from_wasm_abi))]
+#[serde(rename_all = "camelCase")]
+pub struct TargetSystemUpdateRequest {
+    /// Display name.
+    pub name: String,
+    /// Constraints applied when generating a rotated credential.
+    pub password_policy: PasswordPolicy,
+    /// Whether the integration can terminate the account's sessions after rotating.
+    ///
+    /// Applies only to automatic targets; a manual target has no session to terminate, so the
+    /// server ignores it. Withdrawing the capability can be *rejected* when live configs depend on
+    /// it, so a caller should warn before submitting a change from `true` to `false`.
+    pub supports_session_termination: bool,
+}
+
+impl From<TargetSystemUpdateRequest> for UpdateTargetSystemRequestModel {
+    fn from(request: TargetSystemUpdateRequest) -> Self {
+        Self {
+            name: request.name,
+            password_policy: Some(Box::new(request.password_policy.into())),
+            supports_session_termination: Some(request.supports_session_termination),
+        }
+    }
+}
+
+/// Client for PAM rotation target-system operations.
+///
+/// Note that a target system cannot be deleted: the server exposes no delete route, because configs
+/// reference targets and a rotation's history has to stay attributable. Retiring one is
+/// [`disable`](TargetSystemsClient::disable).
+#[cfg_attr(feature = "wasm", wasm_bindgen)]
+#[derive(FromClient)]
+pub struct TargetSystemsClient {
+    pub(crate) api_configurations: Arc<ApiConfigurations>,
+}
+
+#[cfg_attr(feature = "wasm", wasm_bindgen)]
+impl TargetSystemsClient {
+    /// Lists the organization's target systems.
+    pub async fn list(
+        &self,
+        organization_id: OrganizationId,
+    ) -> Result<Vec<TargetSystemView>, RotationError> {
+        let response = self
+            .api_configurations
+            .api_client
+            .pam_access_connector_rotation_target_systems_api()
+            .get_all(organization_id.into())
+            .await?;
+
+        response
+            .data
+            .unwrap_or_default()
+            .into_iter()
+            .map(TargetSystemView::try_from)
+            .collect()
+    }
+
+    /// Validates and creates a target system.
+    pub async fn create(
+        &self,
+        organization_id: OrganizationId,
+        request: TargetSystemCreateRequest,
+    ) -> Result<TargetSystemView, RotationError> {
+        validate_target_system_create(&request)?;
+
+        let response = self
+            .api_configurations
+            .api_client
+            .pam_access_connector_rotation_target_systems_api()
+            .post(organization_id.into(), request.try_into()?)
+            .await?;
+
+        TargetSystemView::try_from(response)
+    }
+
+    /// Validates and updates a target system's name, policy, and session-termination capability.
+    ///
+    /// The server answers with no content, so a caller that renders the result should re-read
+    /// through [`list`](TargetSystemsClient::list) rather than assume the request body is now the
+    /// stored state.
+    pub async fn update(
+        &self,
+        organization_id: OrganizationId,
+        id: TargetSystemId,
+        request: TargetSystemUpdateRequest,
+    ) -> Result<(), RotationError> {
+        validate_target_system_update(&request)?;
+
+        self.api_configurations
+            .api_client
+            .pam_access_connector_rotation_target_systems_api()
+            .put(organization_id.into(), id.into(), request.into())
+            .await?;
+
+        Ok(())
+    }
+
+    /// Returns a disabled target system to service, so new rotation jobs are dispatched for it
+    /// again.
+    pub async fn enable(
+        &self,
+        organization_id: OrganizationId,
+        id: TargetSystemId,
+    ) -> Result<(), RotationError> {
+        self.api_configurations
+            .api_client
+            .pam_access_connector_rotation_target_systems_api()
+            .enable(organization_id.into(), id.into())
+            .await?;
+
+        Ok(())
+    }
+
+    /// Stops new rotation jobs being dispatched for a target system. Jobs already in flight run to
+    /// completion.
+    pub async fn disable(
+        &self,
+        organization_id: OrganizationId,
+        id: TargetSystemId,
+    ) -> Result<(), RotationError> {
+        self.api_configurations
+            .api_client
+            .pam_access_connector_rotation_target_systems_api()
+            .disable(organization_id.into(), id.into())
+            .await?;
+
+        Ok(())
+    }
+}

--- a/bitwarden_license/bitwarden-pam/src/rotation/target_systems.rs
+++ b/bitwarden_license/bitwarden-pam/src/rotation/target_systems.rs
@@ -294,3 +294,653 @@ impl TargetSystemsClient {
         Ok(())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use bitwarden_api_api::{
+        apis::ApiClient,
+        models::{
+            PamPasswordPolicyResponseModel, PamTargetSystemKind as ApiTargetSystemKind,
+            PamTargetSystemMethod as ApiTargetSystemMethod,
+            PamTargetSystemResponseModelListResponseModel,
+            PamTargetSystemStatus as ApiTargetSystemStatus,
+        },
+    };
+    use uuid::{Uuid, uuid};
+
+    use super::*;
+    use crate::rotation::validate::RotationValidationError;
+
+    fn organization_id() -> OrganizationId {
+        OrganizationId::new(uuid!("11111111-1111-1111-1111-111111111111"))
+    }
+
+    fn target_system_id() -> TargetSystemId {
+        TargetSystemId::new(uuid!("22222222-2222-2222-2222-222222222222"))
+    }
+
+    fn client(api_client: ApiClient) -> TargetSystemsClient {
+        TargetSystemsClient {
+            api_configurations: Arc::new(ApiConfigurations::from_api_client(api_client)),
+        }
+    }
+
+    fn policy() -> PasswordPolicy {
+        PasswordPolicy {
+            min_length: 14,
+            max_length: 64,
+            include_uppercase: true,
+            include_lowercase: true,
+            include_digits: true,
+            include_symbols: false,
+        }
+    }
+
+    /// An automatic target with every optional field populated, so a test that clears one is
+    /// unambiguous about which field it is exercising.
+    fn sample_response() -> PamTargetSystemResponseModel {
+        PamTargetSystemResponseModel {
+            id: Some(target_system_id().into()),
+            organization_id: Some(organization_id().into()),
+            name: Some("Prod SQL".to_string()),
+            method: Some(ApiTargetSystemMethod::Automatic),
+            kind: Some(ApiTargetSystemKind::Mssql),
+            password_policy: Some(Box::new(PamPasswordPolicyResponseModel {
+                min_length: Some(14),
+                max_length: Some(64),
+                include_uppercase: Some(true),
+                include_lowercase: Some(true),
+                include_digits: Some(true),
+                include_symbols: Some(false),
+            })),
+            supports_session_termination: Some(true),
+            status: Some(ApiTargetSystemStatus::Active),
+            creation_date: Some("2026-01-01T00:00:00Z".to_string()),
+            revision_date: Some("2026-01-15T00:00:00Z".to_string()),
+            ..Default::default()
+        }
+    }
+
+    fn automatic_create_request() -> TargetSystemCreateRequest {
+        TargetSystemCreateRequest::Automatic {
+            name: "Prod SQL".to_string(),
+            kind: TargetSystemKind::Mssql,
+            password_policy: policy(),
+            supports_session_termination: true,
+        }
+    }
+
+    fn manual_create_request() -> TargetSystemCreateRequest {
+        TargetSystemCreateRequest::Manual {
+            name: "Legacy mainframe".to_string(),
+            password_policy: policy(),
+        }
+    }
+
+    fn update_request() -> TargetSystemUpdateRequest {
+        TargetSystemUpdateRequest {
+            name: "Prod SQL".to_string(),
+            password_policy: policy(),
+            supports_session_termination: true,
+        }
+    }
+
+    #[test]
+    fn a_full_payload_maps_every_field() {
+        let target = TargetSystem::try_from(sample_response()).expect("the payload is valid");
+
+        assert_eq!(target.id, target_system_id());
+        assert_eq!(target.organization_id, organization_id());
+        assert_eq!(target.name, "Prod SQL");
+        assert_eq!(target.method, TargetSystemMethod::Automatic);
+        assert_eq!(target.kind, Some(TargetSystemKind::Mssql));
+        assert_eq!(target.status, TargetSystemStatus::Active);
+        assert_eq!(target.password_policy, Some(policy()));
+        assert_eq!(target.supports_session_termination, Some(true));
+        assert_eq!(
+            target.creation_date,
+            "2026-01-01T00:00:00Z".parse::<DateTime<Utc>>().unwrap()
+        );
+        assert_eq!(
+            target.revision_date,
+            "2026-01-15T00:00:00Z".parse::<DateTime<Utc>>().unwrap()
+        );
+    }
+
+    /// A manual target has no integration and no session to terminate, so those arrive absent
+    /// rather than as a falsy value that would read as "an integration that cannot do it".
+    #[test]
+    fn a_manual_target_has_no_integration_and_no_session_capability() {
+        let response = PamTargetSystemResponseModel {
+            method: Some(ApiTargetSystemMethod::Manual),
+            kind: None,
+            supports_session_termination: None,
+            password_policy: None,
+            ..sample_response()
+        };
+
+        let target = TargetSystem::try_from(response).expect("the payload is valid");
+
+        assert_eq!(target.method, TargetSystemMethod::Manual);
+        assert_eq!(target.kind, None);
+        assert_eq!(target.supports_session_termination, None);
+        assert_eq!(target.password_policy, None);
+    }
+
+    /// A policy the server sent with flags omitted must read as those classes being *off*. Reading
+    /// them as on would show an operator a policy the connector will not generate under.
+    #[test]
+    fn omitted_policy_flags_read_as_disabled() {
+        let response = PamTargetSystemResponseModel {
+            password_policy: Some(Box::new(PamPasswordPolicyResponseModel::default())),
+            ..sample_response()
+        };
+
+        let target = TargetSystem::try_from(response).expect("the payload is valid");
+
+        assert_eq!(
+            target.password_policy,
+            Some(PasswordPolicy {
+                min_length: 0,
+                max_length: 0,
+                include_uppercase: false,
+                include_lowercase: false,
+                include_digits: false,
+                include_symbols: false,
+            })
+        );
+    }
+
+    #[test]
+    fn a_missing_required_field_is_reported_rather_than_defaulted() {
+        for response in [
+            PamTargetSystemResponseModel {
+                id: None,
+                ..sample_response()
+            },
+            PamTargetSystemResponseModel {
+                organization_id: None,
+                ..sample_response()
+            },
+            PamTargetSystemResponseModel {
+                name: None,
+                ..sample_response()
+            },
+            PamTargetSystemResponseModel {
+                method: None,
+                ..sample_response()
+            },
+            PamTargetSystemResponseModel {
+                status: None,
+                ..sample_response()
+            },
+            PamTargetSystemResponseModel {
+                creation_date: None,
+                ..sample_response()
+            },
+            PamTargetSystemResponseModel {
+                revision_date: None,
+                ..sample_response()
+            },
+        ] {
+            assert!(matches!(
+                TargetSystem::try_from(response),
+                Err(RotationError::MissingField(_))
+            ));
+        }
+    }
+
+    #[test]
+    fn an_unparseable_date_is_reported() {
+        for response in [
+            PamTargetSystemResponseModel {
+                creation_date: Some("not a date".to_string()),
+                ..sample_response()
+            },
+            PamTargetSystemResponseModel {
+                revision_date: Some("not a date".to_string()),
+                ..sample_response()
+            },
+        ] {
+            assert!(matches!(
+                TargetSystem::try_from(response),
+                Err(RotationError::Chrono(_))
+            ));
+        }
+    }
+
+    /// A newer server naming a method, kind, or status this version does not model must degrade
+    /// rather than fail the whole list.
+    #[test]
+    fn unrecognized_enum_values_degrade_to_unknown() {
+        let response = PamTargetSystemResponseModel {
+            method: Some(ApiTargetSystemMethod::__Unknown(9)),
+            kind: Some(ApiTargetSystemKind::__Unknown(9)),
+            status: Some(ApiTargetSystemStatus::__Unknown(9)),
+            ..sample_response()
+        };
+
+        let target = TargetSystem::try_from(response).expect("unknown values still map");
+
+        assert_eq!(target.method, TargetSystemMethod::Unknown);
+        assert_eq!(target.kind, Some(TargetSystemKind::Unknown));
+        assert_eq!(target.status, TargetSystemStatus::Unknown);
+    }
+
+    #[test]
+    fn an_automatic_create_request_carries_the_integration_and_the_capability() {
+        let model = RegisterTargetSystemRequestModel::try_from(automatic_create_request())
+            .expect("the request is representable");
+
+        assert_eq!(model.name, "Prod SQL");
+        assert_eq!(model.method, ApiTargetSystemMethod::Automatic);
+        assert_eq!(model.kind, Some(ApiTargetSystemKind::Mssql));
+        assert_eq!(model.supports_session_termination, Some(true));
+        let sent_policy = *model.password_policy.expect("a policy is sent");
+        assert_eq!(sent_policy.min_length, 14);
+        assert_eq!(sent_policy.max_length, 64);
+        assert_eq!(sent_policy.include_symbols, Some(false));
+    }
+
+    /// A manual target must send neither field. Sending `Some(false)` for the capability would have
+    /// the server store a session-termination answer for a rotation no connector performs.
+    #[test]
+    fn a_manual_create_request_sends_no_integration_and_no_capability() {
+        let model = RegisterTargetSystemRequestModel::try_from(manual_create_request())
+            .expect("the request is representable");
+
+        assert_eq!(model.method, ApiTargetSystemMethod::Manual);
+        assert_eq!(model.kind, None);
+        assert_eq!(model.supports_session_termination, None);
+        assert!(
+            model.password_policy.is_some(),
+            "a manual target still carries the rules the operator follows"
+        );
+    }
+
+    /// The write-side refusal from the module docs: a kind this SDK could not name on the way in
+    /// cannot be sent back out, because `__Unknown` would serialize a meaningless tinyint.
+    #[test]
+    fn an_unrecognized_kind_cannot_be_written_back() {
+        let request = TargetSystemCreateRequest::Automatic {
+            name: "Prod SQL".to_string(),
+            kind: TargetSystemKind::Unknown,
+            password_policy: policy(),
+            supports_session_termination: true,
+        };
+
+        assert!(matches!(
+            RegisterTargetSystemRequestModel::try_from(request),
+            Err(RotationError::UnrecognizedVariant)
+        ));
+    }
+
+    #[test]
+    fn an_update_request_carries_the_name_policy_and_capability() {
+        let model = UpdateTargetSystemRequestModel::from(update_request());
+
+        assert_eq!(model.name, "Prod SQL");
+        assert_eq!(model.supports_session_termination, Some(true));
+        assert_eq!(
+            model.password_policy.expect("a policy is sent").min_length,
+            14
+        );
+    }
+
+    /// The create request crosses the WASM boundary as plain data, and the documented wire shape is
+    /// a `method` discriminant matching the server's. A renamed variant would silently produce a
+    /// body the server rejects.
+    #[test]
+    fn a_create_request_serializes_with_the_servers_method_discriminant() {
+        let automatic = serde_json::to_value(automatic_create_request()).expect("it serializes");
+        assert_eq!(automatic["method"], "automatic");
+        assert_eq!(automatic["kind"], "mssql");
+        assert_eq!(automatic["supportsSessionTermination"], true);
+        assert_eq!(automatic["passwordPolicy"]["minLength"], 14);
+
+        let manual = serde_json::to_value(manual_create_request()).expect("it serializes");
+        assert_eq!(manual["method"], "manual");
+        assert_eq!(manual["name"], "Legacy mainframe");
+        assert!(manual.get("kind").is_none());
+    }
+
+    #[tokio::test]
+    async fn list_maps_the_organizations_target_systems() {
+        let api_client = ApiClient::new_mocked(move |mock| {
+            mock.pam_access_connector_rotation_target_systems_api
+                .expect_get_all()
+                .withf(|org_id| *org_id == Uuid::from(organization_id()))
+                .returning(move |_org_id| {
+                    Ok(PamTargetSystemResponseModelListResponseModel {
+                        data: Some(vec![sample_response()]),
+                        ..Default::default()
+                    })
+                })
+                .once();
+        });
+
+        let targets = client(api_client)
+            .list(organization_id())
+            .await
+            .expect("the list succeeds");
+
+        assert_eq!(targets.len(), 1);
+        assert_eq!(targets[0].id, target_system_id());
+    }
+
+    #[tokio::test]
+    async fn an_organization_with_no_target_systems_lists_empty() {
+        let api_client = ApiClient::new_mocked(move |mock| {
+            mock.pam_access_connector_rotation_target_systems_api
+                .expect_get_all()
+                .returning(move |_org_id| {
+                    Ok(PamTargetSystemResponseModelListResponseModel::default())
+                })
+                .once();
+        });
+
+        let targets = client(api_client)
+            .list(organization_id())
+            .await
+            .expect("an absent list is not an error");
+
+        assert!(targets.is_empty());
+    }
+
+    #[tokio::test]
+    async fn list_fails_if_any_target_system_is_malformed() {
+        let api_client = ApiClient::new_mocked(move |mock| {
+            mock.pam_access_connector_rotation_target_systems_api
+                .expect_get_all()
+                .returning(move |_org_id| {
+                    Ok(PamTargetSystemResponseModelListResponseModel {
+                        data: Some(vec![
+                            sample_response(),
+                            PamTargetSystemResponseModel {
+                                id: None,
+                                ..sample_response()
+                            },
+                        ]),
+                        ..Default::default()
+                    })
+                })
+                .once();
+        });
+
+        let result = client(api_client).list(organization_id()).await;
+
+        assert!(matches!(result, Err(RotationError::MissingField(_))));
+    }
+
+    #[tokio::test]
+    async fn list_surfaces_an_api_error() {
+        let api_client = ApiClient::new_mocked(move |mock| {
+            mock.pam_access_connector_rotation_target_systems_api
+                .expect_get_all()
+                .returning(move |_org_id| {
+                    Err(bitwarden_api_api::apis::Error::Response(
+                        bitwarden_api_api::apis::ResponseContent {
+                            status: reqwest::StatusCode::INTERNAL_SERVER_ERROR,
+                            message: String::new(),
+                        },
+                    ))
+                })
+                .once();
+        });
+
+        let result = client(api_client).list(organization_id()).await;
+
+        assert!(matches!(result, Err(RotationError::Api(_))));
+    }
+
+    #[tokio::test]
+    async fn create_sends_the_request_and_returns_the_stored_target_system() {
+        let api_client = ApiClient::new_mocked(move |mock| {
+            mock.pam_access_connector_rotation_target_systems_api
+                .expect_post()
+                .withf(|org_id, request| {
+                    *org_id == Uuid::from(organization_id())
+                        && request.name == "Prod SQL"
+                        && request.method == ApiTargetSystemMethod::Automatic
+                        && request.kind == Some(ApiTargetSystemKind::Mssql)
+                        && request.supports_session_termination == Some(true)
+                })
+                .returning(move |_org_id, _request| Ok(sample_response()))
+                .once();
+        });
+
+        let target = client(api_client)
+            .create(organization_id(), automatic_create_request())
+            .await
+            .expect("creation succeeds");
+
+        assert_eq!(target.id, target_system_id());
+    }
+
+    #[tokio::test]
+    async fn creating_a_manual_target_sends_no_integration() {
+        let api_client = ApiClient::new_mocked(move |mock| {
+            mock.pam_access_connector_rotation_target_systems_api
+                .expect_post()
+                .withf(|_org_id, request| {
+                    request.method == ApiTargetSystemMethod::Manual
+                        && request.kind.is_none()
+                        && request.supports_session_termination.is_none()
+                })
+                .returning(move |_org_id, _request| {
+                    Ok(PamTargetSystemResponseModel {
+                        method: Some(ApiTargetSystemMethod::Manual),
+                        kind: None,
+                        supports_session_termination: None,
+                        ..sample_response()
+                    })
+                })
+                .once();
+        });
+
+        let target = client(api_client)
+            .create(organization_id(), manual_create_request())
+            .await
+            .expect("creation succeeds");
+
+        assert_eq!(target.method, TargetSystemMethod::Manual);
+        assert_eq!(target.kind, None);
+    }
+
+    /// Validation runs before the request is sent, for both methods - the accessors it reads the
+    /// name and policy through have to work on either variant. The mock has no expectations, so
+    /// any call to the server fails the test.
+    #[tokio::test]
+    async fn create_rejects_an_invalid_request_before_calling_the_server() {
+        let unsatisfiable = PasswordPolicy {
+            include_uppercase: false,
+            include_lowercase: false,
+            include_digits: false,
+            include_symbols: false,
+            ..policy()
+        };
+
+        let cases = [
+            (
+                TargetSystemCreateRequest::Automatic {
+                    name: "  ".to_string(),
+                    kind: TargetSystemKind::Mssql,
+                    password_policy: policy(),
+                    supports_session_termination: true,
+                },
+                RotationValidationError::InvalidName,
+            ),
+            (
+                TargetSystemCreateRequest::Manual {
+                    name: String::new(),
+                    password_policy: policy(),
+                },
+                RotationValidationError::InvalidName,
+            ),
+            (
+                TargetSystemCreateRequest::Automatic {
+                    name: "Prod SQL".to_string(),
+                    kind: TargetSystemKind::Mssql,
+                    password_policy: unsatisfiable.clone(),
+                    supports_session_termination: true,
+                },
+                RotationValidationError::NoCharacterClasses,
+            ),
+            (
+                TargetSystemCreateRequest::Manual {
+                    name: "Legacy mainframe".to_string(),
+                    password_policy: PasswordPolicy {
+                        min_length: 64,
+                        max_length: 14,
+                        ..policy()
+                    },
+                },
+                RotationValidationError::InvalidPasswordLengthBounds,
+            ),
+        ];
+
+        for (request, expected) in cases {
+            let result = client(ApiClient::new_mocked(|_| {}))
+                .create(organization_id(), request)
+                .await;
+
+            assert!(
+                matches!(result, Err(RotationError::Validation(ref actual)) if *actual == expected),
+                "expected {expected:?}, got {result:?}"
+            );
+        }
+    }
+
+    /// A kind the SDK cannot name is refused while building the body, which is still before the
+    /// call - so no half-described target system is created.
+    #[tokio::test]
+    async fn create_refuses_an_unrecognized_kind_before_calling_the_server() {
+        let result = client(ApiClient::new_mocked(|_| {}))
+            .create(
+                organization_id(),
+                TargetSystemCreateRequest::Automatic {
+                    name: "Prod SQL".to_string(),
+                    kind: TargetSystemKind::Unknown,
+                    password_policy: policy(),
+                    supports_session_termination: true,
+                },
+            )
+            .await;
+
+        assert!(matches!(result, Err(RotationError::UnrecognizedVariant)));
+    }
+
+    #[tokio::test]
+    async fn update_sends_the_request_to_the_requested_target_system() {
+        let api_client = ApiClient::new_mocked(move |mock| {
+            mock.pam_access_connector_rotation_target_systems_api
+                .expect_put()
+                .withf(|org_id, id, request| {
+                    *org_id == Uuid::from(organization_id())
+                        && *id == Uuid::from(target_system_id())
+                        && request.name == "Prod SQL"
+                        && request.supports_session_termination == Some(true)
+                })
+                .returning(move |_org_id, _id, _request| Ok(()))
+                .once();
+        });
+
+        client(api_client)
+            .update(organization_id(), target_system_id(), update_request())
+            .await
+            .expect("the update succeeds");
+    }
+
+    #[tokio::test]
+    async fn update_rejects_an_invalid_request_before_calling_the_server() {
+        for (request, expected) in [
+            (
+                TargetSystemUpdateRequest {
+                    name: "   ".to_string(),
+                    ..update_request()
+                },
+                RotationValidationError::InvalidName,
+            ),
+            (
+                TargetSystemUpdateRequest {
+                    password_policy: PasswordPolicy {
+                        max_length: 1000,
+                        ..policy()
+                    },
+                    ..update_request()
+                },
+                RotationValidationError::InvalidPasswordLengthBounds,
+            ),
+        ] {
+            let result = client(ApiClient::new_mocked(|_| {}))
+                .update(organization_id(), target_system_id(), request)
+                .await;
+
+            assert!(
+                matches!(result, Err(RotationError::Validation(ref actual)) if *actual == expected),
+                "expected {expected:?}, got {result:?}"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn enable_targets_the_requested_target_system() {
+        let api_client = ApiClient::new_mocked(move |mock| {
+            mock.pam_access_connector_rotation_target_systems_api
+                .expect_enable()
+                .withf(|org_id, id| {
+                    *org_id == Uuid::from(organization_id())
+                        && *id == Uuid::from(target_system_id())
+                })
+                .returning(move |_org_id, _id| Ok(()))
+                .once();
+        });
+
+        client(api_client)
+            .enable(organization_id(), target_system_id())
+            .await
+            .expect("enabling succeeds");
+    }
+
+    #[tokio::test]
+    async fn disable_targets_the_requested_target_system() {
+        let api_client = ApiClient::new_mocked(move |mock| {
+            mock.pam_access_connector_rotation_target_systems_api
+                .expect_disable()
+                .withf(|org_id, id| {
+                    *org_id == Uuid::from(organization_id())
+                        && *id == Uuid::from(target_system_id())
+                })
+                .returning(move |_org_id, _id| Ok(()))
+                .once();
+        });
+
+        client(api_client)
+            .disable(organization_id(), target_system_id())
+            .await
+            .expect("disabling succeeds");
+    }
+
+    #[tokio::test]
+    async fn disable_surfaces_an_api_error() {
+        let api_client = ApiClient::new_mocked(move |mock| {
+            mock.pam_access_connector_rotation_target_systems_api
+                .expect_disable()
+                .returning(move |_org_id, _id| {
+                    Err(bitwarden_api_api::apis::Error::Response(
+                        bitwarden_api_api::apis::ResponseContent {
+                            status: reqwest::StatusCode::CONFLICT,
+                            message: String::new(),
+                        },
+                    ))
+                })
+                .once();
+        });
+
+        let result = client(api_client)
+            .disable(organization_id(), target_system_id())
+            .await;
+
+        assert!(matches!(result, Err(RotationError::Api(_))));
+    }
+}

--- a/bitwarden_license/bitwarden-pam/src/rotation/target_systems.rs
+++ b/bitwarden_license/bitwarden-pam/src/rotation/target_systems.rs
@@ -22,7 +22,7 @@ use crate::TargetSystemId;
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "wasm", derive(Tsify), tsify(into_wasm_abi, from_wasm_abi))]
 #[serde(rename_all = "camelCase")]
-pub struct TargetSystemView {
+pub struct TargetSystem {
     /// The target system's unique identifier.
     pub id: TargetSystemId,
     /// The organization this target system belongs to.
@@ -48,7 +48,7 @@ pub struct TargetSystemView {
     pub revision_date: DateTime<Utc>,
 }
 
-impl TryFrom<PamTargetSystemResponseModel> for TargetSystemView {
+impl TryFrom<PamTargetSystemResponseModel> for TargetSystem {
     type Error = RotationError;
 
     fn try_from(response: PamTargetSystemResponseModel) -> Result<Self, Self::Error> {
@@ -206,7 +206,7 @@ impl TargetSystemsClient {
     pub async fn list(
         &self,
         organization_id: OrganizationId,
-    ) -> Result<Vec<TargetSystemView>, RotationError> {
+    ) -> Result<Vec<TargetSystem>, RotationError> {
         let response = self
             .api_configurations
             .api_client
@@ -218,7 +218,7 @@ impl TargetSystemsClient {
             .data
             .unwrap_or_default()
             .into_iter()
-            .map(TargetSystemView::try_from)
+            .map(TargetSystem::try_from)
             .collect()
     }
 
@@ -227,7 +227,7 @@ impl TargetSystemsClient {
         &self,
         organization_id: OrganizationId,
         request: TargetSystemCreateRequest,
-    ) -> Result<TargetSystemView, RotationError> {
+    ) -> Result<TargetSystem, RotationError> {
         validate_target_system_create(&request)?;
 
         let response = self
@@ -237,7 +237,7 @@ impl TargetSystemsClient {
             .post(organization_id.into(), request.try_into()?)
             .await?;
 
-        TargetSystemView::try_from(response)
+        TargetSystem::try_from(response)
     }
 
     /// Validates and updates a target system's name, policy, and session-termination capability.

--- a/bitwarden_license/bitwarden-pam/src/rotation/validate.rs
+++ b/bitwarden_license/bitwarden-pam/src/rotation/validate.rs
@@ -1,0 +1,379 @@
+use thiserror::Error;
+
+use super::{
+    configs::{RotationConfigCreateRequest, RotationConfigUpdateRequest},
+    models::PasswordPolicy,
+    schedule::is_likely_quartz_cron,
+    target_systems::{TargetSystemCreateRequest, TargetSystemUpdateRequest},
+};
+
+/// Maximum length of a connector or target-system `name`, matching the server's column.
+const MAX_NAME_LENGTH: usize = 200;
+/// Maximum length of a config's `account_identity`, matching the server's column.
+const MAX_ACCOUNT_IDENTITY_LENGTH: usize = 500;
+/// Shortest generated credential a policy may ask for.
+const MIN_PASSWORD_LENGTH: i32 = 1;
+/// Longest generated credential a policy may ask for.
+const MAX_PASSWORD_LENGTH: i32 = 999;
+
+/// Errors returned when a locally-constructed rotation request fails validation before being sent.
+#[derive(Debug, Error, PartialEq, Eq)]
+pub enum RotationValidationError {
+    /// A `name` was empty (after trimming) or exceeded the server's length limit.
+    #[error("Name must be between 1 and {MAX_NAME_LENGTH} characters")]
+    InvalidName,
+    /// `account_identity` was empty (after trimming) or exceeded the server's length limit.
+    #[error("Account identity must be between 1 and {MAX_ACCOUNT_IDENTITY_LENGTH} characters")]
+    InvalidAccountIdentity,
+    /// A password policy's length bounds were outside the permitted range, or `min_length`
+    /// exceeded `max_length`.
+    #[error(
+        "Password length bounds must be between {MIN_PASSWORD_LENGTH} and {MAX_PASSWORD_LENGTH}, with the minimum no greater than the maximum"
+    )]
+    InvalidPasswordLengthBounds,
+    /// A password policy enabled no character classes, so no credential could satisfy it.
+    #[error("A password policy must allow at least one character class")]
+    NoCharacterClasses,
+    /// `schedule_cron` was present but is not shaped like a Quartz cron expression.
+    #[error("Schedule must be a 6- or 7-field Quartz cron expression")]
+    InvalidCron,
+}
+
+/// Validates a name against the server's length limit.
+///
+/// Counted in UTF-16 code units to match the server's `nvarchar` column, so a name of astral
+/// characters is measured the way the database will measure it rather than by Rust `char` count.
+pub(super) fn validate_name(name: &str) -> Result<(), RotationValidationError> {
+    let trimmed = name.trim();
+    if trimmed.is_empty() || trimmed.encode_utf16().count() > MAX_NAME_LENGTH {
+        return Err(RotationValidationError::InvalidName);
+    }
+
+    Ok(())
+}
+
+fn validate_account_identity(identity: &str) -> Result<(), RotationValidationError> {
+    let trimmed = identity.trim();
+    if trimmed.is_empty() || trimmed.encode_utf16().count() > MAX_ACCOUNT_IDENTITY_LENGTH {
+        return Err(RotationValidationError::InvalidAccountIdentity);
+    }
+
+    Ok(())
+}
+
+/// Validates a password policy.
+///
+/// Both checks mirror failures the connector's own generator raises at rotation time. Catching them
+/// here means an operator learns while editing the target system, rather than from a rotation that
+/// fails hours later against a policy no credential can satisfy.
+fn validate_password_policy(policy: &PasswordPolicy) -> Result<(), RotationValidationError> {
+    if policy.min_length < MIN_PASSWORD_LENGTH
+        || policy.max_length > MAX_PASSWORD_LENGTH
+        || policy.min_length > policy.max_length
+    {
+        return Err(RotationValidationError::InvalidPasswordLengthBounds);
+    }
+
+    if !policy.include_uppercase
+        && !policy.include_lowercase
+        && !policy.include_digits
+        && !policy.include_symbols
+    {
+        return Err(RotationValidationError::NoCharacterClasses);
+    }
+
+    Ok(())
+}
+
+/// Validates a cron expression when one is set. `None` means no scheduled rotation, which is valid.
+///
+/// Only the shape is checked. The server owns the minimum-interval floor, because only it knows the
+/// current limit - duplicating the number here would let the two disagree.
+fn validate_schedule_cron(cron: Option<&String>) -> Result<(), RotationValidationError> {
+    match cron {
+        Some(cron) if !is_likely_quartz_cron(cron) => Err(RotationValidationError::InvalidCron),
+        _ => Ok(()),
+    }
+}
+
+/// Validates a target-system create request.
+pub(super) fn validate_target_system_create(
+    request: &TargetSystemCreateRequest,
+) -> Result<(), RotationValidationError> {
+    validate_name(request.name())?;
+    validate_password_policy(request.password_policy())
+}
+
+/// Validates a target-system update request.
+pub(super) fn validate_target_system_update(
+    request: &TargetSystemUpdateRequest,
+) -> Result<(), RotationValidationError> {
+    validate_name(&request.name)?;
+    validate_password_policy(&request.password_policy)
+}
+
+/// Validates a rotation-config create request.
+pub(super) fn validate_config_create(
+    request: &RotationConfigCreateRequest,
+) -> Result<(), RotationValidationError> {
+    validate_account_identity(&request.account_identity)?;
+    validate_schedule_cron(request.schedule_cron.as_ref())
+}
+
+/// Validates a rotation-config update request.
+pub(super) fn validate_config_update(
+    request: &RotationConfigUpdateRequest,
+) -> Result<(), RotationValidationError> {
+    validate_account_identity(&request.account_identity)?;
+    validate_schedule_cron(request.schedule_cron.as_ref())
+}
+
+#[cfg(test)]
+mod tests {
+    use bitwarden_vault::CipherId;
+    use uuid::uuid;
+
+    use super::*;
+    use crate::{TargetSystemId, rotation::models::TargetSystemKind};
+
+    fn policy() -> PasswordPolicy {
+        PasswordPolicy {
+            min_length: 14,
+            max_length: 64,
+            include_uppercase: true,
+            include_lowercase: true,
+            include_digits: true,
+            include_symbols: true,
+        }
+    }
+
+    fn create_request(name: &str) -> TargetSystemCreateRequest {
+        TargetSystemCreateRequest::Automatic {
+            name: name.to_string(),
+            kind: TargetSystemKind::Entra,
+            password_policy: policy(),
+            supports_session_termination: true,
+        }
+    }
+
+    fn config_create(account_identity: &str, cron: Option<&str>) -> RotationConfigCreateRequest {
+        RotationConfigCreateRequest {
+            cipher_id: CipherId::new(uuid!("11111111-1111-1111-1111-111111111111")),
+            target_system_id: TargetSystemId::new(uuid!("22222222-2222-2222-2222-222222222222")),
+            account_identity: account_identity.to_string(),
+            terminate_sessions: false,
+            schedule_cron: cron.map(ToString::to_string),
+            rotate_on_access_end: false,
+        }
+    }
+
+    #[test]
+    fn a_well_formed_create_request_passes() {
+        assert!(validate_target_system_create(&create_request("Prod SQL")).is_ok());
+    }
+
+    #[test]
+    fn a_blank_name_is_rejected() {
+        for name in ["", "   ", "\t\n"] {
+            assert_eq!(
+                validate_target_system_create(&create_request(name)),
+                Err(RotationValidationError::InvalidName),
+                "for {name:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn a_name_at_the_limit_passes_and_one_over_is_rejected() {
+        let at_limit = "a".repeat(MAX_NAME_LENGTH);
+        assert!(validate_target_system_create(&create_request(&at_limit)).is_ok());
+
+        let over_limit = "a".repeat(MAX_NAME_LENGTH + 1);
+        assert_eq!(
+            validate_target_system_create(&create_request(&over_limit)),
+            Err(RotationValidationError::InvalidName)
+        );
+    }
+
+    /// The limit is the server's `nvarchar` budget, which counts UTF-16 code units. An astral
+    /// character costs two, so 100 of them exactly fill a 200-unit column and 101 overflow it -
+    /// a `char`-based count would wave both through.
+    #[test]
+    fn name_length_is_counted_in_utf16_code_units() {
+        let at_limit = "😀".repeat(MAX_NAME_LENGTH / 2);
+        assert!(validate_target_system_create(&create_request(&at_limit)).is_ok());
+
+        let over_limit = "😀".repeat(MAX_NAME_LENGTH / 2 + 1);
+        assert_eq!(
+            validate_target_system_create(&create_request(&over_limit)),
+            Err(RotationValidationError::InvalidName)
+        );
+    }
+
+    /// Leading and trailing whitespace is trimmed before measuring, so padding cannot push an
+    /// otherwise-valid name over.
+    #[test]
+    fn surrounding_whitespace_does_not_count_towards_the_limit() {
+        let padded = format!("  {}  ", "a".repeat(MAX_NAME_LENGTH));
+        assert!(validate_target_system_create(&create_request(&padded)).is_ok());
+    }
+
+    #[test]
+    fn inverted_length_bounds_are_rejected() {
+        let request = TargetSystemCreateRequest::Manual {
+            name: "Manual".to_string(),
+            password_policy: PasswordPolicy {
+                min_length: 64,
+                max_length: 14,
+                ..policy()
+            },
+        };
+
+        assert_eq!(
+            validate_target_system_create(&request),
+            Err(RotationValidationError::InvalidPasswordLengthBounds)
+        );
+    }
+
+    #[test]
+    fn length_bounds_outside_the_permitted_range_are_rejected() {
+        for (min_length, max_length) in [(0, 64), (-1, 64), (14, MAX_PASSWORD_LENGTH + 1)] {
+            let request = TargetSystemCreateRequest::Manual {
+                name: "Manual".to_string(),
+                password_policy: PasswordPolicy {
+                    min_length,
+                    max_length,
+                    ..policy()
+                },
+            };
+
+            assert_eq!(
+                validate_target_system_create(&request),
+                Err(RotationValidationError::InvalidPasswordLengthBounds),
+                "for {min_length}..{max_length}"
+            );
+        }
+    }
+
+    #[test]
+    fn equal_length_bounds_are_accepted() {
+        let request = TargetSystemCreateRequest::Manual {
+            name: "Manual".to_string(),
+            password_policy: PasswordPolicy {
+                min_length: 32,
+                max_length: 32,
+                ..policy()
+            },
+        };
+
+        assert!(validate_target_system_create(&request).is_ok());
+    }
+
+    /// A policy with every class off is unsatisfiable, and the connector's generator raises the
+    /// same failure at rotation time.
+    #[test]
+    fn a_policy_with_no_character_classes_is_rejected() {
+        let request = TargetSystemCreateRequest::Manual {
+            name: "Manual".to_string(),
+            password_policy: PasswordPolicy {
+                include_uppercase: false,
+                include_lowercase: false,
+                include_digits: false,
+                include_symbols: false,
+                ..policy()
+            },
+        };
+
+        assert_eq!(
+            validate_target_system_create(&request),
+            Err(RotationValidationError::NoCharacterClasses)
+        );
+    }
+
+    #[test]
+    fn a_single_character_class_is_enough() {
+        let request = TargetSystemCreateRequest::Manual {
+            name: "Manual".to_string(),
+            password_policy: PasswordPolicy {
+                include_uppercase: false,
+                include_lowercase: true,
+                include_digits: false,
+                include_symbols: false,
+                ..policy()
+            },
+        };
+
+        assert!(validate_target_system_create(&request).is_ok());
+    }
+
+    #[test]
+    fn a_config_with_no_schedule_is_valid() {
+        assert!(validate_config_create(&config_create("svc_rotation", None)).is_ok());
+    }
+
+    #[test]
+    fn a_config_with_a_well_formed_cron_is_valid() {
+        assert!(
+            validate_config_create(&config_create("svc_rotation", Some("0 0 0 * * ?"))).is_ok()
+        );
+    }
+
+    #[test]
+    fn a_malformed_cron_is_rejected() {
+        // A 5-field UNIX cron - the likeliest operator mistake.
+        assert_eq!(
+            validate_config_create(&config_create("svc_rotation", Some("0 0 * * *"))),
+            Err(RotationValidationError::InvalidCron)
+        );
+    }
+
+    #[test]
+    fn a_blank_account_identity_is_rejected() {
+        assert_eq!(
+            validate_config_create(&config_create("   ", None)),
+            Err(RotationValidationError::InvalidAccountIdentity)
+        );
+    }
+
+    #[test]
+    fn an_account_identity_at_the_limit_passes_and_one_over_is_rejected() {
+        let at_limit = "a".repeat(MAX_ACCOUNT_IDENTITY_LENGTH);
+        assert!(validate_config_create(&config_create(&at_limit, None)).is_ok());
+
+        let over_limit = "a".repeat(MAX_ACCOUNT_IDENTITY_LENGTH + 1);
+        assert_eq!(
+            validate_config_create(&config_create(&over_limit, None)),
+            Err(RotationValidationError::InvalidAccountIdentity)
+        );
+    }
+
+    /// The update path guards the same fields as create; a caller must not be able to reach an
+    /// invalid state by editing into it.
+    #[test]
+    fn the_update_path_applies_the_same_guards() {
+        let request = RotationConfigUpdateRequest {
+            account_identity: String::new(),
+            terminate_sessions: false,
+            schedule_cron: None,
+            rotate_on_access_end: false,
+        };
+        assert_eq!(
+            validate_config_update(&request),
+            Err(RotationValidationError::InvalidAccountIdentity)
+        );
+
+        let request = TargetSystemUpdateRequest {
+            name: "Renamed".to_string(),
+            password_policy: PasswordPolicy {
+                min_length: 64,
+                max_length: 14,
+                ..policy()
+            },
+            supports_session_termination: false,
+        };
+        assert_eq!(
+            validate_target_system_update(&request),
+            Err(RotationValidationError::InvalidPasswordLengthBounds)
+        );
+    }
+}

--- a/crates/bitwarden-api-api/src/models/register_access_connector_response_model.rs
+++ b/crates/bitwarden-api-api/src/models/register_access_connector_response_model.rs
@@ -53,7 +53,7 @@ pub struct RegisterAccessConnectorResponseModel {
     )]
     pub creation_date: Option<String>,
     /// The id of the access connector's `dbo.ApiKey` credential. The operator assembles the access
-    /// connector's OAuth client id from it (`access-connector.<ApiKeyId>`, resolved server-side by
+    /// connector's OAuth client id from it (`daemon.<ApiKeyId>`, resolved server-side by
     /// `PamAccessConnectorClientProvider` in Identity).
     #[serde(
         rename = "apiKeyId",
@@ -65,7 +65,7 @@ pub struct RegisterAccessConnectorResponseModel {
     /// credential -- store it now; the server hashes it for storage and never persists or returns
     /// the plaintext again. Pair with the client-wrapped org key you already hold locally to
     /// assemble the access connector's token
-    /// (`0.access-connector.<apiKeyId>.<client_secret>:<encryption_key>`).
+    /// (`0.daemon.<apiKeyId>.<client_secret>:<encryption_key>`).
     #[serde(
         rename = "clientSecret",
         alias = "ClientSecret",

--- a/crates/bitwarden-api-api/src/models/register_access_connector_response_model.rs
+++ b/crates/bitwarden-api-api/src/models/register_access_connector_response_model.rs
@@ -53,7 +53,7 @@ pub struct RegisterAccessConnectorResponseModel {
     )]
     pub creation_date: Option<String>,
     /// The id of the access connector's `dbo.ApiKey` credential. The operator assembles the access
-    /// connector's OAuth client id from it (`daemon.<ApiKeyId>`, resolved server-side by
+    /// connector's OAuth client id from it (`access-connector.<ApiKeyId>`, resolved server-side by
     /// `PamAccessConnectorClientProvider` in Identity).
     #[serde(
         rename = "apiKeyId",
@@ -65,7 +65,7 @@ pub struct RegisterAccessConnectorResponseModel {
     /// credential -- store it now; the server hashes it for storage and never persists or returns
     /// the plaintext again. Pair with the client-wrapped org key you already hold locally to
     /// assemble the access connector's token
-    /// (`0.daemon.<apiKeyId>.<client_secret>:<encryption_key>`).
+    /// (`0.access-connector.<apiKeyId>.<client_secret>:<encryption_key>`).
     #[serde(
         rename = "clientSecret",
         alias = "ClientSecret",


### PR DESCRIPTION
## 🎟️ Tracking

[PM-39040](https://bitwarden.atlassian.net/browse/PM-39040)

Stacked on #1384 (`pam/uat`). Paired `bitwarden/clients` PR to follow — see *Follow-up* below.

## 📔 Objective

Adds a `rotation` module to `bitwarden-pam`, porting the Admin Console's credential-rotation surface out of the web client and into the SDK: the domain enums, server DTO mapping, all 22 admin endpoints, the two pieces of shared business logic, request validation, and the access-connector registration crypto.

The web client's rotation layer was written against a *planned* server contract that shipped differently, so this is not a like-for-like move. The differences are the point of the PR as much as the relocation is:

| Web client today | What the server actually exposes |
|---|---|
| `/organizations/{orgId}/rotation/...` | `/organizations/{orgId}/access-connectors/...` |
| "rotation daemon" | "access connector" (kept server-side naming here; the standalone agent is still the *rotation daemon*) |
| `PUT .../target-systems/{id}/name` **+** `/policy` | one `PUT .../target-systems/{id}`, returning `204` |
| `DELETE .../target-systems/{id}` | **no delete route exists** — `disable` is how a target is retired |
| `PUT .../configs/{id}/settings` **+** `/account` | one `PUT .../configs/{id}` |

Every rotation call in the web client would 404 today, so this is what makes the feature work rather than a refactor.

### Registration crypto

This is the part worth reviewing closely. The web client derived its key with HKDF info `"pam-rotation-daemon"`, while the daemon re-derives from its token with `"sm-access-token"`. A connector registered from the web could therefore never decrypt the payload carrying the organization key — it would derive a different key and fail to authenticate.

This module uses the daemon's constants, which are also Secrets Manager's and match `bitwarden_core::auth::AccessToken`. `ConnectorToken` parses the format immediately beside where `RegistrationSecrets::into_token` mints it, so the two halves cannot drift apart again — splitting them across crates is what allowed the original divergence. The round-trip test walks a connector's entire path: mint → token string → parse → re-derive → decrypt → assert the organization key comes back verbatim.

On the `key` field, where the daemon's `examples/register.rs` ("CONTRACT C4") encrypts the raw seed's base64 and SM encrypts the derived key's base64, this follows **SM** — which is also what the web client does today. Nothing reads that field during registration; it matters only for organization-key rotation. Flagging it for whoever owns C4.

`bitwarden-rotation-daemon` carries a duplicate token parser it can now drop.

### Notes for review

- Every enum has an `Unknown` variant so a newer server never fails a whole list; writing one back is refused with `RotationError::UnrecognizedVariant`.
- `TargetSystemCreateRequest` is a `method`-tagged union rather than a struct of optionals, so the automatic/manual field combinations the server rejects are unrepresentable.
- `RotationConfigActions` derives all five action flags in one call because they are interdependent (pause/resume are complements; rotate-now and record-manual are decided by the same field). Unloaded target status fails closed.
- The server stays authoritative on the minimum rotation interval — deliberately not duplicated here.
- `PamClient`'s existing `key_store` gains a second consumer, so its doc comment now names both.

200 tests, clippy clean, builds for `wasm32-unknown-unknown` with the `wasm` feature.

## 🚨 Breaking Changes

None. Purely additive: a new `pam().rotation()` accessor and its types. No existing signature changes, so the TypeScript surface only gains members.

## Follow-up

Not in this PR — the clients-side migration, which deletes `rotation.ts`, `requests/`, `responses/`, both API services and `helpers/` (~1,500 lines) and rebinds `RotationApiService` to an SDK-backed service. Three UI changes are forced by the real contract and need product input: the target-system delete action has no endpoint to call, and both the target-system and config edit screens currently make two writes where the server takes one.

Registration crypto moving into the SDK is relevant to `@bitwarden/team-key-management-dev`.


[PM-39040]: https://bitwarden.atlassian.net/browse/PM-39040?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ