### PR TITLE
[POC] Hand-rolled SDK debug capabilities (typed debug tree)

### DIFF
--- a/crates/bitwarden-core/Cargo.toml
+++ b/crates/bitwarden-core/Cargo.toml
@@ -24,8 +24,9 @@ normal = [
 [features]
 internal = ["dep:zxcvbn"]
 # Dev-only debug capabilities that reach past the public API into internal
-# state. Never enable in production.
-debug-capabilities = []
+# state. Never enable in production. Requires `internal` (the login-method and
+# persisted-state access it builds on lives behind that feature).
+debug-capabilities = ["internal", "bitwarden-state/debug-capabilities"]
 no-memory-hardening = [
     "bitwarden-crypto/no-memory-hardening",
 ] # Disable memory hardening features

--- a/crates/bitwarden-core/Cargo.toml
+++ b/crates/bitwarden-core/Cargo.toml
@@ -23,6 +23,9 @@ normal = [
 
 [features]
 internal = ["dep:zxcvbn"]
+# Dev-only debug capabilities that reach past the public API into internal
+# state. Never enable in production.
+debug-capabilities = []
 no-memory-hardening = [
     "bitwarden-crypto/no-memory-hardening",
 ] # Disable memory hardening features

--- a/crates/bitwarden-core/src/client/login_method.rs
+++ b/crates/bitwarden-core/src/client/login_method.rs
@@ -19,6 +19,11 @@ pub enum LoginMethod {
 
 #[allow(dead_code)]
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(
+    feature = "wasm",
+    derive(tsify::Tsify),
+    tsify(into_wasm_abi, from_wasm_abi)
+)]
 pub enum UserLoginMethod {
     Username {
         client_id: String,

--- a/crates/bitwarden-core/src/debug.rs
+++ b/crates/bitwarden-core/src/debug.rs
@@ -6,6 +6,8 @@
 //! production. Kept in their own module, deliberately separate from the regular
 //! client API.
 
+use serde_json::Value;
+
 use crate::{
     Client,
     client::login_method::{LoginMethod, UserLoginMethod},
@@ -38,6 +40,62 @@ impl AuthDebug {
         self.client
             .internal
             .set_login_method(LoginMethod::User(method))
+            .await;
+    }
+}
+
+/// Debug access to the SDK's state registry — a generic browse over every
+/// registered repository, both client-managed and SDK-managed.
+///
+/// Holds a cheap, `Arc`-backed [`Client`] clone.
+pub struct StateDebug {
+    client: Client,
+}
+
+impl StateDebug {
+    /// Wrap the owning client. Built by the debug-tree root.
+    pub fn new(client: Client) -> Self {
+        Self { client }
+    }
+
+    /// Names of every registered repository (client- and SDK-managed).
+    pub fn types(&self) -> Vec<String> {
+        self.client.internal.state_registry.debug_types()
+    }
+
+    /// List a repository's values as JSON, addressed by type name. Values only —
+    /// the repository API lists values without their keys. Returns raw stored
+    /// JSON (no redaction); dev-only, bypasses the public API.
+    pub async fn list(&self, type_name: String) -> Value {
+        Value::Array(
+            self.client
+                .internal
+                .state_registry
+                .debug_list(&type_name)
+                .await,
+        )
+    }
+
+    /// Read one item by type name and string key, or `null` if absent.
+    pub async fn get(&self, type_name: String, key: String) -> Value {
+        self.client
+            .internal
+            .state_registry
+            .debug_get(&type_name, &key)
+            .await
+            .unwrap_or(Value::Null)
+    }
+
+    /// Write one item by type name and string key. `value_json` is the item as a
+    /// JSON string. No-ops on an unknown type, bad key, or non-deserializable value.
+    pub async fn set(&self, type_name: String, key: String, value_json: String) {
+        let Ok(value) = serde_json::from_str::<Value>(&value_json) else {
+            return;
+        };
+        self.client
+            .internal
+            .state_registry
+            .debug_set(&type_name, &key, value)
             .await;
     }
 }

--- a/crates/bitwarden-core/src/debug.rs
+++ b/crates/bitwarden-core/src/debug.rs
@@ -1,0 +1,43 @@
+//! Dev-only debug capabilities.
+//!
+//! These reach past the public API into internal client state so automated
+//! tooling can read and drive things the normal API does not expose. They are
+//! compiled only under the `debug-capabilities` feature and must never ship in
+//! production. Kept in their own module, deliberately separate from the regular
+//! client API.
+
+use crate::{
+    Client,
+    client::login_method::{LoginMethod, UserLoginMethod},
+};
+
+/// Debug capabilities over a user's auth/session state.
+///
+/// Holds a cheap, `Arc`-backed [`Client`] clone, so it owns everything it needs
+/// and nothing borrows across an FFI boundary.
+pub struct AuthDebug {
+    client: Client,
+}
+
+impl AuthDebug {
+    /// Wrap the owning client. Built by the debug-tree root, not called directly.
+    pub fn new(client: Client) -> Self {
+        Self { client }
+    }
+
+    /// Read the user's stored login method (client id, email, KDF, and — for
+    /// API-key logins — the client secret). `None` on a locked or
+    /// service-account client. Bypasses the public API.
+    pub async fn login_method(&self) -> Option<UserLoginMethod> {
+        self.client.internal.get_login_method().await
+    }
+
+    /// Overwrite the user's stored login method. Debug-only: bypasses the normal
+    /// login flow to drive a client into a specific state.
+    pub async fn set_login_method(&self, method: UserLoginMethod) {
+        self.client
+            .internal
+            .set_login_method(LoginMethod::User(method))
+            .await;
+    }
+}

--- a/crates/bitwarden-core/src/lib.rs
+++ b/crates/bitwarden-core/src/lib.rs
@@ -7,6 +7,11 @@ mod uniffi_support;
 
 pub mod auth;
 pub mod client;
+/// Dev-only debug capabilities that reach past the public API into internal
+/// state. Compiled only under the `debug-capabilities` feature; never ship in
+/// production.
+#[cfg(feature = "debug-capabilities")]
+pub mod debug;
 mod error;
 pub mod global;
 pub mod key_management;

--- a/crates/bitwarden-crypto/Cargo.toml
+++ b/crates/bitwarden-crypto/Cargo.toml
@@ -16,6 +16,9 @@ keywords.workspace = true
 
 [features]
 default = []
+# Dev-only debug capabilities (key-store slot listing with redacted material).
+# Material is only un-redacted when `dangerous-crypto-debug` is also enabled.
+debug-capabilities = []
 no-memory-hardening = [] # Disable memory hardening features
 uniffi = [
     "argon2/parallel",

--- a/crates/bitwarden-crypto/src/keys/key_encryptable.rs
+++ b/crates/bitwarden-crypto/src/keys/key_encryptable.rs
@@ -17,7 +17,19 @@ impl<T: KeyContainer> KeyContainer for Arc<T> {
 }
 
 #[allow(missing_docs)]
-pub trait CryptoKey {}
+pub trait CryptoKey {
+    /// A debug rendering of this key's material for the introspection surface.
+    ///
+    /// The default is opaque; concrete key types override it. When
+    /// `dangerous-crypto-debug` is off, overrides return a redacted placeholder,
+    /// so raw key bytes can only ever appear behind that gate. A safer
+    /// alternative would be to return a non-reversible fingerprint (a hash of
+    /// the key) here, which would not need the extra gate.
+    #[cfg(feature = "debug-capabilities")]
+    fn debug_material(&self) -> String {
+        "<opaque>".to_string()
+    }
+}
 
 /// An encryption operation that takes the input value and encrypts it into the output value
 /// using a key reference. Implementing this requires a content type to be specified in

--- a/crates/bitwarden-crypto/src/keys/public_key_encryption.rs
+++ b/crates/bitwarden-crypto/src/keys/public_key_encryption.rs
@@ -195,7 +195,22 @@ const _: fn() = || {
     assert_zeroize_on_drop::<RsaPrivateKey>();
 };
 impl zeroize::ZeroizeOnDrop for PrivateKey {}
-impl CryptoKey for PrivateKey {}
+impl CryptoKey for PrivateKey {
+    #[cfg(feature = "debug-capabilities")]
+    fn debug_material(&self) -> String {
+        #[cfg(feature = "dangerous-crypto-debug")]
+        {
+            match self.to_der() {
+                Ok(der) => hex::encode(der.to_vec()),
+                Err(_) => "<error>".to_string(),
+            }
+        }
+        #[cfg(not(feature = "dangerous-crypto-debug"))]
+        {
+            "<redacted: enable dangerous-crypto-debug>".to_string()
+        }
+    }
+}
 
 impl PrivateKey {
     /// Generate a random PrivateKey (RSA-2048).

--- a/crates/bitwarden-crypto/src/keys/symmetric_crypto_key.rs
+++ b/crates/bitwarden-crypto/src/keys/symmetric_crypto_key.rs
@@ -758,7 +758,19 @@ impl TryFrom<EncodedSymmetricKey> for SymmetricCryptoKey {
     }
 }
 
-impl CryptoKey for SymmetricCryptoKey {}
+impl CryptoKey for SymmetricCryptoKey {
+    #[cfg(feature = "debug-capabilities")]
+    fn debug_material(&self) -> String {
+        #[cfg(feature = "dangerous-crypto-debug")]
+        {
+            hex::encode(self.to_encoded().to_vec())
+        }
+        #[cfg(not(feature = "dangerous-crypto-debug"))]
+        {
+            "<redacted: enable dangerous-crypto-debug>".to_string()
+        }
+    }
+}
 
 // We manually implement these to make sure we don't print any sensitive data
 impl std::fmt::Debug for SymmetricCryptoKey {

--- a/crates/bitwarden-crypto/src/lib.rs
+++ b/crates/bitwarden-crypto/src/lib.rs
@@ -36,6 +36,8 @@ mod store;
 pub use store::{
     CipherSuite, KeyStore, KeyStoreContext, RotatedUserKeys, dangerous_get_v2_rotated_account_keys,
 };
+#[cfg(feature = "debug-capabilities")]
+pub use store::{KeyBackendSummary, KeySlotSummary, KeyStoreDebug, KeyStoreSummary};
 mod cose;
 pub(crate) use cose::CONTENT_TYPE_PADDED_CBOR;
 pub use cose::{CoseKeyThumbprint, CoseKeyThumbprintExt, CoseSerializable};

--- a/crates/bitwarden-crypto/src/signing/signing_key.rs
+++ b/crates/bitwarden-crypto/src/signing/signing_key.rs
@@ -55,7 +55,19 @@ const _: fn() = || {
     assert_zeroize_on_drop::<ml_dsa::ExpandedSigningKey<MlDsa44>>();
 };
 impl zeroize::ZeroizeOnDrop for SigningKey {}
-impl CryptoKey for SigningKey {}
+impl CryptoKey for SigningKey {
+    #[cfg(feature = "debug-capabilities")]
+    fn debug_material(&self) -> String {
+        #[cfg(feature = "dangerous-crypto-debug")]
+        {
+            hex::encode(self.to_cose().to_vec())
+        }
+        #[cfg(not(feature = "dangerous-crypto-debug"))]
+        {
+            "<redacted: enable dangerous-crypto-debug>".to_string()
+        }
+    }
+}
 
 impl std::fmt::Debug for SigningKey {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {

--- a/crates/bitwarden-crypto/src/store/backend/implementation/basic.rs
+++ b/crates/bitwarden-crypto/src/store/backend/implementation/basic.rs
@@ -37,6 +37,15 @@ impl<Key: KeySlotId> StoreBackend<Key> for BasicBackend<Key> {
     fn retain(&mut self, f: fn(Key) -> bool) {
         self.keys.retain(|k, _| f(*k));
     }
+
+    #[cfg(feature = "debug-capabilities")]
+    fn debug_slots(&self) -> Vec<(String, String)> {
+        use crate::CryptoKey;
+        self.keys
+            .iter()
+            .map(|(id, key)| (format!("{id:?}"), key.debug_material()))
+            .collect()
+    }
 }
 
 /// [KeySlotId::KeyValue] already implements [ZeroizeOnDrop],

--- a/crates/bitwarden-crypto/src/store/backend/mod.rs
+++ b/crates/bitwarden-crypto/src/store/backend/mod.rs
@@ -35,4 +35,11 @@ pub trait StoreBackend<Key: KeySlotId>: ZeroizeOnDrop + Send + Sync {
     /// Retains only the elements specified by the predicate.
     /// In other words, remove all keys for which `f` returns false.
     fn retain(&mut self, f: fn(Key) -> bool);
+
+    /// Dump each stored slot as `(slot id, key material)` for the introspection
+    /// surface. The default is empty, so a backend opts in by overriding this.
+    #[cfg(feature = "debug-capabilities")]
+    fn debug_slots(&self) -> Vec<(String, String)> {
+        Vec::new()
+    }
 }

--- a/crates/bitwarden-crypto/src/store/mod.rs
+++ b/crates/bitwarden-crypto/src/store/mod.rs
@@ -477,3 +477,78 @@ pub(crate) mod tests {
         }
     }
 }
+
+/// Dev-only debug capabilities over a [`KeyStore`].
+///
+/// Framework-free: a plain wrapper that snapshots the store's loaded slots as
+/// redacted, serializable summaries. Lives here (rather than a sibling crate)
+/// so it can read the store's private backends. Compiled only under the
+/// `debug-capabilities` feature.
+#[cfg(feature = "debug-capabilities")]
+mod debug {
+    use serde::Serialize;
+    #[cfg(feature = "wasm")]
+    use tsify::Tsify;
+
+    use super::{KeySlotIds, KeyStore, StoreBackend};
+
+    /// Redacted snapshot of a key store's loaded slots.
+    #[derive(Serialize)]
+    #[cfg_attr(feature = "wasm", derive(Tsify), tsify(into_wasm_abi))]
+    pub struct KeyStoreSummary {
+        pub cipher_suite: String,
+        pub security_state_version: u64,
+        pub backends: Vec<KeyBackendSummary>,
+    }
+
+    /// One key backend (symmetric / private / signing) and its loaded slots.
+    #[derive(Serialize)]
+    #[cfg_attr(feature = "wasm", derive(Tsify), tsify(into_wasm_abi))]
+    pub struct KeyBackendSummary {
+        pub name: String,
+        pub slots: Vec<KeySlotSummary>,
+    }
+
+    /// One loaded slot. `material` is redacted unless the crate was built with
+    /// `dangerous-crypto-debug`.
+    #[derive(Serialize)]
+    #[cfg_attr(feature = "wasm", derive(Tsify), tsify(into_wasm_abi))]
+    pub struct KeySlotSummary {
+        pub id: String,
+        pub material: String,
+    }
+
+    /// Read-only debug view of a key store. Holds a cheap, `Arc`-backed clone.
+    pub struct KeyStoreDebug<Ids: KeySlotIds>(KeyStore<Ids>);
+
+    impl<Ids: KeySlotIds> KeyStoreDebug<Ids> {
+        /// Wrap the owning store. Built by the debug-tree root.
+        pub fn new(store: KeyStore<Ids>) -> Self {
+            Self(store)
+        }
+
+        /// Snapshot the loaded slots per backend, key material redacted.
+        pub fn summary(&self) -> KeyStoreSummary {
+            let inner = self.0.inner.read().expect("KeyStore lock poisoned");
+            let backend = |name: &str, slots: Vec<(String, String)>| KeyBackendSummary {
+                name: name.to_string(),
+                slots: slots
+                    .into_iter()
+                    .map(|(id, material)| KeySlotSummary { id, material })
+                    .collect(),
+            };
+            KeyStoreSummary {
+                cipher_suite: format!("{:?}", inner.cipher_suite),
+                security_state_version: inner.security_state_version,
+                backends: vec![
+                    backend("symmetric_keys", inner.symmetric_keys.debug_slots()),
+                    backend("private_keys", inner.private_keys.debug_slots()),
+                    backend("signing_keys", inner.signing_keys.debug_slots()),
+                ],
+            }
+        }
+    }
+}
+
+#[cfg(feature = "debug-capabilities")]
+pub use debug::{KeyBackendSummary, KeySlotSummary, KeyStoreDebug, KeyStoreSummary};

--- a/crates/bitwarden-pm/Cargo.toml
+++ b/crates/bitwarden-pm/Cargo.toml
@@ -16,6 +16,11 @@ keywords.workspace = true
 
 [features]
 cli = ["bitwarden-unlock/cli"]
+# Dev-only debug-capability tree rooted on the top-level client.
+debug-capabilities = [
+    "bitwarden-core/debug-capabilities",
+    "bitwarden-crypto/debug-capabilities",
+]
 no-memory-hardening = ["bitwarden-core/no-memory-hardening"]
 uniffi = [
     "bitwarden-collections/uniffi",

--- a/crates/bitwarden-pm/src/debug.rs
+++ b/crates/bitwarden-pm/src/debug.rs
@@ -1,0 +1,42 @@
+//! Dev-only debug-capability tree, rooted on [`PasswordManagerClient`].
+//!
+//! A parallel tree to the public client tree: it mirrors the client hierarchy
+//! but exposes only debug capabilities, and it authors nothing itself. Each node
+//! hands back a capability handle that lives in the crate owning the underlying
+//! state (so that crate's internals are reachable), the same way the real
+//! [`PasswordManagerClient`] hands back sub-clients it did not author. Compiled
+//! only under the `debug-capabilities` feature.
+
+use bitwarden_core::Client;
+
+use crate::PasswordManagerClient;
+
+/// Root of the debug-capability tree. Routes to per-crate capability handles.
+pub struct DebugClient {
+    client: Client,
+}
+
+impl PasswordManagerClient {
+    /// Entry point for dev-only debug capabilities (bypass the public API).
+    pub fn debug(&self) -> DebugClient {
+        DebugClient {
+            client: self.0.clone(),
+        }
+    }
+}
+
+impl DebugClient {
+    /// Auth/session debug capabilities (login method, …). Authored in
+    /// `bitwarden-core`, where the state lives.
+    pub fn auth(&self) -> bitwarden_core::debug::AuthDebug {
+        bitwarden_core::debug::AuthDebug::new(self.client.clone())
+    }
+
+    /// Key-store debug capabilities (slot listing). Authored in
+    /// `bitwarden-crypto`, where the store internals live.
+    pub fn key_store(
+        &self,
+    ) -> bitwarden_crypto::KeyStoreDebug<bitwarden_core::key_management::KeySlotIds> {
+        bitwarden_crypto::KeyStoreDebug::new(self.client.internal.get_key_store().clone())
+    }
+}

--- a/crates/bitwarden-pm/src/debug.rs
+++ b/crates/bitwarden-pm/src/debug.rs
@@ -39,4 +39,10 @@ impl DebugClient {
     ) -> bitwarden_crypto::KeyStoreDebug<bitwarden_core::key_management::KeySlotIds> {
         bitwarden_crypto::KeyStoreDebug::new(self.client.internal.get_key_store().clone())
     }
+
+    /// Persisted-state debug capabilities (browse the SDK's setting registry).
+    /// Authored in `bitwarden-core`, where the state registry lives.
+    pub fn state(&self) -> bitwarden_core::debug::StateDebug {
+        bitwarden_core::debug::StateDebug::new(self.client.clone())
+    }
 }

--- a/crates/bitwarden-pm/src/lib.rs
+++ b/crates/bitwarden-pm/src/lib.rs
@@ -3,6 +3,11 @@
 #[cfg(feature = "bitwarden-license")]
 mod commercial;
 
+/// Dev-only debug-capability tree rooted on the top-level client. Compiled only
+/// under the `debug-capabilities` feature.
+#[cfg(feature = "debug-capabilities")]
+pub mod debug;
+
 use std::sync::Arc;
 
 use bitwarden_auth::AuthClientExt as _;

--- a/crates/bitwarden-state/Cargo.toml
+++ b/crates/bitwarden-state/Cargo.toml
@@ -15,6 +15,8 @@ keywords.workspace = true
 [features]
 uniffi = ["dep:uniffi"]
 wasm = ["bitwarden-threading/wasm"]
+# Dev-only: generic debug dump over registered repositories. Never enable in production.
+debug-capabilities = []
 # Enables browser-mode integration tests (IndexedDB). Requires a webdriver
 # (geckodriver/chromedriver) on PATH at test time.
 browser-tests = []

--- a/crates/bitwarden-state/src/registry.rs
+++ b/crates/bitwarden-state/src/registry.rs
@@ -18,6 +18,95 @@ use crate::{
 pub struct StateRegistry {
     database: SystemDatabase,
     client_managed: RwLock<HashMap<TypeId, Box<dyn Any + Send + Sync>>>,
+    /// Dev-only: per-type get/set/list shims, keyed by `TypeId`. Populated at
+    /// registration (both client-managed and SDK-managed) where the concrete
+    /// type is known, so the generic debug surface can address any registered
+    /// repository by its string name and key.
+    #[cfg(feature = "debug-capabilities")]
+    debug_repos: RwLock<HashMap<TypeId, DebugRepo>>,
+}
+
+/// A future borrowing the registry, boxed so it can cross a fn pointer.
+#[cfg(feature = "debug-capabilities")]
+type DebugFuture<'a, T> = std::pin::Pin<Box<dyn std::future::Future<Output = T> + 'a>>;
+/// Shim: list a repository's values as JSON.
+#[cfg(feature = "debug-capabilities")]
+type DebugListFn = for<'a> fn(&'a StateRegistry) -> DebugFuture<'a, Vec<serde_json::Value>>;
+/// Shim: read one item by string key as JSON.
+#[cfg(feature = "debug-capabilities")]
+type DebugGetFn =
+    for<'a> fn(&'a StateRegistry, &'a str) -> DebugFuture<'a, Option<serde_json::Value>>;
+/// Shim: write one item by string key.
+#[cfg(feature = "debug-capabilities")]
+type DebugSetFn = for<'a> fn(&'a StateRegistry, &'a str, serde_json::Value) -> DebugFuture<'a, ()>;
+
+/// Dev-only monomorphized get/set/list shims for one repository type, so the
+/// registry can offer generic string-addressed access without naming the type.
+#[cfg(feature = "debug-capabilities")]
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct DebugRepo {
+    name: &'static str,
+    list: DebugListFn,
+    get: DebugGetFn,
+    set: DebugSetFn,
+}
+
+#[cfg(feature = "debug-capabilities")]
+impl DebugRepo {
+    /// Capture the shims for a concrete repository type.
+    pub(crate) fn for_type<T: RepositoryItem>() -> Self {
+        Self {
+            name: T::NAME,
+            list: |registry| Box::pin(debug_list_repo::<T>(registry)),
+            get: |registry, key| Box::pin(debug_get_repo::<T>(registry, key)),
+            set: |registry, key, value| Box::pin(debug_set_repo::<T>(registry, key, value)),
+        }
+    }
+}
+
+/// List every item in the `T` repository (client- or SDK-managed) as JSON.
+#[cfg(feature = "debug-capabilities")]
+async fn debug_list_repo<T: RepositoryItem>(registry: &StateRegistry) -> Vec<serde_json::Value> {
+    let Ok(repository) = registry.get::<T>() else {
+        return Vec::new();
+    };
+    match repository.list().await {
+        Ok(items) => items
+            .iter()
+            .filter_map(|item| serde_json::to_value(item).ok())
+            .collect(),
+        Err(_) => Vec::new(),
+    }
+}
+
+/// Read one item from the `T` repository by its string key, as JSON.
+#[cfg(feature = "debug-capabilities")]
+async fn debug_get_repo<T: RepositoryItem>(
+    registry: &StateRegistry,
+    key: &str,
+) -> Option<serde_json::Value> {
+    let key = <T::Key as std::str::FromStr>::from_str(key).ok()?;
+    let value = registry.get::<T>().ok()?.get(key).await.ok().flatten()?;
+    serde_json::to_value(&value).ok()
+}
+
+/// Write one item to the `T` repository at its string key. No-ops on a bad key
+/// or a value that does not deserialize to `T`.
+#[cfg(feature = "debug-capabilities")]
+async fn debug_set_repo<T: RepositoryItem>(
+    registry: &StateRegistry,
+    key: &str,
+    value: serde_json::Value,
+) {
+    let Ok(key) = <T::Key as std::str::FromStr>::from_str(key) else {
+        return;
+    };
+    let Ok(value) = serde_json::from_value::<T>(value) else {
+        return;
+    };
+    if let Ok(repository) = registry.get::<T>() {
+        let _ = repository.set(key, value).await;
+    }
 }
 
 impl std::fmt::Debug for StateRegistry {
@@ -43,6 +132,8 @@ impl StateRegistry {
         StateRegistry {
             database: SystemDatabase::Memory(MemoryDatabase::new()),
             client_managed: RwLock::new(HashMap::new()),
+            #[cfg(feature = "debug-capabilities")]
+            debug_repos: RwLock::new(HashMap::new()),
         }
     }
 
@@ -52,10 +143,25 @@ impl StateRegistry {
         migrations: RepositoryMigrations,
     ) -> Result<Self, DatabaseError> {
         let database = SystemDatabase::initialize(configuration, migrations.clone()).await?;
-        Ok(StateRegistry {
+        let registry = StateRegistry {
             database,
             client_managed: RwLock::new(HashMap::new()),
-        })
+            #[cfg(feature = "debug-capabilities")]
+            debug_repos: RwLock::new(HashMap::new()),
+        };
+        // Register get/set/list shims for every SDK-managed type declared in the
+        // migrations, so the debug surface can enumerate and address them.
+        #[cfg(feature = "debug-capabilities")]
+        {
+            let mut debug_repos = registry
+                .debug_repos
+                .write()
+                .expect("RwLock should not be poisoned");
+            for item in migrations.into_repository_items() {
+                debug_repos.insert(item.type_id(), item.debug);
+            }
+        }
+        Ok(registry)
     }
 
     /// Get a handle to a setting by its type-safe key.
@@ -70,6 +176,60 @@ impl StateRegistry {
             .write()
             .expect("RwLock should not be poisoned")
             .insert(TypeId::of::<T>(), Box::new(value));
+        // Register get/set/list shims for this client-managed type.
+        #[cfg(feature = "debug-capabilities")]
+        self.debug_repos
+            .write()
+            .expect("RwLock should not be poisoned")
+            .insert(TypeId::of::<T>(), DebugRepo::for_type::<T>());
+    }
+
+    /// Dev-only: names of every registered repository (client- and SDK-managed).
+    #[cfg(feature = "debug-capabilities")]
+    pub fn debug_types(&self) -> Vec<String> {
+        self.debug_repos
+            .read()
+            .expect("RwLock should not be poisoned")
+            .values()
+            .map(|repo| repo.name.to_string())
+            .collect()
+    }
+
+    /// Dev-only: list a repository's values as JSON, addressed by type name.
+    /// Values only — the repository API lists values without their keys.
+    #[cfg(feature = "debug-capabilities")]
+    pub async fn debug_list(&self, type_name: &str) -> Vec<serde_json::Value> {
+        match self.debug_repo_named(type_name) {
+            Some(repo) => (repo.list)(self).await,
+            None => Vec::new(),
+        }
+    }
+
+    /// Dev-only: read one item by type name and string key, as JSON.
+    #[cfg(feature = "debug-capabilities")]
+    pub async fn debug_get(&self, type_name: &str, key: &str) -> Option<serde_json::Value> {
+        let repo = self.debug_repo_named(type_name)?;
+        (repo.get)(self, key).await
+    }
+
+    /// Dev-only: write one item by type name and string key. No-ops on an
+    /// unknown type, a bad key, or a value that does not deserialize.
+    #[cfg(feature = "debug-capabilities")]
+    pub async fn debug_set(&self, type_name: &str, key: &str, value: serde_json::Value) {
+        if let Some(repo) = self.debug_repo_named(type_name) {
+            (repo.set)(self, key, value).await;
+        }
+    }
+
+    /// Look up the (copyable) shim set for a repository by its type name.
+    #[cfg(feature = "debug-capabilities")]
+    fn debug_repo_named(&self, type_name: &str) -> Option<DebugRepo> {
+        self.debug_repos
+            .read()
+            .expect("RwLock should not be poisoned")
+            .values()
+            .find(|repo| repo.name == type_name)
+            .copied()
     }
 
     /// Retrieves a client-managed repository from the map given its type.

--- a/crates/bitwarden-state/src/repository.rs
+++ b/crates/bitwarden-state/src/repository.rs
@@ -78,8 +78,12 @@ pub trait RepositoryItem: Internal + Serialize + DeserializeOwned + Send + Sync 
     /// The name of the type implementing this trait.
     const NAME: &'static str;
 
-    /// The type used as a key in the Repository
-    type Key: ToString + Send + Sync + 'static;
+    /// The type used as a key in the Repository.
+    ///
+    /// `FromStr` is required so the debug-capabilities surface can address items
+    /// by a string key; every current key type (String and the `uuid_newtype!`
+    /// ids) already implements it, so this bound is satisfied everywhere.
+    type Key: ToString + std::str::FromStr + Send + Sync + 'static;
 
     /// Returns the `TypeId` of the type implementing this trait.
     fn type_id() -> TypeId {
@@ -98,6 +102,10 @@ pub trait RepositoryItem: Internal + Serialize + DeserializeOwned + Send + Sync 
 pub struct RepositoryItemData {
     type_id: TypeId,
     name: &'static str,
+    /// Dev-only: monomorphized get/set/list shims for this type's repository,
+    /// captured here because `new::<T>` is the point where `T` is still known.
+    #[cfg(feature = "debug-capabilities")]
+    pub(crate) debug: crate::registry::DebugRepo,
 }
 
 impl RepositoryItemData {
@@ -106,6 +114,8 @@ impl RepositoryItemData {
         Self {
             type_id: TypeId::of::<T>(),
             name: T::NAME,
+            #[cfg(feature = "debug-capabilities")]
+            debug: crate::registry::DebugRepo::for_type::<T>(),
         }
     }
 

--- a/crates/bitwarden-wasm-internal/Cargo.toml
+++ b/crates/bitwarden-wasm-internal/Cargo.toml
@@ -22,6 +22,10 @@ crate-type = ["cdylib"]
 
 [features]
 bitwarden-license = ["bitwarden-pm/bitwarden-license", "dep:bitwarden-commercial-vault"]
+# Dev-only hand-rolled debug capabilities, exposed to JS as a typed debug tree.
+# Never enable in production. Key material stays redacted unless
+# `dangerous-crypto-debug` is also enabled.
+debug-capabilities = ["bitwarden-pm/debug-capabilities"]
 # WARNING: This feature is for debugging purposes only and should never be enabled in production.
 # It disables compile-time debug prevention for cryptographic keys, exposing sensitive key material
 # in debug output, and adds tracing debug logs to encrypt/decrypt operations.

--- a/crates/bitwarden-wasm-internal/build.sh
+++ b/crates/bitwarden-wasm-internal/build.sh
@@ -15,6 +15,9 @@ ENABLE_LICENSE_FEATURE=""
 NPM_FOLDER="npm"
 RELEASE_FLAG=""
 BUILD_FOLDER="debug"
+# Dev-only: exposes the hand-rolled debug-capability tree (client.debug()) to JS.
+# Never enable for production builds.
+DEBUG_CAPABILITIES_FEATURE=""
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -25,6 +28,9 @@ while [[ $# -gt 0 ]]; do
     -r)
       RELEASE_FLAG="--release"
       BUILD_FOLDER="release"
+      ;;
+    -d)
+      DEBUG_CAPABILITIES_FEATURE="--features debug-capabilities"
       ;;
   esac
   shift
@@ -52,7 +58,7 @@ fi
 # Note that this requires build-std which is an unstable feature,
 # this normally requires a nightly build, but we can also use the
 # RUSTC_BOOTSTRAP hack to use the same stable version as the normal build
-RUSTFLAGS='-Ctarget-cpu=mvp --cfg getrandom_backend="wasm_js"'" ${NO_COMMERCIAL_CFG}" RUSTC_BOOTSTRAP=1 cargo build -p bitwarden-wasm-internal -Zbuild-std=panic_abort,std --target wasm32-unknown-unknown ${RELEASE_FLAG} ${ENABLE_LICENSE_FEATURE}
+RUSTFLAGS='-Ctarget-cpu=mvp --cfg getrandom_backend="wasm_js"'" ${NO_COMMERCIAL_CFG}" RUSTC_BOOTSTRAP=1 cargo build -p bitwarden-wasm-internal -Zbuild-std=panic_abort,std --target wasm32-unknown-unknown ${RELEASE_FLAG} ${ENABLE_LICENSE_FEATURE} ${DEBUG_CAPABILITIES_FEATURE}
 cargo run -p wasm-bindgen-cli-runner --bin wasm-bindgen-runner -- --target bundler --out-dir crates/bitwarden-wasm-internal/${NPM_FOLDER} ./target/wasm32-unknown-unknown/${BUILD_FOLDER}/bitwarden_wasm_internal.wasm
 cargo run -p wasm-bindgen-cli-runner --bin wasm-bindgen-runner -- --target nodejs --out-dir crates/bitwarden-wasm-internal/${NPM_FOLDER}/node ./target/wasm32-unknown-unknown/${BUILD_FOLDER}/bitwarden_wasm_internal.wasm
 

--- a/crates/bitwarden-wasm-internal/src/client.rs
+++ b/crates/bitwarden-wasm-internal/src/client.rs
@@ -157,6 +157,15 @@ impl PasswordManagerClient {
     pub fn gov_mode(&self) -> bool {
         self.0.0.gov_mode()
     }
+
+    /// Dev-only debug capabilities that reach past the public API into internal
+    /// state, for automated tooling. Rooted debug tree mirroring the client
+    /// tree. Available only when built with the `debug-capabilities` feature,
+    /// which must never be enabled in production.
+    #[cfg(feature = "debug-capabilities")]
+    pub fn debug(&self) -> crate::debug::DebugClient {
+        crate::debug::DebugClient::new(self.0.debug())
+    }
 }
 
 #[bitwarden_error(basic)]

--- a/crates/bitwarden-wasm-internal/src/debug.rs
+++ b/crates/bitwarden-wasm-internal/src/debug.rs
@@ -1,0 +1,62 @@
+//! WASM surface for the dev-only debug-capability tree.
+//!
+//! Mirrors [`bitwarden_pm::debug`] as typed wasm-bindgen handles, so the JS/TS
+//! side discovers capabilities through the generated types and console
+//! autocomplete rather than a runtime crawl. Compiled only under the
+//! `debug-capabilities` feature.
+
+use bitwarden_core::{client::login_method::UserLoginMethod, key_management::KeySlotIds};
+use wasm_bindgen::prelude::*;
+
+/// Root of the debug-capability tree. Reached via `PasswordManagerClient.debug()`.
+#[wasm_bindgen]
+pub struct DebugClient(bitwarden_pm::debug::DebugClient);
+
+impl DebugClient {
+    pub(crate) fn new(inner: bitwarden_pm::debug::DebugClient) -> Self {
+        Self(inner)
+    }
+}
+
+#[wasm_bindgen]
+impl DebugClient {
+    /// Auth/session debug capabilities.
+    pub fn auth(&self) -> AuthDebugClient {
+        AuthDebugClient(self.0.auth())
+    }
+
+    /// Key-store debug capabilities.
+    pub fn key_store(&self) -> KeyStoreDebugClient {
+        KeyStoreDebugClient(self.0.key_store())
+    }
+}
+
+/// Auth/session debug capabilities.
+#[wasm_bindgen]
+pub struct AuthDebugClient(bitwarden_core::debug::AuthDebug);
+
+#[wasm_bindgen]
+impl AuthDebugClient {
+    /// Read the user's stored login method, or `undefined` if none is set.
+    pub async fn login_method(&self) -> Option<UserLoginMethod> {
+        self.0.login_method().await
+    }
+
+    /// Overwrite the user's stored login method. Debug-only.
+    pub async fn set_login_method(&self, method: UserLoginMethod) {
+        self.0.set_login_method(method).await;
+    }
+}
+
+/// Key-store debug capabilities.
+#[wasm_bindgen]
+pub struct KeyStoreDebugClient(bitwarden_crypto::KeyStoreDebug<KeySlotIds>);
+
+#[wasm_bindgen]
+impl KeyStoreDebugClient {
+    /// List the loaded key slots per backend. Key material is redacted unless
+    /// the crypto crate was built with `dangerous-crypto-debug`.
+    pub fn list(&self) -> bitwarden_crypto::KeyStoreSummary {
+        self.0.summary()
+    }
+}

--- a/crates/bitwarden-wasm-internal/src/debug.rs
+++ b/crates/bitwarden-wasm-internal/src/debug.rs
@@ -29,6 +29,11 @@ impl DebugClient {
     pub fn key_store(&self) -> KeyStoreDebugClient {
         KeyStoreDebugClient(self.0.key_store())
     }
+
+    /// Persisted-state debug capabilities.
+    pub fn state(&self) -> StateDebugClient {
+        StateDebugClient(self.0.state())
+    }
 }
 
 /// Auth/session debug capabilities.
@@ -58,5 +63,35 @@ impl KeyStoreDebugClient {
     /// the crypto crate was built with `dangerous-crypto-debug`.
     pub fn list(&self) -> bitwarden_crypto::KeyStoreSummary {
         self.0.summary()
+    }
+}
+
+/// Persisted-state debug capabilities.
+#[wasm_bindgen]
+pub struct StateDebugClient(bitwarden_core::debug::StateDebug);
+
+#[wasm_bindgen]
+impl StateDebugClient {
+    /// Names of every registered repository (client- and SDK-managed).
+    pub fn types(&self) -> Vec<String> {
+        self.0.types()
+    }
+
+    /// List a repository's values as a JSON-array string (`JSON.parse` it),
+    /// addressed by type name. Values only (no keys). Raw stored JSON.
+    pub async fn list(&self, type_name: String) -> String {
+        self.0.list(type_name).await.to_string()
+    }
+
+    /// Read one item by type name and string key, as a JSON string (`"null"` if
+    /// absent).
+    pub async fn get(&self, type_name: String, key: String) -> String {
+        self.0.get(type_name, key).await.to_string()
+    }
+
+    /// Write one item by type name and string key. `value` is the item as a JSON
+    /// string. Debug-only; bypasses the public API.
+    pub async fn set(&self, type_name: String, key: String, value: String) {
+        self.0.set(type_name, key, value).await;
     }
 }

--- a/crates/bitwarden-wasm-internal/src/lib.rs
+++ b/crates/bitwarden-wasm-internal/src/lib.rs
@@ -2,6 +2,8 @@
 
 mod client;
 mod custom_types;
+#[cfg(feature = "debug-capabilities")]
+mod debug;
 mod flight_recorder;
 mod init;
 mod platform;
@@ -14,5 +16,7 @@ pub use bitwarden_organization_invite_link::*;
 pub use bitwarden_server_communication_config::wasm::*;
 pub use bitwarden_shared_unlock::wasm::*;
 pub use client::PasswordManagerClient;
+#[cfg(feature = "debug-capabilities")]
+pub use debug::{AuthDebugClient, DebugClient, KeyStoreDebugClient};
 pub use flight_recorder::FlightRecorderClient;
 pub use init::init_sdk;

--- a/crates/bitwarden-wasm-internal/src/lib.rs
+++ b/crates/bitwarden-wasm-internal/src/lib.rs
@@ -17,6 +17,6 @@ pub use bitwarden_server_communication_config::wasm::*;
 pub use bitwarden_shared_unlock::wasm::*;
 pub use client::PasswordManagerClient;
 #[cfg(feature = "debug-capabilities")]
-pub use debug::{AuthDebugClient, DebugClient, KeyStoreDebugClient};
+pub use debug::{AuthDebugClient, DebugClient, KeyStoreDebugClient, StateDebugClient};
 pub use flight_recorder::FlightRecorderClient;
 pub use init::init_sdk;


### PR DESCRIPTION
## ⚠️ Proof of concept — not for merge

Standalone alternative to the object-graph introspection POC (#1446): drop the
framework (`Introspect` derive, `describe`, `NodeInfo`, the `bitwarden-introspect`
crate) and keep only the hand-rolled capabilities that reach past the public API,
exposed as a small typed **debug tree**. Read/structural access is better served
by logging; the unique value is the capabilities, so this focuses there.

### Shape (convention, not framework)
- Each capability is authored in the crate that owns the state, so internals are
  reachable: `bitwarden_core::debug::AuthDebug` (login method get/set) and
  `bitwarden-crypto`'s `KeyStoreDebug` (redacted slot listing, built on the
  crate's `debug_slots`/`debug_material` primitives).
- `PasswordManagerClient::debug()` (bitwarden-pm) is a thin root that routes to
  those per-crate handles, mirroring the real client tree.
- The WASM layer exposes it as a **typed** tree, so TS discovers capabilities via
  the generated `.d.ts` + console autocomplete, not a runtime crawl:
  `client.debug().auth().login_method()`, `client.debug().key_store().list()`.
- All behind a dev-only `debug-capabilities` feature; build with `build.sh -d`.
  Never compiled into production. Key material stays redacted unless
  `dangerous-crypto-debug` is also enabled.

### Adding a capability
Author a method on the owning crate's `*Debug` handle (or add a new one and route
it from the root). No transport/JS boilerplate per capability.

Verified end-to-end from the desktop client (companion PR: bitwarden/clients#22876).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
