### PR TITLE
Trust a private CA for the domain controller's LDAPS certificate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1249,6 +1249,7 @@ dependencies = [
  "reqwest",
  "reqwest-middleware",
  "rustls",
+ "rustls-native-certs",
  "serde",
  "serde_json",
  "tempfile",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -128,6 +128,7 @@ rustls = { version = "0.23.27", default-features = false, features = [
     "logging",
     "ring",
 ] }
+rustls-native-certs = "0.8.4"
 rustls-platform-verifier = "0.6.2"
 schemars = { version = ">=1.0.0, <2.0", features = ["uuid1", "chrono04"] }
 serde = { version = ">=1.0, <2.0", features = ["derive"] }

--- a/bitwarden_license/bitwarden-rotation-daemon/Cargo.toml
+++ b/bitwarden_license/bitwarden-rotation-daemon/Cargo.toml
@@ -31,6 +31,8 @@ http = { workspace = true }
 ldap3 = { workspace = true }
 reqwest = { workspace = true }
 reqwest-middleware = { workspace = true }
+rustls = { workspace = true }
+rustls-native-certs = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
@@ -43,7 +45,6 @@ uuid = { workspace = true }
 zeroize = { workspace = true }
 
 [dev-dependencies]
-rustls = { workspace = true }
 tempfile = "3"
 tokio = { workspace = true, features = ["rt", "test-util"] }
 wiremock = { workspace = true }

--- a/bitwarden_license/bitwarden-rotation-daemon/README.md
+++ b/bitwarden_license/bitwarden-rotation-daemon/README.md
@@ -202,7 +202,7 @@ source was expected to provide the value.
 | ----------------- | ----------------------------------- |
 | `CustomScript`    | `script`                            |
 | `Entra`           | `tenant_id`, `client_id`            |
-| `ActiveDirectory` | `ldap_host`, `bind_dn`, `base_dn`   |
+| `ActiveDirectory` | `ldap_host`, `bind_dn`, `base_dn`, `ca_certificate` |
 
 ### Secrets are env-only
 
@@ -226,10 +226,10 @@ bash: export: `85808642_BABA_4B8E_8C34_B48000D60A0A_BIND_PASSWORD=…': not a va
 ```
 
 The `[targets]` config section sidesteps this restriction for `script`, `tenant_id`, `client_id`,
-`ldap_host`, `bind_dn`, and `base_dn`; only `client_secret` and `bind_password` remain env-only. For
-a target whose UUID starts with a digit those two have no config-file escape hatch, so set them with
-`env`, which places the name in the child's environment directly and never applies the shell's
-identifier rules:
+`ldap_host`, `bind_dn`, `base_dn`, and `ca_certificate`; only `client_secret` and `bind_password`
+remain env-only. For a target whose UUID starts with a digit those two have no config-file escape
+hatch, so set them with `env`, which places the name in the child's environment directly and never
+applies the shell's identifier rules:
 
 ```sh
 env 85808642_BABA_4B8E_8C34_B48000D60A0A_BIND_PASSWORD="$secret" \
@@ -263,7 +263,7 @@ ABC_1234_5678_ABCD_000000000001_CLIENT_SECRET=...
 | ----------------- | ---------------------------------------------------- |
 | `Entra`           | `TENANT_ID`, `CLIENT_ID`, `CLIENT_SECRET`            |
 | `CustomScript`    | `SCRIPT`                                             |
-| `ActiveDirectory` | `LDAP_HOST`, `BIND_DN`, `BASE_DN`, `BIND_PASSWORD`   |
+| `ActiveDirectory` | `LDAP_HOST`, `BIND_DN`, `BASE_DN`, `BIND_PASSWORD` (plus optional `CA_CERTIFICATE`) |
 | `Mssql`           | `HOST`, `USER`, `SECRET` (unsupported this build)    |
 
 Any additional variables matching the prefix are collected and forwarded to the integration as extra
@@ -435,13 +435,59 @@ plaintext LDAP path, no StartTLS fallback, and no flag to skip certificate valid
 This is not only a Bitwarden policy: a domain controller refuses a `unicodePwd` write on an
 unencrypted connection, answering `confidentialityRequired` (LDAP result code 13).
 
-The domain controller's certificate is validated against the host's native trust store, so the
-**issuing enterprise CA must be trusted by the machine running the daemon**. A validation failure is
-a fatal error, not a retryable one.
+The domain controller's certificate is validated against the host's native trust store. A
+deployment whose DC uses a private or self-signed certificate can name a PEM file of extra trust
+anchors with `ca_certificate` — see [Trusting a private CA](#trusting-a-private-ca). A validation
+failure ends the attempt at once, with no backoff and no second connection inside it; the job itself
+is still re-claimed on later polls until its attempt budget is spent.
 
 `ldap_host` is a bare host name, optionally with a `:port` suffix — never a URL. Anything containing
 a scheme, a path, userinfo, or whitespace is rejected at rotation time so that a mistyped host cannot
 silently downgrade the connection or redirect the bind.
+
+### Trusting a private CA
+
+Most AD deployments issue the LDAPS certificate from an internal enterprise CA, or use the
+self-signed certificate the DC generates for itself. Neither chains to a public root, so the
+connection fails with `TlsHandshakeFailed` unless that CA is trusted. An untrusted anchor therefore
+shows up as a run of identical `target_unreachable` attempts, one per poll, not as a single failure.
+
+Set `ca_certificate` to the path of a PEM file holding the issuing CA certificate (or the DC's own
+self-signed certificate):
+
+```toml
+[targets.00000000-0000-0000-0000-000000000003]
+ldap_host      = "dc01.corp.example"
+bind_dn        = "CN=svc-rotate,OU=Service Accounts,DC=corp,DC=example"
+base_dn        = "OU=Managed Accounts,DC=corp,DC=example"
+ca_certificate = "/etc/bitwarden/ad-ca.pem"
+```
+
+Or via the environment: `<TARGET_ID_UPPER_UNDERSCORE>_CA_CERTIFICATE=/etc/bitwarden/ad-ca.pem`. It
+is a file path, not a secret, so unlike `bind_password` it is accepted in either place; the usual
+precedence applies (config file wins per key, environment is the fallback).
+
+Three properties are worth being explicit about:
+
+- **Additive, never substitutive.** The file's anchors are *added* to the platform trust store. Public CAs keep their standing, and the extra anchor applies only to that target's connections.
+- **Verification is never relaxed.** The certificate chain and the host name are checked exactly as they are for a publicly-issued certificate. There is no `insecure`, `no_verify`, or `skip_hostname` flag, and none will be added: a private CA is an additional anchor, not a reason to stop checking. The `ldap_host` you configure must therefore match a SAN on the DC's certificate.
+- **No silent fallback.** A missing file, an unreadable one, a malformed PEM, or a PEM with no certificate in it aborts the rotation with `credentials_unresolved`. The daemon will not quietly continue on platform roots, because that would leave an operator believing a connection is pinned when it is not.
+
+When `ca_certificate` is absent the connection uses the platform trust store alone, exactly as it
+did before the key existed.
+
+To export a DC's current LDAPS certificate, on the DC:
+
+```powershell
+$c = Get-ChildItem Cert:\LocalMachine\My |
+  Where-Object { $_.Subject -like "*$env:COMPUTERNAME*" -and $_.EnhancedKeyUsageList.FriendlyName -contains 'Server Authentication' } |
+  Select-Object -First 1
+@(
+  '-----BEGIN CERTIFICATE-----'
+  [Convert]::ToBase64String($c.RawData, 'InsertLineBreaks')
+  '-----END CERTIFICATE-----'
+) | Set-Content -Encoding ascii C:\dc-ldaps.pem
+```
 
 ### Bind identity: a delegated service account
 
@@ -496,6 +542,7 @@ lifetime).
 | `BIND_DN`       | DN of the delegated service account                               |
 | `BASE_DN`       | Search base DN for account lookup                                 |
 | `BIND_PASSWORD` | Password of the delegated service account (**environment only**)  |
+| `CA_CERTIFICATE` | *Optional.* Path to a PEM file of additional TLS trust anchors   |
 
 Example (target id `abc-1234-…`):
 
@@ -506,9 +553,9 @@ ABC_1234_…_BASE_DN=OU=Managed Accounts,DC=corp,DC=example
 ABC_1234_…_BIND_PASSWORD=<secret>
 ```
 
-`LDAP_HOST`, `BIND_DN`, and `BASE_DN` may also be supplied in the `[targets.<uuid>]` config section as
-`ldap_host`, `bind_dn`, and `base_dn`. `BIND_PASSWORD` may not — see
-[Secrets are env-only](#secrets-are-env-only).
+`LDAP_HOST`, `BIND_DN`, `BASE_DN`, and `CA_CERTIFICATE` may also be supplied in the
+`[targets.<uuid>]` config section as `ldap_host`, `bind_dn`, `base_dn`, and `ca_certificate`.
+`BIND_PASSWORD` may not — see [Secrets are env-only](#secrets-are-env-only).
 
 ### Error classification
 
@@ -523,6 +570,7 @@ once per attempt.
 | Missing or malformed credential                        | Fatal     | unchanged  | `credentials_unresolved` |
 | TCP failure, reset connection                          | Transient | unchanged  | `target_unreachable`     |
 | TLS handshake or certificate rejected                  | Fatal     | unchanged  | `target_unreachable`     |
+| `ca_certificate` missing, unreadable, or malformed     | Fatal     | unchanged  | `credentials_unresolved` |
 | Bind rejected (rc 49, 50)                              | Fatal     | unchanged  | `target_rejected`        |
 | Account not found or ambiguous                         | Fatal     | unchanged  | `target_rejected`        |
 | Write rejected (rc 13, 19, 32, 53, schema errors)      | Fatal     | unchanged  | `target_rejected`        |

--- a/bitwarden_license/bitwarden-rotation-daemon/dev-config.toml
+++ b/bitwarden_license/bitwarden-rotation-daemon/dev-config.toml
@@ -47,7 +47,13 @@ script = "/tmp/bwrd-dev-rotate.sh"
 # not a Domain Admin. Its password is env-only:
 #   00000000_0000_0000_0000_000000000003_BIND_PASSWORD=<secret>
 #
+# ca_certificate is optional: a PEM of extra trust anchors, ADDED to the platform
+# roots, for a DC whose LDAPS certificate is self-signed or issued by an internal
+# CA. It never relaxes verification, and a bad path is a hard failure rather than
+# a fallback to platform roots. Omit it when the DC's issuer is publicly trusted.
+#
 # [targets.00000000-0000-0000-0000-000000000003]
-# ldap_host = "dc01.corp.example"
-# bind_dn   = "CN=svc-rotate,OU=Service Accounts,DC=corp,DC=example"
-# base_dn   = "OU=Managed Accounts,DC=corp,DC=example"
+# ldap_host      = "dc01.corp.example"
+# bind_dn        = "CN=svc-rotate,OU=Service Accounts,DC=corp,DC=example"
+# base_dn        = "OU=Managed Accounts,DC=corp,DC=example"
+# ca_certificate = "/etc/bitwarden/ad-ca.pem"

--- a/bitwarden_license/bitwarden-rotation-daemon/src/config.rs
+++ b/bitwarden_license/bitwarden-rotation-daemon/src/config.rs
@@ -1318,9 +1318,10 @@ api      = "https://api.example.com"
 identity = "https://identity.example.com"
 
 [targets.00000000-0000-0000-0000-000000000002]
-ldap_host = "dc01.corp.example"
-bind_dn   = "CN=svc-rotate,OU=Service Accounts,DC=corp,DC=example"
-base_dn   = "DC=corp,DC=example"
+ldap_host      = "dc01.corp.example"
+bind_dn        = "CN=svc-rotate,OU=Service Accounts,DC=corp,DC=example"
+base_dn        = "DC=corp,DC=example"
+ca_certificate = "/etc/pki/ad-ca.pem"
 "#;
         let f = write_toml(toml);
         let result = Config::from_cli(file_args(&f));
@@ -1342,6 +1343,10 @@ base_dn   = "DC=corp,DC=example"
         assert_eq!(
             cfg.targets[&uuid].base_dn.as_deref(),
             Some("DC=corp,DC=example")
+        );
+        assert_eq!(
+            cfg.targets[&uuid].ca_certificate.as_deref(),
+            Some("/etc/pki/ad-ca.pem")
         );
     }
 

--- a/bitwarden_license/bitwarden-rotation-daemon/src/integrations/active_directory.rs
+++ b/bitwarden_license/bitwarden-rotation-daemon/src/integrations/active_directory.rs
@@ -13,9 +13,13 @@
 //! connection that is not encrypted, answering `confidentialityRequired`
 //! (result code 13).
 //!
-//! The server certificate is validated against the host's native trust store,
-//! so the issuing enterprise CA must be trusted by the machine running the
-//! daemon.
+//! The server certificate is validated against the host's native trust store.
+//! A deployment whose domain controller uses a private or self-signed
+//! certificate can name a PEM file of additional trust anchors with the
+//! `CA_CERTIFICATE` credential; those anchors are **added** to the platform
+//! roots, never substituted for them. There is deliberately no option to skip
+//! verification or relax the host-name check — an extra anchor is the only
+//! escape hatch offered.
 //!
 //! # Bind identity
 //!
@@ -52,12 +56,16 @@
 //! - Directory-supplied diagnostic text (`LdapResult::text`) and matched DNs are never read into a
 //!   detail. Only the numeric LDAP result code is reported.
 
-use std::{collections::HashSet, time::Duration};
+use std::{collections::HashSet, path::Path, sync::Arc, time::Duration};
 
 use async_trait::async_trait;
 use bitwarden_sensitive_value::ExposeSensitive as _;
 use ldap3::{
     Ldap, LdapConnAsync, LdapConnSettings, LdapError, Mod, ResultEntry, Scope, SearchEntry,
+};
+use rustls::{
+    ClientConfig, RootCertStore,
+    pki_types::{CertificateDer, pem::PemObject as _},
 };
 use tokio::task::JoinHandle;
 use zeroize::Zeroizing;
@@ -82,6 +90,12 @@ const BASE_DN_SUFFIX: &str = "BASE_DN";
 ///
 /// Environment-only; the `[targets]` config section deliberately refuses it.
 const BIND_PASSWORD_SUFFIX: &str = "BIND_PASSWORD";
+
+/// Credential suffix holding a path to a PEM file of additional trust anchors.
+///
+/// Optional. A file path, not a secret, so it may be supplied in the
+/// `[targets]` config section as well as in the environment.
+const CA_CERTIFICATE_SUFFIX: &str = "CA_CERTIFICATE";
 
 /// The Active Directory attribute holding the account password.
 const UNICODE_PWD_ATTR: &[u8] = b"unicodePwd";
@@ -178,12 +192,21 @@ impl ActiveDirectoryIntegration {
     }
 
     /// Open an LDAPS connection and start its protocol driver task.
+    ///
+    /// When `ca_certificate` names a PEM file, the connection trusts the
+    /// platform roots plus that file's anchors. When it is `None` the
+    /// connection uses the LDAP client's own platform-root configuration,
+    /// unchanged.
     async fn connect(
         &self,
         url: &str,
+        ca_certificate: Option<&str>,
         policy: EffectPolicy,
     ) -> Result<LdapSession, IntegrationError> {
-        let settings = LdapConnSettings::new().set_conn_timeout(self.connect_timeout);
+        let mut settings = LdapConnSettings::new().set_conn_timeout(self.connect_timeout);
+        if let Some(path) = ca_certificate {
+            settings = settings.set_config(tls_config_with_extra_anchors(path, policy)?);
+        }
         let (conn, ldap) = LdapConnAsync::with_settings(settings, url)
             .await
             .map_err(|e| classify_ldap_error(&e, policy))?;
@@ -201,7 +224,9 @@ impl ActiveDirectoryIntegration {
         account_identity: &str,
         policy: EffectPolicy,
     ) -> Result<(LdapSession, String), IntegrationError> {
-        let mut session = self.connect(&creds.url, policy).await?;
+        let mut session = self
+            .connect(&creds.url, creds.ca_certificate, policy)
+            .await?;
         session
             .simple_bind(creds.bind_dn, creds.bind_password, self.operation_timeout)
             .await
@@ -335,6 +360,8 @@ struct Credentials<'a> {
     base_dn: &'a str,
     /// Password of the delegated service account.
     bind_password: &'a str,
+    /// Optional path to a PEM file of additional TLS trust anchors.
+    ca_certificate: Option<&'a str>,
 }
 
 impl<'a> Credentials<'a> {
@@ -346,6 +373,7 @@ impl<'a> Credentials<'a> {
             bind_dn: get_cred(creds, BIND_DN_SUFFIX)?,
             base_dn: get_cred(creds, BASE_DN_SUFFIX)?,
             bind_password: get_cred(creds, BIND_PASSWORD_SUFFIX)?,
+            ca_certificate: optional_cred(creds, CA_CERTIFICATE_SUFFIX),
         })
     }
 }
@@ -413,7 +441,11 @@ impl Integration for ActiveDirectoryIntegration {
         lookup.close().await;
 
         let mut session = self
-            .connect(&creds.url, EffectPolicy::AFTER_ROTATION)
+            .connect(
+                &creds.url,
+                creds.ca_certificate,
+                EffectPolicy::AFTER_ROTATION,
+            )
             .await?;
         let bind = session
             .simple_bind(&account_dn, &ctx.new_password, self.operation_timeout)
@@ -503,6 +535,98 @@ fn encode_unicode_pwd(password: &str) -> Zeroizing<Vec<u8>> {
         buf.extend_from_slice(&unit.to_le_bytes());
     }
     buf
+}
+
+// ---------------------------------------------------------------------------
+// TLS trust anchors
+// ---------------------------------------------------------------------------
+
+/// Build a TLS client configuration trusting the platform roots **plus** the
+/// certificates in the PEM file at `path`.
+///
+/// # Additive, never substitutive
+///
+/// The file's anchors are appended to the host's native trust store. A domain
+/// controller using a private or self-signed certificate becomes reachable
+/// without any public CA losing its standing, and without weakening the
+/// verification applied to it: the certificate chain and the host name are
+/// checked exactly as they are for a publicly-issued certificate.
+///
+/// # No silent fallback
+///
+/// Every failure to honour the configured anchor is fatal. A missing file, an
+/// unreadable one, a malformed PEM, or a PEM holding no certificate all abort
+/// the rotation rather than quietly continuing with platform roots only —
+/// falling back would turn a misconfiguration into a connection that the
+/// operator believes is pinned but is not.
+///
+/// The path is reported in no error; only a fixed kind name is.
+fn tls_config_with_extra_anchors(
+    path: &str,
+    policy: EffectPolicy,
+) -> Result<Arc<ClientConfig>, IntegrationError> {
+    let failure = |kind: &'static str| IntegrationError {
+        class: ErrorClass::Fatal,
+        effect: policy.settled,
+        code: FailureCode::CredentialsUnresolved,
+        detail: SafeDetail::from_kind(kind),
+    };
+
+    let roots = root_store_with_extra_anchors(path, policy)?;
+
+    let config =
+        ClientConfig::builder_with_provider(Arc::new(rustls::crypto::ring::default_provider()))
+            .with_safe_default_protocol_versions()
+            .map_err(|_| failure("TlsProviderUnavailable"))?
+            .with_root_certificates(roots)
+            .with_no_client_auth();
+
+    Ok(Arc::new(config))
+}
+
+/// The host's native trust store, as a [`RootCertStore`].
+///
+/// Certificates the platform offers but rustls cannot parse are skipped, which
+/// matches what the LDAP client does for its own default configuration.
+fn platform_roots() -> RootCertStore {
+    let mut roots = RootCertStore::empty();
+    for cert in rustls_native_certs::load_native_certs().certs {
+        let _ = roots.add(cert);
+    }
+    roots
+}
+
+/// [`platform_roots`] plus every certificate in the PEM file at `path`.
+///
+/// The platform roots are the starting point, so the configured anchors can
+/// only widen what is trusted for this one target — they can never remove a
+/// public CA or become the sole trust source.
+fn root_store_with_extra_anchors(
+    path: &str,
+    policy: EffectPolicy,
+) -> Result<RootCertStore, IntegrationError> {
+    let failure = |kind: &'static str| IntegrationError {
+        class: ErrorClass::Fatal,
+        effect: policy.settled,
+        code: FailureCode::CredentialsUnresolved,
+        detail: SafeDetail::from_kind(kind),
+    };
+
+    let anchors: Vec<CertificateDer<'static>> = CertificateDer::pem_file_iter(Path::new(path))
+        .map_err(|_| failure("CaCertificateUnreadable"))?
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|_| failure("CaCertificateInvalid"))?;
+    if anchors.is_empty() {
+        return Err(failure("CaCertificateEmpty"));
+    }
+
+    let mut roots = platform_roots();
+    for anchor in anchors {
+        roots
+            .add(anchor)
+            .map_err(|_| failure("CaCertificateInvalid"))?;
+    }
+    Ok(roots)
 }
 
 // ---------------------------------------------------------------------------
@@ -689,6 +813,14 @@ fn as_applied(mut err: IntegrationError) -> IntegrationError {
 // ---------------------------------------------------------------------------
 // Credential lookup helper
 // ---------------------------------------------------------------------------
+
+/// Look up an optional credential suffix, returning `None` if absent.
+fn optional_cred<'a>(
+    creds: &'a crate::resolver::ResolvedCredentials,
+    suffix: &'static str,
+) -> Option<&'a str> {
+    creds.get(suffix).map(|s| s.expose().as_ref() as &str)
+}
 
 /// Look up a required credential suffix, returning
 /// `Fatal/NotApplied/credentials_unresolved` if absent.
@@ -1190,6 +1322,147 @@ mod tests {
         assert_eq!(err.code, FailureCode::CredentialsUnresolved);
         assert_eq!(err.detail.as_str(), "error kind: MalformedLdapHost");
         assert!(!err.to_string().contains(SECRET));
+    }
+
+    // -----------------------------------------------------------------------
+    // TLS trust anchors
+    // -----------------------------------------------------------------------
+
+    /// A self-signed certificate used only as a parseable trust anchor.
+    const TEST_CA_PEM: &str = "\
+-----BEGIN CERTIFICATE-----\n\
+MIIDJTCCAg2gAwIBAgIUP9bWk+gm4n6VqzhqhQz9YDiwR/UwDQYJKoZIhvcNAQEL\n\
+BQAwIjEgMB4GA1UEAwwXcm90YXRpb24tZGFlbW9uLXRlc3QtY2EwHhcNMjYwODMx\n\
+MjIzODU5WhcNMzYwODI4MjIzODU5WjAiMSAwHgYDVQQDDBdyb3RhdGlvbi1kYWVt\n\
+b24tdGVzdC1jYTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBALCVyUmM\n\
+86vormZ7E/vOxdZMvJOYVjp17OrAI1tPWq0PywOizZ1gJORWXjArJFT0PoG2OqmA\n\
+hafaOoZTeZH0J4DwEjgGVn/rGVIa8f5a8qjfnJdDn23fnqa2Wd+9Tf1/LDeCUZil\n\
+7jZ4NqtddZe+GOkkWJXB+55u7JhxPyX/AdfVK9idmGANXGuCOUZhTLSnz+p5SrLP\n\
+WWDgQeAHTvFlWcpu8eff5Agj5cdhqyJiBcpaLzga0xiUifpdG4yEU/7H/909XKOQ\n\
+/O0wiPwnObHwOVFALDppeHo9FtGmvK0OQArxgo40gaeWEvctURyXc6Lqu5u8eZXV\n\
+MX5nIS+hPAYLZ50CAwEAAaNTMFEwHQYDVR0OBBYEFE7MLaoHaLKLcBeZsdAfGTk0\n\
+0ToLMB8GA1UdIwQYMBaAFE7MLaoHaLKLcBeZsdAfGTk00ToLMA8GA1UdEwEB/wQF\n\
+MAMBAf8wDQYJKoZIhvcNAQELBQADggEBAJyvTvcTCL6s3MPlhYHrcCAfc6/PcVro\n\
+NvLM9fOUvmlqdlyXyvwZ/FOwGogLUSVVR+68wLQ4NFac4nhyeaApiFsKoHP+bA6X\n\
+bsgmmsTYuH0fw43szFTlI+Lw2a8Ai9Nx8JTeyILL9FzCV6ranWW7YcQBEPTvpfB7\n\
+vBWeCGTA+sHqgBbltU/5jsWYslt9YhOpxkoJHHxyt2JA8XYCpdSkfgFOsjReofHn\n\
+SavmVaBabR7Vq3QVTfvp+/WO41z7hGKsGAZ2dVldkHeOjgu4oktTOeblDbnZogZ2\n\
+D2kYx4ka5O/dEuqcrMf/qd6GW5H2PJcrdc4PtRJeIBDR0TgweD2xjJ0=\n\
+-----END CERTIFICATE-----\n";
+
+    fn write_temp(contents: &str) -> tempfile::NamedTempFile {
+        use std::io::Write as _;
+        let mut f = tempfile::NamedTempFile::new().expect("temp file");
+        f.write_all(contents.as_bytes()).expect("write pem");
+        f.flush().expect("flush");
+        f
+    }
+
+    #[test]
+    fn extra_anchor_is_added_to_platform_roots_not_substituted() {
+        let f = write_temp(TEST_CA_PEM);
+        let path = f.path().to_str().expect("utf8 path");
+
+        let baseline = platform_roots().len();
+        let widened = root_store_with_extra_anchors(path, EffectPolicy::BEFORE_MODIFY)
+            .expect("valid PEM should build a root store")
+            .len();
+
+        assert_eq!(
+            widened,
+            baseline + 1,
+            "the anchor must be added to the platform roots, not replace them"
+        );
+    }
+
+    #[test]
+    fn valid_ca_certificate_builds_a_client_config() {
+        let f = write_temp(TEST_CA_PEM);
+        let path = f.path().to_str().expect("utf8 path");
+        assert!(tls_config_with_extra_anchors(path, EffectPolicy::BEFORE_MODIFY).is_ok());
+    }
+
+    #[test]
+    fn missing_ca_certificate_file_is_fatal() {
+        let err = root_store_with_extra_anchors(
+            "/nonexistent/path/to/ca-bundle-2f8a1c.pem",
+            EffectPolicy::BEFORE_MODIFY,
+        )
+        .expect_err("a missing PEM must not fall back to platform roots");
+        assert_eq!(err.class, ErrorClass::Fatal);
+        assert_eq!(err.code, FailureCode::CredentialsUnresolved);
+        assert_eq!(err.detail.as_str(), "error kind: CaCertificateUnreadable");
+    }
+
+    #[test]
+    fn malformed_ca_certificate_is_fatal() {
+        let truncated = "-----BEGIN CERTIFICATE-----\nMIIDJTCCAg2gAwIBAgIUP9bWk\n";
+        let f = write_temp(truncated);
+        let path = f.path().to_str().expect("utf8 path");
+        let err = root_store_with_extra_anchors(path, EffectPolicy::BEFORE_MODIFY)
+            .expect_err("a malformed PEM must not fall back to platform roots");
+        assert_eq!(err.class, ErrorClass::Fatal);
+        assert_eq!(err.detail.as_str(), "error kind: CaCertificateInvalid");
+    }
+
+    #[test]
+    fn ca_certificate_without_a_certificate_is_fatal() {
+        let f = write_temp("# no PEM sections here\n");
+        let path = f.path().to_str().expect("utf8 path");
+        let err = root_store_with_extra_anchors(path, EffectPolicy::BEFORE_MODIFY)
+            .expect_err("a PEM with no certificate must not fall back to platform roots");
+        assert_eq!(err.class, ErrorClass::Fatal);
+        assert_eq!(err.detail.as_str(), "error kind: CaCertificateEmpty");
+    }
+
+    #[test]
+    fn ca_certificate_path_never_reaches_the_error_detail() {
+        let path = "/etc/secrets/ad-ca-9f3b2e.pem";
+        let err = root_store_with_extra_anchors(path, EffectPolicy::BEFORE_MODIFY)
+            .expect_err("missing file");
+        assert!(
+            !err.to_string().contains("9f3b2e"),
+            "the configured path must not appear in the error: {err}"
+        );
+    }
+
+    #[test]
+    fn ca_certificate_failure_after_rotation_reports_applied() {
+        let err =
+            root_store_with_extra_anchors("/nonexistent/ca.pem", EffectPolicy::AFTER_ROTATION)
+                .expect_err("missing file");
+        assert_eq!(err.effect, TargetEffect::Applied);
+    }
+
+    #[test]
+    fn ca_certificate_is_optional_and_absent_by_default() {
+        let mut creds = ResolvedCredentials::new();
+        creds.insert(HOST_SUFFIX.to_string(), "dc01.corp.example".to_string());
+        creds.insert(BIND_DN_SUFFIX.to_string(), "CN=svc,DC=corp".to_string());
+        creds.insert(BASE_DN_SUFFIX.to_string(), "DC=corp".to_string());
+        creds.insert(BIND_PASSWORD_SUFFIX.to_string(), SECRET.to_string());
+
+        let resolved = Credentials::resolve(&creds).expect("credentials resolve without a CA");
+        assert!(
+            resolved.ca_certificate.is_none(),
+            "an absent CA_CERTIFICATE must leave the connection on platform roots"
+        );
+    }
+
+    #[test]
+    fn ca_certificate_is_picked_up_when_present() {
+        let mut creds = ResolvedCredentials::new();
+        creds.insert(HOST_SUFFIX.to_string(), "dc01.corp.example".to_string());
+        creds.insert(BIND_DN_SUFFIX.to_string(), "CN=svc,DC=corp".to_string());
+        creds.insert(BASE_DN_SUFFIX.to_string(), "DC=corp".to_string());
+        creds.insert(BIND_PASSWORD_SUFFIX.to_string(), SECRET.to_string());
+        creds.insert(
+            CA_CERTIFICATE_SUFFIX.to_string(),
+            "/etc/pki/ad-ca.pem".to_string(),
+        );
+
+        let resolved = Credentials::resolve(&creds).expect("credentials resolve");
+        assert_eq!(resolved.ca_certificate, Some("/etc/pki/ad-ca.pem"));
     }
 
     // -----------------------------------------------------------------------

--- a/bitwarden_license/bitwarden-rotation-daemon/src/resolver/config.rs
+++ b/bitwarden_license/bitwarden-rotation-daemon/src/resolver/config.rs
@@ -51,6 +51,11 @@ pub(crate) struct TargetEntry {
     pub(crate) bind_dn: Option<String>,
     /// Search base DN for Active Directory account lookup (`BASE_DN` suffix).
     pub(crate) base_dn: Option<String>,
+    /// Path to a PEM file of additional TLS trust anchors (`CA_CERTIFICATE` suffix).
+    ///
+    /// A file path rather than a secret, so it is accepted here as well as in
+    /// the environment.
+    pub(crate) ca_certificate: Option<String>,
 }
 
 impl TargetEntry {
@@ -63,6 +68,7 @@ impl TargetEntry {
             ("LDAP_HOST", self.ldap_host.as_deref()),
             ("BIND_DN", self.bind_dn.as_deref()),
             ("BASE_DN", self.base_dn.as_deref()),
+            ("CA_CERTIFICATE", self.ca_certificate.as_deref()),
         ]
         .into_iter()
         .filter_map(|(suffix, opt)| opt.map(|v| (suffix, v)))
@@ -190,6 +196,7 @@ mod tests {
                 ldap_host: None,
                 bind_dn: None,
                 base_dn: None,
+                ca_certificate: None,
             },
         );
         // No env vars set for this ID.
@@ -220,6 +227,7 @@ mod tests {
                 ldap_host: None,
                 bind_dn: None,
                 base_dn: None,
+                ca_certificate: None,
             },
         );
 
@@ -262,6 +270,7 @@ mod tests {
                 ldap_host: Some("dc01.corp.example".to_string()),
                 bind_dn: Some("CN=svc-rotate,OU=Service Accounts,DC=corp,DC=example".to_string()),
                 base_dn: Some("DC=corp,DC=example".to_string()),
+                ca_certificate: None,
             },
         );
 
@@ -298,6 +307,7 @@ mod tests {
                 ldap_host: Some("dc01.corp.example".to_string()),
                 bind_dn: Some("CN=svc-rotate,DC=corp,DC=example".to_string()),
                 base_dn: Some("DC=corp,DC=example".to_string()),
+                ca_certificate: None,
             },
         );
 
@@ -322,6 +332,101 @@ bind_password = "should-not-be-accepted"
         assert!(
             err.to_string().contains("unknown field `bind_password`"),
             "must be rejected as an unknown field: {err}"
+        );
+    }
+
+    #[test]
+    fn active_directory_ca_certificate_config_shadows_env() {
+        let id = Uuid::new_v4();
+        let prefix = prefix_for(id);
+
+        let mut targets = HashMap::new();
+        targets.insert(
+            id,
+            TargetEntry {
+                script: None,
+                tenant_id: None,
+                client_id: None,
+                ldap_host: Some("dc01.corp.example".to_string()),
+                bind_dn: Some("CN=svc-rotate,DC=corp,DC=example".to_string()),
+                base_dn: Some("DC=corp,DC=example".to_string()),
+                ca_certificate: Some("/etc/pki/from-config.pem".to_string()),
+            },
+        );
+
+        let mut vars = HashMap::new();
+        vars.insert(format!("{prefix}BIND_PASSWORD"), "bind-secret".to_string());
+        vars.insert(
+            format!("{prefix}CA_CERTIFICATE"),
+            "/etc/pki/from-env.pem".to_string(),
+        );
+
+        let creds = run_resolver_with_env(id, TargetKind::ActiveDirectory, targets, &vars)
+            .expect("should resolve");
+
+        use bitwarden_sensitive_value::ExposeSensitive as _;
+        assert_eq!(
+            **creds.get("CA_CERTIFICATE").expect("ca cert").expose(),
+            "/etc/pki/from-config.pem",
+            "config must win over env for ca_certificate"
+        );
+    }
+
+    #[test]
+    fn active_directory_ca_certificate_falls_back_to_env() {
+        let id = Uuid::new_v4();
+        let prefix = prefix_for(id);
+
+        let mut targets = HashMap::new();
+        targets.insert(
+            id,
+            TargetEntry {
+                script: None,
+                tenant_id: None,
+                client_id: None,
+                ldap_host: Some("dc01.corp.example".to_string()),
+                bind_dn: Some("CN=svc-rotate,DC=corp,DC=example".to_string()),
+                base_dn: Some("DC=corp,DC=example".to_string()),
+                ca_certificate: None,
+            },
+        );
+
+        let mut vars = HashMap::new();
+        vars.insert(format!("{prefix}BIND_PASSWORD"), "bind-secret".to_string());
+        vars.insert(
+            format!("{prefix}CA_CERTIFICATE"),
+            "/etc/pki/from-env.pem".to_string(),
+        );
+
+        let creds = run_resolver_with_env(id, TargetKind::ActiveDirectory, targets, &vars)
+            .expect("should resolve");
+
+        use bitwarden_sensitive_value::ExposeSensitive as _;
+        assert_eq!(
+            **creds.get("CA_CERTIFICATE").expect("ca cert").expose(),
+            "/etc/pki/from-env.pem"
+        );
+    }
+
+    #[test]
+    fn active_directory_ca_certificate_absent_from_both_sources() {
+        let id = Uuid::new_v4();
+        let prefix = prefix_for(id);
+
+        let mut vars = HashMap::new();
+        vars.insert(
+            format!("{prefix}LDAP_HOST"),
+            "dc01.corp.example".to_string(),
+        );
+        vars.insert(format!("{prefix}BIND_DN"), "CN=svc,DC=corp".to_string());
+        vars.insert(format!("{prefix}BASE_DN"), "DC=corp".to_string());
+        vars.insert(format!("{prefix}BIND_PASSWORD"), "bind-secret".to_string());
+
+        let creds = run_resolver_with_env(id, TargetKind::ActiveDirectory, HashMap::new(), &vars)
+            .expect("ca_certificate is optional");
+        assert!(
+            creds.get("CA_CERTIFICATE").is_none(),
+            "an unset ca_certificate must stay unset"
         );
     }
 
@@ -366,6 +471,7 @@ bind_password = "should-not-be-accepted"
                 ldap_host: None,
                 bind_dn: None,
                 base_dn: None,
+                ca_certificate: None,
             },
         );
 

--- a/bitwarden_license/bitwarden-rotation-daemon/src/resolver/env.rs
+++ b/bitwarden_license/bitwarden-rotation-daemon/src/resolver/env.rs
@@ -20,6 +20,10 @@
 //! | `Mssql`        | `HOST`, `USER`, `SECRET`                       |
 //! | `ActiveDirectory` | `LDAP_HOST`, `BIND_DN`, `BASE_DN`, `BIND_PASSWORD` |
 //!
+//! `ActiveDirectory` additionally recognises the optional `CA_CERTIFICATE`
+//! suffix: a path to a PEM file whose certificates are added to the platform
+//! trust store for that target's LDAPS connections.
+//!
 //! If any required variable is absent the resolver returns
 //! [`ResolveError::Missing`] carrying the full variable names (safe to log
 //! and report — names only, never values).


### PR DESCRIPTION
## 🎟️ Tracking

PM-39040

## 📔 Objective

Lets a deployment name a private CA for its domain controller's LDAPS certificate.

- Adds a per-target `ca_certificate` key, a path to a PEM file, resolved through the existing config and env precedence. It is a path rather than a secret, so it may live in either.
- The anchors are added to the platform trust store, never substituted for it. With the key absent, behaviour is byte-identical to before.
- A missing, unreadable, malformed or empty PEM is a fatal error, never a silent fall back to platform roots.
- No flag disables verification or hostname checking; the only effect is an additional anchor.

Most AD deployments issue LDAPS certificates from an internal enterprise CA, or use the DC's self-signed certificate. Neither chains to a public root, and a Linux host typically does not trust either.

## 🚨 Breaking Changes
