### PR TITLE
[PM-43252] Add missing uniffi.toml files and ensure they exist

### DIFF
--- a/.claude/rules/rust-conventions.md
+++ b/.claude/rules/rust-conventions.md
@@ -37,7 +37,10 @@ wasm32.
 ## Exposing types across bindings
 
 - UniFFI: `#[cfg_attr(feature = "uniffi", derive(uniffi::Record))]` on structs, `uniffi::Enum` on
-  enums; crates with UniFFI exports call `uniffi::setup_scaffolding!()` in `lib.rs`.
+  enums; crates with UniFFI exports call `uniffi::setup_scaffolding!()` in `lib.rs` and ship a
+  `uniffi.toml` next to `Cargo.toml`, copying the `[bindings.kotlin]` / `[bindings.swift]` layout
+  from a neighboring crate and substituting this crate's Kotlin package name and Swift module names
+  (enforced by the `missing_uniffi_config` dylint lint, which only checks that the file exists).
 - WASM: `#[derive(Serialize, Deserialize)]` plus
   `#[cfg_attr(feature = "wasm", derive(Tsify), tsify(into_wasm_abi, from_wasm_abi))]`.
 - Errors: annotate with `bitwarden-error` (`basic`/`flat`/`full` modes) to generate the WASM,

--- a/crates/bitwarden-importers/uniffi.toml
+++ b/crates/bitwarden-importers/uniffi.toml
@@ -1,0 +1,11 @@
+[bindings.kotlin]
+package_name = "com.bitwarden.importers"
+generate_immutable_records = true
+android = true
+# Temporary workaround for https://github.com/mozilla/uniffi-rs/issues/2740
+omit_checksums = true
+
+[bindings.swift]
+ffi_module_name = "BitwardenImportersFFI"
+module_name = "BitwardenImporters"
+generate_immutable_records = true

--- a/crates/bitwarden-sensitive-value/uniffi.toml
+++ b/crates/bitwarden-sensitive-value/uniffi.toml
@@ -1,0 +1,11 @@
+[bindings.kotlin]
+package_name = "com.bitwarden.sensitivevalue"
+generate_immutable_records = true
+android = true
+# Temporary workaround for https://github.com/mozilla/uniffi-rs/issues/2740
+omit_checksums = true
+
+[bindings.swift]
+ffi_module_name = "BitwardenSensitiveValueFFI"
+module_name = "BitwardenSensitiveValue"
+generate_immutable_records = true

--- a/support/lints/Cargo.lock
+++ b/support/lints/Cargo.lock
@@ -123,6 +123,7 @@ dependencies = [
  "bitwarden_repr_with_tsify",
  "bitwarden_tracing_instrument",
  "bitwarden_uniffi_async_export",
+ "bitwarden_uniffi_config",
  "dylint_linting",
 ]
 
@@ -155,6 +156,15 @@ dependencies = [
 
 [[package]]
 name = "bitwarden_uniffi_async_export"
+version = "0.1.0"
+dependencies = [
+ "clippy_utils",
+ "dylint_linting",
+ "dylint_testing",
+]
+
+[[package]]
+name = "bitwarden_uniffi_config"
 version = "0.1.0"
 dependencies = [
  "clippy_utils",

--- a/support/lints/Cargo.toml
+++ b/support/lints/Cargo.toml
@@ -15,6 +15,7 @@ bitwarden_error_suffix = { path = "error_suffix", features = ["rlib"] }
 bitwarden_repr_with_tsify = { path = "repr_with_tsify", features = ["rlib"] }
 bitwarden_tracing_instrument = { path = "tracing_instrument", features = ["rlib"] }
 bitwarden_uniffi_async_export = { path = "uniffi_async_export", features = ["rlib"] }
+bitwarden_uniffi_config = { path = "uniffi_config", features = ["rlib"] }
 dylint_linting = { workspace = true }
 
 [package.metadata.rust-analyzer]

--- a/support/lints/README.md
+++ b/support/lints/README.md
@@ -13,3 +13,6 @@ The following lints are currently available:
   `#[cfg_attr(feature = "wasm", wasm_bindgen)]` for repr-encoded enums.
 - `uniffi_async_export`: Ensures `#[uniffi::export]` on `async fn`s (free or inside an impl)
   specifies `async_runtime = "tokio"`.
+- `uniffi_config`: Ensures crates calling `uniffi::setup_scaffolding!()` ship a `uniffi.toml`, so
+  the Kotlin package name and Swift module names are set explicitly instead of derived from the
+  crate name.

--- a/support/lints/src/lib.rs
+++ b/support/lints/src/lib.rs
@@ -14,4 +14,5 @@ pub fn register_lints(sess: &rustc_session::Session, lint_store: &mut rustc_lint
     bitwarden_repr_with_tsify::register_lints(sess, lint_store);
     bitwarden_tracing_instrument::register_lints(sess, lint_store);
     bitwarden_uniffi_async_export::register_lints(sess, lint_store);
+    bitwarden_uniffi_config::register_lints(sess, lint_store);
 }

--- a/support/lints/uniffi_config/Cargo.toml
+++ b/support/lints/uniffi_config/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "bitwarden_uniffi_config"
+version = "0.1.0"
+authors = ["Bitwarden Inc"]
+description = "Lint requiring a `uniffi.toml` in crates that set up UniFFI scaffolding"
+edition = "2021"
+publish = false
+
+[features]
+rlib = ["dylint_linting/constituent"]
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[[example]]
+name = "ui"
+path = "ui/main.rs"
+
+[dependencies]
+clippy_utils = { workspace = true }
+dylint_linting = { workspace = true }
+
+[dev-dependencies]
+dylint_testing = { workspace = true }
+
+[package.metadata.rust-analyzer]
+rustc_private = true

--- a/support/lints/uniffi_config/src/lib.rs
+++ b/support/lints/uniffi_config/src/lib.rs
@@ -1,0 +1,88 @@
+#![feature(rustc_private)]
+#![warn(unused_extern_crates)]
+
+extern crate rustc_ast;
+
+use std::path::Path;
+
+use clippy_utils::diagnostics::span_lint_and_help;
+use rustc_ast::ast::{Item, ItemKind};
+use rustc_lint::{EarlyContext, EarlyLintPass};
+
+dylint_linting::declare_pre_expansion_lint! {
+    /// ### What it does
+    ///
+    /// Warns when a crate calls `uniffi::setup_scaffolding!()` but has no
+    /// `uniffi.toml` next to its `Cargo.toml`.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// `uniffi.toml` is where the Kotlin package name and the Swift module
+    /// names are set. Without it, `uniffi-bindgen` derives them from the crate
+    /// name, so the crate lands in the mobile clients under a name that does
+    /// not match the rest of the SDK, and it misses the shared binding options
+    /// (`generate_immutable_records`, `omit_checksums`, `android`).
+    ///
+    /// ### Example
+    ///
+    /// ```rust,ignore
+    /// // crates/bitwarden-foo/src/lib.rs, with no crates/bitwarden-foo/uniffi.toml
+    /// uniffi::setup_scaffolding!();
+    /// ```
+    ///
+    /// Use instead: add `crates/bitwarden-foo/uniffi.toml`, copying the
+    /// `[bindings.kotlin]` / `[bindings.swift]` layout from a neighboring
+    /// crate and substituting this crate's names.
+    pub MISSING_UNIFFI_CONFIG,
+    Warn,
+    "crates calling `uniffi::setup_scaffolding!()` must ship a `uniffi.toml`"
+}
+
+impl EarlyLintPass for MissingUniffiConfig {
+    fn check_item(&mut self, cx: &EarlyContext<'_>, item: &Item) {
+        if !is_setup_scaffolding(item) {
+            return;
+        }
+
+        // Set by cargo for every crate it compiles, and dylint always runs under cargo.
+        let Some(crate_dir) = std::env::var_os("CARGO_MANIFEST_DIR") else {
+            return;
+        };
+
+        if Path::new(&crate_dir).join("uniffi.toml").is_file() {
+            return;
+        }
+
+        span_lint_and_help(
+            cx,
+            MISSING_UNIFFI_CONFIG,
+            item.span,
+            "this crate sets up UniFFI scaffolding but has no `uniffi.toml`",
+            None,
+            "add a `uniffi.toml` beside `Cargo.toml`, copying the `[bindings.kotlin]` / `[bindings.swift]` layout from a neighboring crate and substituting this crate's names",
+        );
+    }
+}
+
+fn is_setup_scaffolding(item: &Item) -> bool {
+    let ItemKind::MacCall(mac) = &item.kind else {
+        return false;
+    };
+    let segments = &mac.path.segments;
+    let Some(last) = segments.last() else {
+        return false;
+    };
+    if last.ident.name.as_str() != "setup_scaffolding" {
+        return false;
+    }
+    // Accept both `uniffi::setup_scaffolding!()` and an imported `setup_scaffolding!()`.
+    match segments.len() {
+        1 => true,
+        len => segments[len - 2].ident.name.as_str() == "uniffi",
+    }
+}
+
+#[test]
+fn ui() {
+    dylint_testing::ui_test_example(env!("CARGO_PKG_NAME"), "ui");
+}

--- a/support/lints/uniffi_config/ui/main.rs
+++ b/support/lints/uniffi_config/ui/main.rs
@@ -1,0 +1,15 @@
+// The case lives in a `#[cfg(any())]` module so it is parsed by the
+// pre-expansion lint pass but never compiled. This lets us reference
+// `uniffi::setup_scaffolding!` without pulling `uniffi` in as a
+// dev-dependency.
+//
+// Should warn: this lint crate has a `Cargo.toml` but no `uniffi.toml`, which
+// is the situation the lint reports. The passing case (a crate that does ship
+// a `uniffi.toml`) can't be expressed here, since the crate under test is this
+// one.
+#[cfg(any())]
+mod scaffolding_without_config {
+    uniffi::setup_scaffolding!();
+}
+
+fn main() {}

--- a/support/lints/uniffi_config/ui/main.stderr
+++ b/support/lints/uniffi_config/ui/main.stderr
@@ -1,0 +1,11 @@
+warning: this crate sets up UniFFI scaffolding but has no `uniffi.toml`
+  --> $DIR/main.rs:12:5
+   |
+LL |     uniffi::setup_scaffolding!();
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: add a `uniffi.toml` beside `Cargo.toml`, copying the `[bindings.kotlin]` / `[bindings.swift]` layout from a neighboring crate and substituting this crate's names
+   = note: `#[warn(missing_uniffi_config)]` on by default
+
+warning: 1 warning emitted
+


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-43252

## 📔 Objective

Two crates were missing the `uniffi.toml` file, which means they get assigned the wrong package name in Swift/Kotlin, plus the bindings get generated in the wrong directory. 

This PR adds those files, plus it adds a custom lint to ensure they're not missing in the future. Now any crate calling setup_scaffolding!() will warn if the toml file is missing.

## 🚨 Breaking Changes

<!-- Does this PR introduce any breaking changes? If so, please describe the impact and migration path for clients.

If you're unsure, the automated TypeScript compatibility check will run when you open/update this PR and provide feedback.

For breaking changes:
1. Describe what changed in the client interface
2. Explain why the change was necessary
3. Provide migration steps for client developers
4. Link to any paired client PRs if needed

Otherwise, you can remove this section. -->
