### PR TITLE
[PM-43258] Add the 1Password converter, logins only

### DIFF
--- a/.aikido
+++ b/.aikido
@@ -1,4 +1,7 @@
-# Test vectors are derived from a throwaway account, no real secrets there.
+# Test data and test-only code from a throwaway account, no real secrets there.
 exclude:
   paths:
     - crates/bitwarden-importers/src/importers/onepassword/access/fixtures
+    - crates/bitwarden-importers/src/importers/onepassword/fixtures
+    # A #[cfg(test)] module that replays the captured account, so it holds its credentials.
+    - crates/bitwarden-importers/src/importers/onepassword/access/replay.rs

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -951,6 +951,7 @@ dependencies = [
  "hkdf 0.13.0",
  "hmac 0.13.0",
  "icu_normalizer",
+ "itertools 0.15.0",
  "keepass",
  "p256 0.14.0",
  "pbkdf2",

--- a/crates/bitwarden-importers/Cargo.toml
+++ b/crates/bitwarden-importers/Cargo.toml
@@ -16,8 +16,8 @@ license = "GPL-3.0-only OR LicenseRef-Bitwarden-SDK"
 keywords.workspace = true
 
 [features]
-# Re-exports the 1Password access module so the out-of-tree CLI can drive it against a real
-# account. Never enable in production builds.
+# Re-exports the 1Password access and convert modules so the out-of-tree CLI can drive them
+# against a real account. Never enable in production builds.
 # TODO: Remove once the importer consumes the module directly.
 test-utils = []
 uniffi = [
@@ -54,6 +54,7 @@ data-encoding = { workspace = true }
 hkdf = { workspace = true }
 hmac = { workspace = true }
 icu_normalizer = { workspace = true }
+itertools = ">=0.15.0, <0.16"
 keepass = { workspace = true }
 p256 = { version = "=0.14.0", features = ["alloc", "ecdh", "pkcs8"], default-features = false }
 pbkdf2 = { workspace = true, features = ["hmac"] }

--- a/crates/bitwarden-importers/src/importers/onepassword/access/client.rs
+++ b/crates/bitwarden-importers/src/importers/onepassword/access/client.rs
@@ -48,19 +48,7 @@ impl Client {
     ) -> Result<Vec<Vault>, OnePasswordError> {
         let account_key = AccountKey::parse(&credentials.account_key)?;
         let session = self.login(credentials, &account_key, ui).await?;
-        let (keychain, vaults) = unlock(credentials, &account_key, &session).await?;
-
-        let mut downloaded = Vec::with_capacity(vaults.len());
-        for info in &vaults {
-            downloaded.push(Vault {
-                id: info.id.clone(),
-                name: info.name.clone(),
-                description: info.description.clone(),
-                items: download_vault_items(&info.id, &keychain, &session).await?,
-            });
-        }
-
-        Ok(downloaded)
+        download_vaults(credentials, &account_key, &session).await
     }
 
     /// Runs the login sequence, retrying the whole thing when the server rejects a TOTP code.
@@ -106,6 +94,30 @@ impl Client {
 
         Err(OnePasswordError::TwoFactorFailed)
     }
+}
+
+/// Unlocks the account's keys and downloads every vault the session can open.
+///
+/// Split out of [`Client::download_all_vaults`] so the fixture replay can drive the real download
+/// over captured responses without performing the login exchange.
+pub(super) async fn download_vaults(
+    credentials: &Credentials,
+    account_key: &AccountKey,
+    session: &Session,
+) -> Result<Vec<Vault>, OnePasswordError> {
+    let (keychain, vaults) = unlock(credentials, account_key, session).await?;
+
+    let mut downloaded = Vec::with_capacity(vaults.len());
+    for info in &vaults {
+        downloaded.push(Vault {
+            id: info.id.clone(),
+            name: info.name.clone(),
+            description: info.description.clone(),
+            items: download_vault_items(&info.id, &keychain, session).await?,
+        });
+    }
+
+    Ok(downloaded)
 }
 
 /// A vault the account can open, with its attributes already decrypted.

--- a/crates/bitwarden-importers/src/importers/onepassword/access/mod.rs
+++ b/crates/bitwarden-importers/src/importers/onepassword/access/mod.rs
@@ -20,6 +20,8 @@ mod login;
 mod mac;
 pub mod model;
 mod opdata;
+#[cfg(test)]
+pub(in crate::importers::onepassword) mod replay;
 mod rest;
 mod rsa;
 mod session;

--- a/crates/bitwarden-importers/src/importers/onepassword/access/replay.rs
+++ b/crates/bitwarden-importers/src/importers/onepassword/access/replay.rs
@@ -1,0 +1,108 @@
+//! Replays a captured 1Password account through the production download path.
+//!
+//! The fixtures are the session-decrypted response bodies exactly as the server sent them: the
+//! per-item `encOverview` and `encDetails` are still sealed with the vault key. Re-encrypting them
+//! with a known session key and serving them from a mock host means the real client does the
+//! decrypting and parsing, so these tests exercise production code rather than a parallel loader.
+//!
+//! The account is a disposable one kept for exactly this purpose, so its credentials live here.
+
+use bitwarden_api_base::new_http_client;
+use wiremock::{Mock, MockServer, ResponseTemplate, matchers};
+
+use super::{
+    account_key::AccountKey,
+    client::download_vaults,
+    credentials::Credentials,
+    model::Vault,
+    opdata::{AesKey, decode64_loose},
+    rest::RestClient,
+    session::Session,
+    sign_in::{SignInAddress, SignInDomain},
+};
+
+const USERNAME: &str = "lastpass.ruby+01-april-2026@gmail.com";
+const PASSWORD: &str = "what's a password?";
+const ACCOUNT_KEY: &str = "A3-9RVQ2J-EJMXAS-KHSXJ-6M9PJ-3W8WD-E4DRY";
+
+/// The vaults the capture covers, paired with their items response.
+const VAULTS: [(&str, &str); 2] = [
+    (
+        "wv2hn4jgomxwvfh4oiubyjppym",
+        include_str!("../fixtures/vault-wv2hn4jgomxwvfh4oiubyjppym-items-response.json"),
+    ),
+    (
+        "d7z3byaorasfq5xixos3tgaddu",
+        include_str!("../fixtures/vault-d7z3byaorasfq5xixos3tgaddu-items-response.json"),
+    ),
+];
+
+/// Any key works: the fixtures are re-encrypted with it here, then decrypted by the client.
+fn session_key() -> AesKey {
+    AesKey::new(
+        "SESSION",
+        decode64_loose("WyICHHlP5lPigZUGZYoivbJMqgHjSti86UKwdjCryYM").expect("valid key"),
+    )
+}
+
+fn credentials() -> Credentials {
+    Credentials {
+        username: USERNAME.to_string(),
+        password: PASSWORD.to_string(),
+        account_key: ACCOUNT_KEY.to_string(),
+        sign_in_address: SignInAddress::new("my", SignInDomain::Global).expect("valid address"),
+        device_uuid: "replay-device".to_string(),
+    }
+}
+
+/// Serves `body` from `path`, wrapped in an opdata envelope the session key opens.
+async fn mock_encrypted(server: &MockServer, path: String, body: &str) {
+    let envelope = session_key()
+        .encrypt(body.as_bytes(), &[0u8; 12])
+        .expect("encrypts");
+    server
+        .register(
+            Mock::given(matchers::path(path)).respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_json(serde_json::to_value(&envelope).expect("serializes")),
+            ),
+        )
+        .await;
+}
+
+/// Downloads the captured account the same way an import does, minus the login exchange.
+pub(in crate::importers::onepassword) async fn download_captured_account() -> Vec<Vault> {
+    let server = MockServer::start().await;
+    mock_encrypted(
+        &server,
+        "/api/v1/account".to_string(),
+        include_str!("../fixtures/account-response.json"),
+    )
+    .await;
+    mock_encrypted(
+        &server,
+        "/api/v1/account/keysets".to_string(),
+        include_str!("../fixtures/keysets-response.json"),
+    )
+    .await;
+    for (vault_id, items) in VAULTS {
+        mock_encrypted(&server, format!("/api/v1/vault/{vault_id}/0/items"), items).await;
+    }
+
+    let rest = RestClient::new(
+        new_http_client(),
+        format!("http://{}/api", server.address()),
+        "client-id",
+        "user-agent",
+        "op-user-agent",
+    )
+    .expect("valid headers");
+
+    let credentials = credentials();
+    let account_key = AccountKey::parse(&credentials.account_key).expect("valid account key");
+    let session = Session::new(session_key(), rest);
+
+    download_vaults(&credentials, &account_key, &session)
+        .await
+        .expect("the captured responses decrypt and parse")
+}

--- a/crates/bitwarden-importers/src/importers/onepassword/convert.rs
+++ b/crates/bitwarden-importers/src/importers/onepassword/convert.rs
@@ -1,0 +1,274 @@
+//! Maps downloaded 1Password vaults onto the importer's [`ParsedImport`].
+//!
+//! First step: vaults become folders, every item keeps its title and note, and a Login item
+//! picks up its username, password and website addresses. Every other category becomes a secure
+//! note for now. Typed mappings for those categories, and custom fields for whatever a mapping
+//! does not claim, follow in later steps.
+
+use bitwarden_exporters::{
+    CipherType, ImportingCipher, Login, LoginUri, SecureNote, SecureNoteType,
+};
+use chrono::Utc;
+use itertools::Itertools;
+
+use super::access::{
+    model::{Item, ItemCategory, Vault},
+    wire::{VaultItemDetails, VaultItemOverview},
+};
+use crate::pipeline::ParsedImport;
+
+/// Stands in for a title 1Password left empty, matching the KDBX importer.
+const UNTITLED_ITEM: &str = "--";
+
+/// Stands in for a vault name 1Password left empty, matching the KDBX importer's group naming.
+const UNNAMED_VAULT: &str = "-";
+
+/// Converts every downloaded vault into ciphers, one folder per vault.
+pub fn convert(vaults: Vec<Vault>) -> ParsedImport {
+    let mut parsed = ParsedImport {
+        ciphers: Vec::new(),
+        folders: Vec::new(),
+        folder_relationships: Vec::new(),
+    };
+
+    for (folder_index, vault) in vaults.into_iter().enumerate() {
+        parsed
+            .folders
+            .push(non_blank(&vault.name).unwrap_or(UNNAMED_VAULT).to_string());
+
+        for item in vault.items {
+            let cipher_index = parsed.ciphers.len();
+            parsed.ciphers.push(convert_item(item));
+            parsed
+                .folder_relationships
+                .push((cipher_index, folder_index));
+        }
+    }
+
+    parsed
+}
+
+fn convert_item(item: Item) -> ImportingCipher {
+    // The import endpoint sets its own dates, so the ones 1Password sends are not worth carrying.
+    let now = Utc::now();
+
+    ImportingCipher {
+        folder_id: None,
+        name: item
+            .overview
+            .title
+            .as_deref()
+            .and_then(non_blank)
+            .unwrap_or(UNTITLED_ITEM)
+            .to_string(),
+        notes: item
+            .details
+            .note
+            .as_deref()
+            .and_then(non_blank)
+            .map(str::to_string),
+        r#type: cipher_type(&item),
+        favorite: false,
+        reprompt: 0,
+        fields: Vec::new(),
+        revision_date: now,
+        creation_date: now,
+        deleted_date: None,
+    }
+}
+
+/// Picks the Bitwarden cipher type for an item's 1Password category. A category without a mapping
+/// yet becomes a secure note, so the item still arrives with its title and note.
+fn cipher_type(item: &Item) -> CipherType {
+    match item.category {
+        ItemCategory::Login => CipherType::Login(Box::new(login(&item.overview, &item.details))),
+        _ => CipherType::SecureNote(Box::new(SecureNote {
+            r#type: SecureNoteType::Generic,
+        })),
+    }
+}
+
+fn login(overview: &VaultItemOverview, details: &VaultItemDetails) -> Login {
+    let mut login = Login {
+        username: designation(details, "username"),
+        password: designation(details, "password"),
+        login_uris: login_uris(overview),
+        totp: None,
+        fido2_credentials: None,
+    };
+    login.sanitize_uris();
+    login
+}
+
+/// Reads one of the login fields 1Password tags with a `designation`. The designation is stable,
+/// unlike the field's localized `name`.
+fn designation(details: &VaultItemDetails, designation: &str) -> Option<String> {
+    details
+        .fields
+        .iter()
+        .flatten()
+        .find(|field| field.designation.as_deref() == Some(designation))
+        .and_then(|field| field.value.as_deref())
+        .and_then(non_blank)
+        .map(str::to_string)
+}
+
+/// Collects the item's website addresses. 1Password keeps the primary one in `url` and repeats it
+/// in `URLs`, so identical addresses collapse into a single URI.
+fn login_uris(overview: &VaultItemOverview) -> Vec<LoginUri> {
+    let all = overview.url.iter().chain(
+        overview
+            .urls
+            .iter()
+            .flatten()
+            .filter_map(|url| url.url.as_ref()),
+    );
+
+    all.filter_map(|url| non_blank(url))
+        .unique()
+        .map(|uri| LoginUri {
+            uri: Some(uri.to_string()),
+            r#match: None,
+        })
+        .collect()
+}
+
+fn non_blank(value: &str) -> Option<&str> {
+    (!value.trim().is_empty()).then_some(value)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{super::access::replay::download_captured_account, *};
+
+    /// Converts the captured account. The vaults come out of the production download path, driven
+    /// over the recorded server responses, so these tests see exactly what an import would.
+    async fn converted() -> ParsedImport {
+        convert(download_captured_account().await)
+    }
+
+    fn cipher<'a>(parsed: &'a ParsedImport, name: &str) -> &'a ImportingCipher {
+        parsed
+            .ciphers
+            .iter()
+            .find(|cipher| cipher.name == name)
+            .unwrap_or_else(|| panic!("no cipher named {name}"))
+    }
+
+    fn login_of(cipher: &ImportingCipher) -> &Login {
+        match &cipher.r#type {
+            CipherType::Login(login) => login,
+            other => panic!("{} is a {other}, expected a login", cipher.name),
+        }
+    }
+
+    fn uris(login: &Login) -> Vec<&str> {
+        login
+            .login_uris
+            .iter()
+            .map(|uri| uri.uri.as_deref().expect("a uri"))
+            .collect()
+    }
+
+    #[tokio::test]
+    async fn every_vault_becomes_a_folder_holding_its_items() {
+        let parsed = converted().await;
+
+        assert_eq!(parsed.folders, vec!["Personal", "Importer"]);
+        assert_eq!(parsed.ciphers.len(), 28);
+        // Nothing is dropped and nothing is left folderless.
+        assert_eq!(parsed.folder_relationships.len(), parsed.ciphers.len());
+
+        let personal = parsed
+            .folder_relationships
+            .iter()
+            .filter(|(_, folder)| *folder == 0)
+            .count();
+        assert_eq!(personal, 1);
+    }
+
+    #[tokio::test]
+    async fn a_login_takes_its_credentials_from_the_designation_fields() {
+        let parsed = converted().await;
+        let cipher = cipher(&parsed, "Login: username, password and one URL");
+        let login = login_of(cipher);
+
+        assert_eq!(login.username.as_deref(), Some("plain@example.com"));
+        assert_eq!(login.password.as_deref(), Some("plain-pass"));
+        assert_eq!(
+            cipher.notes.as_deref(),
+            Some("A login with nothing but the basics.")
+        );
+    }
+
+    /// 1Password lets both credential fields stay empty; the item is still a login.
+    #[tokio::test]
+    async fn a_login_without_credentials_keeps_its_type() {
+        let parsed = converted().await;
+        let login = login_of(cipher(
+            &parsed,
+            "Login: sections only, no username or password",
+        ));
+
+        assert_eq!(login.username, None);
+        assert_eq!(login.password, None);
+    }
+
+    /// The overview carries the primary address twice, in `url` and again in `URLs`.
+    #[tokio::test]
+    async fn a_repeated_website_address_becomes_one_uri() {
+        let parsed = converted().await;
+        let login = login_of(cipher(&parsed, "Login: username, password and one URL"));
+
+        assert_eq!(uris(login), ["https://plain.example.com"]);
+    }
+
+    #[tokio::test]
+    async fn every_website_address_arrives_in_order() {
+        let parsed = converted().await;
+        let login = login_of(cipher(&parsed, "Login: three website URLs"));
+
+        assert_eq!(
+            uris(login),
+            [
+                "https://primary.example.com",
+                "https://admin.example.com",
+                "https://unlabelled.example.com",
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn a_secure_note_keeps_its_multiline_note() {
+        let parsed = converted().await;
+        let cipher = cipher(&parsed, "Note: multiline text only");
+
+        assert!(matches!(cipher.r#type, CipherType::SecureNote(_)));
+        assert_eq!(
+            cipher.notes.as_deref(),
+            Some("A secret note.\nWith a second line.")
+        );
+    }
+
+    /// Only Login has a mapping so far. Everything else arrives as a note with its title rather
+    /// than failing the import or vanishing.
+    #[tokio::test]
+    async fn every_other_category_becomes_a_secure_note() {
+        let vaults = download_captured_account().await;
+        let others: Vec<String> = vaults
+            .iter()
+            .flat_map(|vault| &vault.items)
+            .filter(|item| item.category != ItemCategory::Login)
+            .map(|item| item.overview.title.clone().expect("a title"))
+            .collect();
+        assert_eq!(others.len(), 15);
+
+        let parsed = convert(vaults);
+        for title in others {
+            assert!(
+                matches!(cipher(&parsed, &title).r#type, CipherType::SecureNote(_)),
+                "{title} has a mapping now, give it a test of its own"
+            );
+        }
+    }
+}

--- a/crates/bitwarden-importers/src/importers/onepassword/fixtures/account-response.json
+++ b/crates/bitwarden-importers/src/importers/onepassword/fixtures/account-response.json
@@ -1,0 +1,688 @@
+{
+  "uuid": "QTRB3RZGRRE67KBZU76TTXE55Q",
+  "name": "LastPass Ruby",
+  "type": "I",
+  "state": "A",
+  "avatar": "",
+  "domain": "my",
+  "attrVersion": 3,
+  "createdAt": "2026-04-01T18:14:27Z",
+  "storageUsed": 112,
+  "baseAvatarURL": "https://a.1passwordusercontent.com/",
+  "baseAttachmentURL": "https://f.1passwordusercontent.com/",
+  "me": {
+    "uuid": "HVE53ZQITRE4LDVGUZZXPY23PY",
+    "createdAt": "2026-04-01T18:14:27Z",
+    "updatedAt": "2026-08-16T10:56:42Z",
+    "lastAuthAt": "2026-08-31T20:58:52Z",
+    "email": "lastpass.ruby+01-april-2026@gmail.com",
+    "firstName": "LastPass Ruby",
+    "lastName": "",
+    "name": "LastPass Ruby",
+    "attrVersion": 12,
+    "keysetVersion": 12,
+    "state": "A",
+    "type": "R",
+    "avatar": "",
+    "language": "en",
+    "accountKeyFormat": "A3",
+    "accountKeyUuid": "9RVQ2J",
+    "keysets": [
+      {
+        "uuid": "vkpeayor2tsxlnxo5vahqz2jee",
+        "encryptedBy": "mp",
+        "sn": 1,
+        "encSymKey": {
+          "alg": "PBES2g-HS256",
+          "cty": "b5+jwk+json",
+          "data": "EUfHdnMpEmywEzVw4su5eG4uvrnKM7_Hj_8sdDA_B27uqSByjJLRXYRNfEL-p2LvFN-3tTP7y_AX7wBLix9NEJDP-1Tgo82fPWVyJ1ORwhc00Nr8j7-DqprT2wA3d-Tpkw-rk-S1qgkMFOpiT0ld1G6QuNcc1nYrG0VyrHwww9s2vF_lueB6989DlLIBZp2hHKAJ0EP1-A7Sb1dBj7e00DPe6lfsZQjP3iI0ybI",
+          "enc": "A256GCM",
+          "iv": "Lfa_bA7rzDNghfia",
+          "kid": "mp",
+          "p2c": 650000,
+          "p2s": "huA1o3xP4Sl29ZbV-ABRBQ"
+        },
+        "encPriKey": {
+          "cty": "b5+jwk+json",
+          "data": "UQ5vfuZe32o_EGsoW2eqMmAOdPS-5LME2LBkKTizId9AkX7Ps8Q0X495LshVGtgervxwwjNESgZD_6qUfo070y4uA6cwMCXbU_YzAE-JJNvLHFcnGgdu2XqD7D_EwpW0CoCWcVSs66uTltVzR_MXl_uWAOTtbJrK1pbiZG_sP3l2CT0z8fzcI_nSKN-UbOp-biuTYDT_UPByEcZIqQP3FrB0uFOAHt80IDhsHnPEW4bZC9A4UzlrsGlIj2oc7hmcpuOabvqAxztBUIhwMKrcqR-lgDJyXH9NXX-Bi3FQbG3hgYg7auCfPuSddhoLjo6TeD6eEMvfH5WJtzfA74ygiQ0Ak9OUtsBplbDYY2fwfl9iGz8GgJAHqHV5dQcRXYsigwHpZaanVT7oPH_MLV2f85LHOK1KSTIHObrkhPGymzG3ChgfHvNTouG4soKU5-OxD7g5RgdJH564FedcsEBsCsLyDzwTg1auBpRIM7DD7Gc2HD8iKnbk3vGH0KXg4qvNbLEKQXB59oNCIapN-Bf45bP32zIVhNLJ9jwyjnEnMysktdwSqMsOmSiAX1Jw4QuB1Br6XsMXaaEJ6hBOzMCSxQuylZy2wu6QbZo9KwWeMYlRVcSIAac-2xp0t8wAd6dPu6kpGosa8rg8rUBTpakQ67IWBNaMIv90zFRPZs8Y3Bl-RZanJZIoPMBOkZ-nuDtK3VwYawK5jtSeTrgcH1yNGWbSU7y_5La_iLddvWVLGF-NOGVOXmJvgAOsQv2Vmimvpwz8Pm3EmWcIPVdQd3c2zce-y6mwrhn17gUFU0DX9TW5O3vMkmr3HbfS5PnV6mdzsgr8zg7nKiwew1kcw61FDi-VmzJC-t8wBa8yW2Ut7uzdrRnmKE6x4-XhNCp9uq7_mJW-jTIk1rOQc0xt1yJo8TXU3JrSkl6ODgHijL1N4puvVdW2sYsjYympSMIiGFMB_-KbTY6eEvhE8AcTYtkHLNBIpM3GGyTk-Dg6IrzQ3dzvuxcJYP5IpmDrPlAu0EnlUtvKrcnjgHN0HX3NIwnKbOmfQePllZO1I_LLAfq3JEO_iPoX1t0rd4FSatQ4UgvVA-2EEaYaqaOLFiDC87nhfEF4M5CxF8mQa1UDg6w41oT_sgQWVLZPc6yTioQwtxRu2zFpTSBjOlpbp6GcOX8ZmjsWov2LIYDN8I3tYGyAV6cg8EltguaMm2k-m2KkeJx8OACMhqwoOaA6rY5Wl0tjz_rn_8d2Z62RoXPE9GLyMZqKRaIuTBjjd9VcYjOGPecO4vIoa2qkPTMaewTSA1PNtNR-xoe7_rFwkhneQmEIWfyFJQPhzvGjWw1NzHJ3PZHKV2T4ReQzDyvNpWCeVB8HD1rt6QQj2p3As3WZo8ohQ04jHXUIQ6f2yIBCo_1hXyjbyvIdksNzj_O2noAJkPd7vHjV5qDL5oDuk8VQpMQJJGA40qutbXgEGL_Vm_u11tPMciY8jwn6KM3_XI0Z_F6OtfYy2bAo7q2nHULXhVAxjItuRUH6VocwoqqJQxQ2Wo6AVb_upW1tUXD1hlxinntku5SQjcCbH7arWjvE6tok8geDQujJAlnN8E7kJiZOuB5jOjEwLS-xxcArj3VXMFZepzYW7JlV_ZppAwA-x72_jdQTPaJzRXKwZ2fc0-S6aSweOMEX54dn9UcaSKljeU2ILMJI5oqgGVELeKiuTWVgCiIvP6YzloViotfm0Q3jMcsSMWxVzE_-zTmO-xXxcSccaRgN5QNDXoSgpsFcr5Rn15jb1ADLwwg9AnzNaEtSirAscLAGjn9Ee4w7GNFpFOHzhMaECdO-JB1pBcbrbsUjVKypERjUDpGa3JjC942gGTvHu_-fxNtWpp-YlEqAmi5xvk53YMls_yq2RZg5pWOq4PbVZ_1YlBDJalliWQVGNEq5o2o3zyxhF27Ez-sLjZBZMw1YJhGW8JqPHf1XW9mMvjF714-xwoSYE4hE6x_ml9NCf4Fc5zUcBqsWc0HOsPQFGoMemjVwKpmS6d_CB5cdMgRmfnXEKC9aUZEpkoQAXekO_49nrRSfRCi-wiHndUeXdgO47uuRXO-FS3Xg0H5CGk4bvOsP2cXEJ6At9Je5-dZE9UOjTd-eIX_1GB0brlocA8MpJf0EgYYhDSPHM0GTjiyHicOzmBsQtc6qnK2KSO3RHQmGIBab5GsXILXZfD4jQFUaNOxviRHbKFu9W5nJD-AKUsjbJ_gXPFxl9XsIdcRcpgwMAB_NDnD4YCFHtj7o_c8hP6UmE0prkyzGIHaAlGEh1RXI",
+          "enc": "A256GCM",
+          "iv": "Tc2oppiliezNSF3T",
+          "kid": "vkpeayor2tsxlnxo5vahqz2jee"
+        },
+        "pubKey": {
+          "kid": "vkpeayor2tsxlnxo5vahqz2jee",
+          "kty": "RSA",
+          "alg": "RSA-OAEP",
+          "key_ops": ["encrypt"],
+          "ext": true,
+          "e": "AQAB",
+          "n": "sAoDWJuMdCA99krpVb38RJdHuxxuZQyUxbij4NtmdjIlFXMUWWEVUGcZ7mT3EIvyvVqzjJ6yeNjfvv1G56fwceuxjt8k18OCbQq3ZlxbU8iRtKHpWdfsEGdIukXt0B941DHBXSZ5Hbz4TkFeSIBW_9JKexe2DzLrG1dHJa5N-pxoYulMkOkQqy7WA6rsDQ5HP9FffVFNgqvwuE2QmZ4jXiyXpvrRDReCwVS8r3tKLEKONThhmdlHCdbrnogDNvwWY_Y4WauD-lWfsX31AGM9PFlgmTv7gH2MF_a2O0UIxD0SPvIyF_acKFDd1T2J9DtscpA4RKtjpvgVanB-23WhkQ"
+        },
+        "encSPriKey": {
+          "cty": "b5+jwk+json",
+          "data": "sBW-vz_uX-uNkyJDNUFOnOBN6Qn_Iha2rvzQePtE3nulDEHB9ScUA91c6IClK4P4pCPq-MB_ACG9HMQUOYz0blQ0D9gTCcWETR0gy3htj9DHxXe2zsgtOfm2qp0e43yjg1iQO9dgy3RanLIcEPucv6dxhilKeXh7UtJDo8kgsNWst3OJgPjeI7kGiSUBevDbLS9VfhY2zNv8fXr3svhwcJAWgCYzsR30hfVy6hes1XFD6w5z6VNscRJUfMg7_tVepF1IJG9fU1K_tacjw03cjSy1VdgNw27GdewV8TnL-KLkrAKoTAGeaFS_uWvx9L-z57FfJ_uciKjKUH29N1ie8zY",
+          "enc": "A256GCM",
+          "iv": "vr8E9DQQLs-p0NxY",
+          "kid": "vkpeayor2tsxlnxo5vahqz2jee"
+        },
+        "spubKey": {
+          "kid": "vkpeayor2tsxlnxo5vahqz2jee",
+          "kty": "EC",
+          "alg": "ES256",
+          "key_ops": ["verify"],
+          "ext": true,
+          "crv": "P-256",
+          "x": "J9_RwX_oIOMlSO1_4TmQzz5PHXOslfbRtt5ZVfKlwlc",
+          "y": "nOU_G47Z5ZsIHzmnPJNNjjXmZOOcYQYqownQw9xW_wU"
+        },
+        "createdAt": "2026-04-01T18:14:27Z",
+        "updatedAt": "2026-08-16T10:56:35Z"
+      }
+    ],
+    "vaultAccess": [
+      {
+        "vaultUuid": "wv2hn4jgomxwvfh4oiubyjppym",
+        "accessorType": "user",
+        "accessorUuid": "HVE53ZQITRE4LDVGUZZXPY23PY",
+        "acl": 15730674,
+        "leaseTimeout": 0,
+        "vaultKeySN": 1,
+        "encryptedBy": "vkpeayor2tsxlnxo5vahqz2jee",
+        "encVaultKey": {
+          "cty": "b5+jwk+json",
+          "data": "AsSNVgJJm2Ws3Jte8G_VzURjM5LjH3mI6krva1Nb7FdOyYowjGlCR_2ybTMcGyf2tHKdGq2rNqSWTAH-8dXe3_MtxxR2g0yt6aHzBhnYgilNWXJ5Li4V6kN5csoeBWFyVmNE-GyLk5wKKn3gZqRNYeojzNkfEL8bXKsx4otm-LT1305L5meO_sFeyGp-P5kSKMgjk5luZoSed3m2WRxj6lbwCwK17sq_QBsqAd4QaAUy8P3uh9bd-g91LZQIrrYeNwDhb6sIC-vRujecfiXc4w3VY4sNKPvA5MiqZDXjgr_XiCPDdit5O69v9DRlNUIouA0CpLsSACCIJptjkiAb2Q",
+          "enc": "RSA-OAEP",
+          "kid": "vkpeayor2tsxlnxo5vahqz2jee"
+        }
+      },
+      {
+        "vaultUuid": "d7z3byaorasfq5xixos3tgaddu",
+        "accessorType": "user",
+        "accessorUuid": "HVE53ZQITRE4LDVGUZZXPY23PY",
+        "acl": 2147483647,
+        "leaseTimeout": 0,
+        "vaultKeySN": 1,
+        "encryptedBy": "vkpeayor2tsxlnxo5vahqz2jee",
+        "encVaultKey": {
+          "cty": "b5+jwk+json",
+          "data": "O3qcQnuLaeo4gE0b_RZxrNLsBZPvJ74It3VEkfMjRDEvGPHUZdoIZdnn9u1R3NxcuRPrbdy7PsjjJ5z-T3pwpyf81DR5LDarj5EFwDXI6qEMPO7sM1LxkRLIoiuL4A3OzVVEtyhRfAKM-kufdaDzh23y93bXz3j-p2eOHk385HjMIjlBw95kjWqFeiGKSN5dUKcQdCnMHwEpVgKOiQGT6lqSRnloZQ2YOmX6A2EbgG2pekX1iYb88yZIfaYkyhsgAky5ABc5zF8ptZEYsunCsOvTBl-RwUojQ-grVS76nPsILjzwtfmNHeFxAfxdi1VqSHzrLVOpBUXAZ5-rMJgdQw",
+          "enc": "RSA-OAEP",
+          "kid": "vkpeayor2tsxlnxo5vahqz2jee"
+        }
+      },
+      {
+        "vaultUuid": "d7z3byaorasfq5xixos3tgaddu",
+        "accessorType": "group",
+        "accessorUuid": "3vsps52ae4au7wmr4wshmp2r4m",
+        "acl": 2,
+        "leaseTimeout": 0,
+        "vaultKeySN": 1,
+        "encryptedBy": "3cahzchvndscx5gjm4jdfcxmca",
+        "encVaultKey": {
+          "cty": "b5+jwk+json",
+          "data": "m34lD8MgAtgsydrHxnHvM5lmcLN5qxpBuJHdJOQ6xZusnaRJsy3M7EC_RhKSNUuw0ctSZsTqc96BEO4pPjbn4S1YTBRLG9vW4uGhkAwKF5o_Y4KdsyPysDjA-38wcL1uaW1IcXLRCebmbJ2hCcDTdz3G-XkSfURzwjla-RpxhhqVSC-2n1S44Tr8xMzYlnbVSpGOGdUl6L8kiUabdRoRw-QkhHgWuvG3SMDoM117SP15i79T4YMBtYmVlIiGNSMCKX993B1MgPVRVdoBKoYWCEnJPUnsc8n_VN8hYsC_BchOTenQ63gq6k6zc6ICGeHeief1_3w0L7CxdAWMp3a9lg",
+          "enc": "RSA-OAEP",
+          "kid": "3cahzchvndscx5gjm4jdfcxmca"
+        }
+      },
+      {
+        "vaultUuid": "d7z3byaorasfq5xixos3tgaddu",
+        "accessorType": "group",
+        "accessorUuid": "fqz5jmlrpdnnbjkggqpm5x2d4q",
+        "acl": 2,
+        "leaseTimeout": 0,
+        "vaultKeySN": 1,
+        "encryptedBy": "zb5pkc2oefehd4cxve7linvmri",
+        "encVaultKey": {
+          "cty": "b5+jwk+json",
+          "data": "mhAO8PwLfHaXeKesRRkprXjj5-Z58k_hYmVFXz3KGSG1Naf5fUaw1bH24dGQtoFqacdFG3KrA9WTYfJGB8nHToGIfw3LbgPm9kPBcMkGujVnTKs2fUYqjaT8DlyNqKmJEzQTLTuUdJBBRgibJ5437n7YL9IyYpUTysGzcfk6c9fGwHbGgfzQykfjOv0i1ZFlo86j9Zk4b5z-kztMLbb5our8oOWDCPSKRoRKZook3l3oG2YRvaM1xX3vTYFiIVwDI6N4DN4UrtKsKkjGDcJCQAyriCCut9IwPoreP6VtpTh81BIFT-1WrcBKwNBBqSKSAkTg3ljWSiUWYLljL9N_VQ",
+          "enc": "RSA-OAEP",
+          "kid": "zb5pkc2oefehd4cxve7linvmri"
+        }
+      }
+    ],
+    "memberships": [
+      {
+        "groupUuid": "3vsps52ae4au7wmr4wshmp2r4m",
+        "memberUuid": "HVE53ZQITRE4LDVGUZZXPY23PY",
+        "createdAt": "2026-04-01T18:14:30Z",
+        "updatedAt": "2026-04-01T18:14:30Z",
+        "version": 1,
+        "state": "A",
+        "role": "A",
+        "keyset": {
+          "uuid": "3cahzchvndscx5gjm4jdfcxmca",
+          "encryptedBy": "vkpeayor2tsxlnxo5vahqz2jee",
+          "sn": 1,
+          "encSymKey": {
+            "cty": "b5+jwk+json",
+            "data": "JjNfqBYigQpS1OX1uEsESf3HwJh9o1ljcHo8BC6ZQZb04lkjx5MklESfVaRTX5X37IkGSSss2I9Mm0SJ5vgx-FA1Sq3Js0l40mS-QvQB6JRCuiVxx-gVqYczpJ7yt9t_5-DLOmOG-GkmSwoHOn5XgcOvjybWNlknvwUyaNi4PpEbDIRvYXHweQzvBUWCTPnvTrlsL6_JITd97nDKcUS6No4Vx0UyO1N-3vH96USmB3wVdw3k8ZAnARYhcdLYT9RYojGxOQ2vv8UQThghMG6cxPZbkmCj7I4daFWNspsbccNtUxgy0spLjV9gprbJZzwDBY2jjAi74MEqbIOLwI9Tyg",
+            "enc": "RSA-OAEP",
+            "kid": "vkpeayor2tsxlnxo5vahqz2jee"
+          },
+          "encPriKey": {
+            "cty": "b5+jwk+json",
+            "data": "Q3LXqdfy6Kh4_lsOfPwAK3MzECG5cs9qmCSkLyubN-u87g79jjBZZiKLMPl8BZ-1KM4LTgtlOjDnDluWZIFkXJ78mDfIFJnUbzEds8Mq-UYvbiRap63Rngs6c4Fj2q8UaunjjJWNcqYGhcbmlE0vpkMb-sP1k9jAhs5nPDY9bMWUO4IBcuuGDdyOVcLNZtYFFShKh9xgpVJY-LrOsNgEsNwYYuDZNCGGN6pXn_FgXw63DquwzzIgA9Ofz1w44tpscX8-AqW1yFnILKc8XoSxUwagULmCQpfQtCH3OSqMIwKZWGghvg1LUrqetN78SL-VwRRtLOjl34GZRflN1rsHnqExnL6e5YBQQ_CTSeZ8xOpcfe2TI42jK1s9jyuoEwuJPJky-kPKhyQVNaxn8sEUzNAl0MPOPvrclifnOU_BgXA8s7rrHiC5s4SikkgBB8aBH9942SMVCakNc2icFv3PyA3lyhmQv55YSL-2mEt9F2UXb8SfCAekjQr2Kd4A32rGM0nljjzLMlC3VLgpbKRzkbzh_0acN5yuuR3w-RERiBVDLOErA_HN1l6Kl0BuqCoikRHlJJFB5pQ-KEh_sZBMvtKC7MuL5-rZlsCamS2jsp5KZKAZTkK49UXGsjM17AU-MmWTaTaNkHsKUXFyguU5Nf7JBQ3PG59Z3SH5Me_biAtkpn26p9XNOP7MMLgsGeweqNUMSDOWuOhwFAk-KGt5xsEQr_u3wGPN8XaSG1rLjMlN65gCrPf2ZErZ-LFEJjSu4zJek54Xk_xDay--wEnZ_HcGJiOA7eG6hM9-zEJrmzxRetFnR5tzyeAAtdprkSYEEr4jML0syWT8SrFaHlywrBAUsUdZQ0-NwTTTO7u1xlM_crAD6UJAbI2F2aCchJ4fBOJaLG9mtexumDAFplENaJFJ3iWXyivrDKFzGH60NKSUyTiS1edNghK-0kmk2vEYgY0vXCbtoQFhw7Sh3vLmf09ZL5xcdNSvH6XPkk_dWouZpDRNA-xaWN5mRhEKLyKITTvmUfxpnxFCz63xmV-3tEMc1iDzAuRYCAsiPIUFPz9hAQ4zTxMETQMilhpxUVL6s_lZgXkGNyekAs5R0CW0MhobETswddU-H0gYyx5vn4YTKtbKN66g2Cio9OvEzLc5ACjitve5JGTA9X7LMygKAPyMuE5zuH-Np8gTHpfbNmw0j1wQHj1ZaiQy02zPmW1sQwCE7XhQpnHbNMFvPzPXSsf1MBmoLr5D7DNKhgCCpo2_QLcu-DIIKFktJowBlPi7n72knxsK_p664cGKSg5F_4HSE5jQWNlaZX1hAxQUuaSGGT4pmaxeuVtVUTZ7-BtkBIhKBMBF8cIv0roigS_pp_0CBmF4jHZWIMUKm7_V1pBfuWwe4vsKQA66M7-Y2JexDBqxhq-Nc83rcHdJOifd4ATHmkfXc4F72fsTUqZkE_thUkM7WBRnY1AXqCVITdVVkrgzcKFXyfrI-jrrpRUsNm6nRtB8QgprAUi8nU9Pbqbd5ffKyVz_CqOcK5ldaQnODbFQdouGuYoLk8bWd02EzvRIRDNcaPwKYna0u7IicCt3yygx1zzIQURTTWVz1m26cOAdsYgpfEatryDNEfPakT0QuWX4jKgMlHidnt94l0fnSmeTIMty8ke6Pc7ZKIH1yUJEWpO2D1HdgQz4LsC2KwE8zZQxTUk2aTutAd6dHX3GMkCYqqfX6n8n5AAd6GqeWEJ84QuTSQoYRASiIAwKc-6_CySfcziezIrb7d0EVntPzVYhDDCQjYpuoitsnjiHmT4C5ZGzsvn4s7A0dXCoDVC4vReFpm6kQSjZ2-Ykr9O5Ix-UMIcS3vFmVoFliEphVXsyj6btEe6kY9U_eb20ZpTL7oSuXF-6PWUJSULTWFr9AGpakggn2rlwv4kv0V04hPovkTybZ4gHogfYfGkRlwv3iITrNpTKhoVN8l8agkPaODM5fu7-QdozZA4OpEVKyWiLbj58XtMZu8Hvv2JUOOKpt7TGWpJ0XI4mKh4Whil6C2aEBWLD5lEQxSPaTjUN-xxOVGGZEjj7J-MbCej-Z-JvbLByxQBRzY9RqhwkSZhe24A_HwJIPCWvUAVZAgJb1zu4IjKms_xj_lFSGIcVyA2qbyf0ufmTNSAUJrFui5AgpSh9MfOhwiWFusjXuc2qkLCZhF_WPVATgMEBJxKNfZUVKh_k8h4eLJkZxBk7lX_EFG9Q-RHgNH-nRp6R1PvxCCvlotkE_2Kdxn-iNJVx9mfdZapaiswE4oixHxwESf6Bs3ed",
+            "enc": "A256GCM",
+            "iv": "DXuXsf2AURNUWWY3",
+            "kid": "3cahzchvndscx5gjm4jdfcxmca"
+          },
+          "pubKey": {
+            "kid": "3cahzchvndscx5gjm4jdfcxmca",
+            "kty": "RSA",
+            "alg": "RSA-OAEP",
+            "key_ops": ["encrypt"],
+            "ext": true,
+            "e": "AQAB",
+            "n": "vHbshhRozH0_VdkCeC88-M7MYQUpFhheAJt6LenG3ZEj-adenVoaFkDBqOvKj9YjGy5wilKYIqpfgg4VtBgl-njeXRzHTYhJr31rcgAZtkEo4LMdKnTrWKDQ_foESa7dPJZYvkIwE4zY2Xyaa8Mr803Wg-6IWKdO_mis99YVRgCqr4rqdgeO8CZzk382zffHZ3d3xreJQzKx0Lhrr_sA8qUnDtYABfxkRGmVi3wBpwH_ZvRwnds4BgpgYVEI1n401trbDg2KRedHtPSDkmFnpXanpuMJXPazRGRxQc4iKovAioZFe-4rzTySPcqgAZLB5jeNRq2PPY5bBk8YdALf7Q"
+          }
+        }
+      },
+      {
+        "groupUuid": "fqz5jmlrpdnnbjkggqpm5x2d4q",
+        "memberUuid": "HVE53ZQITRE4LDVGUZZXPY23PY",
+        "createdAt": "2026-04-01T18:14:30Z",
+        "updatedAt": "2026-04-01T18:14:30Z",
+        "version": 1,
+        "state": "A",
+        "role": "A",
+        "keyset": {
+          "uuid": "zb5pkc2oefehd4cxve7linvmri",
+          "encryptedBy": "vkpeayor2tsxlnxo5vahqz2jee",
+          "sn": 1,
+          "encSymKey": {
+            "cty": "b5+jwk+json",
+            "data": "BAYpLgYoRYWVTHdXnkXqJfRMbCRO6Bs41dE9Fv3rEvptyRag6Oxu0ei-q4xdtD4-fMBiyw_YIF6M7eUqOC45Jx2Gn8tkeNddkWTwCRyyi4V0v0aOMH1c3ckeGYKWu5M3Snoz_kQ5YVe9HrUVGwG_FVrFXT9z9yv82QWSv97dh17i_cdHZD_2kmQDsqQV7B8GlYX8R2FFYoJNPowC95x8qoFn7h0JrDNhbS1oOGO18CqBweiHehMyw2EWPZy5xvKV4k5S3vJaFzpZ5rXsQxycK-9qXApHx-_ZFvNs6g6IdSoBX3qsHipMIvrPUXKJ7V11yyNVH-mG-ti5lgKCF7cBPQ",
+            "enc": "RSA-OAEP",
+            "kid": "vkpeayor2tsxlnxo5vahqz2jee"
+          },
+          "encPriKey": {
+            "cty": "b5+jwk+json",
+            "data": "yq5Zp1S7UK0ubGKTgDuvQT8bj33lduZYL-WYObU7KCUzAR41Qaa31kMmt-p61jW3-mQokNqAiIEayoDRlWqVhkRWihonvBM67sbfh2bfyBZWrSb9P8YCO-KbP0VWXVuIIfiN77HEc36BPgxR2n4FZrtsEaHmIfhGzYyjpX0PL6PuOTagRUjKVkN7juz9f4PfV08vRyikmIdRXYR4MMFjPi35qxn2B3RPQMiLGAsvNjCkwRkdQUJTIwjbbWfu3q6M2oELCTr23Ot4crHlBFg5LwrhMRQ0AYrnfjlKc5_xlmgb1S_r1M91roJHp9I4EUpnBTiRa8Aalvp3mJu47FodCjWMFOPlhDwvaDRC3807aEqJkjU2qlMXS9mlJI7QVhWpTbDF3j7s4byj9GkPPL-AvfoUgcroxMPXyRftllg9FJCWLHfHB86seKpM_sYj_vWvOPPUQx-EEXaDNWp3U7lb6v3jkPgd3wjxz8ec8U-u2C4fdlrBePBwKp_ocsR7ZLKhIvCs_A---Dli79yVWeDM4ALWziKAvX9Q7AAX8ZpppTCzMw2SiaFfcpQskCdAWiKmRnicqNxoyDzVCIkz-l6qAHL7NRu2Tp3jX3L4k5uiqb5RUWCoHx2hTcO39aW0jtMFLNyh-1QTRdZkEaG8YwbtJ3o3Rgv-n4iOPiENPhjKZEbjq5DHamgIZ0SfNFZjCTAQXQLSNhHfLxygTEzMfyNsZ4KKHJ7VRbV1h8AOBl5VvdZzHAlAtcgvpEdNANRgLiSv41kqx-urgnIf_FtOJV23Kv6bikh-4OhyxdHBtIDPH54f0vmGQGBigXK5IgQda5TQX0Vtyr_jmhd_kDQlwfaQzKxI8pvPst8uWS0XdjNoF4ZVRxh8HBU4oM3BYms0rwSRNp7QYgPN_DFyn_bSPqJ2DnBkMvPr-IYHzfipiURmeH1zb8GbmEIwVKp8CfaCL-Y29GIWitesKmJy6gMZvOoOtKIGbWXNUB3bfFRZo2eZpv0eAXE6PSKbWFWxslDsmX4sUxqXwQNdYzCK1jfAC69-8OXIHUa0lauTU2VKfjkY9FoiyScQyoeUfoKr-WuOjNfawfd1JGSnJwlReRCU82JyqmFxnQOKdUa7naPCFh9hPXIpV6U_79Ehkw7myhAGRMaXp1bo6C32Y2t7YiDKOfp2y-WYEwJnfKFyO8FPIA6zu54yfoFJnoh19-wisZYFkosDT-e--vkoHGo5d9oPZr8TMTUXdoLkpjD790bRUocTI3hbgxzUiy05lcwfAaIdkIt-lin9jfzqMhcAWwGib507WMDbwhe1U_iJmAR4goTn1aOnikABpeHBwGf0nKLrJsU60knihxzYJYJxuwHUBqnwm8uP2pl4neu3G_PQNVSXz1aJ0oLTYipS2TR9jf2tDY7ORv47r5sQAZI6Afeg-Yc4CzP3YhiKiya1zdoRjUZgvpCQhFpVjNUGju11nyq3ckBxpIEkRXBwco6I_TJBDsaygRKdbh4s7qhstO23jyTido8EgLHIg6osKAgQ7ySpurBIFi1mjTTJSEsurkJM5IgboIIAQ9pQiNtqGML2FMsK6crfkpUGV3pWqvnXccEDz88vKeSDtA5av60CsydKB2aUacH5UzVNVG7VfOXXpoOgS0e3iO9MGu8aB_DPPimoExPY3OL1NtiMiliK7lKdh-U--DzRFVGBi9uLQmYoy1oY5NcTZFlDYQOzrREVya5MwyvDyPQDOIa4qPotUpODj1r2knL0IvQa4yieAYcOdwrPZ_cnVPDEQDlPMEBNYpdXDc5GVacQLSNA2WZLvAC3UwUcu-y6WtEBBK-SjD_JKkI3AZfEAwUwprhKRLfNvLkn5WaTPkqUnr0HhVXkDPwjw5Fkz-cUg7ygH8mXZy0ssrcUan4ARpLNuspY4j-IL5AE5vSGViOaZGGs2AxxM_OVwc9BKNXo75vQrxsj0YTnakz1CYKR5zSDtYbUj7YJawPVDfs79rHm7DPJ78sIo9fgh7ZrTVySMWmYhHE6EWqAmGw40BnaaqrgDPL30r4kfhLTC8f1PCfvU-cNk8rfRB4b2lDFUXy90pMIdAUYiX86SnbDsPsNR_eXcSRaaAYx4fNGilM3w3araxY23t7ARnq_2R5rszljTHftexW9ySVHWOHrLx3q3Q8iihADhBQLCUe_1CLut4RTOHYJW2hyvNK4_Fvf45WjR9eq2AkO73dd-K8bKLOG7HIBwInVjb4D4Fq2betqaTYt3TK7hGBt8l8zU4lP63QwkPgXVsvPi5bvRGcYFg87kQeQ",
+            "enc": "A256GCM",
+            "iv": "IozFE_pB23YNi98x",
+            "kid": "zb5pkc2oefehd4cxve7linvmri"
+          },
+          "pubKey": {
+            "kid": "zb5pkc2oefehd4cxve7linvmri",
+            "kty": "RSA",
+            "alg": "RSA-OAEP",
+            "key_ops": ["encrypt"],
+            "ext": true,
+            "e": "AQAB",
+            "n": "r6sR3Z06WOv1ruXIjPrTG5oIq-e8ffwdbZiks3SK4_pfg7UGAh_WCsDkWeZ8WkvydHvQnl94yg5sNGsV3N-FDXJbvT1DuJhB5e4NjccWTkdZnFppHKtGTDaRnt8AB9XaTeAgzLnYKoHvDiuEQK2DQMXF-MbJDBE2OgI96GxaMxPRXdWsq9q5tBC6O6woZhrmsxBBFqLCqhP_cGkhemKfy5OjLuGJY8otjkEEmKSRtBY31-_Mw9VUxeN4l2knj7rip8EoGfS66HdRqm9DTuehRUph4RUat_1eAtUCBah4u2puvCVb6JhPOkK7-FNm3uKXoGSqtilDNV8e2J-VMoEcmQ"
+          }
+        }
+      }
+    ],
+    "combinedPermissions": 68719476486,
+    "newsletterPrefs": 0,
+    "preferences": 48,
+    "hasMFAEnabled": true
+  },
+  "users": [
+    {
+      "uuid": "HVE53ZQITRE4LDVGUZZXPY23PY",
+      "firstName": "LastPass Ruby",
+      "lastName": "",
+      "name": "LastPass Ruby",
+      "email": "lastpass.ruby+01-april-2026@gmail.com",
+      "avatar": "",
+      "state": "A",
+      "type": "R"
+    }
+  ],
+  "groups": [
+    {
+      "uuid": "54yncirff4iv2qssoafd4glpce",
+      "type": "R",
+      "name": "Recovery",
+      "desc": "Can reset user passwords if account recovery is enabled.",
+      "createdAt": "2026-04-01T18:14:30Z",
+      "updatedAt": "2026-04-01T18:14:29Z",
+      "activeKeysetUuid": "q53e7fdanjpbgjxydpdoqitcry",
+      "attrVersion": 1,
+      "state": "A",
+      "permissions": 4872,
+      "recoveryKeyset": {
+        "uuid": "q53e7fdanjpbgjxydpdoqitcry",
+        "encryptedBy": "q53e7fdanjpbgjxydpdoqitcry",
+        "sn": 1,
+        "encSymKey": {
+          "cty": "b5+jwk+json",
+          "data": "z99j_B60JLZsI-ncwwX90FDU8zQe9atqE2B4ZzepEr_N51Bc0GeMzQEB5EsxH1ePc4gndFS0XVwWcwXESRDdIm55-cjMTYQnHycMiDVSXHwGAGypKWl3Cb-D5Q_UsaxouOnwlOubHV0OgWtZm6NL9-8NPf6HfemZ340pgSJf4i1vKeB6hvX56J2xLNeeDHn2V5fyGaRIMdHBCC1fjMlAsuPZE1jArbqG_QOCakPEon2Snyy4PLi787n6XXVf32wHe1UN-YXBAjw15vBG3e2wNZ4QEdiq8pZf4E5FuDSMvwweGZNaZy8IcS8XPxEigp6Uu1xuxKb3hL4x-3gIx3aQag",
+          "enc": "RSA-OAEP",
+          "kid": "q53e7fdanjpbgjxydpdoqitcry"
+        },
+        "encPriKey": {
+          "cty": "b5+jwk+json",
+          "data": "yEoKa8tj0HpUj_Q-Zsnaq99cvdC71_VLGFh16X_GHdXm1ugOsSgWTZZbY0SOEwiLAlSSsE6einjPcmDR-dkbECIBn8LNOSbkelJmPCWU2_rPHWi_iomjahlZByLY3htw7DZ6ShISMtH7rGU4PEYtWGTQBQjbeyfEHhJ_d_RxsmjPjOVRECta-A5EdLZVvVGfBprNeBTf05UNtjEXkF2yTRaE9ZOCxn5xtLbf0WlLiNTBlVwarEcpW4B5vOhRbvxrcpMgYZ8pNkzOqZodYmXvOF3ugB7GxP5Tn2I37rRizqgoyJ03Wq1Ip1YcusnJcZ_Ksfu4L9qYCIkXLBgVl6faaFIvO0ptdRI3OVdnPT-K4QdhJ5m4ked9krg2RcHGXDBrfQPYTLb0Vc1JPlHnOyD4ahZNstfnOkNS_v93bajcJW3NO8bKHwFmlkg3wSz5ChS-Y0wQOTntxEQsMW_Pk6XX2qXhqJ_Di4q7_7uTelI_5VGGp0YaoWrRXa_sbNwgHNzMM9rtdF_p-ffWaWKuZ2budu0g20Q2_uu8Gwf3LcQ3AEeyfhD_jlJd5weHXPZrjh0H_cRFAnozBhsHsTag5SM2Y5THCTecxtK_RefObiNvwq1dW4TGBG-NxDb6cmBWpzbIdSjvq1dYGi1iXDnT_t4y_6yaZ_q1suPjD3xjSrTUAYvrzwuGTKlqP3578BwjPgNGc01rsxrYcwYbag6jUh8wlN8mjiSEer-ZxowiBzgIuoiOqYEbXOOCp8jBIgIc3R_G3TflbNSXDC5wvB4UX0pKWqT3V1fON3qPltcM-qvZjHtGD4NIpwl76vsojrUZtI0gTCR82cHd5CMaERvuB0Ht765bm_LL6sG_rZDf_BFu5YaYp1vUmIKY0KAHWn4uEBCeuW0QazwTP2MGs6QgHqCmfHoGyL5anpborhp5PGnEex1HEH5ax6CUarPB0kJkc2k3nCMbPDJ1g-RAswwEGO3_AoANFcU9pcMrTyP-K_NdhK9GMUqQAVvXjzbDOTt65CH34VkTDBhnjy5T584J109WrTiEd8Fp3Pg3VexAVH30aJtGnheMF2QtriZkZOWS2VfA3L9Ukj6bF9lvtJAhRvcTLGJ6K8sd-3NKeOmJhezuMw2W7LLHjzzMUxif99hoI3NPnd6ykIrMR2E-Yp69nK_z3s1Y3rdH-_T7YRW7Rvl_Xn-od86vt01MHSP280oclVeHsNhEWTZoAu586AFAed-iSFKNONhzrnm7RBZdrGN0wn8YJygTXQgI8DmTEMr7RNi5hMl5pf_sH1uXp9ob23sl_hn9aFU49xVd7B-C3_eF_Dy-cUObD3BQlJUAzNRQDECqDzuMf4Nn70Rp-4dyTaPL_n__dR_336V9kVw2unXLeA4I-yMTMSxAoUX9hFdwriXbRGZ6THcJ04vZyvLTAMeUTCyIMIia7Xy7UltNFcXGMzS-w5PRh1lDbX4VdUhJV-tAL-ONskUXeai30Ehhf0wIMa6U1B2gw1nv5qVxmkDR_YaR_RrmcGCPAM1J865Jbqbaw7DkkyRMUH6BgeA2ru8h9eF7LpXvkdwrH-jdID4lbAsfJeLFUmjUlDTGbJPup3IReZJP2hSs3yfVB7vOv561Y4vXB20olMHnmPWH15VAJbawjYDSwMBCREeCjMh7EPqY_iK9_-hL-Zu4ELSrdJlTTjMPeqnu4FRlmAPOciBLQBYl1_tQYEA-oh724IFGs-OpnTVLkIXCazk9tNfLpFMNOHzpA-jzOHeZA1jAZqFHg4-MzMIRDTh421F8ixSUWrU-dnap2HwEo9KRshcjRnQ_KtMh_5TtAFwS4tFIa7x39QL_96J-TzL6w76LZHomZ3uxXk20_QiOqVIXjxkQLjz8fQ03v_q29_wSg2uCUj3K72_J-KWM_oDuJY7DMWwz7Cp41qnLk70RVHJImjRjRb28pOvVv1S9aWD7GUmjdvQB5frieZptt6WSkL6f2M44bSHuPxp7SDc7DPftqv3GRrz9mwKcWb2wwkVKiNsZkjO2CWyHz31nElzRl-p5OjtauHdho9asM7WLXIk2PeNDlAOTz5Ogp2Sfbb9lTLGspzQaInxCYBw3iQnRvHw2ODX7PheNGhUEKZxn4yRDWRkzsGkk3OJXzhuKw3m1zm_Fjpiwy24ykSrb_DC71tRWUNPPWPxnv3tPiF8qc7iagzARt_z6OToAjbiIXJCci-8GHfKLML3rjE5tMJ-wSNxin1o7o3LBuiwOkDL7yNDs67HexrgkBIzSx0C1q7gzSIA7kP8FjQkQTkW3",
+          "enc": "A256GCM",
+          "iv": "YVQadLf3sMUx39aj",
+          "kid": "q53e7fdanjpbgjxydpdoqitcry"
+        },
+        "pubKey": {
+          "kid": "q53e7fdanjpbgjxydpdoqitcry",
+          "kty": "RSA",
+          "alg": "RSA-OAEP",
+          "key_ops": ["encrypt"],
+          "ext": true,
+          "e": "AQAB",
+          "n": "62z6cRI7QISiYabaWCv2r9Fy6lQQi_BnrJLIcaHyCKccTe_7Pbl5EsiTnnu4EmOEK0jUVNhvXp7-FUNUg4qyARFy3gFTb3fXieVy49duQG5vXwCVBQHlwe7nmmw1avhDV9HK3S_aCNjNvzJtnjrdz_D9tnQ-CWMxA4IWTYyPUU1MFOoXBaIJzvfDefCyckkoqGwawo_K1CxzUpIYnAWNLRqWUXdAG3dQk5eB-sW7PMUaUyDjoccFPN-I8L3MF8loE3XVQ0SSjKm4FP82cup-RuzYZRZPCb_khiPmZCrCZNXZesV3ryiaUyrcoan_QBrgp7V6Vwv4YgcHB6iBuRzrFQ"
+        }
+      }
+    },
+    {
+      "uuid": "3vsps52ae4au7wmr4wshmp2r4m",
+      "type": "O",
+      "name": "Owners",
+      "desc": "Access to billing and account administration.",
+      "createdAt": "2026-04-01T18:14:30Z",
+      "updatedAt": "2026-04-01T18:14:29Z",
+      "activeKeysetUuid": "3cahzchvndscx5gjm4jdfcxmca",
+      "attrVersion": 1,
+      "state": "A",
+      "permissions": 68719476482,
+      "userMembership": {
+        "groupUuid": "3vsps52ae4au7wmr4wshmp2r4m",
+        "memberUuid": "HVE53ZQITRE4LDVGUZZXPY23PY",
+        "createdAt": "2026-04-01T18:14:30Z",
+        "updatedAt": "2026-04-01T18:14:30Z",
+        "version": 1,
+        "state": "A",
+        "role": "A",
+        "keyset": {
+          "uuid": "3cahzchvndscx5gjm4jdfcxmca",
+          "encryptedBy": "vkpeayor2tsxlnxo5vahqz2jee",
+          "sn": 1,
+          "encSymKey": {
+            "cty": "b5+jwk+json",
+            "data": "JjNfqBYigQpS1OX1uEsESf3HwJh9o1ljcHo8BC6ZQZb04lkjx5MklESfVaRTX5X37IkGSSss2I9Mm0SJ5vgx-FA1Sq3Js0l40mS-QvQB6JRCuiVxx-gVqYczpJ7yt9t_5-DLOmOG-GkmSwoHOn5XgcOvjybWNlknvwUyaNi4PpEbDIRvYXHweQzvBUWCTPnvTrlsL6_JITd97nDKcUS6No4Vx0UyO1N-3vH96USmB3wVdw3k8ZAnARYhcdLYT9RYojGxOQ2vv8UQThghMG6cxPZbkmCj7I4daFWNspsbccNtUxgy0spLjV9gprbJZzwDBY2jjAi74MEqbIOLwI9Tyg",
+            "enc": "RSA-OAEP",
+            "kid": "vkpeayor2tsxlnxo5vahqz2jee"
+          },
+          "encPriKey": {
+            "cty": "b5+jwk+json",
+            "data": "Q3LXqdfy6Kh4_lsOfPwAK3MzECG5cs9qmCSkLyubN-u87g79jjBZZiKLMPl8BZ-1KM4LTgtlOjDnDluWZIFkXJ78mDfIFJnUbzEds8Mq-UYvbiRap63Rngs6c4Fj2q8UaunjjJWNcqYGhcbmlE0vpkMb-sP1k9jAhs5nPDY9bMWUO4IBcuuGDdyOVcLNZtYFFShKh9xgpVJY-LrOsNgEsNwYYuDZNCGGN6pXn_FgXw63DquwzzIgA9Ofz1w44tpscX8-AqW1yFnILKc8XoSxUwagULmCQpfQtCH3OSqMIwKZWGghvg1LUrqetN78SL-VwRRtLOjl34GZRflN1rsHnqExnL6e5YBQQ_CTSeZ8xOpcfe2TI42jK1s9jyuoEwuJPJky-kPKhyQVNaxn8sEUzNAl0MPOPvrclifnOU_BgXA8s7rrHiC5s4SikkgBB8aBH9942SMVCakNc2icFv3PyA3lyhmQv55YSL-2mEt9F2UXb8SfCAekjQr2Kd4A32rGM0nljjzLMlC3VLgpbKRzkbzh_0acN5yuuR3w-RERiBVDLOErA_HN1l6Kl0BuqCoikRHlJJFB5pQ-KEh_sZBMvtKC7MuL5-rZlsCamS2jsp5KZKAZTkK49UXGsjM17AU-MmWTaTaNkHsKUXFyguU5Nf7JBQ3PG59Z3SH5Me_biAtkpn26p9XNOP7MMLgsGeweqNUMSDOWuOhwFAk-KGt5xsEQr_u3wGPN8XaSG1rLjMlN65gCrPf2ZErZ-LFEJjSu4zJek54Xk_xDay--wEnZ_HcGJiOA7eG6hM9-zEJrmzxRetFnR5tzyeAAtdprkSYEEr4jML0syWT8SrFaHlywrBAUsUdZQ0-NwTTTO7u1xlM_crAD6UJAbI2F2aCchJ4fBOJaLG9mtexumDAFplENaJFJ3iWXyivrDKFzGH60NKSUyTiS1edNghK-0kmk2vEYgY0vXCbtoQFhw7Sh3vLmf09ZL5xcdNSvH6XPkk_dWouZpDRNA-xaWN5mRhEKLyKITTvmUfxpnxFCz63xmV-3tEMc1iDzAuRYCAsiPIUFPz9hAQ4zTxMETQMilhpxUVL6s_lZgXkGNyekAs5R0CW0MhobETswddU-H0gYyx5vn4YTKtbKN66g2Cio9OvEzLc5ACjitve5JGTA9X7LMygKAPyMuE5zuH-Np8gTHpfbNmw0j1wQHj1ZaiQy02zPmW1sQwCE7XhQpnHbNMFvPzPXSsf1MBmoLr5D7DNKhgCCpo2_QLcu-DIIKFktJowBlPi7n72knxsK_p664cGKSg5F_4HSE5jQWNlaZX1hAxQUuaSGGT4pmaxeuVtVUTZ7-BtkBIhKBMBF8cIv0roigS_pp_0CBmF4jHZWIMUKm7_V1pBfuWwe4vsKQA66M7-Y2JexDBqxhq-Nc83rcHdJOifd4ATHmkfXc4F72fsTUqZkE_thUkM7WBRnY1AXqCVITdVVkrgzcKFXyfrI-jrrpRUsNm6nRtB8QgprAUi8nU9Pbqbd5ffKyVz_CqOcK5ldaQnODbFQdouGuYoLk8bWd02EzvRIRDNcaPwKYna0u7IicCt3yygx1zzIQURTTWVz1m26cOAdsYgpfEatryDNEfPakT0QuWX4jKgMlHidnt94l0fnSmeTIMty8ke6Pc7ZKIH1yUJEWpO2D1HdgQz4LsC2KwE8zZQxTUk2aTutAd6dHX3GMkCYqqfX6n8n5AAd6GqeWEJ84QuTSQoYRASiIAwKc-6_CySfcziezIrb7d0EVntPzVYhDDCQjYpuoitsnjiHmT4C5ZGzsvn4s7A0dXCoDVC4vReFpm6kQSjZ2-Ykr9O5Ix-UMIcS3vFmVoFliEphVXsyj6btEe6kY9U_eb20ZpTL7oSuXF-6PWUJSULTWFr9AGpakggn2rlwv4kv0V04hPovkTybZ4gHogfYfGkRlwv3iITrNpTKhoVN8l8agkPaODM5fu7-QdozZA4OpEVKyWiLbj58XtMZu8Hvv2JUOOKpt7TGWpJ0XI4mKh4Whil6C2aEBWLD5lEQxSPaTjUN-xxOVGGZEjj7J-MbCej-Z-JvbLByxQBRzY9RqhwkSZhe24A_HwJIPCWvUAVZAgJb1zu4IjKms_xj_lFSGIcVyA2qbyf0ufmTNSAUJrFui5AgpSh9MfOhwiWFusjXuc2qkLCZhF_WPVATgMEBJxKNfZUVKh_k8h4eLJkZxBk7lX_EFG9Q-RHgNH-nRp6R1PvxCCvlotkE_2Kdxn-iNJVx9mfdZapaiswE4oixHxwESf6Bs3ed",
+            "enc": "A256GCM",
+            "iv": "DXuXsf2AURNUWWY3",
+            "kid": "3cahzchvndscx5gjm4jdfcxmca"
+          },
+          "pubKey": {
+            "kid": "3cahzchvndscx5gjm4jdfcxmca",
+            "kty": "RSA",
+            "alg": "RSA-OAEP",
+            "key_ops": ["encrypt"],
+            "ext": true,
+            "e": "AQAB",
+            "n": "vHbshhRozH0_VdkCeC88-M7MYQUpFhheAJt6LenG3ZEj-adenVoaFkDBqOvKj9YjGy5wilKYIqpfgg4VtBgl-njeXRzHTYhJr31rcgAZtkEo4LMdKnTrWKDQ_foESa7dPJZYvkIwE4zY2Xyaa8Mr803Wg-6IWKdO_mis99YVRgCqr4rqdgeO8CZzk382zffHZ3d3xreJQzKx0Lhrr_sA8qUnDtYABfxkRGmVi3wBpwH_ZvRwnds4BgpgYVEI1n401trbDg2KRedHtPSDkmFnpXanpuMJXPazRGRxQc4iKovAioZFe-4rzTySPcqgAZLB5jeNRq2PPY5bBk8YdALf7Q"
+          }
+        }
+      },
+      "recoveryKeyset": {
+        "uuid": "q53e7fdanjpbgjxydpdoqitcry",
+        "encryptedBy": "3cahzchvndscx5gjm4jdfcxmca",
+        "sn": 1,
+        "encSymKey": {
+          "cty": "b5+jwk+json",
+          "data": "upxdDPtyISviCj1BzyK8Lj6YdtJZsxbO9PtTq2RSuLVl_c94QYuKfb8IrSiJ3E3xI8VOMbKZpWIUT_ZuGIeMYfbjcBREeAEJxn8nHIjKmb3DTdCp2BKGk8vXA7ECtqsCCHqQm4AKj3oiAsU0n3CdnMLcjwBaQPhajOyUgu4QUNuf0prhS_AQd_b5D2jQVe1pvIB_Z8NILbQ6eygEDzORCe5t87KNgLyyAyh-BtuIorxt5N9kMR0uY6-86bghGlgsLzhi9B3rBgYwAgVd9O-Jfxodb_nDBDEOW6HvPcCM1IfWl-iJKJChlyjAEyC_5s_dNGOmqad2PKfxcyIQO2IqBw",
+          "enc": "RSA-OAEP",
+          "kid": "3cahzchvndscx5gjm4jdfcxmca"
+        },
+        "encPriKey": {
+          "cty": "b5+jwk+json",
+          "data": "UxUReWA_zRHUH36-4ypAADkjUWnJTynzc9PiHNkToMZlhHcnXpBdgLBM60zii_b9ahSe7mVEmmyxXtSGcPE0INgS2j6Zcl7xefTNc0HkwEHkA9QHWBYsD7vwMVhhrHsYRgqtEnUDgcVIvLPQnkTsD8FDtMkOucwLrcTqBAsrzqf1XCa3ueod6WTGYBOAXFfsu_mRlE0POCXtNNd_XocH_OzsE3FxoKLb87Dxssw6xuY8KT2OsyuHBPwcA9aPbM_2x95HqAkjBeRMCJVOG60Z33tomBwzFyZIFuRyTmcC7wXa67sxODNq-lCfoWJGfM1XM4pEqLv80lQGxmLjJxPO4T3tkj58XiI1neAJ8TA3kCtjL67OQiQOnGYoR2Hmopy03iyj4QAXhB-jsGW3Vjafh_WywU8bcQ7BkfAenmHKauVSqqOGPg3L2CN5zv_Fwa-Agy5BhAxcLTSow2S1eBSScI7aPr26CM7jonJXfuBJYB5EiaMaqtokceFp2LxK6ssfgy86nQjIu-bUVWthJZeZ8idKMrnuEJJ-LYxS2q_SamCV9KAuX2vTujgtNIYm9iOKycbn597LZWlY9XISWodYn8d3pTHQv5_sMPtY5DvWGwrOkuXwOrZlaU-uV5GZjEZNfgL4y4qBUyjQpMY9AxDEvXEEXrZqK73lRHDLlPYJU-qtphaY_dZ4occqAePKnAY3ZzhfBCBzp3vew6VyShhdbrO0jIUPj5lcUW_bad0vjQvmJQtlpFep60qRLRQAlebzgo8ROsK1m1HSYepZv9xf8ffYkM7XtW8Rsv5WEpgbHeKx4b-dzbrljMnumrpHhhWsyOY0OpwhLQj7TW7oUo_T_fm3p6KoMwpmeobM9ZRtC-neaCI4kK0KHGFsW_4DLTg6a-bsQwnqAr1VzSL9Xrocc_UTlbsc_SWuzfRVHLLyI2QXe3pzGb8V_fWJ7g_zhv6AnpUqpiLzO7QxlhXFJoiribMfG_ZKp6oS0DbVqGjNnRH1UGCQCbtoJWbdudEZlt91CRYmvSPloT3den9DYdxI5YxuN4-X-Q5MGadEWmoEXdgc9_HueefuC-z4T4FH84SM4zme1sFkcUWLBjkmlwwavVqZtIxy0vDixqzYUegqXpccHhyXQ9qWDEGgQxKVYxJOULFmxePdLIJbSnbzAc9B7XoMxOcB1hUZ14FeM6FS3-rDhORWlKjCMgrplxPfvmlYTGIC3rNGIpKo6O9huoo6VGU4wUhSsXxYt54pN_W2QIxNe7HcpjKtOprecD7cFmZQ58CgFuLdS--ceCJ-oefJXL6h9twA81u_ZOeBhrPzWx4sacSg9sXWhf2oNc4Ic10HpRudZck8k-v8GW4JnPfzBSdZU_mRgrWblxBH_8xqy9ehPd8x5mFu7UTYx1DoOWLVGiZ0QkwigABajwUEbvLAeQYfCpgQD5NpOC1SUhiceWF16xwk94qMecGxyFRV0nLmtCYsulPctL1xCEp0fq0dcNwNkpMGZMUll4zNVEiXE_QQQD4cskAwLgMF-rhEpZcDz-WJngT6pv4xNG9_T3qg0x9FUG_1djGzDMSb8uSmAWSIXxS8D7-2RIP1vElyV7WHF3WZWgCRzHAoL75B1FH61L-YzkRzZ2qafQNQMuHp5tq4aTEVmqKU-VuHbQ5FGkcpnp7lVby5L3mBwhB3evLP-WYB2l7zGbEATQU0fk6dmTOvXo9oamfnputBH97_VoY_ePQBCT6fHfS9D8cUf1ufeMF6PD4APqJAHwWCVIqi6SSeXwfjDGDWu-0ad41RjBiV9ta3oJbdnETehOOVzyBv37UjtuaGngj799amAfgBBc3LhjOqhxhEn1Xm3OdP97I5uNbi6lI3JVto2kmMz71v316y9ZPFOeKg8TP_PDFty1zakNKUySc6Lu5a4_hMfbcFNt0IBj241MA8BYOScz4YYPX1RPFe7VLjETuSU9yzACTxXR7aYVSAKzfwhKF9Y4OnszHk7a8k9YlavK57uoi1ba7jgw5U0FxzMxovoEMYas1-ogMtCc5QZOl71wIdfaAmDW13Sx3D4FzthzeLP1eAR35eObjWE-zMV1f-83gXmzoEf1vnM2MUu37K2F3UILsYHaIf3dFiZm8OM2PnBrc4HOJG7_eTrlhdVJIu_veZF1L_bqFoT5P02Ocx3ajCCwM_iRpHjkTl76LJq74ObJG2WPGTfzSlHawMeg0aZg4tN6LpAkbulGPULsLjf8TnfSVe-xnXYbiCdSeWSwaoNecRBpvjtEdQIsNjdQLeoq21qGfOQ1R1",
+          "enc": "A256GCM",
+          "iv": "Rj1acEI5cCoFLLEs",
+          "kid": "q53e7fdanjpbgjxydpdoqitcry"
+        },
+        "pubKey": {
+          "kid": "q53e7fdanjpbgjxydpdoqitcry",
+          "kty": "RSA",
+          "alg": "RSA-OAEP",
+          "key_ops": ["encrypt"],
+          "ext": true,
+          "e": "AQAB",
+          "n": "62z6cRI7QISiYabaWCv2r9Fy6lQQi_BnrJLIcaHyCKccTe_7Pbl5EsiTnnu4EmOEK0jUVNhvXp7-FUNUg4qyARFy3gFTb3fXieVy49duQG5vXwCVBQHlwe7nmmw1avhDV9HK3S_aCNjNvzJtnjrdz_D9tnQ-CWMxA4IWTYyPUU1MFOoXBaIJzvfDefCyckkoqGwawo_K1CxzUpIYnAWNLRqWUXdAG3dQk5eB-sW7PMUaUyDjoccFPN-I8L3MF8loE3XVQ0SSjKm4FP82cup-RuzYZRZPCb_khiPmZCrCZNXZesV3ryiaUyrcoan_QBrgp7V6Vwv4YgcHB6iBuRzrFQ"
+        }
+      }
+    },
+    {
+      "uuid": "fqz5jmlrpdnnbjkggqpm5x2d4q",
+      "type": "A",
+      "name": "Administrators",
+      "desc": "Administration of users, groups, and vaults.",
+      "createdAt": "2026-04-01T18:14:30Z",
+      "updatedAt": "2026-04-01T18:14:29Z",
+      "activeKeysetUuid": "zb5pkc2oefehd4cxve7linvmri",
+      "attrVersion": 1,
+      "state": "A",
+      "permissions": 268435204,
+      "userMembership": {
+        "groupUuid": "fqz5jmlrpdnnbjkggqpm5x2d4q",
+        "memberUuid": "HVE53ZQITRE4LDVGUZZXPY23PY",
+        "createdAt": "2026-04-01T18:14:30Z",
+        "updatedAt": "2026-04-01T18:14:30Z",
+        "version": 1,
+        "state": "A",
+        "role": "A",
+        "keyset": {
+          "uuid": "zb5pkc2oefehd4cxve7linvmri",
+          "encryptedBy": "vkpeayor2tsxlnxo5vahqz2jee",
+          "sn": 1,
+          "encSymKey": {
+            "cty": "b5+jwk+json",
+            "data": "BAYpLgYoRYWVTHdXnkXqJfRMbCRO6Bs41dE9Fv3rEvptyRag6Oxu0ei-q4xdtD4-fMBiyw_YIF6M7eUqOC45Jx2Gn8tkeNddkWTwCRyyi4V0v0aOMH1c3ckeGYKWu5M3Snoz_kQ5YVe9HrUVGwG_FVrFXT9z9yv82QWSv97dh17i_cdHZD_2kmQDsqQV7B8GlYX8R2FFYoJNPowC95x8qoFn7h0JrDNhbS1oOGO18CqBweiHehMyw2EWPZy5xvKV4k5S3vJaFzpZ5rXsQxycK-9qXApHx-_ZFvNs6g6IdSoBX3qsHipMIvrPUXKJ7V11yyNVH-mG-ti5lgKCF7cBPQ",
+            "enc": "RSA-OAEP",
+            "kid": "vkpeayor2tsxlnxo5vahqz2jee"
+          },
+          "encPriKey": {
+            "cty": "b5+jwk+json",
+            "data": "yq5Zp1S7UK0ubGKTgDuvQT8bj33lduZYL-WYObU7KCUzAR41Qaa31kMmt-p61jW3-mQokNqAiIEayoDRlWqVhkRWihonvBM67sbfh2bfyBZWrSb9P8YCO-KbP0VWXVuIIfiN77HEc36BPgxR2n4FZrtsEaHmIfhGzYyjpX0PL6PuOTagRUjKVkN7juz9f4PfV08vRyikmIdRXYR4MMFjPi35qxn2B3RPQMiLGAsvNjCkwRkdQUJTIwjbbWfu3q6M2oELCTr23Ot4crHlBFg5LwrhMRQ0AYrnfjlKc5_xlmgb1S_r1M91roJHp9I4EUpnBTiRa8Aalvp3mJu47FodCjWMFOPlhDwvaDRC3807aEqJkjU2qlMXS9mlJI7QVhWpTbDF3j7s4byj9GkPPL-AvfoUgcroxMPXyRftllg9FJCWLHfHB86seKpM_sYj_vWvOPPUQx-EEXaDNWp3U7lb6v3jkPgd3wjxz8ec8U-u2C4fdlrBePBwKp_ocsR7ZLKhIvCs_A---Dli79yVWeDM4ALWziKAvX9Q7AAX8ZpppTCzMw2SiaFfcpQskCdAWiKmRnicqNxoyDzVCIkz-l6qAHL7NRu2Tp3jX3L4k5uiqb5RUWCoHx2hTcO39aW0jtMFLNyh-1QTRdZkEaG8YwbtJ3o3Rgv-n4iOPiENPhjKZEbjq5DHamgIZ0SfNFZjCTAQXQLSNhHfLxygTEzMfyNsZ4KKHJ7VRbV1h8AOBl5VvdZzHAlAtcgvpEdNANRgLiSv41kqx-urgnIf_FtOJV23Kv6bikh-4OhyxdHBtIDPH54f0vmGQGBigXK5IgQda5TQX0Vtyr_jmhd_kDQlwfaQzKxI8pvPst8uWS0XdjNoF4ZVRxh8HBU4oM3BYms0rwSRNp7QYgPN_DFyn_bSPqJ2DnBkMvPr-IYHzfipiURmeH1zb8GbmEIwVKp8CfaCL-Y29GIWitesKmJy6gMZvOoOtKIGbWXNUB3bfFRZo2eZpv0eAXE6PSKbWFWxslDsmX4sUxqXwQNdYzCK1jfAC69-8OXIHUa0lauTU2VKfjkY9FoiyScQyoeUfoKr-WuOjNfawfd1JGSnJwlReRCU82JyqmFxnQOKdUa7naPCFh9hPXIpV6U_79Ehkw7myhAGRMaXp1bo6C32Y2t7YiDKOfp2y-WYEwJnfKFyO8FPIA6zu54yfoFJnoh19-wisZYFkosDT-e--vkoHGo5d9oPZr8TMTUXdoLkpjD790bRUocTI3hbgxzUiy05lcwfAaIdkIt-lin9jfzqMhcAWwGib507WMDbwhe1U_iJmAR4goTn1aOnikABpeHBwGf0nKLrJsU60knihxzYJYJxuwHUBqnwm8uP2pl4neu3G_PQNVSXz1aJ0oLTYipS2TR9jf2tDY7ORv47r5sQAZI6Afeg-Yc4CzP3YhiKiya1zdoRjUZgvpCQhFpVjNUGju11nyq3ckBxpIEkRXBwco6I_TJBDsaygRKdbh4s7qhstO23jyTido8EgLHIg6osKAgQ7ySpurBIFi1mjTTJSEsurkJM5IgboIIAQ9pQiNtqGML2FMsK6crfkpUGV3pWqvnXccEDz88vKeSDtA5av60CsydKB2aUacH5UzVNVG7VfOXXpoOgS0e3iO9MGu8aB_DPPimoExPY3OL1NtiMiliK7lKdh-U--DzRFVGBi9uLQmYoy1oY5NcTZFlDYQOzrREVya5MwyvDyPQDOIa4qPotUpODj1r2knL0IvQa4yieAYcOdwrPZ_cnVPDEQDlPMEBNYpdXDc5GVacQLSNA2WZLvAC3UwUcu-y6WtEBBK-SjD_JKkI3AZfEAwUwprhKRLfNvLkn5WaTPkqUnr0HhVXkDPwjw5Fkz-cUg7ygH8mXZy0ssrcUan4ARpLNuspY4j-IL5AE5vSGViOaZGGs2AxxM_OVwc9BKNXo75vQrxsj0YTnakz1CYKR5zSDtYbUj7YJawPVDfs79rHm7DPJ78sIo9fgh7ZrTVySMWmYhHE6EWqAmGw40BnaaqrgDPL30r4kfhLTC8f1PCfvU-cNk8rfRB4b2lDFUXy90pMIdAUYiX86SnbDsPsNR_eXcSRaaAYx4fNGilM3w3araxY23t7ARnq_2R5rszljTHftexW9ySVHWOHrLx3q3Q8iihADhBQLCUe_1CLut4RTOHYJW2hyvNK4_Fvf45WjR9eq2AkO73dd-K8bKLOG7HIBwInVjb4D4Fq2betqaTYt3TK7hGBt8l8zU4lP63QwkPgXVsvPi5bvRGcYFg87kQeQ",
+            "enc": "A256GCM",
+            "iv": "IozFE_pB23YNi98x",
+            "kid": "zb5pkc2oefehd4cxve7linvmri"
+          },
+          "pubKey": {
+            "kid": "zb5pkc2oefehd4cxve7linvmri",
+            "kty": "RSA",
+            "alg": "RSA-OAEP",
+            "key_ops": ["encrypt"],
+            "ext": true,
+            "e": "AQAB",
+            "n": "r6sR3Z06WOv1ruXIjPrTG5oIq-e8ffwdbZiks3SK4_pfg7UGAh_WCsDkWeZ8WkvydHvQnl94yg5sNGsV3N-FDXJbvT1DuJhB5e4NjccWTkdZnFppHKtGTDaRnt8AB9XaTeAgzLnYKoHvDiuEQK2DQMXF-MbJDBE2OgI96GxaMxPRXdWsq9q5tBC6O6woZhrmsxBBFqLCqhP_cGkhemKfy5OjLuGJY8otjkEEmKSRtBY31-_Mw9VUxeN4l2knj7rip8EoGfS66HdRqm9DTuehRUph4RUat_1eAtUCBah4u2puvCVb6JhPOkK7-FNm3uKXoGSqtilDNV8e2J-VMoEcmQ"
+          }
+        }
+      },
+      "recoveryKeyset": {
+        "uuid": "q53e7fdanjpbgjxydpdoqitcry",
+        "encryptedBy": "zb5pkc2oefehd4cxve7linvmri",
+        "sn": 1,
+        "encSymKey": {
+          "cty": "b5+jwk+json",
+          "data": "D2hoM8o9tM8hBjKlvDpsWqu7HnFrmz62KODt90Dm7lydIVVZwsMmZYSgCwWS-IA9Rd3yVFRKGoEt_kl-6NbhdCfv816AiORW8zzrd8g5ZD-rQxKHrrWDE0AWVkEArRQMGzVzHe4gaGOKFZ9rh5Ka78vdrKuy7038NpZKUQci56KhiPm3C76uskM5L_7fcwkgQlLu-vlmZcJWWfWhYTKqxKNDg4teeV3mwlu9nclkz5q_uifOnmaTPWJe1z9CKi8rsCQOLTq4OdEt_SgtR3n0VlxXFJAmaKlftSA5oCXzt9BNKDTyM-Na3IvQ6VXrIFl3nfpGRtxJB-HsxAAr2NHdKw",
+          "enc": "RSA-OAEP",
+          "kid": "zb5pkc2oefehd4cxve7linvmri"
+        },
+        "encPriKey": {
+          "cty": "b5+jwk+json",
+          "data": "Mwtbj9j4BmnhPym5g5S6rkHUsMAUy-2y2cxWcla7yc6ND5zpYiGcphL3jWFFFtw6kK1rp8pXiMZDgEe3seostwnCrQEEWcQctastUeCd4KcDBdXZQduVh-rTV1g5gD5MJ6SoojkOjrh8ef_ce3kkNFSRQF3q9l6IiLOJi3nV_NVI6ZgEqp8FORhh67fTToRxUAablQ-Cflf7etLQzLx7CH7J-5kMS-wohj-ZG0CdmnnS9mOE12oFXcy9GVqqrrccFqS6X7N3BTbi28TNTFjvaEWdo4xRZXMcUPYWzh3_n-rQLgHBbE2REgclRbWcaPtyfTF4s4B0b5SeOQ1Ce1NRc2-xFLdvwqy6snFCoYuzC8_BDpiXW92rM35DwMu1SCzI-Q8zCkPkbtHcy4PJL2aF5b6IgiSuYjZQLLyxJN4h2lI3_XwYDVQPA2jkNLHykliuLkIoBavUz88R5ea9DKOA67zyBfR9Uc73bsnaffDttOI2pXXfvTCeBDggjVRhviEf--t65VtLnZ6S0IdElUrwq4mybtvQJ9sBp2b3IjyA7B0vQkPZtTfvxesaLYgHkIiSUwa2zNuwgWhhrxsMUrYnDadwdvmdUwOG2MwiXhC88tie7AQXOtMEog3tZyST_WTMrk0nbtM6nf1xyoR7sN6n04zwSgLSI3t8laIP155dpS6jdWVBEjGxMJCS9eOtY9UqUixmBudCydpM2zAAjSEf06g9aXML6TJelaDxORrNlAeMPFRslKOmrWk0dF4CZvuIkClRbRuEUpsEBsJ1leuH1bug_tcsfkx-PjzEfEz1Z0gNbvMVnCQDjGbUZqWVWnzCMcB3qGeeegsE-JUWiO5xUNjqRuwdfjqLZlGSH3y4pkg5bO6pYYFpResZEvjzOpFB830pXX03q-RGSCs2ec851ajKrPjrsyK5SggC6PgU1CHl0EZBRqrHU9rmCyFaY6M3rGet4zA3CeIYI0nMOesykGDTjZLk7MUrsruNnqEhf0H9x7xs7v-hMIL_YxBsS81ShNTtjREBYT1mZRHIFZJwO7PvuoscFiTlATDATd3eJuMciqxrRDMLd2QpyQIP87a_0-kh8bY8reHtr9Hke6rW8JOnaI9bIZsnDLhVZgm1iaC192Uykg8-0wtzNgTNvm98kdbrVkUL50xFOOpV_0IsyPj0Le_29k5ro3vwQZLl3gItAx9w1YzEJ3aEjA_fBmLw6S2IvWcE8tC2NRrUdmbxxkBuyHZHmvrTUGMzXPUIiwTDtvx9mxqig-fuexiddioivYkSRVsp9QWH0yCivDwve41jUdxOnBpLfht-FnB2AxFvg1HRmr_WaL_uvCFXtaopGo3oiNjZfCbzYsw7gSbO13c57FNdHglmWqC5-WaQueQmljXAohGf9pOc60ZunFc1hBWmVRSm66Y8V9z7V9Dao2a0Jd2vVOzUPuh4nJpUeMtcvqYpx_o4IN6XjKvS3BUTctGYbLh_xm-pb4iTM_AKD1IT6Ba2vgla3gHeWjdPnLhH_bkVFC5w0j3iYwGoZz2P_GhskLNPFRpjRvqGIRYAffZhVdC3JCk3ko2qdKytDhAlu96R9x-tjlIXCQytmkgLSAn_6BSrK0qt-O8vTpx0xfuAOaHWiB_lVpkRI-u8tFwBngFmS9SHj8vi0cOj1yD-OXw60pYgjupo-bd7fxwYWe58n6oi3yp5ze0qN86Zs3f9rjAomlDC4V3bfrMsP-pRYme3W2_5JFfxE1lRKbvwvJmSQkPvEN96EaccA_FxYr9wVLSL2dIyk_cnHj0WAJypumTPDZVwg0cUO1TjloAQvQpMAOKSP3m8RgaxuAeF-7Mril0xNqwRMYdw-pDDK_denCmja2BT1qlw6Wi99mbIvgHdcBNUuB1xTHMv9Y0fxEo3SZfEumlgH3EbvkBKhts3RajbwWA0-farlPQ7yQQ2iFu_Tahjpou9OdC7StRkYozrTkB_WyaJ9fJNcwVack1YUkSuqH4x0CUB5eKfcNVcw1mqgMqcW_zCmvF150ML9xcbbsNVpS5YFGUbzEz7DXs9xfIXFlRmW2sLRiqyX3Q3ZW5Hu7WNQtU-JgeFgbC4Zugk8KZ3q9zkjaDTjIOYRIGoGPoFgWNM-byHZD6vIoohNqLXw8RPG7-3v4BfPYGCLaGkcwcv2hIsS4ESri_Vyh-nRvKFQmvrYx1zZXvG--9Ts05FsRUzehzlQ9vasni2JFXT3NaNP72kPrhjzrbJvfR5PKukNZe3xI17mgpDhj7v9Z2IGyW_TL0PvA4m2RmlCKcSkTCx",
+          "enc": "A256GCM",
+          "iv": "JU1PBdldRgZkhMRb",
+          "kid": "q53e7fdanjpbgjxydpdoqitcry"
+        },
+        "pubKey": {
+          "kid": "q53e7fdanjpbgjxydpdoqitcry",
+          "kty": "RSA",
+          "alg": "RSA-OAEP",
+          "key_ops": ["encrypt"],
+          "ext": true,
+          "e": "AQAB",
+          "n": "62z6cRI7QISiYabaWCv2r9Fy6lQQi_BnrJLIcaHyCKccTe_7Pbl5EsiTnnu4EmOEK0jUVNhvXp7-FUNUg4qyARFy3gFTb3fXieVy49duQG5vXwCVBQHlwe7nmmw1avhDV9HK3S_aCNjNvzJtnjrdz_D9tnQ-CWMxA4IWTYyPUU1MFOoXBaIJzvfDefCyckkoqGwawo_K1CxzUpIYnAWNLRqWUXdAG3dQk5eB-sW7PMUaUyDjoccFPN-I8L3MF8loE3XVQ0SSjKm4FP82cup-RuzYZRZPCb_khiPmZCrCZNXZesV3ryiaUyrcoan_QBrgp7V6Vwv4YgcHB6iBuRzrFQ"
+        }
+      }
+    }
+  ],
+  "vaults": [
+    {
+      "uuid": "wv2hn4jgomxwvfh4oiubyjppym",
+      "type": "P",
+      "createdAt": "2026-04-01T18:14:30Z",
+      "updatedAt": "2026-08-31T13:20:30Z",
+      "attrVersion": 1,
+      "contentVersion": 93,
+      "encAttrs": {
+        "cty": "b5+jwk+json",
+        "data": "PhdC7RMZLT0Dmps_yOGoYfwY9vqk7OZ1IsMyqjEcwbuiG3PSHHt-fdlF0GI8RtcpWcoI648BB1k0ZQqulzit6wLb8DQoj6XbYNOewiJObxrXv66niX_MymEe_32ihPjoe0bvYekkdPt-_--pRj4wen8urfxOcwis",
+        "enc": "A256GCM",
+        "iv": "xWreHj5rNMZDPqZM",
+        "kid": "dpukpj4nztvgvjyz4b2p4dzv3m"
+      },
+      "activeKeyUuid": "",
+      "activeItemCount": 1,
+      "clientAccess": 4294967295,
+      "userUUIDs": ["HVE53ZQITRE4LDVGUZZXPY23PY"],
+      "accessorCount": 1,
+      "access": [
+        {
+          "vaultUuid": "",
+          "accessorType": "user",
+          "accessorUuid": "HVE53ZQITRE4LDVGUZZXPY23PY",
+          "acl": 15730674,
+          "leaseTimeout": 0,
+          "vaultKeySN": 1,
+          "encryptedBy": "vkpeayor2tsxlnxo5vahqz2jee",
+          "encVaultKey": {
+            "cty": "b5+jwk+json",
+            "data": "AsSNVgJJm2Ws3Jte8G_VzURjM5LjH3mI6krva1Nb7FdOyYowjGlCR_2ybTMcGyf2tHKdGq2rNqSWTAH-8dXe3_MtxxR2g0yt6aHzBhnYgilNWXJ5Li4V6kN5csoeBWFyVmNE-GyLk5wKKn3gZqRNYeojzNkfEL8bXKsx4otm-LT1305L5meO_sFeyGp-P5kSKMgjk5luZoSed3m2WRxj6lbwCwK17sq_QBsqAd4QaAUy8P3uh9bd-g91LZQIrrYeNwDhb6sIC-vRujecfiXc4w3VY4sNKPvA5MiqZDXjgr_XiCPDdit5O69v9DRlNUIouA0CpLsSACCIJptjkiAb2Q",
+            "enc": "RSA-OAEP",
+            "kid": "vkpeayor2tsxlnxo5vahqz2jee"
+          }
+        }
+      ],
+      "combinedAccess": {
+        "vaultUuid": "wv2hn4jgomxwvfh4oiubyjppym",
+        "accessorType": "user",
+        "accessorUuid": "HVE53ZQITRE4LDVGUZZXPY23PY",
+        "accessVersion": 1,
+        "acl": 15730674,
+        "leaseTimeout": 0,
+        "vaultKeySN": 1,
+        "encryptedBy": "vkpeayor2tsxlnxo5vahqz2jee",
+        "encVaultKey": {
+          "cty": "b5+jwk+json",
+          "data": "AsSNVgJJm2Ws3Jte8G_VzURjM5LjH3mI6krva1Nb7FdOyYowjGlCR_2ybTMcGyf2tHKdGq2rNqSWTAH-8dXe3_MtxxR2g0yt6aHzBhnYgilNWXJ5Li4V6kN5csoeBWFyVmNE-GyLk5wKKn3gZqRNYeojzNkfEL8bXKsx4otm-LT1305L5meO_sFeyGp-P5kSKMgjk5luZoSed3m2WRxj6lbwCwK17sq_QBsqAd4QaAUy8P3uh9bd-g91LZQIrrYeNwDhb6sIC-vRujecfiXc4w3VY4sNKPvA5MiqZDXjgr_XiCPDdit5O69v9DRlNUIouA0CpLsSACCIJptjkiAb2Q",
+          "enc": "RSA-OAEP",
+          "kid": "vkpeayor2tsxlnxo5vahqz2jee"
+        }
+      }
+    },
+    {
+      "uuid": "d7z3byaorasfq5xixos3tgaddu",
+      "type": "U",
+      "createdAt": "2026-08-31T13:07:44Z",
+      "updatedAt": "2026-08-31T20:58:34Z",
+      "attrVersion": 1,
+      "contentVersion": 36,
+      "encAttrs": {
+        "cty": "b5+jwk+json",
+        "data": "X_4MwOIygdUsqpwtJg1iLI3Ua4dsrOFXWf93Z5_Xj-rNgbAgGFpFmpAGlNuXUyEgwgX2sLvWC1HMtbd2p_ZX9CtxCsrIRH8i1Lei_X-ke92w9bhJMRDPrWzvgs8kVgbsQyR6Hx70r4VUufN_yzN68dFL4X_T-w-5m-kgxwlwKAabX6uXKOqKYsWw7fkzZ3tvclOwW3Lw0eP9yPmBAkcrWNxtlN4wRWH77SvhjNkvUL-4ZQ",
+        "enc": "A256GCM",
+        "iv": "UOZ5kzMibXZC88dp",
+        "kid": "er2hz3idctundugolb6xi3znii"
+      },
+      "activeKeyUuid": "",
+      "activeItemCount": 27,
+      "clientAccess": 4294967295,
+      "userUUIDs": ["HVE53ZQITRE4LDVGUZZXPY23PY"],
+      "accessorCount": 1,
+      "access": [
+        {
+          "vaultUuid": "",
+          "accessorType": "user",
+          "accessorUuid": "HVE53ZQITRE4LDVGUZZXPY23PY",
+          "acl": 2147483647,
+          "leaseTimeout": 0,
+          "vaultKeySN": 1,
+          "encryptedBy": "vkpeayor2tsxlnxo5vahqz2jee",
+          "encVaultKey": {
+            "cty": "b5+jwk+json",
+            "data": "O3qcQnuLaeo4gE0b_RZxrNLsBZPvJ74It3VEkfMjRDEvGPHUZdoIZdnn9u1R3NxcuRPrbdy7PsjjJ5z-T3pwpyf81DR5LDarj5EFwDXI6qEMPO7sM1LxkRLIoiuL4A3OzVVEtyhRfAKM-kufdaDzh23y93bXz3j-p2eOHk385HjMIjlBw95kjWqFeiGKSN5dUKcQdCnMHwEpVgKOiQGT6lqSRnloZQ2YOmX6A2EbgG2pekX1iYb88yZIfaYkyhsgAky5ABc5zF8ptZEYsunCsOvTBl-RwUojQ-grVS76nPsILjzwtfmNHeFxAfxdi1VqSHzrLVOpBUXAZ5-rMJgdQw",
+            "enc": "RSA-OAEP",
+            "kid": "vkpeayor2tsxlnxo5vahqz2jee"
+          }
+        },
+        {
+          "vaultUuid": "",
+          "accessorType": "group",
+          "accessorUuid": "3vsps52ae4au7wmr4wshmp2r4m",
+          "acl": 2,
+          "leaseTimeout": 0,
+          "vaultKeySN": 1,
+          "encryptedBy": "3cahzchvndscx5gjm4jdfcxmca",
+          "encVaultKey": {
+            "cty": "b5+jwk+json",
+            "data": "m34lD8MgAtgsydrHxnHvM5lmcLN5qxpBuJHdJOQ6xZusnaRJsy3M7EC_RhKSNUuw0ctSZsTqc96BEO4pPjbn4S1YTBRLG9vW4uGhkAwKF5o_Y4KdsyPysDjA-38wcL1uaW1IcXLRCebmbJ2hCcDTdz3G-XkSfURzwjla-RpxhhqVSC-2n1S44Tr8xMzYlnbVSpGOGdUl6L8kiUabdRoRw-QkhHgWuvG3SMDoM117SP15i79T4YMBtYmVlIiGNSMCKX993B1MgPVRVdoBKoYWCEnJPUnsc8n_VN8hYsC_BchOTenQ63gq6k6zc6ICGeHeief1_3w0L7CxdAWMp3a9lg",
+            "enc": "RSA-OAEP",
+            "kid": "3cahzchvndscx5gjm4jdfcxmca"
+          }
+        },
+        {
+          "vaultUuid": "",
+          "accessorType": "group",
+          "accessorUuid": "fqz5jmlrpdnnbjkggqpm5x2d4q",
+          "acl": 2,
+          "leaseTimeout": 0,
+          "vaultKeySN": 1,
+          "encryptedBy": "zb5pkc2oefehd4cxve7linvmri",
+          "encVaultKey": {
+            "cty": "b5+jwk+json",
+            "data": "mhAO8PwLfHaXeKesRRkprXjj5-Z58k_hYmVFXz3KGSG1Naf5fUaw1bH24dGQtoFqacdFG3KrA9WTYfJGB8nHToGIfw3LbgPm9kPBcMkGujVnTKs2fUYqjaT8DlyNqKmJEzQTLTuUdJBBRgibJ5437n7YL9IyYpUTysGzcfk6c9fGwHbGgfzQykfjOv0i1ZFlo86j9Zk4b5z-kztMLbb5our8oOWDCPSKRoRKZook3l3oG2YRvaM1xX3vTYFiIVwDI6N4DN4UrtKsKkjGDcJCQAyriCCut9IwPoreP6VtpTh81BIFT-1WrcBKwNBBqSKSAkTg3ljWSiUWYLljL9N_VQ",
+            "enc": "RSA-OAEP",
+            "kid": "zb5pkc2oefehd4cxve7linvmri"
+          }
+        }
+      ],
+      "combinedAccess": {
+        "vaultUuid": "d7z3byaorasfq5xixos3tgaddu",
+        "accessorType": "user",
+        "accessorUuid": "HVE53ZQITRE4LDVGUZZXPY23PY",
+        "accessVersion": 5,
+        "acl": 2147483647,
+        "leaseTimeout": 0,
+        "vaultKeySN": 1,
+        "encryptedBy": "vkpeayor2tsxlnxo5vahqz2jee",
+        "encVaultKey": {
+          "cty": "b5+jwk+json",
+          "data": "O3qcQnuLaeo4gE0b_RZxrNLsBZPvJ74It3VEkfMjRDEvGPHUZdoIZdnn9u1R3NxcuRPrbdy7PsjjJ5z-T3pwpyf81DR5LDarj5EFwDXI6qEMPO7sM1LxkRLIoiuL4A3OzVVEtyhRfAKM-kufdaDzh23y93bXz3j-p2eOHk385HjMIjlBw95kjWqFeiGKSN5dUKcQdCnMHwEpVgKOiQGT6lqSRnloZQ2YOmX6A2EbgG2pekX1iYb88yZIfaYkyhsgAky5ABc5zF8ptZEYsunCsOvTBl-RwUojQ-grVS76nPsILjzwtfmNHeFxAfxdi1VqSHzrLVOpBUXAZ5-rMJgdQw",
+          "enc": "RSA-OAEP",
+          "kid": "vkpeayor2tsxlnxo5vahqz2jee"
+        }
+      }
+    }
+  ],
+  "tier": {
+    "tierId": 8,
+    "name": "20160727_i_standard",
+    "successorTierName": null,
+    "accountType": "I",
+    "isPublic": true,
+    "sortOrder": 100,
+    "trialDays": 14,
+    "backupDays": 365,
+    "guestsIncluded": 0,
+    "maxGuests": 0,
+    "membersIncluded": 1,
+    "maxMembers": 0,
+    "minQuantity": 1,
+    "storagePerAccount": 0,
+    "storagePerUser": 1024,
+    "marketingText": {
+      "defaultPriceDisplayFrequency": "Y",
+      "localizedFeatures": [
+        {
+          "title": "Title 1",
+          "desc": "Password generator"
+        },
+        {
+          "title": "Title 2",
+          "desc": "Login autofill and sharing"
+        },
+        {
+          "title": "Title 3",
+          "desc": "Use on all of your devices"
+        },
+        {
+          "title": "Title 4",
+          "desc": "Watchtower security breach checker"
+        },
+        {
+          "title": "Title 5",
+          "desc": "Friendly, 24/7 support"
+        }
+      ],
+      "name": "Individual",
+      "viewDetailsURL": "https://1password.com/pricing?currency=usd"
+    },
+    "features": [
+      "itemSharingFiles",
+      "deferActiveUserSubscriptionDowngrade",
+      "integrationHubUserManagedServiceAccounts",
+      "automatedQuest",
+      "integrationHubEmailAlias",
+      "serviceAccounts",
+      "shareService",
+      "phantomIntegration"
+    ],
+    "gatedFeatures": [],
+    "plans": [
+      {
+        "frequency": "Y",
+        "sortOrder": 3,
+        "stripePlanUid": "price_1SPsIEHBax7L5HDfbtrKUdPB",
+        "currency": "USD",
+        "display": {
+          "currency": "USD",
+          "amount": 4788,
+          "isPerUser": false,
+          "monthlyRate": "3.99",
+          "priceDescription": "per month//billed annually"
+        },
+        "marketingText": {
+          "currency": "",
+          "monthlyRate": "",
+          "priceDescription": ""
+        }
+      },
+      {
+        "frequency": "M",
+        "sortOrder": 4,
+        "stripePlanUid": "price_1SPsIsHBax7L5HDfaAUPNkZc",
+        "currency": "USD",
+        "display": {
+          "currency": "USD",
+          "amount": 499,
+          "isPerUser": false,
+          "monthlyRate": "4.99",
+          "priceDescription": "per month//billed monthly"
+        },
+        "marketingText": {
+          "currency": "",
+          "monthlyRate": "",
+          "priceDescription": ""
+        }
+      }
+    ],
+    "tierChangeRestrictions": []
+  },
+  "userFlags": {
+    "hasPackages": false,
+    "hasNativeClient": true,
+    "hasNonSafariClient": true,
+    "hasMspConsoleAccess": false,
+    "mustMigrate": false
+  },
+  "billing": {
+    "trialStartedAt": "2026-04-01T18:14:26.599046Z",
+    "trialDays": 14,
+    "status": "F",
+    "provider": "U",
+    "freezesAt": "2026-04-16T04:00:37.385241Z",
+    "isUbpEnrolled": true,
+    "members": 1,
+    "guests": 0,
+    "settings": {}
+  },
+  "invite": {
+    "inviteSecret": "V7LCITMYLJGTFHRW5GCV2FFLC4"
+  },
+  "counts": {
+    "users": 1,
+    "vaults": 2,
+    "groups": 3,
+    "invitations": 0,
+    "activeGuests": 0,
+    "activeUsers": 1,
+    "activeManagedAccounts": 0
+  }
+}

--- a/crates/bitwarden-importers/src/importers/onepassword/fixtures/keysets-response.json
+++ b/crates/bitwarden-importers/src/importers/onepassword/fixtures/keysets-response.json
@@ -1,0 +1,134 @@
+{
+  "version": 12,
+  "keysets": [
+    {
+      "uuid": "vkpeayor2tsxlnxo5vahqz2jee",
+      "encryptedBy": "mp",
+      "sn": 1,
+      "encSymKey": {
+        "alg": "PBES2g-HS256",
+        "cty": "b5+jwk+json",
+        "data": "EUfHdnMpEmywEzVw4su5eG4uvrnKM7_Hj_8sdDA_B27uqSByjJLRXYRNfEL-p2LvFN-3tTP7y_AX7wBLix9NEJDP-1Tgo82fPWVyJ1ORwhc00Nr8j7-DqprT2wA3d-Tpkw-rk-S1qgkMFOpiT0ld1G6QuNcc1nYrG0VyrHwww9s2vF_lueB6989DlLIBZp2hHKAJ0EP1-A7Sb1dBj7e00DPe6lfsZQjP3iI0ybI",
+        "enc": "A256GCM",
+        "iv": "Lfa_bA7rzDNghfia",
+        "kid": "mp",
+        "p2c": 650000,
+        "p2s": "huA1o3xP4Sl29ZbV-ABRBQ"
+      },
+      "encPriKey": {
+        "cty": "b5+jwk+json",
+        "data": "UQ5vfuZe32o_EGsoW2eqMmAOdPS-5LME2LBkKTizId9AkX7Ps8Q0X495LshVGtgervxwwjNESgZD_6qUfo070y4uA6cwMCXbU_YzAE-JJNvLHFcnGgdu2XqD7D_EwpW0CoCWcVSs66uTltVzR_MXl_uWAOTtbJrK1pbiZG_sP3l2CT0z8fzcI_nSKN-UbOp-biuTYDT_UPByEcZIqQP3FrB0uFOAHt80IDhsHnPEW4bZC9A4UzlrsGlIj2oc7hmcpuOabvqAxztBUIhwMKrcqR-lgDJyXH9NXX-Bi3FQbG3hgYg7auCfPuSddhoLjo6TeD6eEMvfH5WJtzfA74ygiQ0Ak9OUtsBplbDYY2fwfl9iGz8GgJAHqHV5dQcRXYsigwHpZaanVT7oPH_MLV2f85LHOK1KSTIHObrkhPGymzG3ChgfHvNTouG4soKU5-OxD7g5RgdJH564FedcsEBsCsLyDzwTg1auBpRIM7DD7Gc2HD8iKnbk3vGH0KXg4qvNbLEKQXB59oNCIapN-Bf45bP32zIVhNLJ9jwyjnEnMysktdwSqMsOmSiAX1Jw4QuB1Br6XsMXaaEJ6hBOzMCSxQuylZy2wu6QbZo9KwWeMYlRVcSIAac-2xp0t8wAd6dPu6kpGosa8rg8rUBTpakQ67IWBNaMIv90zFRPZs8Y3Bl-RZanJZIoPMBOkZ-nuDtK3VwYawK5jtSeTrgcH1yNGWbSU7y_5La_iLddvWVLGF-NOGVOXmJvgAOsQv2Vmimvpwz8Pm3EmWcIPVdQd3c2zce-y6mwrhn17gUFU0DX9TW5O3vMkmr3HbfS5PnV6mdzsgr8zg7nKiwew1kcw61FDi-VmzJC-t8wBa8yW2Ut7uzdrRnmKE6x4-XhNCp9uq7_mJW-jTIk1rOQc0xt1yJo8TXU3JrSkl6ODgHijL1N4puvVdW2sYsjYympSMIiGFMB_-KbTY6eEvhE8AcTYtkHLNBIpM3GGyTk-Dg6IrzQ3dzvuxcJYP5IpmDrPlAu0EnlUtvKrcnjgHN0HX3NIwnKbOmfQePllZO1I_LLAfq3JEO_iPoX1t0rd4FSatQ4UgvVA-2EEaYaqaOLFiDC87nhfEF4M5CxF8mQa1UDg6w41oT_sgQWVLZPc6yTioQwtxRu2zFpTSBjOlpbp6GcOX8ZmjsWov2LIYDN8I3tYGyAV6cg8EltguaMm2k-m2KkeJx8OACMhqwoOaA6rY5Wl0tjz_rn_8d2Z62RoXPE9GLyMZqKRaIuTBjjd9VcYjOGPecO4vIoa2qkPTMaewTSA1PNtNR-xoe7_rFwkhneQmEIWfyFJQPhzvGjWw1NzHJ3PZHKV2T4ReQzDyvNpWCeVB8HD1rt6QQj2p3As3WZo8ohQ04jHXUIQ6f2yIBCo_1hXyjbyvIdksNzj_O2noAJkPd7vHjV5qDL5oDuk8VQpMQJJGA40qutbXgEGL_Vm_u11tPMciY8jwn6KM3_XI0Z_F6OtfYy2bAo7q2nHULXhVAxjItuRUH6VocwoqqJQxQ2Wo6AVb_upW1tUXD1hlxinntku5SQjcCbH7arWjvE6tok8geDQujJAlnN8E7kJiZOuB5jOjEwLS-xxcArj3VXMFZepzYW7JlV_ZppAwA-x72_jdQTPaJzRXKwZ2fc0-S6aSweOMEX54dn9UcaSKljeU2ILMJI5oqgGVELeKiuTWVgCiIvP6YzloViotfm0Q3jMcsSMWxVzE_-zTmO-xXxcSccaRgN5QNDXoSgpsFcr5Rn15jb1ADLwwg9AnzNaEtSirAscLAGjn9Ee4w7GNFpFOHzhMaECdO-JB1pBcbrbsUjVKypERjUDpGa3JjC942gGTvHu_-fxNtWpp-YlEqAmi5xvk53YMls_yq2RZg5pWOq4PbVZ_1YlBDJalliWQVGNEq5o2o3zyxhF27Ez-sLjZBZMw1YJhGW8JqPHf1XW9mMvjF714-xwoSYE4hE6x_ml9NCf4Fc5zUcBqsWc0HOsPQFGoMemjVwKpmS6d_CB5cdMgRmfnXEKC9aUZEpkoQAXekO_49nrRSfRCi-wiHndUeXdgO47uuRXO-FS3Xg0H5CGk4bvOsP2cXEJ6At9Je5-dZE9UOjTd-eIX_1GB0brlocA8MpJf0EgYYhDSPHM0GTjiyHicOzmBsQtc6qnK2KSO3RHQmGIBab5GsXILXZfD4jQFUaNOxviRHbKFu9W5nJD-AKUsjbJ_gXPFxl9XsIdcRcpgwMAB_NDnD4YCFHtj7o_c8hP6UmE0prkyzGIHaAlGEh1RXI",
+        "enc": "A256GCM",
+        "iv": "Tc2oppiliezNSF3T",
+        "kid": "vkpeayor2tsxlnxo5vahqz2jee"
+      },
+      "pubKey": {
+        "kid": "vkpeayor2tsxlnxo5vahqz2jee",
+        "kty": "RSA",
+        "alg": "RSA-OAEP",
+        "key_ops": ["encrypt"],
+        "ext": true,
+        "e": "AQAB",
+        "n": "sAoDWJuMdCA99krpVb38RJdHuxxuZQyUxbij4NtmdjIlFXMUWWEVUGcZ7mT3EIvyvVqzjJ6yeNjfvv1G56fwceuxjt8k18OCbQq3ZlxbU8iRtKHpWdfsEGdIukXt0B941DHBXSZ5Hbz4TkFeSIBW_9JKexe2DzLrG1dHJa5N-pxoYulMkOkQqy7WA6rsDQ5HP9FffVFNgqvwuE2QmZ4jXiyXpvrRDReCwVS8r3tKLEKONThhmdlHCdbrnogDNvwWY_Y4WauD-lWfsX31AGM9PFlgmTv7gH2MF_a2O0UIxD0SPvIyF_acKFDd1T2J9DtscpA4RKtjpvgVanB-23WhkQ"
+      },
+      "encSPriKey": {
+        "cty": "b5+jwk+json",
+        "data": "sBW-vz_uX-uNkyJDNUFOnOBN6Qn_Iha2rvzQePtE3nulDEHB9ScUA91c6IClK4P4pCPq-MB_ACG9HMQUOYz0blQ0D9gTCcWETR0gy3htj9DHxXe2zsgtOfm2qp0e43yjg1iQO9dgy3RanLIcEPucv6dxhilKeXh7UtJDo8kgsNWst3OJgPjeI7kGiSUBevDbLS9VfhY2zNv8fXr3svhwcJAWgCYzsR30hfVy6hes1XFD6w5z6VNscRJUfMg7_tVepF1IJG9fU1K_tacjw03cjSy1VdgNw27GdewV8TnL-KLkrAKoTAGeaFS_uWvx9L-z57FfJ_uciKjKUH29N1ie8zY",
+        "enc": "A256GCM",
+        "iv": "vr8E9DQQLs-p0NxY",
+        "kid": "vkpeayor2tsxlnxo5vahqz2jee"
+      },
+      "spubKey": {
+        "kid": "vkpeayor2tsxlnxo5vahqz2jee",
+        "kty": "EC",
+        "alg": "ES256",
+        "key_ops": ["verify"],
+        "ext": true,
+        "crv": "P-256",
+        "x": "J9_RwX_oIOMlSO1_4TmQzz5PHXOslfbRtt5ZVfKlwlc",
+        "y": "nOU_G47Z5ZsIHzmnPJNNjjXmZOOcYQYqownQw9xW_wU"
+      }
+    },
+    {
+      "uuid": "3cahzchvndscx5gjm4jdfcxmca",
+      "encryptedBy": "vkpeayor2tsxlnxo5vahqz2jee",
+      "sn": 1,
+      "encSymKey": {
+        "cty": "b5+jwk+json",
+        "data": "JjNfqBYigQpS1OX1uEsESf3HwJh9o1ljcHo8BC6ZQZb04lkjx5MklESfVaRTX5X37IkGSSss2I9Mm0SJ5vgx-FA1Sq3Js0l40mS-QvQB6JRCuiVxx-gVqYczpJ7yt9t_5-DLOmOG-GkmSwoHOn5XgcOvjybWNlknvwUyaNi4PpEbDIRvYXHweQzvBUWCTPnvTrlsL6_JITd97nDKcUS6No4Vx0UyO1N-3vH96USmB3wVdw3k8ZAnARYhcdLYT9RYojGxOQ2vv8UQThghMG6cxPZbkmCj7I4daFWNspsbccNtUxgy0spLjV9gprbJZzwDBY2jjAi74MEqbIOLwI9Tyg",
+        "enc": "RSA-OAEP",
+        "kid": "vkpeayor2tsxlnxo5vahqz2jee"
+      },
+      "encPriKey": {
+        "cty": "b5+jwk+json",
+        "data": "Q3LXqdfy6Kh4_lsOfPwAK3MzECG5cs9qmCSkLyubN-u87g79jjBZZiKLMPl8BZ-1KM4LTgtlOjDnDluWZIFkXJ78mDfIFJnUbzEds8Mq-UYvbiRap63Rngs6c4Fj2q8UaunjjJWNcqYGhcbmlE0vpkMb-sP1k9jAhs5nPDY9bMWUO4IBcuuGDdyOVcLNZtYFFShKh9xgpVJY-LrOsNgEsNwYYuDZNCGGN6pXn_FgXw63DquwzzIgA9Ofz1w44tpscX8-AqW1yFnILKc8XoSxUwagULmCQpfQtCH3OSqMIwKZWGghvg1LUrqetN78SL-VwRRtLOjl34GZRflN1rsHnqExnL6e5YBQQ_CTSeZ8xOpcfe2TI42jK1s9jyuoEwuJPJky-kPKhyQVNaxn8sEUzNAl0MPOPvrclifnOU_BgXA8s7rrHiC5s4SikkgBB8aBH9942SMVCakNc2icFv3PyA3lyhmQv55YSL-2mEt9F2UXb8SfCAekjQr2Kd4A32rGM0nljjzLMlC3VLgpbKRzkbzh_0acN5yuuR3w-RERiBVDLOErA_HN1l6Kl0BuqCoikRHlJJFB5pQ-KEh_sZBMvtKC7MuL5-rZlsCamS2jsp5KZKAZTkK49UXGsjM17AU-MmWTaTaNkHsKUXFyguU5Nf7JBQ3PG59Z3SH5Me_biAtkpn26p9XNOP7MMLgsGeweqNUMSDOWuOhwFAk-KGt5xsEQr_u3wGPN8XaSG1rLjMlN65gCrPf2ZErZ-LFEJjSu4zJek54Xk_xDay--wEnZ_HcGJiOA7eG6hM9-zEJrmzxRetFnR5tzyeAAtdprkSYEEr4jML0syWT8SrFaHlywrBAUsUdZQ0-NwTTTO7u1xlM_crAD6UJAbI2F2aCchJ4fBOJaLG9mtexumDAFplENaJFJ3iWXyivrDKFzGH60NKSUyTiS1edNghK-0kmk2vEYgY0vXCbtoQFhw7Sh3vLmf09ZL5xcdNSvH6XPkk_dWouZpDRNA-xaWN5mRhEKLyKITTvmUfxpnxFCz63xmV-3tEMc1iDzAuRYCAsiPIUFPz9hAQ4zTxMETQMilhpxUVL6s_lZgXkGNyekAs5R0CW0MhobETswddU-H0gYyx5vn4YTKtbKN66g2Cio9OvEzLc5ACjitve5JGTA9X7LMygKAPyMuE5zuH-Np8gTHpfbNmw0j1wQHj1ZaiQy02zPmW1sQwCE7XhQpnHbNMFvPzPXSsf1MBmoLr5D7DNKhgCCpo2_QLcu-DIIKFktJowBlPi7n72knxsK_p664cGKSg5F_4HSE5jQWNlaZX1hAxQUuaSGGT4pmaxeuVtVUTZ7-BtkBIhKBMBF8cIv0roigS_pp_0CBmF4jHZWIMUKm7_V1pBfuWwe4vsKQA66M7-Y2JexDBqxhq-Nc83rcHdJOifd4ATHmkfXc4F72fsTUqZkE_thUkM7WBRnY1AXqCVITdVVkrgzcKFXyfrI-jrrpRUsNm6nRtB8QgprAUi8nU9Pbqbd5ffKyVz_CqOcK5ldaQnODbFQdouGuYoLk8bWd02EzvRIRDNcaPwKYna0u7IicCt3yygx1zzIQURTTWVz1m26cOAdsYgpfEatryDNEfPakT0QuWX4jKgMlHidnt94l0fnSmeTIMty8ke6Pc7ZKIH1yUJEWpO2D1HdgQz4LsC2KwE8zZQxTUk2aTutAd6dHX3GMkCYqqfX6n8n5AAd6GqeWEJ84QuTSQoYRASiIAwKc-6_CySfcziezIrb7d0EVntPzVYhDDCQjYpuoitsnjiHmT4C5ZGzsvn4s7A0dXCoDVC4vReFpm6kQSjZ2-Ykr9O5Ix-UMIcS3vFmVoFliEphVXsyj6btEe6kY9U_eb20ZpTL7oSuXF-6PWUJSULTWFr9AGpakggn2rlwv4kv0V04hPovkTybZ4gHogfYfGkRlwv3iITrNpTKhoVN8l8agkPaODM5fu7-QdozZA4OpEVKyWiLbj58XtMZu8Hvv2JUOOKpt7TGWpJ0XI4mKh4Whil6C2aEBWLD5lEQxSPaTjUN-xxOVGGZEjj7J-MbCej-Z-JvbLByxQBRzY9RqhwkSZhe24A_HwJIPCWvUAVZAgJb1zu4IjKms_xj_lFSGIcVyA2qbyf0ufmTNSAUJrFui5AgpSh9MfOhwiWFusjXuc2qkLCZhF_WPVATgMEBJxKNfZUVKh_k8h4eLJkZxBk7lX_EFG9Q-RHgNH-nRp6R1PvxCCvlotkE_2Kdxn-iNJVx9mfdZapaiswE4oixHxwESf6Bs3ed",
+        "enc": "A256GCM",
+        "iv": "DXuXsf2AURNUWWY3",
+        "kid": "3cahzchvndscx5gjm4jdfcxmca"
+      },
+      "pubKey": {
+        "kid": "3cahzchvndscx5gjm4jdfcxmca",
+        "kty": "RSA",
+        "alg": "RSA-OAEP",
+        "key_ops": ["encrypt"],
+        "ext": true,
+        "e": "AQAB",
+        "n": "vHbshhRozH0_VdkCeC88-M7MYQUpFhheAJt6LenG3ZEj-adenVoaFkDBqOvKj9YjGy5wilKYIqpfgg4VtBgl-njeXRzHTYhJr31rcgAZtkEo4LMdKnTrWKDQ_foESa7dPJZYvkIwE4zY2Xyaa8Mr803Wg-6IWKdO_mis99YVRgCqr4rqdgeO8CZzk382zffHZ3d3xreJQzKx0Lhrr_sA8qUnDtYABfxkRGmVi3wBpwH_ZvRwnds4BgpgYVEI1n401trbDg2KRedHtPSDkmFnpXanpuMJXPazRGRxQc4iKovAioZFe-4rzTySPcqgAZLB5jeNRq2PPY5bBk8YdALf7Q"
+      }
+    },
+    {
+      "uuid": "zb5pkc2oefehd4cxve7linvmri",
+      "encryptedBy": "vkpeayor2tsxlnxo5vahqz2jee",
+      "sn": 1,
+      "encSymKey": {
+        "cty": "b5+jwk+json",
+        "data": "BAYpLgYoRYWVTHdXnkXqJfRMbCRO6Bs41dE9Fv3rEvptyRag6Oxu0ei-q4xdtD4-fMBiyw_YIF6M7eUqOC45Jx2Gn8tkeNddkWTwCRyyi4V0v0aOMH1c3ckeGYKWu5M3Snoz_kQ5YVe9HrUVGwG_FVrFXT9z9yv82QWSv97dh17i_cdHZD_2kmQDsqQV7B8GlYX8R2FFYoJNPowC95x8qoFn7h0JrDNhbS1oOGO18CqBweiHehMyw2EWPZy5xvKV4k5S3vJaFzpZ5rXsQxycK-9qXApHx-_ZFvNs6g6IdSoBX3qsHipMIvrPUXKJ7V11yyNVH-mG-ti5lgKCF7cBPQ",
+        "enc": "RSA-OAEP",
+        "kid": "vkpeayor2tsxlnxo5vahqz2jee"
+      },
+      "encPriKey": {
+        "cty": "b5+jwk+json",
+        "data": "yq5Zp1S7UK0ubGKTgDuvQT8bj33lduZYL-WYObU7KCUzAR41Qaa31kMmt-p61jW3-mQokNqAiIEayoDRlWqVhkRWihonvBM67sbfh2bfyBZWrSb9P8YCO-KbP0VWXVuIIfiN77HEc36BPgxR2n4FZrtsEaHmIfhGzYyjpX0PL6PuOTagRUjKVkN7juz9f4PfV08vRyikmIdRXYR4MMFjPi35qxn2B3RPQMiLGAsvNjCkwRkdQUJTIwjbbWfu3q6M2oELCTr23Ot4crHlBFg5LwrhMRQ0AYrnfjlKc5_xlmgb1S_r1M91roJHp9I4EUpnBTiRa8Aalvp3mJu47FodCjWMFOPlhDwvaDRC3807aEqJkjU2qlMXS9mlJI7QVhWpTbDF3j7s4byj9GkPPL-AvfoUgcroxMPXyRftllg9FJCWLHfHB86seKpM_sYj_vWvOPPUQx-EEXaDNWp3U7lb6v3jkPgd3wjxz8ec8U-u2C4fdlrBePBwKp_ocsR7ZLKhIvCs_A---Dli79yVWeDM4ALWziKAvX9Q7AAX8ZpppTCzMw2SiaFfcpQskCdAWiKmRnicqNxoyDzVCIkz-l6qAHL7NRu2Tp3jX3L4k5uiqb5RUWCoHx2hTcO39aW0jtMFLNyh-1QTRdZkEaG8YwbtJ3o3Rgv-n4iOPiENPhjKZEbjq5DHamgIZ0SfNFZjCTAQXQLSNhHfLxygTEzMfyNsZ4KKHJ7VRbV1h8AOBl5VvdZzHAlAtcgvpEdNANRgLiSv41kqx-urgnIf_FtOJV23Kv6bikh-4OhyxdHBtIDPH54f0vmGQGBigXK5IgQda5TQX0Vtyr_jmhd_kDQlwfaQzKxI8pvPst8uWS0XdjNoF4ZVRxh8HBU4oM3BYms0rwSRNp7QYgPN_DFyn_bSPqJ2DnBkMvPr-IYHzfipiURmeH1zb8GbmEIwVKp8CfaCL-Y29GIWitesKmJy6gMZvOoOtKIGbWXNUB3bfFRZo2eZpv0eAXE6PSKbWFWxslDsmX4sUxqXwQNdYzCK1jfAC69-8OXIHUa0lauTU2VKfjkY9FoiyScQyoeUfoKr-WuOjNfawfd1JGSnJwlReRCU82JyqmFxnQOKdUa7naPCFh9hPXIpV6U_79Ehkw7myhAGRMaXp1bo6C32Y2t7YiDKOfp2y-WYEwJnfKFyO8FPIA6zu54yfoFJnoh19-wisZYFkosDT-e--vkoHGo5d9oPZr8TMTUXdoLkpjD790bRUocTI3hbgxzUiy05lcwfAaIdkIt-lin9jfzqMhcAWwGib507WMDbwhe1U_iJmAR4goTn1aOnikABpeHBwGf0nKLrJsU60knihxzYJYJxuwHUBqnwm8uP2pl4neu3G_PQNVSXz1aJ0oLTYipS2TR9jf2tDY7ORv47r5sQAZI6Afeg-Yc4CzP3YhiKiya1zdoRjUZgvpCQhFpVjNUGju11nyq3ckBxpIEkRXBwco6I_TJBDsaygRKdbh4s7qhstO23jyTido8EgLHIg6osKAgQ7ySpurBIFi1mjTTJSEsurkJM5IgboIIAQ9pQiNtqGML2FMsK6crfkpUGV3pWqvnXccEDz88vKeSDtA5av60CsydKB2aUacH5UzVNVG7VfOXXpoOgS0e3iO9MGu8aB_DPPimoExPY3OL1NtiMiliK7lKdh-U--DzRFVGBi9uLQmYoy1oY5NcTZFlDYQOzrREVya5MwyvDyPQDOIa4qPotUpODj1r2knL0IvQa4yieAYcOdwrPZ_cnVPDEQDlPMEBNYpdXDc5GVacQLSNA2WZLvAC3UwUcu-y6WtEBBK-SjD_JKkI3AZfEAwUwprhKRLfNvLkn5WaTPkqUnr0HhVXkDPwjw5Fkz-cUg7ygH8mXZy0ssrcUan4ARpLNuspY4j-IL5AE5vSGViOaZGGs2AxxM_OVwc9BKNXo75vQrxsj0YTnakz1CYKR5zSDtYbUj7YJawPVDfs79rHm7DPJ78sIo9fgh7ZrTVySMWmYhHE6EWqAmGw40BnaaqrgDPL30r4kfhLTC8f1PCfvU-cNk8rfRB4b2lDFUXy90pMIdAUYiX86SnbDsPsNR_eXcSRaaAYx4fNGilM3w3araxY23t7ARnq_2R5rszljTHftexW9ySVHWOHrLx3q3Q8iihADhBQLCUe_1CLut4RTOHYJW2hyvNK4_Fvf45WjR9eq2AkO73dd-K8bKLOG7HIBwInVjb4D4Fq2betqaTYt3TK7hGBt8l8zU4lP63QwkPgXVsvPi5bvRGcYFg87kQeQ",
+        "enc": "A256GCM",
+        "iv": "IozFE_pB23YNi98x",
+        "kid": "zb5pkc2oefehd4cxve7linvmri"
+      },
+      "pubKey": {
+        "kid": "zb5pkc2oefehd4cxve7linvmri",
+        "kty": "RSA",
+        "alg": "RSA-OAEP",
+        "key_ops": ["encrypt"],
+        "ext": true,
+        "e": "AQAB",
+        "n": "r6sR3Z06WOv1ruXIjPrTG5oIq-e8ffwdbZiks3SK4_pfg7UGAh_WCsDkWeZ8WkvydHvQnl94yg5sNGsV3N-FDXJbvT1DuJhB5e4NjccWTkdZnFppHKtGTDaRnt8AB9XaTeAgzLnYKoHvDiuEQK2DQMXF-MbJDBE2OgI96GxaMxPRXdWsq9q5tBC6O6woZhrmsxBBFqLCqhP_cGkhemKfy5OjLuGJY8otjkEEmKSRtBY31-_Mw9VUxeN4l2knj7rip8EoGfS66HdRqm9DTuehRUph4RUat_1eAtUCBah4u2puvCVb6JhPOkK7-FNm3uKXoGSqtilDNV8e2J-VMoEcmQ"
+      }
+    },
+    {
+      "uuid": "q53e7fdanjpbgjxydpdoqitcry",
+      "encryptedBy": "3cahzchvndscx5gjm4jdfcxmca",
+      "sn": 1,
+      "encSymKey": {
+        "cty": "b5+jwk+json",
+        "data": "upxdDPtyISviCj1BzyK8Lj6YdtJZsxbO9PtTq2RSuLVl_c94QYuKfb8IrSiJ3E3xI8VOMbKZpWIUT_ZuGIeMYfbjcBREeAEJxn8nHIjKmb3DTdCp2BKGk8vXA7ECtqsCCHqQm4AKj3oiAsU0n3CdnMLcjwBaQPhajOyUgu4QUNuf0prhS_AQd_b5D2jQVe1pvIB_Z8NILbQ6eygEDzORCe5t87KNgLyyAyh-BtuIorxt5N9kMR0uY6-86bghGlgsLzhi9B3rBgYwAgVd9O-Jfxodb_nDBDEOW6HvPcCM1IfWl-iJKJChlyjAEyC_5s_dNGOmqad2PKfxcyIQO2IqBw",
+        "enc": "RSA-OAEP",
+        "kid": "3cahzchvndscx5gjm4jdfcxmca"
+      },
+      "encPriKey": {
+        "cty": "b5+jwk+json",
+        "data": "UxUReWA_zRHUH36-4ypAADkjUWnJTynzc9PiHNkToMZlhHcnXpBdgLBM60zii_b9ahSe7mVEmmyxXtSGcPE0INgS2j6Zcl7xefTNc0HkwEHkA9QHWBYsD7vwMVhhrHsYRgqtEnUDgcVIvLPQnkTsD8FDtMkOucwLrcTqBAsrzqf1XCa3ueod6WTGYBOAXFfsu_mRlE0POCXtNNd_XocH_OzsE3FxoKLb87Dxssw6xuY8KT2OsyuHBPwcA9aPbM_2x95HqAkjBeRMCJVOG60Z33tomBwzFyZIFuRyTmcC7wXa67sxODNq-lCfoWJGfM1XM4pEqLv80lQGxmLjJxPO4T3tkj58XiI1neAJ8TA3kCtjL67OQiQOnGYoR2Hmopy03iyj4QAXhB-jsGW3Vjafh_WywU8bcQ7BkfAenmHKauVSqqOGPg3L2CN5zv_Fwa-Agy5BhAxcLTSow2S1eBSScI7aPr26CM7jonJXfuBJYB5EiaMaqtokceFp2LxK6ssfgy86nQjIu-bUVWthJZeZ8idKMrnuEJJ-LYxS2q_SamCV9KAuX2vTujgtNIYm9iOKycbn597LZWlY9XISWodYn8d3pTHQv5_sMPtY5DvWGwrOkuXwOrZlaU-uV5GZjEZNfgL4y4qBUyjQpMY9AxDEvXEEXrZqK73lRHDLlPYJU-qtphaY_dZ4occqAePKnAY3ZzhfBCBzp3vew6VyShhdbrO0jIUPj5lcUW_bad0vjQvmJQtlpFep60qRLRQAlebzgo8ROsK1m1HSYepZv9xf8ffYkM7XtW8Rsv5WEpgbHeKx4b-dzbrljMnumrpHhhWsyOY0OpwhLQj7TW7oUo_T_fm3p6KoMwpmeobM9ZRtC-neaCI4kK0KHGFsW_4DLTg6a-bsQwnqAr1VzSL9Xrocc_UTlbsc_SWuzfRVHLLyI2QXe3pzGb8V_fWJ7g_zhv6AnpUqpiLzO7QxlhXFJoiribMfG_ZKp6oS0DbVqGjNnRH1UGCQCbtoJWbdudEZlt91CRYmvSPloT3den9DYdxI5YxuN4-X-Q5MGadEWmoEXdgc9_HueefuC-z4T4FH84SM4zme1sFkcUWLBjkmlwwavVqZtIxy0vDixqzYUegqXpccHhyXQ9qWDEGgQxKVYxJOULFmxePdLIJbSnbzAc9B7XoMxOcB1hUZ14FeM6FS3-rDhORWlKjCMgrplxPfvmlYTGIC3rNGIpKo6O9huoo6VGU4wUhSsXxYt54pN_W2QIxNe7HcpjKtOprecD7cFmZQ58CgFuLdS--ceCJ-oefJXL6h9twA81u_ZOeBhrPzWx4sacSg9sXWhf2oNc4Ic10HpRudZck8k-v8GW4JnPfzBSdZU_mRgrWblxBH_8xqy9ehPd8x5mFu7UTYx1DoOWLVGiZ0QkwigABajwUEbvLAeQYfCpgQD5NpOC1SUhiceWF16xwk94qMecGxyFRV0nLmtCYsulPctL1xCEp0fq0dcNwNkpMGZMUll4zNVEiXE_QQQD4cskAwLgMF-rhEpZcDz-WJngT6pv4xNG9_T3qg0x9FUG_1djGzDMSb8uSmAWSIXxS8D7-2RIP1vElyV7WHF3WZWgCRzHAoL75B1FH61L-YzkRzZ2qafQNQMuHp5tq4aTEVmqKU-VuHbQ5FGkcpnp7lVby5L3mBwhB3evLP-WYB2l7zGbEATQU0fk6dmTOvXo9oamfnputBH97_VoY_ePQBCT6fHfS9D8cUf1ufeMF6PD4APqJAHwWCVIqi6SSeXwfjDGDWu-0ad41RjBiV9ta3oJbdnETehOOVzyBv37UjtuaGngj799amAfgBBc3LhjOqhxhEn1Xm3OdP97I5uNbi6lI3JVto2kmMz71v316y9ZPFOeKg8TP_PDFty1zakNKUySc6Lu5a4_hMfbcFNt0IBj241MA8BYOScz4YYPX1RPFe7VLjETuSU9yzACTxXR7aYVSAKzfwhKF9Y4OnszHk7a8k9YlavK57uoi1ba7jgw5U0FxzMxovoEMYas1-ogMtCc5QZOl71wIdfaAmDW13Sx3D4FzthzeLP1eAR35eObjWE-zMV1f-83gXmzoEf1vnM2MUu37K2F3UILsYHaIf3dFiZm8OM2PnBrc4HOJG7_eTrlhdVJIu_veZF1L_bqFoT5P02Ocx3ajCCwM_iRpHjkTl76LJq74ObJG2WPGTfzSlHawMeg0aZg4tN6LpAkbulGPULsLjf8TnfSVe-xnXYbiCdSeWSwaoNecRBpvjtEdQIsNjdQLeoq21qGfOQ1R1",
+        "enc": "A256GCM",
+        "iv": "Rj1acEI5cCoFLLEs",
+        "kid": "q53e7fdanjpbgjxydpdoqitcry"
+      },
+      "pubKey": {
+        "kid": "q53e7fdanjpbgjxydpdoqitcry",
+        "kty": "RSA",
+        "alg": "RSA-OAEP",
+        "key_ops": ["encrypt"],
+        "ext": true,
+        "e": "AQAB",
+        "n": "62z6cRI7QISiYabaWCv2r9Fy6lQQi_BnrJLIcaHyCKccTe_7Pbl5EsiTnnu4EmOEK0jUVNhvXp7-FUNUg4qyARFy3gFTb3fXieVy49duQG5vXwCVBQHlwe7nmmw1avhDV9HK3S_aCNjNvzJtnjrdz_D9tnQ-CWMxA4IWTYyPUU1MFOoXBaIJzvfDefCyckkoqGwawo_K1CxzUpIYnAWNLRqWUXdAG3dQk5eB-sW7PMUaUyDjoccFPN-I8L3MF8loE3XVQ0SSjKm4FP82cup-RuzYZRZPCb_khiPmZCrCZNXZesV3ryiaUyrcoan_QBrgp7V6Vwv4YgcHB6iBuRzrFQ"
+      }
+    }
+  ]
+}

--- a/crates/bitwarden-importers/src/importers/onepassword/fixtures/vault-d7z3byaorasfq5xixos3tgaddu-items-response.json
+++ b/crates/bitwarden-importers/src/importers/onepassword/fixtures/vault-d7z3byaorasfq5xixos3tgaddu-items-response.json
@@ -1,0 +1,715 @@
+{
+  "contentVersion": 36,
+  "items": [
+    {
+      "uuid": "r5bsh6t42jnutub43ecxh2bvpi",
+      "templateUuid": "001",
+      "trashed": "N",
+      "createdAt": "2026-08-31T13:07:52Z",
+      "updatedAt": "2026-08-31T13:07:52Z",
+      "creatorUuid": "HVE53ZQITRE4LDVGUZZXPY23PY",
+      "changerUuid": "HVE53ZQITRE4LDVGUZZXPY23PY",
+      "itemVersion": 1,
+      "encryptedBy": "er2hz3idctundugolb6xi3znii",
+      "encOverview": {
+        "cty": "b5+jwk+json",
+        "data": "_HX23e8tDjD1AaJd91UphFwNnzyFibfhfa0swBddMhrxJpp2pshx0NSBXzhzvYn4n5KITkBegj0hSZy8xW69XRqKXjGCFGBK1eIJA8_6fSyS0dMB0Hz49LZZ2uW_ATONxFmZ6AHm-Kg_ETS4_pS0Eat_3pGHwwNG0I1lulzHhw1-OH-lBhY",
+        "enc": "A256GCM",
+        "iv": "Kl3aq2Br_sFUjqKh",
+        "kid": "er2hz3idctundugolb6xi3znii"
+      },
+      "encDetails": {
+        "cty": "b5+jwk+json",
+        "data": "I54ntDfhtM8V-WdcERrRomxM2s10DgnfZXTYSshrluq_2nhGmyECB84BFXr_kOsKvB4kyIhj8MkQ3OiWPR2ETVA0rD4exBeKHOS-HSfMdt335HLrVmg7OP8GXQcuLIhOjuUjKrFlLBLTduYc6gWj6FF22y-xJcNrJRAPAsa_IdH5KgAfYjb4FxrPMli3bmWmkIsdx2gA_ouRy0s0lyVlOSbXlYbSHalmulHiYLW46nJjGABDMsKDW350vxam18UeaG3STb3u-yMDFnVXjd6PVfRWtC3CF_WowW416ypI5PbgrX-ouynO7Ocgejm2XXO18nABTS1ECJg_59lX8g-J2FYHEcKzdMe05d6Bfnfkl_EIaHB-ILE1Id8dwKwC-I8WYXU2LxtwHBTXIC3iEXyJAYjHW7ahLxQqMZDuh_YAMX061BV_eFG3QxxVMU9v77GpSbVg0P5xDyI-FZttWwXKpW1GuJKaoBa16YJJy6Dr1t-X4eWei5B9QifKMCLcm4f8i6ALHbnZeC_svB0zUmXzhXz8fGu2z5fgM_o7gvDC1KS674enKOVjX05QaNo5XzjfOXNVrHgK-qYJzTdV6PVPJZeJV56DqVHGUidM9T_xgG-GZTGSzDmBzPjiMDQR2u9ZfmEJnDwmJUn917HgeirVtMesVbqS3lvdatQP0P6V_U3jHDPNg6gtyU-yNuLzbdU43I-BJGedqd8IJ3ewL2dt0ZXz_fa-sXPBFpVvm1jxHs-cv4jK2ZfK8PQUxnkNoUaTXnk5HSiAvw9tIRBAVkV8rEi_ZPfMoJiI0MPqKnFWT187yX4rc2KAgBp_dl0ZcUOdB8NKRnZHyv-9B9bRNVDB3vjOyFEpZpIJxbWDVXMeCpwh5USUp3-mcAizoZVcrH3RtpDd0YhrB9qe2Rb_4YL5SyhlIjbnzF3toMjIZQYTDMpPnrGO5Co4joEqPCNByrkPVMI-LIAqeTFu3AKEGyPj3g1f897rhjKulXYkPl0yVBhxyD7hOG7qqBfrcgAjaKbtTYufJXc9aiLvNG6qsPLTuF75dEkOvFX9cGxE7ltzYc-i9GJUxHE0F-0VltYc96EUfh0SUV-7AycfOXyOYqfHeIlQEp-uAeCFNoxO0qispIwu8ljlP9s9RF3lDtSXUNmrLbS3G2xabJiqNNQ75AJI2jLN6xlT1ug",
+        "enc": "A256GCM",
+        "iv": "ga3wuuDnGRYPxV4K",
+        "kid": "er2hz3idctundugolb6xi3znii"
+      },
+      "packageUuid": ""
+    },
+    {
+      "uuid": "sbdnaodp3axhmiwczcogw3sqna",
+      "templateUuid": "101",
+      "trashed": "N",
+      "createdAt": "2026-08-31T13:07:55Z",
+      "updatedAt": "2026-08-31T13:07:55Z",
+      "creatorUuid": "HVE53ZQITRE4LDVGUZZXPY23PY",
+      "changerUuid": "HVE53ZQITRE4LDVGUZZXPY23PY",
+      "itemVersion": 1,
+      "encryptedBy": "er2hz3idctundugolb6xi3znii",
+      "encOverview": {
+        "cty": "b5+jwk+json",
+        "data": "MB-59teIyUdQjWJN-OEnpxci6jHY2R6FVPdWUSpCgbaJNEFN5mYOxepR1tvVFMIv6AcCiGaYHZv-EATPM6zBo6_e2dlBIFd3JYWCkS793Rj5qxWDcqjMEiLtXOHgSCiF0UNjoMo-EI1GopkfkBtu--3k4uo",
+        "enc": "A256GCM",
+        "iv": "SmT3Y5kRrcazh_p-",
+        "kid": "er2hz3idctundugolb6xi3znii"
+      },
+      "encDetails": {
+        "cty": "b5+jwk+json",
+        "data": "bjQab0C-4RSzFTmeXZYJHdSoFPYzLxDAcbNGs9R9s1yjg2OSdk0ouh-cAy8dXvz1XvlGUz-yvVKlwjGiEFWQwGMHK5umISYzb_44SUFrTWVXgZ7h6cHX3OEsaiQKH394vN9w0C6sbK9pBb4wgIvDXlNmTarAczuGQLH6TQRtSpZe8Gxm5Gg76KbSbPrUm64b2UBKJJjF2XdTN_mnWdIvs6HiQw099ZUZTvr7yMs9_34RqAuEDDClc7RZSujC9dErNmk7zb6VocG96qVVIXyGEHvIxolvSHZTTMEWEvrorHJfzOc70dq_Cxf9FGgvNX2h_2OmqSE7Ka9hlmTOLzpHj9g1TlQzRiLTiYMUvctIS6XG3wOgUZxyg7GLj5s8AvIchi3LCn6_A5mQGc6PXGaX5mbxENmEiHlzvmAbWlocVWBY9qljJG1Q5En--EHWAQhJW7xzW9ODZwEKRaJUtou44CUdJvgQuBNag-5RGKBonWdCTXb6uqT610urcmucEBkl0V2ZekG9fjCuBQ1bohQhC6NfogDwEoCcSO6el_WyFXRn1CLudu8mS_9MvjLsFWTynRAwibmXv6TLb-CDTwU_7Llmz_6u21Ka-BkydXmnlLB3pkTdmlf-Mijy3S8x55HrRJI4_36VKkq5Y73vt7lEpf-jQ7R0fvVcvRyN4mKx6mGfJcblpXac9XSgLnOjc3YFC1ryZu7EAzaB1mhYHNnpTwNTtAdFTDG7pRmQJw2lpRD2macHmel9eDXqLN0vn8uu07vvAzsRXEk90GZwMSslquixQKL9sMQR9bOYagqQwdcXDTJteDVA1Dl9GZMFqGtNztdt2IZtQFXKhauhdfXlhLIlmRYLRuVGjjnzSzmXunzGF45aYJigVlVGrFAjL7sOkPVrxoNM0i_FUIyxN5Hx-pCwISLHVfYyukNVDSACdSrUlv4NHDLfU6RRscMeOszQksC4JVsUMohFbEn_Qnfel53O1UIuDhaT3U7QAEgr0hOOFgoEOQgLJCVrEfTlmjMkhfAT1FAHX_iMEH6bLU1UoTqNq6lMGXM0NImo84Gt4cFyOr7x13aeM9NMVA-mJx62f9L5FrS2splOwOU1TTXR524vSXofSnrAZMxYfchplO0Wkt_KG1dGYOpFIaNzmsp_8p8hrs-VVln7vd3gVLth3RA5BxXh5igk",
+        "enc": "A256GCM",
+        "iv": "3W4V5lVPZsZ7vqpW",
+        "kid": "er2hz3idctundugolb6xi3znii"
+      },
+      "packageUuid": ""
+    },
+    {
+      "uuid": "r5s343eaag32qmwd3jp4cjr324",
+      "templateUuid": "001",
+      "trashed": "N",
+      "createdAt": "2026-08-31T13:07:58Z",
+      "updatedAt": "2026-08-31T13:07:58Z",
+      "creatorUuid": "HVE53ZQITRE4LDVGUZZXPY23PY",
+      "changerUuid": "HVE53ZQITRE4LDVGUZZXPY23PY",
+      "itemVersion": 1,
+      "encryptedBy": "er2hz3idctundugolb6xi3znii",
+      "encOverview": {
+        "cty": "b5+jwk+json",
+        "data": "bB3i3HMNNWFSvZ2N9bKrhoXNY2V7sExxmttGMyjETxNs1ee7T5YF5h1pC9J2pIzay3pHfDI-cYjqFZ8fi_wQqnB1-UE3tnvQkEBx94R2c8xKAk_1wFkdM0dVqqAcRNlfxyP4fh-Eygbq-V4",
+        "enc": "A256GCM",
+        "iv": "H55zihtFXfd2YJJr",
+        "kid": "er2hz3idctundugolb6xi3znii"
+      },
+      "encDetails": {
+        "cty": "b5+jwk+json",
+        "data": "L-A4NkGJDp0Q58o-Bp25MAugvfR7r8FNAez6x0SYv1YVz1I6NyrUzN9NpheNwk3x3gwhTpqs6b8gk_s_C-ab_rYlq7NV9rxZvy2Lbzw2FUah6W4co8Rf2zY4ocUJHyjg7sEFaj3I9PjsaG7Q05w1xVABsXaIRq50nBbcPF5gzOvV0aV0EEs6Cvin61IiL6UFwb6DldHxuHkE9kPW_ahyqUvI_Rcz1nj-x0uwZpDuhU2K8jM7XVdvNhyHgCqaUwNMJCLXGxlX_yHHtBKg6w4idtWtWAUpxd-AQMoegiu000IWWDgZBIwVOehZIUc7X1TfKU8B4xoO41kuoFvbwMhJTHHYhKMezdIxmt-mPnGBvZl3BTuqrGViocBltFRsXnedXRr06f50dmAtB2XBJ8Dyq5tvCh5x31XtE8OEYmsnnft0eDYYCEzDhsSTl_c2RnWTIUOHfJfHlG7vp0fy5j7FDpPVy81_gUpSxnZvr1uvWQTGfaGrk_BhNlaNBb-hOE-R1jiQkmaQ09-zPqajcdW0LswegjmlefzPyN8lCYPuVnnn9l0RLXnpTeVuayR4ga6nYY6YiLYCk5P5ZAFvSy-rEFrWUUKh9SzjUxjQd8FbHs63e40tuNLBMVl52O5FXasbpiKfAa2yQY6H2UR3wWCnABn2Dk-YpNNlH4R9x3Mh-r3tweEEgLUCJwirsESuPvnTcHggEXNdjPlh-F_8Y_wnmJqhPKlPMuevrlIyng53A27VfBYc4VJwkM3b2Bt4Xtg9wp5_JBev_o-u_IaVdjo3GVOy4JJLNuL0CyzUGbQeuSCf-COCyiUf7RqBox1vJkS4DaHkbjpuF5ZnKlrTm2y2ZVtimRvw-PZCe6yWH2ZklDQ89XRLK6jnLsEDPMvTrq2lOxSA36NFy1Jnwk4HwS79f0Gc-V7O_TBRUeraKV_ViZ18tItTknkyLjC9cP1FclHUW5QCyp1qW8fFxnLxUPlbXYgeFpFbWBW8lATPzSO1VD0SFikh5Nj8-stsjdiq1kxLDeF6u-UOeezNJcD_Q9utBXZRFZ-jWP5bXoE17Ibyjbss2Lronl7BLtUI-ltQlROyophAe2KLwsZlGf_-7n5Kutphw6ISFmOkDw3dgzobJoSxjG89X2Imw0adwQl_KI9MCCVJ5JGbBVZWfRDkZ_nTsLKKc70QCHCboLlC_81UEj54LcMfmN9nCGFIfRmIObHdZChs",
+        "enc": "A256GCM",
+        "iv": "n5NRu0JEmVebkK9s",
+        "kid": "er2hz3idctundugolb6xi3znii"
+      },
+      "packageUuid": ""
+    },
+    {
+      "uuid": "4ktzoibksmmjmhc2qemmp6ioeq",
+      "templateUuid": "001",
+      "trashed": "N",
+      "createdAt": "2026-08-31T13:08:01Z",
+      "updatedAt": "2026-08-31T13:08:01Z",
+      "creatorUuid": "HVE53ZQITRE4LDVGUZZXPY23PY",
+      "changerUuid": "HVE53ZQITRE4LDVGUZZXPY23PY",
+      "itemVersion": 1,
+      "encryptedBy": "er2hz3idctundugolb6xi3znii",
+      "encOverview": {
+        "cty": "b5+jwk+json",
+        "data": "49JctVnpsxisbdHPP5mVgvbXToimSfzrTJPTW9e458h1jINg59JKVN-Eqk2mx4Mw_TptkWtbANApX_-32aT3beaDAIwhjt8T_nprUZthHQUz9js7syUw-gb06xQayn106ZiI9cok2KPWNjTC8AznmYU8zv2E494h01x4",
+        "enc": "A256GCM",
+        "iv": "HROiMjYK90Wuh2X_",
+        "kid": "er2hz3idctundugolb6xi3znii"
+      },
+      "encDetails": {
+        "cty": "b5+jwk+json",
+        "data": "g-DRrSofihPHwYodGr0c8D1503ZHefzox2lsiNTzBBuaWttY-7gRFTmEsbFX2w6ZyJieG71v-hFxYXQ_veNUEyLpt3zL17EZDx1hsTGiqjcAmkVfQpYfJhYRVx0134RxDNsrz2z_MWYj9k1u3y1mtFL88D2217s2hBc71aZ-4s0YhSCFk0_8lKzgZ3GnnpOyPJ7gqmqJL07Z0zqyqta-JhvrCQ_4tOT1MS26kHW3ZtmN-ax1HufT3jdQNVeyiPgSsCHVEtvuCNem6n0qLPcfyVDfhsUdFIkzUEBB17K-hcEdgW9gWzVTemhoIMr_oa7H11CxLAwrfr1_E6fLRT9M5-UUhamGxetKwrBfsEvbO2HxVrtnK8VokL7GZbB14JhKC8TGPtxkAh_eNNyMqUM9AA7FL7bSVDHLXWFR9Q8aIGdTklUw24JOvVhyn68x4h50xEx7JVmkGdxvo5a6R4kWNbStaO4cH7_Ye7ZFpahTLDJEyBoYBxNDLN_wq4Rmih_XtsXUlaR-oTJ5eQoFNF4sDNPd-TD63SVvmUb-Mzn-d-lGhH5aEoGMGaVgVn75k1NW86yn5NHFziFQXsGBWGCfuAkhirZ2W7C4Yf-KGuDp1h5kLQke5oO-Q88eOOUCwJz4UmGApBf9su6BEUA4LC5jGSmO4nCeQcnpsoskqst4gHxf9LuEoqyhn2Jx_rVonkCPITL_T0MKu7UlGV_nH_ZSa8EZQvqOxJjUW-oAfFV4s9F8d297GtxoaXPrxgjA6gDVi7GTeL5imDsWPzc-o_yICKoa1BNQGnFXyV0cec9q1_2_0x6K7jCS6aOe4YEWTIOanWcoba4i1SgxWPUNGezt6L97iZgsQnbpc81fC4Fg2v3dVI1XIJ9JKxxDkD0gBSgNC7zI_TQEsNRhZHzLb8Mteu8zHRnFoUmEREzgVQBzi0d9QxwZ4xRclZpkt0_Hs7x4MQUBZRR0",
+        "enc": "A256GCM",
+        "iv": "Sr-FWOxPwQTSegGN",
+        "kid": "er2hz3idctundugolb6xi3znii"
+      },
+      "packageUuid": ""
+    },
+    {
+      "uuid": "5nmj4gwwdmss7zh4heygycdwem",
+      "templateUuid": "102",
+      "trashed": "N",
+      "createdAt": "2026-08-31T13:08:03Z",
+      "updatedAt": "2026-08-31T13:08:03Z",
+      "creatorUuid": "HVE53ZQITRE4LDVGUZZXPY23PY",
+      "changerUuid": "HVE53ZQITRE4LDVGUZZXPY23PY",
+      "itemVersion": 1,
+      "encryptedBy": "er2hz3idctundugolb6xi3znii",
+      "encOverview": {
+        "cty": "b5+jwk+json",
+        "data": "Zr5gfAoDrwqBR_OqTaSbqf4J5P9M17d0QFoe9q1tHn5enB3jvLXUWR7_e86Fpgr6Mn4SW3zPkqxs1wEcdocVrVqV0U71ST48s4pTam6YCusNdQLaEI2jw14Es4ODtXP12FUPqgwmwsoW8CXdl_ox",
+        "enc": "A256GCM",
+        "iv": "qZEaVbdOvSrbgFs2",
+        "kid": "er2hz3idctundugolb6xi3znii"
+      },
+      "encDetails": {
+        "cty": "b5+jwk+json",
+        "data": "2Ybhmw8L5-9fflyMaa-oGY3bCdM-0QmFcn5jadRJ4JVWnoU_Mi5bf-lvfX4NUWw4wXdsj6TupVhGQawW2ZHlMIeR1KFzrJeVfnJpdJXf6B4xRwdwxavawHmipIsbQgRYX0KHroBjXq5NoWekbrG7FADhScc1W8fFFVDIHkyUStsbjIK3Sx6zB8p6R4egIANc2hKm4MB1Y67AXF3v3NqsIT6rTcK4126D8Rs0JsE7phQltoSZiUXuYt3PKpgrqnSqQpSDSXkdxp3s7MVtKQ2Qbz7HdK0wgvI3zfwTMIE6cyXVAr2_D4uSjPHVJUeChsjnlSrcLX_JaVP4mE_mYY3sIGcqgSLioEwgeQ-ZXzgDTEa_yE1jOfmFGZW4verKED1XILfTVvj-MhrvSfsagtkzjackMOxmzdSEmJ5p-kpOreK5nPtZ0aknwEl8300PLpfxxWzrn9nuCnbJ7T_63WIc4ohm3m9hw9qhjfx2GpcGZIOTgjADu6u4i0CW62YrkLrUIh-5RsI9PK-MWrwyZyxD81_qM5fX_QzHUUdac4zCX15XzMIxgjDPo3m7_Xon85AQABfBgc0oOd8rKJK4MMnwyEtZuTNw1rT_wnjn2RrhLX80NY9uPxbfrOlplOnh36wQiTI6vcO5w53n_qwgJyWyd0HcwjPKxB4p0Id3ep18f7a37czOpVFQMPHwByrKZmGL4vNk5sCpBzDo1IvyDEsQ-t9b2i_rQZUytsG95AuARgZ7Ert8OtEmaPL8sTFW04NK5H9AiWUIJwOdrGYZJhc81MuilZ7iANJEzAf5zFwO5IgMdLAMQ97ypSkLwA8L5IJ0mKrX7Q",
+        "enc": "A256GCM",
+        "iv": "gcqoxlGY2QhxcyP5",
+        "kid": "er2hz3idctundugolb6xi3znii"
+      },
+      "packageUuid": ""
+    },
+    {
+      "uuid": "bx2seriij4oxwpribecpm5grjy",
+      "templateUuid": "002",
+      "trashed": "N",
+      "createdAt": "2026-08-31T13:08:06Z",
+      "updatedAt": "2026-08-31T13:08:06Z",
+      "creatorUuid": "HVE53ZQITRE4LDVGUZZXPY23PY",
+      "changerUuid": "HVE53ZQITRE4LDVGUZZXPY23PY",
+      "itemVersion": 1,
+      "encryptedBy": "er2hz3idctundugolb6xi3znii",
+      "encOverview": {
+        "cty": "b5+jwk+json",
+        "data": "Z3BZPXWtErVjvrkLlFiqwkuSr2bcaZJdtQUdGsBLLAQV-7-IymgnrwL9pYGlh0cerxv_PAIJE9JWg67XsXjF8KxwLssNxFybDmsTsXZa6DGPRu-peGpO98tWemTBNT1GkzC2IREjPoWnkQdljrQ",
+        "enc": "A256GCM",
+        "iv": "pQ-4GJVisR1ofR-B",
+        "kid": "er2hz3idctundugolb6xi3znii"
+      },
+      "encDetails": {
+        "cty": "b5+jwk+json",
+        "data": "3G9SlRJiHUeotkS0WHd6DeJO0S03hP7x75r_6hkqXFCOYM5IKcahZ8azf_HUtL_Ukb5rmf-wXHoUeOKXezhlvv6hqECiGMSj9BceUMqisL8mXEESrGpnBLLBMA3hGlxnICaYcIgFVIciSlyIMFREe4BbHO-W2t6tG6mtOj2o-yN0c0BjdhUxxpCkBBqqEZsnKnrHdEmdhuORRDmnY5eo2f5NvirO1DnKwxheBHD3en2sDRSOmnuKJ_PePTeSPCHLCR7dW4z2VIOO_bFcZ01L9U0sPwBp9s-ih-Vz9r1caq0hexJJm9CDv-WdchhXBnc7gnx-T-KyIye1IhUCCNyUWyee0UnXioYDWslqN34kPJMJ4MDTgfvfRRjpOsAQjAhYbh8oOAZ75fxXgqLdIlsOAiGCIFxYAr-zjSsr2kon7TtJPjPwd3EJv49nAck-VRyve-yTG1hRCctN6jDPVWDomGz9VuJm1OIyUj4QyBVtK54LrwNn2tgKTzHp9-6_Eb69pttbNLclku3LbIqehOeVJBsN82U92daNTEt0gnacY_sdTyRf9xxZjqH51iC7HEZ6vmwSWGjJ6DTpK840P7CpxEXwHFY98MoLBiSI2aFWU3wQFI_8Irj52-6NFZn5gf-tZYIU-fEGyG0rHVnahY1fl0x6sxTGyQMZU7pWBmiOw--zcp2aHoWrtUDjTPQb1dvRn_Yd5U2N7g0PLmK11xTxxMoKt_Q2OjdCVrtkEisFokT9h5kuyLLGoktG_JocfccJP0ko6dS5bA5RQvtWNRmBxnN5jO5QyyoybllmBjfS6VXOPJ8GrtbrjY3Hlg3KaJbqmUgNaxKb9T3F_t4jMdfhqbEmQDFW-bXUjAbR0-2whfLfp24_xddht0-_MxeoF7oPosmgHMGymS1Io_co37J4PzDspL-u666rIlaORT3wFQU-OtqH3ZW5oZbneEjcpz9A49OPC7ivFdH8Wui1ZwW5N-pIUesxeov3xQB75gz4PS_62x6tWwrLEOUp6BknEnjlbCoHBstqJ-cWQWqq2pVYe4i_sWkex3u0xHGqRXHSCnAqVEif5AgGe0AgHNv5p6w70vBNK_JVzRcIb8EWdBCI0EDGHKvDX7LrR8KNn6pk3fjWAISfTlUbP9OZxO2MP3Qd842wVuNVu8p5177lh2d3PhZWeEUXnWRfobY0becBxDpz6xxAVpY6rOEH_YzIIb5p2RluZW3ckkUQKEFufp0cTC2IpsPpWG91feWE4MAESfw5qi6G3SWbciyp5AqGOMBPBwaGzQe5qrjBXWnSE7A20WsPYSjKlSwmk9O6wP_LDeznkZZjZKpNE71Ohe6UULUXhzhwKEouWZllg1Tt1KhwGK7SkPlLlWWXUkdLToF5mcYCvyaMwWKCZ8O2MRhpn9iDSOt4MwATkR6z3w36QaBOavo8a7Og0F2_PhgA8Xd_sIl2SAS9GHmkgiAe9wbnJBVWQpdnYq9HnAaFand-bssi6AkKQ8EEwEFRMIf_cTh5LrvRFhgJrXMDQ5D3y2YjSi3L2n5bA2JeIHS2p8_n3LjArx9iFN8c1KVO5B88-jMQpFkgAg61oXScfB7YtlII1wjR1ScFVDcifXjBe_fXzhBDIHZM196dRQ9pzyfYCbodQ7hfpA9KS-qLOak7MLiqdQ",
+        "enc": "A256GCM",
+        "iv": "cHHmaFzqRS_ysrWo",
+        "kid": "er2hz3idctundugolb6xi3znii"
+      },
+      "packageUuid": ""
+    },
+    {
+      "uuid": "ewkbsf3kptmopj3noswezhm2v4",
+      "templateUuid": "110",
+      "trashed": "N",
+      "createdAt": "2026-08-31T13:08:09Z",
+      "updatedAt": "2026-08-31T13:08:09Z",
+      "creatorUuid": "HVE53ZQITRE4LDVGUZZXPY23PY",
+      "changerUuid": "HVE53ZQITRE4LDVGUZZXPY23PY",
+      "itemVersion": 1,
+      "encryptedBy": "er2hz3idctundugolb6xi3znii",
+      "encOverview": {
+        "cty": "b5+jwk+json",
+        "data": "0VkPJXrc2lkyrnq_B_ThuMCi-20Ca8FCa73v_9Pl667ZtwheDPmOv5Yv-O7a6UirBGsxAy7zFGeTOmbfQTgCEoRi4xKUbgXrpJURva-354okL4e2fdXoMnDoBVlfYzcbTA-7c5HO00P8oG9C",
+        "enc": "A256GCM",
+        "iv": "MfNoQpWucLJS1F1j",
+        "kid": "er2hz3idctundugolb6xi3znii"
+      },
+      "encDetails": {
+        "cty": "b5+jwk+json",
+        "data": "wQHa7UXzOP1jtw82TNDoLg6u6eQj0ThD1FMa3XbKQyqOFAXIZzbDBOVUJ5ghe5KstNwIW7UlMLQTxwF_upXWEtaIEc5UN2ARkDKUTBTTDG7fNMGf4EXrZb0CQKVnsF7YLgK4bmTGe2O0T6T53qBTyy9Obo2g0drPc2Ixg1rB8y0pXvP19i8hxgu6H1YX8Q59sX5DRRarcOmD6OZqRHn1LbO76Prb5nLqv8fZs8WsSfHf_xjvACZ7H-mC7TTRzb9O16Ky0M22wXVoNJORRIHM0s-cDQI4s3Tpuo1hyE8EddJSfpuLw6nQ8QRWbr6lwy0StB6J9nbeAH0BE8BwvdVZjmBOhM6BcSb4nJDec3x_Ha57T6jBpSEeHQ-PWxh1fmUkWzb2bmuiHOTMGhGTIja9xMrEET7XYJlEWuTMWoZgdRVbF249pfy5_Yya8kToTXbQXkiTpVDF5yvX52OOzZvSKHyZ3D_aSx9WcZgoLJnhNCxLKZD1CaAcDdRZFsNlx1uQXn4BHXktTXGEFiI-xsroPPm2bVuDxkJG-FL_A1xHsf00IEIN1CFg80m2rusdlgUFb4r3X0caI7KZGDRLFxnoWVetFwTafZEyy3rkcU73apoBXPKy5AVg6kEDnn1F2WyShud8fdS2dOiD9V5UcKCSFgyMi4M-XKdByDiZQTmxg0M2ojzR3MX29f8Wgcc2wUuB4A6oEdDaTNJEv6w8QEJw7UdeUMchqmbzuGq5xlHUPg4CYzuRA1F9xIrF0FNSo2lcS6vv5HPqZguCTku_jwupp7nmsBG62gPjakdKoCgWJKGlbkbvluErJtJznkvAVOW6olMxGOwUbKrq8fv58sxMmHQbaCXqIkbwbiJny1ZUSKTwZL8Pw13etIf0pLzEoVErHZNffRyr7U7FEf5kWb6cVPvgYvb5vwwP7rGRATa_kGNsqIT1nBrU5NuWuVXMHxYyu4eS4eCaCA52GYBDd6uOPMpWxQhRc2UVoy5PXnGCvYRHlp9eUJm4q4W6xfTVKsUAqe_bVc2WOg36_FAA6CdgQghE-IYYFwTD6jpjIne6xYnQI4RG3rBGvZo7NgPZCIyuIMIme5BcWrwXgTjwtRg4oi1VfiP5a5gXJfjUSzWvj8Gicsz0JvCDk554g0QMUN2ukFrZMOblDvNrtDxIseeJyRpDJlSpr6SePOjvnym-Ctn1ccuIqBvNOBv1TnB6yzPDccnwFLSc_t4YWXE0j7lgDZMbvA5IFKrl8PcYvZFXcTCGUsVqcZkNILUycjNVdyuBjRFnff1CzehleJ_xQ5QsKYha9yzkXL2l8Susd4yXknNUAo4kNduN3bL3LUeNHG09MQ",
+        "enc": "A256GCM",
+        "iv": "ZTF6KcOfAdnwtzJi",
+        "kid": "er2hz3idctundugolb6xi3znii"
+      },
+      "packageUuid": ""
+    },
+    {
+      "uuid": "h4ypwqnyymovhglv3uwodufvwi",
+      "templateUuid": "001",
+      "trashed": "N",
+      "createdAt": "2026-08-31T13:08:12Z",
+      "updatedAt": "2026-08-31T13:08:12Z",
+      "creatorUuid": "HVE53ZQITRE4LDVGUZZXPY23PY",
+      "changerUuid": "HVE53ZQITRE4LDVGUZZXPY23PY",
+      "itemVersion": 1,
+      "encryptedBy": "er2hz3idctundugolb6xi3znii",
+      "encOverview": {
+        "cty": "b5+jwk+json",
+        "data": "PaLXGtmD28XCMIJCoVwKybKY-v1c3P-qK5symKlSBdYJXmR6jnKQ1LiuPsq5ptnpoc0aXKHJg2lAvcIakhbPU1IC1bVNUyBl2nzxt3WsBVq2Lrwv4rwLnSxQcVgq-BVdkc8VXHGGaHJqLZwS7XoLHi1YbIqIpOrcGQfnDOQcZSi1opnDfpETKq6t3OuBZAoA7mDHl76-y0sxIE-7dFeKcWoGjImR42cEwmj7cCepyBBcsVY6dICdVHTU8q_iwxQ76OaTIYVJosTNQ7r3JF0",
+        "enc": "A256GCM",
+        "iv": "TW5OOLyQqPlEoMmz",
+        "kid": "er2hz3idctundugolb6xi3znii"
+      },
+      "encDetails": {
+        "cty": "b5+jwk+json",
+        "data": "mCcXr9QRsnweRMiwKUvDU3J6UvNsAQS65Y0atQRj44helhXW7bcECF6op0Yf04L-eap1kUjzUASXhjLytswy2pyHRkfJu84tXhBFhx1QOvAbh-99fyoROoy2bWrXN6d5ROA1akfd1YS4FpxbDWTqzrtV9P42e65ehblWUYmOKVfIFNrFYZy2wMqYDuCVHx8FaeNPKBNol4CIjqg_14G7rBGVnrzoBZED6ub1VuYxguXtsDZ0_ZQ38T_PQCkb-9teYNR0OTzPnPA_EagS7vBWAXzWQbjo9XtBJJMf1K5fk0DVLtk8GfwXn-L2lTfsrItu0cH9C6JprqB-SX0uhgWD5Uapxo88q8rvb_zmbDbxh9WZFZpteTm5t9MJm5hRdqfKuZCRcb47CTyHj_N0dDXXoljS72-3NThgovgDYMSpI-jJEU1Q1El-5ZTO5HLoBLbViFmpLuLOc2HXxbjnVVWlFqsYokMkMP9Mucl_h6rN1dxXVbuGLYpMXAZRj27u6wCf3oLoHNd94C9P1DbcxN9O8rjj7nc7nNUHzYq1gT8SIg1ZkW8a-nLHbjklKffoBYeh_0fuH2WGr-XP55UNYYpAcdr0L_dxyrAeyoPyySNKNMWgKl-w7Kxl6jkOtmoBH73DEvvJj8g8sXETmK9H1G2Kx7V3Rv4hQEkL5vxDwjO5FQLXvwnl8hYjmMOUSrV2FBx__fCcRq5XIJu6ugQrlcQyc_asLYHApjBMtAJDV2sHyOhaCixTXwqc2w6htfSVNglQPbSIGiKQqVbds_P8ybH-CqqOKBim0t569IN25BDsPtbODg1DkUwRBAdBxGOyVbcfvq1qYxpWqIxJtBgHp9j8vSCnPSrURiRhNHnV1VJmshcpdctbeBiY4V8oYTHhLhCmo7sA-K2eOIXQe47cJVyMDnkrOKkOdEfKT_ItzSAdUkaiDnsR4IwSO_PUeSaEjsap4ZYmOp5QBkRFNzLbhPybQQjtq1F5OdKgqj5dIwEavT62FIRky7EUarXahsnifeotfaMcEoT2BAP8gDIKrlGR_pHr5xsNcq72iII4XyClV4pwotiKDdkteiyPJUEeUbR3aFjDgildJSyUpp-d9qokk4I6CbUVsmDXpTFCPh1E-07RS3yxTV9UvFcYY08q4c1UhuV-uaSbEGLoFDh6YjKML22IHyyKWvlyNRu1jUBdzj5hDCZLcDecWb5n5PxNCvoN5uF_34_rgkxQBLqDR3Y1vgrv_VIZ3tDoH8-o4lhGKTKMofIHsB1OBhyBcmTZ1wQxw9hlAjmSootQwGmLW9vr7Lld_nGDvJNxfijCH95YSAoSpyWJ1EnRzvVcPl77ze4SWzvlaSE1N9-kAaq8wmOdTGI0wHnDToFP5w",
+        "enc": "A256GCM",
+        "iv": "fUF25g9hvWRS4Do_",
+        "kid": "er2hz3idctundugolb6xi3znii"
+      },
+      "packageUuid": ""
+    },
+    {
+      "uuid": "4uurkimbeeebrlh2d5urxdzixm",
+      "templateUuid": "106",
+      "trashed": "N",
+      "createdAt": "2026-08-31T13:08:15Z",
+      "updatedAt": "2026-08-31T13:08:15Z",
+      "creatorUuid": "HVE53ZQITRE4LDVGUZZXPY23PY",
+      "changerUuid": "HVE53ZQITRE4LDVGUZZXPY23PY",
+      "itemVersion": 1,
+      "encryptedBy": "er2hz3idctundugolb6xi3znii",
+      "encOverview": {
+        "cty": "b5+jwk+json",
+        "data": "pGrRWsciZyQKhMuy08_asCetK_abPSYm-v-HlNvSqimauhY5MdEUzmouCYYC3RNKRwGgrZYluP4xh4rSkdPY-Ow0s27hoqmsfIFFfAA6hUheEURT3Qsudow3Wk777UgwkSgwuTx6lsXL",
+        "enc": "A256GCM",
+        "iv": "Ss3hey1GnWei9lkF",
+        "kid": "er2hz3idctundugolb6xi3znii"
+      },
+      "encDetails": {
+        "cty": "b5+jwk+json",
+        "data": "i_jkZCidCd4RHGYKT3ZtjGWX-o_EKjAKjR7gwPpP_YeG-Mvjjqk42j1MP1NlAHdAvzJmvdarTqmWdMw_-l7rMLn7R-QDQKnSBIbTldPg3xTZlw5qcKCeGZwhO8Y3V_SnFikSNvppyURL_7sM_hoYZejaMOqooV4lMf7tM8Fp3nKsQwp7eCcVmIvLCx1PhMoYL6DjsGSCE19RN7oXhdYMU1LrtbCbDkWriB7YJXqtkmrOqm4C6Lb6fvGRLRcMjmQP1BNZhn9bJj0hEdlVWJJDw0pmddPz1wuSXm18QJ7RFPvKugAwFuD6htWtdZKOaNlmBkHf2YQ66VUmCVmikpYTgx2cVL5t6R3vPqDifBAajw70gNl_2wnXKkYBR1HLK7biP3pL9MlRqO3WKqC_JUEKysxskTtq5XRfIqFohUihuLBoFG-mQYzrdMVT9jiRg9usoWIxj_mz-2WE0ljnydTIZbROHE62HVb5A5fgcCfmZAOqyTEsmdPA6-SbF3zSyrc2jeE7IkCo60Pq1qGE9tw_bESg-0EkteIIzY0L7DyKS7rsC-Klm_u2cdlQveWmGwfAZ5nVs_PSdZ5dA39qBXF3O5NSd9Ma3NH1kefoDmVbFYbs-tGvCRBKX1o4_n4Z5FDOI7l1FUulf1oDqaY5z3Ch6x3EF4O83EkvBfJoM5BRaPiLXK8d80oCzoiyG6ga0ZeZ8Or9y8uAp90vOmJzUicTYHoLR8uBMqKXYdDTZHvn3QQY7ZRN5LtfDyXDMDZwKcV5eS7baLXxUOOiWGJ-GFa_avnjiG1_c-c8tv6Lh3OL4g2hnU6fWRlKWNaF8PBZpMOJnzcq7M12MsI8cbtSdhvJYBMgBY_dGShkOUYMLqBCS8mNBmce9cOjJYUnx0VND5fB8XG2w0obllrqQBR38pIN6QyTrm03i3YYEFNYf4d17duVaCBq0pAAaixZQttSE2pkqieT_nDchWGekVPXJBhqz8B6YLOrEl451bYj4MdtKLFjA5x3NSGDOpxlKYmPRx4PHNVkIphV5nJ6WNfaxtqDyis2VyKRdcF5BmsKZIkk6UGyt--iG-3NMVFayt5dNg",
+        "enc": "A256GCM",
+        "iv": "BP698y1cH-pgptVm",
+        "kid": "er2hz3idctundugolb6xi3znii"
+      },
+      "packageUuid": ""
+    },
+    {
+      "uuid": "6e5dd4ozx2brfnloxx5sgnfiwe",
+      "templateUuid": "001",
+      "faveIndex": 1,
+      "trashed": "N",
+      "createdAt": "2026-08-31T13:08:18Z",
+      "updatedAt": "2026-08-31T13:08:18Z",
+      "creatorUuid": "HVE53ZQITRE4LDVGUZZXPY23PY",
+      "changerUuid": "HVE53ZQITRE4LDVGUZZXPY23PY",
+      "itemVersion": 1,
+      "encryptedBy": "er2hz3idctundugolb6xi3znii",
+      "encOverview": {
+        "cty": "b5+jwk+json",
+        "data": "r6b_kqiTJ4DWjfP6ZW_Brf1LvPX1pN8dwVIEv2ns9JtBLc2Pl43yHi-UYPJ_onFtjJEtQJcWwmy01YDD1ULX4lQIGGCa7UnMhJIP6dwJE6vMGiEkCPL0SnhPsCqoULRC2NEEOsuvyTaWThrV6CUup-3gocxuSvqH58m2Fol1o9Sn4VzAhweq4o40GCkCPYofKHgWHvSexlZocd422htp_4Km22MgLjoNSAj4Z9W5FoHGuu1ZJmaQjRbnHt25d5t9symT37BltnV6LnzVdaqsxxOzV3d1kWFB5FxY2wzdD7Ku-klQsotSM-EVxg",
+        "enc": "A256GCM",
+        "iv": "8ZKPyyLo6gpu-Pbd",
+        "kid": "er2hz3idctundugolb6xi3znii"
+      },
+      "encDetails": {
+        "cty": "b5+jwk+json",
+        "data": "QaFRj5Wr3Bh_sO-2Alh_AEoycqqYQq8RVmqJq1qlww3Jum-N0sJvwojcWQSG9OQ6-2Ps_9KZ3Wm1-vNd2_HRuwksNAyI93_MO6gaLOIWBwWeqH6Eqvq4SCRlgdLk63Q3Y0_wS_BPWgbRGYh4M9HYF2ZXpMfX3Hk-LQilm6B0kYV6S-wTqRBdTSn4hMGcfFOGkee2YTXjIH_cqU9gOe66-MWQXYSA4hasOMGqK6qrWKVTHSTbd_avHbW_JWxiancm-BedNxuy-w8SyGGAIh7OcbVj2lCmDwoxCyYY-kX7LyulgQZtv4WPn11-bw-G3wP9_eQ",
+        "enc": "A256GCM",
+        "iv": "a0L7QqBRtUmPUNET",
+        "kid": "er2hz3idctundugolb6xi3znii"
+      },
+      "packageUuid": ""
+    },
+    {
+      "uuid": "3d7g2qgbv4fkgb2wi7mgq6ytae",
+      "templateUuid": "005",
+      "trashed": "N",
+      "createdAt": "2026-08-31T13:08:20Z",
+      "updatedAt": "2026-08-31T13:08:20Z",
+      "creatorUuid": "HVE53ZQITRE4LDVGUZZXPY23PY",
+      "changerUuid": "HVE53ZQITRE4LDVGUZZXPY23PY",
+      "itemVersion": 1,
+      "encryptedBy": "er2hz3idctundugolb6xi3znii",
+      "encOverview": {
+        "cty": "b5+jwk+json",
+        "data": "ov-5nXR3f_ogS85O-wgVbIU_TF7-DlbRq2i0387NlGyV_CfwFeYSlga8w9fMeL7QzmlnldcJygA1NRpb6-hgPXDE-YWjQAqM9uQRHIDBynzKx0vJM4kvSXCrovDlcfgTniCZQ4RyPzqe2JZxjxwvqVUpt-XGcMkKnzL5k28paqqIP7bX_Gw4ZryMVPK1R0laviiL",
+        "enc": "A256GCM",
+        "iv": "Fin2CDKsgknxJv2R",
+        "kid": "er2hz3idctundugolb6xi3znii"
+      },
+      "encDetails": {
+        "cty": "b5+jwk+json",
+        "data": "764OPWIRJV38YjQWMPpV4jjVmUUPSxcPxZB9UZYKtmUpXLhEzwqznO-F4WSG_8RnQccib1w7ZO2NXYSYZe6-qDxmqrwt__XKkyf2UA2DKSxPiO_ynnyYWUIlSf_5tG3DthZJ8Is6o6_3KeywlQynTNaJTS2dKO8nar52NLg0dQ-BD5goyIt5sGAteUeW5q9T5IxA3yZZA8_jTgYUtxzg8UhVARDYrSsqffdz9a-wTDkbMI4fVFx4UasZiQp0fi-2NAZFppFqO_E-KK38tC5n3At1acxvh8Z-GB5uuJm4TGclpAKdddlPB1tcFDNpDoEQrbqSWR24wvNBRizDeBkDLfFnGnbPxG34PR0xgg2CX4tnkB0FYi9DymoZi41C5VXVVP0lYy4H2RrlyOYCY2s2WilZyCqWdMUo9IoG52Sdbw0SJwCAuixiIiltXIV_UVwr0osnILKi3cl0MEDfP0CodZoo8BPfib-taSlOyeLcFe9mzs4",
+        "enc": "A256GCM",
+        "iv": "oJaDCmbV0xq1kkeT",
+        "kid": "er2hz3idctundugolb6xi3znii"
+      },
+      "packageUuid": ""
+    },
+    {
+      "uuid": "okadvy7ysacfm4s7k3uwesbj4u",
+      "templateUuid": "003",
+      "trashed": "N",
+      "createdAt": "2026-08-31T13:08:23Z",
+      "updatedAt": "2026-08-31T13:08:23Z",
+      "creatorUuid": "HVE53ZQITRE4LDVGUZZXPY23PY",
+      "changerUuid": "HVE53ZQITRE4LDVGUZZXPY23PY",
+      "itemVersion": 1,
+      "encryptedBy": "er2hz3idctundugolb6xi3znii",
+      "encOverview": {
+        "cty": "b5+jwk+json",
+        "data": "XK2aenss6JNqPL7UktvzaSFVpa1Wa-9froi5MSPcUzQd8kXJIkgW_Uc0rZ4MtcvZcEYeB44ye1uxh9B5O4RuoPic8j_5kn-rcW52zvZiizakORBdnYAnmA2YUdvY-srgdnKPAQ",
+        "enc": "A256GCM",
+        "iv": "pvG-8JMX1mqdtjvk",
+        "kid": "er2hz3idctundugolb6xi3znii"
+      },
+      "encDetails": {
+        "cty": "b5+jwk+json",
+        "data": "K1SgzDXV-cGh-qvcxaboExmz6-ZVo_fbWhNHeDlEQvf3Ktv5HZGD2fRH5sHRqvpXCVBJ9TLt_ARD4QT1abiIXYJzVoFBHcQnnivEQKqtrBZK9x5w99e-UtV1Yt2wJnHchCSgnf9V7g",
+        "enc": "A256GCM",
+        "iv": "K0AZhC8BdKq-IJ7c",
+        "kid": "er2hz3idctundugolb6xi3znii"
+      },
+      "packageUuid": ""
+    },
+    {
+      "uuid": "dvxqwdcg3rxulppylgnesfpgia",
+      "templateUuid": "006",
+      "trashed": "N",
+      "createdAt": "2026-08-31T13:08:26Z",
+      "updatedAt": "2026-08-31T13:08:26Z",
+      "creatorUuid": "HVE53ZQITRE4LDVGUZZXPY23PY",
+      "changerUuid": "HVE53ZQITRE4LDVGUZZXPY23PY",
+      "itemVersion": 1,
+      "encryptedBy": "er2hz3idctundugolb6xi3znii",
+      "encOverview": {
+        "cty": "b5+jwk+json",
+        "data": "JMa89oN4sB_G_doR_i3xEWbdLQcQuVfEw2wy1ERB5rIJxF-sfyH6SfGdcSo-Et7VFAF17ufdukhGrx_HV7sBijx8ndgWhsgHrYTxin8IoeR7Tb14PmSaoV0",
+        "enc": "A256GCM",
+        "iv": "jEFyqBxjrvADHOIE",
+        "kid": "er2hz3idctundugolb6xi3znii"
+      },
+      "encDetails": {
+        "cty": "b5+jwk+json",
+        "data": "nkBG_mDo3hoyJ5_JfhvKMwEF-pnJ7VK0a8DxvZQU_1d7mfstiuwBvCvUqyWXxN8f4CDccVrgDgpLdIzv1GbBR715E8-eAdEVUoZR_8UfzBcEuWle_mP_NajLyyKrU0ry5D_w913q_HgBgK5fZ7awatNKDElTNxp9T4Oz3vVj7oqb3bTIdxmuz13LwqtQERVk7K2fTWoPFTxVbiaUOIuo7hN6gXOZJhi6MtA6gXzkz6Rkri6gQh0C5Aqpr3EcLKpHSQTIcFywU_CB90Nrkp-RjPFhtO_FThNw3ajHGoyS_mDvq6fBJANhOINbPfbcZAMUZgkdrXZs9o3d7Nzpj6aQShE9p-W3iLflX24VVE6lHPH8FAFO8eEDpMasv1Al2i85ZM4Ytp8RS3VEDQkwl1Hf3DXDwJWOx_rpV-LHZDqFujFX2AhypaKMsAFk8zqGcbciEwP_ZTGFbmAEMsZxu4fOfqqgyeQxP4bc7Ud7Nxa7_IMQV1lP3KYuIN0JnX99Sc0_HT4OhlYEsEKD7Byuub1lZznyJKS0DIsdUuFOl1I7yGCYLDm0wQ8AekruDPnCIBAUnFGzv-6NGsbj_q2hk4tIIgz1ivShzk2K5ZbIGoHqjCj7Me9OKzJoKwZDgGdCYIkJnmmM8w5dMasBCHZBTnQ6hUamK_VpFhoi7CJKitwyZFE2hLvmD7BxEhp2eUxG9UwxRt_MKf3uZoR7Y8khzkLIQVy5uqhb0wXhQZK2U08l6iuxNPgxI1U9Xlqx3xkSrB9zhwJd5CVAJWiQUBLSvmj2KpJt_OGuBnKmzf84jPCLnkVwxk4PQ6Mz4gL7ydbgVCFVzliW0M0-I5Fykbg",
+        "enc": "A256GCM",
+        "iv": "ck2-BOIJzkM6PhJv",
+        "kid": "er2hz3idctundugolb6xi3znii"
+      },
+      "packageUuid": ""
+    },
+    {
+      "uuid": "fduowu3eaoqdvw6ffyyvy4r6o4",
+      "templateUuid": "001",
+      "trashed": "N",
+      "createdAt": "2026-08-31T13:08:29Z",
+      "updatedAt": "2026-08-31T13:08:29Z",
+      "creatorUuid": "HVE53ZQITRE4LDVGUZZXPY23PY",
+      "changerUuid": "HVE53ZQITRE4LDVGUZZXPY23PY",
+      "itemVersion": 1,
+      "encryptedBy": "er2hz3idctundugolb6xi3znii",
+      "encOverview": {
+        "cty": "b5+jwk+json",
+        "data": "_AaooCkHtqbAjAvnzg0WNv98S6xCtyzvbOeR_1AAyJK092Rt3Vf7kxyc9-aR8te_tdcwvWfZEWenRyGJZPVntGNPP2i3HHP_qAZXZE5hzqtPcna55PaoQxwf3zCRqODGoPZ8zWUvj_4jo0ZbKrDyabbVGRo",
+        "enc": "A256GCM",
+        "iv": "UWs9bNBAGxejJ97n",
+        "kid": "er2hz3idctundugolb6xi3znii"
+      },
+      "encDetails": {
+        "cty": "b5+jwk+json",
+        "data": "DT0CCs9m9VyeqG_O3JqpL0HqBl8F8oZ_6uaxJrtuTIbWCrbstSGLDtl8YFfVIvOarBB_WZT-6MTPtXjBpJ3WaEVLiGAMIM5moylE_K6E4XanOiqrw34Q38ncHJejyw-skz23suMoPmt02Y0MkpNBsndS9kh11OirVRlj5PJMG48yIFcVL3FpNd_pzrIatdjDHAxfQEfbAWiuY_cki_kAnGX6JTDkv4Gta7-_vvZiLCHCqvqqUhRIEj1gvLPADbuCAoGZwdOJS5_svQH0PjycyaOW2kn69fH7JCBPuRbHoLaGFkGAUJaqFW3QHyIf7oXhs8eAfZd0-f0HP4gxgrGUBd5qtNC5tZ0kdnn8uTo3du3vnR0cMaBj6P3YxpXBhCtApYyD5ri-mmGBusX8uIJcVWAD51gORx8kYlFBSl80xBJewctvDOv7w2pVIAjgOkf6WvPg1LXZBtr4Jfde6Kwd7_xu3qfCqVRhNyaff3bE6YoRJYgWgoToFZb2PpE",
+        "enc": "A256GCM",
+        "iv": "WjfpDpX1Xtg5O8ek",
+        "kid": "er2hz3idctundugolb6xi3znii"
+      },
+      "packageUuid": ""
+    },
+    {
+      "uuid": "lbqbiqdk54arw3elzh6bpjygpu",
+      "templateUuid": "001",
+      "trashed": "N",
+      "createdAt": "2026-08-31T13:08:31Z",
+      "updatedAt": "2026-08-31T13:08:31Z",
+      "creatorUuid": "HVE53ZQITRE4LDVGUZZXPY23PY",
+      "changerUuid": "HVE53ZQITRE4LDVGUZZXPY23PY",
+      "itemVersion": 1,
+      "encryptedBy": "er2hz3idctundugolb6xi3znii",
+      "encOverview": {
+        "cty": "b5+jwk+json",
+        "data": "ye6bTsdskzo95sBDt5QWibKKxpSSkPHTSczD-UuZy2LDHKycsu1LU_RnWpxPOiC9jWJ7GUHbo2AGtE7TxGsXUXRfxThmjh6huT_dEUI3eN6wqXPIRLfz1GZpanaUVaFjdvECdEHlby3Zgd6LwKlxFvArS0ptRV9h1PMwXGkXi2RvLCIKMZlCK_tAELOJj9076pqVBPiw75y4UbUC2LgYOGSsrpEDmE_S2V8iM166C8LjaeDyXCyiBrC_vUwqBnOtJOtc-bEvFYg-TrzGBQ",
+        "enc": "A256GCM",
+        "iv": "JxNnIglbsVt5mvRS",
+        "kid": "er2hz3idctundugolb6xi3znii"
+      },
+      "encDetails": {
+        "cty": "b5+jwk+json",
+        "data": "XU58p6lDCvecHELFFYYVKd-6X4fQYHT_fZrQuvdxGLpTQ_ga3SA_8PxpfS6JiuOMksCweKfffYZ6DVQU7yRo-G9Y_6thF1fnFYYk7R6fZIFRJXHg85Q_kwstRKEcySi4uqsPZgfIYckRhxC4haJv313eSrUpxDUslHzhdr1ODEUHOJW8Vzp1ZVxA6V8dBZ7mH-gwmtQo7-zfzUSROwUZPWAQ4wOKJTG6JIBeyA2Wmd4BjuO3_aqx2XA-THA465vStgHF799wPU3G6PeFXznudxe4MJS66fHnxMry8hnVFzl8g4r3PdQD86u_7Z2uZfkRr9m-ETzteqlW_Aqbo6l7KhP-ClDiZ8JtuW9Aid8qOC6DX3NjJ62JB-RjtkP196UkVpEI0n0ddv_R0ulRHD2cZnhgpFK8V3-qwK7N7VEwcPrmYgg2zvISImGoGYxksg9m",
+        "enc": "A256GCM",
+        "iv": "UhJc_iQZuqD3Lk_g",
+        "kid": "er2hz3idctundugolb6xi3znii"
+      },
+      "packageUuid": ""
+    },
+    {
+      "uuid": "uwnl7jk7onggkogpwpyij5k474",
+      "templateUuid": "003",
+      "trashed": "N",
+      "createdAt": "2026-08-31T13:08:37Z",
+      "updatedAt": "2026-08-31T13:08:37Z",
+      "creatorUuid": "HVE53ZQITRE4LDVGUZZXPY23PY",
+      "changerUuid": "HVE53ZQITRE4LDVGUZZXPY23PY",
+      "itemVersion": 1,
+      "encryptedBy": "er2hz3idctundugolb6xi3znii",
+      "encOverview": {
+        "cty": "b5+jwk+json",
+        "data": "cfGZEsXSk2gVVWHJdu6JEnRdq_yzfaEZA8wbIs6QnR5STCFEch145CShfYUs032-xP7G-KcKppfbugKINdaiFimZ2DvSgneMmEraq8ltaQLwQR7uoeTIDbqIOKKXcvAyuvogEestq96sV3tnyraZ7FsfmPJ5qb4P0K8",
+        "enc": "A256GCM",
+        "iv": "gk21pW2uOAzN4n6j",
+        "kid": "er2hz3idctundugolb6xi3znii"
+      },
+      "encDetails": {
+        "cty": "b5+jwk+json",
+        "data": "GLON8r03LFs_0bSMUDoOa-BhpHODa8yLldpWFW91R_x8vs_Q9Z_ChNTPkKDMVu7EAIcl0SqU1ZIJJ9kUXgT8SsaXnWUy2bMfUZySSFx8EQ4prPFOrr_TQ2sIN7WHqqTSnjzYcsRrVi2S-nM1hHdoY8JLrE3DPndCTpl3H1iNUlLuisFNncogoXg86p5tT_b0Bfl-fvq0eSlNSmZoKyNTLovI9AX1d9ji8fs_HLvG83NRD8fSxujBq-w5F3BA73zB2z1ZFMKq_yswfbRUzCO_p7ZXjmH-8KtVwCqMPyWBgUKh5q0yZNbtvDhHKRaId4Mc8-quMx2cwmLBJU15V-rNyPEYih3V39F6gjLcwEEmbIRQVPDDU5wZksUa1vNG0U4kMgOxuNvtpqnU6WrRzwasn1KpvTXU27r6tLJh6dFl6h_O9_5FFtQwhsdSJRaJG3HQvAbi4ihrSx8",
+        "enc": "A256GCM",
+        "iv": "WxBbroWrl2uaL86l",
+        "kid": "er2hz3idctundugolb6xi3znii"
+      },
+      "packageUuid": ""
+    },
+    {
+      "uuid": "h5c5u5zwsqprqfywbygi6jtpme",
+      "templateUuid": "001",
+      "trashed": "N",
+      "createdAt": "2026-08-31T13:08:40Z",
+      "updatedAt": "2026-08-31T13:08:40Z",
+      "creatorUuid": "HVE53ZQITRE4LDVGUZZXPY23PY",
+      "changerUuid": "HVE53ZQITRE4LDVGUZZXPY23PY",
+      "itemVersion": 1,
+      "encryptedBy": "er2hz3idctundugolb6xi3znii",
+      "encOverview": {
+        "cty": "b5+jwk+json",
+        "data": "5-A5p35ArosdKBon_2A9ZZv9y1vgJcLsz9RvQrhpA-x7MIEkNgKFlDzir7MKpp6XvXDOTUjlVz4Xl_115ckwoDmv_4w9yOPUdvGf0qzcTlf3LwBB0-O38e8v41COZ6Ea4Cb3eZlzA_9y7ug_X0tj5EfHD84CRqPK9U5etxFNG2rYsLsAzHLig5rIzrz3cEDSZFZboepri_1KCC7QzPglXWvmyZZD6dfzdzvGxXHicrU24q-IMi1JUA",
+        "enc": "A256GCM",
+        "iv": "yhogwjClPAVulWFc",
+        "kid": "er2hz3idctundugolb6xi3znii"
+      },
+      "encDetails": {
+        "cty": "b5+jwk+json",
+        "data": "_dPBHdigb-GkIuAcVTZF2upyTg6mgJNEZzKxH7B6XGj8Z6oPUW9VvuoFQPBW2lY6YTkIUrcVvZzuTR6XQpvtGYMgu703xqnQCRYVr1VxnEmYiaq_ui1G1sSRU_Mgbpcqp847UEobnxac5Oenic3GsHB8IvkKo6EWRkx6Cft4dmq5mSiv2NktoPK0TOCl66xmDwgigf6al6wLxlEaXi7xEqWlXWvQZELYdxSJMF7ZpVHVRLYCvMHuqfv8BCa-wcSN47Jrylgv2bd9pXxfjz2EtCbOftY-CG_sBmdzJm-0OmLY1uVtjvXL2jy-JNodHeCA3wfmLeNcCuCwp1OBa6GHH_L5twIUU2KA2wKcnBhvTLhKeGMzCnf0kYTQq-zlyQZpXHYK_-tQh1RAwEMlfQiFZLw0BuAoRB-VY0QrCyl7sNCVfxZp2gsZKmazkxfyHrD8zdA8IAgsbXsd5NP4OVZDesWVvl19-aF9TGE8kCIIa43G5o65mRd-sXFcTGEdmTDdLC9BMYRTR98myWe-99fIQ4hMmF_5fXytwTGOkjVzj2Nr_z7yljcJ8uW3e2UDf9d_01UQol4649hsKbEJj3XLnYFB12Nnz9K_WaU3YyxnPpa4r9W8JULeMebgTCyiJncQu8fgFGQ_-VHJ_LjR",
+        "enc": "A256GCM",
+        "iv": "QGxEgMibn7Y2sA3v",
+        "kid": "er2hz3idctundugolb6xi3znii"
+      },
+      "packageUuid": ""
+    },
+    {
+      "uuid": "o3kxukjjsqr6aunbd7gwy6l53q",
+      "templateUuid": "001",
+      "trashed": "N",
+      "createdAt": "2026-08-31T13:08:45Z",
+      "updatedAt": "2026-08-31T13:08:45Z",
+      "creatorUuid": "HVE53ZQITRE4LDVGUZZXPY23PY",
+      "changerUuid": "HVE53ZQITRE4LDVGUZZXPY23PY",
+      "itemVersion": 1,
+      "encryptedBy": "er2hz3idctundugolb6xi3znii",
+      "encOverview": {
+        "cty": "b5+jwk+json",
+        "data": "gmnse1IVjR7i1pp_EBIdn8N47lyaLeUvDWZHhRQG-VAkdvQP0Hexj5Zz0Qap9bKl_GC-yI6lz9dquwsvLF4sNDOpl46hdfwcXuUtxc9Zp8I9HrRa-_OvFkduCaYGgWaL3mPqLEfXZDUC0sGoGO92vh2I2lEWNod_xNLENgnhniPB0WIF6NP57tcSm26kPDgMHq9DACJVv-zfnOT1Lw6nQR4C187EwanvIBWCd4iSB8kFPaMHvr8bCCAl553BOL1gLKhj9A",
+        "enc": "A256GCM",
+        "iv": "4fYPfEoSho7PrhIG",
+        "kid": "er2hz3idctundugolb6xi3znii"
+      },
+      "encDetails": {
+        "cty": "b5+jwk+json",
+        "data": "bgVgKe-YOCA4_CdZqKmGFTEvLWEIoIizQNbnq3IDvw0b6s4vmU65YInje-lagcFCe-jxMXkdkO6wZxhYeY03CX7cnT1LEgVfH3cHtdAiam_IVcXffpH3Fn6SEGMWXvRS9SsG_6sspow61Xhr-bkjIyuOEqbe7ffsmodhFS6RsHrYPryNzEUalUskllXTaFMTH9ytHvL8wqPK2MvbyZMoO4-kBA8S0zKCNz98ABOFkcpEPPIap2tWQhT1V5zxQZ2kwf2cwrtgj2zH8miQbHZ6l34FXXZyS_2exczmG1ppTnoGYREFGfbKd7makWUX7tfedaMKaWbM-5LGXiQEssMoLaEWk_H3Y3J96_seiWyMzssNkRZ31uZj35oIQkxeh8q8r0p34LZRXi1r6aZXdplY7iZNuwXLAlHbJynWy7PU9v0EehvmUGGyoDenlEJmkryg98fQfyqk8_0eskwcClLnWaNTIlErk-owO3_ZbmL7yGqJKv191RpMRDbfganZBWVToL_W7dDPjkiV7ioCOVbrebrFfNShoNnSrwxE4zbx3sKFNLKW24P8R4HealCryDnFWoDr386oLmQ6UKNs3m5vT8WEvf0rkLGBMDX15jgwgIKRA_Q9LykLQTweTnX6aabMbS3o3VkWJI9H78D0N0t82DqwP_tbB7ZSU72uEYJZWqzYFBZBLariwMi2OecV1IZGcjkxjk6NSWl66lm0veDpXB5CZeKQPaIi2GCcRhw0h5ajeX0njNHozHpfF7Tq1B05UuNL7S7epXqSsh8FXMvg0mvc_qjEYA",
+        "enc": "A256GCM",
+        "iv": "BcXORSMkIpq6papM",
+        "kid": "er2hz3idctundugolb6xi3znii"
+      },
+      "packageUuid": ""
+    },
+    {
+      "uuid": "bobhazrkie2wa6gdnxguq7qn6e",
+      "templateUuid": "001",
+      "trashed": "N",
+      "createdAt": "2026-08-31T13:08:48Z",
+      "updatedAt": "2026-08-31T13:08:48Z",
+      "creatorUuid": "HVE53ZQITRE4LDVGUZZXPY23PY",
+      "changerUuid": "HVE53ZQITRE4LDVGUZZXPY23PY",
+      "itemVersion": 1,
+      "encryptedBy": "er2hz3idctundugolb6xi3znii",
+      "encOverview": {
+        "cty": "b5+jwk+json",
+        "data": "tH_QAtSMDBtwdzLAPUZBODxcYtvvYhoks2rvDGAGlbG_RS6jpNZURtuNF37ukOXVnqt6I7P8jZ--yCUeqAcvJyT2puBz0iu_Xo_mQPKWP8f9A-JZiznY1jFqdn_C1VHELILyqKbUjPT7WWMfTy8CRXp8XgH7PDpgrvaefZTfkTx4u583IhYbzpw9QC9c4ZTg5NrpyFHlXjpjb1PoLGjLm9t536_K0So_x0lGscCC4-x5CdYtyFdIkrNomwY79SH_E72BMqvvANQHq17_w6Xi1G7JqnwytwsU2s4WqF8wEq_bpMCMINVqKNhC7mrMG1t2gnsaZN5WWLarX-p1EP2qUnqSUm5KRMTlt3caX3u9iQ-lzxNJcZNMeXUP-8vWWXJzMvbE6GKFV22RIDQVsoLS",
+        "enc": "A256GCM",
+        "iv": "ZZutG2PGFbgwLFet",
+        "kid": "er2hz3idctundugolb6xi3znii"
+      },
+      "encDetails": {
+        "cty": "b5+jwk+json",
+        "data": "GsB8C-Y5JeNh_5XuA-WuI0XXU42LqB7MZjJ53IT2A4VArtaQKQNAXI7l2FiFlVzYX-ATN8OR6iTau5qJ1sSs5XMbr68jQsBVglP5uBQXDztufS_yr4pz5gThdsLDqFi4yOnP9_k-31zyBip4pCb73VJCTZ1DKUE9hXxgjYHY3fAlb1Cca7R1jJ1XWYwjq5TecxBrfheAsb2QE-FAOaX5CDoyNkrzse9h19ocm-2xzebypMGX7JyvAFPY4pUbpf2NQrmI6STILGKPnTWXKI9ZE1vA11x4P02d7reymDDs-Vp-T6zSzMhJJtQr-Rmh7Sa74bgrg2GMkWh8xq-b5DDs8bq70Fo",
+        "enc": "A256GCM",
+        "iv": "b8OiTxltUca1vp81",
+        "kid": "er2hz3idctundugolb6xi3znii"
+      },
+      "packageUuid": ""
+    },
+    {
+      "uuid": "wqyp2lgg3ozvfythna2zrk4yae",
+      "templateUuid": "112",
+      "trashed": "N",
+      "createdAt": "2026-08-31T13:08:56Z",
+      "updatedAt": "2026-08-31T13:08:56Z",
+      "creatorUuid": "HVE53ZQITRE4LDVGUZZXPY23PY",
+      "changerUuid": "HVE53ZQITRE4LDVGUZZXPY23PY",
+      "itemVersion": 1,
+      "encryptedBy": "er2hz3idctundugolb6xi3znii",
+      "encOverview": {
+        "cty": "b5+jwk+json",
+        "data": "F9HsrfyRYT2KVL06hQzdnlS184BlgHLywUeQf8cfHTcSDSgPnpSQprkxd7jVjPaE3dYrC23vXhxTd7_Goe6jL_o0lphjhEJTopNOg-ypEEDGC3Xzv5fP-c_bVqoVdSrefjoocvyvZpa2FA",
+        "enc": "A256GCM",
+        "iv": "aYMMq2Vq4KO-IRRE",
+        "kid": "er2hz3idctundugolb6xi3znii"
+      },
+      "encDetails": {
+        "cty": "b5+jwk+json",
+        "data": "9z-rZCfecYoTufEIGNn_Iq73A52NoNAzkTY2zuqztrQSZtAnCflE9xoDvucuWy6wiJXxLQr3nK3azlINwVsFHF-_NbbYc0xUT-JqUY-Zkm8RcK_5VDQ-2pLqXZlzliQJ8Mys5b0ejUSbIbAYVBmYNLQs6qWLpCxEpHS9UMZxgn8sonpmxZkTdz5oOeavBfX_72_1ZXhIjU6l8TZtlXqWcDFfL_IPDhKcZ9LmqSlelQai0zx02pn45h3kEMf66CqvwfpHIvbkkV4_dWdAiduuihEa9Z_a0ZlSq7X_oWSzGtcNcw0r3At8SZ2kLSPUuhIYweiYBH6hJWYjs7k11y_dleJBUCb50Gaqe7XJNdCHy106-IxwqCyWOOvGDTKNmYWdlezd9ohpnjw_phcoVqbvIUItV14gLxKZ3Oqr3kzqOdCLhEfxo0nOltY-Hyk2MgzDwaWPCn_YX6_nuWYIDpqICdGgWtEkysz1xoC0zdrpde4zj8XbSdYGDbcyghl_5QYQd4WJnYVOxf9xSjKv_sqIGi7p-pFYJKnOycqnN4yRWBKLvyDH_urW2yUXzs-WLfs10GyE-X32KrO_IgmrY4JmaY-PHNAa14F50uDUCgBgyrZJCaf6mPgYegvqXanD2uhbQwnLt29H4IlSx8gwvgOvgc9mS0Edm8E7wGYLCmNvaEqGDiBcO10jTYCOxM8CiyK6SydSCVk5CxrKjA",
+        "enc": "A256GCM",
+        "iv": "fbnZR1NH4l1hIlOG",
+        "kid": "er2hz3idctundugolb6xi3znii"
+      },
+      "packageUuid": ""
+    },
+    {
+      "uuid": "xypssdzoqdilw7blmhcxiovkay",
+      "templateUuid": "114",
+      "trashed": "N",
+      "createdAt": "2026-08-31T13:12:36Z",
+      "updatedAt": "2026-08-31T13:12:36Z",
+      "creatorUuid": "HVE53ZQITRE4LDVGUZZXPY23PY",
+      "changerUuid": "HVE53ZQITRE4LDVGUZZXPY23PY",
+      "itemVersion": 1,
+      "encryptedBy": "er2hz3idctundugolb6xi3znii",
+      "encOverview": {
+        "cty": "b5+jwk+json",
+        "data": "2pRpA9vYBeRmbX0_VY9Y6J5ezkwalv03C2LEw51Jgm3oomuXT3HdvK_z_55agcQJI1I2yXIOZDik64E72fRM4oHhaYyX7g4VKVMIRM_gGNJo-5x5UylBWKJliwx2HL4wJLUFo-EgEnKxf30-lwhKQGJhk2zYk1eqIoBiJl3nhvS6enSX-Wa3FCm-qO1dFZoiEnOgaEU",
+        "enc": "A256GCM",
+        "iv": "_lPz5WZgDPXJl47R",
+        "kid": "er2hz3idctundugolb6xi3znii"
+      },
+      "encDetails": {
+        "cty": "b5+jwk+json",
+        "data": "K-Aqt5nDTW-4vRArJ3U3iaH5QODyxODsI5eVmyhkuoni61ZjvTixClYe6k0faVc8PYh7G2qxiCGrFHJcr7dZbE7Fw1u7uWbvT-iPxzOTWCOIWNp8kjBbC0gLio4cHn5WxUDmE45iaJDG9R-tIf2M2Xe5TMADXoe0SsZpZU7EvreB9L9Hgw2pfORP6QclWCyB_Ayvj-c9XprfAILdje3dyNwZoLzEjQGTwbRYEqM0ifw07uBMgownmPUWP5ONi51L72Bx91dOvu00ew4kb0gGiRghATKIhDE3ocl2tj95sTOtJdXEIR3TN2dbyPumQIMPhcPyOgdtMHDrZgVJ_3cS7lYbIRRsPga6Z9pRZmuoXnb2ayzQhRa_lq4zV8FgeMbCL3Gkf-x_rdkAJI4FT7SvFJyMuDfMEddqYBxFHiT4u7jPnQq4EpvwBBZIyhOkb2F_xwZNtoVaIjDRmFJnB1LtXmrSrk9orNKEoKWiWVID_I1n5mzNuqMVW_v_3VL-YfkCezHTeyYxd_zpXVo-azb3OhjzNcA-aiJfy3FVQvBpqgL11I993pND0dQEX3zzt4DKNMhfCGss1VvU_VGrMh74_ENB2I7Mga2VQhN3Xv3ztlbLJU62zPFx3JiOh_llVZfKDTB1Ww-6u-Tbzi3_Y4-MRRhABp_RZRZ5ZvVyEm_Weuk5iOnV16xWCPYuNDGw7_U1rqGY60BuIV0Tgln4Q-TX-1yIXwwwYTgWwkTcPoYpjFoCPIarsA66-MhS-0IvIMod5cdJv1Da4H2OxplvGxmY0tza89tuwVvg-gq8QH8NN36aYSoz9NnUb4fHoMSk6Y_LSJij-49H18F3cRHhBAAQF2Bh2k65IUcr-GvHneYyzqILHL4DJ65I12ClXKloUIPj_2CMcSjSNbtVHGW5wUHgjkoXIaxf947LO99oruhCLTtz8byvj19hJ8pL1hfT6_btMfC3cniZvuQEavsz34HiOOEmkLSRA0VvXEkDJ8nw2L1SsE_Kiox8Iy9JglUOfDRVHBWCv6fCE5KIBOvwJsR9XohDuCp6pGzd6lM80cV_KoD6WK0dB3leBS950scq40MkYupPA16u7QV3ig",
+        "enc": "A256GCM",
+        "iv": "gDno67QlK9h-FfiU",
+        "kid": "er2hz3idctundugolb6xi3znii"
+      },
+      "packageUuid": ""
+    },
+    {
+      "uuid": "nrdoajk57ip4zobccuqihh5cma",
+      "templateUuid": "114",
+      "trashed": "N",
+      "createdAt": "2026-08-31T13:12:38Z",
+      "updatedAt": "2026-08-31T13:12:38Z",
+      "creatorUuid": "HVE53ZQITRE4LDVGUZZXPY23PY",
+      "changerUuid": "HVE53ZQITRE4LDVGUZZXPY23PY",
+      "itemVersion": 1,
+      "encryptedBy": "er2hz3idctundugolb6xi3znii",
+      "encOverview": {
+        "cty": "b5+jwk+json",
+        "data": "m_zrtGpEWwrfyW1bHUJFGfJB8cOzC7MjL9JzkoobcyU4VOPZ045Hx-5ywamWos4wCk8-Ow4mahjgViAQXmjMuejdIF5RosmQ0FzH9guvPYBosGzAEbpn0Ykh_fgx3ADKs41bMdRSQYJUfJr-cF8YfgviUMDjB8T84QP7Nelunrg",
+        "enc": "A256GCM",
+        "iv": "H0anIbbFMplU0-za",
+        "kid": "er2hz3idctundugolb6xi3znii"
+      },
+      "encDetails": {
+        "cty": "b5+jwk+json",
+        "data": "orCaOBsd9yfVLFe45REXCwx4s8SQt6EwZ3z8VNXvmlPWz1wXeWFn_XnZDEAOpY76orDzbmwTSlcSbxZnNmKtQJIYBqn258nXreWPr_hylkpIKQ_aCFXFtR_6dhZiUxERg__m6bJW7syz_ZlFTzV8t4FMJTnYAug0zpYL590IzHEDfqu3gAn18MlaCNcMmMYAN77rf528p3hpc9KY8c_KdBHTyfuNguL8cJaYSi-zBzA7F4lXM0_tw5Jn32D3AGev4Xlct2AelBc1JyhjjSj9_zYsQRtDwFhYaRqnCpzyPuy1UpycL5xLM7Bj2Axo6BdVrz5ND2FZCEzcU4_2rI_LDNoet7ywUzP-d4d3bY2XspNBxsoiEBSaTT3Nu0TyIMRd7huyxlwvU9vqRj0Nft4ETi1o3JrKSW_Zun-SsUlF8KnWg1duoEyyNAS8UUNZEEefAiVjsRvYbt6e4MXD1QvJ5w7QONKf8G6RJmunB1rGNwZl3H-G51X30cnZVdaTS_HLDVytrodxJZARSD9MhR266PZffuw_jvB6WNtETM_Zj1soO2q3K-18pR2alXH-MBbFbdrnUYt1KmNf7MWULG_6KDfw5MDYty-Ow739PbLuA6FgDKdKb1kq4AFMpTOmJ9mEyi1aG0JoHLGdqUcQCBQI_0V_OM7YdRcjQb5VufekLZhM9SDojPaYZui24zcKp-iKSJ0imjuAiA3fbz398FLplxB80R4hk69tbZIo21csNpfP-dbvNmEVt4E6D0_XBnmTn0i7BraCeoCoUs5XcTaokQ1ofgtF8fQaix8m-phWUU2I6lTVwjLdthkVzEGmW-rM9R6-ncYkX3OozPVnjNBSKvhWUXL1S5WuLgv-SItqWFaeHGczoZmXpIzinJVOlzl0IszVmTAUQhUMn1vPx5XPm6uLFOc4NcxKFmz31SLx-vVdLdK7SBxacVVvn7QwcqzRhRGemcL8Izp67Ke3id3H0CCiRDCaB2p_JZx4hokhrSyqainnFEi-S3SEbu93nptoeBkI0zygMgXkyGdfX7aVogNqgF9uZuEq6tZYbFcYTYBHg7hyS4IcU10qf92ziqlT6FhBFEi9hnJIzZYc3rjIZnrEODrP2DgbFOl1OnqVFUuLl-N1Nek8rdU-ODrCax14F50fw8U6jMhYsuYQIZ1TCo6xv45FaCM6ptdgxOj-ThZokQ1gxzJjt_IF554KMAMIVm087CefGaldUDXQEnoeJB2k_VQrtK-MVF5MDIJkL5fM3eCEpYhpR9el58KxLVc_0oyaZLJh3X8nD_OYq2AxnIiaAzglY4Xcm6HJ6HJdATyOg59I0pu00dNA7KyMSe_2i1FpV852KIXwRjVntQfVoRHQEUvIxW3v0if3N6XCdeXLwqbzwqFluTZ7Or48IFv7EFhwywC180yNJohW_skPcm5TEAxh8h7nwuzp5orG28fO6r5Oox4HtEbJ4pO3c_Z8fn5FEi6p6B8arl1IJxlRH5aruRGV9m-bUVd_WwGngy9ttjTx0WpzaTNjOZUcPakFg7iYhH_xD4ciAU8Dltp4xy4JhnYkCGKgowi44An_QxxRJEfuJVC7l66f_RxhF3N00wzvPcUYiQsVRxzH3sJV1P1rXfDQOXFbk1MLzGQdcONFFhf72-r20MSu3-lMxKDFs-fEjXkT34BZBPmpp5ALjhu7q1QQkYINwPbYJI1x_E3iR9ujZ2dJhlA9_flfnlRKHiJOJJLaglT0jTtPiybLIaFLrUv-JS32xizCCR9Wl_FPdVPOQueykSWchie31GjDUy0DTQJNtg85tmkAufIzPfS7l615m40R6qYLO9mjUEUfx1eo6FOHU9cXZXNpcwyXH0-rLUiZgKUSv-4KI4rKR3gJqQqR6ZaCuiQ1ssBxdgYAarKUAM8D47-NLoQBYwg7WbG5aEEQAZAX0TNq3gElFtXPp4d_CIRD-pEZ5yidVwBWdohE4xo8rPcpa2xLVknu_JBoEhZWK1tpnsKDjNOtHmE6pVAN8to241eZ3XKKwt7gx_XSp3JjIzHaBfV5XWvGOOJnov3MoDM8vGHTtMd0QIxVkDf__IP-hJyv5aLycvhdwxMqyAxHhapeCKJZrPcHG-DKZGM02frOlCnlCKjAN0ExJ2pLCaWbJLuU4si1-ufU4LYVvcRN0hQW2858E_f-oBT1_8iuWejlAHYofSZHO1Tcf3y8_hgwyVJzMizEavBeUkuSGggsM3_aojBuF2-N6gTQ9t5XODnxJI-XglMqqsGyinYB38W1BXKgEkwaoTECIu17VpkKqce2P2fVZrBwSh5xwkGZM3bUH-Kj7ftypVoaj-4esBVn0X_FyEFt1E8TR5uPADFlAxaGEZFfrdTzd6j93QkDOrqfMkzASUiFwz8WNRUw0zamAr6Qee4pwnoDXpa09cuq2uBiANV6JsvAt3ry9VBiB7DYoNJ3-bga-b7FD552IImJmsqoegnQi6qT5Pf1xGR1eRvTnYn1DXqHQJTwiqSuJXLsKucsPLW9LiGd2IEC6mcT1IfmoTIIatOsyCW_7X6KCJvhSLG5vOdw9QNKjU991UHPIELqcs3G2KYomxbHmNC9YScvtaeCH8LC1yyi5MooWGXqUo1Lpcj8MCmpBStgPgo9sC7Qa-0gKjSpJ78zIC8MPqrNuJdA37DILrC9URTmKf-S-X-Js6Ps84-qzBzCvvMAAm4_BdgTVfeVAN-nDx7PJYKNQ_GOK1gmcRbtiJxyJhF3huJtq5iWL6I9Nzl-AylJE9OdB6MSVHJjNAOnNackObRoOz6vuZ-nZGcwOLWiEjSqjuDgmqaq9QkpTVQRQ5HQV1yGzLZxVe6Dluts09HRDPdXjU_DShVK7irkBIhv4bUydYbVDMWs8uyzLM_W6qmLvVyPV6yGwgkSQAhm_DHBBhsGNpqYgYrxoxZ7va1Q9lFtvjMvtp8Irw9INlip83QxArac-DKGoMZDmDQyd9jaerI0O6oKIo7R3l8BT3htX7gPgs57lTgEGFPGJhGQCtWH6KabrO-lPyHS2IqTPf1Qa0vJSSkM9PtOKjyv-zL0QNmn_pybu_J1dhtNzzxmAqaJZLJzfYC1N0sC2ueXG03fTkqITxeddAi3TlDKGBGny7MRI6kL0wn5GwUbH0hnneABQ5p-7CdVs1gCqhkwaJ0kZKuZygC3mg874bcoX573vBoSR5VbDs5Qaao2_ekaKE5sPG8H9u7g2JUhG4StpjPUcy2EygHL0Y7nb5N7t2ceSK1wjPhMyXbDLd2zwJgpB1K6n-YVdWOnOB0KehrBQa7ypb9fs8Hq0o0YdCBtfGK9yrmKWi3q0UMf5pvCkfNqPok1B8gk_KFtl8H9T1qTaC0V_9ZQ4I8uj8q4bkTkww7-ljW0ACXVGWEpq3lNWrf9UzmCZ8u-f_FOUR7pT8jgJ5NzM71euwFH83yHsOGdlWOzKbsFYNPRXH_JAXRSt_DSwlq9wQXWofE3jtPH3xyDYMiC8JzkPP3WmWMDj4SsoJFoOcuRJiX6eSgkPe4hTh1Ynn4WQbvPgidPkE6LCHmLnqcgEUftwx-6bM0f1djgeRDb1GUJ7yLRC5bczz_L2-m6ENP1W1eV0GG50QoQha9lEUh3cDNTooqLHwitXCdpprd6e4c5TJDLR4PLB___ODApqn8LvI9koVvSrqiWsLeJoiw-Ggz3Wj6fFR_GzJFNF2CiIoq-AVdzri0khLME4FB5DfudH8pAdcdQRrO57iPFnDwSg9aSJ4cFbbbLIGsglgN55zVjuK-de2WjkH_MSEBZOyuIvd0XVoGTze9pVRe1Fq43kE0bAkoB9FP6c7E8v-YTLrSCwzvwKqD_YYKR7ks4YOZi2GS1WF2AgCQl1aLPfmVwEnsS30EboWsyZe0g61vm0x8AZW8Rkbxeg0veO3OajC8qM1uY9mVPCl8U5xip5YTOmLjmGMto0YYCz53xPKssDEejs5N8MzDSrJQvi-OmmdgI2U1Z0UuTaA4igv10Id-nsAVOKsC5a7-JlYBoJIZuFyTl5mPsXf41nrZPAZJp9v_jOfhz1NVcFgv8GxHUM7jF2CXz9NBTCfJfSz-ilwXPZ40NzxSp9pYqjA_64CS1S7woJ0x13RIITCVWvAcUgy3AfXv8usVrsB95FdA703C0D7IMPSgEbc92OaVC1IVTEF6qMTgEI07dFz5SmqIH_xIipYTGeTDoXENo_9_Wz4CsDS3B-3pYQgw7xwiMp5VW0reKp_AGfYmW7KC1SG13DjWaUPWgiNAKRlbRjQStpWNx_wSCO0q-KRle1WjLzwtmnMn2z0wIO7xXd1U2QlAAoSyxJpOB_2tFOfeBRvZsCpefveeOhOOLB6Pkp9CBs82f8HtIYkfaIXc0MxJWs7yj1cItD4DJGsyhSL_zMxxBCF02TQWP_fx-rPDuodSZqDAHs2Seo2nD6anUIzS4EnhYCD_CSE36LWB_5Ez6x2ghA-JHRnYRZp9K2JYyu-H9OZnoRrAMQNyL2ti9iYfmU6wWhNb-liVJ84vVH8xNZH9vmIJmimeG0a6FmhI_39lna2OReF50MM-l3gqWXePr6bfyfRnJQHxqYrmfe2Kf_W-Q8jOHDhz2b_em2Ei9ME888OvzZmlKlggHhV_iIUq4jf9h4DOt5Q39RWANz6oXSCsjjbUGrh0T5vDBT0Go3p73w6dzpZ0D7VHOthLrghH3K4Ucad1pGwSLL24i87Fd7jBqY-lsvzQuCjxjzZAtFpscvm5y2IP_SYDG-qYQRBiUMdiJe4dC9m_Ynd_Q9fhPPHXWqWCvHfA7jI5zNsxMfh7ezAWp_wjun7vvItm-9pkE9ml6_1POGiUcv618ge08caQKXYabP0D9wEcn2VI1gvLEeofhKMRpCwFUsulyMax5MwCKcVyqQicjT_7Im7fTKkPNaCosqiDspczzkhiwHRVI99kpHkjwyKSRvSqemeqmD-5x5HmDNjzOicd0593cs6UXaXrdAjAGROt69gkDHa8i_OOgcI_62TI9tvkTX4EBQ7ZfGyW19oCX0RsTbKLrOGBpch30Mz20x5WM1hvQxvtOERhD_XVq1w7fV5cOdpZyqOyY9cCUwcrRe571fiRg5lUF7Iw6tTqjWO_ySfacLM01mhBsKbI4Wz4g6UX40SoLFlYUWSD6x3ClndFxkhjrBHO99VsPg6l0VW6YEenR6NT5O771HB7tmTsygwgr9o7SOGkCZbAdBbauHjaNBH74RZP4XtiO8QIK4-nPGk2z9L4l4jT9g_7JX94-H9RJlz0dEpNPfudZdZ5IbKUag10snrDGrjNsow8_sHYs9Havw_aB1pGmCUz78PLBMf3n-tpOpHMcWgudyNA6DS58MUIShEaFE1VOlPyhgXDqEVmak6W3icFdLY8AmKW3qj33kB2MD5rzqYxfdwm0RG1xP5b0Jy_AB08b28LbOsxvm_oXrfsNQgy7pwmGOdy8uABRYq3mFdC_DSlXL3y5CAUMARvicoW99q62OTA22nmhdlVlTxqDQeXriK29cttzftrene6HTQo9YP8JMmTobKebKRkfmwQ9KALWAfGg_d78blLN3t3keJcRjp5c0pIpWVAoA1L717Q1hudhJwfdaXbUPCn0fFNTGWBnzzmFC4S8XYQZoxleSj-3yM5CdaFkISgkE_aW9pecW30zxTsEbU3o6QOWGHAWd_TWFyIB-i36MhN7rTF9vfhYa31vjealcliX9IdoGcz7TQkoN7xK4RxbK_Yiy19MdNMTkl4Kyj07D9NL1wsyo8kKInKzsBX1ujDNmr_KznGQ3KZzIbWsSGdPZHesdD4i7Us9k_La3bkcfmBvLxmFScd8G7idN0z66bJMkVsk3RGxeGJ6BQ32ggRNFCs49ukrMGNJ-PE6BOi_ofq7u3DpmZFVYSVoANFSpiFLrMwCEgpNG7DTvM8cyJaQxtywGTkjLgVt5IqblKT2tOQwNRgUUVxnTrAjxAU66QpwWqydrhKtsX526N5taLMT1D9RwPHZSKEqK48JJimPg4pKAVt612AkymOxMbm9XmnERaUsGt1dEPq82VQdlljx0O37rPnsaL8fKJgdbTIHCFa8n0jo7X4WhOrsreH7AeUW9imhk8X3zdCIyCj8VqHKhkho8y00CVYEIZzE8k69d48-CKizJS_XzbFRVmnj2ercQqeaXwrtlHgVz6b9h-s-tkDMCHd6L4jA9myrFxbHe0OXVEow3HAuZZ4rQjCvXTfjRgB8dTW8VSu9bBdQ8NX22oVIJVFmQVUx8ihHoIdPvb7U-gnke2G4ej6HuvzfYOZYgv75EF3HW8KMazqFL7uDsjYHkTwhW62RycDru00WtVzbTHNpJuKu_AXVrcJsceViI5rZbKh6mhIWrmfm2EZIE9zAVPqnsXEvARTZLBC4oOrQx_1sQ4u0Dt9zZLCCc47nirw-q793CreJZtpAWOJm4mDLjlNlhkPdux-eq8DzX8a7uY1lyp7gxWDzr509Q0WE7Y6g4JOKSInL81A9O-L0EucsK3WJXWRciOq7mpTapyLLiQ5JpcgND-jfER2fT6-NTiH4U8cDwWP9ykz4CTFo6OiZd3bpwDLQaRJhJDyejAmjAoSSZGsuQ-IKYnu7xzLnb9Laye3NMF0r9FtzIv6AKonqPo8yKC92J_XJ7oYXYzvvf27Nrwj13B_aUeXrHaLkmUdahjCaZz6AieoYTqa2dCbR13NE9lHsm_jAsNNhkmhjVHmaXKRvakuoVapxbF7KKutuVdd9MPz4TXY-VVZPeTtRF4Khp-hqV1QpJBTdbzMj8vH11qLxQekbufVewAyp04KIREAysOREzeVbhyA82giiStawAD_S0kj0ZSGGpnsaNG0AF6c4zVJZf3sTkKg3ZWeQ1BiFOgzkB9hif-62d3Ra2AYwEZlnQNgzwFRAE47zTYBNy3V5bebrWpPj8qChiPB8KgSOQf5Tsxy7YyayPTodtjZ_bfHstkO85E02f6aiNJ9xlTHEq1h3lTnRHdObqhh6zUOKdeLGotekiDXikRvhcbqK0x-CxmKqcs2EOawaZQTmGfa7QYVdnAXLyaJqakk8wN2XLcOU7od42ulRVZK9pJPZKGS1SFQ-wBZw-6kUDPafKlzOPDWOkqSL6Gb2dF0hQX1sGrhIu0RcJfEPXV8vww9x5H6W26gSqmN1QpR0Z9qoqmMp0JpIBDWnrxFidYaEVbGV9h1LY3EIs3XYjb9Tk6ISHVrZegsvNq7y0iPo6wa4OyzxNnI-bzldiY5LDfcaLkdKBrd5vcXOi12288VhkLoyweHs9of_pgmXMIRzgpc5uUsYwqKizpRA4DpMqdSPdm1p3fV_NRa7p9bF_ZamkaBvYKHI3w_AFP6llgjdehOE6M48Cdv2lmCx41jtNCdrtZ8_9n62yiTUBnEgI1-WokMuFyUtiATsPtvf-0se1Np7pyLgM73ywYU3qxJHFrOJFNCXWIwZqGFKCgxNp3Ml0Bw20RkiuDnKcneTvOxqVGL1JkWuYrqkFafLeepj0_1CtusQ8f8VGY_p278wYzpZaPlWnEUZUVM2GkwRaqmOVr2FvC30ymFeDggBuIRKLDv-xjwZe5u7ernivgqUBiOqzDF01hu4JKA5dnsnN27GtQK0bxr1ijnF_zMy4yP_rB1bE3LsUURbjJqRuIcm5pXm4J_JUeMB6uxfCf1sXhlwgMrSRkkok6xoP2Gu6WNouVJt7FI8ph2rvFC8O51dHlnm0JcWdq-cD6kdWSCOEFYmqdb9KUs_we8z35xG_ILF0hCWko8SHq_oNRFYj6dxbioZ73L_ZMc-lpQ5y7UmhQeHpbZza7sva-gV58tl1hhg0daZgDOtX04oLFi1NN3dJoDWoiVsn4wxYUimYNtzDO4PBPlYeaoPmWbd0rHeKKAvJoeZOvmN0U-DMIf4MdaWoEdHdK1d3G4Tl3yagXfz7C0YSNCWIQ6pQbEN1u1p8M2zQ4xBM5Dbg4gfP4YaGUKA471fap7a7dVYvmjNKKWnkDyclBmMAvxaEMWMi6FJYvngeSRO37gOnF04jZSofjKJR8gCJaS8mzwRuI34WKuOJ0IwL5iO-Nqg8jPFNgLeudXbuaJ85tp0_VlC-OC85w9aj-QH8bxfbEBI3WRlRqqM-RBm20CmmIIfuX1Rv0b_vrkzWlU0ckudjR1W5X1b33-vD6rDroVkaM3j5W6By8KsNe9XihbwCi0yihIc8YdEVpdXp-yRlmYoSUO1dboG2TbwXkZrlR5V-AVB1-TPxK4n8mZvWpgFXv7oXykucwoUSU7dGqe1ij1_r2Aho7d7pZJXOAAngpQ1xrttfYYnGCBdsSFq1w-mnZvFu9nt-WwWhMiGZXe9HKEL3m4m499asSlg5opsh-M-1NkmgbQ2RGnuHien6cc_jtWm1phWw9fElTuxwB83eb5bJUmT2AUG1iZzcEhKefp7lismhz5PbxkdHgZT-vruZeFQv3RbDoFeeTBZgNz8Yr7GzOeCu_evceY_k5-U4XIT6UE2Lbe1flDmLzGykbp5LCCZa4_gRcBD-_inRUZZ8XVmP_sn59ZEM1TRc3wMvQHxzwc8jJnnTk0bXv7Nr6xIlF0bQSsf6ZSWuOiwCUOvXQRbQIewVQM-9mQo3B4lFAsI4g72VCOUEi718KgF1Jyz--m-ZF8BiFjGBPDFBU9rAh55rtilixfkQBAZyAZgRk8t6p3Hqf0nuqE2eQYf_PYfeHKQgvl4lFIiSF2EGgzrpc0fQ7rxF__GBb0eXENK99Uh26k4-qBn7ZdRZfq2Ek747SmWsv4YTT19yFTVoIp-CcE8UIyP3NpCxOUNCp4quhn1OsKhCvTr_4DAzbhkMfbPFeE72r8UHpsURefdWUX5XXK7tOEK-YV5G4JyXpB9O5A7ja22jNZ6gBF38bcgXs4DP74dHd_mA7g4Fy-QFYbx1XBsEChb_sCzMQ3LEKIVUVz5gvDASIk5M2bnmhmY1eFYM2sWH3t3x6kDWgsh5vDCDMVlUUvhfRaVvsrR61inkLpnyA6hz6-oRo4o2ZOBuyGBkTX_CN-Nso2NLIjfTK2GgQvcdHS1AlqVA4G-ETXyDd6sc_0TAQB4y5xYjt_2tcsd8R49egrN5bXJPFpPXwQgRafFq4ip8JO2Nqo4Hdcj-omhXnW19fV0lZx_t2PmhX5N_bNzhqQl7PgeVDayHMIz-gTfKjWNq9F7y8J_1ZFzvcnZpi270BlPm_l5xbxefD1T9SqfXVI-gVuCkTyRTVQ6Isp60ADmAcl6CE2UIlUtHhq5lnVjDPxkQBDGzfUMPGrRkuy2d60uvgoZjfGpZQL5KIyc8bB5-wRF8i-XrJzQhjyFe4_vmscRzBn50DX4Y51zENrkn7mgkkv0YEL69QDbWN27qhVbIaQcNFUuqYNIhlumyFlLCqL1HTcKJcWx4w9sLWO4DNeAR18asKKZwDJKWfUGoSg_Hv_HLy2ys902Dgv2VFvLVBVNsO8QV1Aq6qCmY3G_T7IinIUSmP_3oqlVVuMGGxp0SBoxcvRIDn_T47-HotBUfKoseKHfTr5d2ggEuutcHI9yNaM5UQRxXotyO1Q0_uxFymc4nMgJbujj9n0Luuq5DkmYcWPN-V6siFvJEC3jnVGa2dgvqOFYM6A5e8Wf1bGwjKT8yuDYxVoqiTDxRXDmRpCnriN1wJL0iU2nqDjucKTM1p5NE2eiMbkI6eKq-v_yIyX1sn4nmQKaaXhjsdjrHHfm8giO5J_P2QZ848sbKox5FNRZ8fKlXcfk4h-vH3O3jOKJ3amOIzJavSKmAayu7xd_uvDLU4llOhGzG961YPq9lH-rVe1YoIhen2D2SlSeRm_XgnPCoy27tmo7mMC9SDaee5NBktO3UIPqBSgvMGfxOLeN75yWZ0d6KtJnwgSJA5VVqmzNKj1-N7DZ8nBmybHLZGGPqlXeorN9flCR3UGG2forbuik-uZqtvQrKvo6QKIejUxVcat1b7sPItVwbN36UT41SRsKwWPrVp3kKiPs2Gw0chpFWwz2EjCe7-1F9oYaMdEWxOVjoH1SDw3B5WsG86LUYu4PNtoZtA1bkOHNX8PHLuEdmUfGjZ487cNbd3m_1ziYGSBV8YazM6YYjZa738jM_TZUAurereTWWm3T92WoRhpwFDNHqAM0Fp76lVsGDc4FLB7KS2oROS7zRWK0YIQoiVxe7SzjIXeOWe7rTAxCY59UbrHtc1hoqVN6CuWui5XfIeBE9j7HTMhT9F3cJTERHJQoca9XBBPYAEFlG8RwOl4Pc2mVIkzE0kw",
+        "enc": "A256GCM",
+        "iv": "6nfR06Ia7uHXCYIP",
+        "kid": "er2hz3idctundugolb6xi3znii"
+      },
+      "packageUuid": ""
+    },
+    {
+      "uuid": "avga5lsju5smism4mxnajhcjga",
+      "templateUuid": "004",
+      "trashed": "N",
+      "createdAt": "2026-08-31T13:12:41Z",
+      "updatedAt": "2026-08-31T13:12:41Z",
+      "creatorUuid": "HVE53ZQITRE4LDVGUZZXPY23PY",
+      "changerUuid": "HVE53ZQITRE4LDVGUZZXPY23PY",
+      "itemVersion": 1,
+      "encryptedBy": "er2hz3idctundugolb6xi3znii",
+      "encOverview": {
+        "cty": "b5+jwk+json",
+        "data": "zHMokeCPV0fWlCSLvA2YIg5DOSwWSLEnThb3Kxnow0Xm7oxQcsuwelkeuHezpiVP3gmsQ0J96lmdWFGWfEzBPhyoUr0yh11TEhb8qxGGTXJieCqX5CG61sfklmP_birdgW5mD0FeB_wMIZUM2lxAv_12V1fSEEZ9Qvr4iDXVwA",
+        "enc": "A256GCM",
+        "iv": "Mj6qnY3SfJyAaUkd",
+        "kid": "er2hz3idctundugolb6xi3znii"
+      },
+      "encDetails": {
+        "cty": "b5+jwk+json",
+        "data": "kmX-Hwle0H5AfIT7ZMGKbbtcdO5b8sHGE10mIMX5G4bG3BsQMd8qxNaRupFhxcMbw1yay4rvPRH5PRG9UowVHJxQC4fxK89gTGNhTLpZeKmaizKI83dS7huXXms0w3uJJJ1r_WBqtK4ZgEgXxXC46IZJoiRmCbg1wbYox2QTqCc6GZTPuks_93lTOlduyzPQiY0tVXGTZyegEJ0dE1gUN2GJLzOrc8pRin5D01faVc0nvkxj0gGNubZ2b_5YHRQxcT90X5wSoqMZ_Js0YLyKixrZXwSKLkYl7FCfpkVNc_czJPKvErm9gHyGoaVuIMv8zxRZbGAo-OSW24UuBBJVJSHMJvwChWX1f76I0PA4qhO43HuNHiMnr9sp6wtoQpSHvPRPS47FjQxHaWclYTE_l9jC3v84sTV5rlPQH9Ptvbv-CrbPGs6rzflNU_D2eYZImtnfdkeaOlMuYmG5n38I-40q_b6X47Ve0kjE_Jq4xzKdox0QmzWXlW7ScqPmbct-wEXC-VolYBbFm06cw1t8D5fcUa8M0qGsSTCfyowHoy71_-TXmzXhhNnpYy9onTQtk0TMf12-sNfHb1YD4ef8QDkprSTgWs5WRMKaHPsyy1Ie4rv672N0FwMsAgunOJM-q5LSbsKXs_YJ2KvTsZO2dp_dNEGsB7oN94QYi4XdnXf_io6LRiT8fXID_hChP7PlJJrs0YjRYYM5EKP0NLwb92fBzLQfCwrA8FT9ZYq3wqShDMl1dUqpFiWFlUK2ylq3ZshNWw2t03kpNkmbC9uS_QXYH3jBu1ykHMxTUlCwr2tGpqPMsqrffCsNJnAN_g_xkqUiP2MwtTdidDeZ4UNSLxgay9_b-VKmbT1GzmHpYZ-dgE7GS_TJD1D2AWvjNguCJcTRCOUqqGC5lqFNKKHLh8hV9UleqVsMo_hUkajz6UmzSWq3-RJ2idjo5gQbq3ZTf_t1uZ71Bon3brpqDBlCdQ1Qoxl1LzdZn5lr15uQWXtU084tXNYLce--yHyYHRTvFEkZwu1D-7LPik0dXFtICW0okRNJTuqnrLU8frd_adBQg8YPKDahxB-w7qwY9wuS3Zs7mUOt6vHFLe5043MT__CijBMmowkidudKLkU-U3F4WMYWjQpUDhihr9tkwvDgjJImwf0-w0_GdpGkm8R1oumd2ge5StOfzLNUjgbtN-XTTNrO-uSth1AaESgK4E061a9UvDLurQyKGHrU_c87tZK5lok9TO0LWlkG7Ux49_FDxdGhmy-bg9vA492uHweAmE3gf1mf_FVW1vdSiqnzmrUqsW_SBptoup3RH3BOwkaRy_cmk5O4peKwT4JhDsBAQ8PIj4Z8787mKYLYwIKVrHeBTTK_eloB_YwOGcsvntxKdyVRfLsXVWM_DRxuCu4Qk9IIuD8Zu2bfmXoawncKxFBn4oOPcJe1aae7P0zyQ1AGzYCd_x61vpuaKQMJXR-owVBcIlHsYuJ9zfFGFZ0CKgtiq-3ZJ_FD9EUDAjQKN4GTrw7o9Yfn_SzRxoHQ1C4-MNnBi97GkxzgShoUJoYFYDAoyalvB1PM9DxE2GZs5ZAMsPqmg3gtGZ0z0g9taQ6RAUxKEs_gf12fTULjLTenRvitJid8QPj2GMb-eYwLGnkKRJLgjQ3DFW78TfShqSa1-3UTpdxb7XERYgYQZse2P5-A9yO147Ugj12VREKq0Zpb_Nfr81yjYC5yN0Dt4xFLoyUHmck4U9W864O3PdPFqCpjByqHjkBjEvbft2UR_XWaHV_bWbhM-beq3F4IASN_3UNXOSh6oFrDMRCkT8jKXuulhAkLQ-r-suDS15TNYcsMbH4wPuvnkEddvACQexw7GcoO7NL65Vz7HczCEfvnzJOqz7XjCowKcAUVu9oJwxn6eo1rRZl6pIp4dJ3RKzLUQ6a8g6gRwGRkF37_EUw7eYP2pMyeiABLznus9VswSnIwv28qE1l5YoysV-kGZ9tpfHNzFNSy835YaiIqz2rn_6AicTHgT2eH4D5Ju3_UFaQpj5Ps6ar5fAJh1oAW7Gf5ZGZPkG_rp8PMpMob-QI9caq7AgV3GIpvxL8cp57nNGIoXFrJ2lUpcZWrTpjHWDFlKT3emGJQ8Q3uGRTmnBCNFBqZczsgkXqA6koyPDB4Ho-aNmZ-o4wNUFbPxKacOWAA8WmfmCTBMCJWBh3XRIQVzCzp-lmGovoLArqWigRBygtfR7scck_M1QMA6xSriK9z-kmBHtD-_vAtC0b4rsPRG5nscTXB80OCCr1ZGdX450jUBtc9w-0UIKOSF6VQpXsc2EmRub9ZvkWNQkcKBBqiuIiLJh9OjTy8LRtI8L4uy9BTuhtmQDu6JzSApWToEFj8A3GjfNJS_RAQkG0kDaEbgdJC2U_L4dPNTVtIUVOr",
+        "enc": "A256GCM",
+        "iv": "R5tjjBPnO6Daas0Z",
+        "kid": "er2hz3idctundugolb6xi3znii"
+      },
+      "packageUuid": ""
+    },
+    {
+      "uuid": "fceki3v2nzuy7tckyjl3iirja4",
+      "templateUuid": "001",
+      "trashed": "N",
+      "createdAt": "2026-08-31T13:12:43Z",
+      "updatedAt": "2026-08-31T13:12:43Z",
+      "creatorUuid": "HVE53ZQITRE4LDVGUZZXPY23PY",
+      "changerUuid": "HVE53ZQITRE4LDVGUZZXPY23PY",
+      "itemVersion": 1,
+      "encryptedBy": "er2hz3idctundugolb6xi3znii",
+      "encOverview": {
+        "cty": "b5+jwk+json",
+        "data": "aeWqZj-Rjq7Xyh44Fg1ZBZiNPOlBI0yFDt81WkDlz8wqSaYxcxJCzWupblcginO8wg30ZYkjCDEADc2tUANMZzS8K0ydCT-CH5wN9g_rfmyJBMn9Hn1mWCtYncnwvxoBt-Ntz3QGD-nd_TfQbzxyAmiEPthnKWS37O8tGOpoxIwOvyFMGG1C557gOk6ka7AaIEswAkUCAHT24sO3oqsL8F_7IZ7wgF0gpZlTwE4ZrdF3wSyDSIt5wrJxjmIg1ElcZ9NA_5AJaAfgfxGOuxf3",
+        "enc": "A256GCM",
+        "iv": "V_0MeFUeHaA_0kqN",
+        "kid": "er2hz3idctundugolb6xi3znii"
+      },
+      "encDetails": {
+        "cty": "b5+jwk+json",
+        "data": "rZ2rBVadlgxdPHi3b8UVshhQKR9f-Ij3xv1jYWgxsk4PlBnjkgVKIffm7UM1sDmX0MUYW3NZWBjzh9E6CYVtkOs2iKTjyZQv2yQqZ5RMlqGT3vi4nEEt2tNaFDJE8NO7Qk9cBqDe9IaJTVtAzA15MzcWn_HKySjcRxHEWpNnF-Bp8QJkeWa_MTtyspKPoq5dPab1hldwC6z2PYAfkAaqSGCZ9KXh2xrjK3Wi1XO3qJf01U_y0OFA4gkxz8eNvQ30X_xiEfwwmwhi6lhaag95lnI529RchXY8vFy1X3LgWq0Edph8RDYCel5sulfkRiCwaw_XsXsHpAZwlfEDdhkiGysJcCPsjKo3WimnIWYbgsSgLnVM",
+        "enc": "A256GCM",
+        "iv": "KmAKZpWrLr6zLNrs",
+        "kid": "er2hz3idctundugolb6xi3znii"
+      },
+      "packageUuid": ""
+    },
+    {
+      "uuid": "6jrodr3vnweoqris6wgzvbj33a",
+      "templateUuid": "001",
+      "trashed": "N",
+      "createdAt": "2026-08-31T13:13:07Z",
+      "updatedAt": "2026-08-31T13:13:07Z",
+      "creatorUuid": "HVE53ZQITRE4LDVGUZZXPY23PY",
+      "changerUuid": "HVE53ZQITRE4LDVGUZZXPY23PY",
+      "itemVersion": 1,
+      "encryptedBy": "er2hz3idctundugolb6xi3znii",
+      "encOverview": {
+        "cty": "b5+jwk+json",
+        "data": "EZxhRE2t2Vyv4VJUPu942fTxB1tkvnLBgMJ150Qw3-bTdZnvJMd8HBkBWCz033kWyYATTw3p8CgNtdaTsnhthoRgXyOkvmDqAvUq8eZu4YmfYmu49_7qygeyKhFcdd8W5Ftb4ORJ-MnFPfgUDMjD3n_KM5yaBwxdfUUtxJlH0A",
+        "enc": "A256GCM",
+        "iv": "M7Hx31EdzAOLQAG0",
+        "kid": "er2hz3idctundugolb6xi3znii"
+      },
+      "encDetails": {
+        "cty": "b5+jwk+json",
+        "data": "3nf_Qb0tkv3PFf6SqNGZHvB0SmuelYGALQJLksmcASRWbtcBztSTMFaX1OKk4qsCXaKFSKcQn5-eddCyA1lSM-tNjLOG1HhltVeFYd1WQVzIkwDqFYuasnz7CqXSaMxaZbSh_EdGMg7xGE42bf_hfGH_l3Lu9yu6qTPrUAuwJYXapH7NTjymVR4BR0hDrxAIm8WxCHHvxToxYlHqP1FUJRkUkFsFC34SFOl5yhWfv4A8wofuWmzgNHT0b4F-Oi1t0I0DTQjlnMFUqmIn_mAasQtRHuleWaGt96njVXlfyfGTKUSXwth5x2TPGzP9DtQFb3_cn7-9AcM93HyMjX2zJzoySdg6UZDN3QxaxDkVhNAF7cg7986JOIp_btHj9RKSE3XX42jPsKxpTEJUdTkeXZskT3fTUV5_OMQwFWgNXdIRqbwRd7ewN0SgAscMTN17h16y7ZcCxL9AakuP6ehblNnznm_-NNYDH6QOrdAmQzlbeyeeK42AfSMQ39ux6-wOeQ1fab0Pps-3lsrrwMcgGRVoEw08edG4IsvnHZK2CCnyTsLX-Ioc1MUSgis3zjePaOzBmaILLWq82qjHCMTgTKTshRSNE8N88YyruVuDPj5mXebcHYPXfZOv2W9tl9q-5vvfYo6v0IC3zVYb7IWKXw18ru94Aw",
+        "enc": "A256GCM",
+        "iv": "H0iRe8u8zbesarDG",
+        "kid": "er2hz3idctundugolb6xi3znii"
+      },
+      "packageUuid": ""
+    },
+    {
+      "uuid": "vicpdgssb4xvbrzlrocvsr3cau",
+      "templateUuid": "111",
+      "trashed": "N",
+      "createdAt": "2026-08-31T20:58:32Z",
+      "updatedAt": "2026-08-31T20:58:32Z",
+      "creatorUuid": "HVE53ZQITRE4LDVGUZZXPY23PY",
+      "changerUuid": "HVE53ZQITRE4LDVGUZZXPY23PY",
+      "itemVersion": 1,
+      "encryptedBy": "er2hz3idctundugolb6xi3znii",
+      "encOverview": {
+        "cty": "b5+jwk+json",
+        "data": "LosV_UJK1UmG7aKwSuQTVR3HlU1d-1TQEYYQyqiJXpuRFuicOt99vaM7JF4QXJfJKGVPlbh3Y6Sc5lsTJBmU758mpiv81DJnPu4oEkSYStkRKUU0IgXUxUURrsdzWBSKWKwZiDV9k7eoE3QSwXkCOkAzP3I",
+        "enc": "A256GCM",
+        "iv": "FsPdyYcA1XUrtqau",
+        "kid": "er2hz3idctundugolb6xi3znii"
+      },
+      "encDetails": {
+        "cty": "b5+jwk+json",
+        "data": "oKfB60lyCeF3AJID2dV-w1megdaJliywD1g__2ovjQsPg6WBvAErq7eRaASA_nl3GMem10EPovbANyTqngqHYr273Oe_GrggouRFtvFEljzShdZoxdGtC6QOehj8qvaogEDL8AP9xYDvhpsdKNocKBooQbCHjskXf6yixB5VUNKrkAU2CYaPeq56lpchvIrWJJTcoa_sfkuJKTJEPMHXysDVKDQN9l77swO-Ua1DWJch3FsGr1_vhzbX5z0tzKgUgC2Pv0ZZXyxogoB5JMlVnBcODYHaqtoFo0TqOZCrCaeCJD4gEpTiYujhHu4WsYRINRD9WrcJjlVYrXQzWyGTFI6f4oXFnOVz8GSOokqQaLi9WJoND7F_ppSkCo9cY1NK6FB4ohAikRyplEh2QUij0_sLxefFaKgjBjXz88cpq1H_tiFhJOx8Ck8JgzeQMgZl4DZ9E8_38lcHEddhzN9TUwb5uJYXgGhP_Ncf8iZZWj56U1qWVVqXTH06e9OiD7CwgOspTTCPF30lyhoqmpDlmCQDjLdvJu0dPQEYhfcM_a464EGkKTKpXuKGULdfRs6bAk0zL86-0LNIm1Lq_vACnhOoUTdbkRRuIGfU6q3wKYUplUhphrGPTckN-XgrrQRg3GOo9_zZP2jBz0qXEZevsIgrG0gq9PuZYmctTx6pmXUbZdRaJLhDjU7beCGvL-sbq53jwSMv4A-Qs-9PQAyuaUrqbzutwm69V_JksCEg_cVFRDSSiadSj5M0zDIT2M6j5mvlXCtFJaiqkw0qG1b0BuX8LFWjzzeunkpVgeREXSwoXDzprBBD8z407RF2Tt8ioX5KktjO_3NkaOU0GXW30BeEeq0QCZP6yhkNcOb5AxMzP-6kFmuEtfiDE1lG2GCu3Gv8qSVysIpx447_somy7LsCf0bejjN4Af_rtObwy026FqjeXmbIDnEy47oWm66CqPeREBWWhXgeABglKoFvI_P3fDWcM462o5vJX2g4rhN97Qe7NlmlX5RvUWUi-LqgFL2A_a9AKGwY3R5oMR2mepmvYwDntSaueMSP-N5fQGq3oqaAMx-pMFwXaBJ_M0Ls6_hE9n7oDc3vBVdELc076hqcT_g-tJS8s-e7iBVKV71uyBGsnwteJUG0V685EU8Bt3Dw7ukGfN6T3n8LfK8KEIFbO1DO4TZGyKfjBlYSvnWtvhPI70dJqCM_n0iycHKhKKriHhIE_-q1LjyammnkmDzlVU0Zx8lxYOI80_J2SAhRC7ILDFWSMq1gD_gwN75RgpnuuEbvoH9O0KHAiBgDLCcQWadQrxVw3adG5n_3NMZ62l5-XpQsq4bMUbwvBVTaY5BPzQElyAH_opc3Tp0CqcDDkeARKEaruwEuCQdXt5qEOsxHr5IZVS2FCFeIXHVVtJBj4rFW2RPhHn1969JXXPb-wPxUL01MmdeOQSiyh7JNVIm8SSKmP6bwXq1iF_yL89noOyCLsMiaSEDqNFq7GWGJxWlbFNc8otvEXid1XF1R14w551xhfv37eh4c9burR6RLvEPThOE9c6bw9yk5j0d5bDwY9r6nZY2ThwMa278eN6obU4_k3RJSdiDhCRe9qB053tCp--tSpvyvIEnkkF6r5wKGWWTwCG7JS6O9p22dr8ygRcYVN8m_JYS02MMUc9bc5prDADKZzU0peScHZ2W1dmp9r0EkKUxL2VLRw84kkWb2cPdD15Esk88bLhl3jUgjTaacK-P5BTiSdqdHjklCaKBuDHItyq03qBQpgAklUs7ezo7A0iqzPDLrYPiAo6zAD0HroO9TOTLrslSf0vcZki8wxe8Zm0D0fCK8WZ-sjbxYqrwQugs7bm_SiJ4iVATcLDpX",
+        "enc": "A256GCM",
+        "iv": "FEunRNIaMHA72zs7",
+        "kid": "er2hz3idctundugolb6xi3znii"
+      },
+      "packageUuid": ""
+    },
+    {
+      "uuid": "vz6hkvvvni6ybwkdagslqneffa",
+      "templateUuid": "109",
+      "trashed": "N",
+      "createdAt": "2026-08-31T20:58:34Z",
+      "updatedAt": "2026-08-31T20:58:34Z",
+      "creatorUuid": "HVE53ZQITRE4LDVGUZZXPY23PY",
+      "changerUuid": "HVE53ZQITRE4LDVGUZZXPY23PY",
+      "itemVersion": 1,
+      "encryptedBy": "er2hz3idctundugolb6xi3znii",
+      "encOverview": {
+        "cty": "b5+jwk+json",
+        "data": "rSTiaiha57HYkuheibSM5gqXwSYCnpcubeQLn0UABjiYb2gzOYw8ciP0T1Os7TFvlq3sj6am4gYYHsvEqKscNT0ID8VLLhvEx_7sSNevlFWntvjnmN-yLeI6zPQzcg-B0VFvXc3PVs9_gLk5cWt5VEMaZ5ElkUw",
+        "enc": "A256GCM",
+        "iv": "XbpSjeT5p5mhk6Jp",
+        "kid": "er2hz3idctundugolb6xi3znii"
+      },
+      "encDetails": {
+        "cty": "b5+jwk+json",
+        "data": "CRhIZU5kslQjoki0vygQ_u7fnGgt9KIqshM-SZaXJ22JZmbLiDf_9mPfV4VWzkQNlqZ1RLtxRCL6f94UIH3iFDqv6f7F_p1h6WBW0sKz6OSaqXsoFgJF2FUShDJfqOcK38CUiXC2S_0tTYflm7cSxEdPnTu571y1v4paE8tViE2dwox34b4iLxphtetxAzI7yRJEKtATjzJCjmmET3tmpyylkLPQq7K1OrJM-tiL6q_gZeBbgN7gEUQq0iYkxdLKD9wfHwEDtFfVCMFRJKQqPWOLV40Fg1XkiRgoFx6-HFMqFaGBe4HnVc_HmeIVZCv3zgyi9qGADrEC0w5D5yVGnGvR9VhZI7OrySPtrewBcMtGhTDaV8MkCtbQdFmUtJJMiEN_MxfgiAqFBHkxsiM30bZ6jTsP7Vo0l20U6jDT3ZpQeFcGDpoktNo48c7vDD95adx_P-yZ1qjUmFWBDGgrqgwpzhBKKhgoOMpoAbTQDE-S2-BITq6_GO65jAH3vphiO6Cf1PwB2uP8xU7rbxKD1NOhuLBd0qu7kUZbnpSfpFaob5oDJQrStoYRRycGi6pprAux1k0FKreKTVCFkMUoLdP5m5RI8y701ARU5Bk4kEGR140Q6W8N22IGiqrqs7IAuJPkJ22GI9KvE0gpUZm4b6q7q7wP4KQhAvNE8xHPgbMv0TqUE7eiKmUSyJWTnduYi_FyqmSCiJXT1Cm3a97Ms0BYlEBYD4Q9HyI-7pxbFaZnSqoIhnLr7qkq1V3_qcsOknziqyFWcB6c-omcuG7CG039JLsoyOEre5aZHCRX-OYbOBExL4EIhrNDnxlP7y2xF79I59KHEgdgFG7uHDe7-Ej9V0yoeYxXbp1j1l5WtlMKPOz6Ort1Jk9JTii2GRNPC0VLjrfH3S_T7QX5_l3yYSOJMdg",
+        "enc": "A256GCM",
+        "iv": "xK4D9oJwHiJ5VIwF",
+        "kid": "er2hz3idctundugolb6xi3znii"
+      },
+      "packageUuid": ""
+    }
+  ],
+  "deletedItemUuids": [
+    "emzj56djuwil7it4a3qp2226eq",
+    "jttm64wamedx3mxznchtbulszm",
+    "owglhqvlpvsvvbincogjhdi32e",
+    "wy7fvxmk3mfjv2vty62ilxaumm"
+  ],
+  "batchComplete": true
+}

--- a/crates/bitwarden-importers/src/importers/onepassword/fixtures/vault-wv2hn4jgomxwvfh4oiubyjppym-items-response.json
+++ b/crates/bitwarden-importers/src/importers/onepassword/fixtures/vault-wv2hn4jgomxwvfh4oiubyjppym-items-response.json
@@ -1,0 +1,64 @@
+{
+  "contentVersion": 93,
+  "items": [
+    {
+      "uuid": "6hhj7ea5qmsfdpz4tjjavaosze",
+      "templateUuid": "001",
+      "trashed": "N",
+      "createdAt": "2026-08-31T13:20:08Z",
+      "updatedAt": "2026-08-31T13:20:30Z",
+      "creatorUuid": "HVE53ZQITRE4LDVGUZZXPY23PY",
+      "changerUuid": "HVE53ZQITRE4LDVGUZZXPY23PY",
+      "itemVersion": 10,
+      "encryptedBy": "dpukpj4nztvgvjyz4b2p4dzv3m",
+      "encOverview": {
+        "cty": "b5+jwk+json",
+        "data": "YeKIIJhj_AiyWKahhc0S4K6wCCwh_yYBsBiFwE7oHDea77Gb1_XJTr_GH1x5l73Yf72A1-hHuRt7UfUVqX8yD9nLZxGIqMTcHry4EOht0rV02C203EzAMyGieEbpiGpcEQSlMP0BIZumppv6K67DG4MG_uUgUUw3xLbcJ5DcCaqn28srUrUwLkdYdcvUBJxrV2FpexSbUn7Z4TtEs2KdOLKQNUHq4J96U22v6Qnsb7NFv-6z-ATJF3gNy6JkubhnYsB5gvGL-000EozRaKVMwNjISxfBgPfMWcthPbZO70yPZpDcSZgut_XdG_QnFlop6aH0Tw",
+        "enc": "A256GCM",
+        "iv": "tQIqZ1cNLUaV8Jsu",
+        "kid": "dpukpj4nztvgvjyz4b2p4dzv3m"
+      },
+      "encDetails": {
+        "cty": "b5+jwk+json",
+        "data": "js3fmwo1GJZ-Tqi-q1-tqC1TORDJLkFh7-XnghDrQaZcRMwayZb01kvgbZ3ehiZIN_o5-MYILfbffSxdtfBPi9EsaiOLIiaYzDaaJIaWNiD3iktiQsm9je2s1OXauIdj9sRswxMRoREN5UbOfCU2pkjU5vxc90F7Lsh1s9GM4Ql9NHqCX28G_Evh7oQwiQ1seZg1WbcppxEVpa2t32Dc2CKljgBRKT536wlBWAAsNRjgGjOiutqAIzu66TZ2RYyKC-K66pM8bIw9B7Xnu_cH6KdCq4yIOCNKac90iTz-OtceVPU9JNWZYy2wS8dxrZE2QVjOZne-sYxm9syydh8XufvWk3XnUbfkO6xkBgOoZM7kzzqyZASez5X_MlxWBewU13IrnEnaeHfRzngNcQQdkefauVyEuff2NHRezleUseEQLjDsWvxunUPgLtk5QUBWOENd1TE8n1NMiOTgVY0q148z2DRQ1OIfo4IZvLIPWDyyoaUw3ETSFRg8m9UINNqUAP21E-ZHdoSPMDOKomo9BUkOsm0UVg3Wt2mM8AO2v8ztxWQjviLO6AVXTsfFmtWy4JPwIsxLvKsIlJFY22CN7vMUgcd33FXoWnN9NwfAE5Iyq-DsmBvYAVeCZLsOPDQkn_irlK8Fun2zh0PG3jPrqN5iF29kDWsxuom_blbgwOwjjEVMYKnqvp_s2D2G-bSFJEIygH_U_CHLkJ-VXvs8Pr5AzSeu3o56mEwRsxCWI761BgclVKk4g6jsUnFgBHOqCcik55Je9KPL_ySkohrRJHuFhIkjIkO52E0C-K4F342BCtuTqNYMsIGwN6gGlwD_uwCaElWJenZy6UHgjAd6SIyyMY5BXzbXphmmOFnKSM7wdUaHS0qduYe_qIeLVRbaIN8UWWKEpYeYQ_TTVHSGykQUh-CUw-1AJeC0aYIMzY4BbDsYvnXP_p92BFMgQgC2i2d2iuxW9lm1EiD-jzRoyQZ2fV96FzevF5W8ohcCKi2yPsNmosXzGFJ-DDSlVP71S-ZJRmQ7xqCoC27uP3jSmld0TXinjpF16znyh2LgPilWG0BiHTrKVCfY2pfjb9ZCK2zDX5MiJHTM67telwZ5FeAAViWd1mhgCuIqXmHDTNKOktTKJdFiSB4",
+        "enc": "A256GCM",
+        "iv": "HQyiDnrvVbAEuwld",
+        "kid": "dpukpj4nztvgvjyz4b2p4dzv3m"
+      },
+      "packageUuid": ""
+    }
+  ],
+  "deletedItemUuids": [
+    "52wfgpqnnb7hr2wrivlywcu4c4",
+    "5jylxkdt5rqen6gtll4gv2uwqu",
+    "7iigllqodos6r5n7tx6274ad2i",
+    "amif6vl6vuuwg3jwrpjory3s6i",
+    "b5iwdvpkwe2v76tcuf7hj4ymfa",
+    "bepu3tnhh5asqndcjyve7bvykm",
+    "d65bnzeodbd3f3go2jkpr3u5bm",
+    "egieo4cehjw722tjbw6zxbr3wi",
+    "fazrffhw7x7wyullsje3wxrgse",
+    "fffac42knwjug6sptp2kopqeiu",
+    "fspc36hgdsbj3u3urnvpawlnhm",
+    "fzd4lrxdeexzjzxlm356zxw4am",
+    "huho3tmqdacyvypc6dkwekx6re",
+    "i3ptpeqmfpkxdtc2636rbwcumu",
+    "iu7tumlaah6e25dj3aaq2464m4",
+    "jwunuhjfqvid4vo27z25uzkquq",
+    "k4sbppdvp6xjuqewuogzumoj5e",
+    "l5ojqjsqwtcm3fjpfxauvz2l34",
+    "ld5loelkv55p4jako6y2rvhola",
+    "lpravwlrkfwgt3wow3zvlb3izu",
+    "n3dvm7jw4lvw3rz7cgicovsc6q",
+    "nej26e3gufzwowsxhvjtut277u",
+    "oqog3vvdy237666zkja5ubgyw4",
+    "q7krxtytfuul7bxho2umffgd3q",
+    "rrz3s7pepsayjsnylq526rttde",
+    "tk4iv6kjurawctbef7ye3rnwiq",
+    "uw75rpv364okhcoorkwah5arui",
+    "vrr5wsoin53lqe6fxokc34ogsa",
+    "wtpea56oqcusp5jbyk4ibsqefy",
+    "x5zbuq7q4smfow5o532kfej4ra"
+  ],
+  "batchComplete": true
+}

--- a/crates/bitwarden-importers/src/importers/onepassword/mod.rs
+++ b/crates/bitwarden-importers/src/importers/onepassword/mod.rs
@@ -1,8 +1,12 @@
 //! 1Password importer.
 //!
 //! [`access`] is the Bitwarden-agnostic client that logs in and downloads the vaults.
+//! [`convert`] maps what it returns onto the importer's parsed shape.
 
-// `pub` for the `test-utils` re-export. Nothing in the SDK calls into it yet.
-// TODO: Make it `pub(crate)` once the importer consumes the module directly and the re-export goes.
+// Both are `pub` for the `test-utils` re-export. Nothing in the SDK calls into them yet.
+// TODO: Make them `pub(crate)` and drop the allows once the importer consumes the modules directly
+// and the re-export goes.
 #[allow(dead_code, unused_imports)]
 pub mod access;
+#[allow(dead_code)]
+pub mod convert;

--- a/crates/bitwarden-importers/src/lib.rs
+++ b/crates/bitwarden-importers/src/lib.rs
@@ -25,6 +25,16 @@ mod pipeline;
 // TODO: Remove once the importer consumes the module directly.
 #[cfg(feature = "test-utils")]
 pub use importers::onepassword::access as onepassword_access;
+/// The 1Password conversion step: downloaded vaults to the [`ParsedImport`] the pipeline
+/// submits.
+///
+/// Exposed only under the `test-utils` feature, so the CLI can print what a real account
+/// converts to. Not part of this crate's supported API, and no stability is promised.
+// TODO: Remove once the importer consumes the module directly.
+#[cfg(feature = "test-utils")]
+pub use importers::onepassword::convert as onepassword_convert;
+#[cfg(feature = "test-utils")]
+pub use pipeline::ParsedImport;
 
 /// Destination options for a vault import.
 ///

--- a/crates/bitwarden-importers/src/pipeline.rs
+++ b/crates/bitwarden-importers/src/pipeline.rs
@@ -19,7 +19,10 @@ use crate::{CipherTypeCount, ImportError, ImportOptions, ImportSummary};
 
 /// Format-agnostic parse result: the ciphers, the folder paths, and which cipher belongs to which
 /// folder (by index). Every importer parser produces this for the pipeline to submit.
-pub(crate) struct ParsedImport {
+// `pub` only so the `test-utils` re-export can reach it for the out-of-tree CLI.
+// TODO: Back to `pub(crate)` once the re-export goes.
+pub struct ParsedImport {
+    /// The ciphers to submit, index-aligned with [`Self::folder_relationships`].
     pub ciphers: Vec<ImportingCipher>,
     /// Folder paths (e.g. `"Parent/Child"`), index-aligned with [`Self::folder_relationships`].
     pub folders: Vec<String>,


### PR DESCRIPTION
## 🎟️ Tracking

Follow-up to the 1Password access module (#1371). First of four PRs that turn the downloaded
vaults into an import, split to keep each one small.

## 📔 Objective

Adds `convert.rs`, mapping downloaded 1Password vaults onto the importer's `ParsedImport`:

- Vaults become folders, items keep their title and note.
- Logins get username, password and deduplicated website addresses.
- Every other category becomes a plain secure note for now. Typed mappings and custom fields
  follow in the next PRs.

Nothing is wired into `ImporterClient` yet and no bindings change. Tests replay a captured
throwaway account through the production download path: the fixtures are the server responses,
re-encrypted with a fixed session key and served from wiremock.

## 🚨 Breaking Changes

None.
