### PR TITLE
Add an on-premises Active Directory rotation connector

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -304,6 +304,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "asn1-rs"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f43a50ac4fdca5df8e885c21b835997f0a1cdee65494a6847694a98652d9d8"
+dependencies = [
+ "asn1-rs-derive",
+ "asn1-rs-impl",
+ "displaydoc",
+ "nom",
+ "num-traits",
+ "rusticata-macros",
+ "thiserror 2.0.19",
+ "time",
+]
+
+[[package]]
+name = "asn1-rs-derive"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3109e49b1e4909e9db6515a30c633684d68cdeaa252f215214cb4fa1a5bfee2c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+ "synstructure",
+]
+
+[[package]]
+name = "asn1-rs-impl"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "assert-json-diff"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1039,7 +1078,7 @@ dependencies = [
  "bitwarden-error",
  "serde",
  "serde_json",
- "thiserror 1.0.69",
+ "thiserror 2.0.19",
  "tsify",
  "uniffi",
  "wasm-bindgen",
@@ -1206,12 +1245,13 @@ dependencies = [
  "chrono",
  "clap",
  "http",
+ "ldap3",
  "reqwest",
  "reqwest-middleware",
  "serde",
  "serde_json",
  "tempfile",
- "thiserror 1.0.69",
+ "thiserror 2.0.19",
  "tokio",
  "toml 0.9.12+spec-1.1.0",
  "tracing",
@@ -2706,6 +2746,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "der-parser"
+version = "10.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07da5016415d5a3c4dd39b11ed26f915f52fc4e0dc197d87908bc916e51bc1a6"
+dependencies = [
+ "asn1-rs",
+ "displaydoc",
+ "nom",
+ "num-bigint",
+ "num-traits",
+ "rusticata-macros",
+]
+
+[[package]]
 name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4123,6 +4177,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
+name = "lber"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cbcf559624bfd9fe8d488329a8959766335a43a9b8b2cdd6a2c379fca02909a5"
+dependencies = [
+ "bytes",
+ "nom",
+]
+
+[[package]]
+name = "ldap3"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01fe89f5e7cfb7e4701e3a38ff9f00358e026a9aee940355d88ee9d81e5c7503"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures",
+ "futures-util",
+ "lber",
+ "log",
+ "nom",
+ "percent-encoding",
+ "rustls",
+ "rustls-native-certs",
+ "thiserror 2.0.19",
+ "tokio",
+ "tokio-rustls",
+ "tokio-stream",
+ "tokio-util",
+ "url",
+ "x509-parser",
+]
+
+[[package]]
 name = "leb128"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4455,6 +4544,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "oid-registry"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12f40cff3dde1b6087cc5d5f5d4d65712f34016a03ed60e9c08dcc392736b5b7"
+dependencies = [
+ "asn1-rs",
 ]
 
 [[package]]
@@ -5398,6 +5496,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
  "semver",
+]
+
+[[package]]
+name = "rusticata-macros"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faf0c4a6ece9950b9abdb62b1cfcf2a68b3b67a10ba445b3bb85be2a293d0632"
+dependencies = [
+ "nom",
 ]
 
 [[package]]
@@ -7925,6 +8032,23 @@ name = "writeable"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
+name = "x509-parser"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d43b0f71ce057da06bc0851b23ee24f3f86190b07203dd8f567d0b706a185202"
+dependencies = [
+ "asn1-rs",
+ "data-encoding",
+ "der-parser",
+ "lazy_static",
+ "nom",
+ "oid-registry",
+ "rusticata-macros",
+ "thiserror 2.0.19",
+ "time",
+]
 
 [[package]]
 name = "xaes-256-gcm"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1248,6 +1248,7 @@ dependencies = [
  "ldap3",
  "reqwest",
  "reqwest-middleware",
+ "rustls",
  "serde",
  "serde_json",
  "tempfile",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -98,6 +98,9 @@ icu_normalizer = { version = "2.2.0", features = [
 ], default-features = false }
 js-sys = { version = ">=0.3.72, <0.4" }
 keepass = { version = ">=0.13.7, <0.14", default-features = false }
+ldap3 = { version = "0.12.1", default-features = false, features = [
+    "tls-rustls-ring",
+] }
 mockall = { version = ">=0.13.1, <0.16" }
 password-rules-parser = ">=1.1.0, <2"
 pbkdf2 = { version = "0.13.0-rc.10", default-features = false }

--- a/bitwarden_license/bitwarden-rotation-daemon/Cargo.toml
+++ b/bitwarden_license/bitwarden-rotation-daemon/Cargo.toml
@@ -28,6 +28,7 @@ bitwarden-threading = { workspace = true }
 chrono = { workspace = true }
 clap = { workspace = true, features = ["env"] }
 http = { workspace = true }
+ldap3 = { workspace = true }
 reqwest = { workspace = true }
 reqwest-middleware = { workspace = true }
 serde = { workspace = true }

--- a/bitwarden_license/bitwarden-rotation-daemon/Cargo.toml
+++ b/bitwarden_license/bitwarden-rotation-daemon/Cargo.toml
@@ -43,6 +43,7 @@ uuid = { workspace = true }
 zeroize = { workspace = true }
 
 [dev-dependencies]
+rustls = { workspace = true }
 tempfile = "3"
 tokio = { workspace = true, features = ["rt", "test-util"] }
 wiremock = { workspace = true }

--- a/bitwarden_license/bitwarden-rotation-daemon/README.md
+++ b/bitwarden_license/bitwarden-rotation-daemon/README.md
@@ -198,26 +198,43 @@ source was expected to provide the value.
 
 ### Accepted keys per target kind
 
-| Kind           | Accepted config keys     |
-| -------------- | ------------------------ |
-| `CustomScript` | `script`                 |
-| `Entra`        | `tenant_id`, `client_id` |
+| Kind              | Accepted config keys                |
+| ----------------- | ----------------------------------- |
+| `CustomScript`    | `script`                            |
+| `Entra`           | `tenant_id`, `client_id`            |
+| `ActiveDirectory` | `ldap_host`, `bind_dn`, `base_dn`   |
 
-### `client_secret` is env-only
+### Secrets are env-only
 
-`client_secret` is deliberately not accepted in the `[targets]` section. Config files are typically
-committed to version control; storing a secret there would expose it. Always supply `client_secret`
-via the environment variable (`<TARGET_ID_UPPER_UNDERSCORE>_CLIENT_SECRET`).
+`client_secret` and `bind_password` are deliberately not accepted in the `[targets]` section. Config
+files are typically committed to version control; storing a secret there would expose it. Always
+supply them via the environment variable (`<TARGET_ID_UPPER_UNDERSCORE>_CLIENT_SECRET` /
+`<TARGET_ID_UPPER_UNDERSCORE>_BIND_PASSWORD`).
 
-An unknown field (including `client_secret`) inside a `[targets.<uuid>]` block is a hard startup
-error; the daemon will refuse to start.
+An unknown field (including `client_secret` and `bind_password`) inside a `[targets.<uuid>]` block is
+a hard startup error; the daemon will refuse to start.
 
 ### POSIX shell limitation
 
 Environment variable names derived from a UUID that starts with a digit (e.g.
-`85808642_BABA_4B8E_8C34_B48000D60A0A_SCRIPT`) cannot be `export`ed from a POSIX `/bin/sh` script —
-names must start with a letter or underscore. The `[targets]` config section sidesteps this
-restriction for `script`, `tenant_id`, and `client_id`; only `client_secret` remains env-only.
+`85808642_BABA_4B8E_8C34_B48000D60A0A_SCRIPT`) are not valid POSIX shell identifiers — a name must
+start with a letter or underscore — so the shell refuses to `export` them:
+
+```
+$ export 85808642_BABA_4B8E_8C34_B48000D60A0A_BIND_PASSWORD=…
+bash: export: `85808642_BABA_4B8E_8C34_B48000D60A0A_BIND_PASSWORD=…': not a valid identifier
+```
+
+The `[targets]` config section sidesteps this restriction for `script`, `tenant_id`, `client_id`,
+`ldap_host`, `bind_dn`, and `base_dn`; only `client_secret` and `bind_password` remain env-only. For
+a target whose UUID starts with a digit those two have no config-file escape hatch, so set them with
+`env`, which places the name in the child's environment directly and never applies the shell's
+identifier rules:
+
+```sh
+env 85808642_BABA_4B8E_8C34_B48000D60A0A_BIND_PASSWORD="$secret" \
+  bw-rotation-daemon run --config /etc/bitwarden/rotation.toml
+```
 
 ---
 
@@ -242,11 +259,12 @@ ABC_1234_5678_ABCD_000000000001_CLIENT_SECRET=...
 
 ### Required suffixes per target kind
 
-| Kind           | Required env-var suffixes                         |
-| -------------- | ------------------------------------------------- |
-| `Entra`        | `TENANT_ID`, `CLIENT_ID`, `CLIENT_SECRET`         |
-| `CustomScript` | `SCRIPT`                                          |
-| `Mssql`        | `HOST`, `USER`, `SECRET` (unsupported this build) |
+| Kind              | Required env-var suffixes                            |
+| ----------------- | ---------------------------------------------------- |
+| `Entra`           | `TENANT_ID`, `CLIENT_ID`, `CLIENT_SECRET`            |
+| `CustomScript`    | `SCRIPT`                                             |
+| `ActiveDirectory` | `LDAP_HOST`, `BIND_DN`, `BASE_DN`, `BIND_PASSWORD`   |
+| `Mssql`           | `HOST`, `USER`, `SECRET` (unsupported this build)    |
 
 Any additional variables matching the prefix are collected and forwarded to the integration as extra
 credentials. For example, a custom script may read `OUT_PATH` or `EXIT_CODE` from the `credentials`
@@ -401,6 +419,119 @@ ABC_1234_…_TENANT_ID=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
 ABC_1234_…_CLIENT_ID=yyyyyyyy-yyyy-yyyy-yyyy-yyyyyyyyyyyy
 ABC_1234_…_CLIENT_SECRET=<secret>
 ```
+
+---
+
+## Active Directory integration
+
+The `ActiveDirectory` target kind rotates an on-premises domain account by replacing its
+`unicodePwd` attribute over LDAPS.
+
+### LDAPS is mandatory
+
+Every connection is made with an `ldaps://` URL (implicit TLS, port 636 by default). There is no
+plaintext LDAP path, no StartTLS fallback, and no flag to skip certificate validation.
+
+This is not only a Bitwarden policy: a domain controller refuses a `unicodePwd` write on an
+unencrypted connection, answering `confidentialityRequired` (LDAP result code 13).
+
+The domain controller's certificate is validated against the host's native trust store, so the
+**issuing enterprise CA must be trusted by the machine running the daemon**. A validation failure is
+a fatal error, not a retryable one.
+
+`ldap_host` is a bare host name, optionally with a `:port` suffix — never a URL. Anything containing
+a scheme, a path, userinfo, or whitespace is rejected at rotation time so that a mistyped host cannot
+silently downgrade the connection or redirect the bind.
+
+### Bind identity: a delegated service account
+
+The account named by `bind_dn` is expected to be a **delegated service account** whose only
+privileges on the target OU are:
+
+| Privilege        | Why needed                                             |
+| ---------------- | ------------------------------------------------------ |
+| `Reset Password` | Replace `unicodePwd` on the target accounts            |
+| Read             | Resolve the account identity to a distinguished name   |
+
+Delegate these with the Active Directory Users and Computers *Delegate Control* wizard, scoped to the
+OU that holds the managed accounts. **Do not use a Domain Admin account.** A credential held by a
+long-running daemon should never carry domain-wide authority, and nothing in this integration needs
+it.
+
+### How rotation works
+
+1. Connect to `ldap_host` over LDAPS and simple-bind as `bind_dn`.
+2. Search below `base_dn` (subtree scope) for exactly one user whose `sAMAccountName` or `userPrincipalName` matches the account identity. Zero matches and multiple matches are both fatal — rotating the wrong account is worse than not rotating.
+3. `replace` the account's `unicodePwd` with the new password, wrapped in ASCII double quotes and encoded as little-endian UTF-16 (no BOM), as Active Directory requires.
+
+This is an administrative reset: it never needs the account's current password, which is what allows
+a failed attempt to be retried with a freshly generated password.
+
+The account identity is escaped per RFC 4515 before it enters the search filter, so a hostile
+identity cannot widen the search.
+
+### Verification
+
+`verify` opens a second LDAPS connection and simple-binds **as the rotated account** using the new
+password. A successful bind is direct proof that the directory accepted the write — unlike a
+timestamp read it cannot be stale, and unlike an attribute compare it cannot be satisfied by some
+other change. A rejected bind is fatal.
+
+### Session termination is not supported
+
+`terminate_sessions` always fails with `unsupported_kind`. An LDAP password reset cannot revoke
+Kerberos ticket-granting tickets that have already been issued, and LDAP offers no revocation
+operation; there is no honest implementation. The server advertises
+`supportsSessionTermination: false` for this kind, so the executor should never call it.
+
+Operators who need existing sessions cut off must do it out of band (for example by resetting the
+account's `msDS-KeyVersionNumber`, disabling and re-enabling the account, or waiting out the ticket
+lifetime).
+
+### Resolver env shape (Active Directory)
+
+| Suffix          | Value                                                             |
+| --------------- | ----------------------------------------------------------------- |
+| `LDAP_HOST`     | Domain controller host name, optionally `host:port`               |
+| `BIND_DN`       | DN of the delegated service account                               |
+| `BASE_DN`       | Search base DN for account lookup                                 |
+| `BIND_PASSWORD` | Password of the delegated service account (**environment only**)  |
+
+Example (target id `abc-1234-…`):
+
+```
+ABC_1234_…_LDAP_HOST=dc01.corp.example
+ABC_1234_…_BIND_DN=CN=svc-rotate,OU=Service Accounts,DC=corp,DC=example
+ABC_1234_…_BASE_DN=OU=Managed Accounts,DC=corp,DC=example
+ABC_1234_…_BIND_PASSWORD=<secret>
+```
+
+`LDAP_HOST`, `BIND_DN`, and `BASE_DN` may also be supplied in the `[targets.<uuid>]` config section as
+`ldap_host`, `bind_dn`, and `base_dn`. `BIND_PASSWORD` may not — see
+[Secrets are env-only](#secrets-are-env-only).
+
+### Error classification
+
+**Class** applies within a single attempt: `Transient` is retried in place with exponential backoff
+up to `max_retry_attempts`, `Fatal` ends the attempt on the spot. Neither ends the job. A reported
+failure returns the job to the claimable pool and the daemon re-claims it on a later poll, until the
+server's attempt budget is spent — so a `Fatal` misconfiguration still reaches the domain controller
+once per attempt.
+
+| Condition                                              | Class     | Sync state | Failure code             |
+| ------------------------------------------------------ | --------- | ---------- | ------------------------ |
+| Missing or malformed credential                        | Fatal     | unchanged  | `credentials_unresolved` |
+| TCP failure, reset connection                          | Transient | unchanged  | `target_unreachable`     |
+| TLS handshake or certificate rejected                  | Fatal     | unchanged  | `target_unreachable`     |
+| Bind rejected (rc 49, 50)                              | Fatal     | unchanged  | `target_rejected`        |
+| Account not found or ambiguous                         | Fatal     | unchanged  | `target_rejected`        |
+| Write rejected (rc 13, 19, 32, 53, schema errors)      | Fatal     | unchanged  | `target_rejected`        |
+| DC busy / unavailable / admin limit (rc 51, 52, 11)    | Transient | unchanged  | `target_unreachable`     |
+| Timeout or dropped connection after the write is sent  | Transient | **indeterminate** | `target_unreachable` |
+| Rebind with the new password rejected                  | Fatal     | updated    | `verification_failed`    |
+
+Only the numeric LDAP result code reaches the failure report. The directory's `diagnosticMessage` and
+matched DN are never read: both can echo account names and password-policy text.
 
 ---
 

--- a/bitwarden_license/bitwarden-rotation-daemon/README.md
+++ b/bitwarden_license/bitwarden-rotation-daemon/README.md
@@ -537,6 +537,5 @@ matched DN are never read: both can echo account names and password-policy text.
 
 ## References
 
-- Plan: `~/.claude/plans/let-s-explore-implementing-the-spicy-sun.md`
 - Spec: `rotation-daemon/rotation-daemon.allium`
 - Architecture: https://contributing.bitwarden.com/architecture/sdk/

--- a/bitwarden_license/bitwarden-rotation-daemon/dev-config.toml
+++ b/bitwarden_license/bitwarden-rotation-daemon/dev-config.toml
@@ -40,3 +40,14 @@ script = "/tmp/bwrd-dev-rotate.sh"
 # [targets.00000000-0000-0000-0000-000000000001]
 # tenant_id = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
 # client_id = "yyyyyyyy-yyyy-yyyy-yyyy-yyyyyyyyyyyy"
+
+# Active Directory target. The daemon always connects with ldaps:// on port 636;
+# ldap_host is a bare host name (optionally host:port), never a URL.
+# bind_dn is a delegated service account with Reset Password on the target OU —
+# not a Domain Admin. Its password is env-only:
+#   00000000_0000_0000_0000_000000000003_BIND_PASSWORD=<secret>
+#
+# [targets.00000000-0000-0000-0000-000000000003]
+# ldap_host = "dc01.corp.example"
+# bind_dn   = "CN=svc-rotate,OU=Service Accounts,DC=corp,DC=example"
+# base_dn   = "OU=Managed Accounts,DC=corp,DC=example"

--- a/bitwarden_license/bitwarden-rotation-daemon/src/api/models.rs
+++ b/bitwarden_license/bitwarden-rotation-daemon/src/api/models.rs
@@ -31,16 +31,37 @@ pub(crate) enum TargetKind {
     Mssql,
     /// Operator-supplied custom rotation script.
     CustomScript,
+    /// On-premises Active Directory reached over LDAPS.
+    ActiveDirectory,
     /// Any other integer the server returned; treated as unsupported.
     Unknown(i64),
 }
 
 impl From<PamTargetSystemKind> for TargetKind {
+    /// Maps a wire kind onto the kinds this build can rotate.
+    ///
+    /// # Interim handling of Active Directory
+    ///
+    /// Wire value `3` is Active Directory, but the server does not yet publish
+    /// `PamTargetSystemKind.ActiveDirectory = 3` in its OpenAPI document, so the
+    /// generated enum has no named variant for it and the value arrives through
+    /// the generator's forward-compatibility catch-all as `__Unknown(3)`.
+    ///
+    /// Recognising it here rather than hand-adding a variant to
+    /// `bitwarden-api-api` keeps the workaround in the crate that owns this
+    /// boundary: the generated crates are rebuilt from scratch by
+    /// `support/generate-api-bindings-ci.sh`, which deletes their `src` before
+    /// regenerating, so an edit there does not survive.
+    ///
+    /// Once the server publishes the value, regenerating the bindings produces
+    /// `PamTargetSystemKind::ActiveDirectory` and the `__Unknown(3)` arm below is
+    /// replaced by a match on that variant. That arm is the only site to change.
     fn from(kind: PamTargetSystemKind) -> Self {
         match kind {
             PamTargetSystemKind::Entra => TargetKind::Entra,
             PamTargetSystemKind::Mssql => TargetKind::Mssql,
             PamTargetSystemKind::CustomScript => TargetKind::CustomScript,
+            PamTargetSystemKind::__Unknown(3) => TargetKind::ActiveDirectory,
             PamTargetSystemKind::__Unknown(v) => TargetKind::Unknown(v),
         }
     }
@@ -297,6 +318,16 @@ mod tests {
         assert_eq!(
             TargetKind::from(PamTargetSystemKind::CustomScript),
             TargetKind::CustomScript
+        );
+    }
+
+    #[test]
+    fn target_kind_from_active_directory() {
+        assert_eq!(
+            TargetKind::from(PamTargetSystemKind::from_i64(3)),
+            TargetKind::ActiveDirectory,
+            "wire value 3 is Active Directory, and reaches us as __Unknown until the \
+             server publishes the variant"
         );
     }
 

--- a/bitwarden_license/bitwarden-rotation-daemon/src/config.rs
+++ b/bitwarden_license/bitwarden-rotation-daemon/src/config.rs
@@ -1267,6 +1267,85 @@ client_secret = "{secret_value}"
     }
 
     #[test]
+    fn targets_bind_password_in_file_is_rejected_and_does_not_echo_value() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        unsafe {
+            std::env::set_var("BWRD_TOKEN", VALID_TOKEN);
+            std::env::remove_var("BWRD_API_URL");
+            std::env::remove_var("BWRD_IDENTITY_URL");
+        }
+        let secret_value = "bind-supersecret";
+        let toml = format!(
+            r#"
+[environment]
+api      = "https://api.example.com"
+identity = "https://identity.example.com"
+
+[targets.00000000-0000-0000-0000-000000000001]
+ldap_host     = "dc01.corp.example"
+bind_password = "{secret_value}"
+"#
+        );
+        let f = write_toml(&toml);
+        let result = Config::from_cli(file_args(&f));
+        unsafe {
+            std::env::remove_var("BWRD_TOKEN");
+        }
+        match result {
+            Err(RotationDaemonError::InvalidConfig(msg)) => {
+                assert!(
+                    !msg.contains(secret_value),
+                    "error must not echo secret value; got: {msg}"
+                );
+            }
+            other => {
+                panic!("expected InvalidConfig for bind_password in targets entry, got {other:?}")
+            }
+        }
+    }
+
+    #[test]
+    fn targets_active_directory_entry_parsed() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        unsafe {
+            std::env::set_var("BWRD_TOKEN", VALID_TOKEN);
+            std::env::remove_var("BWRD_API_URL");
+            std::env::remove_var("BWRD_IDENTITY_URL");
+        }
+        let toml = r#"
+[environment]
+api      = "https://api.example.com"
+identity = "https://identity.example.com"
+
+[targets.00000000-0000-0000-0000-000000000002]
+ldap_host = "dc01.corp.example"
+bind_dn   = "CN=svc-rotate,OU=Service Accounts,DC=corp,DC=example"
+base_dn   = "DC=corp,DC=example"
+"#;
+        let f = write_toml(toml);
+        let result = Config::from_cli(file_args(&f));
+        unsafe {
+            std::env::remove_var("BWRD_TOKEN");
+        }
+        let cfg = result
+            .expect("active directory target entry should parse")
+            .into_daemon_config();
+        let uuid: uuid::Uuid = "00000000-0000-0000-0000-000000000002".parse().unwrap();
+        assert_eq!(
+            cfg.targets[&uuid].ldap_host.as_deref(),
+            Some("dc01.corp.example")
+        );
+        assert_eq!(
+            cfg.targets[&uuid].bind_dn.as_deref(),
+            Some("CN=svc-rotate,OU=Service Accounts,DC=corp,DC=example")
+        );
+        assert_eq!(
+            cfg.targets[&uuid].base_dn.as_deref(),
+            Some("DC=corp,DC=example")
+        );
+    }
+
+    #[test]
     fn targets_invalid_uuid_key_is_rejected() {
         let _guard = ENV_LOCK.lock().unwrap();
         unsafe {

--- a/bitwarden_license/bitwarden-rotation-daemon/src/error.rs
+++ b/bitwarden_license/bitwarden-rotation-daemon/src/error.rs
@@ -170,6 +170,15 @@ impl SafeDetail {
         Self(Self::truncate(format!("error kind: {kind}")))
     }
 
+    /// Build a detail from an LDAP result code (RFC 4511 §A.1).
+    ///
+    /// Only the numeric code is included. A directory's `diagnosticMessage` and
+    /// `matchedDN` are never read into a detail: both can echo account names,
+    /// distinguished names, and password-policy text.
+    pub(crate) fn from_ldap_result_code(rc: u32) -> Self {
+        Self(Self::truncate(format!("LDAP result code {rc}")))
+    }
+
     /// Build a detail indicating a timeout after the given number of seconds.
     pub(crate) fn timed_out(secs: u64) -> Self {
         Self(Self::truncate(format!("timed out after {secs}s")))
@@ -268,6 +277,12 @@ mod tests {
     fn safe_detail_from_kind() {
         let d = SafeDetail::from_kind("GraphRequest");
         assert_eq!(d.as_str(), "error kind: GraphRequest");
+    }
+
+    #[test]
+    fn safe_detail_from_ldap_result_code() {
+        let d = SafeDetail::from_ldap_result_code(49);
+        assert_eq!(d.as_str(), "LDAP result code 49");
     }
 
     #[test]

--- a/bitwarden_license/bitwarden-rotation-daemon/src/executor/mod.rs
+++ b/bitwarden_license/bitwarden-rotation-daemon/src/executor/mod.rs
@@ -274,11 +274,19 @@ pub(crate) async fn run(cfg: DaemonConfig, cancel: CancellationToken) -> RunExit
     ));
     registry.register(crate::api::models::TargetKind::Entra, entra);
 
+    let active_directory =
+        Arc::new(crate::integrations::active_directory::ActiveDirectoryIntegration::new());
+    registry.register(
+        crate::api::models::TargetKind::ActiveDirectory,
+        active_directory,
+    );
+
     let integrations = Arc::new(registry);
     tracing::debug!(
         kinds = ?[
             crate::api::models::TargetKind::CustomScript,
             crate::api::models::TargetKind::Entra,
+            crate::api::models::TargetKind::ActiveDirectory,
         ],
         "registered integration kinds"
     );

--- a/bitwarden_license/bitwarden-rotation-daemon/src/executor/mod.rs
+++ b/bitwarden_license/bitwarden-rotation-daemon/src/executor/mod.rs
@@ -259,7 +259,6 @@ pub(crate) async fn run(cfg: DaemonConfig, cancel: CancellationToken) -> RunExit
     // ── Build the integration registry ────────────────────────────────────
     let mut registry = IntegrationRegistry::new();
 
-    // CustomScript integration.
     let custom_script = Arc::new(
         crate::integrations::custom_script::CustomScriptIntegration::new(
             cfg.script_root.clone(),
@@ -268,7 +267,6 @@ pub(crate) async fn run(cfg: DaemonConfig, cancel: CancellationToken) -> RunExit
     );
     registry.register(crate::api::models::TargetKind::CustomScript, custom_script);
 
-    // Entra integration (if enabled).
     let entra = Arc::new(crate::integrations::entra::EntraIntegration::new(
         cfg.entra_verify_probe,
     ));

--- a/bitwarden_license/bitwarden-rotation-daemon/src/integrations/active_directory.rs
+++ b/bitwarden_license/bitwarden-rotation-daemon/src/integrations/active_directory.rs
@@ -56,7 +56,9 @@ use std::{collections::HashSet, time::Duration};
 
 use async_trait::async_trait;
 use bitwarden_sensitive_value::ExposeSensitive as _;
-use ldap3::{Ldap, LdapConnAsync, LdapConnSettings, LdapError, Mod, Scope, SearchEntry};
+use ldap3::{
+    Ldap, LdapConnAsync, LdapConnSettings, LdapError, Mod, ResultEntry, Scope, SearchEntry,
+};
 use tokio::task::JoinHandle;
 use zeroize::Zeroizing;
 
@@ -216,6 +218,9 @@ impl ActiveDirectoryIntegration {
     /// The lookup must match exactly one enabled user object: zero matches and
     /// multiple matches are both fatal, because rotating the wrong account is
     /// worse than not rotating at all.
+    ///
+    /// Only real entries are counted — see [`search_entries_only`] for why the
+    /// search result can hold more than the accounts that matched the filter.
     async fn find_account_dn(
         &self,
         session: &mut LdapSession,
@@ -230,9 +235,10 @@ impl ActiveDirectoryIntegration {
             .search(base_dn, Scope::Subtree, &filter, NO_ATTRS)
             .await
             .map_err(|e| classify_ldap_error(&e, policy))?;
-        let (mut entries, _result) = search
+        let (results, _result) = search
             .success()
             .map_err(|e| classify_ldap_error(&e, policy))?;
+        let mut entries = search_entries_only(results);
 
         if entries.len() > 1 {
             return Err(IntegrationError {
@@ -441,6 +447,36 @@ impl Integration for ActiveDirectoryIntegration {
             detail: SafeDetail::from_kind("ActiveDirectorySessionTerminationUnsupported"),
         })
     }
+}
+
+// ---------------------------------------------------------------------------
+// Search result filtering
+// ---------------------------------------------------------------------------
+
+/// Keep only the `SearchResultEntry` PDUs from a search result.
+///
+/// `ldap3` returns every PDU the search produced in one `Vec<ResultEntry>`:
+/// `SearchResultReference` continuation references and intermediate responses
+/// sit alongside the entries that actually matched the filter, distinguished
+/// only by [`ResultEntry::is_ref`] and [`ResultEntry::is_intermediate`].
+///
+/// Active Directory returns a continuation reference for every naming context
+/// subordinate to the search base, on every subtree search, whatever the filter
+/// matched. A `base_dn` at a domain root therefore always yields references to
+/// `DC=DomainDnsZones,…` and `DC=ForestDnsZones,…`. Counting those as matches
+/// would report `AmbiguousAccountIdentity` for a correctly configured target,
+/// and passing one to [`SearchEntry::construct`] panics, because a reference
+/// carries no entry to unwrap. The README recommends an OU-scoped base, but
+/// nothing rejects a domain-root one, so the count must be taken over entries.
+///
+/// References are dropped rather than chased: this daemon rotates only accounts
+/// below the configured search base, and following a referral would carry the
+/// bind credential to a server the operator never named.
+fn search_entries_only(results: Vec<ResultEntry>) -> Vec<ResultEntry> {
+    results
+        .into_iter()
+        .filter(|entry| !entry.is_ref() && !entry.is_intermediate())
+        .collect()
 }
 
 // ---------------------------------------------------------------------------
@@ -680,7 +716,10 @@ fn get_cred<'a>(
 #[cfg(test)]
 mod tests {
     use chrono::Utc;
-    use ldap3::result::LdapResult;
+    use ldap3::{
+        asn1::{PL, StructureTag, TagClass},
+        result::LdapResult,
+    };
     use uuid::Uuid;
 
     use super::*;
@@ -707,6 +746,122 @@ mod tests {
             refs: Vec::new(),
             ctrls: Vec::new(),
         }
+    }
+
+    /// LDAP protocol-op tag numbers (RFC 4511 §4.5.2, §4.13).
+    const TAG_SEARCH_RESULT_ENTRY: u64 = 4;
+    const TAG_SEARCH_RESULT_REFERENCE: u64 = 19;
+    const TAG_INTERMEDIATE_RESPONSE: u64 = 25;
+
+    /// A `SearchResultEntry` PDU for `dn` with no attributes, shaped the way
+    /// [`SearchEntry::construct`] expects: the DN followed by an empty
+    /// attribute list.
+    fn entry_pdu(dn: &str) -> ResultEntry {
+        ResultEntry::new(StructureTag {
+            class: TagClass::Application,
+            id: TAG_SEARCH_RESULT_ENTRY,
+            payload: PL::C(vec![
+                StructureTag {
+                    class: TagClass::Universal,
+                    id: 4,
+                    payload: PL::P(dn.as_bytes().to_vec()),
+                },
+                StructureTag {
+                    class: TagClass::Universal,
+                    id: 16,
+                    payload: PL::C(Vec::new()),
+                },
+            ]),
+        })
+    }
+
+    /// A continuation reference of the kind AD returns for a subordinate naming
+    /// context under the search base.
+    fn reference_pdu(uri: &str) -> ResultEntry {
+        ResultEntry::new(StructureTag {
+            class: TagClass::Application,
+            id: TAG_SEARCH_RESULT_REFERENCE,
+            payload: PL::C(vec![StructureTag {
+                class: TagClass::Universal,
+                id: 4,
+                payload: PL::P(uri.as_bytes().to_vec()),
+            }]),
+        })
+    }
+
+    fn intermediate_pdu() -> ResultEntry {
+        ResultEntry::new(StructureTag {
+            class: TagClass::Application,
+            id: TAG_INTERMEDIATE_RESPONSE,
+            payload: PL::C(Vec::new()),
+        })
+    }
+
+    /// The references a domain-root subtree search draws from Active Directory
+    /// on every search, whatever the filter matched.
+    fn domain_root_references() -> Vec<ResultEntry> {
+        vec![
+            reference_pdu("ldap://corp.example/DC=DomainDnsZones,DC=corp,DC=example"),
+            reference_pdu("ldap://corp.example/DC=ForestDnsZones,DC=corp,DC=example"),
+        ]
+    }
+
+    // -----------------------------------------------------------------------
+    // Search result filtering
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn one_match_under_a_domain_root_base_is_not_ambiguous() {
+        let mut results = domain_root_references();
+        results.insert(
+            1,
+            entry_pdu("CN=svc-app,OU=Service Accounts,DC=corp,DC=example"),
+        );
+
+        let entries = search_entries_only(results);
+
+        assert_eq!(
+            entries.len(),
+            1,
+            "continuation references must not count towards the match count"
+        );
+        assert_eq!(
+            SearchEntry::construct(entries.into_iter().next().expect("one entry")).dn,
+            "CN=svc-app,OU=Service Accounts,DC=corp,DC=example"
+        );
+    }
+
+    #[test]
+    fn no_match_under_a_domain_root_base_leaves_nothing_to_construct() {
+        let entries = search_entries_only(domain_root_references());
+
+        assert!(
+            entries.is_empty(),
+            "references alone must resolve to AccountNotFound, never be constructed as an entry"
+        );
+    }
+
+    #[test]
+    fn intermediate_responses_are_dropped_too() {
+        let results = vec![
+            intermediate_pdu(),
+            entry_pdu("CN=svc-app,DC=corp,DC=example"),
+        ];
+
+        assert_eq!(search_entries_only(results).len(), 1);
+    }
+
+    #[test]
+    fn two_real_matches_are_still_ambiguous() {
+        let mut results = domain_root_references();
+        results.push(entry_pdu("CN=svc-app,OU=A,DC=corp,DC=example"));
+        results.push(entry_pdu("CN=svc-app,OU=B,DC=corp,DC=example"));
+
+        assert_eq!(
+            search_entries_only(results).len(),
+            2,
+            "filtering references must not mask a genuinely ambiguous identity"
+        );
     }
 
     // -----------------------------------------------------------------------

--- a/bitwarden_license/bitwarden-rotation-daemon/src/integrations/active_directory.rs
+++ b/bitwarden_license/bitwarden-rotation-daemon/src/integrations/active_directory.rs
@@ -1,0 +1,1060 @@
+//! On-premises Active Directory integration for credential rotation.
+//!
+//! [`ActiveDirectoryIntegration`] rotates a domain account's password by
+//! replacing the `unicodePwd` attribute over LDAPS, binding as a delegated
+//! service account that holds reset-password rights on the target OU.
+//!
+//! # LDAPS is mandatory
+//!
+//! Every connection is opened with an `ldaps://` URL on port 636 (implicit TLS).
+//! There is no plaintext LDAP path, no StartTLS fallback, and no
+//! certificate-validation bypass. This is both a Bitwarden requirement and an
+//! Active Directory one: a domain controller refuses a `unicodePwd` write on a
+//! connection that is not encrypted, answering `confidentialityRequired`
+//! (result code 13).
+//!
+//! The server certificate is validated against the host's native trust store,
+//! so the issuing enterprise CA must be trusted by the machine running the
+//! daemon.
+//!
+//! # Bind identity
+//!
+//! The bind DN is expected to be a **delegated service account** whose only
+//! privilege on the target OU is `Reset Password` (plus read access to locate
+//! the account). Binding as Domain Admin is not required and is not supported
+//! as a recommendation — a daemon-held credential should never carry
+//! domain-wide authority.
+//!
+//! # RotationByAdministrativeReset
+//!
+//! Replacing `unicodePwd` in a single `replace` modification is an
+//! administrative reset: it does not require the account's current password.
+//! The daemon never holds the rotated account's old credential, which is what
+//! makes retries converge — see the `custom_script` module docs for the full
+//! reasoning.
+//!
+//! # Session termination
+//!
+//! Not supported. An LDAP password reset cannot revoke already-issued Kerberos
+//! ticket-granting tickets, so there is no honest implementation of
+//! [`Integration::terminate_sessions`] for this kind; it returns a fatal error.
+//! The server marks the Active Directory kind with
+//! `supportsSessionTermination: false`, so the executor should never reach it.
+//!
+//! # Secret handling
+//!
+//! - The bind password and the new account password are never logged, never placed in an error
+//!   string, and never reach a [`SafeDetail`].
+//! - The encoded `unicodePwd` value is built in a [`Zeroizing`] buffer. Handing it to `ldap3`
+//!   requires a plain `Vec<u8>` copy, and `ldap3` copies it again into its BER encoder; neither
+//!   copy is zeroized. The window is a single modify request, but it is a real limitation of the
+//!   third-party client rather than something this module can enforce.
+//! - Directory-supplied diagnostic text (`LdapResult::text`) and matched DNs are never read into a
+//!   detail. Only the numeric LDAP result code is reported.
+
+use std::{collections::HashSet, time::Duration};
+
+use async_trait::async_trait;
+use bitwarden_sensitive_value::ExposeSensitive as _;
+use ldap3::{Ldap, LdapConnAsync, LdapConnSettings, LdapError, Mod, Scope, SearchEntry};
+use tokio::task::JoinHandle;
+use zeroize::Zeroizing;
+
+use super::{Integration, IntegrationError, RotateContext, TargetEffect};
+use crate::error::{ErrorClass, FailureCode, SafeDetail};
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/// Credential suffix holding the domain controller host name.
+const HOST_SUFFIX: &str = "LDAP_HOST";
+
+/// Credential suffix holding the DN of the delegated service account.
+const BIND_DN_SUFFIX: &str = "BIND_DN";
+
+/// Credential suffix holding the search base DN for account lookup.
+const BASE_DN_SUFFIX: &str = "BASE_DN";
+
+/// Credential suffix holding the delegated service account's password.
+///
+/// Environment-only; the `[targets]` config section deliberately refuses it.
+const BIND_PASSWORD_SUFFIX: &str = "BIND_PASSWORD";
+
+/// The Active Directory attribute holding the account password.
+const UNICODE_PWD_ATTR: &[u8] = b"unicodePwd";
+
+/// The "no attributes" OID (RFC 4511 §4.5.1.8) — account lookup needs only the DN.
+const NO_ATTRS: [&str; 1] = ["1.1"];
+
+/// Time budget for establishing the TCP + TLS connection to the domain controller.
+const CONNECT_TIMEOUT: Duration = Duration::from_secs(15);
+
+/// Time budget for each individual LDAP operation (bind, search, modify).
+const OPERATION_TIMEOUT: Duration = Duration::from_secs(30);
+
+// ---------------------------------------------------------------------------
+// LDAP result codes (RFC 4511 §A.1)
+// ---------------------------------------------------------------------------
+
+/// `adminLimitExceeded` — the DC is shedding load.
+const RC_ADMIN_LIMIT_EXCEEDED: u32 = 11;
+
+/// `busy` — the DC is temporarily unable to service the request.
+const RC_BUSY: u32 = 51;
+
+/// `unavailable` — the DC is shutting down or offline.
+const RC_UNAVAILABLE: u32 = 52;
+
+// ---------------------------------------------------------------------------
+// EffectPolicy
+// ---------------------------------------------------------------------------
+
+/// How to attribute [`TargetEffect`] for an error raised in a given phase.
+///
+/// `settled` applies to errors where the outcome of the password write is
+/// known — the directory answered, or the failure happened before the write was
+/// ever sent. `indeterminate` applies to errors where the write may or may not
+/// have been applied, such as a timeout or a dropped connection after the
+/// modify request went out.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct EffectPolicy {
+    /// Effect for errors whose outcome is known.
+    settled: TargetEffect,
+    /// Effect for errors whose outcome is not knowable.
+    indeterminate: TargetEffect,
+}
+
+impl EffectPolicy {
+    /// Connect, bind, and account lookup — the password write has not been sent.
+    const BEFORE_MODIFY: Self = Self {
+        settled: TargetEffect::NotApplied,
+        indeterminate: TargetEffect::NotApplied,
+    };
+
+    /// The `unicodePwd` write itself.
+    ///
+    /// A directory-returned error code means the write was rejected, so the
+    /// credential is unchanged. A transport failure after the request was
+    /// flushed leaves the outcome unknown.
+    const MODIFY: Self = Self {
+        settled: TargetEffect::NotApplied,
+        indeterminate: TargetEffect::Unknown,
+    };
+
+    /// Everything after a successful password write.
+    const AFTER_ROTATION: Self = Self {
+        settled: TargetEffect::Applied,
+        indeterminate: TargetEffect::Applied,
+    };
+}
+
+// ---------------------------------------------------------------------------
+// ActiveDirectoryIntegration
+// ---------------------------------------------------------------------------
+
+/// Active Directory integration driver.
+///
+/// Holds no credentials: the domain controller host, bind DN, search base and
+/// bind password are read out of `ctx.creds` inside each operation, live on the
+/// stack for the duration of that operation, and are dropped afterwards.
+#[derive(Debug)]
+pub(crate) struct ActiveDirectoryIntegration {
+    /// Time budget for establishing a connection.
+    connect_timeout: Duration,
+    /// Time budget for each LDAP operation.
+    operation_timeout: Duration,
+}
+
+impl ActiveDirectoryIntegration {
+    /// Build a driver with the production timeouts.
+    pub(crate) fn new() -> Self {
+        Self {
+            connect_timeout: CONNECT_TIMEOUT,
+            operation_timeout: OPERATION_TIMEOUT,
+        }
+    }
+
+    /// Open an LDAPS connection and start its protocol driver task.
+    async fn connect(
+        &self,
+        url: &str,
+        policy: EffectPolicy,
+    ) -> Result<LdapSession, IntegrationError> {
+        let settings = LdapConnSettings::new().set_conn_timeout(self.connect_timeout);
+        let (conn, ldap) = LdapConnAsync::with_settings(settings, url)
+            .await
+            .map_err(|e| classify_ldap_error(&e, policy))?;
+        let driver = tokio::spawn(async move {
+            let _ = conn.drive().await;
+        });
+        Ok(LdapSession { ldap, driver })
+    }
+
+    /// Open a connection, bind as the delegated service account, and resolve
+    /// `account_identity` to a distinguished name.
+    async fn open_and_locate(
+        &self,
+        creds: &Credentials<'_>,
+        account_identity: &str,
+        policy: EffectPolicy,
+    ) -> Result<(LdapSession, String), IntegrationError> {
+        let mut session = self.connect(&creds.url, policy).await?;
+        session
+            .simple_bind(creds.bind_dn, creds.bind_password, self.operation_timeout)
+            .await
+            .map_err(|e| classify_ldap_error(&e, policy))?;
+        let dn = self
+            .find_account_dn(&mut session, creds.base_dn, account_identity, policy)
+            .await?;
+        Ok((session, dn))
+    }
+
+    /// Resolve an opaque account identity to the account's distinguished name.
+    ///
+    /// The identity is matched against `sAMAccountName` and `userPrincipalName`.
+    /// The lookup must match exactly one enabled user object: zero matches and
+    /// multiple matches are both fatal, because rotating the wrong account is
+    /// worse than not rotating at all.
+    async fn find_account_dn(
+        &self,
+        session: &mut LdapSession,
+        base_dn: &str,
+        account_identity: &str,
+        policy: EffectPolicy,
+    ) -> Result<String, IntegrationError> {
+        let filter = account_filter(account_identity);
+        let search = session
+            .ldap
+            .with_timeout(self.operation_timeout)
+            .search(base_dn, Scope::Subtree, &filter, NO_ATTRS)
+            .await
+            .map_err(|e| classify_ldap_error(&e, policy))?;
+        let (mut entries, _result) = search
+            .success()
+            .map_err(|e| classify_ldap_error(&e, policy))?;
+
+        if entries.len() > 1 {
+            return Err(IntegrationError {
+                class: ErrorClass::Fatal,
+                effect: policy.settled,
+                code: FailureCode::TargetRejected,
+                detail: SafeDetail::from_kind("AmbiguousAccountIdentity"),
+            });
+        }
+        let Some(entry) = entries.pop() else {
+            return Err(IntegrationError {
+                class: ErrorClass::Fatal,
+                effect: policy.settled,
+                code: FailureCode::TargetRejected,
+                detail: SafeDetail::from_kind("AccountNotFound"),
+            });
+        };
+
+        let dn = SearchEntry::construct(entry).dn;
+        if dn.is_empty() {
+            return Err(IntegrationError {
+                class: ErrorClass::Fatal,
+                effect: policy.settled,
+                code: FailureCode::TargetRejected,
+                detail: SafeDetail::from_kind("AccountWithoutDn"),
+            });
+        }
+        Ok(dn)
+    }
+}
+
+impl Default for ActiveDirectoryIntegration {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// LdapSession
+// ---------------------------------------------------------------------------
+
+/// An open LDAPS connection together with the task driving its protocol loop.
+///
+/// Dropping the session aborts the driver task, so an early return anywhere in
+/// an operation cannot leak a background task or a socket.
+struct LdapSession {
+    /// Operation handle.
+    ldap: Ldap,
+    /// The spawned task running [`LdapConnAsync::drive`].
+    driver: JoinHandle<()>,
+}
+
+impl LdapSession {
+    /// Perform a simple bind, treating any non-zero result code as an error.
+    ///
+    /// `password` is passed straight to the LDAP client and is never retained.
+    async fn simple_bind(
+        &mut self,
+        dn: &str,
+        password: &str,
+        timeout: Duration,
+    ) -> Result<(), LdapError> {
+        self.ldap
+            .with_timeout(timeout)
+            .simple_bind(dn, password)
+            .await?
+            .success()?;
+        Ok(())
+    }
+
+    /// Send an unbind request and drop the session.
+    async fn close(mut self) {
+        let _ = self.ldap.unbind().await;
+    }
+}
+
+impl Drop for LdapSession {
+    fn drop(&mut self) {
+        self.driver.abort();
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Credentials
+// ---------------------------------------------------------------------------
+
+/// The resolved connection parameters for one Active Directory target.
+struct Credentials<'a> {
+    /// Validated `ldaps://` URL derived from the configured host.
+    url: String,
+    /// DN of the delegated service account performing the reset.
+    bind_dn: &'a str,
+    /// Search base for account lookup.
+    base_dn: &'a str,
+    /// Password of the delegated service account.
+    bind_password: &'a str,
+}
+
+impl<'a> Credentials<'a> {
+    /// Read and validate all four required credentials.
+    fn resolve(creds: &'a crate::resolver::ResolvedCredentials) -> Result<Self, IntegrationError> {
+        let host = get_cred(creds, HOST_SUFFIX)?;
+        Ok(Self {
+            url: ldaps_url(host)?,
+            bind_dn: get_cred(creds, BIND_DN_SUFFIX)?,
+            base_dn: get_cred(creds, BASE_DN_SUFFIX)?,
+            bind_password: get_cred(creds, BIND_PASSWORD_SUFFIX)?,
+        })
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Integration impl
+// ---------------------------------------------------------------------------
+
+#[async_trait]
+impl Integration for ActiveDirectoryIntegration {
+    /// Replace the account's `unicodePwd` over LDAPS.
+    ///
+    /// | Failure                          | Effect     | Class     | Code                     |
+    /// |----------------------------------|------------|-----------|--------------------------|
+    /// | missing / malformed credential   | NotApplied | Fatal     | credentials_unresolved   |
+    /// | TCP or TLS failure               | NotApplied | Transient | target_unreachable       |
+    /// | certificate rejected             | NotApplied | Fatal     | target_unreachable       |
+    /// | bind rejected (rc 49 / 50)       | NotApplied | Fatal     | target_rejected          |
+    /// | account not found / ambiguous    | NotApplied | Fatal     | target_rejected          |
+    /// | modify rejected (rc 13 / 19 / …) | NotApplied | Fatal     | target_rejected          |
+    /// | DC busy or unavailable           | NotApplied | Transient | target_unreachable       |
+    /// | timeout after the modify is sent | Unknown    | Transient | target_unreachable       |
+    async fn rotate(&self, ctx: &RotateContext) -> Result<(), IntegrationError> {
+        let creds = Credentials::resolve(&ctx.creds)?;
+
+        let (mut session, account_dn) = self
+            .open_and_locate(&creds, &ctx.account_identity, EffectPolicy::BEFORE_MODIFY)
+            .await?;
+
+        let encoded = encode_unicode_pwd(&ctx.new_password);
+        let mods = vec![Mod::Replace(
+            UNICODE_PWD_ATTR.to_vec(),
+            HashSet::from([encoded.to_vec()]),
+        )];
+
+        let result = session
+            .ldap
+            .with_timeout(self.operation_timeout)
+            .modify(&account_dn, mods)
+            .await
+            .map_err(|e| classify_ldap_error(&e, EffectPolicy::MODIFY))?;
+        result
+            .success()
+            .map_err(|e| classify_ldap_error(&e, EffectPolicy::MODIFY))?;
+
+        session.close().await;
+        Ok(())
+    }
+
+    /// Verify the rotation by binding as the rotated account with the new password.
+    ///
+    /// A successful simple bind over LDAPS is proof that the directory accepted
+    /// the new password: unlike a directory attribute read it cannot be stale,
+    /// and unlike a timestamp check it cannot be satisfied by some other write.
+    ///
+    /// Every error carries [`TargetEffect::Applied`] because the password has
+    /// already been changed by the time verify runs. A rejected bind is fatal —
+    /// retrying it cannot change the answer.
+    async fn verify(&self, ctx: &RotateContext) -> Result<(), IntegrationError> {
+        let creds = Credentials::resolve(&ctx.creds).map_err(as_applied)?;
+
+        let (lookup, account_dn) = self
+            .open_and_locate(&creds, &ctx.account_identity, EffectPolicy::AFTER_ROTATION)
+            .await?;
+        lookup.close().await;
+
+        let mut session = self
+            .connect(&creds.url, EffectPolicy::AFTER_ROTATION)
+            .await?;
+        let bind = session
+            .simple_bind(&account_dn, &ctx.new_password, self.operation_timeout)
+            .await;
+        session.close().await;
+
+        match bind {
+            Ok(()) => Ok(()),
+            Err(LdapError::LdapResult { result }) => Err(IntegrationError {
+                class: ErrorClass::Fatal,
+                effect: TargetEffect::Applied,
+                code: FailureCode::VerificationFailed,
+                detail: SafeDetail::from_ldap_result_code(result.rc),
+            }),
+            Err(other) => Err(classify_ldap_error(&other, EffectPolicy::AFTER_ROTATION)),
+        }
+    }
+
+    /// Always fails: Active Directory sessions cannot be terminated by an LDAP
+    /// password reset.
+    ///
+    /// Kerberos ticket-granting tickets already issued to the account remain
+    /// valid until they expire, and LDAP offers no revocation operation. The
+    /// server advertises `supportsSessionTermination: false` for this kind, so
+    /// reaching this method means the target system was misconfigured.
+    async fn terminate_sessions(&self, _ctx: &RotateContext) -> Result<(), IntegrationError> {
+        Err(IntegrationError {
+            class: ErrorClass::Fatal,
+            effect: TargetEffect::NotApplied,
+            code: FailureCode::UnsupportedKind,
+            detail: SafeDetail::from_kind("ActiveDirectorySessionTerminationUnsupported"),
+        })
+    }
+}
+
+// ---------------------------------------------------------------------------
+// unicodePwd encoding
+// ---------------------------------------------------------------------------
+
+/// Encode a password for Active Directory's `unicodePwd` attribute.
+///
+/// AD requires the value to be the password surrounded by ASCII double quotes
+/// and encoded as little-endian UTF-16 with no byte-order mark. A value in any
+/// other shape is rejected with `unwillingToPerform`.
+///
+/// The buffer is [`Zeroizing`], and its capacity is reserved up front so no
+/// intermediate reallocation leaves a copy of the password behind.
+fn encode_unicode_pwd(password: &str) -> Zeroizing<Vec<u8>> {
+    /// UTF-16 code unit for `"`.
+    const QUOTE: u16 = b'"' as u16;
+
+    let mut buf = Zeroizing::new(Vec::with_capacity(password.len() * 2 + 4));
+    for unit in std::iter::once(QUOTE)
+        .chain(password.encode_utf16())
+        .chain(std::iter::once(QUOTE))
+    {
+        buf.extend_from_slice(&unit.to_le_bytes());
+    }
+    buf
+}
+
+// ---------------------------------------------------------------------------
+// Filter construction
+// ---------------------------------------------------------------------------
+
+/// Build the account-lookup filter for an opaque account identity.
+///
+/// `account_identity` arrives from the server and is attacker-influencable, so
+/// it is escaped per RFC 4515 before interpolation. Without escaping, an
+/// identity such as `*)(objectClass=` would widen the search and could make it
+/// match an account the operator never delegated.
+fn account_filter(account_identity: &str) -> String {
+    let escaped = escape_filter_value(account_identity);
+    format!(
+        "(&(objectClass=user)(objectCategory=person)(|(sAMAccountName={escaped})(userPrincipalName={escaped})))"
+    )
+}
+
+/// Escape an assertion value for use inside an LDAP search filter (RFC 4515 §3).
+///
+/// `*`, `(`, `)`, `\` and NUL must be escaped. Control bytes and all non-ASCII
+/// bytes are escaped as well, which keeps multi-byte UTF-8 intact and prevents
+/// a hostile identity from smuggling structure into the filter.
+fn escape_filter_value(value: &str) -> String {
+    let mut out = String::with_capacity(value.len());
+    for byte in value.bytes() {
+        match byte {
+            b'*' => out.push_str("\\2a"),
+            b'(' => out.push_str("\\28"),
+            b')' => out.push_str("\\29"),
+            b'\\' => out.push_str("\\5c"),
+            b if !(0x20..0x7f).contains(&b) => out.push_str(&format!("\\{b:02x}")),
+            b => out.push(b as char),
+        }
+    }
+    out
+}
+
+// ---------------------------------------------------------------------------
+// URL construction
+// ---------------------------------------------------------------------------
+
+/// Build the `ldaps://` URL for a configured domain controller host.
+///
+/// The host is restricted to the characters that can appear in a host name, an
+/// IPv6 literal, or an optional `:port` suffix. Anything else — a scheme, a
+/// path, userinfo, whitespace — is refused rather than normalised, so a
+/// mistyped host can never silently downgrade the connection or redirect the
+/// bind to another server.
+fn ldaps_url(host: &str) -> Result<String, IntegrationError> {
+    let malformed = || IntegrationError {
+        class: ErrorClass::Fatal,
+        effect: TargetEffect::NotApplied,
+        code: FailureCode::CredentialsUnresolved,
+        detail: SafeDetail::from_kind("MalformedLdapHost"),
+    };
+
+    if host.is_empty() {
+        return Err(malformed());
+    }
+    let acceptable = host
+        .bytes()
+        .all(|b| b.is_ascii_alphanumeric() || matches!(b, b'.' | b'-' | b':' | b'[' | b']' | b'_'));
+    if !acceptable {
+        return Err(malformed());
+    }
+
+    Ok(format!("ldaps://{host}"))
+}
+
+// ---------------------------------------------------------------------------
+// Error classification
+// ---------------------------------------------------------------------------
+
+/// Map an [`LdapError`] to an [`IntegrationError`] under the given effect policy.
+///
+/// Transport-level failures are transient; anything the directory decided —
+/// bad credentials, missing rights, schema or policy violations — is fatal,
+/// as is a TLS or configuration failure that a retry cannot change.
+///
+/// Only the LDAP result code and a fixed error-kind name reach the detail. The
+/// directory's `diagnosticMessage` and matched DN are never read: both can
+/// echo account names and, on some DCs, policy text.
+fn classify_ldap_error(err: &LdapError, policy: EffectPolicy) -> IntegrationError {
+    match err {
+        LdapError::Io { source } => IntegrationError {
+            class: ErrorClass::Transient,
+            effect: policy.indeterminate,
+            code: FailureCode::TargetUnreachable,
+            detail: SafeDetail::from_kind(io_error_kind_name(source.kind())),
+        },
+        LdapError::Timeout { .. } => IntegrationError {
+            class: ErrorClass::Transient,
+            effect: policy.indeterminate,
+            code: FailureCode::TargetUnreachable,
+            detail: SafeDetail::from_kind("OperationTimeout"),
+        },
+        LdapError::EndOfStream
+        | LdapError::OpSend { .. }
+        | LdapError::ResultRecv { .. }
+        | LdapError::IdScrubSend { .. }
+        | LdapError::MiscSend { .. } => IntegrationError {
+            class: ErrorClass::Transient,
+            effect: policy.indeterminate,
+            code: FailureCode::TargetUnreachable,
+            detail: SafeDetail::from_kind("ConnectionClosed"),
+        },
+        LdapError::Rustls { .. } => IntegrationError {
+            class: ErrorClass::Fatal,
+            effect: policy.settled,
+            code: FailureCode::TargetUnreachable,
+            detail: SafeDetail::from_kind("TlsHandshakeFailed"),
+        },
+        LdapError::DNSName { .. } => IntegrationError {
+            class: ErrorClass::Fatal,
+            effect: policy.settled,
+            code: FailureCode::TargetUnreachable,
+            detail: SafeDetail::from_kind("TlsInvalidServerName"),
+        },
+        LdapError::UrlParsing { .. }
+        | LdapError::UnknownScheme(_)
+        | LdapError::EmptyUnixPath
+        | LdapError::PortInUnixPath
+        | LdapError::MismatchedStreamType => IntegrationError {
+            class: ErrorClass::Fatal,
+            effect: policy.settled,
+            code: FailureCode::CredentialsUnresolved,
+            detail: SafeDetail::from_kind("MalformedLdapHost"),
+        },
+        LdapError::LdapResult { result } => classify_result_code(result.rc, policy),
+        _ => IntegrationError {
+            class: ErrorClass::Fatal,
+            effect: policy.settled,
+            code: FailureCode::Internal,
+            detail: SafeDetail::from_kind("LdapClientError"),
+        },
+    }
+}
+
+/// Classify a non-zero LDAP result code.
+///
+/// Load-shedding codes are transient; every other rejection is a decision the
+/// directory will repeat, so it is fatal.
+fn classify_result_code(rc: u32, policy: EffectPolicy) -> IntegrationError {
+    let (class, code) = match rc {
+        RC_ADMIN_LIMIT_EXCEEDED | RC_BUSY | RC_UNAVAILABLE => {
+            (ErrorClass::Transient, FailureCode::TargetUnreachable)
+        }
+        _ => (ErrorClass::Fatal, FailureCode::TargetRejected),
+    };
+    IntegrationError {
+        class,
+        effect: policy.settled,
+        code,
+        detail: SafeDetail::from_ldap_result_code(rc),
+    }
+}
+
+/// Map an [`std::io::ErrorKind`] to a fixed name safe to place in a detail.
+fn io_error_kind_name(kind: std::io::ErrorKind) -> &'static str {
+    use std::io::ErrorKind;
+    match kind {
+        ErrorKind::ConnectionRefused => "ConnectionRefused",
+        ErrorKind::ConnectionReset => "ConnectionReset",
+        ErrorKind::ConnectionAborted => "ConnectionAborted",
+        ErrorKind::NotConnected => "NotConnected",
+        ErrorKind::BrokenPipe => "BrokenPipe",
+        ErrorKind::TimedOut => "ConnectTimeout",
+        ErrorKind::UnexpectedEof => "UnexpectedEof",
+        _ => "NetworkError",
+    }
+}
+
+/// Re-attribute an error to [`TargetEffect::Applied`].
+///
+/// Used in `verify`, where helpers that default to `NotApplied` are called
+/// after the password has already been changed.
+fn as_applied(mut err: IntegrationError) -> IntegrationError {
+    err.effect = TargetEffect::Applied;
+    err
+}
+
+// ---------------------------------------------------------------------------
+// Credential lookup helper
+// ---------------------------------------------------------------------------
+
+/// Look up a required credential suffix, returning
+/// `Fatal/NotApplied/credentials_unresolved` if absent.
+///
+/// The error detail names only the missing **suffix**, never a value.
+fn get_cred<'a>(
+    creds: &'a crate::resolver::ResolvedCredentials,
+    suffix: &'static str,
+) -> Result<&'a str, IntegrationError> {
+    creds
+        .get(suffix)
+        .map(|s| s.expose().as_ref() as &str)
+        .ok_or_else(|| IntegrationError {
+            class: ErrorClass::Fatal,
+            effect: TargetEffect::NotApplied,
+            code: FailureCode::CredentialsUnresolved,
+            detail: SafeDetail::from_kind(suffix),
+        })
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use chrono::Utc;
+    use ldap3::result::LdapResult;
+    use uuid::Uuid;
+
+    use super::*;
+    use crate::resolver::ResolvedCredentials;
+
+    /// A password used across leak assertions; must never appear in output.
+    const SECRET: &str = "correct-horse-battery-staple";
+
+    fn make_ctx(creds: ResolvedCredentials) -> RotateContext {
+        RotateContext {
+            target_system_id: Uuid::nil(),
+            account_identity: "svc-app".to_string(),
+            new_password: Zeroizing::new(SECRET.to_string()),
+            creds,
+            rotation_started_at: Utc::now(),
+        }
+    }
+
+    fn ldap_result(rc: u32, text: &str) -> LdapResult {
+        LdapResult {
+            rc,
+            matched: "CN=svc-app,OU=Service Accounts,DC=corp,DC=example".to_string(),
+            text: text.to_string(),
+            refs: Vec::new(),
+            ctrls: Vec::new(),
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // unicodePwd encoding
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn unicode_pwd_is_quoted_utf16le() {
+        let encoded = encode_unicode_pwd("Ab1!");
+        assert_eq!(
+            encoded.as_slice(),
+            &[
+                0x22, 0x00, // "
+                b'A', 0x00, b'b', 0x00, b'1', 0x00, b'!', 0x00, //
+                0x22, 0x00, // "
+            ]
+        );
+    }
+
+    #[test]
+    fn unicode_pwd_empty_password_is_two_quotes() {
+        let encoded = encode_unicode_pwd("");
+        assert_eq!(encoded.as_slice(), &[0x22, 0x00, 0x22, 0x00]);
+    }
+
+    #[test]
+    fn unicode_pwd_encodes_non_bmp_as_surrogate_pair() {
+        // U+1F510 CLOSED LOCK WITH KEY → surrogate pair D83D DD10, little-endian.
+        let encoded = encode_unicode_pwd("\u{1F510}");
+        assert_eq!(
+            encoded.as_slice(),
+            &[0x22, 0x00, 0x3D, 0xD8, 0x10, 0xDD, 0x22, 0x00]
+        );
+    }
+
+    #[test]
+    fn unicode_pwd_has_no_byte_order_mark() {
+        let encoded = encode_unicode_pwd("pw");
+        assert_ne!(&encoded[0..2], &[0xFF, 0xFE]);
+        assert_ne!(&encoded[0..2], &[0xFE, 0xFF]);
+    }
+
+    #[test]
+    fn unicode_pwd_never_contains_the_plain_utf8_password() {
+        let encoded = encode_unicode_pwd(SECRET);
+        assert!(
+            encoded
+                .windows(SECRET.len())
+                .all(|w| w != SECRET.as_bytes()),
+            "password must not appear as plain UTF-8"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // Filter escaping
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn escape_filter_value_escapes_rfc4515_specials() {
+        assert_eq!(escape_filter_value("a*b"), "a\\2ab");
+        assert_eq!(escape_filter_value("a(b"), "a\\28b");
+        assert_eq!(escape_filter_value("a)b"), "a\\29b");
+        assert_eq!(escape_filter_value("a\\b"), "a\\5cb");
+        assert_eq!(escape_filter_value("a\0b"), "a\\00b");
+    }
+
+    #[test]
+    fn escape_filter_value_leaves_ordinary_identities_alone() {
+        assert_eq!(
+            escape_filter_value("svc-app@corp.example"),
+            "svc-app@corp.example"
+        );
+    }
+
+    #[test]
+    fn escape_filter_value_escapes_non_ascii_bytes() {
+        // "é" is 0xC3 0xA9 in UTF-8.
+        assert_eq!(escape_filter_value("é"), "\\c3\\a9");
+    }
+
+    #[test]
+    fn account_filter_neutralises_hostile_identity() {
+        let filter = account_filter("*)(objectClass=*");
+        assert!(
+            !filter.contains("*)("),
+            "filter structure must not be injectable: {filter}"
+        );
+        assert!(filter.contains("\\2a\\29\\28objectClass=\\2a"));
+        assert!(filter.starts_with("(&(objectClass=user)"));
+    }
+
+    #[test]
+    fn account_filter_matches_sam_and_upn() {
+        let filter = account_filter("svc-app");
+        assert!(filter.contains("(sAMAccountName=svc-app)"));
+        assert!(filter.contains("(userPrincipalName=svc-app)"));
+    }
+
+    // -----------------------------------------------------------------------
+    // Host validation
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn ldaps_url_accepts_hostname() {
+        assert_eq!(
+            ldaps_url("dc01.corp.example").expect("valid host"),
+            "ldaps://dc01.corp.example"
+        );
+    }
+
+    #[test]
+    fn ldaps_url_accepts_explicit_port() {
+        assert_eq!(
+            ldaps_url("dc01.corp.example:3269").expect("valid host"),
+            "ldaps://dc01.corp.example:3269"
+        );
+    }
+
+    #[test]
+    fn ldaps_url_is_always_ldaps() {
+        for host in ["dc01.corp.example", "10.0.0.5", "[fe80::1]:636"] {
+            let url = ldaps_url(host).expect("valid host");
+            assert!(url.starts_with("ldaps://"), "must be LDAPS: {url}");
+        }
+    }
+
+    #[test]
+    fn ldaps_url_rejects_hostile_hosts() {
+        for host in [
+            "",
+            "ldap://dc01.corp.example",
+            "dc01.corp.example/path",
+            "evil.example@dc01.corp.example",
+            "dc01.corp.example?query",
+            "dc01 corp example",
+            "dc01.corp.example#frag",
+        ] {
+            match ldaps_url(host) {
+                Ok(url) => panic!("host {host:?} must be rejected, produced {url}"),
+                Err(err) => {
+                    assert_eq!(err.class, ErrorClass::Fatal, "host {host:?}");
+                    assert_eq!(
+                        err.code,
+                        FailureCode::CredentialsUnresolved,
+                        "host {host:?}"
+                    );
+                }
+            }
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Error classification
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn directory_rejections_are_fatal() {
+        // 13 confidentialityRequired, 19 constraintViolation, 32 noSuchObject,
+        // 49 invalidCredentials, 50 insufficientAccessRights, 53 unwillingToPerform,
+        // 16/17/21 schema errors.
+        for rc in [13, 16, 17, 19, 21, 32, 49, 50, 53] {
+            let err = classify_result_code(rc, EffectPolicy::BEFORE_MODIFY);
+            assert_eq!(err.class, ErrorClass::Fatal, "rc {rc} must be fatal");
+            assert_eq!(err.code, FailureCode::TargetRejected, "rc {rc}");
+            assert_eq!(err.effect, TargetEffect::NotApplied, "rc {rc}");
+        }
+    }
+
+    #[test]
+    fn load_shedding_codes_are_transient() {
+        for rc in [RC_ADMIN_LIMIT_EXCEEDED, RC_BUSY, RC_UNAVAILABLE] {
+            let err = classify_result_code(rc, EffectPolicy::BEFORE_MODIFY);
+            assert_eq!(
+                err.class,
+                ErrorClass::Transient,
+                "rc {rc} must be transient"
+            );
+            assert_eq!(err.code, FailureCode::TargetUnreachable, "rc {rc}");
+        }
+    }
+
+    #[test]
+    fn network_errors_are_transient() {
+        let err = classify_ldap_error(
+            &LdapError::Io {
+                source: std::io::Error::from(std::io::ErrorKind::ConnectionRefused),
+            },
+            EffectPolicy::BEFORE_MODIFY,
+        );
+        assert_eq!(err.class, ErrorClass::Transient);
+        assert_eq!(err.code, FailureCode::TargetUnreachable);
+        assert_eq!(err.detail.as_str(), "error kind: ConnectionRefused");
+    }
+
+    #[test]
+    fn dropped_connection_during_modify_is_unknown_not_not_applied() {
+        let err = classify_ldap_error(
+            &LdapError::Io {
+                source: std::io::Error::from(std::io::ErrorKind::ConnectionReset),
+            },
+            EffectPolicy::MODIFY,
+        );
+        assert_eq!(
+            err.effect,
+            TargetEffect::Unknown,
+            "a transport failure after the modify is sent leaves the outcome unknown"
+        );
+    }
+
+    #[test]
+    fn directory_rejection_of_the_modify_is_not_applied() {
+        let err = classify_ldap_error(
+            &LdapError::LdapResult {
+                result: ldap_result(19, "constraint violation"),
+            },
+            EffectPolicy::MODIFY,
+        );
+        assert_eq!(
+            err.effect,
+            TargetEffect::NotApplied,
+            "an answered rejection means the credential is unchanged"
+        );
+        assert_eq!(err.class, ErrorClass::Fatal);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn operation_timeout_during_modify_is_unknown() {
+        let elapsed = tokio::time::timeout(Duration::from_millis(1), std::future::pending::<()>())
+            .await
+            .expect_err("must elapse");
+        let err = classify_ldap_error(&LdapError::from(elapsed), EffectPolicy::MODIFY);
+        assert_eq!(err.effect, TargetEffect::Unknown);
+        assert_eq!(err.class, ErrorClass::Transient);
+        assert_eq!(err.detail.as_str(), "error kind: OperationTimeout");
+    }
+
+    #[test]
+    fn tls_failures_are_fatal() {
+        let err = classify_ldap_error(
+            &LdapError::DNSName {
+                source: rustls::pki_types::ServerName::try_from("not a host name")
+                    .expect_err("must be invalid"),
+            },
+            EffectPolicy::BEFORE_MODIFY,
+        );
+        assert_eq!(err.class, ErrorClass::Fatal);
+        assert_eq!(err.detail.as_str(), "error kind: TlsInvalidServerName");
+    }
+
+    #[test]
+    fn errors_after_rotation_report_applied() {
+        let err = classify_ldap_error(
+            &LdapError::LdapResult {
+                result: ldap_result(49, "invalid credentials"),
+            },
+            EffectPolicy::AFTER_ROTATION,
+        );
+        assert_eq!(err.effect, TargetEffect::Applied);
+    }
+
+    // -----------------------------------------------------------------------
+    // Zero-knowledge
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn detail_carries_only_the_result_code_not_directory_text() {
+        let err = classify_ldap_error(
+            &LdapError::LdapResult {
+                result: ldap_result(53, &format!("rejected password {SECRET}")),
+            },
+            EffectPolicy::MODIFY,
+        );
+        assert_eq!(err.detail.as_str(), "LDAP result code 53");
+        let rendered = err.to_string();
+        assert!(!rendered.contains(SECRET), "password leaked: {rendered}");
+        assert!(
+            !rendered.contains("OU=Service Accounts"),
+            "matched DN leaked: {rendered}"
+        );
+    }
+
+    #[test]
+    fn integration_debug_holds_no_secrets() {
+        let integration = ActiveDirectoryIntegration::new();
+        let debug = format!("{integration:?}");
+        assert!(!debug.contains(SECRET), "debug leaked a secret: {debug}");
+    }
+
+    #[tokio::test]
+    async fn rotate_context_debug_redacts_the_new_password() {
+        let mut creds = ResolvedCredentials::new();
+        creds.insert(BIND_PASSWORD_SUFFIX.to_string(), SECRET.to_string());
+        let ctx = make_ctx(creds);
+        let debug = format!("{ctx:?}");
+        assert!(!debug.contains(SECRET), "password leaked: {debug}");
+    }
+
+    #[tokio::test]
+    async fn missing_credential_error_names_the_suffix_only() {
+        let integration = ActiveDirectoryIntegration::new();
+        let ctx = make_ctx(ResolvedCredentials::new());
+        let err = integration
+            .rotate(&ctx)
+            .await
+            .expect_err("empty credentials must fail before connecting");
+        assert_eq!(err.class, ErrorClass::Fatal);
+        assert_eq!(err.code, FailureCode::CredentialsUnresolved);
+        assert_eq!(err.effect, TargetEffect::NotApplied);
+        assert_eq!(err.detail.as_str(), "error kind: LDAP_HOST");
+    }
+
+    #[tokio::test]
+    async fn malformed_host_fails_before_connecting() {
+        let integration = ActiveDirectoryIntegration::new();
+        let mut creds = ResolvedCredentials::new();
+        creds.insert(HOST_SUFFIX.to_string(), "ldap://dc01".to_string());
+        creds.insert(BIND_DN_SUFFIX.to_string(), "CN=svc,DC=corp".to_string());
+        creds.insert(BASE_DN_SUFFIX.to_string(), "DC=corp".to_string());
+        creds.insert(BIND_PASSWORD_SUFFIX.to_string(), SECRET.to_string());
+        let ctx = make_ctx(creds);
+
+        let err = integration
+            .rotate(&ctx)
+            .await
+            .expect_err("a non-LDAPS host must be refused");
+        assert_eq!(err.code, FailureCode::CredentialsUnresolved);
+        assert_eq!(err.detail.as_str(), "error kind: MalformedLdapHost");
+        assert!(!err.to_string().contains(SECRET));
+    }
+
+    // -----------------------------------------------------------------------
+    // Session termination
+    // -----------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn terminate_sessions_is_unsupported() {
+        let integration = ActiveDirectoryIntegration::new();
+        let ctx = make_ctx(ResolvedCredentials::new());
+        let err = integration
+            .terminate_sessions(&ctx)
+            .await
+            .expect_err("session termination is not supported for Active Directory");
+        assert_eq!(err.class, ErrorClass::Fatal);
+        assert_eq!(err.code, FailureCode::UnsupportedKind);
+        assert_eq!(err.effect, TargetEffect::NotApplied);
+        assert_eq!(
+            err.detail.as_str(),
+            "error kind: ActiveDirectorySessionTerminationUnsupported"
+        );
+    }
+}

--- a/bitwarden_license/bitwarden-rotation-daemon/src/integrations/mod.rs
+++ b/bitwarden_license/bitwarden-rotation-daemon/src/integrations/mod.rs
@@ -11,9 +11,7 @@
 //! # TargetKind
 //!
 //! [`TargetKind`] is defined in [`crate::api::models`] and re-exported here for
-//! use by the resolver and integration implementations.  The local mirror that
-//! was written while `api/models.rs` was still a stub has been removed now that
-//! the parallel agent has landed the canonical definition.
+//! use by the resolver and integration implementations.
 
 pub(crate) mod active_directory;
 pub(crate) mod custom_script;

--- a/bitwarden_license/bitwarden-rotation-daemon/src/integrations/mod.rs
+++ b/bitwarden_license/bitwarden-rotation-daemon/src/integrations/mod.rs
@@ -15,6 +15,7 @@
 //! was written while `api/models.rs` was still a stub has been removed now that
 //! the parallel agent has landed the canonical definition.
 
+pub(crate) mod active_directory;
 pub(crate) mod custom_script;
 pub(crate) mod entra;
 

--- a/bitwarden_license/bitwarden-rotation-daemon/src/resolver/config.rs
+++ b/bitwarden_license/bitwarden-rotation-daemon/src/resolver/config.rs
@@ -12,9 +12,9 @@
 //!
 //! # Security note
 //!
-//! `client_secret` is deliberately absent from [`TargetEntry`].  Secrets must be supplied
-//! via environment variables only; the config file is typically checked in to a repo and
-//! must not hold credentials.
+//! `client_secret` and `bind_password` are deliberately absent from [`TargetEntry`].  Secrets
+//! must be supplied via environment variables only; the config file is typically checked in to
+//! a repo and must not hold credentials.
 
 use std::collections::HashMap;
 
@@ -34,8 +34,8 @@ use crate::{
 /// Per-target credential overrides from the `[targets]` TOML section.
 ///
 /// All fields are optional.  Any `Some` value shadows the corresponding environment
-/// variable.  The `client_secret` field is intentionally absent — secrets must be
-/// supplied via environment variables only.
+/// variable.  The `client_secret` and `bind_password` fields are intentionally absent —
+/// secrets must be supplied via environment variables only.
 #[derive(Debug, Clone, serde::Deserialize)]
 #[serde(deny_unknown_fields)]
 pub(crate) struct TargetEntry {
@@ -45,6 +45,12 @@ pub(crate) struct TargetEntry {
     pub(crate) tenant_id: Option<String>,
     /// Application (client) ID of the service principal (`CLIENT_ID` suffix).
     pub(crate) client_id: Option<String>,
+    /// Host name of the Active Directory domain controller (`LDAP_HOST` suffix).
+    pub(crate) ldap_host: Option<String>,
+    /// DN of the delegated Active Directory service account (`BIND_DN` suffix).
+    pub(crate) bind_dn: Option<String>,
+    /// Search base DN for Active Directory account lookup (`BASE_DN` suffix).
+    pub(crate) base_dn: Option<String>,
 }
 
 impl TargetEntry {
@@ -54,6 +60,9 @@ impl TargetEntry {
             ("SCRIPT", self.script.as_deref()),
             ("TENANT_ID", self.tenant_id.as_deref()),
             ("CLIENT_ID", self.client_id.as_deref()),
+            ("LDAP_HOST", self.ldap_host.as_deref()),
+            ("BIND_DN", self.bind_dn.as_deref()),
+            ("BASE_DN", self.base_dn.as_deref()),
         ]
         .into_iter()
         .filter_map(|(suffix, opt)| opt.map(|v| (suffix, v)))
@@ -178,6 +187,9 @@ mod tests {
                 script: Some("/opt/scripts/rotate.sh".to_string()),
                 tenant_id: None,
                 client_id: None,
+                ldap_host: None,
+                bind_dn: None,
+                base_dn: None,
             },
         );
         // No env vars set for this ID.
@@ -205,6 +217,9 @@ mod tests {
                 script: None,
                 tenant_id: Some("config-tenant".to_string()),
                 client_id: None,
+                ldap_host: None,
+                bind_dn: None,
+                base_dn: None,
             },
         );
 
@@ -228,6 +243,86 @@ mod tests {
 
         // CLIENT_SECRET comes from env.
         assert!(creds.get("CLIENT_SECRET").is_some());
+    }
+
+    // ── Active Directory: config keys resolve, password stays env-only ───────
+
+    #[test]
+    fn active_directory_config_keys_resolve_with_env_only_password() {
+        let id = Uuid::new_v4();
+        let prefix = prefix_for(id);
+
+        let mut targets = HashMap::new();
+        targets.insert(
+            id,
+            TargetEntry {
+                script: None,
+                tenant_id: None,
+                client_id: None,
+                ldap_host: Some("dc01.corp.example".to_string()),
+                bind_dn: Some("CN=svc-rotate,OU=Service Accounts,DC=corp,DC=example".to_string()),
+                base_dn: Some("DC=corp,DC=example".to_string()),
+            },
+        );
+
+        let mut vars = HashMap::new();
+        vars.insert(format!("{prefix}BIND_PASSWORD"), "bind-secret".to_string());
+
+        let creds = run_resolver_with_env(id, TargetKind::ActiveDirectory, targets, &vars)
+            .expect("config host/DNs plus env password should resolve");
+
+        use bitwarden_sensitive_value::ExposeSensitive as _;
+        assert_eq!(
+            **creds.get("LDAP_HOST").expect("host").expose(),
+            "dc01.corp.example"
+        );
+        assert_eq!(
+            **creds.get("BASE_DN").expect("base dn").expose(),
+            "DC=corp,DC=example"
+        );
+        assert!(creds.get("BIND_PASSWORD").is_some());
+    }
+
+    #[test]
+    fn active_directory_bind_password_absent_is_reported_as_env_var() {
+        let id = Uuid::new_v4();
+        let prefix = prefix_for(id);
+
+        let mut targets = HashMap::new();
+        targets.insert(
+            id,
+            TargetEntry {
+                script: None,
+                tenant_id: None,
+                client_id: None,
+                ldap_host: Some("dc01.corp.example".to_string()),
+                bind_dn: Some("CN=svc-rotate,DC=corp,DC=example".to_string()),
+                base_dn: Some("DC=corp,DC=example".to_string()),
+            },
+        );
+
+        let err = run_resolver_with_env(id, TargetKind::ActiveDirectory, targets, &HashMap::new())
+            .expect_err("bind password cannot come from the config file");
+
+        match err {
+            ResolveError::Missing(names) => {
+                assert_eq!(names, vec![format!("{prefix}BIND_PASSWORD")]);
+            }
+        }
+    }
+
+    #[test]
+    fn active_directory_bind_password_in_config_is_an_unknown_field() {
+        let toml_src = r#"
+ldap_host = "dc01.corp.example"
+bind_password = "should-not-be-accepted"
+"#;
+        let err = toml::from_str::<TargetEntry>(toml_src)
+            .expect_err("bind_password must not be accepted in a [targets] entry");
+        assert!(
+            err.to_string().contains("unknown field `bind_password`"),
+            "must be rejected as an unknown field: {err}"
+        );
     }
 
     // ── env fallback when config absent ──────────────────────────────────────
@@ -268,6 +363,9 @@ mod tests {
                 script: None,
                 tenant_id: Some("my-tenant".to_string()),
                 client_id: None,
+                ldap_host: None,
+                bind_dn: None,
+                base_dn: None,
             },
         );
 

--- a/bitwarden_license/bitwarden-rotation-daemon/src/resolver/env.rs
+++ b/bitwarden_license/bitwarden-rotation-daemon/src/resolver/env.rs
@@ -18,6 +18,7 @@
 //! | `Entra`        | `TENANT_ID`, `CLIENT_ID`, `CLIENT_SECRET`      |
 //! | `CustomScript` | `SCRIPT`                                       |
 //! | `Mssql`        | `HOST`, `USER`, `SECRET`                       |
+//! | `ActiveDirectory` | `LDAP_HOST`, `BIND_DN`, `BASE_DN`, `BIND_PASSWORD` |
 //!
 //! If any required variable is absent the resolver returns
 //! [`ResolveError::Missing`] carrying the full variable names (safe to log
@@ -39,6 +40,7 @@ pub(crate) fn required_suffixes(kind: TargetKind) -> &'static [&'static str] {
         TargetKind::Entra => &["TENANT_ID", "CLIENT_ID", "CLIENT_SECRET"],
         TargetKind::CustomScript => &["SCRIPT"],
         TargetKind::Mssql => &["HOST", "USER", "SECRET"],
+        TargetKind::ActiveDirectory => &["LDAP_HOST", "BIND_DN", "BASE_DN", "BIND_PASSWORD"],
         // Unknown kinds have no required suffixes; the executor will report
         // `unsupported_kind` before the resolver is invoked in practice.
         TargetKind::Unknown(_) => &[],
@@ -280,6 +282,44 @@ mod tests {
                 assert!(names.iter().any(|n| n.ends_with("CLIENT_ID")));
                 assert!(names.iter().any(|n| n.ends_with("CLIENT_SECRET")));
                 assert!(!names.iter().any(|n| n.ends_with("TENANT_ID")));
+            }
+        }
+    }
+
+    #[test]
+    fn active_directory_all_required_vars_present() {
+        let id = Uuid::new_v4();
+        let prefix = prefix_for(id);
+        let mut vars = HashMap::new();
+        vars.insert(
+            format!("{prefix}LDAP_HOST"),
+            "dc01.corp.example".to_string(),
+        );
+        vars.insert(
+            format!("{prefix}BIND_DN"),
+            "CN=svc-rotate,OU=Service Accounts,DC=corp,DC=example".to_string(),
+        );
+        vars.insert(format!("{prefix}BASE_DN"), "DC=corp,DC=example".to_string());
+        vars.insert(format!("{prefix}BIND_PASSWORD"), "bind-secret".to_string());
+        let creds = run_resolver_with_env(id, TargetKind::ActiveDirectory, &vars).unwrap();
+        assert!(creds.get("LDAP_HOST").is_some());
+        assert!(creds.get("BIND_DN").is_some());
+        assert!(creds.get("BASE_DN").is_some());
+        assert!(creds.get("BIND_PASSWORD").is_some());
+    }
+
+    #[test]
+    fn active_directory_missing_all_lists_every_required_var() {
+        let id = Uuid::new_v4();
+        let err =
+            run_resolver_with_env(id, TargetKind::ActiveDirectory, &HashMap::new()).unwrap_err();
+        let prefix = prefix_for(id);
+        match err {
+            ResolveError::Missing(names) => {
+                assert!(names.iter().any(|n| n == &format!("{prefix}LDAP_HOST")));
+                assert!(names.iter().any(|n| n == &format!("{prefix}BIND_DN")));
+                assert!(names.iter().any(|n| n == &format!("{prefix}BASE_DN")));
+                assert!(names.iter().any(|n| n == &format!("{prefix}BIND_PASSWORD")));
             }
         }
     }


### PR DESCRIPTION
## 🎟️ Tracking

PM-39040

## 📔 Objective

Adds an on-premises Active Directory rotation connector to the daemon.

- Rotates over LDAPS only: bind, RFC 4515 escaped subtree search matching exactly one account, `unicodePwd` replace as quoted UTF-16LE, then verify by rebinding as the rotated account. Zero and multiple matches are both fatal.
- No plaintext fallback, no StartTLS-optional path, and no certificate-validation bypass. AD refuses a `unicodePwd` write over an unencrypted connection regardless.
- Session termination is unsupported and reported as such: an LDAP password reset cannot revoke live Kerberos tickets.
- Per-target credentials resolve through the existing config and env precedence; the bind password is env-only, like `client_secret`.
- Adds `ldap3 0.12.1` (MIT/Apache-2.0) with `default-features = false` and `tls-rustls-ring`: no `sync`, no `native-tls`, no GSSAPI. It pins `rustls 0.23.31`, compatible with the workspace's existing ring build, so no second TLS stack is introduced. That dependency is a self-contained first commit, reviewable without the feature diff.

Registering an Active Directory target needs the server enum, which is a separate PR in `bitwarden/server`.

## 🚨 Breaking Changes
