### PR TITLE
Pin tsify

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -143,6 +143,7 @@
         "tracing",
         "tracing-subscriber",
         "tsify",
+        "tsify-macros",
         "uniffi",
         "uniffi_core",
         "uniffi_macros",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1621,6 +1621,7 @@ dependencies = [
  "tracing-subscriber",
  "tracing-web",
  "tsify",
+ "tsify-macros",
  "uuid",
  "wasm-bindgen",
  "wasm-bindgen-futures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -143,9 +143,16 @@ tracing-subscriber = { version = "0.3.20", features = [
     "env-filter",
     "tracing-log",
 ] }
-tsify = { version = ">=0.5.5, <0.6", features = [
+# Tsify is pinned as newer versions deprecate from/into_wasm_abi
+# We use this extensively and the migration is going to be complex,
+# but in the meantime we want to avoid CI failures here.
+# https://github.com/madonoharu/tsify/blob/main/CHANGELOG.md#v057
+tsify = { version = ">=0.5.5, <0.5.7", features = [
     "js",
 ], default-features = false }
+# The deprecation is emitted by the proc macro, and `tsify` only requires
+# `tsify-macros ^0.5.5`, so the bound above has to be repeated here to hold.
+tsify-macros = ">=0.5.5, <0.5.7"
 uniffi = "=0.32.0"
 url = ">=2.5.8, <3.0"
 uuid = { version = ">=1.3.3, <2.0", features = ["serde", "v4", "js"] }

--- a/crates/bitwarden-wasm-internal/Cargo.toml
+++ b/crates/bitwarden-wasm-internal/Cargo.toml
@@ -12,10 +12,10 @@ repository.workspace = true
 license = "GPL-3.0-only OR LicenseRef-Bitwarden-SDK"
 keywords.workspace = true
 
+# Neither is imported directly: bitwarden-organization-crypto is here to enable wasm-bindgen,
+# tsify-macros to hold the workspace version bound. See [dependencies] below.
 [package.metadata.cargo-udeps.ignore]
-normal = [
-    "bitwarden-organization-crypto",
-] # Only used to enable wasm-bindgen, not imported directly
+normal = ["bitwarden-organization-crypto", "tsify-macros"]
 
 [lib]
 crate-type = ["cdylib"]
@@ -67,6 +67,9 @@ tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 tracing-web = { version = "0.1.3" }
 tsify = { workspace = true }
+# Not used directly. `tsify` only requires `tsify-macros ^0.5.5`, so the workspace pin
+# on it is only enforced if a member depends on it directly.
+tsify-macros = { workspace = true }
 uuid = { workspace = true }
 wasm-bindgen = { workspace = true }
 wasm-bindgen-futures = { workspace = true }


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-42985

## 📔 Objective

The latest versions of tsify deprecate the use of from_wasm_abi and to_wasm_abi, as they introduce memory leaks on failures. The expected migration path is to use the new `Ts<T>` wrapper, but that requires changes to every WASM exposed function. 

Instead, we'll very likely migrate to a custom wasm_export macro that does the correct thing automatically, but that's a very large mechanical diff, so for now let's just reduce the tsify range to avoid CI failures.

https://github.com/madonoharu/tsify/blob/main/CHANGELOG.md#v057

## 🚨 Breaking Changes

<!-- Does this PR introduce any breaking changes? If so, please describe the impact and migration path for clients.

If you're unsure, the automated TypeScript compatibility check will run when you open/update this PR and provide feedback.

For breaking changes:
1. Describe what changed in the client interface
2. Explain why the change was necessary
3. Provide migration steps for client developers
4. Link to any paired client PRs if needed

Otherwise, you can remove this section. -->
