### PR TITLE
Extract AnyMap from the state registry

### DIFF
--- a/crates/bitwarden-state/src/any_map.rs
+++ b/crates/bitwarden-state/src/any_map.rs
@@ -1,0 +1,95 @@
+use std::{
+    any::{Any, TypeId},
+    collections::HashMap,
+    sync::RwLock,
+};
+
+/// A concurrent map holding type-erased values, each keyed by its own type.
+pub(crate) struct AnyMap {
+    inner: RwLock<HashMap<TypeId, Box<dyn Any + Send + Sync>>>,
+}
+
+impl AnyMap {
+    /// Creates an empty map.
+    pub(crate) fn new() -> Self {
+        Self {
+            inner: RwLock::new(HashMap::new()),
+        }
+    }
+
+    /// Inserts a value under its own type, replacing any existing value of that type.
+    ///
+    /// The key is the static type of `value` at the call site, so any coercion has to happen
+    /// before inserting: `Arc<ConcreteRepo>` and `Arc<dyn Repository<T>>` are different keys.
+    pub(crate) fn insert<V: Send + Sync + 'static>(&self, value: V) {
+        self.inner
+            .write()
+            .expect("RwLock should not be poisoned")
+            .insert(TypeId::of::<V>(), Box::new(value));
+    }
+
+    /// Retrieves a clone of the value of type `V`, or `None` if none was inserted.
+    pub(crate) fn get<V: Clone + Send + Sync + 'static>(&self) -> Option<V> {
+        self.inner
+            .read()
+            .expect("RwLock should not be poisoned")
+            .get(&TypeId::of::<V>())
+            .and_then(|value| value.downcast_ref::<V>())
+            .cloned()
+    }
+
+    /// Removes all entries.
+    pub(crate) fn clear(&self) {
+        self.inner
+            .write()
+            .expect("RwLock should not be poisoned")
+            .clear();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_roundtrip() {
+        let map = AnyMap::new();
+
+        map.insert(42_u32);
+        map.insert("hello".to_string());
+
+        assert_eq!(map.get::<u32>(), Some(42));
+        assert_eq!(map.get::<String>(), Some("hello".to_string()));
+    }
+
+    #[test]
+    fn test_get_missing_type_returns_none() {
+        let map = AnyMap::new();
+        map.insert(42_u32);
+
+        assert_eq!(map.get::<String>(), None);
+        assert_eq!(map.get::<u8>(), None);
+    }
+
+    #[test]
+    fn test_insert_overwrites() {
+        let map = AnyMap::new();
+
+        map.insert(1_u32);
+        map.insert(2_u32);
+
+        assert_eq!(map.get::<u32>(), Some(2));
+    }
+
+    #[test]
+    fn test_clear() {
+        let map = AnyMap::new();
+        map.insert(1_u32);
+        map.insert("a".to_string());
+
+        map.clear();
+
+        assert_eq!(map.get::<u32>(), None);
+        assert_eq!(map.get::<String>(), None);
+    }
+}

--- a/crates/bitwarden-state/src/lib.rs
+++ b/crates/bitwarden-state/src/lib.rs
@@ -12,6 +12,7 @@ pub mod registry;
 /// Type-safe settings repository for storing application configuration and state.
 pub mod settings;
 
+pub(crate) mod any_map;
 pub(crate) mod sdk_managed;
 
 pub use sdk_managed::{DatabaseConfiguration, DatabaseError};

--- a/crates/bitwarden-state/src/registry.rs
+++ b/crates/bitwarden-state/src/registry.rs
@@ -1,13 +1,10 @@
-use std::{
-    any::{Any, TypeId},
-    collections::HashMap,
-    sync::{Arc, RwLock},
-};
+use std::sync::Arc;
 
 use bitwarden_error::bitwarden_error;
 use thiserror::Error;
 
 use crate::{
+    any_map::AnyMap,
     repository::{Repository, RepositoryItem, RepositoryMigrations},
     sdk_managed::{Database, DatabaseConfiguration, DatabaseError, MemoryDatabase, SystemDatabase},
     settings::{Key, Setting, SettingItem},
@@ -17,7 +14,7 @@ use crate::{
 /// These repositories can be either managed by the client or by the SDK itself.
 pub struct StateRegistry {
     database: SystemDatabase,
-    client_managed: RwLock<HashMap<TypeId, Box<dyn Any + Send + Sync>>>,
+    client_managed: AnyMap,
 }
 
 impl std::fmt::Debug for StateRegistry {
@@ -42,7 +39,7 @@ impl StateRegistry {
     pub fn new_with_memory_db() -> Self {
         StateRegistry {
             database: SystemDatabase::Memory(MemoryDatabase::new()),
-            client_managed: RwLock::new(HashMap::new()),
+            client_managed: AnyMap::new(),
         }
     }
 
@@ -54,7 +51,7 @@ impl StateRegistry {
         let database = SystemDatabase::initialize(configuration, migrations.clone()).await?;
         Ok(StateRegistry {
             database,
-            client_managed: RwLock::new(HashMap::new()),
+            client_managed: AnyMap::new(),
         })
     }
 
@@ -66,20 +63,12 @@ impl StateRegistry {
 
     /// Registers a client-managed repository into the map, associating it with its type.
     pub fn register_client_managed<T: RepositoryItem>(&self, value: Arc<dyn Repository<T>>) {
-        self.client_managed
-            .write()
-            .expect("RwLock should not be poisoned")
-            .insert(TypeId::of::<T>(), Box::new(value));
+        self.client_managed.insert(value);
     }
 
     /// Retrieves a client-managed repository from the map given its type.
     fn get_client_managed<T: RepositoryItem>(&self) -> Option<Arc<dyn Repository<T>>> {
-        self.client_managed
-            .read()
-            .expect("RwLock should not be poisoned")
-            .get(&TypeId::of::<T>())
-            .and_then(|boxed| boxed.downcast_ref::<Arc<dyn Repository<T>>>())
-            .map(Arc::clone)
+        self.client_managed.get()
     }
 
     /// Retrieves a SDK-managed repository from the database.
@@ -119,10 +108,7 @@ impl StateRegistry {
     pub async fn wipe(&self) -> Result<(), DatabaseError> {
         // Clear client-managed first so a failure in the persistent-store wipe
         // still releases the in-memory Arc references.
-        self.client_managed
-            .write()
-            .expect("RwLock should not be poisoned")
-            .clear();
+        self.client_managed.clear();
         self.database.wipe().await
     }
 }
@@ -176,6 +162,9 @@ mod tests {
     struct TestB(String);
     #[derive(PartialEq, Eq, Debug)]
     struct TestC(Vec<u8>);
+    /// A second implementation for the same item type as [`TestA`].
+    #[derive(PartialEq, Eq, Debug)]
+    struct TestD(usize);
     #[derive(PartialEq, Eq, Debug, Serialize, Deserialize)]
     struct TestItem<T>(T);
 
@@ -186,6 +175,7 @@ mod tests {
     impl_repository!(TestA, TestItem<usize>);
     impl_repository!(TestB, TestItem<String>);
     impl_repository!(TestC, TestItem<Vec<u8>>);
+    impl_repository!(TestD, TestItem<usize>);
 
     #[tokio::test]
     async fn test_state_registry() {
@@ -309,5 +299,18 @@ mod tests {
         // Delete and confirm gone
         setting.delete().await.unwrap();
         assert_eq!(setting.get().await.unwrap(), None::<String>);
+    }
+
+    /// The concrete implementation is erased by the coercion to `Arc<dyn Repository<T>>`, so two
+    /// implementations of the same item type share a slot and the later registration wins.
+    #[tokio::test]
+    async fn test_register_client_managed_replaces_previous_implementation() {
+        let registry = StateRegistry::new_with_memory_db();
+
+        registry.register_client_managed(Arc::new(TestA(1)));
+        registry.register_client_managed(Arc::new(TestD(2)));
+
+        let repo = registry.get_client_managed::<TestItem<usize>>().unwrap();
+        assert_eq!(repo.get(String::new()).await.unwrap(), Some(TestItem(2)));
     }
 }


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective

Part of some BEEEP work I'm doing on improving the state handling. The registry's client-managed repositories are stored in a hand-rolled `RwLock<HashMap<TypeId, Box<dyn Any + Send + Sync>>>` with the locking and downcasting inlined at each use. This couples them together making it harder to reason and reuse. 

This PR splits the map logic into a separate type with its own tests.

## 🚨 Breaking Changes

<!-- Does this PR introduce any breaking changes? If so, please describe the impact and migration path for clients.

If you're unsure, the automated TypeScript compatibility check will run when you open/update this PR and provide feedback.

For breaking changes:
1. Describe what changed in the client interface
2. Explain why the change was necessary
3. Provide migration steps for client developers
4. Link to any paired client PRs if needed

Otherwise, you can remove this section. -->
