### PR TITLE
[PM-39819] Add method to support updating an invite's confirmation

### DIFF
--- a/crates/bitwarden-organization-invite-link/src/invite_link_client.rs
+++ b/crates/bitwarden-organization-invite-link/src/invite_link_client.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use bitwarden_api_api::models::{
     AcceptOrganizationInviteLinkRequestModel, ConfirmOrganizationInviteLinkRequestModel,
     CreateOrganizationInviteLinkRequestModel, GetOrganizationInviteRequestModel,
-    RefreshOrganizationInviteLinkRequestModel,
+    RefreshOrganizationInviteLinkRequestModel, UpdateInviteSupportConfirmRequestModel,
 };
 use bitwarden_core::{
     ApiError, Client, FromClient, MissingFieldError, OrganizationId,
@@ -112,6 +112,52 @@ impl InviteLinkClient {
             .refresh(
                 organization_id.into(),
                 Some(RefreshOrganizationInviteLinkRequestModel {
+                    invite: String::from(&invite),
+                    supports_confirmation: invite.supports_confirmation(),
+                }),
+            )
+            .await?;
+
+        OrganizationInviteLink::try_from(response)
+    }
+
+    /// Updates whether an existing invite link supports confirmation, re-sealing the given invite
+    /// accordingly and persisting it to the server.
+    ///
+    /// Enabling confirmation re-seals the organization key under the invite's existing invite key;
+    /// disabling it strips that envelope. Either way the invite key, code, and secret are left
+    /// untouched, so links already handed out stay valid. Use
+    /// [`InviteLinkClient::refresh_invite_link`] instead when the code and secret must be rotated.
+    ///
+    /// # Security
+    /// Only the re-sealed invite is posted to the server; the invite secret is never sent.
+    pub async fn set_invite_confirmation(
+        &self,
+        organization_id: OrganizationId,
+        invite: Invite,
+        supports_confirmation: bool,
+    ) -> Result<OrganizationInviteLink, InviteLinkError> {
+        let mut invite = invite;
+
+        // Confine the (non-Send) key store context to a synchronous scope; the re-sealed invite it
+        // produces is consumed by the request posted after the `.await` below.
+        {
+            let mut ctx = self.key_store.context();
+            let org_key = SymmetricKeySlotId::Organization(organization_id);
+            if supports_confirmation {
+                invite.enable_confirmation(org_key, &mut ctx)?;
+            } else {
+                invite.disable_confirmation();
+            }
+        }
+
+        let response = self
+            .api_configurations
+            .api_client
+            .organization_invite_links_api()
+            .update_invite_support_confirm(
+                organization_id.into(),
+                Some(UpdateInviteSupportConfirmRequestModel {
                     invite: String::from(&invite),
                     supports_confirmation: invite.supports_confirmation(),
                 }),
@@ -610,6 +656,151 @@ mod tests {
         );
 
         let result = client.create_invite_link(org_id, vec![], false).await;
+
+        assert!(matches!(result, Err(InviteLinkError::Api(_))));
+    }
+
+    #[tokio::test]
+    async fn set_invite_confirmation_enables_confirmation_on_an_existing_invite() {
+        let org_id = OrganizationId::new_v4();
+        // Captures the invite posted to the server so it can be checked independently of the
+        // echoed response.
+        let posted = Arc::new(std::sync::Mutex::new(None::<String>));
+        let for_mock = posted.clone();
+        let client = make_client(
+            org_id,
+            ApiClient::new_mocked(move |mock| {
+                mock.organization_invite_links_api
+                    .expect_update_invite_support_confirm()
+                    .returning(move |org, model| {
+                        let model = model.unwrap();
+                        *for_mock.lock().unwrap() = Some(model.invite.clone());
+                        Ok(echo_link_response(
+                            org,
+                            vec![],
+                            model.invite,
+                            model.supports_confirmation,
+                        ))
+                    })
+                    .once();
+            }),
+        );
+
+        // Start from an invite with confirmation stripped; the invite key is still sealed under the
+        // organization key, so confirmation can be re-enabled from it.
+        let (_secret, mut invite, _org_public_key) = build_invite(&client, org_id);
+        invite.disable_confirmation();
+        assert!(!invite.supports_confirmation());
+
+        let link = client
+            .set_invite_confirmation(org_id, invite, true)
+            .await
+            .unwrap();
+
+        assert!(link.supports_confirmation);
+        assert!(link.invite.supports_confirmation());
+        let posted: Invite = posted.lock().unwrap().clone().unwrap().parse().unwrap();
+        assert!(posted.supports_confirmation());
+    }
+
+    #[tokio::test]
+    async fn set_invite_confirmation_disables_confirmation_on_an_existing_invite() {
+        let org_id = OrganizationId::new_v4();
+        let client = make_client(
+            org_id,
+            ApiClient::new_mocked(|mock| {
+                mock.organization_invite_links_api
+                    .expect_update_invite_support_confirm()
+                    .returning(|org, model| {
+                        let model = model.unwrap();
+                        Ok(echo_link_response(
+                            org,
+                            vec![],
+                            model.invite,
+                            model.supports_confirmation,
+                        ))
+                    })
+                    .once();
+            }),
+        );
+
+        let (_secret, invite, _org_public_key) = build_invite(&client, org_id);
+        assert!(invite.supports_confirmation());
+
+        let link = client
+            .set_invite_confirmation(org_id, invite, false)
+            .await
+            .unwrap();
+
+        assert!(!link.supports_confirmation);
+        assert!(!link.invite.supports_confirmation());
+    }
+
+    #[tokio::test]
+    async fn set_invite_confirmation_preserves_the_invite_secret() {
+        let org_id = OrganizationId::new_v4();
+        let client = make_client(
+            org_id,
+            ApiClient::new_mocked(|mock| {
+                mock.organization_invite_links_api
+                    .expect_update_invite_support_confirm()
+                    .returning(|org, model| {
+                        let model = model.unwrap();
+                        Ok(echo_link_response(
+                            org,
+                            vec![],
+                            model.invite,
+                            model.supports_confirmation,
+                        ))
+                    })
+                    .once();
+            }),
+        );
+
+        // Toggling confirmation must not rotate the invite key, so already-distributed links (which
+        // carry the secret) keep working.
+        let (secret, invite, _org_public_key) = build_invite(&client, org_id);
+        let link = client
+            .set_invite_confirmation(org_id, invite, false)
+            .await
+            .unwrap();
+
+        let recovered = client.get_invite_secret(org_id, link.invite).unwrap();
+        assert_eq!(String::from(&recovered), String::from(&secret));
+    }
+
+    #[tokio::test]
+    async fn set_invite_confirmation_with_unknown_organization_id_fails() {
+        let org_id = OrganizationId::new_v4();
+        let other_org_id = OrganizationId::new_v4();
+        let client = make_client(org_id, ApiClient::new_mocked(|_| {}));
+
+        // The invite key is sealed to the client's own org key; re-sealing under a different
+        // organization's key slot (which is absent from the store) must fail before any request.
+        let (_secret, mut invite, _org_public_key) = build_invite(&client, org_id);
+        invite.disable_confirmation();
+
+        let result = client
+            .set_invite_confirmation(other_org_id, invite, true)
+            .await;
+
+        assert!(matches!(result, Err(InviteLinkError::Invite(_))));
+    }
+
+    #[tokio::test]
+    async fn set_invite_confirmation_surfaces_api_errors() {
+        let org_id = OrganizationId::new_v4();
+        let client = make_client(
+            org_id,
+            ApiClient::new_mocked(|mock| {
+                mock.organization_invite_links_api
+                    .expect_update_invite_support_confirm()
+                    .returning(|_org, _model| Err(std::io::Error::other("boom").into()));
+            }),
+        );
+
+        let (_secret, invite, _org_public_key) = build_invite(&client, org_id);
+        let result = client.set_invite_confirmation(org_id, invite, false).await;
 
         assert!(matches!(result, Err(InviteLinkError::Api(_))));
     }

--- a/crates/bitwarden-wasm-internal/integration-tests/tests/organizations/invite-link-server.ts
+++ b/crates/bitwarden-wasm-internal/integration-tests/tests/organizations/invite-link-server.ts
@@ -1,4 +1,4 @@
-// Happy-path stand-ins for the seven endpoints `InviteLinkClient` calls.
+// Happy-path stand-ins for the eight endpoints `InviteLinkClient` calls.
 
 import { Routes } from "../http-mock";
 import {
@@ -16,6 +16,7 @@ export const ROUTES = {
   publicKey: `GET /organizations/${ORG}/public-key`,
   create: `POST /organizations/${ORG}/invite-link`,
   refresh: `POST /organizations/${ORG}/invite-link/refresh`,
+  supportConfirm: `PUT /organizations/${ORG}/invite-link/support-confirm`,
   getInvite: "POST /organizations/users/invite-link/invite",
   confirm: "POST /organizations/users/invite-link/confirm",
   accept: "POST /organizations/users/invite-link/accept",
@@ -33,7 +34,10 @@ export interface InviteLinkServerOptions {
   invite?: string | (() => string);
   /** The organization public key, i.e. the account-recovery key an invitee enrolls into. */
   publicKey?: string;
-  /** Called with the invite posted to create/refresh, standing in for the server persisting it. */
+  /**
+   * Called with the invite posted to create/refresh/support-confirm, standing in for the server
+   * persisting it.
+   */
   onCreate?: (invite: string) => void;
 }
 
@@ -78,6 +82,7 @@ export function inviteLinkRoutes(options: InviteLinkServerOptions = {}): Routes 
     [ROUTES.publicKey]: () => ({ json: { object: "organizationPublicKey", publicKey } }),
     [ROUTES.create]: (request) => link(request.json()),
     [ROUTES.refresh]: (request) => link(request.json()),
+    [ROUTES.supportConfirm]: (request) => link(request.json()),
     [ROUTES.getInvite]: () => ({ json: { invite: invite() } }),
     [ROUTES.confirm]: () => ({}),
     [ROUTES.accept]: () => ({}),

--- a/crates/bitwarden-wasm-internal/integration-tests/tests/organizations/invite-link.test.ts
+++ b/crates/bitwarden-wasm-internal/integration-tests/tests/organizations/invite-link.test.ts
@@ -121,6 +121,109 @@ describe("invite link client", () => {
     });
   });
 
+  describe("set_invite_confirmation", () => {
+    it("strips the organization-key envelope when disabling confirmation", async () => {
+      mock = installHttpMock(inviteLinkRoutes());
+
+      const link = await admin
+        .invite_link()
+        .set_invite_confirmation(TEST_ORGANIZATION_ID, TEST_INVITE, false);
+
+      // No key material is fetched — the invite carries everything needed.
+      expect(mock.routes()).toEqual([ROUTES.supportConfirm]);
+
+      const posted = mock.bodyFor(ROUTES.supportConfirm);
+      expect(Object.keys(posted).sort()).toEqual(["invite", "supportsConfirmation"]);
+      expect(posted.supportsConfirmation).toBe(false);
+      // The envelope is nulled out rather than dropped, and the other four are untouched.
+      const stripped = JSON.parse(posted.invite);
+      expect(stripped.invite_key_sealed_organization_key).toBeNull();
+      const original = JSON.parse(TEST_INVITE as unknown as string);
+      expect(original.invite_key_sealed_organization_key).not.toBeNull();
+      for (const key of [
+        "sealed_invite_data",
+        "invite_key_sealed_invite_data_cek",
+        "invite_secret_sealed_invite_key",
+        "organization_key_sealed_invite_key",
+      ]) {
+        expect(stripped[key]).toBe(original[key]);
+      }
+
+      expect(link.supportsConfirmation).toBe(false);
+      expect(link.invite).toBe(posted.invite);
+    });
+
+    it("re-seals the organization key when enabling confirmation", async () => {
+      mock = installHttpMock(inviteLinkRoutes());
+
+      const link = await admin
+        .invite_link()
+        .set_invite_confirmation(TEST_ORGANIZATION_ID, TEST_INVITE_NO_CONFIRMATION, true);
+
+      const posted = mock.bodyFor(ROUTES.supportConfirm);
+      expect(posted.supportsConfirmation).toBe(true);
+      // A fresh envelope appears where the fixture had `null`; the invite key it wraps is
+      // unchanged, so `organization_key_sealed_invite_key` must not be rotated.
+      const resealed = JSON.parse(posted.invite);
+      const original = JSON.parse(TEST_INVITE_NO_CONFIRMATION as unknown as string);
+      expect(resealed.invite_key_sealed_organization_key).toEqual(expect.any(String));
+      expect(resealed.organization_key_sealed_invite_key).toBe(
+        original.organization_key_sealed_invite_key,
+      );
+      expect(link.supportsConfirmation).toBe(true);
+    });
+
+    it("preserves the invite secret so distributed links keep working", async () => {
+      mock = installHttpMock(inviteLinkRoutes());
+      const inviteLink = admin.invite_link();
+
+      const link = await inviteLink.set_invite_confirmation(
+        TEST_ORGANIZATION_ID,
+        TEST_INVITE,
+        false,
+      );
+
+      expect(inviteLink.get_invite_secret(TEST_ORGANIZATION_ID, link.invite)).toEqual(
+        TEST_INVITE_SECRET,
+      );
+      for (const request of mock.requests) {
+        expect(request.body).not.toContain(TEST_INVITE_SECRET);
+      }
+    });
+
+    it("lets an invitee redeem a link whose confirmation was turned off after creation", async () => {
+      // Whatever the admin posts to support-confirm is what the server hands back to the invitee.
+      let persisted: string | undefined;
+      mock = installHttpMock(
+        inviteLinkRoutes({
+          onCreate: (invite) => {
+            persisted = invite;
+          },
+          invite: () => persisted!,
+        }),
+      );
+
+      const link = await admin
+        .invite_link()
+        .set_invite_confirmation(TEST_ORGANIZATION_ID, TEST_INVITE, false);
+      expect(persisted).toBe(link.invite);
+
+      await invitee
+        .invite_link()
+        .accept_and_optionally_confirm(
+          TEST_ORGANIZATION_ID,
+          link.code,
+          TEST_INVITE_SECRET,
+          COLLECTION_NAME,
+          false,
+        );
+
+      // Confirmation was stripped, so the invitee can only accept.
+      expect(mock.routes()).toEqual([ROUTES.supportConfirm, ROUTES.getInvite, ROUTES.accept]);
+      expect(mock.called(ROUTES.confirm)).toBe(false);
+    });
+  });
+
   describe("get_invite_secret", () => {
     it("recovers the invite secret from an invite passed as a parameter", () => {
       mock = installHttpMock(inviteLinkRoutes());


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-39819

## 📔 Objective

Implements new method to be utilized for Invite Link for setting up the auto confirm feature toggle.
