### PR TITLE
Rename the OAuth client_id prefix to access-connector

### DIFF
--- a/bitwarden_license/bitwarden-rotation-daemon/examples/register.rs
+++ b/bitwarden_license/bitwarden-rotation-daemon/examples/register.rs
@@ -234,7 +234,7 @@ fn main() {
     // it in the token string — but it goes to stdout only, not logs.
     println!();
     println!(
-        "token template: 0.daemon.<apiKeyId>.<clientSecret>:{}",
+        "token template: 0.access-connector.<apiKeyId>.<clientSecret>:{}",
         payload.encryption_key_b64.as_str()
     );
     println!("(substitute <apiKeyId> and <clientSecret> from the register API response)");
@@ -278,7 +278,7 @@ mod tests {
         let fake_api_key_id = "00000000-0000-0000-0000-000000000001";
         let fake_client_secret = "testsecret";
         let token_str = format!(
-            "0.daemon.{}.{}:{}",
+            "0.access-connector.{}.{}:{}",
             fake_api_key_id,
             fake_client_secret,
             payload.encryption_key_b64.as_str()

--- a/bitwarden_license/bitwarden-rotation-daemon/src/api/mod.rs
+++ b/bitwarden_license/bitwarden-rotation-daemon/src/api/mod.rs
@@ -662,7 +662,7 @@ mod tests {
 
     // ── Shared test helpers ────────────────────────────────────────────────
 
-    const VALID_TOKEN_STR: &str = "0.daemon.ec2c1d46-6a4b-4751-a310-af9601317f2d.C2IgxjjLF7qSshsbwe8JGcbM075YXw:X8vbvA0bduihIDe/qrzIQQ==";
+    const VALID_TOKEN_STR: &str = "0.access-connector.ec2c1d46-6a4b-4751-a310-af9601317f2d.C2IgxjjLF7qSshsbwe8JGcbM075YXw:X8vbvA0bduihIDe/qrzIQQ==";
 
     fn test_token() -> crate::token::DaemonToken {
         use std::str::FromStr;

--- a/bitwarden_license/bitwarden-rotation-daemon/src/api/mod.rs
+++ b/bitwarden_license/bitwarden-rotation-daemon/src/api/mod.rs
@@ -213,8 +213,7 @@ pub(crate) fn build_api_client(
 ///
 /// # Error classification
 ///
-/// See [`ApiError`] for the full taxonomy.  The classification follows the rules
-/// in the plan §4:
+/// See [`ApiError`] for the full taxonomy.  The classification rules are:
 ///
 /// - Post-retry 401 → consult `session.phase()`: terminal → `SessionLost`, else `Transient`.
 /// - 404 on poll/claim (daemon/job routes) → `NotEligible`.

--- a/bitwarden_license/bitwarden-rotation-daemon/src/auth/identity.rs
+++ b/bitwarden_license/bitwarden-rotation-daemon/src/auth/identity.rs
@@ -182,7 +182,7 @@ mod tests {
     use super::{AuthError, IdentityClient};
     use crate::token::DaemonToken;
 
-    const VALID_TOKEN_STR: &str = "0.daemon.ec2c1d46-6a4b-4751-a310-af9601317f2d.C2IgxjjLF7qSshsbwe8JGcbM075YXw:X8vbvA0bduihIDe/qrzIQQ==";
+    const VALID_TOKEN_STR: &str = "0.access-connector.ec2c1d46-6a4b-4751-a310-af9601317f2d.C2IgxjjLF7qSshsbwe8JGcbM075YXw:X8vbvA0bduihIDe/qrzIQQ==";
 
     fn test_token() -> DaemonToken {
         DaemonToken::from_str(VALID_TOKEN_STR).expect("valid token")
@@ -228,7 +228,7 @@ mod tests {
             .and(path("/connect/token"))
             .and(body_string_contains("grant_type=client_credentials"))
             .and(body_string_contains("scope=api.pam.rotation"))
-            .and(body_string_contains("client_id=daemon."))
+            .and(body_string_contains("client_id=access-connector."))
             .respond_with(
                 ResponseTemplate::new(200)
                     .set_body_string(success_body("tok", 3600))

--- a/bitwarden_license/bitwarden-rotation-daemon/src/auth/session.rs
+++ b/bitwarden_license/bitwarden-rotation-daemon/src/auth/session.rs
@@ -516,7 +516,7 @@ mod tests {
     use super::*;
     use crate::{auth::identity::IdentityClient, crypto::DaemonSymmSlotId, token::DaemonToken};
 
-    const VALID_TOKEN_STR: &str = "0.daemon.ec2c1d46-6a4b-4751-a310-af9601317f2d.C2IgxjjLF7qSshsbwe8JGcbM075YXw:X8vbvA0bduihIDe/qrzIQQ==";
+    const VALID_TOKEN_STR: &str = "0.access-connector.ec2c1d46-6a4b-4751-a310-af9601317f2d.C2IgxjjLF7qSshsbwe8JGcbM075YXw:X8vbvA0bduihIDe/qrzIQQ==";
 
     fn test_token() -> DaemonToken {
         use std::str::FromStr;

--- a/bitwarden_license/bitwarden-rotation-daemon/src/cli.rs
+++ b/bitwarden_license/bitwarden-rotation-daemon/src/cli.rs
@@ -112,7 +112,6 @@ mod tests {
 
     #[test]
     fn cli_rejects_removed_settings_flags() {
-        // Per-setting flags were removed; settings live in the config file only.
         for args in [
             ["bw-rotation-daemon", "run", "--poll-interval", "30"].as_slice(),
             [

--- a/bitwarden_license/bitwarden-rotation-daemon/src/cli.rs
+++ b/bitwarden_license/bitwarden-rotation-daemon/src/cli.rs
@@ -87,7 +87,7 @@ mod tests {
             "bw-rotation-daemon",
             "run",
             "--token",
-            "0.daemon.some-id.secret:key==",
+            "0.access-connector.some-id.secret:key==",
         ]);
         assert!(
             result.is_err(),

--- a/bitwarden_license/bitwarden-rotation-daemon/src/config.rs
+++ b/bitwarden_license/bitwarden-rotation-daemon/src/config.rs
@@ -350,7 +350,7 @@ mod tests {
     use super::*;
 
     /// A valid token string for testing (same vector used in token.rs tests).
-    const VALID_TOKEN: &str = "0.daemon.ec2c1d46-6a4b-4751-a310-af9601317f2d.C2IgxjjLF7qSshsbwe8JGcbM075YXw:X8vbvA0bduihIDe/qrzIQQ==";
+    const VALID_TOKEN: &str = "0.access-connector.ec2c1d46-6a4b-4751-a310-af9601317f2d.C2IgxjjLF7qSshsbwe8JGcbM075YXw:X8vbvA0bduihIDe/qrzIQQ==";
 
     /// Use the process-wide env lock so config tests and custom_script tests
     /// serialise all environment mutations across modules.

--- a/bitwarden_license/bitwarden-rotation-daemon/src/executor/mod.rs
+++ b/bitwarden_license/bitwarden-rotation-daemon/src/executor/mod.rs
@@ -556,7 +556,7 @@ mod tests {
         token::DaemonToken,
     };
 
-    const VALID_TOKEN_STR: &str = "0.daemon.ec2c1d46-6a4b-4751-a310-af9601317f2d.C2IgxjjLF7qSshsbwe8JGcbM075YXw:X8vbvA0bduihIDe/qrzIQQ==";
+    const VALID_TOKEN_STR: &str = "0.access-connector.ec2c1d46-6a4b-4751-a310-af9601317f2d.C2IgxjjLF7qSshsbwe8JGcbM075YXw:X8vbvA0bduihIDe/qrzIQQ==";
 
     fn test_token() -> DaemonToken {
         use std::str::FromStr;

--- a/bitwarden_license/bitwarden-rotation-daemon/src/executor/rotation.rs
+++ b/bitwarden_license/bitwarden-rotation-daemon/src/executor/rotation.rs
@@ -915,7 +915,7 @@ mod tests {
             .mount(&server).await;
 
         let token = DaemonToken::from_str(
-            "0.daemon.ec2c1d46-6a4b-4751-a310-af9601317f2d.C2IgxjjLF7qSshsbwe8JGcbM075YXw:X8vbvA0bduihIDe/qrzIQQ=="
+            "0.access-connector.ec2c1d46-6a4b-4751-a310-af9601317f2d.C2IgxjjLF7qSshsbwe8JGcbM075YXw:X8vbvA0bduihIDe/qrzIQQ=="
         ).unwrap();
         let identity = IdentityClient::new(server.uri()).unwrap();
         let session = SessionManager::new(identity, token).await.unwrap();
@@ -992,7 +992,7 @@ mod tests {
             .mount(&server).await;
 
         let token = DaemonToken::from_str(
-            "0.daemon.ec2c1d46-6a4b-4751-a310-af9601317f2d.C2IgxjjLF7qSshsbwe8JGcbM075YXw:X8vbvA0bduihIDe/qrzIQQ=="
+            "0.access-connector.ec2c1d46-6a4b-4751-a310-af9601317f2d.C2IgxjjLF7qSshsbwe8JGcbM075YXw:X8vbvA0bduihIDe/qrzIQQ=="
         ).unwrap();
         let identity = IdentityClient::new(server.uri()).unwrap();
         let session = SessionManager::new(identity, token).await.unwrap();
@@ -1235,7 +1235,7 @@ mod tests {
 
         // ── SessionManager ───────────────────────────────────────────────────
         let token = DaemonToken::from_str(
-            "0.daemon.ec2c1d46-6a4b-4751-a310-af9601317f2d.C2IgxjjLF7qSshsbwe8JGcbM075YXw:X8vbvA0bduihIDe/qrzIQQ=="
+            "0.access-connector.ec2c1d46-6a4b-4751-a310-af9601317f2d.C2IgxjjLF7qSshsbwe8JGcbM075YXw:X8vbvA0bduihIDe/qrzIQQ=="
         ).unwrap();
         let identity = IdentityClient::new(identity_server.uri()).unwrap();
         let session = SessionManager::new(identity, token).await.unwrap();

--- a/bitwarden_license/bitwarden-rotation-daemon/src/executor/rotation.rs
+++ b/bitwarden_license/bitwarden-rotation-daemon/src/executor/rotation.rs
@@ -1080,7 +1080,6 @@ mod tests {
 
     #[test]
     fn target_effect_to_sync_state_mapping() {
-        // Verify the explicit mappings specified by the plan.
         assert_eq!(
             effect_to_sync_state(TargetEffect::NotApplied),
             SyncState::TargetUnchanged
@@ -1138,7 +1137,7 @@ mod tests {
         assert_eq!(s, r#""unsupported_kind""#);
     }
 
-    // ── Fix-5: get_cipher Protocol error → target_updated failure reported ──
+    // ── get_cipher Protocol error → target_updated failure reported ──────
 
     /// After a successful rotate (step 3), a Protocol error from get_cipher
     /// must produce a `target_updated` failure report rather than being silently

--- a/bitwarden_license/bitwarden-rotation-daemon/src/token.rs
+++ b/bitwarden_license/bitwarden-rotation-daemon/src/token.rs
@@ -1,7 +1,7 @@
 //! Daemon token parsing and key derivation.
 //!
 //! Operator-provisioned credential string format:
-//! `0.daemon.<api-key-id-uuid>.<client-secret>:<b64-16-byte-encryption-key>`
+//! `0.access-connector.<api-key-id-uuid>.<client-secret>:<b64-16-byte-encryption-key>`
 //!
 //! The encryption key is derived via [`bitwarden_crypto::derive_shareable_key`] using the
 //! constants `DERIVE_NAME` and `DERIVE_INFO`.
@@ -50,7 +50,7 @@ pub enum DaemonTokenInvalidError {
 /// A parsed and validated daemon credential token.
 ///
 /// Parsed from the operator-provisioned token string:
-/// `0.daemon.<api-key-id-uuid>.<client-secret>:<b64-16-byte-encryption-key>`
+/// `0.access-connector.<api-key-id-uuid>.<client-secret>:<b64-16-byte-encryption-key>`
 pub struct DaemonToken {
     /// The API key identifier used to construct the OAuth `client_id`.
     pub api_key_id: Uuid,
@@ -73,9 +73,9 @@ impl fmt::Debug for DaemonToken {
 impl DaemonToken {
     /// Returns the OAuth `client_id` for this daemon token.
     ///
-    /// Format: `daemon.<api_key_id>`.
+    /// Format: `access-connector.<api_key_id>`.
     pub fn client_id(&self) -> String {
-        format!("daemon.{}", self.api_key_id)
+        format!("access-connector.{}", self.api_key_id)
     }
 }
 
@@ -99,7 +99,7 @@ impl FromStr for DaemonToken {
             return Err(DaemonTokenInvalidError::WrongVersion);
         }
 
-        if prefix != "daemon" {
+        if prefix != "access-connector" {
             return Err(DaemonTokenInvalidError::WrongPrefix);
         }
 
@@ -141,7 +141,7 @@ mod tests {
     ///
     /// Original SM vector (access_token.rs): key `X8vbvA0bduihIDe/qrzIQQ==`, uuid
     /// `ec2c1d46-6a4b-4751-a310-af9601317f2d`, secret `C2IgxjjLF7qSshsbwe8JGcbM075YXw`.
-    const VALID_TOKEN: &str = "0.daemon.ec2c1d46-6a4b-4751-a310-af9601317f2d.C2IgxjjLF7qSshsbwe8JGcbM075YXw:X8vbvA0bduihIDe/qrzIQQ==";
+    const VALID_TOKEN: &str = "0.access-connector.ec2c1d46-6a4b-4751-a310-af9601317f2d.C2IgxjjLF7qSshsbwe8JGcbM075YXw:X8vbvA0bduihIDe/qrzIQQ==";
 
     /// Known-answer derived key for the SM test vector (same C1 constants as access_token.rs).
     const EXPECTED_KEY_B64: &str =
@@ -170,20 +170,20 @@ mod tests {
         let token = DaemonToken::from_str(VALID_TOKEN).expect("valid token must parse");
         assert_eq!(
             token.client_id(),
-            "daemon.ec2c1d46-6a4b-4751-a310-af9601317f2d"
+            "access-connector.ec2c1d46-6a4b-4751-a310-af9601317f2d"
         );
     }
 
     #[test]
     fn base64_without_padding_is_accepted() {
         // The SM test shows padding-free b64 is accepted.
-        let t = "0.daemon.ec2c1d46-6a4b-4751-a310-af9601317f2d.C2IgxjjLF7qSshsbwe8JGcbM075YXw:X8vbvA0bduihIDe/qrzIQQ";
+        let t = "0.access-connector.ec2c1d46-6a4b-4751-a310-af9601317f2d.C2IgxjjLF7qSshsbwe8JGcbM075YXw:X8vbvA0bduihIDe/qrzIQQ";
         assert!(DaemonToken::from_str(t).is_ok());
     }
 
     #[test]
     fn wrong_version_is_rejected() {
-        let t = "1.daemon.ec2c1d46-6a4b-4751-a310-af9601317f2d.C2IgxjjLF7qSshsbwe8JGcbM075YXw:X8vbvA0bduihIDe/qrzIQQ==";
+        let t = "1.access-connector.ec2c1d46-6a4b-4751-a310-af9601317f2d.C2IgxjjLF7qSshsbwe8JGcbM075YXw:X8vbvA0bduihIDe/qrzIQQ==";
         assert!(matches!(
             DaemonToken::from_str(t),
             Err(DaemonTokenInvalidError::WrongVersion)
@@ -221,7 +221,7 @@ mod tests {
 
     #[test]
     fn too_many_dot_parts_gives_wrong_parts() {
-        let t = "0.daemon.extra.ec2c1d46-6a4b-4751-a310-af9601317f2d.C2IgxjjLF7qSshsbwe8JGcbM075YXw:X8vbvA0bduihIDe/qrzIQQ==";
+        let t = "0.access-connector.extra.ec2c1d46-6a4b-4751-a310-af9601317f2d.C2IgxjjLF7qSshsbwe8JGcbM075YXw:X8vbvA0bduihIDe/qrzIQQ==";
         assert!(matches!(
             DaemonToken::from_str(t),
             Err(DaemonTokenInvalidError::WrongParts)
@@ -230,7 +230,8 @@ mod tests {
 
     #[test]
     fn invalid_uuid_is_rejected() {
-        let t = "0.daemon.not-a-uuid.C2IgxjjLF7qSshsbwe8JGcbM075YXw:X8vbvA0bduihIDe/qrzIQQ==";
+        let t =
+            "0.access-connector.not-a-uuid.C2IgxjjLF7qSshsbwe8JGcbM075YXw:X8vbvA0bduihIDe/qrzIQQ==";
         assert!(matches!(
             DaemonToken::from_str(t),
             Err(DaemonTokenInvalidError::InvalidUuid)
@@ -240,7 +241,7 @@ mod tests {
     #[test]
     fn invalid_base64_is_rejected() {
         // '!' is not a valid base64 character.
-        let t = "0.daemon.ec2c1d46-6a4b-4751-a310-af9601317f2d.C2IgxjjLF7qSshsbwe8JGcbM075YXw:!!!notbase64!!!";
+        let t = "0.access-connector.ec2c1d46-6a4b-4751-a310-af9601317f2d.C2IgxjjLF7qSshsbwe8JGcbM075YXw:!!!notbase64!!!";
         assert!(matches!(
             DaemonToken::from_str(t),
             Err(DaemonTokenInvalidError::InvalidBase64(_))
@@ -252,7 +253,8 @@ mod tests {
         // 15-byte key (too short).
         use bitwarden_encoding::B64;
         let short_key = B64::from([0u8; 15].as_slice()).to_string();
-        let t = format!("0.daemon.ec2c1d46-6a4b-4751-a310-af9601317f2d.secret:{short_key}");
+        let t =
+            format!("0.access-connector.ec2c1d46-6a4b-4751-a310-af9601317f2d.secret:{short_key}");
         assert!(matches!(
             DaemonToken::from_str(&t),
             Err(DaemonTokenInvalidError::InvalidLength {

--- a/bitwarden_license/bitwarden-rotation-daemon/tests/daemon_flow.rs
+++ b/bitwarden_license/bitwarden-rotation-daemon/tests/daemon_flow.rs
@@ -42,7 +42,7 @@ static ENV_LOCK: Mutex<()> = Mutex::new(());
 // ---------------------------------------------------------------------------
 
 /// The test daemon token (SM test vector, adapted to the 4-part daemon format).
-const TEST_TOKEN_STR: &str = "0.daemon.ec2c1d46-6a4b-4751-a310-af9601317f2d.C2IgxjjLF7qSshsbwe8JGcbM075YXw:X8vbvA0bduihIDe/qrzIQQ==";
+const TEST_TOKEN_STR: &str = "0.access-connector.ec2c1d46-6a4b-4751-a310-af9601317f2d.C2IgxjjLF7qSshsbwe8JGcbM075YXw:X8vbvA0bduihIDe/qrzIQQ==";
 
 fn test_token() -> DaemonToken {
     DaemonToken::from_str(TEST_TOKEN_STR).expect("test token must parse")


### PR DESCRIPTION
## 🎟️ Tracking

PM-39040

## 📔 Objective

Migrates the rotation daemon to the renamed OAuth `client_id` prefix, without which it cannot authenticate at all.

- The server renamed the connector token prefix from `daemon` to `access-connector` and shipped no compatibility shim: `DynamicClientStore` splits on the first `.` and finds no keyed provider, so Identity answers `invalid_client`.
- Sends `access-connector.<apiKeyId>`, and accepts only that prefix when parsing an operator's token string.
- The wire assertion in the identity tests moves in lockstep, since it was the only test pinning the id actually sent.

Unrelated to Active Directory and based directly on `pam/rotation-daemon`. Bottom of a five PR stack, but nothing above it is needed for this to be worth merging.

## 🚨 Breaking Changes

An operator holding a token string with the old `daemon.` prefix must retype the prefix. The credential itself, the API key id and secret, is unchanged.
