### PR TITLE
[PM-43254] Decouple settings from the repository API

### DIFF
--- a/crates/bitwarden-core/src/platform/state_client.rs
+++ b/crates/bitwarden-core/src/platform/state_client.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use bitwarden_state::{
-    Key, Setting, SettingItem, SettingsError,
+    Key, PersistentValue, Setting, SettingsError,
     registry::StateRegistryError,
     repository::{Repository, RepositoryItem},
 };
@@ -61,8 +61,7 @@ impl StateClient {
     /// # Ok(())
     /// # }
     /// ```
-    pub fn setting<T>(&self, key: Key<T>) -> Result<Setting<T>, SettingsError> {
-        let repository = self.client.internal.state_registry.get::<SettingItem>()?;
-        Ok(Setting::new(repository, key))
+    pub fn setting<T: PersistentValue>(&self, key: Key<T>) -> Result<Setting<T>, SettingsError> {
+        Ok(self.client.internal.state_registry.setting(key)?)
     }
 }

--- a/crates/bitwarden-core/src/platform/state_client.rs
+++ b/crates/bitwarden-core/src/platform/state_client.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use bitwarden_state::{
-    Key, PersistentValue, Setting, SettingsError,
+    Key, Persist, Setting, SettingsError,
     registry::StateRegistryError,
     repository::{Repository, RepositoryItem},
 };
@@ -61,7 +61,7 @@ impl StateClient {
     /// # Ok(())
     /// # }
     /// ```
-    pub fn setting<T: PersistentValue>(&self, key: Key<T>) -> Result<Setting<T>, SettingsError> {
+    pub fn setting<T: Persist>(&self, key: Key<T>) -> Result<Setting<T>, SettingsError> {
         Ok(self.client.internal.state_registry.setting(key)?)
     }
 }

--- a/crates/bitwarden-state/src/lib.rs
+++ b/crates/bitwarden-state/src/lib.rs
@@ -9,10 +9,12 @@ pub mod repository;
 /// This module provides a registry for managing repositories of different types.
 pub mod registry;
 
-/// Type-safe settings repository for storing application configuration and state.
+/// Type-safe settings API for storing application configuration and state.
 pub mod settings;
 
+pub(crate) mod persistent_value;
 pub(crate) mod sdk_managed;
 
+pub use persistent_value::PersistentValue;
 pub use sdk_managed::{DatabaseConfiguration, DatabaseError};
-pub use settings::{Key, Setting, SettingItem, SettingsError};
+pub use settings::{Key, Setting, SettingItem, SettingTrait, SettingsError};

--- a/crates/bitwarden-state/src/lib.rs
+++ b/crates/bitwarden-state/src/lib.rs
@@ -13,9 +13,9 @@ pub mod registry;
 pub mod settings;
 
 pub(crate) mod any_map;
-pub(crate) mod persistent_value;
+pub(crate) mod persist;
 pub(crate) mod sdk_managed;
 
-pub use persistent_value::PersistentValue;
+pub use persist::Persist;
 pub use sdk_managed::{DatabaseConfiguration, DatabaseError};
 pub use settings::{Key, Setting, SettingItem, SettingTrait, SettingsError};

--- a/crates/bitwarden-state/src/persist.rs
+++ b/crates/bitwarden-state/src/persist.rs
@@ -1,0 +1,10 @@
+use serde::{Serialize, de::DeserializeOwned};
+
+/// A value that can be persisted to SDK-managed storage.
+///
+/// This exists purely as a shorthand for the bounds every stored value must satisfy, so they
+/// don't have to be repeated at every use site. It carries no behavior and is implemented
+/// automatically for any type that meets them.
+pub trait Persist: Serialize + DeserializeOwned + Send + Sync + 'static {}
+
+impl<T: Serialize + DeserializeOwned + Send + Sync + 'static> Persist for T {}

--- a/crates/bitwarden-state/src/persistent_value.rs
+++ b/crates/bitwarden-state/src/persistent_value.rs
@@ -1,0 +1,9 @@
+use serde::{Serialize, de::DeserializeOwned};
+
+/// A value that can be persisted to SDK-managed storage.
+///
+/// This is a marker for the bounds every stored value must satisfy, and is implemented
+/// automatically for any type that meets them.
+pub trait PersistentValue: Serialize + DeserializeOwned + Send + Sync + 'static {}
+
+impl<T: Serialize + DeserializeOwned + Send + Sync + 'static> PersistentValue for T {}

--- a/crates/bitwarden-state/src/persistent_value.rs
+++ b/crates/bitwarden-state/src/persistent_value.rs
@@ -1,9 +1,0 @@
-use serde::{Serialize, de::DeserializeOwned};
-
-/// A value that can be persisted to SDK-managed storage.
-///
-/// This is a marker for the bounds every stored value must satisfy, and is implemented
-/// automatically for any type that meets them.
-pub trait PersistentValue: Serialize + DeserializeOwned + Send + Sync + 'static {}
-
-impl<T: Serialize + DeserializeOwned + Send + Sync + 'static> PersistentValue for T {}

--- a/crates/bitwarden-state/src/registry.rs
+++ b/crates/bitwarden-state/src/registry.rs
@@ -8,9 +8,10 @@ use bitwarden_error::bitwarden_error;
 use thiserror::Error;
 
 use crate::{
+    persistent_value::PersistentValue,
     repository::{Repository, RepositoryItem, RepositoryMigrations},
     sdk_managed::{Database, DatabaseConfiguration, DatabaseError, MemoryDatabase, SystemDatabase},
-    settings::{Key, Setting, SettingItem},
+    settings::{Key, Setting},
 };
 
 /// A registry that contains repositories for different types of items.
@@ -59,9 +60,14 @@ impl StateRegistry {
     }
 
     /// Get a handle to a setting by its type-safe key.
-    pub fn setting<T>(&self, key: Key<T>) -> Result<Setting<T>, StateRegistryError> {
-        let repo = self.get::<SettingItem>()?;
-        Ok(Setting::new(repo, key))
+    ///
+    /// # Errors
+    /// This method never fails, but returns a Result for backwards compatibility.
+    pub fn setting<T: PersistentValue>(
+        &self,
+        key: Key<T>,
+    ) -> Result<Setting<T>, StateRegistryError> {
+        Ok(Setting::new(self.database.get_setting::<T>(key.name)))
     }
 
     /// Registers a client-managed repository into the map, associating it with its type.
@@ -309,5 +315,78 @@ mod tests {
         // Delete and confirm gone
         setting.delete().await.unwrap();
         assert_eq!(setting.get().await.unwrap(), None::<String>);
+    }
+
+    #[tokio::test]
+    async fn test_settings_are_isolated_by_key() {
+        use crate::register_setting_key;
+        register_setting_key!(const THEME: String = "test_theme");
+        register_setting_key!(const LOCALE: String = "test_locale");
+
+        let registry = StateRegistry::new_with_memory_db();
+        let theme = registry.setting(THEME).unwrap();
+        let locale = registry.setting(LOCALE).unwrap();
+
+        theme.update("dark".to_string()).await.unwrap();
+        locale.update("en-US".to_string()).await.unwrap();
+
+        theme.delete().await.unwrap();
+        assert_eq!(theme.get().await.unwrap(), None::<String>);
+        assert_eq!(locale.get().await.unwrap(), Some("en-US".to_string()));
+    }
+
+    #[tokio::test]
+    async fn test_setting_is_stored_in_the_setting_table_as_bare_json() {
+        use crate::{register_setting_key, settings::SettingItem};
+
+        #[derive(Debug, PartialEq, serde::Serialize, serde::Deserialize)]
+        struct Config {
+            theme: String,
+        }
+        register_setting_key!(const CONFIG: Config = "test_config");
+
+        let registry = StateRegistry::new_with_memory_db();
+        let value = Config {
+            theme: "dark".to_string(),
+        };
+        let expected = serde_json::to_value(&value).unwrap();
+        registry
+            .setting(CONFIG)
+            .unwrap()
+            .update(value)
+            .await
+            .unwrap();
+
+        // Storage contract for existing databases: settings live in the `Setting` table,
+        // addressed by key name, holding the bare serialized value.
+        assert_eq!(SettingItem::NAME, "Setting");
+        let raw: SettingItem = registry
+            .database
+            .get::<SettingItem>("test_config")
+            .await
+            .unwrap()
+            .expect("setting is present");
+        assert_eq!(raw.0, expected);
+    }
+
+    #[tokio::test]
+    async fn test_setting_reports_closed_after_wipe() {
+        use crate::{register_setting_key, settings::SettingsError};
+        register_setting_key!(const TEST_SETTING: String = "test_wiped_setting");
+
+        let registry = StateRegistry::new_with_memory_db();
+        let setting = registry.setting(TEST_SETTING).unwrap();
+        setting.update("hello".to_string()).await.unwrap();
+
+        registry.wipe().await.unwrap();
+
+        assert!(matches!(
+            setting.get().await,
+            Err(SettingsError::Database(DatabaseError::Closed))
+        ));
+        assert!(matches!(
+            setting.update("bye".to_string()).await,
+            Err(SettingsError::Database(DatabaseError::Closed))
+        ));
     }
 }

--- a/crates/bitwarden-state/src/registry.rs
+++ b/crates/bitwarden-state/src/registry.rs
@@ -5,7 +5,7 @@ use thiserror::Error;
 
 use crate::{
     any_map::AnyMap,
-    persistent_value::PersistentValue,
+    persist::Persist,
     repository::{Repository, RepositoryItem, RepositoryMigrations},
     sdk_managed::{Database, DatabaseConfiguration, DatabaseError, MemoryDatabase, SystemDatabase},
     settings::{Key, Setting},
@@ -60,10 +60,7 @@ impl StateRegistry {
     ///
     /// # Errors
     /// This method never fails, but returns a Result for backwards compatibility.
-    pub fn setting<T: PersistentValue>(
-        &self,
-        key: Key<T>,
-    ) -> Result<Setting<T>, StateRegistryError> {
+    pub fn setting<T: Persist>(&self, key: Key<T>) -> Result<Setting<T>, StateRegistryError> {
         Ok(Setting::new(self.database.get_setting::<T>(key.name)))
     }
 

--- a/crates/bitwarden-state/src/registry.rs
+++ b/crates/bitwarden-state/src/registry.rs
@@ -57,9 +57,6 @@ impl StateRegistry {
     }
 
     /// Get a handle to a setting by its type-safe key.
-    ///
-    /// # Errors
-    /// This method never fails, but returns a Result for backwards compatibility.
     pub fn setting<T: Persist>(&self, key: Key<T>) -> Result<Setting<T>, StateRegistryError> {
         Ok(Setting::new(self.database.get_setting::<T>(key.name)))
     }

--- a/crates/bitwarden-state/src/repository.rs
+++ b/crates/bitwarden-state/src/repository.rs
@@ -1,8 +1,6 @@
 use std::{any::TypeId, sync::Arc};
 
-use serde::{Serialize, de::DeserializeOwned};
-
-use crate::registry::StateRegistryError;
+use crate::{persistent_value::PersistentValue, registry::StateRegistryError};
 
 /// An error resulting from operations on a repository.
 #[derive(thiserror::Error, Debug)]
@@ -72,9 +70,9 @@ pub trait Repository<V: RepositoryItem>: Send + Sync {
 /// It should not be implemented manually; instead, users should
 /// use the [crate::register_repository_item] macro to register their item types.
 ///
-/// All repository items must implement `Serialize` and `DeserializeOwned` to support
-/// SDK-managed repositories that persist items to storage.
-pub trait RepositoryItem: Internal + Serialize + DeserializeOwned + Send + Sync + 'static {
+/// All repository items must be a [`PersistentValue`] to support SDK-managed repositories
+/// that persist items to storage.
+pub trait RepositoryItem: Internal + PersistentValue {
     /// The name of the type implementing this trait.
     const NAME: &'static str;
 

--- a/crates/bitwarden-state/src/repository.rs
+++ b/crates/bitwarden-state/src/repository.rs
@@ -1,6 +1,6 @@
 use std::{any::TypeId, sync::Arc};
 
-use crate::{persistent_value::PersistentValue, registry::StateRegistryError};
+use crate::{persist::Persist, registry::StateRegistryError};
 
 /// An error resulting from operations on a repository.
 #[derive(thiserror::Error, Debug)]
@@ -70,9 +70,9 @@ pub trait Repository<V: RepositoryItem>: Send + Sync {
 /// It should not be implemented manually; instead, users should
 /// use the [crate::register_repository_item] macro to register their item types.
 ///
-/// All repository items must be a [`PersistentValue`] to support SDK-managed repositories
-/// that persist items to storage.
-pub trait RepositoryItem: Internal + PersistentValue {
+/// The [`Persist`] bound is what makes an item storable by SDK-managed repositories. It is
+/// satisfied automatically by any type that is serializable and thread-safe.
+pub trait RepositoryItem: Internal + Persist {
     /// The name of the type implementing this trait.
     const NAME: &'static str;
 

--- a/crates/bitwarden-state/src/sdk_managed/mod.rs
+++ b/crates/bitwarden-state/src/sdk_managed/mod.rs
@@ -3,7 +3,11 @@ use std::sync::Arc;
 use bitwarden_error::bitwarden_error;
 use thiserror::Error;
 
-use crate::repository::{Repository, RepositoryError, RepositoryItem, RepositoryMigrations};
+use crate::{
+    persistent_value::PersistentValue,
+    repository::{Repository, RepositoryError, RepositoryItem, RepositoryMigrations},
+    settings::{SettingItem, SettingTrait, SettingsError},
+};
 
 mod configuration;
 pub use configuration::DatabaseConfiguration;
@@ -242,10 +246,47 @@ impl<V: RepositoryItem> Repository<V> for DBRepository<V> {
     }
 }
 
+/// Stores a single setting in the `Setting` table, keyed by `name`, as the bare serialized value.
+struct DBSetting<T> {
+    database: SystemDatabase,
+    name: &'static str,
+    _marker: std::marker::PhantomData<fn() -> T>,
+}
+
+#[async_trait::async_trait]
+impl<T: PersistentValue> SettingTrait<T> for DBSetting<T> {
+    async fn get(&self) -> Result<Option<T>, SettingsError> {
+        match self.database.get::<SettingItem>(self.name).await? {
+            Some(item) => Ok(Some(serde_json::from_value::<T>(item.0)?)),
+            None => Ok(None),
+        }
+    }
+
+    async fn set(&self, value: T) -> Result<(), SettingsError> {
+        let item = SettingItem(serde_json::to_value(&value)?);
+        Ok(self.database.set::<SettingItem>(self.name, item).await?)
+    }
+
+    async fn remove(&self) -> Result<(), SettingsError> {
+        Ok(self.database.remove::<SettingItem>(self.name).await?)
+    }
+}
+
 impl SystemDatabase {
     pub(super) fn get_repository<V: RepositoryItem>(&self) -> Arc<dyn Repository<V>> {
         Arc::new(DBRepository {
             database: self.clone(),
+            _marker: std::marker::PhantomData,
+        })
+    }
+
+    pub(super) fn get_setting<T: PersistentValue>(
+        &self,
+        name: &'static str,
+    ) -> Arc<dyn SettingTrait<T>> {
+        Arc::new(DBSetting {
+            database: self.clone(),
+            name,
             _marker: std::marker::PhantomData,
         })
     }

--- a/crates/bitwarden-state/src/sdk_managed/mod.rs
+++ b/crates/bitwarden-state/src/sdk_managed/mod.rs
@@ -250,7 +250,7 @@ impl<V: RepositoryItem> Repository<V> for DBRepository<V> {
 struct DBSetting<T> {
     database: SystemDatabase,
     name: &'static str,
-    _marker: std::marker::PhantomData<fn() -> T>,
+    _marker: std::marker::PhantomData<T>,
 }
 
 #[async_trait::async_trait]

--- a/crates/bitwarden-state/src/sdk_managed/mod.rs
+++ b/crates/bitwarden-state/src/sdk_managed/mod.rs
@@ -4,7 +4,7 @@ use bitwarden_error::bitwarden_error;
 use thiserror::Error;
 
 use crate::{
-    persistent_value::PersistentValue,
+    persist::Persist,
     repository::{Repository, RepositoryError, RepositoryItem, RepositoryMigrations},
     settings::{SettingItem, SettingTrait, SettingsError},
 };
@@ -254,7 +254,7 @@ struct DBSetting<T> {
 }
 
 #[async_trait::async_trait]
-impl<T: PersistentValue> SettingTrait<T> for DBSetting<T> {
+impl<T: Persist> SettingTrait<T> for DBSetting<T> {
     async fn get(&self) -> Result<Option<T>, SettingsError> {
         match self.database.get::<SettingItem>(self.name).await? {
             Some(item) => Ok(Some(serde_json::from_value::<T>(item.0)?)),
@@ -280,10 +280,7 @@ impl SystemDatabase {
         })
     }
 
-    pub(super) fn get_setting<T: PersistentValue>(
-        &self,
-        name: &'static str,
-    ) -> Arc<dyn SettingTrait<T>> {
+    pub(super) fn get_setting<T: Persist>(&self, name: &'static str) -> Arc<dyn SettingTrait<T>> {
         Arc::new(DBSetting {
             database: self.clone(),
             name,

--- a/crates/bitwarden-state/src/settings/mod.rs
+++ b/crates/bitwarden-state/src/settings/mod.rs
@@ -1,7 +1,7 @@
-//! Type-safe settings repository for storing application configuration and state.
+//! Type-safe settings API for storing application configuration and state.
 //!
-//! This module provides a type-safe key-value API for storing settings, backed by
-//! the SDK's repository pattern.
+//! This module provides a type-safe key-value API for storing settings. Each setting resolves to
+//! its own backend, defaulting to the SDK-managed database.
 //!
 //! # Usage
 //!
@@ -44,4 +44,4 @@ mod key;
 mod setting;
 
 pub use key::Key;
-pub use setting::{Setting, SettingItem, SettingsError};
+pub use setting::{Setting, SettingItem, SettingTrait, SettingsError};

--- a/crates/bitwarden-state/src/settings/setting.rs
+++ b/crates/bitwarden-state/src/settings/setting.rs
@@ -5,13 +5,11 @@ use std::sync::Arc;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
-use super::Key;
 use crate::{
-    registry::StateRegistryError,
-    repository::{Repository, RepositoryError},
+    persistent_value::PersistentValue, registry::StateRegistryError, sdk_managed::DatabaseError,
 };
 
-/// Internal setting value stored in the settings repository.
+/// Internal setting value as stored in the SDK-managed database.
 ///
 /// This type wraps a JSON value for flexible storage. Users should not work with
 /// this type directly - use the [`Setting<T>`] handle via `StateClient::setting()` instead,
@@ -20,8 +18,15 @@ use crate::{
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct SettingItem(pub(crate) serde_json::Value);
 
-// Register SettingItem for repository usage
 crate::register_repository_item!(String => SettingItem, "Setting");
+
+#[doc(hidden)]
+#[async_trait::async_trait]
+pub trait SettingTrait<T: PersistentValue>: Send + Sync {
+    async fn get(&self) -> Result<Option<T>, SettingsError>;
+    async fn set(&self, value: T) -> Result<(), SettingsError>;
+    async fn remove(&self) -> Result<(), SettingsError>;
+}
 
 /// A handle to a single setting value in storage.
 ///
@@ -46,15 +51,16 @@ crate::register_repository_item!(String => SettingItem, "Setting");
 /// setting.delete().await?;
 /// ```
 #[derive(Clone)]
-pub struct Setting<T> {
-    repository: Arc<dyn Repository<SettingItem>>,
-    key: Key<T>,
+pub struct Setting<T: PersistentValue> {
+    backend: Arc<dyn SettingTrait<T>>,
 }
 
-impl<T> Setting<T> {
-    /// Create a new setting handle from a repository and key.
-    pub fn new(repository: Arc<dyn Repository<SettingItem>>, key: Key<T>) -> Self {
-        Self { repository, key }
+impl<T: PersistentValue> Setting<T> {
+    /// Create a new setting handle from a backend.
+    ///
+    /// The backend is already bound to a single key, so it decides where the value is stored.
+    pub fn new(backend: Arc<dyn SettingTrait<T>>) -> Self {
+        Self { backend }
     }
 
     /// Get the current value of this setting.
@@ -67,34 +73,18 @@ impl<T> Setting<T> {
     /// - Schema evolution problems (type definition changed)
     /// - Data corruption
     /// - Type mismatch (wrong `Key<T>` type for stored data)
-    pub async fn get(&self) -> Result<Option<T>, SettingsError>
-    where
-        T: for<'de> Deserialize<'de>,
-    {
-        match self.repository.get(self.key.name.to_string()).await? {
-            Some(item) => Ok(Some(serde_json::from_value::<T>(item.0)?)),
-            None => Ok(None),
-        }
+    pub async fn get(&self) -> Result<Option<T>, SettingsError> {
+        self.backend.get().await
     }
 
     /// Update (or create) this setting with a new value.
-    pub async fn update(&self, value: T) -> Result<(), SettingsError>
-    where
-        T: Serialize,
-    {
-        let json_value = serde_json::to_value(&value)?;
-        let item = SettingItem(json_value);
-
-        self.repository.set(self.key.name.to_string(), item).await?;
-
-        Ok(())
+    pub async fn update(&self, value: T) -> Result<(), SettingsError> {
+        self.backend.set(value).await
     }
 
     /// Delete this setting from storage.
     pub async fn delete(&self) -> Result<(), SettingsError> {
-        self.repository.remove(self.key.name.to_string()).await?;
-
-        Ok(())
+        self.backend.remove().await
     }
 }
 
@@ -104,9 +94,9 @@ pub enum SettingsError {
     /// Failed to serialize/deserialize setting value
     #[error("Failed to serialize/deserialize setting: {0}")]
     Json(#[from] serde_json::Error),
-    /// Repository operation failed
+    /// Database operation failed
     #[error(transparent)]
-    Repository(#[from] RepositoryError),
+    Database(#[from] DatabaseError),
     /// State registry operation failed
     #[error(transparent)]
     Registry(#[from] StateRegistryError),

--- a/crates/bitwarden-state/src/settings/setting.rs
+++ b/crates/bitwarden-state/src/settings/setting.rs
@@ -5,9 +5,7 @@ use std::sync::Arc;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
-use crate::{
-    persistent_value::PersistentValue, registry::StateRegistryError, sdk_managed::DatabaseError,
-};
+use crate::{persist::Persist, registry::StateRegistryError, sdk_managed::DatabaseError};
 
 /// Internal setting value as stored in the SDK-managed database.
 ///
@@ -22,7 +20,7 @@ crate::register_repository_item!(String => SettingItem, "Setting");
 
 #[doc(hidden)]
 #[async_trait::async_trait]
-pub trait SettingTrait<T: PersistentValue>: Send + Sync {
+pub trait SettingTrait<T: Persist>: Send + Sync {
     async fn get(&self) -> Result<Option<T>, SettingsError>;
     async fn set(&self, value: T) -> Result<(), SettingsError>;
     async fn remove(&self) -> Result<(), SettingsError>;
@@ -51,11 +49,11 @@ pub trait SettingTrait<T: PersistentValue>: Send + Sync {
 /// setting.delete().await?;
 /// ```
 #[derive(Clone)]
-pub struct Setting<T: PersistentValue> {
+pub struct Setting<T: Persist> {
     backend: Arc<dyn SettingTrait<T>>,
 }
 
-impl<T: PersistentValue> Setting<T> {
+impl<T: Persist> Setting<T> {
     /// Create a new setting handle from a backend.
     ///
     /// The backend is already bound to a single key, so it decides where the value is stored.

--- a/crates/bitwarden-sync/src/sync_client.rs
+++ b/crates/bitwarden-sync/src/sync_client.rs
@@ -323,17 +323,13 @@ mod tests {
 
     /// Helper to create a SyncClient with a state-backed last_sync setting.
     ///
-    /// If `stored_last_sync` is `Some`, it is written into the in-memory repository so
+    /// If `stored_last_sync` is `Some`, it is written into the in-memory setting so
     /// that subsequent calls to `needs_sync` see it.
     async fn test_client_with_last_sync(
         api_client: bitwarden_api_api::apis::ApiClient,
         stored_last_sync: Option<DateTime<Utc>>,
     ) -> SyncClient {
-        let repo: Arc<dyn bitwarden_state::repository::Repository<bitwarden_state::SettingItem>> =
-            Arc::new(bitwarden_test::MemoryRepository::<
-                bitwarden_state::SettingItem,
-            >::default());
-        let setting = bitwarden_state::Setting::new(repo, crate::state::LAST_SYNC);
+        let setting = bitwarden_test::MemorySetting::create();
         if let Some(dt) = stored_last_sync {
             setting.update(dt).await.expect("pre-populate last_sync");
         }
@@ -614,11 +610,7 @@ mod tests {
         let error_log_clone = error_log.clone();
 
         // Build Setting manually so we can inspect it after sync.
-        let repo: Arc<dyn bitwarden_state::repository::Repository<bitwarden_state::SettingItem>> =
-            Arc::new(bitwarden_test::MemoryRepository::<
-                bitwarden_state::SettingItem,
-            >::default());
-        let setting = bitwarden_state::Setting::new(repo, crate::state::LAST_SYNC);
+        let setting = bitwarden_test::MemorySetting::create();
         setting
             .update(stored_last_sync)
             .await

--- a/crates/bitwarden-test/src/lib.rs
+++ b/crates/bitwarden-test/src/lib.rs
@@ -6,4 +6,7 @@ pub use api::*;
 mod repository;
 pub use repository::*;
 
+mod setting;
+pub use setting::*;
+
 pub mod play;

--- a/crates/bitwarden-test/src/setting.rs
+++ b/crates/bitwarden-test/src/setting.rs
@@ -1,0 +1,37 @@
+use std::sync::{Arc, Mutex};
+
+use bitwarden_state::{PersistentValue, Setting, SettingTrait, SettingsError};
+
+/// A simple in-memory setting backend. The data is only stored in memory and will not persist
+/// beyond the lifetime of the backend instance.
+///
+/// Primary use case is for unit and integration tests.
+pub struct MemorySetting<T> {
+    value: Mutex<Option<T>>,
+}
+
+impl<T: Clone + PersistentValue> MemorySetting<T> {
+    /// Create a setting handle backed by a fresh in-memory store.
+    pub fn create() -> Setting<T> {
+        Setting::new(Arc::new(Self {
+            value: Mutex::new(None),
+        }))
+    }
+}
+
+#[async_trait::async_trait]
+impl<T: Clone + PersistentValue> SettingTrait<T> for MemorySetting<T> {
+    async fn get(&self) -> Result<Option<T>, SettingsError> {
+        Ok(self.value.lock().expect("Mutex is not poisoned").clone())
+    }
+
+    async fn set(&self, value: T) -> Result<(), SettingsError> {
+        *self.value.lock().expect("Mutex is not poisoned") = Some(value);
+        Ok(())
+    }
+
+    async fn remove(&self) -> Result<(), SettingsError> {
+        *self.value.lock().expect("Mutex is not poisoned") = None;
+        Ok(())
+    }
+}

--- a/crates/bitwarden-test/src/setting.rs
+++ b/crates/bitwarden-test/src/setting.rs
@@ -1,6 +1,6 @@
 use std::sync::{Arc, Mutex};
 
-use bitwarden_state::{PersistentValue, Setting, SettingTrait, SettingsError};
+use bitwarden_state::{Persist, Setting, SettingTrait, SettingsError};
 
 /// A simple in-memory setting backend. The data is only stored in memory and will not persist
 /// beyond the lifetime of the backend instance.
@@ -10,7 +10,7 @@ pub struct MemorySetting<T> {
     value: Mutex<Option<T>>,
 }
 
-impl<T: Clone + PersistentValue> MemorySetting<T> {
+impl<T: Clone + Persist> MemorySetting<T> {
     /// Create a setting handle backed by a fresh in-memory store.
     pub fn create() -> Setting<T> {
         Setting::new(Arc::new(Self {
@@ -20,7 +20,7 @@ impl<T: Clone + PersistentValue> MemorySetting<T> {
 }
 
 #[async_trait::async_trait]
-impl<T: Clone + PersistentValue> SettingTrait<T> for MemorySetting<T> {
+impl<T: Clone + Persist> SettingTrait<T> for MemorySetting<T> {
     async fn get(&self) -> Result<Option<T>, SettingsError> {
         Ok(self.value.lock().expect("Mutex is not poisoned").clone())
     }


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-43254

## 📔 Objective

Update `Setting` to be a first class citizen rather than rely on `Repository`. Instead, the `Setting` type now builds upon a trait, which is currently implemented by directly wrapping the DB like `Repository` does. This will open up the possibility of having client-managed settings in the future, but it's not part of this PR.

Also added a blanket `Persist` trait to avoid duplicating the `Serialize+Deserialize+Send+Sync+'static` bounds everywhere.

## 🚨 Breaking Changes

<!-- Does this PR introduce any breaking changes? If so, please describe the impact and migration path for clients.

If you're unsure, the automated TypeScript compatibility check will run when you open/update this PR and provide feedback.

For breaking changes:
1. Describe what changed in the client interface
2. Explain why the change was necessary
3. Provide migration steps for client developers
4. Link to any paired client PRs if needed

Otherwise, you can remove this section. -->
